### PR TITLE
Ignore spotbugs encapsulation warnings for gradle

### DIFF
--- a/servicetalk-gradle-plugin-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-gradle-plugin-internal/gradle/spotbugs/main-exclusions.xml
@@ -25,4 +25,14 @@
     </Or>
     <Bug pattern="SE_NO_SERIALVERSIONID"/>
   </Match>
+  <Match>
+    <Or>
+      <Class name="~io.servicetalk.gradle.plugin.internal.ProjectUtils.*"/>
+      <Class name="~io.servicetalk.gradle.plugin.internal.ServiceTalkCorePlugin.*"/>
+      <Class name="~io.servicetalk.gradle.plugin.internal.ServiceTalkLibraryPlugin.*"/>
+      <Class name="~io.servicetalk.gradle.plugin.internal.ServiceTalkRootPlugin.*"/>
+      <Class name="~io.servicetalk.gradle.plugin.internal.Versions.*"/>
+    </Or>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Motivation:
The recent spotbugs upgrade triggers warnings on the ServiceTalk Gradle
plugin. These issues can be safely ignored.
Modifications:
Exclusions added for encapsulation issues with Gradle plugin.
Result:
No spotbug warnings reported.