### PR TITLE
Update to use PMD PrimitiveWrapperInstantiation rule

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/pmd/basic.xml
+++ b/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/pmd/basic.xml
@@ -43,13 +43,13 @@
   <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP"/>
   <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
   <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate" />
+  <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation"/>
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
 
   <rule ref="category/java/codestyle.xml/ExtendsObject"/>
   <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
 
   <rule ref="category/java/performance.xml/BigIntegerInstantiation"/>
-  <rule ref="category/java/performance.xml/BooleanInstantiation"/>
 
   <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
   <rule ref="category/java/design.xml/MutableStaticState" />

--- a/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/pmd/basic.xml
+++ b/servicetalk-gradle-plugin-internal/src/main/resources/io/servicetalk/gradle/plugin/internal/pmd/basic.xml
@@ -44,6 +44,7 @@
   <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
   <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate" />
   <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation"/>
+  <rule ref="category/java/bestpractices.xml/SimplifiableTestAssertion"/>  
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
 
   <rule ref="category/java/codestyle.xml/ExtendsObject"/>


### PR DESCRIPTION
Motivation:
The recent PMD upgrade now warns that the `BooleanInstantiation` rule
is deprecated. `PrimitiveWrapperInstantiation` is the replacement.
Modifications:
Replace use of the `BooleanInstantiation` rule with
`PrimitiveWrapperInstantiation`
Result:
Reduced warnings