### PR TITLE
gRPC add MethodDescriptor Collection to services

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcBindableService.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcBindableService.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.grpc.api;
 
+import java.util.Collection;
+
 /**
  * A <a href="https://www.grpc.io">gRPC</a> service that can generate {@link GrpcServiceFactory factory} instances bound
  * to itself.
@@ -32,4 +34,10 @@ public interface GrpcBindableService<F extends S, S extends GrpcService,
      * @return A service factory bound to this service with other appropriate configuration.
      */
     GrpcServiceFactory<F, S, FF> bindService();
+
+    /**
+     * Get a {@link Collection} of all {@link MethodDescriptor}s for this service.
+     * @return a {@link Collection} of all {@link MethodDescriptor}s for this service.
+     */
+    Collection<MethodDescriptor<?, ?>> methodDescriptors();
 }

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -51,6 +51,7 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-utils-internal")
   testImplementation project(":servicetalk-transport-netty")
+  testImplementation project(":servicetalk-serializer-utils")
   testImplementation "io.grpc:grpc-core:$grpcVersion"
   testImplementation("io.grpc:grpc-netty:$grpcVersion") {
     exclude group: "io.netty"

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/AsyncUserService.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/AsyncUserService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.customtransport;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.netty.TesterProto.TestRequest;
+import io.servicetalk.grpc.netty.TesterProto.TestResponse;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.grpc.customtransport.Utils.newResp;
+
+final class AsyncUserService implements TesterService {
+    @Override
+    public Single<TestResponse> test(final GrpcServiceContext ctx, final TestRequest request) {
+        return succeeded(newResp("hello " + request.getName()));
+    }
+
+    @Override
+    public Publisher<TestResponse> testBiDiStream(final GrpcServiceContext ctx,
+                                                  final Publisher<TestRequest> request) {
+        return request.map(req -> newResp("hello " + req.getName()));
+    }
+
+    @Override
+    public Publisher<TestResponse> testResponseStream(final GrpcServiceContext ctx,
+                                                      final TestRequest request) {
+        return from(newResp("hello " + request.getName() + "1"), newResp("hello " + request.getName() + "2"));
+    }
+
+    @Override
+    public Single<TestResponse> testRequestStream(final GrpcServiceContext ctx,
+                                                  final Publisher<TestRequest> request) {
+        return request.collect(StringBuilder::new, (sb, req) -> sb.append(req.getName()).append(", "))
+                .map(sb -> newResp("hello " + sb));
+    }
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/BlockingUserService.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/BlockingUserService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.customtransport;
+
+import io.servicetalk.concurrent.BlockingIterable;
+import io.servicetalk.grpc.api.GrpcPayloadWriter;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.netty.TesterProto.TestRequest;
+import io.servicetalk.grpc.netty.TesterProto.TestResponse;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterService;
+
+import static io.servicetalk.grpc.customtransport.Utils.newResp;
+
+final class BlockingUserService implements BlockingTesterService {
+    @Override
+    public TestResponse test(final GrpcServiceContext ctx, final TestRequest request) throws Exception {
+        return TestResponse.newBuilder().setMessage("hello " + request.getName()).build();
+    }
+
+    @Override
+    public void testBiDiStream(final GrpcServiceContext ctx, final BlockingIterable<TestRequest> request,
+                               final GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
+        for (TestRequest req : request) {
+            responseWriter.write(newResp("hello " + req.getName()));
+        }
+        responseWriter.close();
+    }
+
+    @Override
+    public void testResponseStream(final GrpcServiceContext ctx, final TestRequest request,
+                                   final GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
+        responseWriter.write(newResp("hello " + request.getName() + "1"));
+        responseWriter.write(newResp("hello " + request.getName() + "2"));
+        responseWriter.close();
+    }
+
+    @Override
+    public TestResponse testRequestStream(final GrpcServiceContext ctx, final BlockingIterable<TestRequest> request)
+            throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (TestRequest req : request) {
+            sb.append(req.getName()).append(", ");
+        }
+        return newResp("hello " + sb);
+    }
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ClientTransport.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ClientTransport.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.customtransport;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.api.Publisher;
+
+interface ClientTransport {
+    Publisher<Buffer> send(String method, Publisher<Buffer> requestMessages);
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ClientTransportGrpcCallFactory.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ClientTransportGrpcCallFactory.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.customtransport;
+
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.encoding.api.BufferDecoderGroup;
+import io.servicetalk.grpc.api.GrpcClientCallFactory;
+import io.servicetalk.grpc.api.GrpcExecutionContext;
+import io.servicetalk.grpc.api.GrpcSerializationProvider;
+import io.servicetalk.grpc.api.MethodDescriptor;
+import io.servicetalk.grpc.customtransport.Utils.UtilGrpcExecutionContext;
+
+import io.netty.channel.EventLoopGroup;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
+import static io.servicetalk.grpc.customtransport.Utils.deserializeResp;
+import static io.servicetalk.grpc.customtransport.Utils.serializeReq;
+import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
+import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoopGroup;
+
+final class ClientTransportGrpcCallFactory implements GrpcClientCallFactory {
+    private final ClientTransport transport;
+    private final GrpcExecutionContext ctx;
+    private final ListenableAsyncCloseable closeable = emptyAsyncCloseable();
+
+    ClientTransportGrpcCallFactory(ClientTransport transport, EventLoopGroup group) {
+        this.transport = transport;
+        ctx = new UtilGrpcExecutionContext(DEFAULT_ALLOCATOR, fromNettyEventLoopGroup(group),
+                globalExecutionContext().executor());
+    }
+
+    @Override
+    public <Req, Resp> ClientCall<Req, Resp> newCall(final MethodDescriptor<Req, Resp> methodDescriptor,
+                                                     final BufferDecoderGroup decompressors) {
+        return (metadata, request) -> deserializeResp(methodDescriptor).deserialize(
+                transport.send(methodDescriptor.httpPath(),
+                        serializeReq(methodDescriptor)
+                                .serialize(Publisher.from(request), ctx.bufferAllocator())),
+                ctx.bufferAllocator()).firstOrError();
+    }
+
+    @Override
+    public <Req, Resp> StreamingClientCall<Req, Resp> newStreamingCall(
+            final MethodDescriptor<Req, Resp> methodDescriptor, final BufferDecoderGroup decompressors) {
+        return (metadata, request) -> deserializeResp(methodDescriptor).deserialize(
+                transport.send(methodDescriptor.httpPath(),
+                        serializeReq(methodDescriptor)
+                                .serialize(request, ctx.bufferAllocator())),
+                ctx.bufferAllocator());
+    }
+
+    @Override
+    public <Req, Resp> RequestStreamingClientCall<Req, Resp> newRequestStreamingCall(
+            final MethodDescriptor<Req, Resp> methodDescriptor, final BufferDecoderGroup decompressors) {
+        return (metadata, request) -> deserializeResp(methodDescriptor).deserialize(
+                transport.send(methodDescriptor.httpPath(),
+                        serializeReq(methodDescriptor)
+                                .serialize(request, ctx.bufferAllocator())),
+                ctx.bufferAllocator()).firstOrError();
+    }
+
+    @Override
+    public <Req, Resp> ResponseStreamingClientCall<Req, Resp> newResponseStreamingCall(
+            final MethodDescriptor<Req, Resp> methodDescriptor, final BufferDecoderGroup decompressors) {
+        return (metadata, request) -> deserializeResp(methodDescriptor).deserialize(
+                transport.send(methodDescriptor.httpPath(),
+                        serializeReq(methodDescriptor)
+                                .serialize(Publisher.from(request), ctx.bufferAllocator())),
+                ctx.bufferAllocator());
+    }
+
+    @Override
+    public <Req, Resp> BlockingClientCall<Req, Resp> newBlockingCall(
+            final MethodDescriptor<Req, Resp> methodDescriptor, final BufferDecoderGroup decompressors) {
+        return (metadata, request) -> deserializeResp(methodDescriptor).deserialize(
+                transport.send(methodDescriptor.httpPath(),
+                        serializeReq(methodDescriptor)
+                                .serialize(Publisher.from(request), ctx.bufferAllocator())),
+                ctx.bufferAllocator()).firstOrError().toFuture().get();
+    }
+
+    @Override
+    public <Req, Resp> BlockingStreamingClientCall<Req, Resp> newBlockingStreamingCall(
+            final MethodDescriptor<Req, Resp> methodDescriptor, final BufferDecoderGroup decompressors) {
+        return (metadata, request) -> deserializeResp(methodDescriptor).deserialize(
+                transport.send(methodDescriptor.httpPath(),
+                        serializeReq(methodDescriptor)
+                                .serialize(Publisher.fromIterable(request), ctx.bufferAllocator())),
+                ctx.bufferAllocator()).toIterable();
+    }
+
+    @Override
+    public <Req, Resp> BlockingRequestStreamingClientCall<Req, Resp> newBlockingRequestStreamingCall(
+            final MethodDescriptor<Req, Resp> methodDescriptor, final BufferDecoderGroup decompressors) {
+        return (metadata, request) -> deserializeResp(methodDescriptor).deserialize(
+                transport.send(methodDescriptor.httpPath(),
+                        serializeReq(methodDescriptor)
+                                .serialize(Publisher.fromIterable(request), ctx.bufferAllocator())),
+                ctx.bufferAllocator()).firstOrError().toFuture().get();
+    }
+
+    @Override
+    public <Req, Resp> BlockingResponseStreamingClientCall<Req, Resp> newBlockingResponseStreamingCall(
+            final MethodDescriptor<Req, Resp> methodDescriptor, final BufferDecoderGroup decompressors) {
+        return (metadata, request) -> deserializeResp(methodDescriptor).deserialize(
+                transport.send(methodDescriptor.httpPath(),
+                        serializeReq(methodDescriptor)
+                                .serialize(Publisher.from(request), ctx.bufferAllocator())),
+                ctx.bufferAllocator()).toIterable();
+    }
+
+    @Override
+    public GrpcExecutionContext executionContext() {
+        return ctx;
+    }
+
+    @Override
+    public Completable onClose() {
+        return closeable.onClose();
+    }
+
+    @Override
+    public Completable closeAsync() {
+        return closeable.closeAsync();
+    }
+
+    @Override
+    public Completable closeAsyncGracefully() {
+        return closeable.closeAsyncGracefully();
+    }
+
+    @Deprecated
+    @Override
+    public <Req, Resp> ClientCall<Req, Resp> newCall(final GrpcSerializationProvider serializationProvider,
+                                                     final Class<Req> requestClass,
+                                                     final Class<Resp> responseClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    @Override
+    public <Req, Resp> StreamingClientCall<Req, Resp> newStreamingCall(
+            final GrpcSerializationProvider serializationProvider, final Class<Req> requestClass,
+            final Class<Resp> responseClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    @Override
+    public <Req, Resp> RequestStreamingClientCall<Req, Resp> newRequestStreamingCall(
+            final GrpcSerializationProvider serializationProvider, final Class<Req> requestClass,
+            final Class<Resp> responseClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    @Override
+    public <Req, Resp> ResponseStreamingClientCall<Req, Resp> newResponseStreamingCall(
+            final GrpcSerializationProvider serializationProvider, final Class<Req> requestClass,
+            final Class<Resp> responseClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    @Override
+    public <Req, Resp> BlockingClientCall<Req, Resp> newBlockingCall(
+            final GrpcSerializationProvider serializationProvider, final Class<Req> requestClass,
+            final Class<Resp> responseClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    @Override
+    public <Req, Resp> BlockingStreamingClientCall<Req, Resp> newBlockingStreamingCall(
+            final GrpcSerializationProvider serializationProvider, final Class<Req> requestClass,
+            final Class<Resp> responseClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    @Override
+    public <Req, Resp> BlockingRequestStreamingClientCall<Req, Resp> newBlockingRequestStreamingCall(
+            final GrpcSerializationProvider serializationProvider, final Class<Req> requestClass,
+            final Class<Resp> responseClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    @Override
+    public <Req, Resp> BlockingResponseStreamingClientCall<Req, Resp> newBlockingResponseStreamingCall(
+            final GrpcSerializationProvider serializationProvider, final Class<Req> requestClass,
+            final Class<Resp> responseClass) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/CustomTransportTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/CustomTransportTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.customtransport;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.grpc.api.GrpcBindableService;
+import io.servicetalk.grpc.api.GrpcClientCallFactory;
+import io.servicetalk.grpc.netty.TesterProto.TestRequest;
+import io.servicetalk.grpc.netty.TesterProto.Tester;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterClient;
+import io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutor;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.grpc.customtransport.Utils.newResp;
+import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+class CustomTransportTest {
+    enum ServiceType {
+        ASYNC(new AsyncUserService()), BLOCKING(new BlockingUserService());
+
+        final GrpcBindableService<?, ?, ?> grpcService;
+
+        ServiceType(GrpcBindableService<?, ?, ?> grpcService) {
+            this.grpcService = grpcService;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ServiceType.class)
+    void testCustomTransport(final ServiceType serviceType) throws Exception {
+        // You can re-use the EventLoopGroup used by your Netty application, we create one to demonstrate its use.
+        EventLoopAwareNettyIoExecutor ioExecutor = createIoExecutor("netty-el-");
+        // This is the Netty channel which is reading the request. See getServiceContext(Channel), depending
+        // upon what control you want to give users knowing this may not be necessary.
+        Channel c = new EmbeddedChannel();
+        try {
+            ServerTransport serverTransport = new InMemoryServerTransport(DEFAULT_ALLOCATOR, serviceType.grpcService);
+
+            // Build the client with the custom transport and bridge to server's transport.
+            Tester.TesterClient client = new Tester.ClientFactory() {
+                @Override
+                public TesterClient newClient(final GrpcClientCallFactory factory) {
+                    return super.newClient(factory);
+                }
+            }.newClient(new ClientTransportGrpcCallFactory(
+                    // Build the client transport, which just calls the server transport directly.
+                    (method, requestMessages) -> serverTransport.handle(c, "clientId", method, requestMessages),
+                    ioExecutor.eventLoopGroup()));
+
+            // Test using the client.
+            assertThat(client.test(newReq("scalar")).toFuture().get(), is(newResp("hello scalar")));
+            assertThat(client.testRequestStream(newReqStream("req")).toFuture().get(),
+                    is(newResp("hello reqstream1, reqstream2, ")));
+            assertThat(client.testResponseStream(newReq("respStream")).toFuture().get(),
+                    contains(newResp("hello respStream1"), newResp("hello respStream2")));
+            assertThat(client.testBiDiStream(newReqStream("duplex")).toFuture().get(),
+                    contains(newResp("hello duplexstream1"), newResp("hello duplexstream2")));
+        } finally {
+            c.close();
+
+            ioExecutor.closeAsync().toFuture().get();
+        }
+    }
+
+    private static Publisher<TestRequest> newReqStream(String prefix) {
+        return from(newReq(prefix + "stream1"), newReq(prefix + "stream2"));
+    }
+
+    private static TestRequest newReq(String name) {
+        return TestRequest.newBuilder().setName(name).build();
+    }
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/CustomTransportTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/CustomTransportTest.java
@@ -51,7 +51,7 @@ class CustomTransportTest {
     @EnumSource(ServiceType.class)
     void testCustomTransport(final ServiceType serviceType) throws Exception {
         // You can re-use the EventLoopGroup used by your Netty application, we create one to demonstrate its use.
-        EventLoopAwareNettyIoExecutor ioExecutor = createIoExecutor("netty-el-");
+        EventLoopAwareNettyIoExecutor ioExecutor = createIoExecutor("netty-el");
         // This is the Netty channel which is reading the request. See getServiceContext(Channel), depending
         // upon what control you want to give users knowing this may not be necessary.
         Channel c = new EmbeddedChannel();

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/InMemoryServerTransport.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/InMemoryServerTransport.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.customtransport;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.BlockingIterable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.internal.ConnectablePayloadWriter;
+import io.servicetalk.grpc.api.GrpcBindableService;
+import io.servicetalk.grpc.api.GrpcExecutionContext;
+import io.servicetalk.grpc.api.GrpcPayloadWriter;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.grpc.api.MethodDescriptor;
+import io.servicetalk.grpc.api.ParameterDescriptor;
+import io.servicetalk.grpc.api.SerializerDescriptor;
+import io.servicetalk.grpc.customtransport.Utils.ChannelGrpcServiceContext;
+import io.servicetalk.grpc.customtransport.Utils.GrpcStreamingDeserializer;
+import io.servicetalk.grpc.customtransport.Utils.GrpcStreamingSerializer;
+import io.servicetalk.grpc.customtransport.Utils.UtilGrpcExecutionContext;
+import io.servicetalk.serializer.api.StreamingDeserializer;
+import io.servicetalk.serializer.api.StreamingSerializer;
+import io.servicetalk.transport.netty.internal.GlobalExecutionContext;
+import io.servicetalk.transport.netty.internal.NettyIoExecutors;
+
+import com.google.rpc.Status;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Publisher.defer;
+import static io.servicetalk.concurrent.api.Publisher.failed;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.grpc.api.GrpcStatusCode.INTERNAL;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static java.lang.Math.ceil;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
+import static java.util.Objects.requireNonNull;
+
+final class InMemoryServerTransport implements ServerTransport {
+    private static final AttributeKey<GrpcServiceContext> GRPC_SERVICE_CONTEXT_KEY =
+            AttributeKey.newInstance("GrpcServiceContext");
+    private static final Map<EventLoop, GrpcExecutionContext> EVENT_LOOP_GRPC_EXECUTION_CONTEXT_MAP =
+            new ConcurrentHashMap<>();
+    private final Map<String, Route> routeMap;
+    private final BufferAllocator allocator;
+
+    InMemoryServerTransport(final BufferAllocator allocator, final GrpcBindableService<?, ?, ?> grpcService)
+            throws NoSuchMethodException, IllegalAccessException {
+        this.allocator = requireNonNull(allocator);
+        routeMap = new HashMap<>((int) ceil(grpcService.methodDescriptors().size() / 0.75));
+        for (MethodDescriptor<?, ?> md : grpcService.methodDescriptors()) {
+            routeMap.put(md.httpPath(), new Route(md, grpcService));
+        }
+    }
+
+    @Override
+    public Publisher<Buffer> handle(Channel channel,
+                                    @Nullable final String clientId, final String method,
+                                    final Publisher<Buffer> requestMessages) {
+        Route route = routeMap.get(method);
+        if (route == null) {
+            return failed(GrpcStatusException.of(Status.newBuilder().setCode(UNIMPLEMENTED.value())
+                    .setMessage("unimplemented method: " + method).build()));
+        }
+        try {
+            return route.handle(getServiceContext(channel, allocator), allocator, requestMessages);
+        } catch (Throwable cause) {
+            return failed((cause instanceof GrpcStatusException) ? cause : mapUnknownException(cause));
+        }
+    }
+
+    private static final class Route {
+        private final StreamingDeserializer<?> deserializer;
+        private final StreamingSerializer<?> serializer;
+        private final GrpcBindableService<?, ?, ?> grpcService;
+        private final MethodHandle methodHandle;
+        private final byte methodSignature;
+
+        Route(MethodDescriptor<?, ?> descriptor, final GrpcBindableService<?, ?, ?> grpcService)
+                throws NoSuchMethodException, IllegalAccessException {
+            requireNonNull(descriptor);
+            this.grpcService = requireNonNull(grpcService);
+            deserializer = new GrpcStreamingDeserializer<>(
+                    descriptor.requestDescriptor().serializerDescriptor().serializer());
+            SerializerDescriptor<?> respSerDesc = descriptor.responseDescriptor().serializerDescriptor();
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            final StreamingSerializer<?> localSerializer =
+                    new GrpcStreamingSerializer(respSerDesc.bytesEstimator(), respSerDesc.serializer());
+            serializer = localSerializer;
+            final MethodType mt;
+            final ParameterDescriptor<?> respDesc = descriptor.responseDescriptor();
+            final ParameterDescriptor<?> reqDesc = descriptor.requestDescriptor();
+            if (respDesc.isStreaming()) {
+                if (respDesc.isAsync()) {
+                    if (reqDesc.isStreaming()) {
+                        mt = methodType(Publisher.class, GrpcServiceContext.class, Publisher.class);
+                        methodSignature = 0;
+                    } else {
+                        mt = methodType(Publisher.class, GrpcServiceContext.class, reqDesc.parameterClass());
+                        methodSignature = 1;
+                    }
+                } else if (reqDesc.isStreaming()) { // 3 params!
+                    mt = methodType(Void.TYPE, GrpcServiceContext.class, BlockingIterable.class,
+                            GrpcPayloadWriter.class);
+                    methodSignature = 2;
+                } else { // 3 params!
+                    mt = methodType(Void.TYPE, GrpcServiceContext.class, reqDesc.parameterClass(),
+                            GrpcPayloadWriter.class);
+                    methodSignature = 3;
+                }
+            } else if (respDesc.isAsync()) {
+                assert reqDesc.isStreaming() == reqDesc.isAsync();
+                if (reqDesc.isStreaming()) {
+                    mt = methodType(Single.class, GrpcServiceContext.class, Publisher.class);
+                    methodSignature = 4;
+                } else {
+                    mt = methodType(Single.class, GrpcServiceContext.class, reqDesc.parameterClass());
+                    methodSignature = 5;
+                }
+            } else {
+                assert !reqDesc.isAsync();
+                if (reqDesc.isStreaming()) {
+                    mt = methodType(respDesc.parameterClass(), GrpcServiceContext.class, BlockingIterable.class);
+                    methodSignature = 6;
+                } else {
+                    mt = methodType(respDesc.parameterClass(), GrpcServiceContext.class, reqDesc.parameterClass());
+                    methodSignature = 7;
+                }
+            }
+            methodHandle = lookup().findVirtual(grpcService.getClass(), descriptor.javaMethodName(), mt);
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Publisher<Buffer> handle(GrpcServiceContext ctx, BufferAllocator allocator, Publisher<Buffer> requestMessages)
+                throws Throwable {
+            final Publisher<Buffer> result;
+            switch (methodSignature) {
+                case 0:
+                    result = serializer.serialize((Publisher) methodHandle.invoke(grpcService, ctx,
+                            deserializer.deserialize(requestMessages, allocator)), allocator);
+                    break;
+                case 1:
+                    result = deserializer.deserialize(requestMessages, allocator).flatMapMerge(req -> {
+                        try {
+                            return serializer.serialize((Publisher) methodHandle.invoke(grpcService, ctx, req),
+                                    allocator);
+                        } catch (Throwable t) {
+                            return failed(t);
+                        }
+                    });
+                    break;
+                case 2:
+                    result = defer(() -> {
+                        ConnectablePayloadWriter payloadWriter = new ConnectablePayloadWriter();
+                        GrpcPayloadWriter grpcWriter = new GrpcPayloadWriter() {
+                            @Override
+                            public void flush() throws IOException {
+                                payloadWriter.flush();
+                            }
+
+                            @Override
+                            public void close() throws IOException {
+                                payloadWriter.close();
+                            }
+
+                            @Override
+                            public void write(final Object o) throws IOException {
+                                payloadWriter.write(o);
+                            }
+
+                            @Override
+                            public void close(final Throwable cause) throws IOException {
+                                payloadWriter.close(cause);
+                            }
+                        };
+                        return ctx.executionContext().executor().submit(() -> {
+                            try {
+                                methodHandle.invoke(grpcService, ctx,
+                                        deserializer.deserialize(requestMessages, allocator).toIterable(), grpcWriter);
+                            } catch (Throwable t) {
+                                throwException(t);
+                            }
+                        }).merge(serializer.serialize(payloadWriter.connect(), allocator));
+                    });
+                    break;
+                case 3:
+                    result = deserializer.deserialize(requestMessages, allocator).flatMapMerge(req -> {
+                        ConnectablePayloadWriter payloadWriter = new ConnectablePayloadWriter();
+                        GrpcPayloadWriter grpcWriter = new GrpcPayloadWriter() {
+                            @Override
+                            public void flush() throws IOException {
+                                payloadWriter.flush();
+                            }
+
+                            @Override
+                            public void close() throws IOException {
+                                payloadWriter.close();
+                            }
+
+                            @Override
+                            public void write(final Object o) throws IOException {
+                                payloadWriter.write(o);
+                            }
+
+                            @Override
+                            public void close(final Throwable cause) throws IOException {
+                                payloadWriter.close(cause);
+                            }
+                        };
+                        return ctx.executionContext().executor().submit(() -> {
+                            try {
+                                methodHandle.invoke(grpcService, ctx, req, grpcWriter);
+                            } catch (Throwable t) {
+                                throwException(t);
+                            }
+                        }).merge(serializer.serialize(payloadWriter.connect(), allocator));
+                    });
+                    break;
+                case 4:
+                    result = serializer.serialize(((Single) methodHandle.invoke(grpcService, ctx,
+                            deserializer.deserialize(requestMessages, allocator))).toPublisher(), allocator);
+                    break;
+                case 5:
+                    result = deserializer.deserialize(requestMessages, allocator).flatMapMerge(req -> {
+                        try {
+                            return serializer.serialize(((Single) methodHandle.invoke(grpcService, ctx, req))
+                                    .toPublisher(), allocator);
+                        } catch (Throwable t) {
+                            return failed(t);
+                        }
+                    });
+                    break;
+                case 6:
+                    result = serializer.serialize((Publisher) from(methodHandle.invoke(grpcService, ctx,
+                                    deserializer.deserialize(requestMessages, allocator).toIterable())), allocator)
+                            .subscribeOn(ctx.executionContext().executor());
+                    break;
+                case 7:
+                    result = deserializer.deserialize(requestMessages, allocator).flatMapMerge(req -> {
+                        try {
+                            return serializer.serialize(
+                                    (Publisher) from(methodHandle.invoke(grpcService, ctx, req)), allocator);
+                        } catch (Throwable t) {
+                            return failed(t);
+                        }
+                    }).subscribeOn(ctx.executionContext().executor());
+                    break;
+                default:
+                    result = unexpectedMethodSignature();
+                    break;
+            }
+
+            return applyErrorRecovery(result);
+        }
+
+        private Publisher<Buffer> unexpectedMethodSignature() {
+            return failed(new IllegalStateException("unexpected methodSignature: " + (int) methodSignature));
+        }
+
+        private static Publisher<Buffer> applyErrorRecovery(Publisher<Buffer> publisher) {
+            return publisher.onErrorMap(cause -> !(cause instanceof GrpcStatusException),
+                    InMemoryServerTransport::mapUnknownException);
+        }
+    }
+
+    private static GrpcStatusException mapUnknownException(Throwable cause) {
+        return GrpcStatusException.of(Status.newBuilder().setCode(INTERNAL.value())
+                .setMessage("unexpected exception: " + cause).build());
+    }
+
+    private static GrpcServiceContext getServiceContext(Channel channel, BufferAllocator allocator) {
+        // GrpcServiceContext is 1:1 with the Channel for the request. Closing it also closes the connection.
+        Attribute<GrpcServiceContext> attr = channel.attr(GRPC_SERVICE_CONTEXT_KEY);
+        GrpcServiceContext serviceContext = attr.get();
+        if (serviceContext != null) {
+            return serviceContext;
+        }
+
+        // GrpcExecutionContext exposes IoExecutor which is 1:1 with EventLoop. You could also use a
+        // FastThreadLocal to store this info as well.
+        GrpcExecutionContext executionContext =
+                EVENT_LOOP_GRPC_EXECUTION_CONTEXT_MAP.computeIfAbsent(channel.eventLoop(), el ->
+                        new UtilGrpcExecutionContext(allocator, NettyIoExecutors.fromNettyEventLoop(el),
+                                GlobalExecutionContext.globalExecutionContext().executor()));
+
+        serviceContext = new ChannelGrpcServiceContext(channel, executionContext);
+        attr.set(serviceContext);
+        return serviceContext;
+    }
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ServerTransport.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ServerTransport.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.customtransport;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.api.Publisher;
+
+import io.netty.channel.Channel;
+
+import javax.annotation.Nullable;
+
+interface ServerTransport {
+    // Channel may be optional depending on what capabilities you want to provide to the Service.
+    // GrpcServiceContext is part of the gRPC service interface which is 1:1 with a child channel (h2 stream) in
+    // ServiceTalk. The service therefore has the ability to close/reset the channel/stream and listen for its
+    // closure.
+    Publisher<Buffer> handle(Channel channel,
+                             @Nullable String clientId, String method,
+                             Publisher<Buffer> requestMessages);
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.customtransport;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.AsyncCloseable;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
+import io.servicetalk.encoding.api.ContentCodec;
+import io.servicetalk.grpc.api.GrpcExecutionContext;
+import io.servicetalk.grpc.api.GrpcExecutionStrategies;
+import io.servicetalk.grpc.api.GrpcExecutionStrategy;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.api.MethodDescriptor;
+import io.servicetalk.grpc.netty.TesterProto;
+import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.serializer.api.Deserializer;
+import io.servicetalk.serializer.api.SerializationException;
+import io.servicetalk.serializer.api.Serializer;
+import io.servicetalk.serializer.api.StreamingDeserializer;
+import io.servicetalk.serializer.api.StreamingSerializer;
+import io.servicetalk.serializer.utils.FramedDeserializerOperator;
+import io.servicetalk.transport.api.IoExecutor;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.ToIntFunction;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+final class Utils {
+    private static final int METADATA_SIZE = 5; // 1 byte for compression flag and 4 bytes for length of data
+    private static final byte FLAG_UNCOMPRESSED = 0x0;
+    private static final byte FLAG_COMPRESSED = 0x1;
+    private Utils() {
+    }
+
+    static final class UtilGrpcExecutionContext implements GrpcExecutionContext {
+        private final BufferAllocator allocator;
+        private final IoExecutor ioExecutor;
+        private final Executor executor;
+
+        UtilGrpcExecutionContext(final BufferAllocator allocator,
+                                 final IoExecutor ioExecutor, final Executor executor) {
+            this.allocator = allocator;
+            this.ioExecutor = ioExecutor;
+            this.executor = executor;
+        }
+
+        @Override
+        public BufferAllocator bufferAllocator() {
+            return allocator;
+        }
+
+        @Override
+        public IoExecutor ioExecutor() {
+            return ioExecutor;
+        }
+
+        @Override
+        public Executor executor() {
+            return executor;
+        }
+
+        @Override
+        public GrpcExecutionStrategy executionStrategy() {
+            return GrpcExecutionStrategies.noOffloadsStrategy();
+        }
+    }
+
+    static final class ChannelGrpcServiceContext implements GrpcServiceContext {
+        private final ListenableAsyncCloseable closeAsync;
+        private final GrpcExecutionContext ctx;
+
+        ChannelGrpcServiceContext(Channel channel, GrpcExecutionContext ctx) {
+            closeAsync = toListenableAsyncCloseable(new AsyncCloseable() {
+                private final Completable closeAsync = new SubscribableCompletable() {
+                    @Override
+                    protected void handleSubscribe(final Subscriber subscriber) {
+                        ChannelFuture closeFuture;
+                        try {
+                            subscriber.onSubscribe(IGNORE_CANCEL);
+                            closeFuture = channel.close();
+                        } catch (Throwable cause) {
+                            handleExceptionFromOnSubscribe(subscriber, cause);
+                            return;
+                        }
+                        closeFuture.addListener(f -> {
+                            Throwable cause = f.cause();
+                            if (cause == null) {
+                                subscriber.onComplete();
+                            } else {
+                                subscriber.onError(cause);
+                            }
+                        });
+                    }
+                };
+
+                @Override
+                public Completable closeAsync() {
+                    return closeAsync;
+                }
+            });
+            this.ctx = Objects.requireNonNull(ctx);
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return closeAsync.closeAsync();
+        }
+
+        @Override
+        public Completable closeAsyncGracefully() {
+            return closeAsync.closeAsyncGracefully();
+        }
+
+        @Override
+        public Completable onClose() {
+            return closeAsync.onClose();
+        }
+
+        @Deprecated
+        @Override
+        public String path() {
+            return "<deprecated>";
+        }
+
+        @Override
+        public SocketAddress localAddress() {
+            return InMemorySocketAddress.INSTANCE;
+        }
+
+        @Override
+        public SocketAddress remoteAddress() {
+            return InMemorySocketAddress.INSTANCE;
+        }
+
+        @Nullable
+        @Override
+        public SSLSession sslSession() {
+            return null;
+        }
+
+        @Override
+        public GrpcExecutionContext executionContext() {
+            return ctx;
+        }
+
+        @Nullable
+        @Override
+        public <T> T socketOption(final SocketOption<T> option) {
+            return null;
+        }
+
+        @Override
+        public GrpcProtocol protocol() {
+            return InMemoryGrpcProtocol.INSTANCE;
+        }
+
+        @Deprecated
+        @Override
+        public List<ContentCodec> supportedMessageCodings() {
+            return Collections.emptyList();
+        }
+    }
+
+    private static final class InMemorySocketAddress extends SocketAddress {
+        static final SocketAddress INSTANCE = new InMemorySocketAddress();
+        private InMemorySocketAddress() {
+        }
+
+        @Override
+        public String toString() {
+            return "InMemory";
+        }
+    }
+
+    private static final class InMemoryGrpcProtocol implements GrpcServiceContext.GrpcProtocol {
+        static final GrpcServiceContext.GrpcProtocol INSTANCE = new InMemoryGrpcProtocol();
+        private InMemoryGrpcProtocol() {
+        }
+
+        @Override
+        public String name() {
+            return "gRPC";
+        }
+
+        @Override
+        public HttpProtocolVersion httpProtocol() {
+            return HttpProtocolVersion.HTTP_2_0;
+        }
+    }
+
+    static TesterProto.TestResponse newResp(String msg) {
+        return TesterProto.TestResponse.newBuilder().setMessage(msg).build();
+    }
+
+    static <Resp> StreamingDeserializer<Resp> deserializeResp(MethodDescriptor<?, Resp> methodDescriptor) {
+        return new GrpcStreamingDeserializer<>(
+                methodDescriptor.responseDescriptor().serializerDescriptor().serializer());
+    }
+
+    static <Req> StreamingSerializer<Req> serializeReq(MethodDescriptor<Req, ?> methodDescriptor) {
+        return new GrpcStreamingSerializer<>(
+                methodDescriptor.requestDescriptor().serializerDescriptor().bytesEstimator(),
+                methodDescriptor.requestDescriptor().serializerDescriptor().serializer());
+    }
+
+    static final class GrpcStreamingDeserializer<T> implements StreamingDeserializer<T> {
+        private final Deserializer<T> serializer;
+
+        GrpcStreamingDeserializer(final Deserializer<T> serializer) {
+            this.serializer = requireNonNull(serializer);
+        }
+
+        @Override
+        public Publisher<T> deserialize(final Publisher<Buffer> serializedData, final BufferAllocator allocator) {
+            return serializedData.liftSync(new FramedDeserializerOperator<>(serializer, GrpcDeframer::new, allocator))
+                    .flatMapConcatIterable(identity());
+        }
+
+        private static final class GrpcDeframer implements BiFunction<Buffer, BufferAllocator, Buffer> {
+            private int expectedLength = -1;
+
+            @Nullable
+            @Override
+            public Buffer apply(final Buffer buffer, final BufferAllocator allocator) {
+                if (expectedLength < 0) {
+                    if (buffer.readableBytes() < METADATA_SIZE) {
+                        return null;
+                    }
+                    if (isCompressed(buffer)) {
+                        throw new SerializationException("Compressed flag set, compression not supported");
+                    }
+                    expectedLength = buffer.readInt();
+                    if (expectedLength < 0) {
+                        throw new SerializationException("Message-Length invalid: " + expectedLength);
+                    }
+                }
+                if (buffer.readableBytes() < expectedLength) {
+                    return null;
+                }
+                Buffer result = buffer.readBytes(expectedLength);
+                expectedLength = -1;
+                return result;
+            }
+        }
+
+        private static boolean isCompressed(Buffer buffer) throws SerializationException {
+            final byte compressionFlag = buffer.readByte();
+            if (compressionFlag == FLAG_UNCOMPRESSED) {
+                return false;
+            } else if (compressionFlag == FLAG_COMPRESSED) {
+                return true;
+            }
+            throw new SerializationException("Compression flag must be 0 or 1 but was: " + compressionFlag);
+        }
+    }
+
+    static final class GrpcStreamingSerializer<T> implements StreamingSerializer<T> {
+        private final ToIntFunction<T> serializedBytesEstimator;
+        private final Serializer<T> serializer;
+
+        GrpcStreamingSerializer(final ToIntFunction<T> serializedBytesEstimator,
+                                final Serializer<T> serializer) {
+            this.serializedBytesEstimator = requireNonNull(serializedBytesEstimator);
+            this.serializer = requireNonNull(serializer);
+        }
+
+        @Override
+        public Publisher<Buffer> serialize(final Publisher<T> toSerialize, final BufferAllocator allocator) {
+            return toSerialize.map(t -> {
+                final int sizeEstimate = serializedBytesEstimator.applyAsInt(t);
+                Buffer buffer = allocator.newBuffer(METADATA_SIZE + sizeEstimate);
+                final int writerIndexBefore = buffer.writerIndex();
+                buffer.writerIndex(writerIndexBefore + METADATA_SIZE);
+                serializer.serialize(t, allocator, buffer);
+                // Compression isn't supported for this example.
+                buffer.setByte(writerIndexBefore, FLAG_UNCOMPRESSED);
+                buffer.setInt(writerIndexBefore + 1, buffer.writerIndex() - writerIndexBefore - METADATA_SIZE);
+                return buffer;
+            });
+        }
+    }
+}

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Types.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Types.java
@@ -18,6 +18,7 @@ package io.servicetalk.grpc.protoc;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.WildcardTypeName;
 
 import static com.squareup.javapoet.ClassName.bestGuess;
 
@@ -34,9 +35,12 @@ final class Types {
     private static final String routerApiPkg = basePkg + ".router.api";
     private static final String protobufDataPkg = basePkg + ".data.protobuf";
 
+    private static final TypeName Wildcard = WildcardTypeName.subtypeOf(Object.class);
     static final ClassName List = ClassName.get("java.util", "List");
     static final ClassName Objects = ClassName.get("java.util", "Objects");
     static final ClassName Collections = ClassName.get("java.util", "Collections");
+    static final ClassName Arrays = ClassName.get("java.util", "Arrays");
+    private static final ClassName Collection = ClassName.get("java.util", "Collection");
 
     private static final ClassName RouteExecutionStrategyFactory =
             bestGuess(routerApiPkg + ".RouteExecutionStrategyFactory");
@@ -77,6 +81,8 @@ final class Types {
     static final ClassName GrpcServiceFilterFactory = bestGuess(grpcApiPkg + ".GrpcServiceFilterFactory");
     static final ClassName GrpcMethodDescriptor = bestGuess(grpcApiPkg + ".MethodDescriptor");
     static final ClassName GrpcMethodDescriptors = bestGuess(grpcApiPkg + ".MethodDescriptors");
+    static final ParameterizedTypeName GrpcMethodDescriptorCollection = ParameterizedTypeName.get(Collection,
+            ParameterizedTypeName.get(GrpcMethodDescriptor, Wildcard, Wildcard));
 
     static final ClassName BlockingClientCall = bestGuess(GrpcClientCallFactory + ".BlockingClientCall");
     static final ClassName BlockingRequestStreamingClientCall =

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
@@ -50,6 +50,7 @@ final class Words {
     static final String bufferEncoders = "bufferEncoders";
     static final String strategyFactory = strategy + "Factory";
     static final String methodDescriptor = "methodDescriptor";
+    static final String methodDescriptors = methodDescriptor + "s";
     static final String Service = "Service";
     static final String Blocking = "Blocking";
     static final String Builder = "Builder";
@@ -70,6 +71,8 @@ final class Words {
     static final String JAVADOC_RETURN = "@return ";
     static final String JAVADOC_THROWS = "@throws ";
     static final String JAVADOC_DEPRECATED = "@deprecated";
+    static final String ASYNC_METHOD_DESCRIPTORS = "ASYNC_METHOD_DESCRIPTORS";
+    static final String BLOCKING_METHOD_DESCRIPTORS = "BLOCKING_METHOD_DESCRIPTORS";
 
     private Words() {
         // no instance


### PR DESCRIPTION
Motivation:
It is currently not possible for a user to get a Collection of
MethodDescriptors corresponding to a service. The collection of
MethodDescriptors is necessary to build dynamic routing in the event of
a custom transport.

Modifications:
- Add `Collection<MethodDescriptor<?, ?>>` method to
  `GrpcBindableService` API.
- Add a unit test which introduces a custom in memory transport and
  dynamic routing for a service, and also a client that routes to that
  transport in memory.

Result:
It is now possible to get a Collection of MethodDescriptor from a
service, and dynamically build routing for a custom transport.