### PR TITLE
Account for recent TFO changes in netty 4.1.67 for macOS

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static io.servicetalk.http.netty.TcpFastOpenTest.assumeTcpFastOpen;
 import static io.servicetalk.http.netty.TcpFastOpenTest.clientTcpFastOpenOptions;
 import static io.servicetalk.http.netty.TcpFastOpenTest.serverTcpFastOpenOptions;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
@@ -59,7 +60,7 @@ class MutualSslTest {
     private static final List<Map<SocketOption, Object>> CLIENT_OPTIONS =
             asList(emptyMap(), clientTcpFastOpenOptions());
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "unused"})
     private static Collection<Arguments> params() {
         List<Arguments> params = new ArrayList<>();
         for (SslProvider serverSslProvider : SSL_PROVIDERS) {
@@ -79,9 +80,10 @@ class MutualSslTest {
     @MethodSource("params")
     void mutualSsl(SslProvider serverSslProvider,
                    SslProvider clientSslProvider,
-                   Map<SocketOption, Object> serverListenOptions,
-                   Map<SocketOption, Object> clientOptions)
-            throws Exception {
+                   @SuppressWarnings("rawtypes") Map<SocketOption, Object> serverListenOptions,
+                   @SuppressWarnings("rawtypes") Map<SocketOption, Object> clientOptions) throws Exception {
+        assumeTcpFastOpen(clientOptions);
+
         HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0))
                 .sslConfig(new ServerSslConfigBuilder(
                         DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
@@ -103,7 +105,7 @@ class MutualSslTest {
         }
     }
 
-    private SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilder(
+    private static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilder(
             ServerContext serverContext, @SuppressWarnings("rawtypes") Map<SocketOption, Object> clientOptions) {
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
                 HttpClients.forSingleAddress(serverHostAndPort(serverContext));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static io.netty.util.internal.PlatformDependent.isOsx;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
 import static io.servicetalk.http.netty.HttpProtocol.toConfigs;
@@ -50,6 +51,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class TcpFastOpenTest {
 
@@ -85,8 +87,9 @@ class TcpFastOpenTest {
     void requestSucceedsEvenIfTcpFastOpenNotEnabledOrSupported(final Collection<HttpProtocol> protocols,
             final boolean secure,
             @SuppressWarnings("rawtypes") final Map<SocketOption, Object> serverListenOptions,
-            @SuppressWarnings("rawtypes") final Map<SocketOption, Object> clientOptions)
-        throws Exception {
+            @SuppressWarnings("rawtypes") final Map<SocketOption, Object> clientOptions) throws Exception {
+        assumeTcpFastOpen(clientOptions);
+
         HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0))
                 .protocols(toConfigs(protocols));
         if (secure) {
@@ -121,5 +124,12 @@ class TcpFastOpenTest {
             builder.socketOption(option, entry.getValue());
         }
         return builder.buildBlocking();
+    }
+
+    static void assumeTcpFastOpen(@SuppressWarnings("rawtypes") final Map<SocketOption, Object> clientOptions) {
+        // FIXME: remove after https://github.com/netty/netty/pull/11588 is released
+        if (clientOptions.containsKey(TCP_FASTOPEN_CONNECT)) {
+            assumeFalse(isOsx(), "TCP Fast Open is not supported on macOS yet");
+        }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SocketOptionUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SocketOptionUtils.java
@@ -20,7 +20,6 @@ import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.epoll.EpollChannelOption;
 
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
@@ -55,7 +54,7 @@ public final class SocketOptionUtils {
                 stThreshold -> new WriteBufferWaterMark(stThreshold >>> 1, stThreshold));
         putOpt(ChannelOption.TCP_FASTOPEN_CONNECT, ServiceTalkSocketOptions.TCP_FASTOPEN_CONNECT);
         putOpt(ChannelOption.SO_BACKLOG, ServiceTalkSocketOptions.SO_BACKLOG);
-        putOpt(EpollChannelOption.TCP_FASTOPEN, ServiceTalkSocketOptions.TCP_FASTOPEN_BACKLOG);
+        putOpt(ChannelOption.TCP_FASTOPEN, ServiceTalkSocketOptions.TCP_FASTOPEN_BACKLOG);
     }
 
     private SocketOptionUtils() {


### PR DESCRIPTION
Motivation:

1. Netty offers a new transport-agnostic channel option for TFO:
`ChannelOption.TCP_FASTOPEN`;
2. macOS impl of client-side TFO has a bug, which affects some of our
existing tests: https://github.com/netty/netty/pull/11588

Modifications:

- Use `ChannelOption.TCP_FASTOPEN` instead of deprecated
`EpollChannelOption.TCP_FASTOPEN`;
- Skip tests that use `ServiceTalkSocketOptions.TCP_FASTOPEN_CONNECT`
when run on macOS;

Result:

No deprecated netty API is used, not test failures on macOS.