### PR TITLE
Conditional `publishOn` and `subscribeOn` javadoc clarification

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1382,27 +1382,37 @@ public abstract class Completable {
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #publishOn(Executor, Supplier)}, current operator always enforces offloading to the passed
+     * {@link Executor}.
      *
      * @param executor {@link Executor} to use.
-     * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods on the
-     * {@link Subscriber}.
+     * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all {@link Subscriber}
+     * methods.
+     * @see #publishOn(Executor, Supplier).
      */
     public final Completable publishOn(Executor executor) {
         return PublishAndSubscribeOnCompletables.publishOn(this, () -> Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Completable} that map use the passed {@link Executor} to invoke {@link Subscriber}
+     * Creates a new {@link Completable} that may use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #publishOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
+     * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload provides a hint whether offloading to executor can be omitted. Offloading may still occur
-     * even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods on the
-     * {@link Subscriber}.
+     * @param shouldOffload {@link Supplier} that will be triggered on each
+     * {@link CompletableSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
+     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
+     * signal ordering.
+     * @return A new {@link Completable} that may use the passed {@link Executor} to invoke all {@link Subscriber}
+     * methods.
+     * @see #publishOn(Executor).
      */
     public final Completable publishOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnCompletables.publishOn(this, shouldOffload, executor);
@@ -1417,17 +1427,21 @@ public abstract class Completable {
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #subscribeOn(Executor, Supplier)}, current operator always enforces offloading to the passed
+     * {@link Executor}.
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
+     * @see #subscribeOn(Executor, Supplier).
      */
     public final Completable subscribeOn(Executor executor) {
         return PublishAndSubscribeOnCompletables.subscribeOn(this, () -> Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Completable} that map use the passed {@link Executor} to invoke the following methods:
+     * Creates a new {@link Completable} that may use the passed {@link Executor} to invoke the following methods:
      * <ul>
      *     <li>All {@link Cancellable} methods.</li>
      *     <li>The {@link #handleSubscribe(CompletableSource.Subscriber)} method.</li>
@@ -1435,12 +1449,18 @@ public abstract class Completable {
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #subscribeOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
+     * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload provides a hint whether offloading to executor can be omitted. Offloading may still occur
-     * even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods of
+     * @param shouldOffload {@link Supplier} that will be triggered on each
+     * {@link CompletableSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
+     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
+     * signal ordering.
+     * @return A new {@link Completable} that may use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
+     * @see #subscribeOn(Executor).
      */
     public final Completable subscribeOn(Executor executor, Supplier<BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnCompletables.subscribeOn(this, shouldOffload, executor);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1389,7 +1389,7 @@ public abstract class Completable {
      * @param executor {@link Executor} to use.
      * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
-     * @see #publishOn(Executor, Supplier).
+     * @see #publishOn(Executor, Supplier)
      */
     public final Completable publishOn(Executor executor) {
         return PublishAndSubscribeOnCompletables.publishOn(this, () -> Boolean.TRUE::booleanValue, executor);
@@ -1412,7 +1412,7 @@ public abstract class Completable {
      * signal ordering.
      * @return A new {@link Completable} that may use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
-     * @see #publishOn(Executor).
+     * @see #publishOn(Executor)
      */
     public final Completable publishOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnCompletables.publishOn(this, shouldOffload, executor);
@@ -1434,7 +1434,7 @@ public abstract class Completable {
      * @param executor {@link Executor} to use.
      * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
-     * @see #subscribeOn(Executor, Supplier).
+     * @see #subscribeOn(Executor, Supplier)
      */
     public final Completable subscribeOn(Executor executor) {
         return PublishAndSubscribeOnCompletables.subscribeOn(this, () -> Boolean.TRUE::booleanValue, executor);
@@ -1460,7 +1460,7 @@ public abstract class Completable {
      * signal ordering.
      * @return A new {@link Completable} that may use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
-     * @see #subscribeOn(Executor).
+     * @see #subscribeOn(Executor)
      */
     public final Completable subscribeOn(Executor executor, Supplier<BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnCompletables.subscribeOn(this, shouldOffload, executor);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
@@ -77,6 +77,8 @@ final class PublishAndSubscribeOnCompletables {
                 Subscriber upstreamSubscriber =
                         new CompletableSubscriberOffloadedTerminals(subscriber, shouldOffload, executor());
 
+                // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
+                // the Subscriber.
                 super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider);
             } catch (Throwable throwable) {
                 deliverErrorFromSource(subscriber, throwable);
@@ -107,6 +109,8 @@ final class PublishAndSubscribeOnCompletables {
                 Subscriber upstreamSubscriber =
                         new CompletableSubscriberOffloadedCancellable(subscriber, shouldOffload, executor());
 
+                // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
+                // the Subscriber.
                 if (shouldOffload.getAsBoolean()) {
                     // offload the remainder of subscribe()
                     executor().execute(() -> super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider));

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
@@ -74,6 +74,8 @@ final class PublishAndSubscribeOnPublishers {
                 final Subscriber<? super T> upstreamSubscriber =
                         new OffloadedSubscriber<>(subscriber, shouldOffload, executor());
 
+                // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
+                // the Subscriber.
                 super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider);
             } catch (Throwable throwable) {
                 // We assume that if executor accepted the task, it will be run otherwise handle thrown exception
@@ -107,6 +109,8 @@ final class PublishAndSubscribeOnPublishers {
                 final Subscriber<? super T> upstreamSubscriber =
                         new OffloadedSubscriptionSubscriber<>(subscriber, shouldOffload, executor());
 
+                // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
+                // the Subscriber.
                 if (shouldOffload.getAsBoolean()) {
                     // offload the remainder of subscribe()
                     executor().execute(() -> super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider));

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
@@ -73,6 +73,8 @@ final class PublishAndSubscribeOnSingles {
                 Subscriber<? super T> upstreamSubscriber =
                         new SingleSubscriberOffloadedTerminals<>(subscriber, shouldOffload, executor());
 
+                // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
+                // the Subscriber.
                 super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider);
             } catch (Throwable throwable) {
                 deliverErrorFromSource(subscriber, throwable);
@@ -103,6 +105,8 @@ final class PublishAndSubscribeOnSingles {
                 Subscriber<? super T> upstreamSubscriber =
                         new SingleSubscriberOffloadedCancellable<>(subscriber, shouldOffload, executor());
 
+                // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
+                // the Subscriber.
                 if (shouldOffload.getAsBoolean()) {
                     // offload the remainder of subscribe()
                     executor().execute(() -> super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider));

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2872,7 +2872,7 @@ public abstract class Publisher<T> {
      * @param executor {@link Executor} to use.
      * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
-     * @see #publishOn(Executor, Supplier).
+     * @see #publishOn(Executor, Supplier)
      */
     public final Publisher<T> publishOn(Executor executor) {
         return PublishAndSubscribeOnPublishers.publishOn(this, () -> Boolean.TRUE::booleanValue, executor);
@@ -2895,7 +2895,7 @@ public abstract class Publisher<T> {
      * signal ordering.
      * @return A new {@link Publisher} that may use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
-     * @see #publishOn(Executor).
+     * @see #publishOn(Executor)
      */
     public final Publisher<T> publishOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnPublishers.publishOn(this, shouldOffload, executor);
@@ -2917,7 +2917,7 @@ public abstract class Publisher<T> {
      * @param executor {@link Executor} to use.
      * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods of
      * {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
-     * @see #subscribeOn(Executor, Supplier).
+     * @see #subscribeOn(Executor, Supplier)
      */
     public final Publisher<T> subscribeOn(Executor executor) {
         return PublishAndSubscribeOnPublishers.subscribeOn(this, () -> Boolean.TRUE::booleanValue, executor);
@@ -2943,7 +2943,7 @@ public abstract class Publisher<T> {
      * signal ordering.
      * @return A new {@link Publisher} that may use the passed {@link Executor} to invoke all methods of
      * {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
-     * @see #subscribeOn(Executor).
+     * @see #subscribeOn(Executor)
      */
     public final Publisher<T> subscribeOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnPublishers.subscribeOn(this, shouldOffload, executor);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2865,27 +2865,37 @@ public abstract class Publisher<T> {
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #publishOn(Executor, Supplier)}, current operator always enforces offloading to the passed
+     * {@link Executor}.
      *
      * @param executor {@link Executor} to use.
-     * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods of
-     * {@link Subscriber}.
+     * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all {@link Subscriber}
+     * methods.
+     * @see #publishOn(Executor, Supplier).
      */
     public final Publisher<T> publishOn(Executor executor) {
         return PublishAndSubscribeOnPublishers.publishOn(this, () -> Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Publisher} that may use the passed {@link Executor} to invoke {@link Subscriber}
+     * Creates a new {@link Publisher} that may use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #publishOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
+     * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload provides a hint whether offloading to executor can be omitted. Offloading may still occur
-     * even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods of
-     * {@link Subscriber}.
+     * @param shouldOffload {@link Supplier} that will be triggered on each
+     * {@link PublisherSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
+     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
+     * signal ordering.
+     * @return A new {@link Publisher} that may use the passed {@link Executor} to invoke all {@link Subscriber}
+     * methods.
+     * @see #publishOn(Executor).
      */
     public final Publisher<T> publishOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnPublishers.publishOn(this, shouldOffload, executor);
@@ -2900,10 +2910,14 @@ public abstract class Publisher<T> {
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #subscribeOn(Executor, Supplier)}, current operator always enforces offloading to the passed
+     * {@link Executor}.
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods of
      * {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
+     * @see #subscribeOn(Executor, Supplier).
      */
     public final Publisher<T> subscribeOn(Executor executor) {
         return PublishAndSubscribeOnPublishers.subscribeOn(this, () -> Boolean.TRUE::booleanValue, executor);
@@ -2918,12 +2932,18 @@ public abstract class Publisher<T> {
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #subscribeOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
+     * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload provides a hint whether offloading to executor can be omitted. Offloading may still occur
-     * even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods of
+     * @param shouldOffload {@link Supplier} that will be triggered on each
+     * {@link PublisherSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
+     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
+     * signal ordering.
+     * @return A new {@link Publisher} that may use the passed {@link Executor} to invoke all methods of
      * {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
+     * @see #subscribeOn(Executor).
      */
     public final Publisher<T> subscribeOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnPublishers.subscribeOn(this, shouldOffload, executor);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1361,7 +1361,7 @@ public abstract class Single<T> {
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Single} that will use the passed {@link Executor} to invoke all {@link Subscriber} methods.
-     * @see #publishOn(Executor, Supplier).
+     * @see #publishOn(Executor, Supplier)
      */
     public final Single<T> publishOn(Executor executor) {
         return PublishAndSubscribeOnSingles.publishOn(this, () -> Boolean.TRUE::booleanValue, executor);
@@ -1382,7 +1382,7 @@ public abstract class Single<T> {
      * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
      * signal ordering.
      * @return A new {@link Single} that may use the passed {@link Executor} to invoke all {@link Subscriber} methods.
-     * @see #publishOn(Executor).
+     * @see #publishOn(Executor)
      */
     public final Single<T> publishOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnSingles.publishOn(this, shouldOffload, executor);
@@ -1404,7 +1404,7 @@ public abstract class Single<T> {
      * @param executor {@link Executor} to use.
      * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
-     * @see #subscribeOn(Executor, Supplier).
+     * @see #subscribeOn(Executor, Supplier)
      */
     public final Single<T> subscribeOn(Executor executor) {
         return PublishAndSubscribeOnSingles.subscribeOn(this, () -> Boolean.TRUE::booleanValue, executor);
@@ -1430,7 +1430,7 @@ public abstract class Single<T> {
      * signal ordering.
      * @return A new {@link Single} that may use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
-     * @see #subscribeOn(Executor).
+     * @see #subscribeOn(Executor)
      */
     public final Single<T> subscribeOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnSingles.subscribeOn(this, shouldOffload, executor);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1355,26 +1355,34 @@ public abstract class Single<T> {
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #publishOn(Executor, Supplier)}, current operator always enforces offloading to the passed
+     * {@link Executor}.
      *
      * @param executor {@link Executor} to use.
-     * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods on the
-     * {@link Subscriber}.
+     * @return A new {@link Single} that will use the passed {@link Executor} to invoke all {@link Subscriber} methods.
+     * @see #publishOn(Executor, Supplier).
      */
     public final Single<T> publishOn(Executor executor) {
         return PublishAndSubscribeOnSingles.publishOn(this, () -> Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Single} that may use the passed {@link Executor} to invoke {@link Subscriber} methods.
+     * Creates a new {@link Single} that may use the passed {@link Executor} to invoke all {@link Subscriber} methods.
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #publishOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
+     * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload provides a hint whether offloading to executor can be omitted. Offloading may still occur
-     * even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods on the
-     * {@link Subscriber}.
+     * @param shouldOffload {@link Supplier} that will be triggered on each
+     * {@link SingleSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
+     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
+     * signal ordering.
+     * @return A new {@link Single} that may use the passed {@link Executor} to invoke all {@link Subscriber} methods.
+     * @see #publishOn(Executor).
      */
     public final Single<T> publishOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnSingles.publishOn(this, shouldOffload, executor);
@@ -1389,10 +1397,14 @@ public abstract class Single<T> {
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #subscribeOn(Executor, Supplier)}, current operator always enforces offloading to the passed
+     * {@link Executor}.
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
+     * @see #subscribeOn(Executor, Supplier).
      */
     public final Single<T> subscribeOn(Executor executor) {
         return PublishAndSubscribeOnSingles.subscribeOn(this, () -> Boolean.TRUE::booleanValue, executor);
@@ -1407,12 +1419,18 @@ public abstract class Single<T> {
      * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
      * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
+     * <p>
+     * Note: unlike {@link #subscribeOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
+     * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload provides a hint whether offloading to executor can be omitted. Offloading may still occur
-     * even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods of
+     * @param shouldOffload {@link Supplier} that will be triggered on each
+     * {@link SingleSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
+     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
+     * signal ordering.
+     * @return A new {@link Single} that may use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
+     * @see #subscribeOn(Executor).
      */
     public final Single<T> subscribeOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
         return PublishAndSubscribeOnSingles.subscribeOn(this, shouldOffload, executor);


### PR DESCRIPTION
Motivation:

Clarify differences between conditional and unconditional implementation
of `publishOn` and `subscribeOn` operators.

Modifications:
- Add notes that clarify the difference;
- Add `@see` tag to reference each other;
- Clarify that `shouldOffload` is a `Supplier`;
- Make the first line and `@return` message consistent;
- Fix typos;

Result:

Improved documentation of `publishOn` and `subscribeOn` operators.