### PR TITLE
ZipkinPublisher remove unnecessary data

### DIFF
--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/AbstractInMemorySpanBuilder.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/AbstractInMemorySpanBuilder.java
@@ -24,7 +24,6 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tag;
-import io.opentracing.tag.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +47,7 @@ abstract class AbstractInMemorySpanBuilder implements InMemorySpanBuilder {
     private long startTimestampMicros = -1;
     private boolean ignoreActiveSpan;
 
-    protected AbstractInMemorySpanBuilder(String operationName, int maxTagSize) {
+    AbstractInMemorySpanBuilder(String operationName, int maxTagSize) {
         this.operationName = requireNonNull(operationName);
         this.maxTagSize = maxTagSize;
     }
@@ -106,8 +105,7 @@ abstract class AbstractInMemorySpanBuilder implements InMemorySpanBuilder {
         if (startTimestampMicros == -1) {
             startTimestampMicros = System.currentTimeMillis() * 1000;
         }
-        return createSpan((String) tags.get(Tags.SPAN_KIND.getKey()), operationName, references, tags, maxTagSize,
-                ignoreActiveSpan, startTimestampMicros);
+        return createSpan(operationName, references, tags, maxTagSize, ignoreActiveSpan, startTimestampMicros);
     }
 
     @SuppressWarnings("ForLoopReplaceableByForEach")
@@ -140,7 +138,6 @@ abstract class AbstractInMemorySpanBuilder implements InMemorySpanBuilder {
     /**
      * Create a span with current builder settings.
      *
-     * @param kind Value of the {@code span.kind} tag if specified, could be null.
      * @param operationName the operation name.
      * @param references references for the span.
      * @param tags tags for the span.
@@ -149,7 +146,6 @@ abstract class AbstractInMemorySpanBuilder implements InMemorySpanBuilder {
      * @param startTimestampMicros the span start time in micro seconds.
      * @return newly created span
      */
-    protected abstract InMemorySpan createSpan(@Nullable String kind, String operationName,
-                                               List<InMemoryReference> references, Map<String, Object> tags,
-                                               int maxTagSize, boolean ignoreActiveSpan, long startTimestampMicros);
+    abstract InMemorySpan createSpan(String operationName, List<InMemoryReference> references, Map<String, Object> tags,
+                                     int maxTagSize, boolean ignoreActiveSpan, long startTimestampMicros);
 }

--- a/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/DefaultInMemoryTracer.java
+++ b/servicetalk-opentracing-inmemory/src/main/java/io/servicetalk/opentracing/inmemory/DefaultInMemoryTracer.java
@@ -201,8 +201,8 @@ public final class DefaultInMemoryTracer extends AbstractInMemoryTracer {
         }
 
         @Override
-        protected InMemorySpan createSpan(
-                @Nullable String kind, String operationName, List<InMemoryReference> references,
+        InMemorySpan createSpan(
+                String operationName, List<InMemoryReference> references,
                 Map<String, Object> tags, int maxTagSize, boolean ignoreActiveSpan, long startTimestampMicros) {
             InMemorySpanContext maybeParent = parent();
             if (maybeParent == null && !ignoreActiveSpan) {


### PR DESCRIPTION
Motivation:
We currently publish a time stamp for begin, a duration, and a timestamp
for end. We can remove the end timestamp which can be derived by doing
begin+end. We also publish a tag for the type of span, but there is also
an explicit field for the type.

Modifications:
- Remove the tag from the span before publishing, remove end timestamp
  in ZipkinPublisher.

Result:
Less unnecessary data published from ZipkinPublisher.