### PR TITLE
gRPC protoc plugin proto3 optional support

### DIFF
--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Main.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Main.java
@@ -30,6 +30,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import static com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest.parseFrom;
+import static com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL;
 import static io.servicetalk.grpc.protoc.StringUtils.parseOptions;
 import static java.lang.Boolean.parseBoolean;
 import static java.util.Collections.emptyMap;
@@ -110,7 +111,10 @@ public final class Main {
      * @return The code generation response
      */
     private static CodeGeneratorResponse generate(final CodeGeneratorRequest request) {
-        final CodeGeneratorResponse.Builder responseBuilder = CodeGeneratorResponse.newBuilder();
+        final CodeGeneratorResponse.Builder responseBuilder = CodeGeneratorResponse.newBuilder()
+                // Optional support only impacts "message" types, this plugin only targets "service" types.
+                // However the protoc compiler will fail if the feature isn't marked as supported.
+                .setSupportedFeatures(FEATURE_PROTO3_OPTIONAL.getNumber());
 
         final Set<String> filesToGenerate = new HashSet<>(request.getFileToGenerateList());
 

--- a/servicetalk-grpc-protoc/src/test/proto/test_single.proto
+++ b/servicetalk-grpc-protoc/src/test/proto/test_single.proto
@@ -50,6 +50,8 @@ service Fareweller {
 // The request message containing the user's name.
 message UserRequest {
     string name = 1;
+
+    optional int32 value = 2;
 }
 
 // The response message containing the greetings


### PR DESCRIPTION
Motivation:
protobuf 3.15 changed optional field support from experimental to
on-by-default. It also requires plugins to opt-in indicating the feature
is supported or else it throws an error and prevents usage of the
plugin.

[1] https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.0

Modifications:
- indicate the feature is supported, although services don't interact
  with the optional keyword

Result:
ServiceTalk gRPC protoc plugin can be used when the "optional" proto3
keyword is present.