### PR TITLE
Propogate InterruptedException to the NettyPipelinedConnectionTest tests

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCancellable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCancellable.java
@@ -56,7 +56,9 @@ public class TestCancellable implements Cancellable {
     /**
      * Wait until {@link #cancel()} is called without being interrupted. This method catches an
      * {@link InterruptedException} and discards it silently.
+     * @deprecated Use {@link #awaitCancelled()} instead.
      */
+    @Deprecated
     public final void awaitCancelledUninterruptibly() {
         boolean interrupted = false;
         synchronized (waitingLock) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
@@ -259,7 +259,7 @@ class NettyPipelinedConnectionTest {
     }
 
     @Test
-    void readCancelErrorsPendingReadCancelsPendingWrite() {
+    void readCancelErrorsPendingReadCancelsPendingWrite() throws Exception {
         TestSubscription writePublisher1Subscription = new TestSubscription();
         toSource(requester.write(writePublisher1
                 .afterSubscription(() -> writePublisher1Subscription))).subscribe(readSubscriber);
@@ -274,13 +274,13 @@ class NettyPipelinedConnectionTest {
         // should be terminated, cancelled, or not subscribed.
 
         assertThat(readSubscriber2.awaitOnError(), is(instanceOf(ClosedChannelException.class)));
-        writePublisher1Subscription.awaitCancelledUninterruptibly();
+        writePublisher1Subscription.awaitCancelled();
         assertFalse(writePublisher2.isSubscribed());
         assertFalse(channel.isOpen());
     }
 
     @Test
-    void channelCloseErrorsPendingReadCancelsPendingWrite() {
+    void channelCloseErrorsPendingReadCancelsPendingWrite() throws Exception {
         TestSubscription writePublisher1Subscription = new TestSubscription();
         toSource(requester.write(writePublisher1
                 .afterSubscription(() -> writePublisher1Subscription))).subscribe(readSubscriber);
@@ -295,12 +295,12 @@ class NettyPipelinedConnectionTest {
 
         assertThat(readSubscriber.awaitOnError(), is(instanceOf(ClosedChannelException.class)));
         assertThat(readSubscriber2.awaitOnError(), is(instanceOf(ClosedChannelException.class)));
-        writePublisher1Subscription.awaitCancelledUninterruptibly();
+        writePublisher1Subscription.awaitCancelled();
         assertFalse(writePublisher2.isSubscribed());
     }
 
     @Test
-    void readCancelClosesConnectionThenWriteDoesNotSubscribe() {
+    void readCancelClosesConnectionThenWriteDoesNotSubscribe() throws Exception {
         TestSubscription writePublisher1Subscription = new TestSubscription();
         toSource(requester.write(writePublisher1
                 .afterSubscription(() -> writePublisher1Subscription))).subscribe(readSubscriber);
@@ -313,7 +313,7 @@ class NettyPipelinedConnectionTest {
         // readSubscriber was cancelled, so it may or may not terminate, but other sources that have not terminated
         // should be terminated, cancelled, or not subscribed.
 
-        writePublisher1Subscription.awaitCancelledUninterruptibly();
+        writePublisher1Subscription.awaitCancelled();
         assertFalse(channel.isOpen());
 
         toSource(requester.write(writePublisher2)).subscribe(readSubscriber2);


### PR DESCRIPTION
Motivation:

The current usage of `awaitCancelledUninterruptibly()` catches
`InterruptedException` and silently discards it. jUnit5 uses
thread interrupt to stop tests after the timeout expires. As a
result, these tests may hang forever as the `InterruptedException`
is not propagated.

Modifications:

- use `awaitCancelled()`, which throws `InterruptedException`
- Declare `InterruptedException` on method declaration.

Result:

The `InterruptedException` is propagated to the test methods,
which allows jUnit5 to stop a hanging test when the test's
timeout expires.

This is related to #1684. The plan for the future is to propagate
`InterruptedException` by changing the usage of the other methods 
described in the issue. This is my first contribution and I am not
100% sure if I understood the issue correctly, so please correct me
if my assumptions on the issue are wrong.