### PR TITLE
Replace actions/cache with new setup-java cache feature of GitHub Actions

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -18,18 +18,11 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Print JDK Version
         run: java -version
       - name: Make gradlew Executable
         run: chmod +x gradlew
-      - name: Cache Gradle Packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
       # https://github.community/t/error-the-paging-file-is-too-small-for-this-operation-to-complete/17141
       - name: Configure Windows Pagefile
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -16,18 +16,11 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Print JDK Version
         run: java -version
       - name: Make gradlew Executable
         run: chmod +x gradlew
-      - name: Cache Gradle packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
       - name: Build with Gradle
         env:
           CI: true

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -20,18 +20,11 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Print JDK Version
         run: java -version
       - name: Make gradlew Executable
         run: chmod +x gradlew
-      - name: Cache Gradle packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
       - name: Build with Gradle
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -21,18 +21,11 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Print JDK Version
         run: java -version
       - name: Make gradlew Executable
         run: chmod +x gradlew
-      - name: Cache Gradle packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
       - name: Build with Gradle
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}


### PR DESCRIPTION
Motivation:

Github Actions announced a new "cache" feature for setup-java:
https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/

Modifications:

- Replace actions/cache with new setup-java cache feature;

Result:

No custom `actions/cache` step, less yaml code for GitHub Actions
configuration.