### PR TITLE
Enable wrapping Callable with AsyncContext via public API

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import java.util.ConcurrentModificationException;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -240,6 +241,16 @@ public final class AsyncContext {
     public static Runnable wrapRunnable(Runnable runnable) {
         AsyncContextProvider provider = provider();
         return provider.wrapRunnable(runnable, provider.contextMap());
+    }
+
+    /**
+     * Wrap a {@link Callable} to ensure it is able to track {@link AsyncContext} correctly.
+     * @param callable The callable to wrap.
+     * @return The wrapped {@link Callable}.
+     */
+    public static Callable wrapCallable(Callable callable) {
+        AsyncContextProvider provider = provider();
+        return provider.wrapCallable(callable, provider.contextMap());
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
@@ -246,9 +246,10 @@ public final class AsyncContext {
     /**
      * Wrap a {@link Callable} to ensure it is able to track {@link AsyncContext} correctly.
      * @param callable The callable to wrap.
+     * @param <V> The type of data returned by {@code callable}.
      * @return The wrapped {@link Callable}.
      */
-    public static Callable wrapCallable(Callable callable) {
+    public static <V> Callable<V> wrapCallable(Callable<V> callable) {
         AsyncContextProvider provider = provider();
         return provider.wrapCallable(callable, provider.contextMap());
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -186,6 +187,14 @@ interface AsyncContextProvider {
      * @return The wrapped {@link Runnable}.
      */
     Runnable wrapRunnable(Runnable runnable, AsyncContextMap contextMap);
+
+    /**
+     * Wrap a {@link Callable} to ensure it is able to track {@link AsyncContext} correctly.
+     * @param callable The callable to wrap.
+     * @param contextMap The {@link AsyncContext}.
+     * @return The wrapped {@link Callable}.
+     */
+    Callable wrapCallable(Callable callable, AsyncContextMap contextMap);
 
     /**
      * Wrap a {@link Consumer} to ensure it is able to track {@link AsyncContext} correctly.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
@@ -192,9 +192,10 @@ interface AsyncContextProvider {
      * Wrap a {@link Callable} to ensure it is able to track {@link AsyncContext} correctly.
      * @param callable The callable to wrap.
      * @param contextMap The {@link AsyncContext}.
+     * @param <V> The type of data returned by {@code callable}.
      * @return The wrapped {@link Callable}.
      */
-    Callable wrapCallable(Callable callable, AsyncContextMap contextMap);
+    <V> Callable<V> wrapCallable(Callable<V> callable, AsyncContextMap contextMap);
 
     /**
      * Wrap a {@link Consumer} to ensure it is able to track {@link AsyncContext} correctly.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
@@ -243,8 +243,8 @@ final class DefaultAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
-    public Callable wrapCallable(final Callable callable, final AsyncContextMap contextMap) {
-        return new ContextPreservingCallable(callable, contextMap);
+    public <V> Callable<V> wrapCallable(final Callable<V> callable, final AsyncContextMap contextMap) {
+        return new ContextPreservingCallable<>(callable, contextMap);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.SingleSource;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -239,6 +240,11 @@ final class DefaultAsyncContextProvider implements AsyncContextProvider {
     @Override
     public Runnable wrapRunnable(final Runnable runnable, final AsyncContextMap contextMap) {
         return new ContextPreservingRunnable(runnable, contextMap);
+    }
+
+    @Override
+    public Callable wrapCallable(final Callable callable, final AsyncContextMap contextMap) {
+        return new ContextPreservingCallable(callable, contextMap);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NoopAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NoopAsyncContextProvider.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.SingleSource;
 
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -128,6 +129,11 @@ final class NoopAsyncContextProvider implements AsyncContextProvider {
     @Override
     public Runnable wrapRunnable(final Runnable runnable, final AsyncContextMap contextMap) {
         return runnable;
+    }
+
+    @Override
+    public Callable wrapCallable(final Callable callable, final AsyncContextMap contextMap) {
+        return callable;
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NoopAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NoopAsyncContextProvider.java
@@ -132,7 +132,7 @@ final class NoopAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
-    public Callable wrapCallable(final Callable callable, final AsyncContextMap contextMap) {
+    public <V> Callable<V> wrapCallable(final Callable<V> callable, final AsyncContextMap contextMap) {
         return callable;
     }
 


### PR DESCRIPTION
Motivation:
It is currently not possible for a user to wrap Callable to ensure it is able to track AsyncContext correctly.

Modifications:
- Add wrapCallable method to AsyncContext
- Add wrapCallable method to AsyncContextProvider interface
- Implement wrapCallable method in NoopAsyncContextProvider
- Implement wrapCallable method in DefaultAsyncContextProvider using existing ContextPreservingCallable class

Result:
It is now possible for a user to wrap Callable to ensure it is able to track AsyncContext correctly.