### PR TITLE
Improve deprecation docs on TypeHolder

### DIFF
--- a/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/TypeHolder.java
+++ b/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/TypeHolder.java
@@ -31,7 +31,9 @@ import java.lang.reflect.Type;
  * <a href="http://gafter.blogspot.com/2006/12/super-type-tokens.html">this article.</a>.
  * @param <T> Type to be inferred.
  * @deprecated General {@link Type} serialization is not supported by all serializers. Defer
- * to your specific {@link io.servicetalk.serializer.api.Serializer} implementation.
+ * to your specific {@link io.servicetalk.serializer.api.Serializer} implementation. For example jackson offers
+ * <a href="https://fasterxml.github.io/jackson-core/javadoc/2.2.0/com/fasterxml/jackson/core/type/TypeReference.html">TypeReference</a>
+ * which can be used directly.
  */
 @Deprecated
 public abstract class TypeHolder<T> {

--- a/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/TypeHolder.java
+++ b/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/TypeHolder.java
@@ -32,8 +32,8 @@ import java.lang.reflect.Type;
  * @param <T> Type to be inferred.
  * @deprecated General {@link Type} serialization is not supported by all serializers. Defer
  * to your specific {@link io.servicetalk.serializer.api.Serializer} implementation. For example jackson offers
- * <a href="https://fasterxml.github.io/jackson-core/javadoc/2.2.0/com/fasterxml/jackson/core/type/TypeReference.html">TypeReference</a>
- * which can be used directly.
+ * <a href="https://fasterxml.github.io/jackson-core/javadoc/2.2.0/com/fasterxml/jackson/core/type/TypeReference.html">
+ * TypeReference</a> which can be used directly.
  */
 @Deprecated
 public abstract class TypeHolder<T> {


### PR DESCRIPTION
Motivation:
The deprecated serialization.api.TypeHolder class has a direct
replacement for jackson which is the most common use. We should
explicitly mention the replacement to help people migration from
deprecated APIs.