### PR TITLE
Fix gradle grpc protoc project local dependency sequencing

### DIFF
--- a/servicetalk-examples/grpc/compression/build.gradle
+++ b/servicetalk-examples/grpc/compression/build.gradle
@@ -41,15 +41,21 @@ protobuf {
   }
   plugins {
     servicetalk_grpc {
-      //// Users are expected to use "artifact" instead of "path". we use "path"
-      //// only because we want to use the gradle project local version of the plugin
-      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+      //// "path" is used only because we want to use the gradle project local version of the plugin.
       path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
     }
   }
   generateProtoTasks {
     all().each { task ->
+      //// REMOVE if outside of ServiceTalk gradle project
+      task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+      //// REMOVE if outside of ServiceTalk gradle project
+
       task.plugins {
         servicetalk_grpc {
           // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
@@ -60,10 +66,4 @@ protobuf {
     }
   }
   generatedFilesBaseDir = "$buildDir/generated/sources/proto"
-}
-
-// The following setting must be omitted in users projects and is necessary here
-// only because we want to use the locally built version of the plugin
-afterEvaluate {
-  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
 }

--- a/servicetalk-examples/grpc/deadline/build.gradle
+++ b/servicetalk-examples/grpc/deadline/build.gradle
@@ -39,15 +39,21 @@ protobuf {
   }
   plugins {
     servicetalk_grpc {
-      //// Users are expected to use "artifact" instead of "path". we use "path"
-      //// only because we want to use the gradle project local version of the plugin
-      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+      //// "path" is used only because we want to use the gradle project local version of the plugin.
       path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
     }
   }
   generateProtoTasks {
     all().each { task ->
+      //// REMOVE if outside of ServiceTalk gradle project
+      task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+      //// REMOVE if outside of ServiceTalk gradle project
+
       task.plugins {
         servicetalk_grpc {
           // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
@@ -58,10 +64,4 @@ protobuf {
     }
   }
   generatedFilesBaseDir = "$buildDir/generated/sources/proto"
-}
-
-// The following setting must be omitted in users projects and is necessary here
-// only because we want to use the locally built version of the plugin
-afterEvaluate {
-  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
 }

--- a/servicetalk-examples/grpc/errors/build.gradle
+++ b/servicetalk-examples/grpc/errors/build.gradle
@@ -40,15 +40,21 @@ protobuf {
   }
   plugins {
     servicetalk_grpc {
-      //// Users are expected to use "artifact" instead of "path". we use "path"
-      //// only because we want to use the gradle project local version of the plugin
-      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+      //// "path" is used only because we want to use the gradle project local version of the plugin.
       path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
     }
   }
   generateProtoTasks {
     all().each { task ->
+      //// REMOVE if outside of ServiceTalk gradle project
+      task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+      //// REMOVE if outside of ServiceTalk gradle project
+
       task.plugins {
         servicetalk_grpc {
           // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
@@ -59,10 +65,4 @@ protobuf {
     }
   }
   generatedFilesBaseDir = "$buildDir/generated/sources/proto"
-}
-
-// The following setting must be omitted in users projects and is necessary here
-// only because we want to use the locally built version of the plugin
-afterEvaluate {
-  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
 }

--- a/servicetalk-examples/grpc/helloworld/build.gradle
+++ b/servicetalk-examples/grpc/helloworld/build.gradle
@@ -40,15 +40,21 @@ protobuf {
   }
   plugins {
     servicetalk_grpc {
-      //// Users are expected to use "artifact" instead of "path". we use "path"
-      //// only because we want to use the gradle project local version of the plugin
-      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+      //// "path" is used only because we want to use the gradle project local version of the plugin.
       path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
     }
   }
   generateProtoTasks {
     all().each { task ->
+      //// REMOVE if outside of ServiceTalk gradle project
+      task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+      //// REMOVE if outside of ServiceTalk gradle project
+
       task.plugins {
         servicetalk_grpc {
           // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
@@ -59,10 +65,4 @@ protobuf {
     }
   }
   generatedFilesBaseDir = "$buildDir/generated/sources/proto"
-}
-
-// The following setting must be omitted in users projects and is necessary here
-// only because we want to use the locally built version of the plugin
-afterEvaluate {
-  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
 }

--- a/servicetalk-examples/grpc/protoc-options/build.gradle
+++ b/servicetalk-examples/grpc/protoc-options/build.gradle
@@ -40,15 +40,21 @@ protobuf {
   }
   plugins {
     servicetalk_grpc {
-      //// Users are expected to use "artifact" instead of "path". we use "path"
-      //// only because we want to use the gradle project local version of the plugin
-      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+      //// "path" is used only because we want to use the gradle project local version of the plugin.
       path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
     }
   }
   generateProtoTasks {
     all().each { task ->
+      //// REMOVE if outside of ServiceTalk gradle project
+      task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+      //// REMOVE if outside of ServiceTalk gradle project
+
       task.plugins {
         servicetalk_grpc {
           // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
@@ -61,10 +67,4 @@ protobuf {
     }
   }
   generatedFilesBaseDir = "$buildDir/generated/sources/proto"
-}
-
-// The following setting must be omitted in users projects and is necessary here
-// only because we want to use the locally built version of the plugin
-afterEvaluate {
-  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
 }

--- a/servicetalk-examples/grpc/routeguide/build.gradle
+++ b/servicetalk-examples/grpc/routeguide/build.gradle
@@ -41,15 +41,21 @@ protobuf {
   }
   plugins {
     servicetalk_grpc {
-      //// Users are expected to use "artifact" instead of "path". we use "path"
-      //// only because we want to use the gradle project local version of the plugin
-      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+      //// "path" is used only because we want to use the gradle project local version of the plugin.
       path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
                   "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
     }
   }
   generateProtoTasks {
     all().each { task ->
+      //// REMOVE if outside of ServiceTalk gradle project
+      task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+      //// REMOVE if outside of ServiceTalk gradle project
+
       task.plugins {
         servicetalk_grpc {
           // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
@@ -60,10 +66,4 @@ protobuf {
     }
   }
   generatedFilesBaseDir = "$buildDir/generated/sources/proto"
-}
-
-// The following setting must be omitted in users projects and is necessary here
-// only because we want to use the locally built version of the plugin
-afterEvaluate {
-  generateProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
 }

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -76,14 +76,17 @@ protobuf {
       artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
     }
     servicetalk_grpc {
-      //// Users are expected to use "artifact" instead of "path". we use "path"
-      //// only because we want to use the gradle project local version of the plugin
+      // use gradle project local grpc-protoc dependency
       path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
                   "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
     }
   }
   generateProtoTasks {
     all().each { task ->
+      if (task.isTest) {
+        task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+      }
+
       task.plugins {
         grpc {}
         servicetalk_grpc {
@@ -93,10 +96,4 @@ protobuf {
     }
   }
   generatedFilesBaseDir = "$buildDir/generated/sources/proto"
-}
-
-//// The following setting must be omitted in users projects and is necessary here
-//// only because we want to use the gradle project local version of the plugin
-afterEvaluate {
-  generateTestProto.dependsOn(":servicetalk-grpc-protoc:buildExecutable")
 }

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -93,6 +93,10 @@ protobuf {
   }
   generateProtoTasks {
     all().each { task ->
+      if (task.isTest) {
+        task.dependsOn(buildExecutable)
+      }
+
       task.plugins {
         servicetalk_grpc {
           // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated


### PR DESCRIPTION
Motivation:
servicetalk-grpc-protoc has tests in the local directory that depend
upon the compileJava task to complete and the buildExecutable task to
complete. However the dynamically generated generateTestProto task
didn't have an explicit ordering/sequencing dependency on the
buildExecutable task so the build would occasionally fail due to lack of
grpc-protoc artifact.

Modifications:
- Add an explicit dependency from the generateTestProto task on the
  buildExecutable task
- Use a consistent strategy to specify the dependency for other
  sub-projects in the same gradle projects.

Result:
No more spurious build failures due to missing grpc-protoc artifacts.