### PR TITLE
`NettyHttpServer`: log `DecoderException`s at `WARN` level

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -563,13 +563,19 @@ final class NettyHttpServer {
                     return;
                 }
                 if (t.getCause() instanceof DecoderException) {
-                    LOGGER.warn("Can not decode HTTP message, no more requests will be received on this connection.",
-                            t);
+                    decoderException(t.getCause());
                     return;
                 }
+            } else if (t instanceof DecoderException) {
+                decoderException(t);
+                return;
             }
             LOGGER.debug("Unexpected error received while processing connection, {}",
                     "no more requests will be received on this connection.", t);
+        }
+
+        private static void decoderException(final Throwable t) {
+            LOGGER.warn("Can not decode HTTP message, no more requests will be received on this connection.", t);
         }
     }
 }


### PR DESCRIPTION
Motivation:

Usually, `DecoderException` triggers connection closure and is wrapped
with `CloseEventObservedException`. But if the decoding error is
observed after the previous request is already parsed (some left-over
bytes after the request), it may be propagated without wrapping.

Modifications:

- Make sure `ErrorLoggingHttpSubscriber` logs wrapped and non-wrapped
`DecoderException`s;

Result:

Users don't miss `DecoderException` in logs.