### PR TITLE
Increase memory for quality build tasks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@
 #
 
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xms2g -Xmx4g -dsa -da -ea:io.servicetalk... -XX:+HeapDumpOnOutOfMemoryError
 
 group=io.servicetalk
 version=0.42.0-SNAPSHOT


### PR DESCRIPTION
Motivation:
checkstyle 9 on JDK 8 has been observed to exhaust memory and fail
builds. We don't tune the default JVM arguments and should increase
memory to give quality build tasks more memory headroom.