### PR TITLE
Move isIoThreadSupported to IoExecutor

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -29,7 +29,6 @@ import io.servicetalk.transport.api.IoThreadFactory;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.TransportObserver;
-import io.servicetalk.transport.netty.internal.NettyIoExecutor;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
@@ -127,7 +126,7 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
 
     @Override
     protected BooleanSupplier shouldOffload(IoExecutor ioExecutor) {
-        return ioExecutor instanceof NettyIoExecutor && ((NettyIoExecutor) ioExecutor).isIoThreadSupported() ?
+        return ioExecutor.isIoThreadSupported() ?
                 () -> Thread.currentThread() instanceof IoThreadFactory.IoThread :
                 Boolean.TRUE::booleanValue;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -30,7 +30,6 @@ import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.FlushStrategyHolder;
 import io.servicetalk.transport.netty.internal.NettyChannelListenableAsyncCloseable;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
-import io.servicetalk.transport.netty.internal.NettyIoExecutor;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 import io.servicetalk.transport.netty.internal.StacklessClosedChannelException;
 
@@ -75,10 +74,8 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
                               final FlushStrategy flushStrategy, @Nullable final Long idleTimeoutMs,
                               final KeepAliveManager keepAliveManager) {
         super(channel, executionContext.executor());
-        boolean supportsIoThread = executionContext.ioExecutor() instanceof NettyIoExecutor &&
-                ((NettyIoExecutor) executionContext.ioExecutor()).isIoThreadSupported();
         this.executionContext = new DefaultHttpExecutionContext(executionContext.bufferAllocator(),
-                fromNettyEventLoop(channel.eventLoop(), supportsIoThread),
+                fromNettyEventLoop(channel.eventLoop(), executionContext.ioExecutor().isIoThreadSupported()),
                 executionContext.executor(), executionContext.executionStrategy());
         this.flushStrategyHolder = new FlushStrategyHolder(flushStrategy);
         this.idleTimeoutMs = idleTimeoutMs;

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
@@ -38,4 +38,12 @@ public interface IoExecutor extends ListenableAsyncCloseable {
      * @return {@code true} if supported
      */
     boolean isFileDescriptorSocketAddressSupported();
+
+    /**
+     * Determine if threads used by this {@link IoExecutor} are marked with {@link IoThreadFactory.IoThread} interface.
+     *
+     * @return {@code true} if supported
+     * @see IoThreadFactory.IoThread
+     */
+    boolean isIoThreadSupported();
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -216,10 +216,8 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             Protocol protocol, @Nullable SSLSession sslSession,
             @Nullable ChannelConfig parentChannelConfig, StreamObserver streamObserver, boolean isClient,
             UnaryOperator<Throwable> enrichProtocolError) {
-        boolean supportsIoThread = executionContext.ioExecutor() instanceof NettyIoExecutor &&
-                ((NettyIoExecutor) executionContext.ioExecutor()).isIoThreadSupported();
         DefaultExecutionContext childExecutionContext = new DefaultExecutionContext(executionContext.bufferAllocator(),
-                fromNettyEventLoop(channel.eventLoop(), supportsIoThread),
+                fromNettyEventLoop(channel.eventLoop(), executionContext.ioExecutor().isIoThreadSupported()),
                 executionContext.executor(), executionContext.executionStrategy());
         DefaultNettyConnection<Read, Write> connection = new DefaultNettyConnection<>(channel, childExecutionContext,
                 terminalPredicate, closeHandler, flushStrategy, idleTimeoutMs, protocol,
@@ -266,8 +264,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 final DelayedCancellable delayedCancellable;
                 try {
                     delayedCancellable = new DelayedCancellable();
-                    boolean supportsIoThread = ioExecutor instanceof NettyIoExecutor &&
-                            ((NettyIoExecutor) ioExecutor).isIoThreadSupported();
+                    boolean supportsIoThread = null != ioExecutor && ioExecutor.isIoThreadSupported();
                     DefaultExecutionContext executionContext = new DefaultExecutionContext(allocator,
                             fromNettyEventLoop(channel.eventLoop(), supportsIoThread), executor, executionStrategy);
                     DefaultNettyConnection<Read, Write> connection = new DefaultNettyConnection<>(channel,

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
@@ -17,7 +17,6 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.IoThreadFactory;
 
 /**
  * {@link IoExecutor} for Netty.
@@ -34,11 +33,4 @@ public interface NettyIoExecutor extends IoExecutor {
      * @return an {@link Executor} which will use an {@link IoExecutor} thread for execution.
      */
     Executor asExecutor();
-
-    /**
-     * Determine if threads used by this {@link IoExecutor} are marked with {@link IoThreadFactory.IoThread} interface.
-     *
-     * @return {@code true} if supported
-     */
-    boolean isIoThreadSupported();
 }


### PR DESCRIPTION
Motivation:
The `isIoThreadSupported` method was recently added to the
`NettyIoExecutor` as a mechanism for determining if the threads of the
`IoExecutor` were marked using the `IoThreadfactory.IoThread`
interface. It is useful to know this for all `IoExecutors`.
Modifications:
Move `isIoThreadSupported` from `NettyIoExecutor` the parent interface
`IoExecutor`
Result:
More situations can use conditional offloading by querying
`IoExecutor`s whether their threads support IoThread identification.