### PR TITLE
Cleanup of PartitionedHttpClientBuilder

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -195,8 +195,7 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>>
      * Appends the filter to the chain of filters used to decorate the {@link HttpClient} created by this
      * builder.
      * <p>
-     * Note this method will be used to decorate the result of {@link #build()} before it is
-     * returned to the user.
+     * Note this method will be used to decorate the result of {@link #build()} before it is returned to the user.
      * <p>
      * The order of execution of these filters are in order of append. If 3 filters are added as follows:
      * <pre>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -16,22 +16,13 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.client.api.AutoRetryStrategyProvider;
-import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.client.api.partition.PartitionAttributes;
 import io.servicetalk.client.api.partition.PartitionMapFactory;
 import io.servicetalk.client.api.partition.PartitionedServiceDiscovererEvent;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
-import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.IoExecutor;
-
-import java.net.SocketOption;
-import java.util.function.BiFunction;
-import java.util.function.BooleanSupplier;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * A builder of homogeneous {@link StreamingHttpClient} instances which call the server associated with a partition
@@ -43,15 +34,14 @@ import java.util.function.Predicate;
  * @param <U> the type of address before resolution (unresolved address)
  * @param <R> the type of address after resolution (resolved address)
  */
-public abstract class PartitionedHttpClientBuilder<U, R>
-        extends BaseSingleAddressHttpClientBuilder<U, R, PartitionedServiceDiscovererEvent<R>> {
+public interface PartitionedHttpClientBuilder<U, R> extends HttpClientBuildFinalizer, ExecutionContextAwareHttpBuilder {
     /**
      * Initializes the {@link SingleAddressHttpClientBuilder} for each new client.
      * @param <U> the type of address before resolution (unresolved address)
      * @param <R> the type of address after resolution (resolved address)
      */
     @FunctionalInterface
-    public interface SingleAddressInitializer<U, R> {
+    interface SingleAddressInitializer<U, R> {
         /**
          * Configures the passed {@link SingleAddressHttpClientBuilder} for a given set of {@link PartitionAttributes}.
          *
@@ -76,190 +66,36 @@ public abstract class PartitionedHttpClientBuilder<U, R>
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#ioExecutor(IoExecutor)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
     @Override
-    public abstract PartitionedHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#executionStrategy(HttpExecutionStrategy)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#bufferAllocator(BufferAllocator)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#socketOption(SocketOption, Object)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract <T> PartitionedHttpClientBuilder<U, R> socketOption(SocketOption<T> option, T value);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#enableWireLogging(String, LogLevel, BooleanSupplier)} on the last argument
-     * of {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> enableWireLogging(String loggerName,
-                                                                         LogLevel logLevel,
-                                                                         BooleanSupplier logUserData);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#protocols(HttpProtocolConfig...)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> protocols(HttpProtocolConfig... protocols);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendConnectionFilter(StreamingHttpConnectionFilterFactory)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> appendConnectionFilter(
-            StreamingHttpConnectionFilterFactory factory);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendConnectionFilter(Predicate, StreamingHttpConnectionFilterFactory)} on
-     * the last argument of {@link SingleAddressInitializer#initialize(PartitionAttributes,
-     * SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public PartitionedHttpClientBuilder<U, R> appendConnectionFilter(Predicate<StreamingHttpRequest> predicate,
-                                                                     StreamingHttpConnectionFilterFactory factory) {
-        return (PartitionedHttpClientBuilder<U, R>)
-                super.appendConnectionFilter(predicate, factory);
-    }
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendConnectionFactoryFilter(ConnectionFactoryFilter)} on the last
-     * argument of {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> appendConnectionFactoryFilter(
-            ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> factory);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> disableHostHeaderFallback();
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#allowDropResponseTrailers(boolean)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> allowDropResponseTrailers(boolean allowDrop);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#autoRetryStrategy(AutoRetryStrategyProvider)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> autoRetryStrategy(
-            AutoRetryStrategyProvider autoRetryStrategyProvider);
+    PartitionedHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
     @Override
-    public abstract PartitionedHttpClientBuilder<U, R> serviceDiscoverer(
+    PartitionedHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);
+
+    @Override
+    PartitionedHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);
+
+    /**
+     * Sets a {@link ServiceDiscoverer} to resolve addresses of remote servers to connect to.
+     *
+     * @param serviceDiscoverer The {@link ServiceDiscoverer} to resolve addresses of remote servers to connect to.
+     * Lifecycle of the provided {@link ServiceDiscoverer} is managed externally and it should be
+     * {@link ServiceDiscoverer#closeAsync() closed} after all built {@link StreamingHttpClient}s will be closed and
+     * this {@link ServiceDiscoverer} is no longer needed.
+     * @return {@code this}.
+     */
+    PartitionedHttpClientBuilder<U, R> serviceDiscoverer(
             ServiceDiscoverer<U, R, PartitionedServiceDiscovererEvent<R>> serviceDiscoverer);
 
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
+    /**
+     * Sets a retry strategy to retry errors emitted by {@link ServiceDiscoverer}.
+     *
+     * @param retryStrategy a retry strategy to retry errors emitted by {@link ServiceDiscoverer}.
+     * @return {@code this}.
+     * @see DefaultServiceDiscoveryRetryStrategy.Builder
+     */
+    PartitionedHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
             ServiceDiscoveryRetryStrategy<R, PartitionedServiceDiscovererEvent<R>> retryStrategy);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#loadBalancerFactory(HttpLoadBalancerFactory)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> loadBalancerFactory(
-            HttpLoadBalancerFactory<R> loadBalancerFactory);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} on the last argument of
-     * {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> unresolvedAddressToHost(
-            Function<U, CharSequence> unresolvedAddressToHostFunction);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)} on the last argument
-     * of {@link SingleAddressInitializer#initialize(PartitionAttributes, SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public abstract PartitionedHttpClientBuilder<U, R> appendClientFilter(StreamingHttpClientFilterFactory function);
-
-    /**
-     * {@inheritDoc}
-     * @deprecated {@link #initializer(SingleAddressInitializer)} and
-     * {@link SingleAddressHttpClientBuilder#appendClientFilter(Predicate, StreamingHttpClientFilterFactory)} on the
-     * last argument of {@link SingleAddressInitializer#initialize(PartitionAttributes,
-     * SingleAddressHttpClientBuilder)}.
-     */
-    @Deprecated
-    @Override
-    public PartitionedHttpClientBuilder<U, R> appendClientFilter(Predicate<StreamingHttpRequest> predicate,
-                                                                 StreamingHttpClientFilterFactory factory) {
-        return (PartitionedHttpClientBuilder<U, R>)
-                super.appendClientFilter(predicate, factory);
-    }
 
     /**
      * Sets the maximum amount of {@link ServiceDiscovererEvent} objects that will be queued for each partition.
@@ -271,7 +107,7 @@ public abstract class PartitionedHttpClientBuilder<U, R>
      * queued for each partition.
      * @return {@code this}.
      */
-    public abstract PartitionedHttpClientBuilder<U, R> serviceDiscoveryMaxQueueSize(int serviceDiscoveryMaxQueueSize);
+    PartitionedHttpClientBuilder<U, R> serviceDiscoveryMaxQueueSize(int serviceDiscoveryMaxQueueSize);
 
     /**
      * Sets {@link PartitionMapFactory} to use by all {@link StreamingHttpClient}s created by this builder.
@@ -279,19 +115,7 @@ public abstract class PartitionedHttpClientBuilder<U, R>
      * @param partitionMapFactory {@link PartitionMapFactory} to use.
      * @return {@code this}.
      */
-    public abstract PartitionedHttpClientBuilder<U, R> partitionMapFactory(PartitionMapFactory partitionMapFactory);
-
-    /**
-     * Sets a function that allows customizing the {@link SingleAddressHttpClientBuilder} used to create the client for
-     * a given partition based on its {@link PartitionAttributes}.
-     * @deprecated Use {@link #initializer(SingleAddressInitializer)}.
-     * @param clientFilterFunction {@link BiFunction} used to customize the {@link SingleAddressHttpClientBuilder}
-     * before creating the client for the partition
-     * @return {@code this}
-     */
-    @Deprecated
-    public abstract PartitionedHttpClientBuilder<U, R> appendClientBuilderFilter(
-            PartitionHttpClientBuilderConfigurator<U, R> clientFilterFunction);
+    PartitionedHttpClientBuilder<U, R> partitionMapFactory(PartitionMapFactory partitionMapFactory);
 
     /**
      * Set a function which can customize options for each {@link StreamingHttpClient} that is built.
@@ -299,5 +123,5 @@ public abstract class PartitionedHttpClientBuilder<U, R>
      * {@link StreamingHttpClient}s.
      * @return {@code this}
      */
-    public abstract PartitionedHttpClientBuilder<U, R> initializer(SingleAddressInitializer<U, R> initializer);
+    PartitionedHttpClientBuilder<U, R> initializer(SingleAddressInitializer<U, R> initializer);
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -16,9 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ClientGroup;
-import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.internal.DefaultPartitionedClientGroup;
 import io.servicetalk.client.api.internal.DefaultPartitionedClientGroup.PartitionedClientFactory;
@@ -36,11 +34,8 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.DefaultServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
-import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
-import io.servicetalk.http.api.HttpLoadBalancerFactory;
-import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.PartitionHttpClientBuilderConfigurator;
@@ -48,18 +43,13 @@ import io.servicetalk.http.api.PartitionedHttpClientBuilder;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.StreamingHttpClient;
-import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
-import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.HttpClientBuildContext;
-import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.IoExecutor;
 
-import java.net.SocketOption;
-import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -72,7 +62,7 @@ import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.de
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
-class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBuilder<U, R> {
+class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttpClientBuilder<U, R> {
 
     private ServiceDiscoverer<U, R, PartitionedServiceDiscovererEvent<R>> serviceDiscoverer;
     @Nullable
@@ -273,58 +263,6 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
     }
 
     @Override
-    public <T> PartitionedHttpClientBuilder<U, R> socketOption(final SocketOption<T> option, final T value) {
-        builderTemplate.socketOption(option, value);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> enableWireLogging(final String loggerName, final LogLevel logLevel,
-                                                                final BooleanSupplier logUserData) {
-        builderTemplate.enableWireLogging(loggerName, logLevel, logUserData);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> protocols(HttpProtocolConfig... protocols) {
-        builderTemplate.protocols(protocols);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> appendConnectionFilter(
-            final StreamingHttpConnectionFilterFactory factory) {
-        builderTemplate.appendConnectionFilter(factory);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> appendConnectionFactoryFilter(
-            final ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> factory) {
-        builderTemplate.appendConnectionFactoryFilter(factory);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> disableHostHeaderFallback() {
-        builderTemplate.disableHostHeaderFallback();
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> allowDropResponseTrailers(final boolean allowDrop) {
-        builderTemplate.allowDropResponseTrailers(allowDrop);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> autoRetryStrategy(
-            final AutoRetryStrategyProvider autoRetryStrategyProvider) {
-        builderTemplate.autoRetryStrategy(autoRetryStrategyProvider);
-        return this;
-    }
-
-    @Override
     public PartitionedHttpClientBuilder<U, R> serviceDiscoverer(
             final ServiceDiscoverer<U, R, PartitionedServiceDiscovererEvent<R>> serviceDiscoverer) {
         this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
@@ -339,25 +277,6 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
     }
 
     @Override
-    public PartitionedHttpClientBuilder<U, R> loadBalancerFactory(HttpLoadBalancerFactory<R> loadBalancerFactory) {
-        builderTemplate.loadBalancerFactory(loadBalancerFactory);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> unresolvedAddressToHost(
-            final Function<U, CharSequence> unresolvedAddressToHostFunction) {
-        builderTemplate.unresolvedAddressToHost(unresolvedAddressToHostFunction);
-        return this;
-    }
-
-    @Override
-    public PartitionedHttpClientBuilder<U, R> appendClientFilter(final StreamingHttpClientFilterFactory function) {
-        builderTemplate.appendClientFilter(function);
-        return this;
-    }
-
-    @Override
     public PartitionedHttpClientBuilder<U, R> serviceDiscoveryMaxQueueSize(final int serviceDiscoveryMaxQueueSize) {
         this.serviceDiscoveryMaxQueueSize = serviceDiscoveryMaxQueueSize;
         return this;
@@ -366,14 +285,6 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
     @Override
     public PartitionedHttpClientBuilder<U, R> partitionMapFactory(final PartitionMapFactory partitionMapFactory) {
         this.partitionMapFactory = partitionMapFactory;
-        return this;
-    }
-
-    @Deprecated
-    @Override
-    public PartitionedHttpClientBuilder<U, R> appendClientBuilderFilter(
-            final PartitionHttpClientBuilderConfigurator<U, R> clientFilterFunction) {
-        this.clientFilterFunction = this.clientFilterFunction.append(clientFilterFunction);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -285,9 +285,10 @@ public final class HttpClients {
      * @param serviceDiscoverer The {@link ServiceDiscoverer} to resolve addresses of remote servers to connect to.
      * The lifecycle of the provided {@link ServiceDiscoverer} should be managed by the caller.
      * @param address the {@code UnresolvedAddress} to resolve using the provided {@code serviceDiscoverer}.
-     * This address will also be used for the {@link HttpHeaderNames#HOST} using a best effort conversion. Use {@link
-     * PartitionedHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value or
-     * {@link PartitionedHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
+     * This address will also be used for the {@link HttpHeaderNames#HOST} using a best effort conversion.
+     * Use {@link PartitionedHttpClientBuilder#initializer(PartitionedHttpClientBuilder.SingleAddressInitializer)}
+     * and {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
+     * or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
      * @param partitionAttributesBuilderFactory The factory {@link Function} used to build {@link PartitionAttributes}
      * from {@link HttpRequestMetaData}.
      * @param <U> the type of address before resolution (unresolved address)


### PR DESCRIPTION
Motivation:

The `PartitionedHttpClientBuilder` includes an initializer method for
individual underlying clients. Most of the methods of the outer client
builder were deprecated. This PR removes those methods.

Modifications:

- `PartitionedHttpClientBuilder` no longer depends on `BaseSingleAddressHttpClientBuilder`,
- Converted `PartitionedHttpClientBuilder` to an interface,
- Similarly to `MultiAddressHttpClientBuilder`, added extension of
  `ExecutionContextAwareHttpBuilder` and de-deprecated its` methods
  (`ioExecutor`, `executionStrategy`, and `bufferAllocator`),
- Copied over javadoc of `serviceDiscoverer` and `retryServiceDiscoveryErrors`
  methods as they are now not inherited,
- Corrected `HttpClients` javadoc for creating a partitioned client to
  mention `PartitionedHttpClientBuilder#initializer` as the method to
  configure individual clients.

Result:

Cleaner API, one way to configure underlying partition-oriented clients.