### PR TITLE
`MultiAddressHttpClientBuilder` deprecation and de-deprecation refactoring

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -75,33 +75,12 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#ioExecutor(IoExecutor)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#executionStrategy(HttpExecutionStrategy)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);
 
-    /**
-     * {@inheritDoc}
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#bufferAllocator(BufferAllocator)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);
 
@@ -293,11 +272,16 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
      * <pre>
      *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
-     *
+     * @deprecated Use
+     *   {@link #initializer(SingleAddressInitializer)} and
+     *   {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)}
+     *   on the last argument of
+     *   {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
      * @param factory {@link MultiAddressHttpClientFilterFactory} to decorate a {@link StreamingHttpClient} for the
      * purpose of filtering.
      * @return {@code this}
      */
+    @Deprecated
     public abstract MultiAddressHttpClientBuilder<U, R> appendClientFilter(
             MultiAddressHttpClientFilterFactory<U> factory);
 
@@ -316,12 +300,17 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
      * <pre>
      *     filter1 ⇒ filter2 ⇒ filter3 ⇒ client
      * </pre>
-     *
+     * @deprecated Use
+     *   {@link #initializer(SingleAddressInitializer)} and
+     *   {@link SingleAddressHttpClientBuilder#appendClientFilter(Predicate, StreamingHttpClientFilterFactory)}
+     *   on the last argument of
+     *   {@link SingleAddressInitializer#initialize(String, Object, SingleAddressHttpClientBuilder)}.
      * @param predicate the {@link Predicate} to test if the filter must be applied.
      * @param factory {@link MultiAddressHttpClientFilterFactory} to decorate a {@link StreamingHttpClient} for the
      * purpose of filtering.
      * @return {@code this}
      */
+    @Deprecated
     public MultiAddressHttpClientBuilder<U, R> appendClientFilter(Predicate<StreamingHttpRequest> predicate,
                                                                   MultiAddressHttpClientFilterFactory<U> factory) {
         requireNonNull(predicate);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientFilterFactory.java
@@ -19,6 +19,7 @@ import io.servicetalk.client.api.GroupKey;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toClientFactory;
@@ -26,10 +27,17 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A factory for {@link StreamingHttpClientFilter} to filter clients for different unresolved addresses.
- *
+ * @deprecated Use
+ *   {@link MultiAddressHttpClientBuilder#initializer(MultiAddressHttpClientBuilder.SingleAddressInitializer)} and
+ *   {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)} or
+ *   {@link SingleAddressHttpClientBuilder#appendClientFilter(Predicate, StreamingHttpClientFilterFactory)}
+ *   on the last argument of
+ *   {@link io.servicetalk.http.api.MultiAddressHttpClientBuilder.SingleAddressInitializer#initialize(
+ *   String, Object, SingleAddressHttpClientBuilder)}.
  * @param <U> the type of address before resolution (unresolved address).
  * @see StreamingHttpClientFilterFactory
  */
+@Deprecated
 @FunctionalInterface
 public interface MultiAddressHttpClientFilterFactory<U> {
     /**


### PR DESCRIPTION
Motivation:

The `MultiAddressHttpClientBuilder` deprecated methods which should stay
and allow configuring the `ExecutionContext` (`ioExecutor,
`executionStrategy`, `bufferAllocator`). Furthermore, methods
influencing the client filters have not been deprecated, but should, as
the `SingleAddressInitializer` allows configuring the filters in a
satisfactory fashion.
This PR is a prequel to https://github.com/apple/servicetalk/pull/1721 which introduces an intended cleanup of the `MultiAddressHttpClientBuilder` API.

Modifications:

- List the changes
- Removed `@Deprecated` annotation from `ioExecutor`, `executionStrategy`,
  and `bufferAllocator` methods,
- Deprecated `MultiAddressHttpClientFilterFactory`,
- Deprecated `appendClientFilter` methods accepting
  `MultiAddressHttpClientFilterFactory`.

Result:

The current API reflects the future direction for
`MultiAddressHttpClientBuilder` and how it should be used.