### PR TITLE
Allow users enable validation for header values

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
@@ -20,21 +20,53 @@ package io.servicetalk.http.api;
  */
 public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
 
-    public static final HttpHeadersFactory INSTANCE = new DefaultHttpHeadersFactory(true, true);
+    private static final boolean DEFAULT_VALIDATE_VALUES = false;
+    public static final HttpHeadersFactory INSTANCE = new DefaultHttpHeadersFactory(true, true,
+            DEFAULT_VALIDATE_VALUES);
 
     private final boolean validateNames;
     private final boolean validateCookies;
+    private final boolean validateValues;
     private final int headersArraySizeHint;
     private final int trailersArraySizeHint;
 
     /**
      * Create an instance of the factory with the default array size hint.
      *
+     * @deprecated Use {@link #DefaultHttpHeadersFactory(boolean, boolean, boolean)}.
      * @param validateNames {@code true} to validate header/trailer names.
      * @param validateCookies {@code true} to validate cookie contents when parsing.
      */
+    @Deprecated
     public DefaultHttpHeadersFactory(final boolean validateNames, final boolean validateCookies) {
-        this(validateNames, validateCookies, 16, 4);
+        this(validateNames, validateCookies, DEFAULT_VALIDATE_VALUES);
+    }
+
+    /**
+     * Create an instance of the factory with the default array size hint.
+     *
+     * @param validateNames {@code true} to validate header/trailer names.
+     * @param validateCookies {@code true} to validate cookie contents when parsing.
+     * @param validateValues {@code true} to validate header/trailer values.
+     */
+    public DefaultHttpHeadersFactory(final boolean validateNames, final boolean validateCookies,
+                                     final boolean validateValues) {
+        this(validateNames, validateCookies, validateValues, 16, 4);
+    }
+
+    /**
+     * Create an instance of the factory.
+     *
+     * @deprecated Use {@link #DefaultHttpHeadersFactory(boolean, boolean, boolean, int, int)}.
+     * @param validateNames {@code true} to validate header/trailer names.
+     * @param validateCookies {@code true} to validate cookie contents when parsing.
+     * @param headersArraySizeHint A hint as to how large the hash data structure should be for the headers.
+     * @param trailersArraySizeHint A hint as to how large the hash data structure should be for the trailers.
+     */
+    @Deprecated
+    public DefaultHttpHeadersFactory(final boolean validateNames, final boolean validateCookies,
+                                     final int headersArraySizeHint, final int trailersArraySizeHint) {
+        this(validateNames, validateCookies, DEFAULT_VALIDATE_VALUES, headersArraySizeHint, trailersArraySizeHint);
     }
 
     /**
@@ -42,34 +74,42 @@ public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
      *
      * @param validateNames {@code true} to validate header/trailer names.
      * @param validateCookies {@code true} to validate cookie contents when parsing.
+     * @param validateValues {@code true} to validate header/trailer values.
      * @param headersArraySizeHint A hint as to how large the hash data structure should be for the headers.
      * @param trailersArraySizeHint A hint as to how large the hash data structure should be for the trailers.
      */
     public DefaultHttpHeadersFactory(final boolean validateNames, final boolean validateCookies,
+                                     final boolean validateValues,
                                      final int headersArraySizeHint, final int trailersArraySizeHint) {
         this.validateNames = validateNames;
         this.validateCookies = validateCookies;
+        this.validateValues = validateValues;
         this.headersArraySizeHint = headersArraySizeHint;
         this.trailersArraySizeHint = trailersArraySizeHint;
     }
 
     @Override
     public HttpHeaders newHeaders() {
-        return new DefaultHttpHeaders(headersArraySizeHint, validateNames, validateCookies);
+        return new DefaultHttpHeaders(headersArraySizeHint, validateNames, validateCookies, validateValues);
     }
 
     @Override
     public HttpHeaders newTrailers() {
-        return new DefaultHttpHeaders(trailersArraySizeHint, validateNames, validateCookies);
+        return new DefaultHttpHeaders(trailersArraySizeHint, validateNames, validateCookies, validateValues);
     }
 
     @Override
     public HttpHeaders newEmptyTrailers() {
-        return new DefaultHttpHeaders(0, validateNames, validateCookies);
+        return new DefaultHttpHeaders(0, validateNames, validateCookies, validateValues);
     }
 
     @Override
     public boolean validateCookies() {
         return validateCookies;
+    }
+
+    @Override
+    public boolean validateValues() {
+        return validateValues;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -44,7 +44,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
     private static final String ENCODED_LABEL_SAMESITE = "; samesite=";
 
     /**
-     * An underlying size of 16 has been shown with the current {@link CharSequences#newAsciiString(String)} hash
+     * An underlying size of 16 has been shown with the current {@link CharSequences#newAsciiString(CharSequence)} hash
      * algorithm to have no collisions with the current set of supported cookie names.
      * If more cookie names are supported, or the hash algorithm changes this initial value should be re-evaluated.
      * <p>
@@ -52,7 +52,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
      * if/else block we lean on {@link HttpHeaders} which provides an associative array that compares keys in a case
      * case-insensitive manner.
      */
-    private static final HttpHeaders AV_FIELD_NAMES = new DefaultHttpHeaders(16, false, false);
+    private static final HttpHeaders AV_FIELD_NAMES = new DefaultHttpHeaders(16, false, false, false);
 
     static {
         AV_FIELD_NAMES.add(newAsciiString("path"), new ParseStateCharSequence(ParseState.ParsingPath));

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.buffer.api.ByteProcessor;
 import io.servicetalk.encoding.api.ContentCodec;
 import io.servicetalk.encoding.api.Identity;
 import io.servicetalk.serialization.api.SerializationException;
@@ -84,10 +83,10 @@ public final class HeaderUtils {
                 }
                 return "<filtered>";
             };
-    private static final ByteProcessor TOKEN_VALIDATOR = value -> {
-        validateToken(value);
-        return true;
-    };
+    // ASCII symbols:
+    private static final byte HT = 9;
+    private static final byte DEL = 127;
+    private static final byte CONTROL_CHARS_MASK = (byte) 0xE0;
 
     private static final Pattern HAS_CHARSET_PATTERN = compile(".+;\\s*charset=.+", CASE_INSENSITIVE);
     private static final Map<Charset, Pattern> CHARSET_PATTERNS;
@@ -269,7 +268,11 @@ public final class HeaderUtils {
      * @param key the cookie name or header name to validate.
      */
     static void validateCookieTokenAndHeaderName(final CharSequence key) {
-        forEachByte(key, TOKEN_VALIDATOR);
+        forEachByte(key, HeaderUtils::validateToken);
+    }
+
+    static void validateHeaderValue(final CharSequence value) {
+        forEachByte(value, HeaderUtils::validateHeaderValue);
     }
 
     /**
@@ -770,11 +773,11 @@ public final class HeaderUtils {
     }
 
     /**
-     * Validate char is valid <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> character.
+     * Validate char is a valid <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> character.
      *
      * @param value the character to validate.
      */
-    private static void validateToken(final byte value) {
+    private static boolean validateToken(final byte value) {
         // HEADER
         // header-field   = field-name ":" OWS field-value OWS
         //
@@ -805,10 +808,37 @@ public final class HeaderUtils {
             throw new IllegalCharacterException(value,
                     "! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA");
         }
+        return true;
     }
 
     // visible for testing
     static boolean isTchar(final byte value) {
         return isBitSet(value, TCHAR_LMASK, TCHAR_HMASK);
+    }
+
+    /**
+     * Validate char is a valid <a href="https://tools.ietf.org/html/rfc7230#section-3.2">field-value</a> character.
+     *
+     * @param value the character to validate.
+     */
+    private static boolean validateHeaderValue(final byte value) {
+        // HEADER
+        // header-field   = field-name ":" OWS field-value OWS
+        //
+        // field-value    = *( field-content / obs-fold )
+        // field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+        // field-vchar    = VCHAR / obs-text
+        //
+        // obs-fold       = CRLF 1*( SP / HTAB )
+        //                ; obsolete line folding
+        //                ; see Section 3.2.4
+        //
+        // Note: we do not support obs-fold.
+        // Illegal chars are control chars (0-31) except HT (9), and DEL (127):
+        if (((value & CONTROL_CHARS_MASK) != 0 && value != HT) || value == DEL) {
+            throw new IllegalCharacterException(value,
+                    "(VCHAR / obs-text) [ 1*(SP / HTAB) (VCHAR / obs-text) ]");
+        }
+        return true;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -835,7 +835,7 @@ public final class HeaderUtils {
         //
         // Note: we do not support obs-fold.
         // Illegal chars are control chars (0-31) except HT (9), and DEL (127):
-        if (((value & CONTROL_CHARS_MASK) != 0 && value != HT) || value == DEL) {
+        if (((value & CONTROL_CHARS_MASK) == 0 && value != HT) || value == DEL) {
             throw new IllegalCharacterException(value,
                     "(VCHAR / obs-text) [ 1*(SP / HTAB) (VCHAR / obs-text) ]");
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeadersFactory.java
@@ -48,9 +48,16 @@ public interface HttpHeadersFactory {
     }
 
     /**
-     * Determine if a cookies should be validated during parsing into {@link HttpSetCookie}s.
+     * Determine if cookies should be validated during parsing into {@link HttpSetCookie}s.
      *
      * @return {@code true} if a cookies should be validated during parsing into {@link HttpSetCookie}s.
      */
     boolean validateCookies();
+
+    /**
+     * Determine if header values should be validated during parsing into {@link HttpHeaders}s.
+     *
+     * @return {@code true} if header values should be validated during parsing into {@link HttpHeaders}s.
+     */
+    boolean validateValues();
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpHeadersTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpHeadersTest.java
@@ -23,6 +23,6 @@ public class DefaultHttpHeadersTest extends AbstractHttpHeadersTest {
 
     @Override
     protected HttpHeaders newHeaders(final int initialSizeHint) {
-        return new DefaultHttpHeaders(initialSizeHint, true, true);
+        return new DefaultHttpHeaders(initialSizeHint, true, true, true);
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookiesTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookiesTest.java
@@ -739,7 +739,7 @@ class DefaultHttpSetCookiesTest {
 
     @Test
     void invalidCookieNameNoThrowIfNoValidate() {
-        final HttpHeaders headers = new DefaultHttpHeadersFactory(false, false).newHeaders();
+        final HttpHeaders headers = new DefaultHttpHeadersFactory(false, false, false).newHeaders();
         headers.add("set-cookie", "q@werty=12345");
         headers.getSetCookie("q@werty");
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StreamingHttpPayloadHolderTest.java
@@ -101,7 +101,7 @@ class StreamingHttpPayloadHolderTest {
         this.updateMode = updateMode;
         this.doubleTransform = doubleTransform;
         headers = mock(HttpHeaders.class);
-        headersFactory = new DefaultHttpHeadersFactory(false, false);
+        headersFactory = new DefaultHttpHeadersFactory(false, false, false);
         if (sourceType == SourceType.Trailers) {
             when(headers.valuesIterator(TRANSFER_ENCODING)).then(__ -> singletonList(CHUNKED).iterator());
         } else {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
@@ -27,23 +27,54 @@ import java.util.function.BiPredicate;
  */
 public final class H2HeadersFactory implements HttpHeadersFactory {
 
-    public static final HttpHeadersFactory INSTANCE = new H2HeadersFactory(true, true);
+    private static final boolean DEFAULT_VALIDATE_VALUES = false;
+    public static final HttpHeadersFactory INSTANCE = new H2HeadersFactory(true, true, DEFAULT_VALIDATE_VALUES);
 
     static final BiPredicate<CharSequence, CharSequence> DEFAULT_SENSITIVITY_DETECTOR = (name, value) -> false;
 
     private final boolean validateNames;
     private final boolean validateCookies;
+    private final boolean validateValues;
     private final int headersArraySizeHint;
     private final int trailersArraySizeHint;
 
     /**
      * Create an instance of the factory with the default array size hint.
      *
+     * @deprecated Use {@link #H2HeadersFactory(boolean, boolean, boolean)}.
      * @param validateNames {@code true} to validate header/trailer names.
      * @param validateCookies {@code true} to validate cookie contents when parsing.
      */
+    @Deprecated
     public H2HeadersFactory(final boolean validateNames, final boolean validateCookies) {
-        this(validateNames, validateCookies, 16, 4);
+        this(validateNames, validateCookies, DEFAULT_VALIDATE_VALUES);
+    }
+
+    /**
+     * Create an instance of the factory with the default array size hint.
+     *
+     * @param validateNames {@code true} to validate header/trailer names.
+     * @param validateCookies {@code true} to validate cookie contents when parsing.
+     * @param validateValues {@code true} to validate header values.
+     */
+    public H2HeadersFactory(final boolean validateNames, final boolean validateCookies,
+                            final boolean validateValues) {
+        this(validateNames, validateCookies, validateValues, 16, 4);
+    }
+
+    /**
+     * Create an instance of the factory.
+     *
+     * @deprecated Use {@link #H2HeadersFactory(boolean, boolean, boolean, int, int)}.
+     * @param validateNames {@code true} to validate header/trailer names.
+     * @param validateCookies {@code true} to validate cookie contents when parsing.
+     * @param headersArraySizeHint A hint as to how large the hash data structure should be for the headers.
+     * @param trailersArraySizeHint A hint as to how large the hash data structure should be for the trailers.
+     */
+    @Deprecated
+    public H2HeadersFactory(final boolean validateNames, final boolean validateCookies,
+                            final int headersArraySizeHint, final int trailersArraySizeHint) {
+        this(validateNames, validateCookies, DEFAULT_VALIDATE_VALUES, headersArraySizeHint, trailersArraySizeHint);
     }
 
     /**
@@ -51,13 +82,16 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
      *
      * @param validateNames {@code true} to validate header/trailer names.
      * @param validateCookies {@code true} to validate cookie contents when parsing.
+     * @param validateValues {@code true} to validate header values.
      * @param headersArraySizeHint A hint as to how large the hash data structure should be for the headers.
      * @param trailersArraySizeHint A hint as to how large the hash data structure should be for the trailers.
      */
     public H2HeadersFactory(final boolean validateNames, final boolean validateCookies,
+                            final boolean validateValues,
                             final int headersArraySizeHint, final int trailersArraySizeHint) {
         this.validateNames = validateNames;
         this.validateCookies = validateCookies;
+        this.validateValues = validateValues;
         this.headersArraySizeHint = headersArraySizeHint;
         this.trailersArraySizeHint = trailersArraySizeHint;
     }
@@ -65,22 +99,28 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
     @Override
     public HttpHeaders newHeaders() {
         return new NettyH2HeadersToHttpHeaders(new DefaultHttp2Headers(validateNames, headersArraySizeHint),
-                validateCookies);
+                validateCookies, validateValues);
     }
 
     @Override
     public HttpHeaders newTrailers() {
         return new NettyH2HeadersToHttpHeaders(new DefaultHttp2Headers(validateNames, trailersArraySizeHint),
-                validateCookies);
+                validateCookies, validateValues);
     }
 
     @Override
     public HttpHeaders newEmptyTrailers() {
-        return new NettyH2HeadersToHttpHeaders(new DefaultHttp2Headers(validateNames, 0), validateCookies);
+        return new NettyH2HeadersToHttpHeaders(new DefaultHttp2Headers(validateNames, 0),
+                validateCookies, validateValues);
     }
 
     @Override
     public boolean validateCookies() {
         return validateCookies;
+    }
+
+    @Override
+    public boolean validateValues() {
+        return validateValues;
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -179,6 +179,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                         " request");
             }
         }
-        return new NettyH2HeadersToHttpHeaders(h2Headers, headersFactory.validateCookies());
+        return new NettyH2HeadersToHttpHeaders(h2Headers, headersFactory.validateCookies(),
+                headersFactory.validateValues());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -148,11 +148,13 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                         ") header is not expected for " + httpMethod.name() + " request");
             }
         }
-        return new NettyH2HeadersToHttpHeaders(h2Headers, headersFactory.validateCookies());
+        return new NettyH2HeadersToHttpHeaders(h2Headers, headersFactory.validateCookies(),
+                headersFactory.validateValues());
     }
 
     private NettyH2HeadersToHttpHeaders h2TrailersToH1TrailersServer(Http2Headers h2Headers) {
-        return new NettyH2HeadersToHttpHeaders(h2Headers, headersFactory.validateCookies());
+        return new NettyH2HeadersToHttpHeaders(h2Headers, headersFactory.validateCookies(),
+                headersFactory.validateValues());
     }
 
     private static HttpRequestMethod sequenceToHttpRequestMethod(CharSequence sequence) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyH2HeadersToHttpHeaders.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyH2HeadersToHttpHeaders.java
@@ -543,7 +543,7 @@ final class NettyH2HeadersToHttpHeaders implements HttpHeaders {
         //
         // Note: we do not support obs-fold.
         // Illegal chars are control chars (0-31) except HT (9), and DEL (127):
-        if (((value & CONTROL_CHARS_MASK) != 0 && value != HT) || value == DEL) {
+        if (((value & CONTROL_CHARS_MASK) == 0 && value != HT) || value == DEL) {
             throw new IllegalCharacterException(value,
                     "(VCHAR / obs-text) [ 1*(SP / HTAB) (VCHAR / obs-text) ]");
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyH2HeadersToHttpHeaders.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyH2HeadersToHttpHeaders.java
@@ -19,6 +19,7 @@ import io.servicetalk.http.api.HeaderUtils;
 import io.servicetalk.http.api.HttpCookiePair;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpSetCookie;
+import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http2.Http2Headers;
@@ -33,6 +34,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.CharSequences.contentEquals;
 import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
+import static io.servicetalk.buffer.api.CharSequences.forEachByte;
 import static io.servicetalk.http.api.DefaultHttpSetCookie.parseSetCookie;
 import static io.servicetalk.http.api.HeaderUtils.DEFAULT_HEADER_FILTER;
 import static io.servicetalk.http.api.HeaderUtils.domainMatches;
@@ -45,12 +47,21 @@ import static io.servicetalk.http.api.HttpHeaderNames.SET_COOKIE;
 import static java.util.Collections.emptyIterator;
 
 final class NettyH2HeadersToHttpHeaders implements HttpHeaders {
-    private final boolean validateCookies;
-    private final Http2Headers nettyHeaders;
 
-    NettyH2HeadersToHttpHeaders(final Http2Headers nettyHeaders, final boolean validateCookies) {
+    // ASCII symbols:
+    private static final byte HT = 9;
+    private static final byte DEL = 127;
+    private static final byte CONTROL_CHARS_MASK = (byte) 0xE0;
+
+    private final Http2Headers nettyHeaders;
+    private final boolean validateCookies;
+    private final boolean validateValues;
+
+    NettyH2HeadersToHttpHeaders(final Http2Headers nettyHeaders, final boolean validateCookies,
+                                final boolean validateValues) {
         this.nettyHeaders = nettyHeaders;
         this.validateCookies = validateCookies;
+        this.validateValues = validateValues;
     }
 
     Http2Headers nettyHeaders() {
@@ -101,45 +112,45 @@ final class NettyH2HeadersToHttpHeaders implements HttpHeaders {
 
     @Override
     public HttpHeaders add(final CharSequence name, final CharSequence value) {
-        nettyHeaders.add(name, value);
+        nettyHeaders.add(name, validateHeaderValue(value));
         return this;
     }
 
     @Override
     public HttpHeaders add(final CharSequence name, final Iterable<? extends CharSequence> values) {
-        nettyHeaders.add(name, values);
+        nettyHeaders.add(name, validateHeaderValue(values));
         return this;
     }
 
     @Override
     public HttpHeaders add(final CharSequence name, final CharSequence... values) {
-        nettyHeaders.add(name, values);
+        nettyHeaders.add(name, validateHeaderValue(values));
         return this;
     }
 
     @Override
     public HttpHeaders add(final HttpHeaders headers) {
         for (Entry<CharSequence, CharSequence> entry : headers) {
-            nettyHeaders.add(entry.getKey(), entry.getValue());
+            nettyHeaders.add(entry.getKey(), validateHeaderValue(entry.getValue()));
         }
         return this;
     }
 
     @Override
     public HttpHeaders set(final CharSequence name, final CharSequence value) {
-        nettyHeaders.set(name, value);
+        nettyHeaders.set(name, validateHeaderValue(value));
         return this;
     }
 
     @Override
     public HttpHeaders set(final CharSequence name, final Iterable<? extends CharSequence> values) {
-        nettyHeaders.set(name, values);
+        nettyHeaders.set(name, validateHeaderValue(values));
         return this;
     }
 
     @Override
     public HttpHeaders set(final CharSequence name, final CharSequence... values) {
-        nettyHeaders.set(name, values);
+        nettyHeaders.set(name, validateHeaderValue(values));
         return this;
     }
 
@@ -327,6 +338,7 @@ final class NettyH2HeadersToHttpHeaders implements HttpHeaders {
         return sizeBefore != size();
     }
 
+    @SuppressWarnings("ClassNameSameAsAncestorName")
     private static final class CookiesIterator extends HeaderUtils.CookiesIterator {
         private final Iterator<CharSequence> valueItr;
         @Nullable
@@ -352,6 +364,7 @@ final class NettyH2HeadersToHttpHeaders implements HttpHeaders {
         }
     }
 
+    @SuppressWarnings("ClassNameSameAsAncestorName")
     private static final class CookiesByNameIterator extends HeaderUtils.CookiesByNameIterator {
         private final Iterator<CharSequence> valueItr;
         @Nullable
@@ -484,5 +497,56 @@ final class NettyH2HeadersToHttpHeaders implements HttpHeaders {
         public void remove() {
             valueItr.remove();
         }
+    }
+
+    private CharSequence validateHeaderValue(final CharSequence value) {
+        if (validateValues) {
+            forEachByte(value, NettyH2HeadersToHttpHeaders::validateHeaderValue);
+        }
+        return value;
+    }
+
+    private Iterable<? extends CharSequence> validateHeaderValue(final Iterable<? extends CharSequence> values) {
+        if (validateValues) {
+            for (CharSequence v : values) {
+                forEachByte(v, NettyH2HeadersToHttpHeaders::validateHeaderValue);
+            }
+        }
+        return values;
+    }
+
+    private CharSequence[] validateHeaderValue(final CharSequence... values) {
+        if (validateValues) {
+            for (CharSequence v : values) {
+                forEachByte(v, NettyH2HeadersToHttpHeaders::validateHeaderValue);
+            }
+        }
+        return values;
+    }
+
+    /**
+     * Validate char is a valid <a href="https://tools.ietf.org/html/rfc7230#section-3.2">field-value</a> character.
+     *
+     * @param value the character to validate.
+     */
+    private static boolean validateHeaderValue(final byte value) {
+        // HEADER
+        // header-field   = field-name ":" OWS field-value OWS
+        //
+        // field-value    = *( field-content / obs-fold )
+        // field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+        // field-vchar    = VCHAR / obs-text
+        //
+        // obs-fold       = CRLF 1*( SP / HTAB )
+        //                ; obsolete line folding
+        //                ; see Section 3.2.4
+        //
+        // Note: we do not support obs-fold.
+        // Illegal chars are control chars (0-31) except HT (9), and DEL (127):
+        if (((value & CONTROL_CHARS_MASK) != 0 && value != HT) || value == DEL) {
+            throw new IllegalCharacterException(value,
+                    "(VCHAR / obs-text) [ 1*(SP / HTAB) (VCHAR / obs-text) ]");
+        }
+        return true;
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilterTest.java
@@ -47,7 +47,7 @@ class AbsoluteAddressHttpRequesterFilterTest {
     private FilterableStreamingHttpClient delegate;
     @Mock
     private StreamingHttpResponse response;
-    private final HttpHeadersFactory headersFactory = new DefaultHttpHeadersFactory(false, false);
+    private final HttpHeadersFactory headersFactory = new DefaultHttpHeadersFactory(false, false, false);
     private final StreamingHttpRequest request = StreamingHttpRequests.newRequest(HttpRequestMethod.GET, "",
             HttpProtocolVersion.HTTP_1_1, headersFactory.newHeaders(), DEFAULT_ALLOCATOR, headersFactory);
     private final ArgumentCaptor<StreamingHttpRequest> requestCapture =

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -275,8 +275,7 @@ abstract class AbstractNettyHttpServerTest {
         this.serverTransportObserver = requireNonNull(server);
     }
 
-    StreamingHttpResponse makeRequest(final StreamingHttpRequest request)
-            throws Exception {
+    StreamingHttpResponse makeRequest(final StreamingHttpRequest request) throws Exception {
         return awaitIndefinitelyNonNull(httpConnection.request(request));
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -87,7 +87,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class ContentHeadersTest extends AbstractNettyHttpServerTest {
 
-    private static final DefaultHttpHeadersFactory headersFactory = new DefaultHttpHeadersFactory(false, false);
+    private static final DefaultHttpHeadersFactory headersFactory = new DefaultHttpHeadersFactory(false, false, false);
     private static final String EXISTING_CONTENT = "Hello World!";
     private static final int EXISTING_CONTENT_LENGTH = EXISTING_CONTENT.length();
     private static final String PAYLOAD = "Hello";

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthTest.java
@@ -65,7 +65,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 class ContentLengthTest {
 
-    private static final DefaultHttpHeadersFactory headersFactory = new DefaultHttpHeadersFactory(false, false);
+    private static final DefaultHttpHeadersFactory headersFactory = new DefaultHttpHeadersFactory(false, false, false);
 
     @Test
     void shouldNotCalculateRequestContentLengthFromEmptyPublisher() throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -164,7 +164,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
         Buffer buffer = allocator.wrap(content);
 
         HttpRequestMetaData request = newRequestMetaData(HTTP_1_1, GET, "/some/path?foo=bar&baz=yyy",
-                new DefaultHttpHeadersFactory(false, false).newHeaders());
+                new DefaultHttpHeadersFactory(false, false, false).newHeaders());
         request.headers()
                 .add(" " + CONNECTION + " ", " " + KEEP_ALIVE)
                 .add("  " + USER_AGENT + "   ", "    unit-test   ")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
@@ -94,7 +94,7 @@ class HttpResponseEncoderTest extends HttpEncoderTest<HttpResponseMetaData> {
         Buffer buffer = DEFAULT_ALLOCATOR.wrap(content);
 
         HttpResponseMetaData response = newResponseMetaData(HTTP_1_1, OK,
-                new DefaultHttpHeadersFactory(false, false).newHeaders());
+                new DefaultHttpHeadersFactory(false, false, false).newHeaders());
         response.headers()
                 .add(" " + CONNECTION + " ", " " + KEEP_ALIVE)
                 .add("  " + SERVER + "   ", "    unit-test   ")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IllegalHeaderValueTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IllegalHeaderValueTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.HttpProtocolConfig;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpService;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpHeaderNames.HOST;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
+import static io.servicetalk.logging.api.LogLevel.TRACE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IllegalHeaderValueTest extends AbstractNettyHttpServerTest {
+
+    private static final CharSequence HEADER_NAME = newAsciiString("header-name");
+    private static final CharSequence X_HEADER_NAME = newAsciiString("x-header-name");
+    private static final CharSequence ILLEGAL_HEADER_VALUE = newAsciiString("header-value\r\n");
+    private static final CharSequence OK_HEADER_VALUE = newAsciiString("!ok\t value~");
+
+    @Override
+    void service(final StreamingHttpService ignore) {
+        super.service((ctx, request, responseFactory) -> {
+            StreamingHttpResponse ok = responseFactory.ok();
+            request.headers().forEach(entry -> {
+                if (contentEqualsIgnoreCase(HOST, entry.getKey())) {
+                    return;
+                }
+                ok.addHeader(entry.getKey(), entry.getValue());
+            });
+            return succeeded(ok);
+        });
+    }
+
+    @ParameterizedTest(name = "{index}: protocol={0}")
+    @EnumSource(HttpProtocol.class)
+    void noHeaderValueValidation(HttpProtocol protocol) throws Exception {
+        protocol(config(protocol, false));
+        setUp(CACHED, CACHED_SERVER);
+
+        StreamingHttpConnection connection = streamingHttpConnection();
+        StreamingHttpResponse response = requestWithInvalidHeader(connection);
+        assertResponse(response, protocol.version, OK, 0);
+
+        if (protocol == HTTP_1) {
+            // HTTP/1.1 will try parsing the X_HEADER_NAME as a new request and fail, closing the connection:
+            ExecutionException e = assertThrows(ExecutionException.class, () -> requestWithInvalidHeader(connection));
+            assertThat(e.getCause(), instanceOf(IOException.class));
+        } else {
+            // HTTP/2 uses binary encoding and can transfer illegal header values with not problem:
+            StreamingHttpResponse secondResponse = requestWithInvalidHeader(connection);
+            assertResponse(secondResponse, protocol.version, OK, 0);
+        }
+    }
+
+    @ParameterizedTest(name = "{index}: protocol={0}")
+    @EnumSource(HttpProtocol.class)
+    void withHeaderValueValidation(HttpProtocol protocol) throws Exception {
+        protocol(config(protocol, true));
+        setUp(CACHED, CACHED_SERVER);
+
+        assertThrows(IllegalArgumentException.class, () -> streamingHttpConnection().get("/")
+                .addHeader(HEADER_NAME, ILLEGAL_HEADER_VALUE));
+    }
+
+    private static HttpProtocolConfig config(HttpProtocol protocol, boolean validateHeaderValues) {
+        switch (protocol) {
+            case HTTP_1:
+                return h1().headersFactory(new DefaultHttpHeadersFactory(true, true, validateHeaderValues)).build();
+            case HTTP_2:
+                return h2().headersFactory(new H2HeadersFactory(true, true, validateHeaderValues))
+                        .enableFrameLogging("servicetalk-tests-h2-frame-logger", TRACE, () -> true)
+                        .build();
+            default:
+                throw new IllegalArgumentException("Unsupported protocol: " + protocol);
+        }
+    }
+
+    private StreamingHttpResponse requestWithInvalidHeader(StreamingHttpConnection connection) throws Exception {
+        return makeRequest(connection.get("/")
+                // enable wire-logging and make that the header with ILLEGAL_HEADER_VALUE is *not* the last one:
+                .addHeader(HEADER_NAME, ILLEGAL_HEADER_VALUE)
+                .addHeader(X_HEADER_NAME, OK_HEADER_VALUE));
+    }
+}


### PR DESCRIPTION
Motivation:

RFC7230, section 3.2 defines format for header-field / field-value, but
we currently do not validate field-value. It may impact HTTP/1.1 decoder
if the field-value contains illegal control characters, like CRLF.
Because field-value may be relatively long, validation may cause perf
issues. Therefore, this is an opt-in feature for now.

Modifications:

- Enhance `DefaultHttpHeadersFactory` and `H2HeadersFactory` to take
a `validateValues` argument;
- Deprecate ctors that do not take `validateValues`;
- Test how connection behaves with and without validation;

Result:

Ability to validate header values before encoding/decoding HTTP
messages.