### PR TITLE
Deprecate `payloadBody(CloseableIterable<Buffer>)` methods

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpMessageBodyUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpMessageBodyUtils.java
@@ -92,6 +92,7 @@ final class BlockingStreamingHttpMessageBodyUtils {
         }
 
         @Nullable
+        @Override
         public HttpHeaders trailers() {
             return trailers;
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -110,7 +110,10 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * @deprecated Use {@link #payloadBody(Iterable)}.
      */
     @Deprecated
-    BlockingStreamingHttpRequest payloadBody(CloseableIterable<Buffer> payloadBody);
+    default BlockingStreamingHttpRequest payloadBody(CloseableIterable<Buffer> payloadBody) {
+        payloadBody((Iterable<Buffer>) payloadBody);
+        return this;
+    }
 
     /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -184,7 +184,11 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * @deprecated Use {@link #payloadBody(Iterable, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> BlockingStreamingHttpRequest payloadBody(CloseableIterable<T> payloadBody, HttpSerializer<T> serializer);
+    default <T> BlockingStreamingHttpRequest payloadBody(CloseableIterable<T> payloadBody,
+                                                         HttpSerializer<T> serializer) {
+        payloadBody((Iterable<T>) payloadBody, serializer);
+        return this;
+    }
 
     /**
      * Set the {@link HttpMessageBodyIterable} for this response.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -107,7 +107,9 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body.
      * @return {@code this}
+     * @deprecated Use {@link #payloadBody(Iterable)}.
      */
+    @Deprecated
     BlockingStreamingHttpRequest payloadBody(CloseableIterable<Buffer> payloadBody);
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -181,7 +181,11 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * @deprecated Use {@link #payloadBody(Iterable, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> BlockingStreamingHttpResponse payloadBody(CloseableIterable<T> payloadBody, HttpSerializer<T> serializer);
+    default <T> BlockingStreamingHttpResponse payloadBody(CloseableIterable<T> payloadBody,
+                                                          HttpSerializer<T> serializer) {
+        payloadBody((Iterable<T>) payloadBody, serializer);
+        return this;
+    }
 
     /**
      * Set the {@link HttpMessageBodyIterable} for this response.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -106,7 +106,10 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * @deprecated Use {@link #payloadBody(Iterable)}.
      */
     @Deprecated
-    BlockingStreamingHttpResponse payloadBody(CloseableIterable<Buffer> payloadBody);
+    default BlockingStreamingHttpResponse payloadBody(CloseableIterable<Buffer> payloadBody) {
+        payloadBody((Iterable<Buffer>) payloadBody);
+        return this;
+    }
 
     /**
      * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to {@code payloadBody}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -103,7 +103,9 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body.
      * @return {@code this}
+     * @deprecated Use {@link #payloadBody(Iterable)}.
      */
+    @Deprecated
     BlockingStreamingHttpResponse payloadBody(CloseableIterable<Buffer> payloadBody);
 
     /**


### PR DESCRIPTION
Motivation:

`BlockingStreamingHttpRequest` and `BlockingStreamingHttpResponse`
already have a `payloadBody(Iterable<Buffer>)` overload that can be
used instead. There is no need for more specialized overload for
`CloseableIterable`.

Modifications:

- Mark `payloadBody(CloseableIterable<Buffer>)` methods as `@Deprecated`;
- Add `default` implementations for `payloadBody(CloseableIterable<Buffer>)`
and `payloadBody(CloseableIterable<Buffer>, HttpSerializer<T>)`;

Result:

Less public API on `BlockingStreamingHttpRequest` and
`BlockingStreamingHttpResponse`.