### PR TITLE
`ExecutionStrategy` simplification deprecations

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -45,7 +45,8 @@ public final class GrpcExecutionStrategies {
      *
      * @param executor {@link Executor} to use.
      * @return Default {@link GrpcExecutionStrategy}.
-     * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext}.
+     * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext} using
+     * {@code executor(Executor)} methods on client/server builders.
      */
     @Deprecated
     public static GrpcExecutionStrategy defaultStrategy(final Executor executor) {
@@ -135,7 +136,8 @@ public final class GrpcExecutionStrategies {
          *
          * @param executor {@link Executor} to use.
          * @return {@code this}.
-         * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext}.
+         * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext} using
+         * {@code executor(Executor)} methods on client/server builders.
          */
         @Deprecated
         public Builder executor(Executor executor) {
@@ -147,8 +149,8 @@ public final class GrpcExecutionStrategies {
          * Enable thread affinity while offloading. When enabled, offloading implementation will favor using a
          * single thread per subscribe of a source.
          * @return {@code this}.
-         * @deprecated Use a single threaded executor set on {@link io.servicetalk.transport.api.ExecutionContext} to
-         * ensure affinity.
+         * @deprecated Use a single threaded executor set on {@link io.servicetalk.transport.api.ExecutionContext} using
+         * {@code executor(Executor)} methods on client/server builders to ensure affinity.
          */
         @Deprecated
         public Builder offloadWithThreadAffinity() {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -45,7 +45,9 @@ public final class GrpcExecutionStrategies {
      *
      * @param executor {@link Executor} to use.
      * @return Default {@link GrpcExecutionStrategy}.
+     * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext}.
      */
+    @Deprecated
     public static GrpcExecutionStrategy defaultStrategy(final Executor executor) {
         return new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.defaultStrategy(executor));
     }
@@ -133,7 +135,9 @@ public final class GrpcExecutionStrategies {
          *
          * @param executor {@link Executor} to use.
          * @return {@code this}.
+         * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext}.
          */
+        @Deprecated
         public Builder executor(Executor executor) {
             httpBuilder.executor(executor);
             return this;
@@ -143,7 +147,8 @@ public final class GrpcExecutionStrategies {
          * Enable thread affinity while offloading. When enabled, offloading implementation will favor using a
          * single thread per subscribe of a source.
          * @return {@code this}.
-         * @deprecated Use a single threaded executor with {@link #executor(Executor)} to ensure affinity.
+         * @deprecated Use a single threaded executor set on {@link io.servicetalk.transport.api.ExecutionContext} to
+         * ensure affinity.
          */
         @Deprecated
         public Builder offloadWithThreadAffinity() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.IoExecutor;
 
 /**
@@ -35,6 +36,14 @@ interface HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> {
      * @return {@code this}.
      */
     HttpClientBuilder<U, R, SDE> ioExecutor(IoExecutor ioExecutor);
+
+    /**
+     * Sets the {@link Executor} for all connections created from this builder.
+     *
+     * @param executor {@link Executor} to use.
+     * @return {@code this}.
+     */
+    HttpClientBuilder<U, R, SDE> executor(Executor executor);
 
     /**
      * Sets the {@link BufferAllocator} for all connections created from this builder.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -66,7 +66,8 @@ public final class HttpExecutionStrategies {
      *
      * @param executor {@link Executor} to use.
      * @return Default {@link HttpExecutionStrategy}.
-     * @deprecated Set the {@link Executor} to use in the {@link io.servicetalk.transport.api.ExecutionContext}.
+     * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext} using
+     * {@code executor(Executor)} methods on client/server builders.
      */
     @Deprecated
     public static HttpExecutionStrategy defaultStrategy(Executor executor) {
@@ -226,7 +227,8 @@ public final class HttpExecutionStrategies {
          *
          * @param executor {@link Executor} to use.
          * @return {@code this}.
-         * @deprecated Set the {@link Executor} to use in the {@link io.servicetalk.transport.api.ExecutionContext}.
+         * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext} using
+         * {@code executor(Executor)} methods on client/server builders.
          */
         @Deprecated
         public Builder executor(Executor executor) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -66,7 +66,9 @@ public final class HttpExecutionStrategies {
      *
      * @param executor {@link Executor} to use.
      * @return Default {@link HttpExecutionStrategy}.
+     * @deprecated Set the {@link Executor} to use in the {@link io.servicetalk.transport.api.ExecutionContext}.
      */
+    @Deprecated
     public static HttpExecutionStrategy defaultStrategy(Executor executor) {
         return customStrategyBuilder().offloadAll().executor(executor).mergeStrategy(ReturnOther).build();
     }
@@ -224,7 +226,9 @@ public final class HttpExecutionStrategies {
          *
          * @param executor {@link Executor} to use.
          * @return {@code this}.
+         * @deprecated Set the {@link Executor} to use in the {@link io.servicetalk.transport.api.ExecutionContext}.
          */
+        @Deprecated
         public Builder executor(Executor executor) {
             this.executor = requireNonNull(executor);
             return this;
@@ -246,8 +250,10 @@ public final class HttpExecutionStrategies {
          *
          * @param mergeStrategy {@link MergeStrategy} to use.
          * @return {@code this}.
+         * @deprecated Will be removed
          */
         // Intentionally package-private, API is not required to be public for the lack of use cases.
+        @Deprecated
         Builder mergeStrategy(MergeStrategy mergeStrategy) {
             this.mergeStrategy = mergeStrategy;
             return this;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
@@ -60,7 +60,8 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * @param service {@link Function} representing a service.
      * @return A {@link Single} that invokes the passed {@link Function} and returns the result asynchronously.
      * Invocation of {@link Function} will be offloaded if configured.
-     * @deprecated Copy the implementation from {@link DefaultHttpExecutionStrategy#invokeService(Executor, Function)}.
+     * @deprecated This method will be removed in future releases. If you depend on it, copy the implementation from
+     * {@link DefaultHttpExecutionStrategy#invokeService(Executor, Function)}.
      */
     @Deprecated
     <T> Single<T> invokeService(Executor fallback, Function<Executor, T> service);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
@@ -40,7 +40,10 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * trailers, for the passed {@link StreamingHttpRequest} returns a {@link Single}.
      * @param <FS> The {@code FlushStrategy} type to use.
      * @return {@link Single} which is offloaded as required.
+     * @deprecated Copy the implementation from
+     * {@link DefaultHttpExecutionStrategy#invokeClient(Executor, Publisher, Object, ClientInvoker)}.
      */
+    @Deprecated
     <FS> Single<StreamingHttpResponse> invokeClient(Executor fallback, Publisher<Object> flattenedRequest,
                                                     @Nullable FS flushStrategy, ClientInvoker<FS> client);
 
@@ -57,7 +60,9 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * @param service {@link Function} representing a service.
      * @return A {@link Single} that invokes the passed {@link Function} and returns the result asynchronously.
      * Invocation of {@link Function} will be offloaded if configured.
+     * @deprecated Copy the implementation from {@link DefaultHttpExecutionStrategy#invokeService(Executor, Function)}.
      */
+    @Deprecated
     <T> Single<T> invokeService(Executor fallback, Function<Executor, T> service);
 
     /**
@@ -67,7 +72,9 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * {@link Executor}.
      * @param handler {@link StreamingHttpService} to wrap.
      * @return Wrapped {@link StreamingHttpService}.
+     * @deprecated Will be replaced with a new class {@code StreamingHttpServiceToOffloadedStreamingHttpService}.
      */
+    @Deprecated
     StreamingHttpService offloadService(Executor fallback, StreamingHttpService handler);
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
@@ -73,7 +73,8 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * {@link Executor}.
      * @param handler {@link StreamingHttpService} to wrap.
      * @return Wrapped {@link StreamingHttpService}.
-     * @deprecated Will be replaced with a new class {@code StreamingHttpServiceToOffloadedStreamingHttpService}.
+     * @deprecated This method will be removed in future releases. If you depend on it, copy the implementation from
+     * {@link DefaultHttpExecutionStrategy#offloadService(Executor, StreamingHttpService)}.
      */
     @Deprecated
     StreamingHttpService offloadService(Executor fallback, StreamingHttpService handler);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
@@ -40,7 +40,7 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * trailers, for the passed {@link StreamingHttpRequest} returns a {@link Single}.
      * @param <FS> The {@code FlushStrategy} type to use.
      * @return {@link Single} which is offloaded as required.
-     * @deprecated Copy the implementation from
+     * @deprecated This method will be removed in future releases. If you depend on it, copy the implementation from
      * {@link DefaultHttpExecutionStrategy#invokeClient(Executor, Publisher, Object, ClientInvoker)}.
      */
     @Deprecated

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -323,6 +323,14 @@ public abstract class HttpServerBuilder {
     public abstract HttpServerBuilder ioExecutor(IoExecutor ioExecutor);
 
     /**
+     * Sets the {@link Executor} to use.
+     *
+     * @param executor {@link Executor} to use.
+     * @return {@code this}.
+     */
+    public abstract HttpServerBuilder executor(Executor executor);
+
+    /**
      * Sets the {@link BufferAllocator} to be used by this server.
      *
      * @param allocator {@link BufferAllocator} to use.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -328,7 +328,9 @@ public abstract class HttpServerBuilder {
      * @param executor {@link Executor} to use.
      * @return {@code this}.
      */
-    public abstract HttpServerBuilder executor(Executor executor);
+    public HttpServerBuilder executor(Executor executor) {
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
+    }
 
     /**
      * Sets the {@link BufferAllocator} to be used by this server.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -20,9 +20,6 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.IoExecutor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * A builder of {@link StreamingHttpClient} instances which have a capacity to call any server based on the parsed
  * absolute-form URL address information from each {@link StreamingHttpRequest}.
@@ -36,9 +33,6 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class MultiAddressHttpClientBuilder<U, R>
         implements HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(MultiAddressHttpClientBuilder.class);
-
     /**
      * Initializes the {@link SingleAddressHttpClientBuilder} for each new client.
      * @param <U> The unresolved address type.
@@ -75,8 +69,7 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
 
     @Override
     public MultiAddressHttpClientBuilder<U, R> executor(Executor executor) {
-        LOGGER.warn("Unimplemented method MultiAddressHttpClientBuilder::executor() called");
-        return this;
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.IoExecutor;
 
 /**
@@ -65,6 +66,9 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
+
+    @Override
+    public abstract MultiAddressHttpClientBuilder<U, R> executor(Executor executor);
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -20,6 +20,9 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.IoExecutor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A builder of {@link StreamingHttpClient} instances which have a capacity to call any server based on the parsed
  * absolute-form URL address information from each {@link StreamingHttpRequest}.
@@ -33,6 +36,9 @@ import io.servicetalk.transport.api.IoExecutor;
  */
 public abstract class MultiAddressHttpClientBuilder<U, R>
         implements HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultiAddressHttpClientBuilder.class);
+
     /**
      * Initializes the {@link SingleAddressHttpClientBuilder} for each new client.
      * @param <U> The unresolved address type.
@@ -68,7 +74,10 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     public abstract MultiAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
     @Override
-    public abstract MultiAddressHttpClientBuilder<U, R> executor(Executor executor);
+    public MultiAddressHttpClientBuilder<U, R> executor(Executor executor) {
+        LOGGER.warn("Unimplemented method MultiAddressHttpClientBuilder::executor() called");
+        return this;
+    }
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -22,7 +22,11 @@ import io.servicetalk.client.api.partition.PartitionAttributes;
 import io.servicetalk.client.api.partition.PartitionMapFactory;
 import io.servicetalk.client.api.partition.PartitionedServiceDiscovererEvent;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.IoExecutor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A builder of homogeneous {@link StreamingHttpClient} instances which call the server associated with a partition
@@ -35,6 +39,9 @@ import io.servicetalk.transport.api.IoExecutor;
  * @param <R> the type of address after resolution (resolved address)
  */
 public abstract class PartitionedHttpClientBuilder<U, R> implements HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PartitionedHttpClientBuilder.class);
+
     /**
      * Initializes the {@link SingleAddressHttpClientBuilder} for each new client.
      * @param <U> the type of address before resolution (unresolved address)
@@ -68,6 +75,12 @@ public abstract class PartitionedHttpClientBuilder<U, R> implements HttpClientBu
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
+
+    @Override
+    public PartitionedHttpClientBuilder<U, R> executor(Executor executor) {
+        LOGGER.warn("Unimplemented method MultiAddressHttpClientBuilder::executor() called");
+        return this;
+    }
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -25,9 +25,6 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.IoExecutor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * A builder of homogeneous {@link StreamingHttpClient} instances which call the server associated with a partition
  * selected from a set of {@link PartitionedServiceDiscovererEvent}s resolved from a single unresolved address.
@@ -39,9 +36,6 @@ import org.slf4j.LoggerFactory;
  * @param <R> the type of address after resolution (resolved address)
  */
 public abstract class PartitionedHttpClientBuilder<U, R> implements HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PartitionedHttpClientBuilder.class);
-
     /**
      * Initializes the {@link SingleAddressHttpClientBuilder} for each new client.
      * @param <U> the type of address before resolution (unresolved address)
@@ -78,8 +72,7 @@ public abstract class PartitionedHttpClientBuilder<U, R> implements HttpClientBu
 
     @Override
     public PartitionedHttpClientBuilder<U, R> executor(Executor executor) {
-        LOGGER.warn("Unimplemented method MultiAddressHttpClientBuilder::executor() called");
-        return this;
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -23,6 +23,7 @@ import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.BiIntPredicate;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ClientSslConfig;
@@ -163,6 +164,9 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
+
+    @Override
+    public abstract SingleAddressHttpClientBuilder<U, R> executor(Executor executor);
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -31,9 +31,6 @@ import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.TransportObserver;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.util.function.BooleanSupplier;
@@ -54,9 +51,6 @@ import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toCondi
  */
 public abstract class SingleAddressHttpClientBuilder<U, R>
         implements HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SingleAddressHttpClientBuilder.class);
-
     /**
      * Adds a {@link SocketOption} for all connections created by this builder.
      *
@@ -172,8 +166,7 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
 
     @Override
     public SingleAddressHttpClientBuilder<U, R> executor(Executor executor) {
-        LOGGER.warn("Unimplemented method SingleAddressHttpClientBuilder::executor() called");
-        return this;
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -31,6 +31,9 @@ import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.TransportObserver;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.util.function.BooleanSupplier;
@@ -51,6 +54,8 @@ import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toCondi
  */
 public abstract class SingleAddressHttpClientBuilder<U, R>
         implements HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SingleAddressHttpClientBuilder.class);
 
     /**
      * Adds a {@link SocketOption} for all connections created by this builder.
@@ -166,7 +171,10 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
     public abstract SingleAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
     @Override
-    public abstract SingleAddressHttpClientBuilder<U, R> executor(Executor executor);
+    public SingleAddressHttpClientBuilder<U, R> executor(Executor executor) {
+        LOGGER.warn("Unimplemented method SingleAddressHttpClientBuilder::executor() called");
+        return this;
+    }
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -98,6 +99,12 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
     @Override
     public HttpServerBuilder ioExecutor(final IoExecutor ioExecutor) {
         executionContextBuilder.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public HttpServerBuilder executor(final Executor executor) {
+        executionContextBuilder.executor(executor);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.ClientGroup;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
@@ -314,6 +315,12 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> ioExecutor(final IoExecutor ioExecutor) {
         builderTemplate.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> executor(final Executor executor) {
+        builderTemplate.executor(executor);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -28,6 +28,7 @@ import io.servicetalk.client.api.partition.PartitionMapFactory;
 import io.servicetalk.client.api.partition.PartitionedServiceDiscovererEvent;
 import io.servicetalk.client.api.partition.UnknownPartitionException;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
@@ -253,6 +254,12 @@ final class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpCli
     @Override
     public PartitionedHttpClientBuilder<U, R> ioExecutor(final IoExecutor ioExecutor) {
         builderTemplate.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientBuilder<U, R> executor(final Executor executor) {
+        builderTemplate.executor(executor);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -29,6 +29,7 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.DefaultServiceDiscoveryRetryStrategy;
@@ -421,6 +422,12 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     @Override
     public DefaultSingleAddressHttpClientBuilder<U, R> ioExecutor(final IoExecutor ioExecutor) {
         executionContextBuilder.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public DefaultSingleAddressHttpClientBuilder<U, R> executor(final Executor executor) {
+        executionContextBuilder.executor(executor);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -50,6 +51,17 @@ final class HttpExecutionContextBuilder {
      */
     public HttpExecutionContextBuilder ioExecutor(IoExecutor ioExecutor) {
         executionContextBuilder.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    /**
+     * Sets the {@link Executor} to use.
+     *
+     * @param executor {@link Executor} to use.
+     * @return {@code this}.
+     */
+    public HttpExecutionContextBuilder executor(Executor executor) {
+        executionContextBuilder.executor(executor);
         return this;
     }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
@@ -71,10 +71,12 @@ public interface ExecutionStrategy {
     <T> Publisher<T> offloadReceive(Executor fallback, Publisher<T> original);
 
     /**
-     * Returns the {@link Executor}, if any for this {@link ExecutionStrategy}.
+     * Returns the {@link Executor}, if any, for this {@link ExecutionStrategy}.
      *
      * @return {@link Executor} for this {@link ExecutionStrategy}. {@code null} if none specified.
+     * @deprecated Set the {@link Executor} to use in the {@link io.servicetalk.transport.api.ExecutionContext}.
      */
+    @Deprecated
     @Nullable
     Executor executor();
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
@@ -74,7 +74,7 @@ public interface ExecutionStrategy {
      * Returns the {@link Executor}, if any, for this {@link ExecutionStrategy}.
      *
      * @return {@link Executor} for this {@link ExecutionStrategy}. {@code null} if none specified.
-     * @deprecated Set the {@link Executor} to use in the {@link io.servicetalk.transport.api.ExecutionContext}.
+     * @deprecated Take the {@link Executor} from the {@link io.servicetalk.transport.api.ExecutionContext}.
      */
     @Deprecated
     @Nullable

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
@@ -74,7 +74,8 @@ public interface ExecutionStrategy {
      * Returns the {@link Executor}, if any, for this {@link ExecutionStrategy}.
      *
      * @return {@link Executor} for this {@link ExecutionStrategy}. {@code null} if none specified.
-     * @deprecated Take the {@link Executor} from the {@link io.servicetalk.transport.api.ExecutionContext}.
+     * @deprecated The {@link Executor} from the {@link io.servicetalk.transport.api.ExecutionContext} should be used
+     * instead.
      */
     @Deprecated
     @Nullable


### PR DESCRIPTION
Motivation:
removed methods should be deprecated before they are removed.
Modifications:
Marks methods to be removed in #1695 as deprecated and, where possible,
suggests alternatives.
Result:
Warnings for future method removals are provided.