### PR TITLE
Deprecate `IoExecutor` create w/ `ThreadFactory`

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
@@ -17,7 +17,7 @@ package io.servicetalk.grpc.netty;
 
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.netty.internal.IoThreadFactory;
+import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 import io.grpc.examples.helloworld.Greeter.BlockingGreeterClient;
 import io.grpc.examples.helloworld.Greeter.ClientFactory;
@@ -45,7 +45,7 @@ class GrpcUdsTest {
 
     @BeforeAll
     static void beforeClass() {
-        ioExecutor = createIoExecutor(new IoThreadFactory("io-executor"));
+        ioExecutor = createIoExecutor(new NettyIoThreadFactory("io-executor"));
     }
 
     @AfterAll

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -46,7 +46,7 @@ import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.NettyIoExecutors;
-import io.servicetalk.transport.netty.internal.IoThreadFactory;
+import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
 import org.junit.jupiter.api.AfterAll;
@@ -145,8 +145,8 @@ abstract class AbstractNettyHttpServerTest {
 
     @BeforeAll
     static void createIoExecutors() {
-        clientIoExecutor = NettyIoExecutors.createIoExecutor(new IoThreadFactory("client-io-executor"));
-        serverIoExecutor = NettyIoExecutors.createIoExecutor(new IoThreadFactory("server-io-executor"));
+        clientIoExecutor = NettyIoExecutors.createIoExecutor(new NettyIoThreadFactory("client-io-executor"));
+        serverIoExecutor = NettyIoExecutors.createIoExecutor(new NettyIoThreadFactory("server-io-executor"));
     }
 
     private void startServer() throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -34,7 +34,7 @@ import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
-import io.servicetalk.transport.netty.internal.IoThreadFactory;
+import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,10 +70,10 @@ class HttpOffloadingTest {
 
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-        ExecutionContextExtension.cached(new IoThreadFactory(IO_EXECUTOR_NAME_PREFIX));
+        ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX));
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached(new IoThreadFactory(IO_EXECUTOR_NAME_PREFIX));
+        ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX));
 
     private StreamingHttpConnection httpConnection;
     private Queue<Throwable> errors;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerMultipleRequestsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerMultipleRequestsTest.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.AsyncCloseables;
 import io.servicetalk.concurrent.api.CompositeCloseable;
-import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpConnection;
@@ -26,6 +25,7 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
+import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -47,7 +47,6 @@ import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.cached;
-import static java.lang.Thread.NORM_PRIORITY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -57,10 +56,10 @@ class HttpServerMultipleRequestsTest {
 
     @RegisterExtension
     final ExecutionContextExtension serverExecution =
-            cached(new DefaultThreadFactory("server-io", true, NORM_PRIORITY));
+            cached(new NettyIoThreadFactory("server-io"));
     @RegisterExtension
     final ExecutionContextExtension clientExecution =
-            cached(new DefaultThreadFactory("client-io", true, NORM_PRIORITY));
+            cached(new NettyIoThreadFactory("client-io"));
 
     @Disabled("https://github.com/apple/servicetalk/issues/981")
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpUdsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpUdsTest.java
@@ -19,7 +19,7 @@ import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.netty.internal.IoThreadFactory;
+import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -37,7 +37,7 @@ class HttpUdsTest {
 
     @BeforeAll
     static void beforeClass() {
-        ioExecutor = createIoExecutor(new IoThreadFactory("io-executor"));
+        ioExecutor = createIoExecutor(new NettyIoThreadFactory("io-executor"));
     }
 
     @AfterAll

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -23,7 +23,7 @@ import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
-import io.servicetalk.transport.netty.internal.IoThreadFactory;
+import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,7 +91,7 @@ class HttpsProxyTest {
 
     void startServer() throws Exception {
         serverContext = HttpServers.forAddress(localAddress(0))
-                .ioExecutor(serverIoExecutor = createIoExecutor(new IoThreadFactory("server-io-executor")))
+                .ioExecutor(serverIoExecutor = createIoExecutor(new NettyIoThreadFactory("server-io-executor")))
                 .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
                         DefaultTestCerts::loadServerKey).build())
                 .listenAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslProvidersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslProvidersTest.java
@@ -23,7 +23,7 @@ import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
 import io.servicetalk.transport.api.SslProvider;
 import io.servicetalk.transport.netty.NettyIoExecutors;
-import io.servicetalk.transport.netty.internal.IoThreadFactory;
+import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -73,7 +73,7 @@ class SslProvidersTest {
                 });
 
         client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
-                .ioExecutor(NettyIoExecutors.createIoExecutor(new IoThreadFactory("client-io")))
+                .ioExecutor(NettyIoExecutors.createIoExecutor(new NettyIoThreadFactory("client-io")))
                 .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                         .peerHost(serverPemHostname()).provider(clientSslProvider).build())
                 .buildBlocking();

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractJerseyStreamingHttpServiceTest.java
@@ -32,7 +32,7 @@ import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
-import io.servicetalk.transport.netty.internal.IoThreadFactory;
+import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
@@ -89,7 +89,7 @@ public abstract class AbstractJerseyStreamingHttpServiceTest {
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-            ExecutionContextExtension.cached(new IoThreadFactory("stserverio"));
+            ExecutionContextExtension.cached(new NettyIoThreadFactory("stserverio"));
 
     protected RouterApi api;
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoThreadFactory.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoThreadFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+import io.servicetalk.transport.api.IoThreadFactory.IoThread;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Thread factory for use with {@link IoExecutor}.
+ *
+ * @param <T> Type of threads created
+ */
+@FunctionalInterface
+public interface IoThreadFactory<T extends Thread & IoThread> extends ThreadFactory {
+
+    /**
+     * Marker interface for IO Threads. All threads created by a {@link IoThreadFactory} are expected to implement this
+     * interface.
+     */
+    interface IoThread {
+    }
+
+    @Override
+    T newThread(Runnable r);
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoThreadFactory.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoThreadFactory.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.transport.api;
 
+import io.servicetalk.concurrent.api.AsyncContextMapHolder;
 import io.servicetalk.transport.api.IoThreadFactory.IoThread;
 
 import java.util.concurrent.ThreadFactory;
@@ -31,7 +32,7 @@ public interface IoThreadFactory<T extends Thread & IoThread> extends ThreadFact
      * Marker interface for IO Threads. All threads created by a {@link IoThreadFactory} are expected to implement this
      * interface.
      */
-    interface IoThread {
+    interface IoThread extends AsyncContextMapHolder {
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+  ~ Copyright © 2021 Apple Inc. and the ServiceTalk project authors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<FindBugsFilter>
+  <Match>
+    <!-- For legacy compatibility class is not renamed in 0.41 branch -->
+    <Source name="~IoThreadFactory\.java"/>
+    <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE"/>
+  </Match>
+</FindBugsFilter>

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
@@ -62,7 +62,7 @@ public final class GlobalExecutionContext {
 
         static {
             final IoExecutor ioExecutor = new GlobalIoExecutor(createIoExecutor(
-                    new IoThreadFactory(GlobalIoExecutor.NAME_PREFIX, true)));
+                    new NettyIoThreadFactory(GlobalIoExecutor.NAME_PREFIX, true)));
             final Executor executor = new GlobalExecutor(newCachedThreadExecutor(
                     new DefaultThreadFactory(GlobalExecutor.NAME_PREFIX, true, NORM_PRIORITY)));
             INSTANCE = new DefaultExecutionContext(DEFAULT_ALLOCATOR, ioExecutor, executor, OFFLOAD_ALL_STRATEGY);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
@@ -17,6 +17,7 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.api.AsyncContextMap;
 import io.servicetalk.concurrent.api.AsyncContextMapHolder;
+import io.servicetalk.transport.netty.internal.IoThreadFactory.NettyIoThread;
 
 import io.netty.util.concurrent.FastThreadLocalThread;
 
@@ -33,7 +34,7 @@ import static java.util.Objects.requireNonNull;
  */
 @Deprecated
 public final class IoThreadFactory implements
-                                   io.servicetalk.transport.api.IoThreadFactory<IoThreadFactory.NettyIoThread> {
+                                   io.servicetalk.transport.api.IoThreadFactory<NettyIoThread> {
     private static final AtomicInteger factoryCount = new AtomicInteger();
     private final AtomicInteger threadCount = new AtomicInteger();
     private final String namePrefix;
@@ -75,7 +76,8 @@ public final class IoThreadFactory implements
         return t;
     }
 
-    public static class NettyIoThread extends FastThreadLocalThread implements IoThread {
+    public static class NettyIoThread extends FastThreadLocalThread
+            implements io.servicetalk.transport.api.IoThreadFactory.IoThread {
         NettyIoThread(ThreadGroup group, Runnable target, String name) {
             super(group, target, name);
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
@@ -75,7 +75,7 @@ public class IoThreadFactory implements io.servicetalk.transport.api.IoThreadFac
         return t;
     }
 
-    public static class NettyIoThread extends FastThreadLocalThread
+    public static final class NettyIoThread extends FastThreadLocalThread
             implements io.servicetalk.transport.api.IoThreadFactory.IoThread {
 
         @Nullable

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
@@ -16,7 +16,6 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.api.AsyncContextMap;
-import io.servicetalk.concurrent.api.AsyncContextMapHolder;
 import io.servicetalk.transport.netty.internal.IoThreadFactory.NettyIoThread;
 
 import io.netty.util.concurrent.FastThreadLocalThread;
@@ -28,13 +27,13 @@ import static java.lang.Thread.NORM_PRIORITY;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Default {@link IoThreadFactory} to create IO {@link IoThread}s.
+ * Default {@link io.servicetalk.transport.api.IoThreadFactory} to create IO {@link IoThread}s.
  *
- * @deprecated The name of this class will change in future versions of ServiceTalk to {@code NettyIoThreadFactory}.
+ * @deprecated Use {@link NettyIoThreadFactory}.
+ * @see NettyIoThreadFactory
  */
 @Deprecated
-public final class IoThreadFactory implements
-                                   io.servicetalk.transport.api.IoThreadFactory<NettyIoThread> {
+public class IoThreadFactory implements io.servicetalk.transport.api.IoThreadFactory<NettyIoThread> {
     private static final AtomicInteger factoryCount = new AtomicInteger();
     private final AtomicInteger threadCount = new AtomicInteger();
     private final String namePrefix;
@@ -66,7 +65,7 @@ public final class IoThreadFactory implements
 
     @Override
     public NettyIoThread newThread(Runnable r) {
-        NettyIoThread t = new AsyncContextHolderNettyThread(threadGroup, r, namePrefix + threadCount.incrementAndGet());
+        NettyIoThread t = new NettyIoThread(threadGroup, r, namePrefix + threadCount.incrementAndGet());
         if (t.isDaemon() != daemon) {
             t.setDaemon(daemon);
         }
@@ -78,17 +77,11 @@ public final class IoThreadFactory implements
 
     public static class NettyIoThread extends FastThreadLocalThread
             implements io.servicetalk.transport.api.IoThreadFactory.IoThread {
-        NettyIoThread(ThreadGroup group, Runnable target, String name) {
-            super(group, target, name);
-        }
-    }
 
-    private static final class AsyncContextHolderNettyThread extends NettyIoThread
-            implements AsyncContextMapHolder {
         @Nullable
         private AsyncContextMap asyncContextMap;
 
-        AsyncContextHolderNettyThread(ThreadGroup group, Runnable target, String name) {
+        NettyIoThread(ThreadGroup group, Runnable target, String name) {
             super(group, target, name);
         }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.IoThreadFactory;
 import io.servicetalk.transport.api.IoThreadFactory.IoThread;
 
 import io.netty.channel.EventLoop;
@@ -44,23 +45,22 @@ public final class NettyIoExecutors {
      * Create a new {@link NettyIoExecutor} with the default number of {@code ioThreads}.
      *
      * @param <T> Type of the IO thread instances created by factory.
-     * @param threadFactory the {@link io.servicetalk.transport.api.IoThreadFactory} to use. If possible you should use
-     * an instance of {@link IoThreadFactory} as it allows internal optimizations.
+     * @param threadFactory the {@link IoThreadFactory} to use. If possible you should use an instance of
+     * {@link NettyIoThreadFactory} as it allows internal optimizations.
      * @return The created {@link IoExecutor}
      */
     public static <T extends Thread & IoThread> EventLoopAwareNettyIoExecutor createIoExecutor(
-            io.servicetalk.transport.api.IoThreadFactory threadFactory) {
+            IoThreadFactory<T> threadFactory) {
         return createIoExecutor(getRuntime().availableProcessors() * 2, threadFactory);
     }
 
     /**
      * Create a new {@link NettyIoExecutor} with the default number of {@code ioThreads}.
      *
-     * @param threadFactory the {@link ThreadFactory} to use.
+     * @param threadFactory the {@link ThreadFactory} to use. If possible you should use an instance of
+     * {@link NettyIoThreadFactory} as it allows internal optimizations.
      * @return The created {@link IoExecutor}
-     * @deprecated Future versions of ServiceTalk will require a
-     * {@link io.servicetalk.transport.api.IoThreadFactory} for creating {@link IoExecutor} threads, use
-     * {@link #createEventLoopGroup(int, io.servicetalk.transport.api.IoThreadFactory)} instead.
+     * @deprecated Use {@link #createIoExecutor(IoThreadFactory)}.
      */
     @Deprecated
     public static EventLoopAwareNettyIoExecutor createIoExecutor(ThreadFactory threadFactory) {
@@ -72,12 +72,12 @@ public final class NettyIoExecutors {
      *
      * @param <T> Type of the IO thread instances created by factory.
      * @param ioThreads number of threads.
-     * @param threadFactory the {@link io.servicetalk.transport.api.IoThreadFactory} to use. If possible you should use
-     * an instance of {@link IoThreadFactory} as it allows internal optimizations.
+     * @param threadFactory the {@link IoThreadFactory} to use. If possible you should use an instance of
+     * {@link NettyIoThreadFactory} as it allows internal optimizations.
      * @return The created {@link IoExecutor}
      */
     public static <T extends Thread & IoThread> EventLoopAwareNettyIoExecutor createIoExecutor(
-            int ioThreads, io.servicetalk.transport.api.IoThreadFactory threadFactory) {
+            int ioThreads, IoThreadFactory<T> threadFactory) {
         validateIoThreads(ioThreads);
         return new EventLoopGroupIoExecutor(createEventLoopGroup(ioThreads, threadFactory), true);
     }
@@ -87,11 +87,9 @@ public final class NettyIoExecutors {
      *
      * @param ioThreads number of threads.
      * @param threadFactory the {@link ThreadFactory} to use. If possible you should use an instance of
-     * {@link IoThreadFactory} as it allows internal optimizations.
+     * {@link NettyIoThreadFactory} as it allows internal optimizations.
      * @return The created {@link IoExecutor}
-     * @deprecated Future versions of ServiceTalk will require a {@link io.servicetalk.transport.api.IoThreadFactory}
-     * for creating {@link IoExecutor} threads, use
-     * {@link #createIoExecutor(int, io.servicetalk.transport.api.IoThreadFactory)} instead.
+     * @deprecated Use {@link #createIoExecutor(int, IoThreadFactory)}.
      */
     @Deprecated
     public static EventLoopAwareNettyIoExecutor createIoExecutor(int ioThreads, ThreadFactory threadFactory) {
@@ -99,16 +97,8 @@ public final class NettyIoExecutors {
         return new EventLoopGroupIoExecutor(createEventLoopGroup(ioThreads, threadFactory), true);
     }
 
-    /**
-     * Create a new {@link EventLoopGroup}.
-     *
-     * @param <T> Type of the IO thread instances created by factory.
-     * @param ioThreads number of threads
-     * @param threadFactory the {@link io.servicetalk.transport.api.IoThreadFactory} to use.
-     * @return The created {@link IoExecutor}
-     */
-    public static <T extends Thread & IoThread> EventLoopGroup createEventLoopGroup(int ioThreads,
-            io.servicetalk.transport.api.IoThreadFactory threadFactory) {
+    private static <T extends Thread & IoThread> EventLoopGroup createEventLoopGroup(int ioThreads,
+            IoThreadFactory<T> threadFactory) {
         validateIoThreads(ioThreads);
         return isEpollAvailable() ? new EpollEventLoopGroup(ioThreads, threadFactory) :
                 isKQueueAvailable() ? new KQueueEventLoopGroup(ioThreads, threadFactory) :
@@ -118,12 +108,12 @@ public final class NettyIoExecutors {
     /**
      * Create a new {@link EventLoopGroup}.
      *
-     * @param ioThreads number of threads
+     * @param ioThreads number of threads.
      * @param threadFactory the {@link ThreadFactory} to use.
      * @return The created {@link IoExecutor}
-     * @deprecated Future versions of ServiceTalk will require a
-     * {@link io.servicetalk.transport.api.IoThreadFactory} for creating {@link IoExecutor} threads, use
-     * {@link #createEventLoopGroup(int, io.servicetalk.transport.api.IoThreadFactory)} instead.
+     * @deprecated Use {@link EventLoopAwareNettyIoExecutors#toEventLoopAwareNettyIoExecutor(IoExecutor)} and
+     * {@link EventLoopAwareNettyIoExecutor#eventLoopGroup()} with any {@link NettyIoExecutor} created by other factory
+     * methods in this class.
      */
     @Deprecated
     public static EventLoopGroup createEventLoopGroup(int ioThreads, ThreadFactory threadFactory) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoThreadFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.servicetalk.transport.netty.internal;
 /**
  * Default {@link io.servicetalk.transport.api.IoThreadFactory} to create IO {@link IoThread}s.
  */
-public final class NettyIoThreadFactory extends io.servicetalk.transport.netty.internal.IoThreadFactory {
+public final class NettyIoThreadFactory extends IoThreadFactory {
 
     /**
      * Create a new instance.
@@ -33,7 +33,6 @@ public final class NettyIoThreadFactory extends io.servicetalk.transport.netty.i
      * @param threadNamePrefix the name prefix used for the created {@link Thread}s.
      * @param daemon {@code true} if the created {@link Thread} should be a daemon thread.
      */
-    @SuppressWarnings("PMD.AvoidThreadGroup")
     public NettyIoThreadFactory(String threadNamePrefix, boolean daemon) {
         super(threadNamePrefix, daemon);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoThreadFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoThreadFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+/**
+ * Default {@link io.servicetalk.transport.api.IoThreadFactory} to create IO {@link IoThread}s.
+ */
+public final class NettyIoThreadFactory extends io.servicetalk.transport.netty.internal.IoThreadFactory {
+
+    /**
+     * Create a new instance.
+     * @param threadNamePrefix the name prefix used for the created {@link Thread}s.
+     */
+    public NettyIoThreadFactory(String threadNamePrefix) {
+        this(threadNamePrefix, true);
+    }
+
+    /**
+     * Create a new instance.
+     * @param threadNamePrefix the name prefix used for the created {@link Thread}s.
+     * @param daemon {@code true} if the created {@link Thread} should be a daemon thread.
+     */
+    @SuppressWarnings("PMD.AvoidThreadGroup")
+    public NettyIoThreadFactory(String threadNamePrefix, boolean daemon) {
+        super(threadNamePrefix, daemon);
+    }
+}

--- a/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextExtension.java
+++ b/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextExtension.java
@@ -23,6 +23,7 @@ import io.servicetalk.transport.api.DefaultExecutionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.IoThreadFactory;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -31,7 +32,6 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.util.concurrent.ThreadFactory;
 import java.util.function.Supplier;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
@@ -75,19 +75,19 @@ public final class ExecutionContextExtension implements AfterEachCallback, Befor
     }
 
     public static ExecutionContextExtension immediate() {
-        return immediate(new IoThreadFactory(IO_THREAD_PREFIX));
+        return immediate(new NettyIoThreadFactory(IO_THREAD_PREFIX));
     }
 
-    private static ExecutionContextExtension immediate(ThreadFactory ioThreadFactory) {
+    private static ExecutionContextExtension immediate(IoThreadFactory ioThreadFactory) {
         return new ExecutionContextExtension(() -> DEFAULT_ALLOCATOR, newIoExecutor(ioThreadFactory),
                 Executors::immediate);
     }
 
     public static ExecutionContextExtension cached() {
-        return cached(new IoThreadFactory(IO_THREAD_PREFIX));
+        return cached(new NettyIoThreadFactory(IO_THREAD_PREFIX));
     }
 
-    public static ExecutionContextExtension cached(ThreadFactory ioThreadFactory) {
+    public static ExecutionContextExtension cached(IoThreadFactory ioThreadFactory) {
         return new ExecutionContextExtension(() -> DEFAULT_ALLOCATOR, newIoExecutor(ioThreadFactory),
                 Executors::newCachedThreadExecutor
         );
@@ -95,15 +95,15 @@ public final class ExecutionContextExtension implements AfterEachCallback, Befor
 
     public static ExecutionContextExtension cached(String ioThreadPrefix, String executorThreadPrefix) {
         return new ExecutionContextExtension(() -> DEFAULT_ALLOCATOR,
-                newIoExecutor(new IoThreadFactory(ioThreadPrefix)),
+                newIoExecutor(new NettyIoThreadFactory(ioThreadPrefix)),
                 () -> newCachedThreadExecutor(new DefaultThreadFactory(executorThreadPrefix)));
     }
 
     private static ExecutionContextExtension fixed(int size) {
-        return fixed(size, new IoThreadFactory(IO_THREAD_PREFIX));
+        return fixed(size, new NettyIoThreadFactory(IO_THREAD_PREFIX));
     }
 
-    private static ExecutionContextExtension fixed(int size, ThreadFactory ioThreadFactory) {
+    private static ExecutionContextExtension fixed(int size, IoThreadFactory ioThreadFactory) {
         return new ExecutionContextExtension(() -> DEFAULT_ALLOCATOR, newIoExecutor(ioThreadFactory),
                 () -> Executors.newFixedSizeExecutor(size)
         );
@@ -113,7 +113,7 @@ public final class ExecutionContextExtension implements AfterEachCallback, Befor
         return fixed(1);
     }
 
-    public static ExecutionContextExtension single(ThreadFactory ioThreadFactory) {
+    public static ExecutionContextExtension single(IoThreadFactory ioThreadFactory) {
         return fixed(1, ioThreadFactory);
     }
 
@@ -142,7 +142,7 @@ public final class ExecutionContextExtension implements AfterEachCallback, Befor
         return ctx.executionStrategy();
     }
 
-    private static Supplier<IoExecutor> newIoExecutor(ThreadFactory threadFactory) {
+    private static Supplier<IoExecutor> newIoExecutor(IoThreadFactory threadFactory) {
         return () -> createIoExecutor(threadFactory);
     }
 

--- a/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextRule.java
+++ b/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextRule.java
@@ -87,7 +87,8 @@ public final class ExecutionContextRule extends ExternalResource implements Exec
     }
 
     public static ExecutionContextRule cached(String ioThreadPrefix, String executorThreadPrefix) {
-        return new ExecutionContextRule(() -> DEFAULT_ALLOCATOR, newIoExecutor(new IoThreadFactory(ioThreadPrefix)),
+        return new ExecutionContextRule(() -> DEFAULT_ALLOCATOR,
+                newIoExecutor(new IoThreadFactory(ioThreadPrefix)),
                 () -> newCachedThreadExecutor(new DefaultThreadFactory(executorThreadPrefix)));
     }
 

--- a/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextRule.java
+++ b/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextRule.java
@@ -68,7 +68,7 @@ public final class ExecutionContextRule extends ExternalResource implements Exec
     }
 
     public static ExecutionContextRule immediate() {
-        return immediate(new IoThreadFactory(IO_THREAD_PREFIX));
+        return immediate(new NettyIoThreadFactory(IO_THREAD_PREFIX));
     }
 
     public static ExecutionContextRule immediate(ThreadFactory ioThreadFactory) {
@@ -77,7 +77,7 @@ public final class ExecutionContextRule extends ExternalResource implements Exec
     }
 
     public static ExecutionContextRule cached() {
-        return cached(new IoThreadFactory(IO_THREAD_PREFIX));
+        return cached(new NettyIoThreadFactory(IO_THREAD_PREFIX));
     }
 
     public static ExecutionContextRule cached(ThreadFactory ioThreadFactory) {
@@ -88,12 +88,12 @@ public final class ExecutionContextRule extends ExternalResource implements Exec
 
     public static ExecutionContextRule cached(String ioThreadPrefix, String executorThreadPrefix) {
         return new ExecutionContextRule(() -> DEFAULT_ALLOCATOR,
-                newIoExecutor(new IoThreadFactory(ioThreadPrefix)),
+                newIoExecutor(new NettyIoThreadFactory(ioThreadPrefix)),
                 () -> newCachedThreadExecutor(new DefaultThreadFactory(executorThreadPrefix)));
     }
 
     public static ExecutionContextRule fixed(int size) {
-        return fixed(size, new IoThreadFactory(IO_THREAD_PREFIX));
+        return fixed(size, new NettyIoThreadFactory(IO_THREAD_PREFIX));
     }
 
     public static ExecutionContextRule fixed(int size, ThreadFactory ioThreadFactory) {

--- a/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
+++ b/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.netty;
 
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.IoThreadFactory.IoThread;
 import io.servicetalk.transport.netty.internal.IoThreadFactory;
 import io.servicetalk.transport.netty.internal.NettyIoExecutor;
 
@@ -34,11 +35,27 @@ public final class NettyIoExecutors {
      * Creates a new {@link IoExecutor} with the specified number of {@code ioThreads}.
      *
      * @param ioThreads number of threads.
-     * @param threadFactory the {@link ThreadFactory} to use. If possible you should use an instance
-     * of {@link IoThreadFactory} as it allows internal optimizations.
+     * @param threadFactory the {@link ThreadFactory} to use.
+     * @return The created {@link IoExecutor}
+     * @deprecated Future versions of ServiceTalk will require a {@link io.servicetalk.transport.api.IoThreadFactory}
+     * for creating {@link IoExecutor} threads, use
+     * {@link #createIoExecutor(int, io.servicetalk.transport.api.IoThreadFactory)} instead.
+     */
+    @Deprecated
+    public static IoExecutor createIoExecutor(int ioThreads, ThreadFactory threadFactory) {
+        return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor(ioThreads, threadFactory);
+    }
+
+    /**
+     * Creates a new {@link IoExecutor} with the specified number of {@code ioThreads}.
+     *
+     * @param <T> Type of the IO thread instances created by factory.
+     * @param ioThreads number of threads.
+     * @param threadFactory the {@link io.servicetalk.transport.api.IoThreadFactory} to use.
      * @return The created {@link IoExecutor}
      */
-    public static IoExecutor createIoExecutor(int ioThreads, ThreadFactory threadFactory) {
+    public static <T extends Thread & IoThread> IoExecutor createIoExecutor(int ioThreads,
+            io.servicetalk.transport.api.IoThreadFactory threadFactory) {
         return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor(ioThreads, threadFactory);
     }
 
@@ -55,10 +72,25 @@ public final class NettyIoExecutors {
     /**
      * Creates a new {@link IoExecutor} with the default number of {@code ioThreads}.
      *
-     * @param threadFactory the {@link ThreadFactory} to use. If possible you should use an instance
-     * of {@link IoThreadFactory} as it allows internal optimizations.
+     * @param <T> Type of the IO thread instances created by factory.
+     * @param threadFactory the {@link io.servicetalk.transport.api.IoThreadFactory} to use.
      * @return The created {@link IoExecutor}
      */
+    public static <T extends Thread & IoThread> IoExecutor createIoExecutor(
+            io.servicetalk.transport.api.IoThreadFactory threadFactory) {
+        return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor(threadFactory);
+    }
+
+    /**
+     * Creates a new {@link IoExecutor} with the default number of {@code ioThreads}.
+     *
+     * @param threadFactory the {@link ThreadFactory} to use.
+     * @return The created {@link IoExecutor}
+     * @deprecated Future versions of ServiceTalk will require a {@link io.servicetalk.transport.api.IoThreadFactory}
+     * for creating {@link IoExecutor} threads, use
+     * {@link #createIoExecutor(io.servicetalk.transport.api.IoThreadFactory)} instead.
+     */
+    @Deprecated
     public static IoExecutor createIoExecutor(ThreadFactory threadFactory) {
         return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor(threadFactory);
     }

--- a/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
+++ b/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
@@ -16,8 +16,8 @@
 package io.servicetalk.transport.netty;
 
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.IoThreadFactory;
 import io.servicetalk.transport.api.IoThreadFactory.IoThread;
-import io.servicetalk.transport.netty.internal.IoThreadFactory;
 import io.servicetalk.transport.netty.internal.NettyIoExecutor;
 
 import java.util.concurrent.ThreadFactory;
@@ -37,9 +37,7 @@ public final class NettyIoExecutors {
      * @param ioThreads number of threads.
      * @param threadFactory the {@link ThreadFactory} to use.
      * @return The created {@link IoExecutor}
-     * @deprecated Future versions of ServiceTalk will require a {@link io.servicetalk.transport.api.IoThreadFactory}
-     * for creating {@link IoExecutor} threads, use
-     * {@link #createIoExecutor(int, io.servicetalk.transport.api.IoThreadFactory)} instead.
+     * @deprecated Use {@link #createIoExecutor(int, IoThreadFactory)}.
      */
     @Deprecated
     public static IoExecutor createIoExecutor(int ioThreads, ThreadFactory threadFactory) {
@@ -51,11 +49,11 @@ public final class NettyIoExecutors {
      *
      * @param <T> Type of the IO thread instances created by factory.
      * @param ioThreads number of threads.
-     * @param threadFactory the {@link io.servicetalk.transport.api.IoThreadFactory} to use.
+     * @param threadFactory the {@link IoThreadFactory} to use.
      * @return The created {@link IoExecutor}
      */
     public static <T extends Thread & IoThread> IoExecutor createIoExecutor(int ioThreads,
-            io.servicetalk.transport.api.IoThreadFactory threadFactory) {
+            IoThreadFactory<T> threadFactory) {
         return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor(ioThreads, threadFactory);
     }
 
@@ -66,18 +64,18 @@ public final class NettyIoExecutors {
      * @return The created {@link IoExecutor}
      */
     public static IoExecutor createIoExecutor(int ioThreads) {
-        return createIoExecutor(ioThreads, newIoThreadFactory());
+        return createIoExecutor(ioThreads,
+            new io.servicetalk.transport.netty.internal.NettyIoThreadFactory(NettyIoExecutor.class.getSimpleName()));
     }
 
     /**
      * Creates a new {@link IoExecutor} with the default number of {@code ioThreads}.
      *
      * @param <T> Type of the IO thread instances created by factory.
-     * @param threadFactory the {@link io.servicetalk.transport.api.IoThreadFactory} to use.
+     * @param threadFactory the {@link IoThreadFactory} to use.
      * @return The created {@link IoExecutor}
      */
-    public static <T extends Thread & IoThread> IoExecutor createIoExecutor(
-            io.servicetalk.transport.api.IoThreadFactory threadFactory) {
+    public static <T extends Thread & IoThread> IoExecutor createIoExecutor(IoThreadFactory<T> threadFactory) {
         return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor(threadFactory);
     }
 
@@ -86,9 +84,7 @@ public final class NettyIoExecutors {
      *
      * @param threadFactory the {@link ThreadFactory} to use.
      * @return The created {@link IoExecutor}
-     * @deprecated Future versions of ServiceTalk will require a {@link io.servicetalk.transport.api.IoThreadFactory}
-     * for creating {@link IoExecutor} threads, use
-     * {@link #createIoExecutor(io.servicetalk.transport.api.IoThreadFactory)} instead.
+     * @deprecated Use {@link #createIoExecutor(IoThreadFactory)}.
      */
     @Deprecated
     public static IoExecutor createIoExecutor(ThreadFactory threadFactory) {
@@ -101,10 +97,7 @@ public final class NettyIoExecutors {
      * @return The created {@link IoExecutor}
      */
     public static IoExecutor createIoExecutor() {
-        return createIoExecutor(newIoThreadFactory());
-    }
-
-    private static IoThreadFactory newIoThreadFactory() {
-        return new IoThreadFactory(NettyIoExecutor.class.getSimpleName());
+        return createIoExecutor(
+            new io.servicetalk.transport.netty.internal.NettyIoThreadFactory(NettyIoExecutor.class.getSimpleName()));
     }
 }

--- a/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
+++ b/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.IoThreadFactory;
 import io.servicetalk.transport.api.IoThreadFactory.IoThread;
 import io.servicetalk.transport.netty.internal.NettyIoExecutor;
+import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 import java.util.concurrent.ThreadFactory;
 
@@ -64,8 +65,7 @@ public final class NettyIoExecutors {
      * @return The created {@link IoExecutor}
      */
     public static IoExecutor createIoExecutor(int ioThreads) {
-        return createIoExecutor(ioThreads,
-            new io.servicetalk.transport.netty.internal.NettyIoThreadFactory(NettyIoExecutor.class.getSimpleName()));
+        return createIoExecutor(ioThreads, new NettyIoThreadFactory(NettyIoExecutor.class.getSimpleName()));
     }
 
     /**
@@ -97,7 +97,6 @@ public final class NettyIoExecutors {
      * @return The created {@link IoExecutor}
      */
     public static IoExecutor createIoExecutor() {
-        return createIoExecutor(
-            new io.servicetalk.transport.netty.internal.NettyIoThreadFactory(NettyIoExecutor.class.getSimpleName()));
+        return createIoExecutor(new NettyIoThreadFactory(NettyIoExecutor.class.getSimpleName()));
     }
 }


### PR DESCRIPTION
Motivation:
Future versions of ServiceTalk will require that all IoExecutor threads
implement the `IoThreadFactory.IoThread` marker interface so that the
threads can be recognized for offloading. Usages pf existing APIs which
accept a `ThreadFactory` need to be replaced to use variants that
accept an `IoThreadFactory`.
Modifications:
Introduces `IoThreadFactory` which will be required in the future for
`IoExecutor`. Adds new methods accepting `IoThreadFactory` and
deprecates existing `IoExecutor` creation APIs which accept
`ThreadFactory`.
Result:
API and deprecations anticipate future required behavior.