### PR TITLE
Fix javadoc in example

### DIFF
--- a/servicetalk-examples/grpc/deadline/src/main/java/io/servicetalk/examples/grpc/deadline/DeadlineClient.java
+++ b/servicetalk-examples/grpc/deadline/src/main/java/io/servicetalk/examples/grpc/deadline/DeadlineClient.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CountDownLatch;
 /**
  * Extends the async "Hello World!" example to demonstrate use of
  * <a href="https://grpc.io/docs/what-is-grpc/core-concepts/#deadlines">gRPC deadlines</a> aka timeout feature.
- * <p/>
+ * <p>
  * Start the {@link DeadlineServer} first.
  *
  * @see <a href="https://grpc.io/blog/deadlines/">gRPC and Deadlines</a>

--- a/servicetalk-examples/grpc/deadline/src/main/java/io/servicetalk/examples/grpc/deadline/DeadlineServer.java
+++ b/servicetalk-examples/grpc/deadline/src/main/java/io/servicetalk/examples/grpc/deadline/DeadlineServer.java
@@ -31,7 +31,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 /**
  * Extends the async "Hello World!" example to demonstrate use of
  * <a href="https://grpc.io/docs/what-is-grpc/core-concepts/#deadlines">gRPC deadlines</a> aka timeout feature.
- * <p/>
+ * <p>
  * Start this server first and then run the {@link DeadlineClient}.
  *
  * @see <a href="https://grpc.io/blog/deadlines/">gRPC and Deadlines</a>

--- a/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldClient.java
+++ b/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldClient.java
@@ -25,9 +25,9 @@ import java.util.concurrent.CountDownLatch;
 
 /**
  * Implementation of the
- * <a herf="https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto">gRPC hello world example</a>
+ * <a href="https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto">gRPC hello world example</a>
  * using async ServiceTalk APIS.
- * <p/>
+ * <p>
  * Start the {@link HelloWorldServer} first.
  */
 public final class HelloWorldClient {

--- a/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldServer.java
+++ b/servicetalk-examples/grpc/helloworld/src/main/java/io/servicetalk/examples/grpc/helloworld/async/HelloWorldServer.java
@@ -27,9 +27,9 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 
 /**
  * Implementation of the
- * <a herf="https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto">gRPC hello world example</a>
+ * <a href="https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto">gRPC hello world example</a>
  * using async ServiceTalk APIS.
- * <p/>
+ * <p>
  * Start this server first and then run the {@link HelloWorldClient}.
  */
 public class HelloWorldServer {

--- a/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsResource.java
+++ b/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsResource.java
@@ -156,10 +156,10 @@ public class HelloWorldJaxRsResource {
      * operators for processing it on the produce side.
      * <p>
      * Test with:
-     * <pre>
+     * <pre>{@code
      * echo "An empty file" > sample.txt && curl -vF "file=@sample.txt" \
      * http://localhost:8080/greetings/multipart-hello
-     * </pre>
+     * }</pre>
      *
      * @param ctx the {@link ConnectionContext}.
      * @param file the multi-part file contents.


### PR DESCRIPTION
Motivation:

`./gradlew javadoc` command fails due to some javadoc rules violations
in examples.

Modifications:

- Don't use self-closing tags;
- Fix a link attribute for `a` tag;
- Use `<pre>` + `{@code ...}` to not worry about manual chars escape;

Result:

`./gradlew javadoc` command is happy.