### PR TITLE
Adds stack capture to OffloadingTest

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/AbstractCompletableOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/AbstractCompletableOffloadingTest.java
@@ -55,55 +55,55 @@ public abstract class AbstractCompletableOffloadingTest extends AbstractOffloadi
                 // Insert a custom value into AsyncContext map
                 AsyncContext.current().put(ASYNC_CONTEXT_CUSTOM_KEY, ASYNC_CONTEXT_VALUE);
 
-                capture(CaptureSlot.IN_APP);
+                capture(CaptureSlot.APP);
 
                 // Add thread/context recording test points
                 final Completable original = testCompletable
                         .liftSync(subscriber -> {
-                            capture(CaptureSlot.IN_OFFLOADED_SUBSCRIBE);
+                            capture(CaptureSlot.OFFLOADED_SUBSCRIBE);
                             return subscriber;
                         })
-                        .beforeOnSubscribe(cancellable -> capture(CaptureSlot.IN_ORIGINAL_ON_SUBSCRIBE))
+                        .beforeOnSubscribe(cancellable -> capture(CaptureSlot.ORIGINAL_ON_SUBSCRIBE))
                         .beforeFinally(new TerminalSignalConsumer() {
 
                             @Override
                             public void onComplete() {
-                                capture(CaptureSlot.IN_ORIGINAL_ON_COMPLETE);
+                                capture(CaptureSlot.ORIGINAL_ON_COMPLETE);
                             }
 
                             @Override
                             public void onError(final Throwable throwable) {
-                                capture(CaptureSlot.IN_ORIGINAL_ON_ERROR);
+                                capture(CaptureSlot.ORIGINAL_ON_ERROR);
                             }
 
                             @Override
                             public void cancel() {
-                                capture(CaptureSlot.IN_OFFLOADED_CANCEL);
+                                capture(CaptureSlot.OFFLOADED_CANCEL);
                             }
                         });
 
                 // Perform offloading and add more thread/context recording test points
                 Completable offloaded = offloadingFunction.apply(original, testExecutor.executor())
                         .liftSync(subscriber -> {
-                            capture(CaptureSlot.IN_ORIGINAL_SUBSCRIBE);
+                            capture(CaptureSlot.ORIGINAL_SUBSCRIBE);
                             return subscriber;
                         })
-                        .beforeOnSubscribe(cancellable -> capture(CaptureSlot.IN_OFFLOADED_ON_SUBSCRIBE))
+                        .beforeOnSubscribe(cancellable -> capture(CaptureSlot.OFFLOADED_ON_SUBSCRIBE))
                         .beforeFinally(new TerminalSignalConsumer() {
 
                             @Override
                             public void onComplete() {
-                                capture(CaptureSlot.IN_OFFLOADED_ON_COMPLETE);
+                                capture(CaptureSlot.OFFLOADED_ON_COMPLETE);
                             }
 
                             @Override
                             public void onError(final Throwable throwable) {
-                                capture(CaptureSlot.IN_OFFLOADED_ON_ERROR);
+                                capture(CaptureSlot.OFFLOADED_ON_ERROR);
                             }
 
                             @Override
                             public void cancel() {
-                                capture(CaptureSlot.IN_ORIGINAL_CANCEL);
+                                capture(CaptureSlot.ORIGINAL_CANCEL);
                             }
                         });
 
@@ -163,15 +163,15 @@ public abstract class AbstractCompletableOffloadingTest extends AbstractOffloadi
         }
 
         // Ensure that Async Context Map was correctly set during signals
-        AsyncContextMap appMap = capturedContexts.captured(CaptureSlot.IN_APP);
+        AsyncContextMap appMap = capturedContexts.captured(CaptureSlot.APP);
         assertThat(appMap, notNullValue());
-        AsyncContextMap subscribeMap = capturedContexts.captured(CaptureSlot.IN_ORIGINAL_SUBSCRIBE);
+        AsyncContextMap subscribeMap = capturedContexts.captured(CaptureSlot.ORIGINAL_SUBSCRIBE);
         assertThat(subscribeMap, notNullValue());
         assertThat("Map was shared not copied", subscribeMap, not(sameInstance(appMap)));
         assertThat("Missing custom async context entry ",
                 subscribeMap.get(ASYNC_CONTEXT_CUSTOM_KEY), sameInstance(ASYNC_CONTEXT_VALUE));
         EnumSet<CaptureSlot> checkSlots =
-                EnumSet.complementOf(EnumSet.of(CaptureSlot.IN_APP, CaptureSlot.IN_ORIGINAL_SUBSCRIBE));
+                EnumSet.complementOf(EnumSet.of(CaptureSlot.APP, CaptureSlot.ORIGINAL_SUBSCRIBE));
         checkSlots.stream()
                 .filter(slot -> null != capturedContexts.captured(slot))
                 .forEach(slot -> {

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/OffloadingTest.java
@@ -23,23 +23,23 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_APP;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_CANCEL;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_COMPLETE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_ERROR;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_SUBSCRIBE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_SUBSCRIBE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_CANCEL;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_COMPLETE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_ERROR;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_SUBSCRIBE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.APP;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_CANCEL;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_COMPLETE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_ERROR;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_CANCEL;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_COMPLETE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_ERROR;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_SUBSCRIBE;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -48,77 +48,77 @@ class OffloadingTest extends AbstractCompletableOffloadingTest {
     enum OffloadCase {
         NO_OFFLOAD_SUCCESS(0, "none",
                 (c, e) -> c, TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
                 EnumSet.noneOf(CaptureSlot.class)),
         NO_OFFLOAD_ERROR(0, "none",
                 (c, e) -> c, TerminalOperation.ERROR,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_ERROR, IN_OFFLOADED_ON_ERROR),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_ERROR, OFFLOADED_ON_ERROR),
                 EnumSet.noneOf(CaptureSlot.class)),
         NO_OFFLOAD_CANCEL(0, "none",
                 (c, e) -> c, TerminalOperation.CANCEL,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_CANCEL, IN_OFFLOADED_CANCEL),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_CANCEL, OFFLOADED_CANCEL),
                 EnumSet.noneOf(CaptureSlot.class)),
         SUBSCRIBE_ON_SUCCESS(1, "subscribe",
                 Completable::subscribeOn, TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
-                EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
+                EnumSet.of(OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE)),
         SUBSCRIBE_ON_CONDITIONAL_NEVER(0, "none",
                 (c, e) -> c.subscribeOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
                 EnumSet.noneOf(CaptureSlot.class)),
         SUBSCRIBE_ON_ERROR(1, "subscribe",
                 Completable::subscribeOn, TerminalOperation.ERROR,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE,
-                        IN_ORIGINAL_ON_ERROR, IN_OFFLOADED_ON_ERROR),
-                EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE,
+                        ORIGINAL_ON_ERROR, OFFLOADED_ON_ERROR),
+                EnumSet.of(OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE)),
         SUBSCRIBE_ON_CANCEL(2, "subscribe, cancel",
                 Completable::subscribeOn, TerminalOperation.CANCEL,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_ORIGINAL_CANCEL),
-                EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_OFFLOADED_CANCEL)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, ORIGINAL_CANCEL),
+                EnumSet.of(OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        OFFLOADED_CANCEL)),
         PUBLISH_ON_SUCCESS(2, "onSubscribe, onComplete",
                 Completable::publishOn, TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_ORIGINAL_ON_COMPLETE),
-                EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE, IN_OFFLOADED_ON_COMPLETE)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, ORIGINAL_ON_COMPLETE),
+                EnumSet.of(OFFLOADED_ON_SUBSCRIBE, OFFLOADED_ON_COMPLETE)),
         PUBLISH_ON_CONDITIONAL_NEVER(0, "none",
                 (c, e) -> c.publishOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
                 EnumSet.noneOf(CaptureSlot.class)),
         PUBLISH_ON_CONDITIONAL_SECOND(1, "onComplete",
                 (c, e) -> Completable.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
                     return c.publishOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
                 }), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE),
-                EnumSet.of(IN_OFFLOADED_ON_COMPLETE)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE),
+                EnumSet.of(OFFLOADED_ON_COMPLETE)),
         PUBLISH_ON_ERROR(2, "onSubscribe, onError",
                 Completable::publishOn, TerminalOperation.ERROR,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_ORIGINAL_ON_ERROR),
-                EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE, IN_OFFLOADED_ON_ERROR)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, ORIGINAL_ON_ERROR),
+                EnumSet.of(OFFLOADED_ON_SUBSCRIBE, OFFLOADED_ON_ERROR)),
         PUBLISH_ON_CANCEL(1, "onSubscribe",
                 Completable::publishOn, TerminalOperation.CANCEL,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE,
-                        IN_ORIGINAL_CANCEL, IN_OFFLOADED_CANCEL),
-                EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE));
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE,
+                        ORIGINAL_CANCEL, OFFLOADED_CANCEL),
+                EnumSet.of(OFFLOADED_ON_SUBSCRIBE));
 
         final int offloadsExpected;
         final String expectedOffloads;
@@ -129,13 +129,15 @@ class OffloadingTest extends AbstractCompletableOffloadingTest {
         OffloadCase(int offloadsExpected, String expectedOffloads,
                     BiFunction<Completable, Executor, Completable> offloadOperator,
                     TerminalOperation terminal,
-                    Set<CaptureSlot> nonOffloaded, EnumSet<CaptureSlot> offloaded) {
+                    EnumSet<CaptureSlot> nonOffloaded, EnumSet<CaptureSlot> offloaded) {
             this.offloadsExpected = offloadsExpected;
             this.expectedOffloads = expectedOffloads;
             this.offloadOperator = offloadOperator;
             this.terminal = terminal;
             EnumSet.allOf(CaptureSlot.class).forEach(slot -> this.threadNameMatchers.put(slot, nullValue()));
-            this.threadNameMatchers.put(IN_APP, APP_EXECUTOR);
+            this.threadNameMatchers.put(APP, APP_EXECUTOR);
+            assertThat("Overlapping non-offloading and offloading slots",
+                    Collections.disjoint(nonOffloaded, offloaded));
             nonOffloaded.forEach(slot -> this.threadNameMatchers.put(slot, APP_EXECUTOR));
             offloaded.forEach(slot -> this.threadNameMatchers.put(slot, OFFLOAD_EXECUTOR));
         }
@@ -148,6 +150,7 @@ class OffloadingTest extends AbstractCompletableOffloadingTest {
         assertThat("Unexpected offloads: " + offloadCase.expectedOffloads,
                 offloads, CoreMatchers.is(offloadCase.offloadsExpected));
         offloadCase.threadNameMatchers.forEach((slot, matcher) ->
-                capturedThreads.assertCaptured("Match failed " + slot + " : " + capturedThreads, slot, matcher));
+                capturedThreads.assertCaptured("Match failed " + slot + " : " + capturedThreads,
+                        capturedStacks.captured(slot), slot, matcher));
     }
 }

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/AbstractOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/AbstractOffloadingTest.java
@@ -45,21 +45,21 @@ public abstract class AbstractOffloadingTest {
             AsyncContextMap.Key.newKey(ASYNC_CONTEXT_KEY);
 
     public enum CaptureSlot {
-        IN_APP,
-        IN_ORIGINAL_SUBSCRIBE,
-        IN_OFFLOADED_SUBSCRIBE,
-        IN_ORIGINAL_ON_COMPLETE,
-        IN_OFFLOADED_ON_COMPLETE,
-        IN_ORIGINAL_ON_SUBSCRIBE,
-        IN_OFFLOADED_ON_SUBSCRIBE,
-        IN_ORIGINAL_ON_ERROR,
-        IN_OFFLOADED_ON_ERROR,
-        IN_ORIGINAL_REQUEST,
-        IN_OFFLOADED_REQUEST,
-        IN_ORIGINAL_ON_NEXT,
-        IN_OFFLOADED_ON_NEXT,
-        IN_ORIGINAL_CANCEL,
-        IN_OFFLOADED_CANCEL
+        APP,
+        ORIGINAL_SUBSCRIBE,
+        OFFLOADED_SUBSCRIBE,
+        ORIGINAL_ON_SUBSCRIBE,
+        OFFLOADED_ON_SUBSCRIBE,
+        ORIGINAL_CANCEL,
+        OFFLOADED_CANCEL,
+        ORIGINAL_REQUEST,
+        OFFLOADED_REQUEST,
+        ORIGINAL_ON_NEXT,
+        OFFLOADED_ON_NEXT,
+        ORIGINAL_ON_COMPLETE,
+        OFFLOADED_ON_COMPLETE,
+        ORIGINAL_ON_ERROR,
+        OFFLOADED_ON_ERROR
     }
 
     protected enum TerminalOperation {
@@ -87,15 +87,18 @@ public abstract class AbstractOffloadingTest {
     public final ExecutorExtension<TestExecutor> testExecutor = ExecutorExtension.withTestExecutor();
 
     protected final CaptureReferences<CaptureSlot, String> capturedThreads;
+    protected final CaptureReferences<CaptureSlot, Throwable> capturedStacks;
     protected final CaptureReferences<CaptureSlot, AsyncContextMap> capturedContexts;
 
     protected AbstractOffloadingTest() {
         this.capturedThreads = new CaptureReferences(CaptureSlot.class, () -> Thread.currentThread().getName());
+        this.capturedStacks = new CaptureReferences(CaptureSlot.class, () -> new Throwable("Stack Dump"));
         this.capturedContexts = new CaptureReferences(CaptureSlot.class, AsyncContext::current);
     }
 
     protected void capture(CaptureSlot slot) {
         capturedThreads.capture(slot);
+        capturedStacks.capture(slot);
         capturedContexts.capture(slot);
     }
 }

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/CaptureReferences.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/CaptureReferences.java
@@ -109,4 +109,23 @@ public class CaptureReferences<E extends Enum<E>, R> {
     public void assertCaptured(String reason, E slot, Matcher<? super R> matcher) throws AssertionError {
         org.hamcrest.MatcherAssert.assertThat(reason + " : " + slot, captured(slot), matcher);
     }
+
+    /**
+     * Asserts that the reference captured in the specified slot matches the provided matcher.
+     *
+     * @param reason message to include for failed matches
+     * @param stack the stack to include
+     * @param slot slot of interest
+     * @param matcher the matcher which will be applied to the captured reference
+     * @throws AssertionError if the captured value of the slot does not match
+     */
+    public void assertCaptured(String reason, Throwable stack, E slot, Matcher<? super R> matcher)
+            throws AssertionError {
+        try {
+            org.hamcrest.MatcherAssert.assertThat(reason + " : " + slot, captured(slot), matcher);
+        } catch (AssertionError assertionError) {
+            assertionError.initCause(stack);
+            throw assertionError;
+        }
+    }
 }

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/OffloadingTest.java
@@ -20,148 +20,152 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_APP;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_CANCEL;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_COMPLETE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_ERROR;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_NEXT;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_SUBSCRIBE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_REQUEST;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_SUBSCRIBE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_CANCEL;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_COMPLETE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_ERROR;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_NEXT;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_SUBSCRIBE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_REQUEST;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.APP;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_CANCEL;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_COMPLETE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_ERROR;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_NEXT;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_REQUEST;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_CANCEL;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_COMPLETE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_ERROR;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_NEXT;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_REQUEST;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_SUBSCRIBE;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Execution(ExecutionMode.CONCURRENT)
 class OffloadingTest extends AbstractPublisherOffloadingTest {
 
     enum OffloadCase {
         NO_OFFLOAD_SUCCESS(0, "none",
                 (c, e) -> c, TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_ON_NEXT, IN_OFFLOADED_ON_NEXT,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST, OFFLOADED_REQUEST,
+                        ORIGINAL_ON_NEXT, OFFLOADED_ON_NEXT,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
                 EnumSet.noneOf(CaptureSlot.class)),
         NO_OFFLOAD_ERROR(0, "none",
                 (c, e) -> c, TerminalOperation.ERROR,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_ON_ERROR, IN_OFFLOADED_ON_ERROR),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST, OFFLOADED_REQUEST,
+                        ORIGINAL_ON_ERROR, OFFLOADED_ON_ERROR),
                 EnumSet.noneOf(CaptureSlot.class)),
         NO_OFFLOAD_CANCEL(0, "none",
                 (c, e) -> c, TerminalOperation.CANCEL,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_CANCEL, IN_OFFLOADED_CANCEL),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST, OFFLOADED_REQUEST,
+                        ORIGINAL_CANCEL, OFFLOADED_CANCEL),
                 EnumSet.noneOf(CaptureSlot.class)),
         SUBSCRIBE_ON_SUCCESS(2, "subscribe, request",
                 Publisher::subscribeOn, TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST,
-                        IN_ORIGINAL_ON_NEXT, IN_OFFLOADED_ON_NEXT,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
-                EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_OFFLOADED_REQUEST)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE,
+                        ORIGINAL_REQUEST,
+                        ORIGINAL_ON_NEXT, OFFLOADED_ON_NEXT,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
+                EnumSet.of(OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        OFFLOADED_REQUEST)),
         SUBSCRIBE_ON_CONDITIONAL_NEVER(0, "none",
                 (p, e) -> p.subscribeOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_ON_NEXT, IN_OFFLOADED_ON_NEXT,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST, OFFLOADED_REQUEST,
+                        ORIGINAL_ON_NEXT, OFFLOADED_ON_NEXT,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
                 EnumSet.noneOf(CaptureSlot.class)),
         SUBSCRIBE_ON_CONDITIONAL_SECOND(1, "request",
                 (p, e) -> Publisher.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
                     return p.subscribeOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
                 }), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_ON_NEXT, IN_OFFLOADED_ON_NEXT,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
-                EnumSet.of(IN_OFFLOADED_REQUEST)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST,
+                        ORIGINAL_ON_NEXT, OFFLOADED_ON_NEXT,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
+                EnumSet.of(OFFLOADED_REQUEST)),
         SUBSCRIBE_ON_ERROR(2, "subscribe, request",
                 Publisher::subscribeOn, TerminalOperation.ERROR,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST,
-                        IN_ORIGINAL_ON_ERROR, IN_OFFLOADED_ON_ERROR),
-                EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_OFFLOADED_REQUEST)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE,
+                        ORIGINAL_REQUEST,
+                        ORIGINAL_ON_ERROR, OFFLOADED_ON_ERROR),
+                EnumSet.of(OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        OFFLOADED_REQUEST)),
         SUBSCRIBE_ON_CANCEL(3, "subscribe, request, cancel",
                 Publisher::subscribeOn, TerminalOperation.CANCEL,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST,
-                        IN_ORIGINAL_CANCEL),
-                EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_OFFLOADED_REQUEST, IN_OFFLOADED_CANCEL)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE,
+                        ORIGINAL_REQUEST,
+                        ORIGINAL_CANCEL),
+                EnumSet.of(OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        OFFLOADED_REQUEST, OFFLOADED_CANCEL)),
         PUBLISH_ON_SUCCESS(3, "onSubscribe, onNext, onComplete",
                 Publisher::publishOn, TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_ON_NEXT,
-                        IN_ORIGINAL_ON_COMPLETE),
-                EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_OFFLOADED_ON_NEXT,
-                        IN_OFFLOADED_ON_COMPLETE)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST, OFFLOADED_REQUEST,
+                        ORIGINAL_ON_NEXT,
+                        ORIGINAL_ON_COMPLETE),
+                EnumSet.of(OFFLOADED_ON_SUBSCRIBE,
+                        OFFLOADED_ON_NEXT,
+                        OFFLOADED_ON_COMPLETE)),
         PUBLISH_ON_CONDITIONAL_NEVER(0, "none",
                 (p, e) -> p.publishOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_ON_NEXT, IN_OFFLOADED_ON_NEXT,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST, OFFLOADED_REQUEST,
+                        ORIGINAL_ON_NEXT, OFFLOADED_ON_NEXT,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
                 EnumSet.noneOf(CaptureSlot.class)),
         PUBLISH_ON_CONDITIONAL_SECOND(2, "onNext, onComplete",
                 (p, e) -> Publisher.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
                     return p.publishOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
                 }), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_ON_NEXT,
-                        IN_ORIGINAL_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST, OFFLOADED_REQUEST,
+                        ORIGINAL_ON_NEXT,
+                        ORIGINAL_ON_COMPLETE),
                 EnumSet.of(
-                        IN_OFFLOADED_ON_NEXT,
-                        IN_OFFLOADED_ON_COMPLETE)),
+                        OFFLOADED_ON_NEXT,
+                        OFFLOADED_ON_COMPLETE)),
         PUBLISH_ON_ERROR(2, "onSubscribe, onError",
                 Publisher::publishOn, TerminalOperation.ERROR,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_ON_ERROR),
-                EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_OFFLOADED_ON_ERROR)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST, OFFLOADED_REQUEST,
+                        ORIGINAL_ON_ERROR),
+                EnumSet.of(OFFLOADED_ON_SUBSCRIBE,
+                        OFFLOADED_ON_ERROR)),
         PUBLISH_ON_CANCEL(1, "onSubscribe",
                 Publisher::publishOn, TerminalOperation.CANCEL,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE,
-                        IN_ORIGINAL_REQUEST, IN_OFFLOADED_REQUEST,
-                        IN_ORIGINAL_CANCEL, IN_OFFLOADED_CANCEL),
-                EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE));
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE,
+                        ORIGINAL_REQUEST, OFFLOADED_REQUEST,
+                        ORIGINAL_CANCEL, OFFLOADED_CANCEL),
+                EnumSet.of(OFFLOADED_ON_SUBSCRIBE));
 
         final int offloadsExpected;
         final String expectedOffloads;
@@ -178,7 +182,9 @@ class OffloadingTest extends AbstractPublisherOffloadingTest {
             this.offloadOperator = offloadOperator;
             this.terminal = terminal;
             EnumSet.allOf(CaptureSlot.class).forEach(slot -> this.threadNameMatchers.put(slot, nullValue()));
-            this.threadNameMatchers.put(IN_APP, APP_EXECUTOR);
+            this.threadNameMatchers.put(APP, APP_EXECUTOR);
+            assertThat("Overlapping non-offloading and offloading slots",
+                    Collections.disjoint(nonOffloaded, offloaded));
             nonOffloaded.forEach(slot -> this.threadNameMatchers.put(slot, APP_EXECUTOR));
             offloaded.forEach(slot -> this.threadNameMatchers.put(slot, OFFLOAD_EXECUTOR));
         }
@@ -191,6 +197,7 @@ class OffloadingTest extends AbstractPublisherOffloadingTest {
         assertThat("Unexpected offloads: " + offloadCase.expectedOffloads,
                 offloads, CoreMatchers.is(offloadCase.offloadsExpected));
         offloadCase.threadNameMatchers.forEach((slot, matcher) ->
-                capturedThreads.assertCaptured("Match failed " + slot + " : " + capturedThreads, slot, matcher));
+                capturedThreads.assertCaptured("Match failed " + slot + " : " + capturedThreads,
+                        capturedStacks.captured(slot), slot, matcher));
     }
 }

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/AbstractSingleOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/AbstractSingleOffloadingTest.java
@@ -58,55 +58,55 @@ public abstract class AbstractSingleOffloadingTest extends AbstractOffloadingTes
                 // Insert a custom value into AsyncContext map
                 AsyncContext.current().put(ASYNC_CONTEXT_CUSTOM_KEY, ASYNC_CONTEXT_VALUE);
 
-                capture(CaptureSlot.IN_APP);
+                capture(CaptureSlot.APP);
 
                 // Add thread recording test points
                 final Single<String> original = testSingle
                         .liftSync((SingleOperator<String, String>) subscriber -> {
-                            capture(CaptureSlot.IN_OFFLOADED_SUBSCRIBE);
+                            capture(CaptureSlot.OFFLOADED_SUBSCRIBE);
                             return subscriber;
                         })
-                        .beforeOnSubscribe(cancellable -> capture(CaptureSlot.IN_ORIGINAL_ON_SUBSCRIBE))
+                        .beforeOnSubscribe(cancellable -> capture(CaptureSlot.ORIGINAL_ON_SUBSCRIBE))
                         .beforeFinally(new TerminalSignalConsumer() {
 
                             @Override
                             public void onComplete() {
-                                capture(CaptureSlot.IN_ORIGINAL_ON_COMPLETE);
+                                capture(CaptureSlot.ORIGINAL_ON_COMPLETE);
                             }
 
                             @Override
                             public void onError(final Throwable throwable) {
-                                capture(CaptureSlot.IN_ORIGINAL_ON_ERROR);
+                                capture(CaptureSlot.ORIGINAL_ON_ERROR);
                             }
 
                             @Override
                             public void cancel() {
-                                capture(CaptureSlot.IN_OFFLOADED_CANCEL);
+                                capture(CaptureSlot.OFFLOADED_CANCEL);
                             }
                         });
 
                 // Perform offloading and add more thread recording test points
                 Single<String> offloaded = offloadingFunction.apply(original, testExecutor.executor())
                         .liftSync((SingleOperator<String, String>) subscriber -> {
-                            capture(CaptureSlot.IN_ORIGINAL_SUBSCRIBE);
+                            capture(CaptureSlot.ORIGINAL_SUBSCRIBE);
                             return subscriber;
                         })
-                        .beforeOnSubscribe(cancellable -> capture(CaptureSlot.IN_OFFLOADED_ON_SUBSCRIBE))
+                        .beforeOnSubscribe(cancellable -> capture(CaptureSlot.OFFLOADED_ON_SUBSCRIBE))
                         .beforeFinally(new TerminalSignalConsumer() {
 
                             @Override
                             public void onComplete() {
-                                capture(CaptureSlot.IN_OFFLOADED_ON_COMPLETE);
+                                capture(CaptureSlot.OFFLOADED_ON_COMPLETE);
                             }
 
                             @Override
                             public void onError(final Throwable throwable) {
-                                capture(CaptureSlot.IN_OFFLOADED_ON_ERROR);
+                                capture(CaptureSlot.OFFLOADED_ON_ERROR);
                             }
 
                             @Override
                             public void cancel() {
-                                capture(CaptureSlot.IN_ORIGINAL_CANCEL);
+                                capture(CaptureSlot.ORIGINAL_CANCEL);
                             }
                         });
 
@@ -167,15 +167,15 @@ public abstract class AbstractSingleOffloadingTest extends AbstractOffloadingTes
         }
 
         // Ensure that Async Context Map was correctly set during signals
-        AsyncContextMap appMap = capturedContexts.captured(CaptureSlot.IN_APP);
+        AsyncContextMap appMap = capturedContexts.captured(CaptureSlot.APP);
         assertThat(appMap, notNullValue());
-        AsyncContextMap subscribeMap = capturedContexts.captured(CaptureSlot.IN_ORIGINAL_SUBSCRIBE);
+        AsyncContextMap subscribeMap = capturedContexts.captured(CaptureSlot.ORIGINAL_SUBSCRIBE);
         assertThat(subscribeMap, notNullValue());
         assertThat("Map was shared not copied", subscribeMap, not(sameInstance(appMap)));
         assertThat("Missing custom async context entry ",
                 subscribeMap.get(ASYNC_CONTEXT_CUSTOM_KEY), sameInstance(ASYNC_CONTEXT_VALUE));
         EnumSet<CaptureSlot> checkSlots =
-                EnumSet.complementOf(EnumSet.of(CaptureSlot.IN_APP, CaptureSlot.IN_ORIGINAL_SUBSCRIBE));
+                EnumSet.complementOf(EnumSet.of(CaptureSlot.APP, CaptureSlot.ORIGINAL_SUBSCRIBE));
         checkSlots.stream()
                 .filter(slot -> null != capturedContexts.captured(slot))
                 .forEach(slot -> {

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/OffloadingTest.java
@@ -23,23 +23,23 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_APP;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_CANCEL;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_COMPLETE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_ERROR;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_ON_SUBSCRIBE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_OFFLOADED_SUBSCRIBE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_CANCEL;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_COMPLETE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_ERROR;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_ON_SUBSCRIBE;
-import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.IN_ORIGINAL_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.APP;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_CANCEL;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_COMPLETE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_ERROR;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_ON_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.OFFLOADED_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_CANCEL;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_COMPLETE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_ERROR;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_ON_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.CaptureSlot.ORIGINAL_SUBSCRIBE;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -48,76 +48,76 @@ class OffloadingTest extends AbstractSingleOffloadingTest {
     enum OffloadCase {
         NO_OFFLOAD_SUCCESS(0, "none",
                 (c, e) -> c, TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
                 EnumSet.noneOf(CaptureSlot.class)),
         NO_OFFLOAD_ERROR(0, "none",
                 (c, e) -> c, TerminalOperation.ERROR,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_ERROR, IN_OFFLOADED_ON_ERROR),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_ERROR, OFFLOADED_ON_ERROR),
                 EnumSet.noneOf(CaptureSlot.class)),
         NO_OFFLOAD_CANCEL(0, "none",
                 (c, e) -> c, TerminalOperation.CANCEL,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_CANCEL, IN_OFFLOADED_CANCEL),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_CANCEL, OFFLOADED_CANCEL),
                 EnumSet.noneOf(CaptureSlot.class)),
         SUBSCRIBE_ON_SUCCESS(1, "subscribe",
                 Single::subscribeOn, TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
-                EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
+                EnumSet.of(OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE)),
         SUBSCRIBE_ON_CONDITIONAL_NEVER(0, "none",
                 (s, e) -> s.subscribeOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
                 EnumSet.noneOf(CaptureSlot.class)),
         SUBSCRIBE_ON_ERROR(1, "subscribe",
                 Single::subscribeOn, TerminalOperation.ERROR,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE,
-                        IN_ORIGINAL_ON_ERROR, IN_OFFLOADED_ON_ERROR),
-                EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE,
+                        ORIGINAL_ON_ERROR, OFFLOADED_ON_ERROR),
+                EnumSet.of(OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE)),
         SUBSCRIBE_ON_CANCEL(2, "subscribe, cancel",
                 Single::subscribeOn, TerminalOperation.CANCEL,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_ORIGINAL_CANCEL),
-                EnumSet.of(IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE, IN_OFFLOADED_CANCEL)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, ORIGINAL_CANCEL),
+                EnumSet.of(OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE, OFFLOADED_CANCEL)),
         PUBLISH_ON_SUCCESS(2, "onSubscribe, onComplete",
                 Single::publishOn, TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_ORIGINAL_ON_COMPLETE),
-                EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE, IN_OFFLOADED_ON_COMPLETE)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, ORIGINAL_ON_COMPLETE),
+                EnumSet.of(OFFLOADED_ON_SUBSCRIBE, OFFLOADED_ON_COMPLETE)),
         PUBLISH_ON_CONDITIONAL_NEVER(0, "none",
                 (s, e) -> s.publishOn(e, Boolean.FALSE::booleanValue), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE, IN_OFFLOADED_ON_COMPLETE),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE, OFFLOADED_ON_COMPLETE),
                 EnumSet.noneOf(CaptureSlot.class)),
         PUBLISH_ON_CONDITIONAL_SECOND(1, "onComplete",
                 (s, e) -> Single.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
                     return s.publishOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
                 }), TerminalOperation.COMPLETE,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_OFFLOADED_ON_SUBSCRIBE,
-                        IN_ORIGINAL_ON_COMPLETE),
-                EnumSet.of(IN_OFFLOADED_ON_COMPLETE)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
+                        ORIGINAL_ON_COMPLETE),
+                EnumSet.of(OFFLOADED_ON_COMPLETE)),
         PUBLISH_ON_ERROR(2, "onSubscribe, onError",
                 Single::publishOn, TerminalOperation.ERROR,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE, IN_ORIGINAL_ON_ERROR),
-                EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE, IN_OFFLOADED_ON_ERROR)),
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE, ORIGINAL_ON_ERROR),
+                EnumSet.of(OFFLOADED_ON_SUBSCRIBE, OFFLOADED_ON_ERROR)),
         PUBLISH_ON_CANCEL(1, "onSubscribe",
                 Single::publishOn, TerminalOperation.CANCEL,
-                EnumSet.of(IN_ORIGINAL_SUBSCRIBE, IN_OFFLOADED_SUBSCRIBE,
-                        IN_ORIGINAL_ON_SUBSCRIBE,
-                        IN_ORIGINAL_CANCEL, IN_OFFLOADED_CANCEL),
-                EnumSet.of(IN_OFFLOADED_ON_SUBSCRIBE));
+                EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
+                        ORIGINAL_ON_SUBSCRIBE,
+                        ORIGINAL_CANCEL, OFFLOADED_CANCEL),
+                EnumSet.of(OFFLOADED_ON_SUBSCRIBE));
 
         final int offloadsExpected;
         final String expectedOffloads;
@@ -128,13 +128,15 @@ class OffloadingTest extends AbstractSingleOffloadingTest {
         OffloadCase(int offloadsExpected, String expectedOffloads,
                     BiFunction<Single<String>, Executor, Single<String>> offloadOperator,
                     TerminalOperation terminal,
-                    Set<CaptureSlot> nonOffloaded, EnumSet<CaptureSlot> offloaded) {
+                    EnumSet<CaptureSlot> nonOffloaded, EnumSet<CaptureSlot> offloaded) {
             this.offloadsExpected = offloadsExpected;
             this.expectedOffloads = expectedOffloads;
             this.offloadOperator = offloadOperator;
             this.terminal = terminal;
             EnumSet.allOf(CaptureSlot.class).forEach(slot -> this.threadNameMatchers.put(slot, nullValue()));
-            this.threadNameMatchers.put(IN_APP, APP_EXECUTOR);
+            this.threadNameMatchers.put(APP, APP_EXECUTOR);
+            assertThat("Overlapping non-offloading and offloading slots",
+                    Collections.disjoint(nonOffloaded, offloaded));
             nonOffloaded.forEach(slot -> this.threadNameMatchers.put(slot, APP_EXECUTOR));
             offloaded.forEach(slot -> this.threadNameMatchers.put(slot, OFFLOAD_EXECUTOR));
         }
@@ -147,6 +149,7 @@ class OffloadingTest extends AbstractSingleOffloadingTest {
         assertThat("Unexpected offloads: " + offloadCase.expectedOffloads,
                 offloads, CoreMatchers.is(offloadCase.offloadsExpected));
         offloadCase.threadNameMatchers.forEach((slot, matcher) ->
-                capturedThreads.assertCaptured("Match failed " + slot + " : " + capturedThreads, slot, matcher));
+                capturedThreads.assertCaptured("Match failed " + slot + " : " + capturedThreads,
+                        capturedStacks.captured(slot), slot, matcher));
     }
 }


### PR DESCRIPTION
Motivation:
There have been occasional failures with the offloading test but the
test failure reports lack a critical piece of information; the stack
dump for the failure.
Modifications:
Add stack capturing to `AbstractOffloadingTest`
Result:
Hopefully more information for debugging flaky tests.