### PR TITLE
Simplify conditional offloading

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/OffloadingTest.java
@@ -71,7 +71,7 @@ class OffloadingTest extends AbstractCompletableOffloadingTest {
                 EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE)),
         SUBSCRIBE_ON_CONDITIONAL_NEVER(0, "none",
-                (c, e) -> c.subscribeOn(e, () -> Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
+                (c, e) -> c.subscribeOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
                         IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
@@ -94,7 +94,7 @@ class OffloadingTest extends AbstractCompletableOffloadingTest {
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_ORIGINAL_ON_COMPLETE),
                 EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE, IN_OFFLOADED_ON_COMPLETE)),
         PUBLISH_ON_CONDITIONAL_NEVER(0, "none",
-                (c, e) -> c.publishOn(e, () -> Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
+                (c, e) -> c.publishOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
                         IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
@@ -102,7 +102,7 @@ class OffloadingTest extends AbstractCompletableOffloadingTest {
         PUBLISH_ON_CONDITIONAL_SECOND(1, "onComplete",
                 (c, e) -> Completable.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
-                    return c.publishOn(e, () -> () -> countdown.decrementAndGet() < 0).subscribeShareContext();
+                    return c.publishOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
                 }), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/OffloadingTest.java
@@ -82,7 +82,7 @@ class OffloadingTest extends AbstractPublisherOffloadingTest {
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
                         IN_OFFLOADED_REQUEST)),
         SUBSCRIBE_ON_CONDITIONAL_NEVER(0, "none",
-                (p, e) -> p.subscribeOn(e, () -> Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
+                (p, e) -> p.subscribeOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
                         IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
@@ -92,7 +92,7 @@ class OffloadingTest extends AbstractPublisherOffloadingTest {
         SUBSCRIBE_ON_CONDITIONAL_SECOND(1, "request",
                 (p, e) -> Publisher.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
-                    return p.subscribeOn(e, () -> () -> countdown.decrementAndGet() < 0).subscribeShareContext();
+                    return p.subscribeOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
                 }), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
@@ -127,7 +127,7 @@ class OffloadingTest extends AbstractPublisherOffloadingTest {
                         IN_OFFLOADED_ON_NEXT,
                         IN_OFFLOADED_ON_COMPLETE)),
         PUBLISH_ON_CONDITIONAL_NEVER(0, "none",
-                (p, e) -> p.publishOn(e, () -> Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
+                (p, e) -> p.publishOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
                         IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
@@ -137,7 +137,7 @@ class OffloadingTest extends AbstractPublisherOffloadingTest {
         PUBLISH_ON_CONDITIONAL_SECOND(2, "onNext, onComplete",
                 (p, e) -> Publisher.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
-                    return p.publishOn(e, () -> () -> countdown.decrementAndGet() < 0).subscribeShareContext();
+                    return p.publishOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
                 }), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/OffloadingTest.java
@@ -71,7 +71,7 @@ class OffloadingTest extends AbstractSingleOffloadingTest {
                 EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE)),
         SUBSCRIBE_ON_CONDITIONAL_NEVER(0, "none",
-                (s, e) -> s.subscribeOn(e, () -> Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
+                (s, e) -> s.subscribeOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
                         IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
@@ -93,7 +93,7 @@ class OffloadingTest extends AbstractSingleOffloadingTest {
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_ORIGINAL_ON_COMPLETE),
                 EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE, IN_OFFLOADED_ON_COMPLETE)),
         PUBLISH_ON_CONDITIONAL_NEVER(0, "none",
-                (s, e) -> s.publishOn(e, () -> Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
+                (s, e) -> s.publishOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
                         IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
@@ -101,7 +101,7 @@ class OffloadingTest extends AbstractSingleOffloadingTest {
         PUBLISH_ON_CONDITIONAL_SECOND(1, "onComplete",
                 (s, e) -> Single.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
-                    return s.publishOn(e, () -> () -> countdown.decrementAndGet() < 0).subscribeShareContext();
+                    return s.publishOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
                 }), TerminalOperation.COMPLETE,
                 EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
                         IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1383,16 +1383,16 @@ public abstract class Completable {
      * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
      * <p>
-     * Note: unlike {@link #publishOn(Executor, Supplier)}, current operator always enforces offloading to the passed
-     * {@link Executor}.
+     * Note: unlike {@link #publishOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
+     * passed {@link Executor}.
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
-     * @see #publishOn(Executor, Supplier)
+     * @see #publishOn(Executor, BooleanSupplier)
      */
     public final Completable publishOn(Executor executor) {
-        return PublishAndSubscribeOnCompletables.publishOn(this, () -> Boolean.TRUE::booleanValue, executor);
+        return PublishAndSubscribeOnCompletables.publishOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
@@ -1406,15 +1406,13 @@ public abstract class Completable {
      * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload {@link Supplier} that will be triggered on each
-     * {@link CompletableSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
-     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
-     * signal ordering.
+     * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
+     * still occur even if {@code false} is returned in order to preserve signal ordering.
      * @return A new {@link Completable} that may use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
      * @see #publishOn(Executor)
      */
-    public final Completable publishOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
+    public final Completable publishOn(Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnCompletables.publishOn(this, shouldOffload, executor);
     }
 
@@ -1428,16 +1426,16 @@ public abstract class Completable {
      * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
      * <p>
-     * Note: unlike {@link #subscribeOn(Executor, Supplier)}, current operator always enforces offloading to the passed
-     * {@link Executor}.
+     * Note: unlike {@link #subscribeOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
+     * passed {@link Executor}.
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
-     * @see #subscribeOn(Executor, Supplier)
+     * @see #subscribeOn(Executor, BooleanSupplier)
      */
     public final Completable subscribeOn(Executor executor) {
-        return PublishAndSubscribeOnCompletables.subscribeOn(this, () -> Boolean.TRUE::booleanValue, executor);
+        return PublishAndSubscribeOnCompletables.subscribeOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
@@ -1454,15 +1452,13 @@ public abstract class Completable {
      * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload {@link Supplier} that will be triggered on each
-     * {@link CompletableSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
-     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
-     * signal ordering.
+     * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
+     * still occur even if {@code false} is returned in order to preserve signal ordering.
      * @return A new {@link Completable} that may use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
      * @see #subscribeOn(Executor)
      */
-    public final Completable subscribeOn(Executor executor, Supplier<BooleanSupplier> shouldOffload) {
+    public final Completable subscribeOn(Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnCompletables.subscribeOn(this, shouldOffload, executor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 
 import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
@@ -46,12 +45,12 @@ final class PublishAndSubscribeOnCompletables {
     }
 
     static Completable publishOn(final Completable original,
-                                 final Supplier<? extends BooleanSupplier> shouldOffload, final Executor executor) {
+                                 final BooleanSupplier shouldOffload, final Executor executor) {
         return executor == immediate() ? original : new PublishOn(original, shouldOffload, executor);
     }
 
     static Completable subscribeOn(final Completable original,
-                                   final Supplier<? extends BooleanSupplier> shouldOffload, final Executor executor) {
+                                   final BooleanSupplier shouldOffload, final Executor executor) {
         return executor == immediate() ? original : new SubscribeOn(original, shouldOffload, executor);
     }
 
@@ -65,15 +64,15 @@ final class PublishAndSubscribeOnCompletables {
     private static final class PublishOn extends TaskBasedAsyncCompletableOperator {
 
         PublishOn(final Completable original,
-                  final Supplier<? extends BooleanSupplier> shouldOffloadSupplier, final Executor executor) {
-            super(original, shouldOffloadSupplier, executor);
+                  final BooleanSupplier shouldOffload, final Executor executor) {
+            super(original, shouldOffload, executor);
         }
 
         @Override
         void handleSubscribe(final Subscriber subscriber,
                              final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
             try {
-                BooleanSupplier shouldOffload = shouldOffloadSupplier();
+                BooleanSupplier shouldOffload = shouldOffload();
                 Subscriber upstreamSubscriber =
                         new CompletableSubscriberOffloadedTerminals(subscriber, shouldOffload, executor());
 
@@ -97,15 +96,15 @@ final class PublishAndSubscribeOnCompletables {
     private static final class SubscribeOn extends TaskBasedAsyncCompletableOperator {
 
         SubscribeOn(final Completable original,
-                    final Supplier<? extends BooleanSupplier> shouldOffloadSupplier, final Executor executor) {
-            super(original, shouldOffloadSupplier, executor);
+                    final BooleanSupplier shouldOffload, final Executor executor) {
+            super(original, shouldOffload, executor);
         }
 
         @Override
         void handleSubscribe(final Subscriber subscriber,
                              final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
             try {
-                BooleanSupplier shouldOffload = shouldOffloadSupplier();
+                BooleanSupplier shouldOffload = shouldOffload();
                 Subscriber upstreamSubscriber =
                         new CompletableSubscriberOffloadedCancellable(subscriber, shouldOffload, executor());
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.SingleSource;
 
 import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
@@ -42,12 +41,12 @@ final class PublishAndSubscribeOnSingles {
     }
 
     static <T> Single<T> publishOn(final Single<T> original,
-                                   final Supplier<? extends BooleanSupplier> shouldOffload, final Executor executor) {
+                                   final BooleanSupplier shouldOffload, final Executor executor) {
         return immediate() == executor ? original : new PublishOn<>(original, shouldOffload, executor);
     }
 
     static <T> Single<T> subscribeOn(final Single<T> original,
-                                     final Supplier<? extends BooleanSupplier> shouldOffload, final Executor executor) {
+                                     final BooleanSupplier shouldOffload, final Executor executor) {
         return immediate() == executor ? original : new SubscribeOn<>(original, shouldOffload, executor);
     }
 
@@ -61,15 +60,15 @@ final class PublishAndSubscribeOnSingles {
     private static final class PublishOn<T> extends TaskBasedAsyncSingleOperator<T> {
 
         PublishOn(final Single<T> original,
-                  final Supplier<? extends BooleanSupplier> shouldOffloadSupplier, final Executor executor) {
-            super(original, shouldOffloadSupplier, executor);
+                  final BooleanSupplier shouldOffload, final Executor executor) {
+            super(original, shouldOffload, executor);
         }
 
         @Override
         void handleSubscribe(final Subscriber<? super T> subscriber,
                                     final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
             try {
-                BooleanSupplier shouldOffload = shouldOffloadSupplier();
+                BooleanSupplier shouldOffload = shouldOffload();
                 Subscriber<? super T> upstreamSubscriber =
                         new SingleSubscriberOffloadedTerminals<>(subscriber, shouldOffload, executor());
 
@@ -93,15 +92,15 @@ final class PublishAndSubscribeOnSingles {
     private static final class SubscribeOn<T> extends TaskBasedAsyncSingleOperator<T> {
 
         SubscribeOn(final Single<T> original,
-                    final Supplier<? extends BooleanSupplier> shouldOffloadSupplier, final Executor executor) {
-            super(original, shouldOffloadSupplier, executor);
+                    final BooleanSupplier shouldOffload, final Executor executor) {
+            super(original, shouldOffload, executor);
         }
 
         @Override
         public void handleSubscribe(final Subscriber<? super T> subscriber,
                                     final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
             try {
-                BooleanSupplier shouldOffload = shouldOffloadSupplier();
+                BooleanSupplier shouldOffload = shouldOffload();
                 Subscriber<? super T> upstreamSubscriber =
                         new SingleSubscriberOffloadedCancellable<>(subscriber, shouldOffload, executor());
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2866,16 +2866,16 @@ public abstract class Publisher<T> {
      * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
      * <p>
-     * Note: unlike {@link #publishOn(Executor, Supplier)}, current operator always enforces offloading to the passed
-     * {@link Executor}.
+     * Note: unlike {@link #publishOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
+     * passed {@link Executor}.
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
-     * @see #publishOn(Executor, Supplier)
+     * @see #publishOn(Executor, BooleanSupplier)
      */
     public final Publisher<T> publishOn(Executor executor) {
-        return PublishAndSubscribeOnPublishers.publishOn(this, () -> Boolean.TRUE::booleanValue, executor);
+        return PublishAndSubscribeOnPublishers.publishOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
@@ -2889,15 +2889,13 @@ public abstract class Publisher<T> {
      * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload {@link Supplier} that will be triggered on each
-     * {@link PublisherSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
-     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
-     * signal ordering.
+     * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
+     * still occur even if {@code false} is returned in order to preserve signal ordering.
      * @return A new {@link Publisher} that may use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
      * @see #publishOn(Executor)
      */
-    public final Publisher<T> publishOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
+    public final Publisher<T> publishOn(Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnPublishers.publishOn(this, shouldOffload, executor);
     }
 
@@ -2911,16 +2909,16 @@ public abstract class Publisher<T> {
      * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
      * <p>
-     * Note: unlike {@link #subscribeOn(Executor, Supplier)}, current operator always enforces offloading to the passed
-     * {@link Executor}.
+     * Note: unlike {@link #subscribeOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
+     * passed {@link Executor}.
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods of
      * {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
-     * @see #subscribeOn(Executor, Supplier)
+     * @see #subscribeOn(Executor, BooleanSupplier)
      */
     public final Publisher<T> subscribeOn(Executor executor) {
-        return PublishAndSubscribeOnPublishers.subscribeOn(this, () -> Boolean.TRUE::booleanValue, executor);
+        return PublishAndSubscribeOnPublishers.subscribeOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
@@ -2937,15 +2935,13 @@ public abstract class Publisher<T> {
      * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload {@link Supplier} that will be triggered on each
-     * {@link PublisherSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
-     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
-     * signal ordering.
+     * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
+     * still occur even if {@code false} is returned in order to preserve signal ordering.
      * @return A new {@link Publisher} that may use the passed {@link Executor} to invoke all methods of
      * {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
      * @see #subscribeOn(Executor)
      */
-    public final Publisher<T> subscribeOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
+    public final Publisher<T> subscribeOn(Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnPublishers.subscribeOn(this, shouldOffload, executor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1356,15 +1356,15 @@ public abstract class Single<T> {
      * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
      * <p>
-     * Note: unlike {@link #publishOn(Executor, Supplier)}, current operator always enforces offloading to the passed
-     * {@link Executor}.
+     * Note: unlike {@link #publishOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
+     * passed {@link Executor}.
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Single} that will use the passed {@link Executor} to invoke all {@link Subscriber} methods.
-     * @see #publishOn(Executor, Supplier)
+     * @see #publishOn(Executor, BooleanSupplier)
      */
     public final Single<T> publishOn(Executor executor) {
-        return PublishAndSubscribeOnSingles.publishOn(this, () -> Boolean.TRUE::booleanValue, executor);
+        return PublishAndSubscribeOnSingles.publishOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
@@ -1377,14 +1377,12 @@ public abstract class Single<T> {
      * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload {@link Supplier} that will be triggered on each
-     * {@link SingleSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
-     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
-     * signal ordering.
+     * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
+     * still occur even if {@code false} is returned in order to preserve signal ordering.
      * @return A new {@link Single} that may use the passed {@link Executor} to invoke all {@link Subscriber} methods.
      * @see #publishOn(Executor)
      */
-    public final Single<T> publishOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
+    public final Single<T> publishOn(Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnSingles.publishOn(this, shouldOffload, executor);
     }
 
@@ -1398,16 +1396,16 @@ public abstract class Single<T> {
      * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
      * {@link Executor}.
      * <p>
-     * Note: unlike {@link #subscribeOn(Executor, Supplier)}, current operator always enforces offloading to the passed
-     * {@link Executor}.
+     * Note: unlike {@link #subscribeOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
+     * passed{@link Executor}.
      *
      * @param executor {@link Executor} to use.
      * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
-     * @see #subscribeOn(Executor, Supplier)
+     * @see #subscribeOn(Executor, BooleanSupplier)
      */
     public final Single<T> subscribeOn(Executor executor) {
-        return PublishAndSubscribeOnSingles.subscribeOn(this, () -> Boolean.TRUE::booleanValue, executor);
+        return PublishAndSubscribeOnSingles.subscribeOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
@@ -1424,15 +1422,13 @@ public abstract class Single<T> {
      * depending on the result of the {@link BooleanSupplier} hint.
      *
      * @param executor {@link Executor} to use.
-     * @param shouldOffload {@link Supplier} that will be triggered on each
-     * {@link SingleSource#subscribe(Subscriber) subscribe}. Its result provides a hint whether offloading to the
-     * executor can be omitted or not. Offloading may still occur even if {@code false} is returned in order to preserve
-     * signal ordering.
+     * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
+     * still occur even if {@code false} is returned in order to preserve signal ordering.
      * @return A new {@link Single} that may use the passed {@link Executor} to invoke all methods of
      * {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
      * @see #subscribeOn(Executor)
      */
-    public final Single<T> subscribeOn(Executor executor, Supplier<? extends BooleanSupplier> shouldOffload) {
+    public final Single<T> subscribeOn(Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnSingles.subscribeOn(this, shouldOffload, executor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncSingleOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncSingleOperator.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeCancel;
@@ -55,19 +54,19 @@ abstract class TaskBasedAsyncSingleOperator<T> extends AbstractNoHandleSubscribe
     };
 
     private final Single<T> original;
-    private final Supplier<? extends BooleanSupplier> shouldOffloadSupplier;
+    private final BooleanSupplier shouldOffload;
     private final Executor executor;
 
     TaskBasedAsyncSingleOperator(final Single<T> original,
-                                 final Supplier<? extends BooleanSupplier> shouldOffloadSupplier,
+                                 final BooleanSupplier shouldOffload,
                                  final Executor executor) {
         this.original = original;
-        this.shouldOffloadSupplier = shouldOffloadSupplier;
+        this.shouldOffload = shouldOffload;
         this.executor = executor;
     }
 
-    final BooleanSupplier shouldOffloadSupplier() {
-        return requireNonNull(shouldOffloadSupplier.get(), "shouldOffload");
+    final BooleanSupplier shouldOffload() {
+        return shouldOffload;
     }
 
     final Executor executor() {


### PR DESCRIPTION
Motivation:
The conditional offloading API of `publishOn()` and `subscribeOn()`
use of a `Supplier<? extends BooleanSupplier>` to be invoked once per
subscribe can be instead used more conventionally with a simply a
`BooleanSupplier`. If per-subscribe `BooleanSupplier` is needed it can
be provided instead in a defer() operator.
Modifications:
Replaces `Supplier<? extends BooleanSupplier>` with `BooleanSupplier`
for conditional `publishOn` and `subscribeOn`.
Ensures that the source is cancelled if the `BooleanSupplier `throws
an exception.
Result:
Simpler conditional offload API. More consistent cancel behavior.