### PR TITLE
`ExecutionStrategy` simplification deprecations (#1781)

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -45,7 +45,10 @@ public final class GrpcExecutionStrategies {
      *
      * @param executor {@link Executor} to use.
      * @return Default {@link GrpcExecutionStrategy}.
+     * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext} using
+     * {@code executor(Executor)} methods on client/server builders.
      */
+    @Deprecated
     public static GrpcExecutionStrategy defaultStrategy(final Executor executor) {
         return new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.defaultStrategy(executor));
     }
@@ -133,7 +136,10 @@ public final class GrpcExecutionStrategies {
          *
          * @param executor {@link Executor} to use.
          * @return {@code this}.
+         * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext} using
+         * {@code executor(Executor)} methods on client/server builders.
          */
+        @Deprecated
         public Builder executor(Executor executor) {
             httpBuilder.executor(executor);
             return this;
@@ -142,10 +148,9 @@ public final class GrpcExecutionStrategies {
         /**
          * Enable thread affinity while offloading. When enabled, offloading implementation will favor using a
          * single thread per subscribe of a source.
-         *
-         * @deprecated Use a single threaded executor with {@link #executor(Executor)} to ensure affinity.
-         *
          * @return {@code this}.
+         * @deprecated Use a single threaded executor set on {@link io.servicetalk.transport.api.ExecutionContext} using
+         * {@code executor(Executor)} methods on client/server builders to ensure affinity.
          */
         @Deprecated
         public Builder offloadWithThreadAffinity() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
@@ -34,6 +35,14 @@ import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toCondi
  * @param <ResolvedAddress> the type of address after resolution (resolved address)
  */
 abstract class BaseHttpBuilder<ResolvedAddress> {
+
+    /**
+     * Sets the {@link Executor} for all connections created from this builder.
+     *
+     * @param executor {@link Executor} to use.
+     * @return {@code this}.
+     */
+    public abstract BaseHttpBuilder<ResolvedAddress> executor(Executor executor);
 
     /**
      * Sets the {@link IoExecutor} for all connections created from this builder.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -23,6 +23,7 @@ import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.BiIntPredicate;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ExecutionContext;
@@ -44,6 +45,9 @@ import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toCondi
  * @param <SDE> the type of {@link ServiceDiscovererEvent}
  */
 abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> extends BaseHttpBuilder<R> {
+
+    @Override
+    public abstract HttpClientBuilder<U, R, SDE> executor(Executor executor);
 
     @Override
     public abstract HttpClientBuilder<U, R, SDE> ioExecutor(IoExecutor ioExecutor);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -66,7 +66,10 @@ public final class HttpExecutionStrategies {
      *
      * @param executor {@link Executor} to use.
      * @return Default {@link HttpExecutionStrategy}.
+     * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext} using
+     * {@code executor(Executor)} methods on client/server builders.
      */
+    @Deprecated
     public static HttpExecutionStrategy defaultStrategy(Executor executor) {
         return customStrategyBuilder().offloadAll().executor(executor).mergeStrategy(ReturnOther).build();
     }
@@ -226,7 +229,10 @@ public final class HttpExecutionStrategies {
          *
          * @param executor {@link Executor} to use.
          * @return {@code this}.
+         * @deprecated Set the executor to use on the {@link io.servicetalk.transport.api.ExecutionContext} using
+         * {@code executor(Executor)} methods on client/server builders.
          */
+        @Deprecated
         public Builder executor(Executor executor) {
             this.executor = requireNonNull(executor);
             return this;
@@ -251,8 +257,10 @@ public final class HttpExecutionStrategies {
          *
          * @param mergeStrategy {@link MergeStrategy} to use.
          * @return {@code this}.
+         * @deprecated Will be removed
          */
         // Intentionally package-private, API is not required to be public for the lack of use cases.
+        @Deprecated
         Builder mergeStrategy(MergeStrategy mergeStrategy) {
             this.mergeStrategy = mergeStrategy;
             return this;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
@@ -40,7 +40,10 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * trailers, for the passed {@link StreamingHttpRequest} returns a {@link Single}.
      * @param <FS> The {@code FlushStrategy} type to use.
      * @return {@link Single} which is offloaded as required.
+     * @deprecated This method will be removed in future releases. If you depend on it, copy the implementation from
+     * {@link DefaultHttpExecutionStrategy#invokeClient(Executor, Publisher, Object, ClientInvoker)}.
      */
+    @Deprecated
     <FS> Single<StreamingHttpResponse> invokeClient(Executor fallback, Publisher<Object> flattenedRequest,
                                                     @Nullable FS flushStrategy, ClientInvoker<FS> client);
 
@@ -77,7 +80,10 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * @param service {@link Function} representing a service.
      * @return A {@link Single} that invokes the passed {@link Function} and returns the result asynchronously.
      * Invocation of {@link Function} will be offloaded if configured.
+     * @deprecated This method will be removed in future releases. If you depend on it, copy the implementation from
+     * {@link DefaultHttpExecutionStrategy#invokeService(Executor, Function)}.
      */
+    @Deprecated
     <T> Single<T> invokeService(Executor fallback, Function<Executor, T> service);
 
     /**
@@ -87,7 +93,10 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * {@link Executor}.
      * @param handler {@link StreamingHttpService} to wrap.
      * @return Wrapped {@link StreamingHttpService}.
+     * @deprecated This method will be removed in future releases. If you depend on it, copy the implementation from
+     * {@link DefaultHttpExecutionStrategy#offloadService(Executor, StreamingHttpService)}.
      */
+    @Deprecated
     StreamingHttpService offloadService(Executor fallback, StreamingHttpService handler);
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpApiConversions.ServiceAdapterHolder;
 import io.servicetalk.logging.api.LogLevel;
@@ -281,6 +282,16 @@ public abstract class HttpServerBuilder {
      * @return {@code this}.
      */
     public abstract HttpServerBuilder ioExecutor(IoExecutor ioExecutor);
+
+    /**
+     * Sets the {@link Executor} to use.
+     *
+     * @param executor {@link Executor} to use.
+     * @return {@code this}.
+     */
+    public HttpServerBuilder executor(Executor executor) {
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
+    }
 
     /**
      * Sets the {@link BufferAllocator} to be used by this server.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ClientSecurityConfigurator;
 import io.servicetalk.transport.api.ClientSslConfig;
@@ -81,6 +82,11 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
+
+    @Override
+    public MultiAddressHttpClientBuilder<U, R> executor(Executor executor) {
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
+    }
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -24,6 +24,7 @@ import io.servicetalk.client.api.partition.PartitionAttributes;
 import io.servicetalk.client.api.partition.PartitionMapFactory;
 import io.servicetalk.client.api.partition.PartitionedServiceDiscovererEvent;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.IoExecutor;
@@ -86,6 +87,11 @@ public abstract class PartitionedHttpClientBuilder<U, R>
     @Deprecated
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
+
+    @Override
+    public PartitionedHttpClientBuilder<U, R> executor(Executor executor) {
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
+    }
 
     /**
      * {@inheritDoc}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.IoExecutor;
@@ -74,6 +75,11 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
                                                                        StreamingHttpConnectionFilterFactory factory) {
         return (SingleAddressHttpClientBuilder<U, R>)
                 super.appendConnectionFilter(predicate, factory);
+    }
+
+    @Override
+    public SingleAddressHttpClientBuilder<U, R> executor(Executor executor) {
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -129,6 +130,12 @@ final class DefaultHttpServerBuilder extends HttpServerBuilder {
     @Override
     public HttpServerBuilder ioExecutor(final IoExecutor ioExecutor) {
         executionContextBuilder.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public HttpServerBuilder executor(final Executor executor) {
+        executionContextBuilder.executor(executor);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -24,6 +24,7 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
@@ -353,6 +354,12 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> ioExecutor(final IoExecutor ioExecutor) {
         builderTemplate.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> executor(final Executor executor) {
+        builderTemplate.executor(executor);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -30,6 +30,7 @@ import io.servicetalk.client.api.partition.PartitionMapFactory;
 import io.servicetalk.client.api.partition.PartitionedServiceDiscovererEvent;
 import io.servicetalk.client.api.partition.UnknownPartitionException;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
@@ -262,6 +263,12 @@ class DefaultPartitionedHttpClientBuilder<U, R> extends PartitionedHttpClientBui
     @Override
     public PartitionedHttpClientBuilder<U, R> ioExecutor(final IoExecutor ioExecutor) {
         builderTemplate.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public PartitionedHttpClientBuilder<U, R> executor(final Executor executor) {
+        builderTemplate.executor(executor);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -29,6 +29,7 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.DefaultServiceDiscoveryRetryStrategy;
@@ -415,6 +416,12 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     @Override
     public DefaultSingleAddressHttpClientBuilder<U, R> ioExecutor(final IoExecutor ioExecutor) {
         executionContextBuilder.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public DefaultSingleAddressHttpClientBuilder<U, R> executor(final Executor executor) {
+        executionContextBuilder.executor(executor);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -50,6 +51,17 @@ final class HttpExecutionContextBuilder {
      */
     public HttpExecutionContextBuilder ioExecutor(IoExecutor ioExecutor) {
         executionContextBuilder.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    /**
+     * Sets the {@link Executor} to use.
+     *
+     * @param executor {@link Executor} to use.
+     * @return {@code this}.
+     */
+    public HttpExecutionContextBuilder executor(Executor executor) {
+        executionContextBuilder.executor(executor);
         return this;
     }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
@@ -71,10 +71,13 @@ public interface ExecutionStrategy {
     <T> Publisher<T> offloadReceive(Executor fallback, Publisher<T> original);
 
     /**
-     * Returns the {@link Executor}, if any for this {@link ExecutionStrategy}.
+     * Returns the {@link Executor}, if any, for this {@link ExecutionStrategy}.
      *
      * @return {@link Executor} for this {@link ExecutionStrategy}. {@code null} if none specified.
+     * @deprecated The {@link Executor} from the {@link io.servicetalk.transport.api.ExecutionContext} should be used
+     * instead.
      */
+    @Deprecated
     @Nullable
     Executor executor();
 }


### PR DESCRIPTION
Motivation:
removed methods should be deprecated before they are removed.
Modifications:
Marks methods to be removed in #1695 as deprecated and, where possible,
provides and suggests alternatives.
Result:
Warnings for future method removals are provided.