### PR TITLE
Load balancer unhealthy hosts

### DIFF
--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerRoundRobinLoadBalancerTest.java
@@ -106,13 +106,7 @@ public class EagerRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest 
     }
 
     @Override
-    protected RoundRobinLoadBalancer<String, TestLoadBalancedConnection> defaultLb() {
-        return newTestLoadBalancer(true);
-    }
-
-    @Override
-    protected RoundRobinLoadBalancer<String, TestLoadBalancedConnection> defaultLb(
-            RoundRobinLoadBalancerTest.DelegatingConnectionFactory connectionFactory) {
-        return newTestLoadBalancer(serviceDiscoveryPublisher, connectionFactory, true);
+    protected boolean eagerConnectionShutdown() {
+        return true;
     }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringRoundRobinLoadBalancerTest.java
@@ -309,13 +309,7 @@ public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerT
     }
 
     @Override
-    protected RoundRobinLoadBalancer<String, TestLoadBalancedConnection> defaultLb() {
-        return newTestLoadBalancer(false);
-    }
-
-    @Override
-    protected RoundRobinLoadBalancer<String, TestLoadBalancedConnection> defaultLb(
-            RoundRobinLoadBalancerTest.DelegatingConnectionFactory connectionFactory) {
-        return newTestLoadBalancer(serviceDiscoveryPublisher, connectionFactory, false);
+    protected boolean eagerConnectionShutdown() {
+        return false;
     }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -25,10 +25,13 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorRule;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.TestExecutor;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.internal.DeliberateException;
@@ -65,6 +68,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitely;
@@ -90,6 +94,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -105,6 +110,9 @@ abstract class RoundRobinLoadBalancerTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
+    @Rule
+    public final ExecutorRule<TestExecutor> executor = ExecutorRule.withTestExecutor();
+
     protected final TestSingleSubscriber<TestLoadBalancedConnection> selectConnectionListener =
             new TestSingleSubscriber<>();
     protected final List<TestLoadBalancedConnection> connectionsCreated = new CopyOnWriteArrayList<>();
@@ -116,6 +124,8 @@ abstract class RoundRobinLoadBalancerTest {
 
     protected RoundRobinLoadBalancer<String, TestLoadBalancedConnection> lb;
 
+    protected TestExecutor testExecutor;
+
     protected static <T> Predicate<T> any() {
       return __ -> true;
     }
@@ -124,14 +134,21 @@ abstract class RoundRobinLoadBalancerTest {
         return cnx -> lb.usedAddresses().stream().noneMatch(addr -> addr.getValue().stream().anyMatch(cnx::equals));
     }
 
-    protected abstract RoundRobinLoadBalancer<String, TestLoadBalancedConnection> defaultLb();
+    protected RoundRobinLoadBalancer<String, TestLoadBalancedConnection> defaultLb() {
+        return newTestLoadBalancer(eagerConnectionShutdown());
+    }
 
-    protected abstract RoundRobinLoadBalancer<String, TestLoadBalancedConnection> defaultLb(
-            DelegatingConnectionFactory connectionFactory);
+    protected RoundRobinLoadBalancer<String, TestLoadBalancedConnection> defaultLb(
+            DelegatingConnectionFactory connectionFactory) {
+        return newTestLoadBalancer(serviceDiscoveryPublisher, connectionFactory, eagerConnectionShutdown());
+    }
+
+    protected abstract boolean eagerConnectionShutdown();
 
     @Before
     public void initialize() {
         lb = defaultLb();
+        testExecutor = executor.executor();
         connectionsCreated.clear();
         connectionRealizers.clear();
     }
@@ -381,6 +398,93 @@ abstract class RoundRobinLoadBalancerTest {
         awaitIndefinitely(connection.onClose());
     }
 
+    @Test
+    public void hostUnhealthyIsHealthChecked() throws Exception {
+        serviceDiscoveryPublisher.onComplete();
+        final Single<TestLoadBalancedConnection> properConnection = newRealizedConnectionSingle("address-1");
+        final UnhealthyHostConnectionFactory unhealthyHostConnectionFactory =
+                new UnhealthyHostConnectionFactory(properConnection);
+        final DelegatingConnectionFactory connectionFactory = unhealthyHostConnectionFactory.createFactory();
+
+        lb = defaultLb(connectionFactory);
+
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+
+        Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any()).toFuture().get());
+        assertThat(e.getCause(), instanceOf(DELIBERATE_EXCEPTION.getClass()));
+
+        unhealthyHostConnectionFactory.momentInTime.incrementAndGet();
+        testExecutor.advanceTimeBy(1, SECONDS);
+        unhealthyHostConnectionFactory.momentInTime.incrementAndGet();
+        testExecutor.advanceTimeBy(1, SECONDS);
+        unhealthyHostConnectionFactory.momentInTime.incrementAndGet();
+        testExecutor.advanceTimeBy(1, SECONDS);
+
+        final TestLoadBalancedConnection selectedConnection = lb.selectConnection(any()).toFuture().get();
+        assertThat(selectedConnection, equalTo(properConnection.toFuture().get()));
+
+        // 1 failed attempt triggers health check, 2 health check attempts fail, 3rd health check attempt
+        // uses the proper connection, final selection reuses that connection. 4 total creation attempts.
+        int expectedConnectionAttempts = 4;
+        assertThat(unhealthyHostConnectionFactory.requests.get(), equalTo(expectedConnectionAttempts));
+    }
+
+    @Test
+    public void hostUnhealthyDoesntRaceToRunHealthCheck() throws Exception {
+        serviceDiscoveryPublisher.onComplete();
+
+        final Single<TestLoadBalancedConnection> properConnection = newRealizedConnectionSingle("address-1");
+        final UnhealthyHostConnectionFactory unhealthyHostConnectionFactory =
+                new UnhealthyHostConnectionFactory(properConnection);
+        final DelegatingConnectionFactory connectionFactory = unhealthyHostConnectionFactory.createFactory();
+
+        lb = defaultLb(connectionFactory);
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+
+        // Imitate concurrency by running multiple threads attempting to establish connections.
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        final Runnable runnable = () ->
+                assertThrows(ExecutionException.class, () -> lb.selectConnection(any()).toFuture().get());
+
+        for (int i = 0; i < 1000; i++) {
+            executor.submit(runnable);
+        }
+
+        // From test main thread, wait until the host becomes UNHEALTHY, which is apparent from NoHostAvailableException
+        // being thrown from selection.
+        try {
+            awaitIndefinitely(lb.selectConnection(any()).retry((i, t) -> t instanceof DeliberateException));
+        } catch (Exception e) {
+            assertThat(e.getCause(), instanceOf(NoAvailableHostException.class));
+        }
+
+        // At this point, either the above selection caused the host to be marked as UNHEALTHY,
+        // or any background thread. We can assume from now on that only the health check can attempt establishing
+        // new connections. Therefore we can count those attempts. If our assumption doesn't hold, the UNHEALTHY
+        // state is either not properly set or multiple health checks run at the same time.
+        int requestsBefore = unhealthyHostConnectionFactory.requests.get();
+        unhealthyHostConnectionFactory.momentInTime.incrementAndGet();
+        testExecutor.advanceTimeBy(1, SECONDS);
+
+        assertThat(unhealthyHostConnectionFactory.requests.get(), equalTo(requestsBefore + 1));
+
+        unhealthyHostConnectionFactory.momentInTime.incrementAndGet();
+        testExecutor.advanceTimeBy(1, SECONDS);
+        assertThat(unhealthyHostConnectionFactory.requests.get(), equalTo(requestsBefore + 2));
+
+        executor.shutdownNow();
+        executor.awaitTermination(10, SECONDS);
+
+        unhealthyHostConnectionFactory.momentInTime.incrementAndGet();
+        testExecutor.advanceTimeBy(1, SECONDS);
+        assertThat(unhealthyHostConnectionFactory.requests.get(), equalTo(requestsBefore + 3));
+
+        // After 3 increments a proper established connection is returned and the host should be eligible for selection.
+        final TestLoadBalancedConnection selectedConnection = lb.selectConnection(any()).toFuture().get();
+        assertThat(selectedConnection, equalTo(properConnection.toFuture().get()));
+        assertThat(unhealthyHostConnectionFactory.requests.get(), equalTo(requestsBefore + 3));
+    }
+
     @SuppressWarnings("unchecked")
     protected void sendServiceDiscoveryEvents(final ServiceDiscovererEvent... events) {
         sendServiceDiscoveryEvents(serviceDiscoveryPublisher, events);
@@ -408,7 +512,22 @@ abstract class RoundRobinLoadBalancerTest {
     protected RoundRobinLoadBalancer<String, TestLoadBalancedConnection> newTestLoadBalancer(
             final TestPublisher<ServiceDiscovererEvent<String>> serviceDiscoveryPublisher,
             final DelegatingConnectionFactory connectionFactory, final boolean eagerConnectionShutdown) {
-        return new RoundRobinLoadBalancer<>(serviceDiscoveryPublisher, connectionFactory, eagerConnectionShutdown);
+        return new RoundRobinLoadBalancer<>(serviceDiscoveryPublisher, connectionFactory,
+                eagerConnectionShutdown, testExecutor);
+    }
+
+    protected RoundRobinLoadBalancer<String, TestLoadBalancedConnection> newTestLoadBalancer(
+            final TestPublisher<ServiceDiscovererEvent<String>> serviceDiscoveryPublisher,
+            final DelegatingConnectionFactory connectionFactory, final boolean eagerConnectionShutdown,
+            @Nullable final Executor executor) {
+        RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection> builder =
+                new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                        .eagerConnectionShutdown(eagerConnectionShutdown);
+        if (executor != null) {
+            builder.backgroundExecutor(executor);
+        }
+        return (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>) builder.build()
+                .newLoadBalancer(serviceDiscoveryPublisher, connectionFactory);
     }
 
     @SafeVarargs
@@ -508,6 +627,40 @@ abstract class RoundRobinLoadBalancerTest {
 
         boolean isClosed() {
             return closed.get();
+        }
+    }
+
+    protected static class UnhealthyHostConnectionFactory {
+        final AtomicInteger momentInTime = new AtomicInteger();
+        final AtomicInteger requests = new AtomicInteger();
+        final Single<TestLoadBalancedConnection> properConnection;
+
+        Function<String, Single<TestLoadBalancedConnection>> factory
+                = new Function<String, Single<TestLoadBalancedConnection>>() {
+
+            final List<Single<TestLoadBalancedConnection>> connections =
+                    Arrays.asList(
+                            failed(DELIBERATE_EXCEPTION),
+                            failed(DELIBERATE_EXCEPTION),
+                            failed(DELIBERATE_EXCEPTION)
+                    );
+
+            @Override
+            public Single<TestLoadBalancedConnection> apply(final String s) {
+                requests.incrementAndGet();
+                if (momentInTime.get() >= connections.size()) {
+                    return properConnection;
+                }
+                return connections.get(momentInTime.get());
+            }
+        };
+
+        UnhealthyHostConnectionFactory(Single<TestLoadBalancedConnection> properConnection) {
+            this.properConnection = properConnection;
+        }
+
+        DelegatingConnectionFactory createFactory() {
+            return new DelegatingConnectionFactory(this.factory);
         }
     }
 }


### PR DESCRIPTION
This PR is still WIP, the clear description is still pending. The basic idea is to remove unhealthy hosts from connection establishment in round robin load balancing for some time until a connection can be established again.