### PR TITLE
Remove `ExecutionStrategy` `offload*` methods

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionStrategy.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionStrategy.java
@@ -15,9 +15,6 @@
  */
 package io.servicetalk.grpc.api;
 
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 
 import static java.util.Objects.requireNonNull;
@@ -48,26 +45,6 @@ final class DefaultGrpcExecutionStrategy implements GrpcExecutionStrategy {
     @Override
     public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
         return delegate.merge(other);
-    }
-
-    @Override
-    public <T> Single<T> offloadSend(final Executor executor, final Single<T> original) {
-        return delegate.offloadSend(executor, original);
-    }
-
-    @Override
-    public <T> Single<T> offloadReceive(final Executor executor, final Single<T> original) {
-        return delegate.offloadReceive(executor, original);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadSend(final Executor executor, final Publisher<T> original) {
-        return delegate.offloadSend(executor, original);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadReceive(final Executor executor, final Publisher<T> original) {
-        return delegate.offloadReceive(executor, original);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
@@ -15,10 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
-
 import java.util.EnumSet;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.HttpOffload.OFFLOAD_RECEIVE_DATA;
@@ -105,28 +101,6 @@ enum DefaultHttpExecutionStrategy implements HttpExecutionStrategy {
         (byte) ((strategy.isDataReceiveOffloaded() ? OFFLOAD_RECEIVE_DATA.mask() : 0) |
                 (strategy.isMetadataReceiveOffloaded() ? OFFLOAD_RECEIVE_META.mask() : 0) |
                 (strategy.isSendOffloaded() ? OFFLOAD_SEND.mask() : 0));
-    }
-
-    @Override
-    public <T> Single<T> offloadSend(final Executor executor, final Single<T> original) {
-        return offloaded(OFFLOAD_SEND) ? original.subscribeOn(executor) : original;
-    }
-
-    @Override
-    public <T> Single<T> offloadReceive(final Executor executor, final Single<T> original) {
-        return offloaded(OFFLOAD_RECEIVE_META) || offloaded(OFFLOAD_RECEIVE_DATA) ?
-                original.publishOn(executor) : original;
-    }
-
-    @Override
-    public <T> Publisher<T> offloadSend(final Executor executor, final Publisher<T> original) {
-        return offloaded(OFFLOAD_SEND) ? original.subscribeOn(executor) : original;
-    }
-
-    @Override
-    public <T> Publisher<T> offloadReceive(final Executor executor, final Publisher<T> original) {
-        return offloaded(OFFLOAD_RECEIVE_META) || offloaded(OFFLOAD_RECEIVE_DATA) ?
-                original.publishOn(executor) : original;
     }
 
     // Visible for testing

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
@@ -15,10 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
-
 /**
  *  Package private special purpose implementation for {@link HttpExecutionStrategy} to be used across programming model
  *  adapters, should not be made public. Provides a special execution strategy that overrides offloading behavior.
@@ -62,26 +58,6 @@ enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
         public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
             return this;
         }
-
-        @Override
-        public <T> Single<T> offloadSend(final Executor executor, final Single<T> original) {
-            return original;
-        }
-
-        @Override
-        public <T> Single<T> offloadReceive(final Executor executor, final Single<T> original) {
-            return original;
-        }
-
-        @Override
-        public <T> Publisher<T> offloadSend(final Executor executor, final Publisher<T> original) {
-            return original;
-        }
-
-        @Override
-        public <T> Publisher<T> offloadReceive(final Executor executor, final Publisher<T> original) {
-            return original;
-        }
     },
     /**
      * "default safe" execution strategy that offloads everything and defers to other execution strategies when merged.
@@ -117,26 +93,6 @@ enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
         @Override
         public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
             return other;
-        }
-
-        @Override
-        public <T> Single<T> offloadSend(final Executor executor, final Single<T> original) {
-            return DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY.offloadSend(executor, original);
-        }
-
-        @Override
-        public <T> Single<T> offloadReceive(final Executor executor, final Single<T> original) {
-            return DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY.offloadReceive(executor, original);
-        }
-
-        @Override
-        public <T> Publisher<T> offloadSend(final Executor executor, final Publisher<T> original) {
-            return DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY.offloadSend(executor, original);
-        }
-
-        @Override
-        public <T> Publisher<T> offloadReceive(final Executor executor, final Publisher<T> original) {
-            return DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY.offloadReceive(executor, original);
         }
     }
 }

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/DelegatingHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/DelegatingHttpExecutionStrategy.java
@@ -15,10 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
-
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -57,26 +53,6 @@ public class DelegatingHttpExecutionStrategy implements HttpExecutionStrategy {
         // Since any methods can be overridden to change behavior, we leverage the other strategy to also account for
         // the overridden methods here.
         return other.merge(this);
-    }
-
-    @Override
-    public <T> Single<T> offloadSend(final Executor executor, final Single<T> original) {
-        return delegate.offloadSend(executor, original);
-    }
-
-    @Override
-    public <T> Single<T> offloadReceive(final Executor executor, final Single<T> original) {
-        return delegate.offloadReceive(executor, original);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadSend(final Executor executor, final Publisher<T> original) {
-        return delegate.offloadSend(executor, original);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadReceive(final Executor executor, final Publisher<T> original) {
-        return delegate.offloadReceive(executor, original);
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -121,8 +121,10 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
     @Override
     public Single<ReservedStreamingHttpConnection> reserveConnection(final HttpExecutionStrategy strategy,
                                                                      final HttpRequestMetaData metaData) {
-        return strategy.offloadReceive(executionContext.executor(),
-                loadBalancer.selectConnection(SELECTOR_FOR_RESERVE).map(identity()));
+        Single<ReservedStreamingHttpConnection> connection =
+                loadBalancer.selectConnection(SELECTOR_FOR_RESERVE).map(identity());
+        return strategy.isMetadataReceiveOffloaded() || strategy.isDataReceiveOffloaded() ?
+                connection.publishOn(executionContext.executor()) : connection;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -30,6 +30,7 @@ import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.utils.BeforeFinallyHttpOperator;
+import io.servicetalk.transport.api.IoThreadFactory;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Predicate;
@@ -124,7 +125,8 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
         Single<ReservedStreamingHttpConnection> connection =
                 loadBalancer.selectConnection(SELECTOR_FOR_RESERVE).map(identity());
         return strategy.isMetadataReceiveOffloaded() || strategy.isDataReceiveOffloaded() ?
-                connection.publishOn(executionContext.executor()) : connection;
+                connection.publishOn(executionContext.executor(), IoThreadFactory.IoThread::currentThreadIsIoThread) :
+                connection;
     }
 
     @Override

--- a/servicetalk-http-router-jersey-internal/src/main/java/io/servicetalk/http/router/jersey/internal/BufferPublisherInputStream.java
+++ b/servicetalk-http-router-jersey-internal/src/main/java/io/servicetalk/http/router/jersey/internal/BufferPublisherInputStream.java
@@ -86,7 +86,8 @@ public final class BufferPublisherInputStream extends InputStream {
     public void offloadSourcePublisher(final HttpExecutionStrategy executionStrategy,
                                 final Executor executor) {
         if (inputStream == EMPTY_INPUT_STREAM) {
-            publisher = executionStrategy.offloadReceive(executor, publisher);
+            publisher = executionStrategy.isMetadataReceiveOffloaded() || executionStrategy.isDataReceiveOffloaded() ?
+                    publisher.publishOn(executor) : publisher;
         } else {
             throw new IllegalStateException("Can't offload source publisher because it is consumed via InputStream");
         }

--- a/servicetalk-http-router-jersey-internal/src/main/java/io/servicetalk/http/router/jersey/internal/BufferPublisherInputStream.java
+++ b/servicetalk-http-router-jersey-internal/src/main/java/io/servicetalk/http/router/jersey/internal/BufferPublisherInputStream.java
@@ -20,6 +20,7 @@ import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.transport.api.IoThreadFactory;
 
 import org.glassfish.jersey.message.internal.EntityInputStream;
 
@@ -86,7 +87,7 @@ public final class BufferPublisherInputStream extends InputStream {
     public void offloadSourcePublisher(final HttpExecutionStrategy executionStrategy, final Executor executor) {
         if (inputStream == EMPTY_INPUT_STREAM) {
             publisher = executionStrategy.isMetadataReceiveOffloaded() || executionStrategy.isDataReceiveOffloaded() ?
-                    publisher.publishOn(executor) : publisher;
+                    publisher.publishOn(executor, IoThreadFactory.IoThread::currentThreadIsIoThread) : publisher;
         } else {
             throw new IllegalStateException("Can't offload source publisher because it is consumed via InputStream");
         }

--- a/servicetalk-http-router-jersey-internal/src/main/java/io/servicetalk/http/router/jersey/internal/BufferPublisherInputStream.java
+++ b/servicetalk-http-router-jersey-internal/src/main/java/io/servicetalk/http/router/jersey/internal/BufferPublisherInputStream.java
@@ -83,8 +83,7 @@ public final class BufferPublisherInputStream extends InputStream {
      * @param executionStrategy the {@link HttpExecutionStrategy} to use.
      * @param executor the {@link Executor} to use with the {@link HttpExecutionStrategy}.
      */
-    public void offloadSourcePublisher(final HttpExecutionStrategy executionStrategy,
-                                final Executor executor) {
+    public void offloadSourcePublisher(final HttpExecutionStrategy executionStrategy, final Executor executor) {
         if (inputStream == EMPTY_INPUT_STREAM) {
             publisher = executionStrategy.isMetadataReceiveOffloaded() || executionStrategy.isDataReceiveOffloaded() ?
                     publisher.publishOn(executor) : publisher;

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultContainerResponseWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultContainerResponseWriter.java
@@ -236,7 +236,9 @@ final class DefaultContainerResponseWriter implements ContainerResponseWriter {
             final HttpExecutionStrategy executionStrategy = getResponseExecutionStrategy(request);
             // TODO(scott): use request factory methods that accept a payload body to avoid overhead of payloadBody.
             final Publisher<Buffer> payloadBody = (executionStrategy != null ?
-                    executionStrategy.offloadSend(serviceCtx.executionContext().executor(), content) : content)
+                    executionStrategy.isSendOffloaded() ?
+                            content.subscribeOn(serviceCtx.executionContext().executor()) :
+                            content : content)
                     .beforeCancel(this::cancelResponse);  // Cleanup internal state if server cancels response body
 
             response = responseFactory.newResponse(status)

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultContainerResponseWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultContainerResponseWriter.java
@@ -27,6 +27,7 @@ import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.transport.api.IoThreadFactory;
 
 import org.glassfish.jersey.server.ContainerException;
 import org.glassfish.jersey.server.ContainerRequest;
@@ -235,10 +236,9 @@ final class DefaultContainerResponseWriter implements ContainerResponseWriter {
         if (content != null && !isHeadRequest()) {
             final HttpExecutionStrategy executionStrategy = getResponseExecutionStrategy(request);
             // TODO(scott): use request factory methods that accept a payload body to avoid overhead of payloadBody.
-            final Publisher<Buffer> payloadBody = (executionStrategy != null ?
-                    executionStrategy.isSendOffloaded() ?
-                            content.subscribeOn(serviceCtx.executionContext().executor()) :
-                            content : content)
+            final Publisher<Buffer> payloadBody = (executionStrategy != null && executionStrategy.isSendOffloaded() ?
+                    content.subscribeOn(serviceCtx.executionContext().executor(),
+                            IoThreadFactory.IoThread::currentThreadIsIoThread) : content)
                     .beforeCancel(this::cancelResponse);  // Cleanup internal state if server cancels response body
 
             response = responseFactory.newResponse(status)

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
@@ -259,8 +259,8 @@ final class EndpointEnhancingRequestFilter implements ContainerRequestFilter {
             final Cancellable cancellable;
             if (effectiveRouteStrategy != null) {
                 assert executor != null;
-                cancellable = effectiveRouteStrategy
-                        .offloadSend(executor, responseSingle)
+                cancellable = (effectiveRouteStrategy.isSendOffloaded() ?
+                        responseSingle.subscribeOn(executor) : responseSingle)
                         .subscribe(asyncContext::resume);
             } else {
                 cancellable = responseSingle.subscribe(asyncContext::resume);

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
@@ -27,6 +27,7 @@ import io.servicetalk.transport.api.DelegatingConnectionContext;
 import io.servicetalk.transport.api.DelegatingExecutionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ExecutionStrategy;
+import io.servicetalk.transport.api.IoThreadFactory;
 
 import org.glassfish.jersey.internal.util.collection.Ref;
 import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
@@ -260,7 +261,8 @@ final class EndpointEnhancingRequestFilter implements ContainerRequestFilter {
             if (effectiveRouteStrategy != null) {
                 assert executor != null;
                 cancellable = (effectiveRouteStrategy.isSendOffloaded() ?
-                        responseSingle.subscribeOn(executor) : responseSingle)
+                        responseSingle.subscribeOn(executor, IoThreadFactory.IoThread::currentThreadIsIoThread) :
+                        responseSingle)
                         .subscribe(asyncContext::resume);
             } else {
                 cancellable = responseSingle.subscribe(asyncContext::resume);

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/JerseyRouteExecutionStrategy.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/JerseyRouteExecutionStrategy.java
@@ -16,8 +16,6 @@
 package io.servicetalk.http.router.jersey;
 
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 
 import static java.util.Objects.requireNonNull;
@@ -77,26 +75,6 @@ class JerseyRouteExecutionStrategy implements HttpExecutionStrategy {
     @Override
     public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
         return delegate.merge(other);
-    }
-
-    @Override
-    public <T> Single<T> offloadSend(final Executor fallback, final Single<T> original) {
-        return delegate.offloadSend(executor(fallback), original);
-    }
-
-    @Override
-    public <T> Single<T> offloadReceive(final Executor fallback, final Single<T> original) {
-        return delegate.offloadReceive(executor(fallback), original);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadSend(final Executor fallback, final Publisher<T> original) {
-        return delegate.offloadSend(executor(fallback), original);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadReceive(final Executor fallback, final Publisher<T> original) {
-        return delegate.offloadReceive(executor(fallback), original);
     }
 
     public Executor executor() {

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
@@ -15,64 +15,8 @@
  */
 package io.servicetalk.transport.api;
 
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
-
 /**
  * An execution strategy for all transports.
  */
 public interface ExecutionStrategy {
-
-    /**
-     * Offloads the {@code original} {@link Single} for sending data on the transport.
-     *
-     * @param executor {@link Executor} to use as executor.
-     * @param original {@link Single} to offload.
-     * @param <T> Type of result of the {@code original} {@link Single}.
-     * @return Offloaded {@link Single}.
-     * @deprecated This method will be removed. If you depend upon it consider copying the implementation from
-     * {@code DefaultHttpExecutionStrategy#offloadSend()}
-     */
-    @Deprecated
-    <T> Single<T> offloadSend(Executor executor, Single<T> original);
-
-    /**
-     * Offloads the {@code original} {@link Single} for receiving data from the transport.
-     *
-     * @param executor {@link Executor} to use as executor.
-     * @param original {@link Single} to offload.
-     * @param <T> Type of result of the {@code original} {@link Single}.
-     * @return Offloaded {@link Single}.
-     * @deprecated This method will be removed. If you depend upon it consider copying the implementation from
-     * {@code DefaultHttpExecutionStrategy#offloadReceive()}
-     */
-    @Deprecated
-    <T> Single<T> offloadReceive(Executor executor, Single<T> original);
-
-    /**
-     * Offloads the {@code original} {@link Publisher} for sending data on the transport.
-     *
-     * @param executor {@link Executor} to use as executor.
-     * @param original {@link Publisher} to offload.
-     * @param <T> Type of items emitted from the {@code original} {@link Publisher}.
-     * @return Offloaded {@link Publisher}.
-     * @deprecated This method will be removed. If you depend upon it consider copying the implementation from
-     * {@code DefaultHttpExecutionStrategy#offloadSend()}
-     */
-    @Deprecated
-    <T> Publisher<T> offloadSend(Executor executor, Publisher<T> original);
-
-    /**
-     * Offloads the {@code original} {@link Publisher} for receiving data from the transport.
-     *
-     * @param executor {@link Executor} to use as executor.
-     * @param original {@link Publisher} to offload.
-     * @param <T> Type of items emitted from the {@code original} {@link Publisher}.
-     * @return Offloaded {@link Publisher}.
-     * @deprecated This method will be removed. If you depend upon it consider copying the implementation from
-     * {@code DefaultHttpExecutionStrategy#offloadReceive()}
-     */
-    @Deprecated
-    <T> Publisher<T> offloadReceive(Executor executor, Publisher<T> original);
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/OffloadFromIOExecutionStrategy.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/OffloadFromIOExecutionStrategy.java
@@ -15,11 +15,7 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionStrategy;
-import io.servicetalk.transport.api.IoThreadFactory;
 
 final class OffloadFromIOExecutionStrategy implements ExecutionStrategy {
 
@@ -27,25 +23,5 @@ final class OffloadFromIOExecutionStrategy implements ExecutionStrategy {
 
     private OffloadFromIOExecutionStrategy() {
         // Singleton
-    }
-
-    @Override
-    public <T> Single<T> offloadSend(final Executor executor, final Single<T> original) {
-        return original.subscribeOn(executor, IoThreadFactory.IoThread::currentThreadIsIoThread);
-    }
-
-    @Override
-    public <T> Single<T> offloadReceive(final Executor executor, final Single<T> original) {
-        return original.publishOn(executor, IoThreadFactory.IoThread::currentThreadIsIoThread);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadSend(final Executor executor, final Publisher<T> original) {
-        return original.subscribeOn(executor, IoThreadFactory.IoThread::currentThreadIsIoThread);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadReceive(final Executor executor, final Publisher<T> original) {
-        return original.publishOn(executor, IoThreadFactory.IoThread::currentThreadIsIoThread);
     }
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NoopExecutionStrategy.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NoopExecutionStrategy.java
@@ -15,9 +15,6 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionStrategy;
 
 final class NoopExecutionStrategy implements ExecutionStrategy {
@@ -26,25 +23,5 @@ final class NoopExecutionStrategy implements ExecutionStrategy {
 
     private NoopExecutionStrategy() {
         // Singleton
-    }
-
-    @Override
-    public <T> Single<T> offloadSend(final Executor executor, final Single<T> original) {
-        return original;
-    }
-
-    @Override
-    public <T> Single<T> offloadReceive(final Executor executor, final Single<T> original) {
-        return original;
-    }
-
-    @Override
-    public <T> Publisher<T> offloadSend(final Executor executor, final Publisher<T> original) {
-        return original;
-    }
-
-    @Override
-    public <T> Publisher<T> offloadReceive(final Executor executor, final Publisher<T> original) {
-        return original;
     }
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/OffloadAllExecutionStrategy.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/OffloadAllExecutionStrategy.java
@@ -15,9 +15,6 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionStrategy;
 
 final class OffloadAllExecutionStrategy implements ExecutionStrategy {
@@ -26,25 +23,5 @@ final class OffloadAllExecutionStrategy implements ExecutionStrategy {
 
     private OffloadAllExecutionStrategy() {
         // Singleton
-    }
-
-    @Override
-    public <T> Single<T> offloadSend(final Executor executor, final Single<T> original) {
-        return original.subscribeOn(executor);
-    }
-
-    @Override
-    public <T> Single<T> offloadReceive(final Executor executor, final Single<T> original) {
-        return original.publishOn(executor);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadSend(final Executor executor, final Publisher<T> original) {
-        return original.subscribeOn(executor);
-    }
-
-    @Override
-    public <T> Publisher<T> offloadReceive(final Executor executor, final Publisher<T> original) {
-        return original.publishOn(executor);
     }
 }


### PR DESCRIPTION
Motivation:
These methods are so sparsely used that including them in the interface
serves no useful purpose.
Modifications:
"Inline" the implementation to the current call sites and remove the
`offloadSend` and `offloadReceive` methods.
Result:
Reduced public interface for `ExecutionStrategy`.
