### PR TITLE
Fix grpc-protoc maven publications

### DIFF
--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -52,8 +52,8 @@ jar {
 }
 
 shadowJar {
-  archiveBaseName = project.name + "-all"
-  classifier = ''
+  archiveBaseName = project.name
+  classifier = 'all'
 }
 
 def grpcPluginUberJarName = project.name + "-" + project.version + "-all.jar"
@@ -68,17 +68,6 @@ task buildExecutable(type: Copy) {
   }
 }
 tasks.compileJava.finalizedBy(buildExecutable)
-
-publishing {
-  publications {
-    mavenJava {
-      artifact(shadowJar.outputs.files.singleFile) {
-        classifier = "all"
-        extension = "jar"
-      }
-    }
-  }
-}
 
 protobuf {
   protoc {


### PR DESCRIPTION
Motivation:
e844dcdb82922f8e6efec448c193879190f9dc0a updated shadowJar plugin which
changed behavior of how artifacts are published. The build is broken due
to duplicate artifacts being published.

Modifications:
- Let the shadowJar configure the artifacts automatically, as manually
  adding the shaded artifacts to publications is no longer required

Result:
grpc-protoc build works and artifacts are published.