### PR TITLE
Make sure `ConnectionInfo#toString()` format is consistent

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
@@ -115,5 +115,10 @@ final class DefaultGrpcServiceContext extends DefaultGrpcMetadata implements Grp
         public HttpProtocolVersion httpProtocol() {
             return httpProtocol;
         }
+
+        @Override
+        public String toString() {
+            return name() + "-over-" + httpProtocol();
+        }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
@@ -51,7 +51,7 @@ public class DelegatingHttpServiceContext extends HttpServiceContext {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "{delegate=" + delegate + "}";
+        return delegate.toString();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -146,7 +146,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
 
     @Override
     public final String toString() {
-        return getClass().getSimpleName() + '(' + channel() + ')';
+        return channel().toString();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -476,7 +476,7 @@ final class NettyHttpServer {
 
         @Override
         public String toString() {
-            return getClass().getSimpleName() + '(' + connection + ')';
+            return connection.toString();
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
@@ -187,7 +187,7 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + '(' + connection + ')';
+        return connection.toString();
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -124,6 +124,8 @@ abstract class AbstractNettyHttpServerTest {
     private StreamingHttpConnection httpConnection;
     private StreamingHttpService service;
     @Nullable
+    private StreamingHttpServiceFilterFactory nonOffloadingServiceFilterFactory;
+    @Nullable
     private StreamingHttpServiceFilterFactory serviceFilterFactory;
     @Nullable
     private ConnectionFactoryFilter<InetSocketAddress, FilterableStreamingHttpConnection> connectionFactoryFilter;
@@ -165,6 +167,9 @@ abstract class AbstractNettyHttpServerTest {
         if (sslEnabled) {
             serverBuilder.sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
                     DefaultTestCerts::loadServerKey).build());
+        }
+        if (nonOffloadingServiceFilterFactory != null) {
+            serverBuilder.appendNonOffloadingServiceFilter(nonOffloadingServiceFilterFactory);
         }
         if (serviceFilterFactory != null) {
             serverBuilder.appendServiceFilter(serviceFilterFactory);
@@ -211,6 +216,10 @@ abstract class AbstractNettyHttpServerTest {
 
     void service(final StreamingHttpService service) {
         this.service = service;
+    }
+
+    void nonOffloadingServiceFilterFactory(StreamingHttpServiceFilterFactory nonOffloadingServiceFilterFactory) {
+        this.nonOffloadingServiceFilterFactory = nonOffloadingServiceFilterFactory;
     }
 
     void serviceFilterFactory(StreamingHttpServiceFilterFactory serviceFilterFactory) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionInfoTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionInfoTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.startsWith;
+
+class ConnectionInfoTest extends AbstractNettyHttpServerTest {
+
+    @ParameterizedTest(name = "{index}: protocol={0}")
+    @EnumSource(HttpProtocol.class)
+    void verifyToStringFormat(HttpProtocol protocol) throws Exception {
+        CtxInterceptingServiceFilterFactory ff = new CtxInterceptingServiceFilterFactory();
+        nonOffloadingServiceFilterFactory(ff);
+        serviceFilterFactory(ff);
+        protocol(protocol.config);
+        setUp(CACHED, CACHED_SERVER);
+
+        StreamingHttpConnection connection = streamingHttpConnection();
+        assertFormat(connection.connectionContext().toString(), protocol, true);
+        StreamingHttpResponse response = makeRequest(connection.get(SVC_ECHO));
+        assertResponse(response, protocol.version, OK, 0);
+
+        assertFormat(ff.queue.take(), protocol, false);
+        assertFormat(ff.queue.take(), protocol, false);
+        assertThat(ff.queue, empty());
+    }
+
+    private static void assertFormat(String ctxStr, HttpProtocol protocol, boolean client) {
+        assertThat(ctxStr, startsWith("[id: 0x"));
+        assertThat(ctxStr, endsWith(client || protocol == HTTP_1 ? "]" : ")"));
+    }
+
+    private static final class CtxInterceptingServiceFilterFactory implements StreamingHttpServiceFilterFactory,
+                                                                              HttpExecutionStrategyInfluencer {
+
+        final BlockingQueue<String> queue = new LinkedBlockingDeque<>();
+
+        @Override
+        public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+            return new StreamingHttpServiceFilter(service) {
+                @Override
+                public Single<StreamingHttpResponse> handle(HttpServiceContext ctx,
+                                                            StreamingHttpRequest request,
+                                                            StreamingHttpResponseFactory responseFactory) {
+                    queue.add(ctx.toString());
+                    return delegate().handle(ctx, request, responseFactory);
+                }
+            };
+        }
+
+        @Override
+        public HttpExecutionStrategy influenceStrategy(final HttpExecutionStrategy strategy) {
+            return strategy;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

`ConnectionInfo` has different implementations and may be wrapped. We
want to make sure its `toString()` method is always consistent.

Modifications:

- Add test that verifies `ConnectionInfo#toString()` format;
- Adjust `ConnectionInfo` implementations to pass the test;
- Implement `DefaultGrpcProtocol#toString()`;

Result:

`ConnectionInfo#toString()` format is always consistent.