### PR TITLE
IoThreadFactory create daemon threads by default

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
@@ -43,7 +43,7 @@ public final class IoThreadFactory implements ThreadFactory {
      * @param threadNamePrefix the name prefix used for the created {@link Thread}s.
      */
     public IoThreadFactory(String threadNamePrefix) {
-        this(threadNamePrefix, false);
+        this(threadNamePrefix, true);
     }
 
     /**


### PR DESCRIPTION
Motivation:
The `IoThreadFactory` default constructor creates non-daemon threads
by default. For some types of servers a non-daemon thread is
advantageous where the initial thread starts the server and eventually
exits. The server thread then keeps the JVM running as long as The
server continues to accept connections. As ServiceTalk applications
don't rely on this behaviour all ServiceTalk threads should be daemon
threads.
Modifications:
`IoThreadFactory(String threadNamePrefix)` constructor changed to
create daemon threads.
Result:
ServiceTalk IO Threads will no longer keep JVM alive if application
threads have quit.