### PR TITLE
Downgrade checkstyle 9.0 -> 8.45.1

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.JavaVersion
 import static org.gradle.api.JavaVersion.VERSION_1_8
 
 final class Versions {
-  static final String CHECKSTYLE_VERSION = "9.0"
+  static final String CHECKSTYLE_VERSION = "8.45.1"
   static final String PMD_VERSION = "6.38.0"
   static final String SPOTBUGS_VERSION = "4.4.0"
   static final String PITEST_VERSION = "1.6.7"


### PR DESCRIPTION
Motivation:
Checkstyle is exhausting memory during builds on JDK8, and resulting in
failed builds.