### PR TITLE
Correctly accept responses with `grpc-encoding: identity`

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -349,7 +349,7 @@ final class GrpcUtils {
                                             final List<T> supportedEncoders,
                                             final Function<T, CharSequence> messageEncodingFunc) {
         final CharSequence encoding = headers.get(GRPC_MESSAGE_ENCODING_KEY);
-        if (encoding == null) {
+        if (encoding == null || contentEqualsIgnoreCase(Identity.identityEncoder().encodingName(), encoding)) {
             return identityEncoder;
         }
         final T result = encodingForRaw(supportedEncoders, messageEncodingFunc, encoding);

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -673,7 +673,7 @@ class ProtocolCompatibilityTest {
 
     private static void testRequestResponse(final CompatClient client, final TestServerContext server,
                                             final boolean streaming,
-                                            @Nullable final String compression) {
+                                            @Nullable final String compression) throws Exception {
         try {
             final BufferEncoder compressor = serviceTalkCompression(compression);
             final GrpcClientMetadata metadata = compressor == null ? DefaultGrpcClientMetadata.INSTANCE :
@@ -716,8 +716,6 @@ class ProtocolCompatibilityTest {
                 assertEquals(1000004, response4List.get(1).getSize());
                 assertEquals(1000005, response4List.get(2).getSize());
             }
-        } catch (Exception ex) {
-            ex.printStackTrace();
         } finally {
             closeAll(client, server);
         }


### PR DESCRIPTION
Motivation:

Some gRPC servers may add `grpc-encoding: identity` in response headers.
ST gRPC client should consider it in the same way as not having this
header.

Modifications:

- Improve `GrpcUtils.readGrpcMessageEncodingRaw` to allow
`grpc-encoding: identity`;
- Avoid hiding exceptions for the failed tests;

Result:

gRPC client accepts requests with `grpc-encoding: identity` header.