### PR TITLE
HTTP OpenTracing filters Format<TextMap> support

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -9,6 +9,7 @@
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#MetaData[MetaData]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#HTTP2[HTTP/2]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Mutual-TLS[Mutual TLS]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#OpenTracing[OpenTracing]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Redirects[Redirects]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#uds[Unix Domain Sockets]
 ** xref:{page-version}@servicetalk-examples::http/service-composition.adoc[Service Composition]

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -172,6 +172,22 @@ Using the following classes:
 NOTE: This example uses the link:#blocking-aggregated[blocking + aggregated] API, as the TLS/SSL configuration API is
 the same across all the HTTP APIs.
 
+[#OpenTracing]
+== OpenTracing
+
+This example demonstrates the following:
+
+- automatically generate and propagate distributed tracing metadata
+- make span IDs available in log statements via MDC
+- publish span IDs via Zipkin's HTTP API and to a local console logger
+
+Using the following classes:
+
+- link:{source-root}/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/OpenTracingServer.java[OpenTracingServer] - A server that generates/propagates span IDs, makes spans available in logs via MDC, publishes spans via Zipkin's HTTP API.
+- link:{source-root}/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/OpenTracingClient.java[OpenTracingClient] - A client that generates/propagates span IDs, makes spans available in logs via MDC, publishes spans via local console logger.
+- link:{source-root}/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/ZipkinServerSimulator.java[ZipkinServerSimulator] - A server that simulates/mocks a Zipkin server, and logs requests to the console.
+- link:{source-root}/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/BraveTracingServer.java[BraveTracingServer] - A server that uses link:https://github.com/openzipkin-contrib/brave-opentracing[Brave OpenTracing] implementation.
+
 [#Redirects]
 == Redirects
 

--- a/servicetalk-examples/http/opentracing/build.gradle
+++ b/servicetalk-examples/http/opentracing/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation project(":servicetalk-opentracing-http") // http client/server filters
   implementation project(":servicetalk-opentracing-inmemory") // ServiceTalk Tracer and related classes
   implementation project(":servicetalk-opentracing-asynccontext") // ServiceTalk ScopeManager
-  implementation project(":servicetalk-opentracing-log4j2") // optional: persist trace information in MDC
+  implementation project(":servicetalk-opentracing-log4j2") // optional: persist ServiceTalk ScopeManager traces to MDC
   implementation project(":servicetalk-opentracing-zipkin-publisher") // optional: publish traces to Zipkin
 
   implementation 'io.opentracing.brave:brave-opentracing:1.0.0' // optional: use 3rd party OpenTracing implementation

--- a/servicetalk-examples/http/opentracing/build.gradle
+++ b/servicetalk-examples/http/opentracing/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-http-netty")
+  implementation project(":servicetalk-opentracing-http") // http client/server filters
+  implementation project(":servicetalk-opentracing-inmemory") // ServiceTalk Tracer and related classes
+  implementation project(":servicetalk-opentracing-asynccontext") // ServiceTalk ScopeManager
+  implementation project(":servicetalk-opentracing-log4j2") // optional: persist trace information in MDC
+  implementation project(":servicetalk-opentracing-zipkin-publisher") // optional: publish traces to Zipkin
+
+  implementation 'io.opentracing.brave:brave-opentracing:1.0.0' // optional: use 3rd party OpenTracing implementation
+  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+
+  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}

--- a/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/BraveTracingServer.java
+++ b/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/BraveTracingServer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.opentracing;
+
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.AsyncContextMap;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.http.netty.HttpServers;
+import io.servicetalk.opentracing.http.TracingHttpServiceFilter;
+import io.servicetalk.opentracing.zipkin.publisher.reporter.HttpReporter;
+
+import brave.Tracing;
+import brave.opentracing.BraveTracer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import io.opentracing.Tracer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin2.reporter.brave.ZipkinSpanHandler;
+
+import javax.annotation.Nullable;
+
+import static io.opentracing.propagation.Format.Builtin.TEXT_MAP;
+import static io.servicetalk.concurrent.api.AsyncContextMap.Key.newKey;
+
+/**
+ * A server that does distributed tracing via {@link BraveTracer}.
+ */
+public final class BraveTracingServer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BraveTracingServer.class);
+
+    public static void main(String[] args) throws Exception {
+        // Publishing to Zipkin is optional, but demonstrated for completeness.
+        try (Tracing tracing = Tracing.newBuilder().addSpanHandler(ZipkinSpanHandler.create(
+                        new HttpReporter.Builder(HttpClients.forSingleAddress("localhost", 8081)).build()))
+                .currentTraceContext(AsyncContextTraceContext.INSTANCE).build();
+             Tracer tracer = BraveTracer.newBuilder(tracing)
+                     .build()) {
+            HttpServers.forPort(8080)
+                    .appendServiceFilter(new TracingHttpServiceFilter(tracer, TEXT_MAP, "servicetalk-test-server"))
+                    .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                        LOGGER.info("processed request {}", request.toString((name, value) -> value));
+                        return responseFactory.ok();
+                    }).awaitShutdown();
+        }
+    }
+
+    private static final class AsyncContextTraceContext extends CurrentTraceContext {
+        private static final AsyncContextMap.Key<TraceContext> SCOPE_KEY = newKey("bravetracing");
+        public static final CurrentTraceContext INSTANCE = new AsyncContextTraceContext();
+
+        private AsyncContextTraceContext() {
+        }
+
+        @Nullable
+        @Override
+        public TraceContext get() {
+            return AsyncContext.get(SCOPE_KEY);
+        }
+
+        @Override
+        public Scope newScope(final TraceContext context) {
+            AsyncContextMap contextMap = AsyncContext.current();
+            TraceContext previous = contextMap.get(SCOPE_KEY);
+            contextMap.put(SCOPE_KEY, context);
+            return decorateScope(context,
+                    previous == null ? RemoveScopeOnClose.INSTANCE : new RevertScopeOnClose(previous));
+        }
+
+        private static final class RemoveScopeOnClose implements Scope {
+            private static final Scope INSTANCE = new RemoveScopeOnClose();
+
+            private RemoveScopeOnClose() {
+            }
+
+            @Override
+            public void close() {
+                AsyncContext.remove(SCOPE_KEY);
+            }
+        }
+
+        private static final class RevertScopeOnClose implements Scope {
+            private final TraceContext previousScope;
+
+            RevertScopeOnClose(TraceContext previous) {
+                this.previousScope = previous;
+            }
+
+            @Override
+            public void close() {
+                AsyncContext.put(SCOPE_KEY, previousScope);
+            }
+        }
+    }
+}

--- a/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/OpenTracingClient.java
+++ b/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/OpenTracingClient.java
@@ -26,7 +26,6 @@ import io.servicetalk.opentracing.zipkin.publisher.reporter.LoggingReporter;
 import io.opentracing.Tracer;
 
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
-import static io.servicetalk.opentracing.zipkin.publisher.reporter.LoggingReporter.*;
 
 /**
  * A client that does distributed tracing.
@@ -34,13 +33,16 @@ import static io.servicetalk.opentracing.zipkin.publisher.reporter.LoggingReport
 public final class OpenTracingClient {
     public static void main(String[] args) throws Exception {
         // Publishing to Zipkin is optional, but demonstrated for completeness.
-        try (ZipkinPublisher zipkinPublisher = new ZipkinPublisher.Builder("servicetalk-test-client", CONSOLE).build();
+        try (ZipkinPublisher zipkinPublisher = new ZipkinPublisher.Builder("servicetalk-test-client",
+                LoggingReporter.CONSOLE).build();
              Tracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).addListener(zipkinPublisher).build();
              BlockingHttpClient client = HttpClients.forSingleAddress("localhost", 8080)
                      .appendClientFilter(new TracingHttpRequesterFilter(tracer, "servicetalk-test-client"))
                      .buildBlocking()) {
-            HttpResponse response = client.request(client.get("/"));
+            HttpResponse response = client.request(client.get("/1"));
             System.out.println(response.toString((name, value) -> value));
+            HttpResponse response2 = client.request(client.get("/2"));
+            System.out.println(response2.toString((name, value) -> value));
         }
     }
 }

--- a/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/OpenTracingClient.java
+++ b/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/OpenTracingClient.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.opentracing;
+
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.opentracing.http.TracingHttpRequesterFilter;
+import io.servicetalk.opentracing.inmemory.DefaultInMemoryTracer;
+import io.servicetalk.opentracing.zipkin.publisher.ZipkinPublisher;
+import io.servicetalk.opentracing.zipkin.publisher.reporter.LoggingReporter;
+
+import io.opentracing.Tracer;
+
+import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
+import static io.servicetalk.opentracing.zipkin.publisher.reporter.LoggingReporter.*;
+
+/**
+ * A client that does distributed tracing.
+ */
+public final class OpenTracingClient {
+    public static void main(String[] args) throws Exception {
+        // Publishing to Zipkin is optional, but demonstrated for completeness.
+        try (ZipkinPublisher zipkinPublisher = new ZipkinPublisher.Builder("servicetalk-test-client", CONSOLE).build();
+             Tracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).addListener(zipkinPublisher).build();
+             BlockingHttpClient client = HttpClients.forSingleAddress("localhost", 8080)
+                     .appendClientFilter(new TracingHttpRequesterFilter(tracer, "servicetalk-test-client"))
+                     .buildBlocking()) {
+            HttpResponse response = client.request(client.get("/"));
+            System.out.println(response.toString((name, value) -> value));
+        }
+    }
+}

--- a/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/OpenTracingServer.java
+++ b/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/OpenTracingServer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.opentracing;
+
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.http.netty.HttpServers;
+import io.servicetalk.opentracing.http.TracingHttpServiceFilter;
+import io.servicetalk.opentracing.inmemory.DefaultInMemoryTracer;
+import io.servicetalk.opentracing.zipkin.publisher.ZipkinPublisher;
+import io.servicetalk.opentracing.zipkin.publisher.reporter.HttpReporter;
+
+import io.opentracing.Tracer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
+
+/**
+ * A server that does distributed tracing.
+ */
+public final class OpenTracingServer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenTracingServer.class);
+
+    public static void main(String[] args) throws Exception {
+        // Publishing to Zipkin is optional, but demonstrated for completeness.
+        try (ZipkinPublisher zipkinPublisher = new ZipkinPublisher.Builder("servicetalk-test-server",
+                // Use ServiceTalk's HTTP client to publish spans to Zipkin's HTTP API (run ZipkinServerSimulator).
+                new HttpReporter.Builder(HttpClients.forSingleAddress("localhost", 8081)).build()).build();
+             Tracer tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).addListener(zipkinPublisher).build()) {
+            HttpServers.forPort(8080)
+                    .appendServiceFilter(new TracingHttpServiceFilter(tracer, "servicetalk-test-server"))
+                    .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                        LOGGER.info("processed request {}", request.toString((name, value) -> value));
+                        return responseFactory.ok();
+                    }).awaitShutdown();
+        }
+    }
+}

--- a/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/ZipkinServerSimulator.java
+++ b/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/ZipkinServerSimulator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.opentracing;
+
+import io.servicetalk.http.netty.HttpServers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Simple mock/simulated Zipkin server.
+ */
+public class ZipkinServerSimulator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZipkinServerSimulator.class);
+
+    public static void main(String[] args) throws Exception {
+        HttpServers.forPort(8081)
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                    LOGGER.info("request {} {}", request.toString((name, value) -> value),
+                            request.payloadBody().toString(UTF_8));
+                    return responseFactory.ok();
+                }).awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/package-info.java
+++ b/servicetalk-examples/http/opentracing/src/main/java/io/servicetalk/examples/http/opentracing/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.opentracing.inmemory.api;
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.opentracing;
 
-import io.opentracing.propagation.Format;
-
-/**
- * A {@link Format} compatible with {@link InMemorySpanContext}.
- * @param <C> the carrier type.
- */
-public interface InMemorySpanContextFormat<C> extends Format<C>,
-                                                      InMemorySpanContextInjector<C>,
-                                                      InMemorySpanContextExtractor<C> {
-}
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/opentracing/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/opentracing/src/main/resources/log4j2.xml
@@ -21,10 +21,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!-- Enables wire logging and h2-frame logging messages -->
-    <Logger name="servicetalk-examples-wire-logger" level="TRACE"/>
-    <Logger name="servicetalk-examples-h2-frame-logger" level="TRACE"/>
-
     <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
     <Root level="${sys:servicetalk.logger.level:-INFO}">
       <AppenderRef ref="Console"/>

--- a/servicetalk-examples/http/opentracing/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/opentracing/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t traceId=%X{traceId} spanId=%X{spanId} parentSpanId=%X{parentSpanId} [%-5level] %-15logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Enables wire logging and h2-frame logging messages -->
+    <Logger name="servicetalk-examples-wire-logger" level="TRACE"/>
+    <Logger name="servicetalk-examples-h2-frame-logger" level="TRACE"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpanContextExtractor.java
+++ b/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpanContextExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,20 @@
  */
 package io.servicetalk.opentracing.inmemory.api;
 
-import io.opentracing.propagation.Format;
+import javax.annotation.Nullable;
 
 /**
- * A {@link Format} compatible with {@link InMemorySpanContext}.
+ * Used to extract {@link InMemorySpanContext} from a carrier of type {@link C}.
  * @param <C> the carrier type.
  */
-public interface InMemorySpanContextFormat<C> extends Format<C>,
-                                                      InMemorySpanContextInjector<C>,
-                                                      InMemorySpanContextExtractor<C> {
+public interface InMemorySpanContextExtractor<C> {
+    /**
+     * Extract the trace state from a carrier.
+     *
+     * @param carrier carrier to extract from
+     * @return extracted {@link InMemorySpanContext}, may be {@code null} if the carrier doesn't contain a valid span
+     * @throws Exception if any parsing error happened during extraction
+     */
+    @Nullable
+    InMemorySpanContext extract(C carrier) throws Exception;
 }

--- a/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpanContextInjector.java
+++ b/servicetalk-opentracing-inmemory-api/src/main/java/io/servicetalk/opentracing/inmemory/api/InMemorySpanContextInjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,16 @@
  */
 package io.servicetalk.opentracing.inmemory.api;
 
-import io.opentracing.propagation.Format;
-
 /**
- * A {@link Format} compatible with {@link InMemorySpanContext}.
+ * Used to inject {@link InMemorySpanContext} into a carrier of type {@link C}.
  * @param <C> the carrier type.
  */
-public interface InMemorySpanContextFormat<C> extends Format<C>,
-                                                      InMemorySpanContextInjector<C>,
-                                                      InMemorySpanContextExtractor<C> {
+public interface InMemorySpanContextInjector<C> {
+    /**
+     * Inject a trace state into a carrier.
+     *
+     * @param context span context
+     * @param carrier carrier to inject into
+     */
+    void inject(InMemorySpanContext context, C carrier);
 }

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/TextMapFormatter.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/TextMapFormatter.java
@@ -16,9 +16,11 @@
 package io.servicetalk.opentracing.inmemory;
 
 import io.servicetalk.opentracing.inmemory.api.InMemorySpanContext;
-import io.servicetalk.opentracing.inmemory.api.InMemorySpanContextFormat;
+import io.servicetalk.opentracing.inmemory.api.InMemorySpanContextExtractor;
+import io.servicetalk.opentracing.inmemory.api.InMemorySpanContextInjector;
 
-import io.opentracing.propagation.TextMap;
+import io.opentracing.propagation.TextMapExtract;
+import io.opentracing.propagation.TextMapInject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,8 +36,9 @@ import static io.servicetalk.opentracing.internal.ZipkinHeaderNames.TRACE_ID;
 /**
  * Zipkin-styled header serialization format.
  */
-final class TextMapFormatter implements InMemorySpanContextFormat<TextMap> {
-    public static final TextMapFormatter INSTANCE = new TextMapFormatter();
+final class TextMapFormatter implements InMemorySpanContextInjector<TextMapInject>,
+                                        InMemorySpanContextExtractor<TextMapExtract> {
+    static final TextMapFormatter INSTANCE = new TextMapFormatter();
     private static final Logger logger = LoggerFactory.getLogger(TextMapFormatter.class);
 
     private TextMapFormatter() {
@@ -43,7 +46,7 @@ final class TextMapFormatter implements InMemorySpanContextFormat<TextMap> {
     }
 
     @Override
-    public void inject(final InMemorySpanContext context, final TextMap carrier) {
+    public void inject(final InMemorySpanContext context, final TextMapInject carrier) {
         carrier.put(TRACE_ID, context.toTraceId());
         carrier.put(SPAN_ID, context.toSpanId());
         if (context.parentSpanId() != null) {
@@ -57,7 +60,7 @@ final class TextMapFormatter implements InMemorySpanContextFormat<TextMap> {
 
     @Nullable
     @Override
-    public InMemorySpanContext extract(TextMap carrier) {
+    public InMemorySpanContext extract(TextMapExtract carrier) {
         String traceId = null;
         String spanId = null;
         String parentSpanId = null;

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,6 +50,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:http:http2",
         "servicetalk-examples:http:jaxrs",
         "servicetalk-examples:http:metadata",
+        "servicetalk-examples:http:opentracing",
         "servicetalk-examples:http:serialization",
         "servicetalk-examples:http:service-composition",
         "servicetalk-examples:http:uds",
@@ -107,6 +108,7 @@ project(":servicetalk-examples:http:debugging").name = "servicetalk-examples-htt
 project(":servicetalk-examples:http:timeout").name = "servicetalk-examples-http-timeout"
 project(":servicetalk-examples:http:jaxrs").name = "servicetalk-examples-http-jaxrs"
 project(":servicetalk-examples:http:metadata").name = "servicetalk-examples-http-metadata"
+project(":servicetalk-examples:http:opentracing").name = "servicetalk-examples-http-opentracing"
 project(":servicetalk-examples:http:serialization").name = "servicetalk-examples-http-serialization"
 project(":servicetalk-examples:http:service-composition").name = "servicetalk-examples-http-service-composition"
 project(":servicetalk-examples:http:uds").name = "servicetalk-examples-http-uds"


### PR DESCRIPTION
Motivation:
3rd party Tracer implementations use `Format<TextMap>` to inject/extract
spans. TracingHttpRequesterFilter and TracingHttpServiceFilter currently
don't support `Format<TextMap>` and don't easily interoperate with 3rd
party Tracer implementations.

Modifications:
- TracingHttpRequesterFilter and TracingHttpServiceFilter allow the user
  to pass in a custom `Format<TextMap>` which is passed directly to the
  Tracer to inject/extract spans.
- Add examples for tracing with ServiceTalk and Brave Tracer
  implementations that also publish to Zipkin.

Result:
TracingHttpRequesterFilter and TracingHttpServiceFilter more easily
interoperate with 3rd party Tracers.