### PR TITLE
Add examples for redirect handling

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -9,6 +9,7 @@
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#MetaData[MetaData]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#HTTP2[HTTP/2]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Mutual-TLS[Mutual TLS]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#Redirects[Redirects]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#uds[Unix Domain Sockets]
 ** xref:{page-version}@servicetalk-examples::http/service-composition.adoc[Service Composition]
 * xref:{page-version}@servicetalk-examples::grpc/index.adoc[gRPC]

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -175,7 +175,7 @@ the same across all the HTTP APIs.
 [#Redirects]
 == Redirects
 
-Extends the async "Hello World" example to demonstrate different ways how users can support redirects in ServiceTalk
+Extends the async "Hello World" example to demonstrate different ways that users can support redirects in ServiceTalk
 applications. You should read and understand the async "Hello World" example first to understand the additions this
 example adds. No separate example is needed for the other API variants as the usage of the debugging features are the
 same for all API styles.

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -172,6 +172,24 @@ Using the following classes:
 NOTE: This example uses the link:#blocking-aggregated[blocking + aggregated] API, as the TLS/SSL configuration API is
 the same across all the HTTP APIs.
 
+[#Redirects]
+== Redirects
+
+Extends the async "Hello World" example to demonstrate different ways how users can support redirects in ServiceTalk
+applications. You should read and understand the async "Hello World" example first to understand the additions this
+example adds. No separate example is needed for the other API variants as the usage of the debugging features are the
+same for all API styles.
+
+* link:{source-root}/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/RedirectingServer.java[RedirectingServer] -
+Starts two servers, one of them (HTTP) redirects to another (HTTPS).
+* link:{source-root}/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/ManualRedirectClient.java[ManualRedirectClient.java] -
+Async `Hello World` example that demonstrates how redirects can be handled manually when single-address clients are used.
+* link:{source-root}/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/SimpleRedirectUrlClient.java[SimpleRedirectUrlClient.java] -
+Async `Hello World` example that demonstrates how redirects can be handled automatically by a multi-address client.
+* link:{source-root}/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/RedirectWithStateUrlClient.java[RedirectWithStateUrlClient.java] -
+Async `Hello World` example that demonstrates how redirects can be handled automatically by a multi-address client.
+It demonstrates how users can preserve headers and payload body of the original request while redirecting.
+
 [#HTTP2]
 == HTTP/2
 

--- a/servicetalk-examples/http/redirects/build.gradle
+++ b/servicetalk-examples/http/redirects/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-http-netty")
+
+  // This dependency brings self-signed TLS certificates for demonstration purposes.
+  // Users have to use their own certificates instead.
+  implementation project(":servicetalk-test-resources")
+
+  // This dependency enables OpenSSL provider that supports ALPN. It's recommended to use OpenSSL provider for the
+  // best SSL performance.
+  runtimeOnly "io.netty:netty-tcnative-boringssl-static:$tcnativeVersion"
+
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}

--- a/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/ManualRedirectClient.java
+++ b/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/ManualRedirectClient.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.redirects;
+
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+
+import java.util.concurrent.CountDownLatch;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.examples.http.redirects.RedirectingServer.CUSTOM_HEADER;
+import static io.servicetalk.examples.http.redirects.RedirectingServer.NON_SECURE_SERVER_PORT;
+import static io.servicetalk.examples.http.redirects.RedirectingServer.SECURE_SERVER_PORT;
+import static io.servicetalk.http.api.HttpHeaderNames.LOCATION;
+import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.REDIRECTION_3XX;
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+
+/**
+ * Async "Hello World" example that demonstrates how redirects can be handled manually when single-address clients are
+ * used with possibilities to:
+ * <ol>
+ *     <li>Change the target server or perform a relative redirect.</li>
+ *     <li>Preserve headers while redirecting.</li>
+ *     <li>Preserve payload body while redirecting.</li>
+ * </ol>
+ */
+public final class ManualRedirectClient {
+
+    public static void main(String... args) throws Exception {
+        try (HttpClient secureClient = HttpClients.forSingleAddress("localhost", SECURE_SERVER_PORT)
+                // The custom SSL configuration here is necessary only because this example uses self-signed
+                // certificates. For cases when it's enough to use the local trust store, the trust cert supplier
+                // argument for ClientSslConfigBuilder may be skipped.
+                .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build()).build()) {
+
+            try (HttpClient client = HttpClients.forSingleAddress("localhost", NON_SECURE_SERVER_PORT).build()) {
+                // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+                // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+                // demonstration purposes.
+                CountDownLatch responseProcessedLatch = new CountDownLatch(1);
+
+                // Redirect of a GET request with a custom header:
+                HttpRequest originalGet = client.get("http://localhost:8080/sayHello")
+                        .addHeader(CUSTOM_HEADER, "value");
+                client.request(originalGet)
+                        .flatMap(response -> {
+                            if (response.status().statusClass() == REDIRECTION_3XX) {
+                                CharSequence location = response.headers().get(LOCATION);
+                                HttpClient redirectClient = lookupClient(location, client, secureClient);
+                                return redirectClient.request(redirectClient
+                                        .newRequest(originalGet.method(), location.toString())
+                                        .addHeader(CUSTOM_HEADER, originalGet.headers().get(CUSTOM_HEADER)));
+                            }
+                            // Decided not to follow redirect, return the original response or an error:
+                            return succeeded(response);
+                        })
+                        .afterFinally(responseProcessedLatch::countDown)
+                        .subscribe(resp -> {
+                            System.out.println(resp.toString((name, value) -> value));
+                            System.out.println(resp.payloadBody(textDeserializer()));
+                            System.out.println();
+                        });
+
+                responseProcessedLatch.await();
+
+                // Redirect of a POST request with a payload body:
+                responseProcessedLatch = new CountDownLatch(1);
+                HttpRequest originalPost = client.post("http://localhost:8080/sayHello")
+                        .payloadBody(client.executionContext().bufferAllocator().fromAscii("some_content"));
+                client.request(originalPost)
+                        .flatMap(response -> {
+                            if (response.status().statusClass() == REDIRECTION_3XX) {
+                                CharSequence location = response.headers().get(LOCATION);
+                                HttpClient redirectClient = lookupClient(location, client, secureClient);
+                                return redirectClient.request(redirectClient
+                                        .newRequest(originalPost.method(), location.toString())
+                                        .payloadBody(originalPost.payloadBody()));
+                            }
+                            // Decided not to follow redirect, return the original response or an error:
+                            return succeeded(response);
+                        })
+                        .afterFinally(responseProcessedLatch::countDown)
+                        .subscribe(resp -> {
+                            System.out.println(resp.toString((name, value) -> value));
+                            System.out.println(resp.payloadBody(textDeserializer()));
+                        });
+
+                responseProcessedLatch.await();
+            }
+        }
+    }
+
+    private static HttpClient lookupClient(CharSequence location, HttpClient sameClient, HttpClient secureClient) {
+        if (location == null || location.length() < 1) {
+            throw new IllegalArgumentException("Response does not contain redirect location");
+        }
+        String loc = location.toString();
+        if (loc.charAt(0) == '/' || loc.startsWith("http://localhost:" + NON_SECURE_SERVER_PORT)) {
+            return sameClient; // Relative redirect
+        }
+        if (loc.startsWith("https://localhost:" + SECURE_SERVER_PORT)) {
+            return secureClient;    // Redirect to a different target server
+        }
+        throw new IllegalArgumentException("Attempt to redirect to unknown or untrusted target server");
+    }
+}

--- a/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/RedirectWithStateUrlClient.java
+++ b/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/RedirectWithStateUrlClient.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.redirects;
+
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.AsyncContextMap;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+
+import java.util.concurrent.CountDownLatch;
+
+import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKey;
+import static io.servicetalk.examples.http.redirects.RedirectingServer.CUSTOM_HEADER;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
+import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
+import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
+import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.REDIRECTION_3XX;
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+
+/**
+ * Async `Hello World` example that demonstrates how redirects can be handled automatically by a
+ * {@link HttpClients#forMultiAddressUrl() multi-address} client. It demonstrates how users can preserve headers and
+ * payload body of the original request while redirecting.
+ *
+ * For security reasons, headers and payload body are not automatically populated for the redirect request. Users have
+ * to explicitly cary the original state when they are sure that redirect does not forward to a malicious target server.
+ *
+ * For backward compatibility with legacy HTTP clients, ServiceTalk preserves behavior for
+ * {@link HttpRequestMethod#POST} requests described in RFC7231, sections
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.2">6.4.2</a> and
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.3">6.4.3</a>. For these status codes, manual
+ * action may be required to preserve the original request method.
+ */
+public final class RedirectWithStateUrlClient {
+
+    private static final AsyncContextMap.Key<StreamingHttpRequest> ORIGINAL_REQUEST = newKey();
+
+    public static void main(String... args) throws Exception {
+        try (HttpClient client = HttpClients.forMultiAddressUrl()
+                // This is an optional configuration that applies more restrictive limit for the number or redirects:
+                .maxRedirects(1)
+                .initializer((scheme, address, builder) -> {
+                    // Add a filter to preserve the original request information, while redirecting:
+                    builder.appendClientFilter(c -> new StreamingHttpClientFilter(c) {
+                        @Override
+                        protected Single<StreamingHttpResponse> request(StreamingHttpRequester delegate,
+                                                                        HttpExecutionStrategy strategy,
+                                                                        StreamingHttpRequest request) {
+                            StreamingHttpRequest original = AsyncContext.get(ORIGINAL_REQUEST);
+                            if (original != null) {
+                                // If the previous response was a redirect, carry headers and payload body. But before
+                                // doing so, make sure that the redirect location is trusted to avoid leaking sensitive
+                                // content. It can be done by manual checking of the target hostname and port number or
+                                // by configuring mutual TLS. This is out of scope of this example.
+                                CharSequence headerValue = original.headers().get(CUSTOM_HEADER);
+                                if (headerValue != null) {
+                                    request.setHeader(CUSTOM_HEADER, headerValue);
+                                }
+                                // As described in javadoc for this example, 301 and 302 status codes may change
+                                // POST to GET for the redirect. Override it explicitly to preserve POST.
+                                if (POST.equals(original.method())) {
+                                    request.method(POST)
+                                            // Note: the original request must have re-playable payload body publisher.
+                                            .payloadBody(original.payloadBody());
+                                    // Preserve correct header for the payload body length/format definition:
+                                    CharSequence cl = original.headers().get(CONTENT_LENGTH);
+                                    if (cl != null) {
+                                        request.setHeader(CONTENT_LENGTH, cl);
+                                    } else {
+                                        request.setHeader(TRANSFER_ENCODING, CHUNKED);
+                                    }
+                                }
+                            }
+                            return delegate().request(strategy, request).map(response -> {
+                                if (response.status().statusClass() == REDIRECTION_3XX) {
+                                    // In case of a redirect, remember original request in the context:
+                                    AsyncContext.put(ORIGINAL_REQUEST, request);
+                                } else {
+                                    // Clear the state to make sure retries won't use the state in the context:
+                                    AsyncContext.remove(ORIGINAL_REQUEST);
+                                }
+                                return response;
+                            });
+                        }
+                    });
+                    // The custom SSL configuration here is necessary only because this example uses self-signed
+                    // certificates. For cases when it's enough to use the local trust store, MultiAddressUrl client
+                    // already provides default SSL configuration and this step may be skipped.
+                    if ("https".equalsIgnoreCase(scheme)) {
+                        builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build());
+                    }
+                })
+                .build()) {
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(1);
+            client.request(client.post("http://localhost:8080/sayHello")
+                    .addHeader(CUSTOM_HEADER, "value")
+                    .payloadBody(client.executionContext().bufferAllocator().fromAscii("some_content")))
+                    .afterFinally(responseProcessedLatch::countDown)
+                    .subscribe(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.payloadBody(textDeserializer()));
+                    });
+
+            responseProcessedLatch.await();
+        }
+    }
+}

--- a/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/RedirectingServer.java
+++ b/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/RedirectingServer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.redirects;
+
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.netty.HttpServers;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.ServerSslConfigBuilder;
+
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.http.api.HttpHeaderNames.LOCATION;
+import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
+import static io.servicetalk.logging.api.LogLevel.TRACE;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+/**
+ * Starts two servers, one of them (HTTP) redirects to another (HTTPS).
+ *
+ * Run it first before executing any of the client-side examples in this package.
+ */
+public final class RedirectingServer {
+
+    static final int SECURE_SERVER_PORT = 8443;
+    static final int NON_SECURE_SERVER_PORT = 8080;
+
+    static final CharSequence CUSTOM_HEADER = newAsciiString("custom-header");
+
+    public static void main(String... args) throws Exception {
+        ServerContext finalServer = HttpServers.forPort(SECURE_SERVER_PORT)
+                .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                        .build())
+                .enableWireLogging("servicetalk-examples-https-server-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                    HttpResponse response = responseFactory.ok();
+                    CharSequence customHeaderValue = request.headers().get(CUSTOM_HEADER);
+                    if (customHeaderValue != null) {
+                        response.addHeader(CUSTOM_HEADER, customHeaderValue);
+                    }
+                    return response.payloadBody("Redirect complete!" + (request.payloadBody().readableBytes() > 0 ?
+                                    " Request payloadBody received: " + request.payloadBody().toString(US_ASCII) : ""),
+                                    textSerializer());
+                });
+
+        try {
+            HttpServers.forPort(NON_SECURE_SERVER_PORT)
+                    .enableWireLogging("servicetalk-examples-redirecting-server-wire-logger", TRACE,
+                            Boolean.TRUE::booleanValue)
+                    .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.movedPermanently()
+                            .addHeader(LOCATION, "https://localhost:" + SECURE_SERVER_PORT + '/'))
+                    .awaitShutdown();
+        } finally {
+            finalServer.closeAsync().toFuture().get();
+        }
+    }
+}

--- a/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/SimpleRedirectUrlClient.java
+++ b/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/SimpleRedirectUrlClient.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.redirects;
+
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+
+import java.util.concurrent.CountDownLatch;
+
+import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
+
+/**
+ * Async `Hello World` example that demonstrates how redirects can be handled automatically by a
+ * {@link HttpClients#forMultiAddressUrl() multi-address} client.
+ *
+ * Automatic redirects have limitations. See {@link RedirectWithStateUrlClient} for more information.
+ */
+public final class SimpleRedirectUrlClient {
+
+    public static void main(String... args) throws Exception {
+        try (HttpClient client = HttpClients.forMultiAddressUrl()
+                // This is an optional configuration that applies more restrictive limit for the number or redirects:
+                .maxRedirects(1)
+                .initializer((scheme, address, builder) -> {
+                    // The custom SSL configuration here is necessary only because this example uses self-signed
+                    // certificates. For cases when it's enough to use the local trust store, MultiAddressUrl client
+                    // already provides default SSL configuration and this step may be skipped.
+                    if ("https".equalsIgnoreCase(scheme)) {
+                        builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build());
+                    }
+                })
+                .build()) {
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for a streaming API but is useful for
+            // demonstration purposes.
+            CountDownLatch responseProcessedLatch = new CountDownLatch(1);
+            client.request(client.get("http://localhost:8080/sayHello"))
+                    .afterFinally(responseProcessedLatch::countDown)
+                    .subscribe(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.payloadBody(textDeserializer()));
+                    });
+
+            responseProcessedLatch.await();
+        }
+    }
+}

--- a/servicetalk-examples/http/redirects/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/redirects/src/main/resources/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
+
+    <!-- Enables wire logging messages -->
+    <Logger name="servicetalk-examples-https-server-wire-logger" level="TRACE"/>
+    <Logger name="servicetalk-examples-redirecting-server-wire-logger" level="TRACE"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,6 +46,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:grpc:deadline",
         "servicetalk-examples:http:helloworld",
         "servicetalk-examples:http:mutual-tls",
+        "servicetalk-examples:http:redirects",
         "servicetalk-examples:http:http2",
         "servicetalk-examples:http:jaxrs",
         "servicetalk-examples:http:metadata",
@@ -108,4 +109,5 @@ project(":servicetalk-examples:http:serialization").name = "servicetalk-examples
 project(":servicetalk-examples:http:service-composition").name = "servicetalk-examples-http-service-composition"
 project(":servicetalk-examples:http:uds").name = "servicetalk-examples-http-uds"
 project(":servicetalk-examples:http:mutual-tls").name = "servicetalk-examples-http-mutual-tls"
+project(":servicetalk-examples:http:redirects").name = "servicetalk-examples-http-redirects"
 project(":servicetalk-examples:http:compression").name = "servicetalk-examples-http-compression"


### PR DESCRIPTION
Motivation:

Demonstrate how users can handle redirects with ServiceTalk, describe
what is not copied from the original request automatically, and how
users can redirect with headers and payload body.

Modifications:
- Add `servicetalk-examples-http-redirects` module;
- Add links in documentation for the new example;

Result:

Users can see different ways how to handle redirects.