### PR TITLE
NettyIoExecutors executors support IoThread

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
@@ -94,7 +94,7 @@ public final class NettyIoExecutors {
     public static <T extends Thread & IoThread> EventLoopAwareNettyIoExecutor createIoExecutor(
             int ioThreads, IoThreadFactory<T> threadFactory) {
         validateIoThreads(ioThreads);
-        return new EventLoopGroupIoExecutor(createEventLoopGroup(ioThreads, threadFactory), true);
+        return new EventLoopGroupIoExecutor(createEventLoopGroup(ioThreads, threadFactory), true, true);
     }
 
     private static <T extends Thread & IoThread> EventLoopGroup createEventLoopGroup(int ioThreads,

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/GlobalExecutionContextTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/GlobalExecutionContextTest.java
@@ -23,7 +23,8 @@ import java.util.concurrent.CountDownLatch;
 
 import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.toNettyIoExecutor;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 class GlobalExecutionContextTest {
 
@@ -31,8 +32,10 @@ class GlobalExecutionContextTest {
     void testGetGlobalExecutionContext() throws InterruptedException {
         ExecutionContext gec = globalExecutionContext();
         CountDownLatch scheduleLatch = new CountDownLatch(2);
-        gec.executor().schedule(scheduleLatch::countDown, 1, SECONDS);
-        toNettyIoExecutor(gec.ioExecutor()).asExecutor().schedule(scheduleLatch::countDown, 1, SECONDS);
+        gec.executor().schedule(scheduleLatch::countDown, 5, MILLISECONDS);
+        NettyIoExecutor ioExecutor = toNettyIoExecutor(gec.ioExecutor());
+        assertThat("global ioExecutor does not support IoThread", ioExecutor.isIoThreadSupported());
+        ioExecutor.asExecutor().schedule(scheduleLatch::countDown, 5, MILLISECONDS);
         scheduleLatch.await();
     }
 }


### PR DESCRIPTION
Motivation:
The global context `IoExecutor` and other executors created using the
`NettyIoExecutors::createIoExecutor` were being created without being
 marked as `supportsIoThread` which causes mandatory offloading.
Modifications:
Create executors with correct flags to mark them as supporting
`IoThread` thread marker interface.
Result:
Conditional offloading is supported in more situations.