### PR TITLE
Safer offloading handleSubscribe invocation

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
@@ -23,6 +23,7 @@ import java.util.function.BooleanSupplier;
 
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
 
 /**
  * A set of factory methods that provides implementations for the various publish/subscribeOn methods on
@@ -42,6 +43,20 @@ final class PublishAndSubscribeOnCompletables {
                                              AsyncContextMap contextMap, AsyncContextProvider contextProvider,
                                              Throwable cause) {
         deliverErrorFromSource(contextProvider.wrapCompletableSubscriber(subscriber, contextMap), cause);
+    }
+
+    @FunctionalInterface
+    interface HandleSubscribe {
+        void handleSubscribe(Subscriber subscriber, AsyncContextMap contextMap, AsyncContextProvider contextProvider);
+    }
+
+    static void safeHandleSubscribe(final HandleSubscribe handler, final Subscriber subscriber,
+                                    final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+        try {
+            handler.handleSubscribe(subscriber, contextMap, contextProvider);
+        } catch (Throwable throwable) {
+            safeOnError(subscriber, throwable);
+        }
     }
 
     static Completable publishOn(final Completable original,
@@ -71,17 +86,20 @@ final class PublishAndSubscribeOnCompletables {
         @Override
         void handleSubscribe(final Subscriber subscriber,
                              final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+            final Subscriber upstreamSubscriber;
             try {
                 BooleanSupplier shouldOffload = shouldOffload();
-                Subscriber upstreamSubscriber =
+                upstreamSubscriber =
                         new CompletableSubscriberOffloadedTerminals(subscriber, shouldOffload, executor());
 
                 // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
                 // the Subscriber.
-                super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider);
             } catch (Throwable throwable) {
                 deliverErrorFromSource(subscriber, throwable);
+                return;
             }
+
+            safeHandleSubscribe(super::handleSubscribe, upstreamSubscriber, contextMap, contextProvider);
         }
     }
 
@@ -103,24 +121,28 @@ final class PublishAndSubscribeOnCompletables {
         @Override
         void handleSubscribe(final Subscriber subscriber,
                              final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+            final Subscriber upstreamSubscriber;
             try {
                 BooleanSupplier shouldOffload = shouldOffload();
-                Subscriber upstreamSubscriber =
+                upstreamSubscriber =
                         new CompletableSubscriberOffloadedCancellable(subscriber, shouldOffload, executor());
 
                 // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
                 // the Subscriber.
                 if (shouldOffload.getAsBoolean()) {
                     // offload the remainder of subscribe()
-                    executor().execute(() -> super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider));
-                } else {
-                    // continue on the current thread
-                    super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider);
+                    executor().execute(() -> safeHandleSubscribe(super::handleSubscribe,
+                            upstreamSubscriber, contextMap, contextProvider));
+                    return;
                 }
             } catch (Throwable throwable) {
                 // We assume that if executor accepted the task, it will be run otherwise handle thrown exception
                 deliverErrorFromSource(subscriber, throwable);
+                return;
             }
+
+            // non-offloaded
+            safeHandleSubscribe(super::handleSubscribe, upstreamSubscriber, contextMap, contextProvider);
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
@@ -22,6 +22,7 @@ import java.util.function.BooleanSupplier;
 
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
 
 /**
  * A set of factory methods that provides implementations for the various publish/subscribeOn methods on
@@ -37,6 +38,21 @@ final class PublishAndSubscribeOnPublishers {
                                                  AsyncContextMap contextMap, AsyncContextProvider contextProvider,
                                                  Throwable cause) {
         deliverErrorFromSource(contextProvider.wrapPublisherSubscriber(subscriber, contextMap), cause);
+    }
+
+    @FunctionalInterface
+    interface HandleSubscribe<T> {
+        void handleSubscribe(Subscriber<? super T> subscriber,
+                             AsyncContextMap contextMap, AsyncContextProvider contextProvider);
+    }
+
+    static <T> void safeHandleSubscribe(final HandleSubscribe handler, final Subscriber<? super T> subscriber,
+                                    final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+        try {
+            handler.handleSubscribe(subscriber, contextMap, contextProvider);
+        } catch (Throwable throwable) {
+            safeOnError(subscriber, throwable);
+        }
     }
 
     static <T> Publisher<T> publishOn(final Publisher<T> original,
@@ -68,19 +84,22 @@ final class PublishAndSubscribeOnPublishers {
         @Override
         void handleSubscribe(final Subscriber<? super T> subscriber,
                              final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+            final Subscriber<? super T> upstreamSubscriber;
             try {
                 BooleanSupplier shouldOffload = shouldOffload();
-                final Subscriber<? super T> upstreamSubscriber =
+                upstreamSubscriber =
                         new OffloadedSubscriber<>(subscriber, shouldOffload, executor());
 
                 // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
                 // the Subscriber.
-                super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider);
             } catch (Throwable throwable) {
                 // We assume that if executor accepted the task, it will be run otherwise handle thrown exception
                 // note that the subscriber error is not offloaded.
                 deliverErrorFromSource(subscriber, throwable);
+                return;
             }
+
+            safeHandleSubscribe(super::handleSubscribe, upstreamSubscriber, contextMap, contextProvider);
         }
     }
 
@@ -103,25 +122,28 @@ final class PublishAndSubscribeOnPublishers {
         @Override
         public void handleSubscribe(final Subscriber<? super T> subscriber,
                                     final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+            final Subscriber<? super T> upstreamSubscriber;
             try {
                 BooleanSupplier shouldOffload = shouldOffload();
-                final Subscriber<? super T> upstreamSubscriber =
+                upstreamSubscriber =
                         new OffloadedSubscriptionSubscriber<>(subscriber, shouldOffload, executor());
 
                 // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
                 // the Subscriber.
                 if (shouldOffload.getAsBoolean()) {
                     // offload the remainder of subscribe()
-                    executor().execute(() -> super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider));
-                } else {
-                    // continue on the current thread
-                    super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider);
+                    executor().execute(() -> safeHandleSubscribe(super::handleSubscribe,
+                            upstreamSubscriber, contextMap, contextProvider));
+                    return;
                 }
             } catch (Throwable throwable) {
                 // We assume that if executor accepted the task, it will be run otherwise handle thrown exception
                 // note that the subscriber error is not offloaded.
                 deliverErrorFromSource(subscriber, throwable);
+                return;
             }
+
+            safeHandleSubscribe(super::handleSubscribe, upstreamSubscriber, contextMap, contextProvider);
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
@@ -23,6 +23,7 @@ import java.util.function.BooleanSupplier;
 
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
 
 /**
  * A set of factory methods that provides implementations for the various publish/subscribeOn methods on
@@ -38,6 +39,22 @@ final class PublishAndSubscribeOnSingles {
                                                  AsyncContextMap contextMap,
                                                  AsyncContextProvider contextProvider, Throwable cause) {
         deliverErrorFromSource(contextProvider.wrapSingleSubscriber(subscriber, contextMap), cause);
+    }
+
+    @FunctionalInterface
+    interface HandleSubscribe<T> {
+        void handleSubscribe(SingleSource.Subscriber<? super T> subscriber,
+                             AsyncContextMap contextMap, AsyncContextProvider contextProvider);
+    }
+
+    static <T> void safeHandleSubscribe(final HandleSubscribe handler,
+                                        final SingleSource.Subscriber<? super T> subscriber,
+                                        final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+        try {
+            handler.handleSubscribe(subscriber, contextMap, contextProvider);
+        } catch (Throwable throwable) {
+            safeOnError(subscriber, throwable);
+        }
     }
 
     static <T> Single<T> publishOn(final Single<T> original,
@@ -67,17 +84,20 @@ final class PublishAndSubscribeOnSingles {
         @Override
         void handleSubscribe(final Subscriber<? super T> subscriber,
                                     final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+            Subscriber<? super T> upstreamSubscriber;
             try {
                 BooleanSupplier shouldOffload = shouldOffload();
-                Subscriber<? super T> upstreamSubscriber =
+                upstreamSubscriber =
                         new SingleSubscriberOffloadedTerminals<>(subscriber, shouldOffload, executor());
 
                 // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
                 // the Subscriber.
-                super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider);
             } catch (Throwable throwable) {
                 deliverErrorFromSource(subscriber, throwable);
+                return;
             }
+
+            safeHandleSubscribe(super::handleSubscribe, upstreamSubscriber, contextMap, contextProvider);
         }
     }
 
@@ -99,25 +119,28 @@ final class PublishAndSubscribeOnSingles {
         @Override
         public void handleSubscribe(final Subscriber<? super T> subscriber,
                                     final AsyncContextMap contextMap, final AsyncContextProvider contextProvider) {
+            Subscriber<? super T> upstreamSubscriber;
             try {
                 BooleanSupplier shouldOffload = shouldOffload();
-                Subscriber<? super T> upstreamSubscriber =
+                upstreamSubscriber =
                         new SingleSubscriberOffloadedCancellable<>(subscriber, shouldOffload, executor());
 
                 // Note that the Executor is wrapped by default to preserve AsyncContext, so we don't have to re-wrap
                 // the Subscriber.
                 if (shouldOffload.getAsBoolean()) {
                     // offload the remainder of subscribe()
-                    executor().execute(() -> super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider));
-                } else {
-                    // continue on the current thread
-                    super.handleSubscribe(upstreamSubscriber, contextMap, contextProvider);
+                    executor().execute(() -> safeHandleSubscribe(super::handleSubscribe,
+                            upstreamSubscriber, contextMap, contextProvider));
+                    return;
                 }
             } catch (Throwable throwable) {
                 // We assume that if executor accepted the task, it will be run otherwise handle thrown exception
                 // note that the subscriber error is not offloaded.
                 deliverErrorFromSource(subscriber, throwable);
+                return;
             }
+
+            safeHandleSubscribe(super::handleSubscribe, upstreamSubscriber, contextMap, contextProvider);
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncCompletableOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncCompletableOperator.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.Cancellable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
@@ -50,8 +51,8 @@ abstract class TaskBasedAsyncCompletableOperator extends AbstractNoHandleSubscri
                                       final BooleanSupplier shouldOffload,
                                       final Executor executor) {
         this.original = original;
-        this.shouldOffload = shouldOffload;
-        this.executor = executor;
+        this.shouldOffload = Objects.requireNonNull(shouldOffload, "shouldOffload");
+        this.executor = Objects.requireNonNull(executor, "executor");
     }
 
     final BooleanSupplier shouldOffload() {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncPublisherOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncPublisherOperator.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.internal.TerminalNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -66,8 +67,8 @@ abstract class TaskBasedAsyncPublisherOperator<T> extends AbstractNoHandleSubscr
                                     final BooleanSupplier shouldOffload,
                                     final Executor executor) {
         this.original = original;
-        this.shouldOffload = shouldOffload;
-        this.executor = executor;
+        this.shouldOffload = Objects.requireNonNull(shouldOffload, "shouldOffload");
+        this.executor = Objects.requireNonNull(executor, "executor");
     }
 
     final BooleanSupplier shouldOffload() {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncSingleOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncSingleOperator.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.internal.TerminalNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 
@@ -61,8 +62,8 @@ abstract class TaskBasedAsyncSingleOperator<T> extends AbstractNoHandleSubscribe
                                  final BooleanSupplier shouldOffload,
                                  final Executor executor) {
         this.original = original;
-        this.shouldOffload = shouldOffload;
-        this.executor = executor;
+        this.shouldOffload = Objects.requireNonNull(shouldOffload, "shouldOffload");
+        this.executor = Objects.requireNonNull(executor, "executor");
     }
 
     final BooleanSupplier shouldOffload() {


### PR DESCRIPTION
Motivation:
The current offloading operators have the possibility to call
`onSubscribe` twice if the `onSubscribe` method throws an exception.
This should be avoided.
Modifications:
Introduces a new safeHandleSubscribe static method that is invoked in
a slightly different context that avoids the possibility of double
calls to `onSubscribe`.
Result:
Better conformance to reactive specification.