### PR TITLE
Migrate `servicetalk-loadbalancer` module tests to jUnit5

### DIFF
--- a/servicetalk-loadbalancer/build.gradle
+++ b/servicetalk-loadbalancer/build.gradle
@@ -31,7 +31,9 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "junit:junit:$junitVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerRoundRobinLoadBalancerTest.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.loadbalancer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,10 +25,10 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class EagerRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest {
+class EagerRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest {
 
     @Test
-    public void duplicateEventsAreIgnored() {
+    void duplicateEventsAreIgnored() {
         assertThat(lb.usedAddresses(), is(empty()));
 
         sendServiceDiscoveryEvents(upEvent("address-1"));
@@ -43,7 +43,7 @@ public class EagerRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest 
     }
 
     @Test
-    public void handleDiscoveryEvents() {
+    void handleDiscoveryEvents() {
         assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
 
         sendServiceDiscoveryEvents(upEvent("address-1"));
@@ -79,7 +79,7 @@ public class EagerRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest 
     }
 
     @Test
-    public void hostDownGracefullyClosesConnections() throws Exception {
+    void hostDownGracefullyClosesConnections() throws Exception {
         sendServiceDiscoveryEvents(upEvent("address-1"));
         TestLoadBalancedConnection host1Conn1 = lb.selectConnection(alwaysNewConnectionFilter()).toFuture().get();
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringRoundRobinLoadBalancerTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Executors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -34,21 +34,21 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest {
+class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest {
 
     @Test
-    public void hostDownDoesntCloseConnectionCloseLB() throws Exception {
+    void hostDownDoesntCloseConnectionCloseLB() throws Exception {
         hostDownDoesntCloseConnection(false);
     }
 
     @Test
-    public void hostDownDoesntCloseConnectionCloseLBGracefully() throws Exception {
+    void hostDownDoesntCloseConnectionCloseLBGracefully() throws Exception {
         hostDownDoesntCloseConnection(true);
     }
 
@@ -73,7 +73,7 @@ public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerT
     }
 
     @Test
-    public void closedConnectionRemovesExpiredHost() throws Exception {
+    void closedConnectionRemovesExpiredHost() throws Exception {
         sendServiceDiscoveryEvents(upEvent("address-1"));
         final Predicate<TestLoadBalancedConnection> connectionFilter = alwaysNewConnectionFilter();
 
@@ -93,7 +93,7 @@ public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerT
 
     // Concurrency test, worth running ~10K times to spot concurrency issues.
     @Test
-    public void closureOfLastConnectionDoesntRaceWithNewAvailableEvent() throws Exception {
+    void closureOfLastConnectionDoesntRaceWithNewAvailableEvent() throws Exception {
         Executor executor = Executors.newFixedSizeExecutor(1);
         try {
             sendServiceDiscoveryEvents(upEvent("address-1"));
@@ -116,7 +116,7 @@ public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerT
 
     // Concurrency test, worth running >10K times to spot concurrency issues.
     @Test
-    public void expiringAHostDoesntRaceWithConnectionAdding() throws Exception {
+    void expiringAHostDoesntRaceWithConnectionAdding() throws Exception {
         Executor executor = Executors.newFixedSizeExecutor(1);
         try {
             sendServiceDiscoveryEvents(upEvent("address-1"));
@@ -167,7 +167,7 @@ public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerT
 
     // Concurrency test, worth running >10K times to spot concurrency issues.
     @Test
-    public void expiringHostWhileConnectionsClose() throws Exception {
+    void expiringHostWhileConnectionsClose() throws Exception {
         Executor executor = Executors.newFixedSizeExecutor(1);
         try {
             sendServiceDiscoveryEvents(upEvent("address-1"));
@@ -192,7 +192,7 @@ public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerT
     }
 
     @Test
-    public void closedConnectionDoesntRemoveActiveHost() throws Exception {
+    void closedConnectionDoesntRemoveActiveHost() throws Exception {
         sendServiceDiscoveryEvents(upEvent("address-1"));
         final Predicate<TestLoadBalancedConnection> connectionFilter = alwaysNewConnectionFilter();
 
@@ -206,7 +206,7 @@ public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerT
     }
 
     @Test
-    public void handleDiscoveryEventsForExpiredHostBecomingAvailable() throws Exception {
+    void handleDiscoveryEventsForExpiredHostBecomingAvailable() throws Exception {
         assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
 
         sendServiceDiscoveryEvents(upEvent("address-1"));
@@ -233,7 +233,7 @@ public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerT
     }
 
     @Test
-    public void handleDiscoveryEventsForConnectedHosts() throws Exception {
+    void handleDiscoveryEventsForConnectedHosts() throws Exception {
         assertThat(lb.usedAddresses(), is(empty()));
 
         final Predicate<TestLoadBalancedConnection> connectionFilter = alwaysNewConnectionFilter();
@@ -276,7 +276,7 @@ public class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerT
     }
 
     @Test
-    public void handleDiscoveryEventsForNotConnectedHosts() {
+    void handleDiscoveryEventsForNotConnectedHosts() {
         assertThat(lb.usedAddresses(), is(empty()));
 
         sendServiceDiscoveryEvents(upEvent("address-1"));


### PR DESCRIPTION
Motivation:

JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain.
JUnit 5 has added some very useful new features for describing, organizing, and executing tests. For instance, tests get better display names and can be organized hierarchically.
JUnit 5 is organized into multiple libraries, so only the features you need are imported into your project. With build systems such as Maven and Gradle, including the right libraries is easy.
JUnit 5 can use more than one extension at a time, which JUnit 4 could not (only one runner could be used at a time). This means you can easily combine the Spring extension with other extensions (such as your own custom extension).
Modifications:

- Unit tests of `servicetalk-loadbalancer` module have been migrated from JUnit 4 to JUnit 5;

Result:

Converted `servicetalk-loadbalancer` module now runs tests using JUnit 5.