### PR TITLE
Deprecate syncUninterruptibly() and awaitRequestNUninterruptibly() in tests

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSubscription.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSubscription.java
@@ -103,9 +103,11 @@ public final class TestSubscription extends TestCancellable implements Subscript
     /**
      * Wait until the {@link Subscription#request(long)} amount exceeds {@code amount} without being interrupted. This
      * method catches an {@link InterruptedException} and discards it silently.
+     * @deprecated use {@link #awaitRequestN(long)} instead.
      *
      * @param amount the amount to wait for.
      */
+    @Deprecated
     public void awaitRequestNUninterruptibly(long amount) {
         boolean interrupted = false;
         synchronized (waitingLock) {

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyChannelContentCodec.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyChannelContentCodec.java
@@ -280,7 +280,7 @@ final class NettyChannelContentCodec extends AbstractContentCodec {
 
     private static void preparePendingData(final EmbeddedChannel channel) {
         try {
-            channel.close().syncUninterruptibly().get();
+            channel.close().sync().get();
             channel.checkException();
         } catch (InterruptedException | ExecutionException ex) {
             throwException(ex);

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyCompressionSerializer.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyCompressionSerializer.java
@@ -117,7 +117,7 @@ final class NettyCompressionSerializer implements SerializerDeserializer<Buffer>
 
     static void preparePendingData(final EmbeddedChannel channel) {
         try {
-            channel.close().syncUninterruptibly().get();
+            channel.close().sync().get();
             channel.checkException();
         } catch (InterruptedException | ExecutionException ex) {
             throwException(ex);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
@@ -83,7 +83,7 @@ class H2ConcurrencyControllerTest {
     private final CountDownLatch[] latches = new CountDownLatch[N_ITERATIONS];
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         serverEventLoopGroup = createIoExecutor(1, "server-io").eventLoopGroup();
         for (int i = 0; i < N_ITERATIONS; i++) {
             latches[i] = new CountDownLatch(1);
@@ -149,9 +149,9 @@ class H2ConcurrencyControllerTest {
     }
 
     @AfterEach
-    void tearDown() {
-        safeSync(() -> serverAcceptorChannel.close().syncUninterruptibly());
-        safeSync(() -> serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).syncUninterruptibly());
+    void tearDown() throws Exception {
+        safeSync(() -> serverAcceptorChannel.close().sync());
+        safeSync(() -> serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).sync());
         safeClose(client);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -193,12 +193,12 @@ class H2PriorKnowledgeFeatureParityTest {
     @AfterEach
     void teardown() throws Exception {
         if (serverAcceptorChannel != null) {
-            serverAcceptorChannel.close().syncUninterruptibly();
+            serverAcceptorChannel.close().sync();
         }
         if (h1ServerContext != null) {
             h1ServerContext.close();
         }
-        serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).syncUninterruptibly();
+        serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).sync();
         Executor executor = clientExecutionStrategy.executor();
         if (executor != null) {
             executor.closeAsync().toFuture().get();
@@ -1322,7 +1322,7 @@ class H2PriorKnowledgeFeatureParityTest {
             serverChannelLatch.await();
             Channel serverParentChannel = serverParentChannelRef.get();
             serverParentChannel.writeAndFlush(new DefaultHttp2SettingsFrame(
-                    new Http2Settings().maxConcurrentStreams(expectedMaxConcurrent))).syncUninterruptibly();
+                    new Http2Settings().maxConcurrentStreams(expectedMaxConcurrent))).sync();
 
             Iterator<? extends ConsumableEvent<Integer>> maxItr = maxConcurrentPubQueue.take().toIterable().iterator();
             // Verify that the initial maxConcurrency value is the default number
@@ -1488,7 +1488,7 @@ class H2PriorKnowledgeFeatureParityTest {
 
     static Channel bindH2Server(EventLoopGroup serverEventLoopGroup, ChannelHandler childChannelHandler,
                                 Consumer<ChannelPipeline> parentChannelInitializer,
-                                UnaryOperator<Http2FrameCodecBuilder> configureH2Codec) {
+                                UnaryOperator<Http2FrameCodecBuilder> configureH2Codec) throws Exception {
         ServerBootstrap sb = new ServerBootstrap();
         sb.group(serverEventLoopGroup);
         sb.channel(serverChannel(serverEventLoopGroup, InetSocketAddress.class));
@@ -1500,7 +1500,7 @@ class H2PriorKnowledgeFeatureParityTest {
                 parentChannelInitializer.accept(ch.pipeline());
             }
         });
-        return sb.bind(localAddress(0)).syncUninterruptibly().channel();
+        return sb.bind(localAddress(0)).sync().channel();
     }
 
     private InetSocketAddress bindHttpEchoServer() throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
@@ -98,7 +98,7 @@ class MalformedDataAfterHttpMessageTest {
             assertThrows(DecoderException.class, () -> connection.request(connection.get("/")));
             connectionClosedLatch.await();
         } finally {
-            server.close().syncUninterruptibly();
+            server.close().sync();
         }
     }
 
@@ -126,7 +126,7 @@ class MalformedDataAfterHttpMessageTest {
         }
     }
 
-    private static ServerSocketChannel nettyServer(String response) {
+    private static ServerSocketChannel nettyServer(String response) throws Exception {
         EventLoopGroup eventLoopGroup = toEventLoopAwareNettyIoExecutor(SERVER_CTX.ioExecutor()).eventLoopGroup();
         ServerBootstrap bs = new ServerBootstrap();
         bs.group(eventLoopGroup);
@@ -147,7 +147,7 @@ class MalformedDataAfterHttpMessageTest {
                 });
             }
         });
-        return (ServerSocketChannel) bs.bind(localAddress(0)).syncUninterruptibly().channel();
+        return (ServerSocketChannel) bs.bind(localAddress(0)).sync().channel();
     }
 
     private static ServerContext stServer() throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
@@ -119,7 +119,7 @@ class NettyHttpServerConnectionTest {
         String payloadBodyString = "foo";
         TestSubscription testSubscription1 = new TestSubscription();
         responsePublisher.onSubscribe(testSubscription1);
-        testSubscription1.awaitRequestNUninterruptibly(1);
+        testSubscription1.awaitRequestN(1);
         responsePublisher.onNext(DEFAULT_ALLOCATOR.fromAscii(payloadBodyString));
         responsePublisher.onComplete();
         customFlushSender.flush();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
@@ -108,7 +108,7 @@ class PrematureClosureBeforeResponsePayloadBodyTest {
         bs.childOption(ALLOW_HALF_CLOSURE, true);
         bs.childOption(AUTO_CLOSE, false);
         server = (ServerSocketChannel) bs.bind(localAddress(0))
-            .syncUninterruptibly().channel();
+            .sync().channel();
 
         client = HttpClients.forSingleAddress(HostAndPort.of(server.localAddress()))
                 .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true)
@@ -125,7 +125,7 @@ class PrematureClosureBeforeResponsePayloadBodyTest {
         try {
             client.closeGracefully();
         } finally {
-            server.close().syncUninterruptibly();
+            server.close().sync();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -94,7 +94,7 @@ class ServerRespondsOnClosingTest {
             serverConnection.closeAsyncGracefully().toFuture().get();
         } finally {
             channel.finishAndReleaseAll();
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
         }
     }
 
@@ -244,9 +244,9 @@ class ServerRespondsOnClosingTest {
         assertThat("Unexpected response trailers object", trailers.readableBytes(), is(0));
     }
 
-    private void respondWithFIN() {
+    private void respondWithFIN() throws Exception {
         assertThat("Server did not shutdown output", channel.isOutputShutdown(), is(true));
-        channel.shutdownInput().syncUninterruptibly();    // simulate FIN from the client
+        channel.shutdownInput().sync();    // simulate FIN from the client
     }
 
     private void assertServerConnectionClosed() throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentEncodingCompatibilityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentEncodingCompatibilityTest.java
@@ -87,7 +87,7 @@ class ServiceTalkContentEncodingCompatibilityTest extends BaseContentEncodingTes
                     p.addLast(EchoServerHandler.INSTANCE);
                 }
             });
-            serverAcceptorChannel = sb.bind(localAddress(0)).syncUninterruptibly().channel();
+            serverAcceptorChannel = sb.bind(localAddress(0)).sync().channel();
 
             try (BlockingHttpClient client = HttpClients.forSingleAddress(
                     HostAndPort.of((InetSocketAddress) serverAcceptorChannel.localAddress()))
@@ -106,9 +106,9 @@ class ServiceTalkContentEncodingCompatibilityTest extends BaseContentEncodingTes
             }
         } finally {
             if (serverAcceptorChannel != null) {
-                serverAcceptorChannel.close().syncUninterruptibly();
+                serverAcceptorChannel.close().sync();
             }
-            serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).syncUninterruptibly();
+            serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).sync();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkToNettyContentCodingCompatibilityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkToNettyContentCodingCompatibilityTest.java
@@ -59,7 +59,7 @@ class ServiceTalkToNettyContentCodingCompatibilityTest extends ServiceTalkConten
     private BlockingHttpClient client;
 
     @Override
-    void start() {
+    void start() throws Exception {
         serverEventLoopGroup = createIoExecutor(2, "server-io").eventLoopGroup();
         serverAcceptorChannel = newNettyServer();
         InetSocketAddress serverAddress = (InetSocketAddress) serverAcceptorChannel.localAddress();
@@ -70,17 +70,17 @@ class ServiceTalkToNettyContentCodingCompatibilityTest extends ServiceTalkConten
     @AfterEach
     void finish() throws Exception {
         if (serverAcceptorChannel != null) {
-            serverAcceptorChannel.close().syncUninterruptibly();
+            serverAcceptorChannel.close().sync();
         }
         if (serverEventLoopGroup != null) {
-            serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).syncUninterruptibly();
+            serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).sync();
         }
         if (client != null) {
             client.close();
         }
     }
 
-    private Channel newNettyServer() {
+    private Channel newNettyServer() throws Exception {
         ServerBootstrap sb = new ServerBootstrap();
         sb.group(serverEventLoopGroup);
         sb.channel(serverChannel(serverEventLoopGroup, InetSocketAddress.class));
@@ -97,7 +97,7 @@ class ServiceTalkToNettyContentCodingCompatibilityTest extends ServiceTalkConten
                 p.addLast(EchoServerHandler.INSTANCE);
             }
         });
-        return sb.bind(localAddress(0)).syncUninterruptibly().channel();
+        return sb.bind(localAddress(0)).sync().channel();
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -133,6 +133,7 @@ class StreamObserverTest {
         try {
             callable.call();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw e;
         } catch (Exception e) {
             e.printStackTrace();

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -112,7 +112,7 @@ final class TcpClient {
      */
     public NettyConnection<Buffer, Buffer> connectWithFdBlocking(ExecutionContext executionContext,
                                                                  SocketAddress address)
-            throws ExecutionException, InterruptedException {
+            throws Exception {
         assumeTrue(executionContext.ioExecutor().isFileDescriptorSocketAddressSupported());
         assumeTrue(Epoll.isAvailable() || KQueue.isAvailable());
 
@@ -137,10 +137,10 @@ final class TcpClient {
                     }
                 })
                 .connect(address)
-                .syncUninterruptibly().channel();
+                .sync().channel();
 
         // Unregister it from the netty EventLoop as we want to to handle it via ST.
-        channel.deregister().syncUninterruptibly();
+        channel.deregister().sync();
         FileDescriptorSocketAddress fd = new FileDescriptorSocketAddress(channel.fd().intValue());
         NettyConnection<Buffer, Buffer> connection = connectBlocking(executionContext, fd);
         assertThat("Data read on the FileDescriptor from netty pipeline.",

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -95,7 +95,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
                 conn.closeAsync().toFuture().get();
             } finally {
                 channel.finishAndReleaseAll();
-                channel.close().syncUninterruptibly();
+                channel.close().sync();
             }
         }
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -328,8 +328,8 @@ class DefaultNettyConnectionTest {
     }
 
     @Test
-    void testNoErrorEnrichmentWithoutCloseHandlerOnError() {
-        channel.close().syncUninterruptibly();
+    void testNoErrorEnrichmentWithoutCloseHandlerOnError() throws Exception {
+        channel.close().sync();
         toSource(conn.write(publisher)).subscribe(writeListener);
 
         Throwable error = writeListener.awaitOnError();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
@@ -518,7 +518,7 @@ class RequestResponseCloseHandlerTest {
     class RequestResponseUserEventTest {
 
         @Test
-        void clientOutboundDataEndEventEmitsUserEventAlways() {
+        void clientOutboundDataEndEventEmitsUserEventAlways() throws Exception {
             AtomicBoolean ab = new AtomicBoolean(false);
             final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
                 @Override
@@ -532,12 +532,12 @@ class RequestResponseCloseHandlerTest {
             final RequestResponseCloseHandler ch = new RequestResponseCloseHandler(true);
             channel.eventLoop().execute(() -> ch.protocolPayloadEndOutbound(channel.pipeline().firstContext(),
                     channel.newPromise()));
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
             assertThat("OutboundDataEndEvent not fired", ab.get(), is(true));
         }
 
         @Test
-        void serverOutboundDataEndEventDoesntEmitUntilClosing() {
+        void serverOutboundDataEndEventDoesntEmitUntilClosing() throws Exception {
             AtomicBoolean ab = new AtomicBoolean(false);
             final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
                 @Override
@@ -551,7 +551,7 @@ class RequestResponseCloseHandlerTest {
             final RequestResponseCloseHandler ch = new RequestResponseCloseHandler(false);
             channel.eventLoop().execute(() ->
                     ch.protocolPayloadEndOutbound(channel.pipeline().firstContext(), channel.newPromise()));
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
             assertThat("OutboundDataEndEvent should not fire", ab.get(), is(false));
         }
 
@@ -584,12 +584,12 @@ class RequestResponseCloseHandlerTest {
             // Response #2
             channel.eventLoop().execute(() -> ch.protocolPayloadBeginOutbound(ctx));
             channel.eventLoop().execute(() -> ch.protocolPayloadEndOutbound(ctx, ctx.newPromise()));
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
             assertThat("OutboundDataEndEvent not fired", ab.get(), is(true));
         }
 
         @Test
-        void serverOutboundDataEndEventEmitsUserEventWhenClosing() {
+        void serverOutboundDataEndEventEmitsUserEventWhenClosing() throws Exception {
             AtomicBoolean ab = new AtomicBoolean(false);
             final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
                 @Override
@@ -604,7 +604,7 @@ class RequestResponseCloseHandlerTest {
             channel.eventLoop().execute(() -> ch.gracefulUserClosing(channel));
             channel.eventLoop().execute(() ->
                     ch.protocolPayloadEndOutbound(channel.pipeline().firstContext(), channel.newPromise()));
-            channel.close().syncUninterruptibly();
+            channel.close().sync();
             assertThat("OutboundDataEndEvent not fired", ab.get(), is(true));
         }
     }
@@ -634,21 +634,21 @@ class RequestResponseCloseHandlerTest {
 
         @BeforeEach
         @SuppressWarnings("unchecked")
-        public void setup() throws InterruptedException {
+        public void setup() throws Exception {
             ssChannel = startServer();
             cChannel = connectClient(ssChannel.localAddress());
             connectedLatch.await();
         }
 
         @AfterEach
-        public void dispose() {
-            cChannel.close().syncUninterruptibly();
-            sChannel.close().syncUninterruptibly();
-            ssChannel.close().syncUninterruptibly();
+        public void dispose() throws Exception {
+            cChannel.close().sync();
+            sChannel.close().sync();
+            ssChannel.close().sync();
         }
 
         // Based on TcpServerInitializer
-        private ServerSocketChannel startServer() {
+        private ServerSocketChannel startServer() throws Exception {
             EventLoopAwareNettyIoExecutor eventLoopAwareNettyIoExecutor =
                     toEventLoopAwareNettyIoExecutor(serverCtx.ioExecutor());
             EventLoop loop = eventLoopAwareNettyIoExecutor.eventLoopGroup().next();
@@ -683,11 +683,11 @@ class RequestResponseCloseHandlerTest {
             bs.childOption(AUTO_CLOSE, false);
 
             return (ServerSocketChannel) bs.bind(localAddress(0))
-                    .syncUninterruptibly().channel();
+                    .sync().channel();
         }
 
         // Based on TcpConnector
-        private SocketChannel connectClient(InetSocketAddress address) {
+        private SocketChannel connectClient(InetSocketAddress address) throws Exception {
             EventLoopAwareNettyIoExecutor eventLoopAwareNettyIoExecutor =
                     toEventLoopAwareNettyIoExecutor(clientCtx.ioExecutor());
             EventLoop loop = eventLoopAwareNettyIoExecutor.eventLoopGroup().next();
@@ -719,12 +719,12 @@ class RequestResponseCloseHandlerTest {
             bs.option(ALLOW_HALF_CLOSURE, true);
             bs.option(AUTO_CLOSE, false);
 
-            return (SocketChannel) bs.connect(address).syncUninterruptibly().channel();
+            return (SocketChannel) bs.connect(address).sync().channel();
         }
 
         @Test
-        void clientCloseEmitsNoShutdownEventsOnClient() {
-            cChannel.close().syncUninterruptibly();
+        void clientCloseEmitsNoShutdownEventsOnClient() throws Exception {
+            cChannel.close().sync();
             assertThat(clientOutputShutdownLatch.getCount(), equalTo(1L));
             assertThat(clientInputShutdownLatch.getCount(), equalTo(1L));
             assertThat(clientInputShutdownReadCompleteLatch.getCount(), equalTo(1L));
@@ -735,7 +735,7 @@ class RequestResponseCloseHandlerTest {
 
         @Test
         void clientCloseEmitsServerInputShutdownImmediatelyAndOutputAfterWriting() throws Exception {
-            cChannel.close().syncUninterruptibly();
+            cChannel.close().sync();
             serverInputShutdownReadCompleteLatch.await();
             serverInputShutdownLatch.await();
             assertThat(sChannel.isInputShutdown(), is(true));
@@ -749,7 +749,7 @@ class RequestResponseCloseHandlerTest {
 
         @Test
         void clientShutdownOutputEmitsClientOutputShutdownAndServerInputShutdown() throws Exception {
-            cChannel.shutdownOutput().syncUninterruptibly();
+            cChannel.shutdownOutput().sync();
             clientOutputShutdownLatch.await();
             serverInputShutdownReadCompleteLatch.await();
             serverInputShutdownLatch.await();
@@ -764,7 +764,7 @@ class RequestResponseCloseHandlerTest {
         @Test
         void serverShutdownInputEmitsServerInputShutdownReadCompleteOnly() throws Exception {
             assumeFalse(sChannel instanceof NioSocketChannel, "Windows doesn't emit ChannelInputShutdownReadComplete. Investigation Required.");
-            sChannel.shutdownInput().syncUninterruptibly();
+            sChannel.shutdownInput().sync();
             serverInputShutdownReadCompleteLatch.await();
             assertThat(serverInputShutdownLatch.getCount(), is(1L));
             assertThat(sChannel.isInputShutdown(), is(true));
@@ -776,8 +776,8 @@ class RequestResponseCloseHandlerTest {
         }
 
         @Test
-        void serverCloseEmitsNoShutdownEventsOnServer() {
-            sChannel.close().syncUninterruptibly();
+        void serverCloseEmitsNoShutdownEventsOnServer() throws Exception {
+            sChannel.close().sync();
             assertThat(serverOutputShutdownLatch.getCount(), equalTo(1L));
             assertThat(serverInputShutdownLatch.getCount(), equalTo(1L));
             assertThat(serverInputShutdownReadCompleteLatch.getCount(), equalTo(1L));
@@ -788,7 +788,7 @@ class RequestResponseCloseHandlerTest {
 
         @Test
         void serverCloseEmitsClientInputShutdownImmediatelyAndOutputAfterWriting() throws Exception {
-            sChannel.close().syncUninterruptibly();
+            sChannel.close().sync();
             clientInputShutdownReadCompleteLatch.await();
             clientInputShutdownLatch.await();
             assertThat(cChannel.isInputShutdown(), is(true));
@@ -800,12 +800,12 @@ class RequestResponseCloseHandlerTest {
             assertThat(cChannel.isOpen(), is(true));
         }
 
-        private void writeUntilFailure(Channel channel) throws InterruptedException {
-            channel.writeAndFlush(channel.alloc().buffer(1).writeZero(1)).syncUninterruptibly(); // triggers RST
+        private void writeUntilFailure(Channel channel) throws Exception {
+            channel.writeAndFlush(channel.alloc().buffer(1).writeZero(1)).sync(); // triggers RST
             for (;;) {
                 try {
                     // observes error
-                    channel.writeAndFlush(channel.alloc().buffer(1).writeZero(1)).syncUninterruptibly();
+                    channel.writeAndFlush(channel.alloc().buffer(1).writeZero(1)).sync();
                 } catch (Exception ignored) {
                     break;
                 }


### PR DESCRIPTION
Motivation:
Currently netty's syncUninterruptibly() and
awaitRequestNUninterruptibly() do not
propogate `InterruptedException`, meaning that jUnit5 is not
able to stop timeouted tests.

Modifications:
- change the uses of `syncUninterruptibly()` to `sync()`
- on `safeSync()` use `Callable` instead of `Runnable`, because
`Runnable` is unable to throw exception;
- Change all usages of `awaitRequestNUninterruptibly()`
to `awaitRequestN()`;
- add `@Deprecated` to `awaitRequestNUninterruptibly()`;

Result:
`InterruptedException` is no longer silently discarded,
meaning jUnit5 will be able to abort the timeouted test.

Related to #1684.

Questions from my side:
1. Why the N in awaitRequestN()?
2. Doesn’t safeClose() in HttpsProxyTest also not 
Propagate the InterruptedException, which might 
result in timeouts as well?
3. I couldn't figure out what the function of 
safeSync(), so I changed it to use Callable,
could someone explain what it does in 
a bit more in depth?