### PR TITLE
gRPC send RST_STREAM on client deadline expire

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -97,7 +97,6 @@ final class GrpcUtils {
                 @Override
                 protected HttpHeaders payloadFailed(final Throwable cause, final HttpHeaders trailers)
                         throws Throwable {
-
                     // local cancel
                     if (cause instanceof CancellationException) {
                         // include the cause so that caller can determine who cancelled request
@@ -106,12 +105,8 @@ final class GrpcUtils {
 
                     // local timeout
                     if (cause instanceof TimeoutException) {
-                        // omit the cause unless DEBUG logging has been configured
-                        throw new GrpcStatusException(
-                                LOGGER.isDebugEnabled() ?
-                                    new GrpcStatus(DEADLINE_EXCEEDED, cause) :
-                                    DEADLINE_EXCEEDED.status(),
-                                () -> null);
+                        // include the cause so the caller sees the time duration.
+                        throw new GrpcStatusException(new GrpcStatus(DEADLINE_EXCEEDED, cause), () -> null);
                     }
 
                     throw cause;

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -229,8 +229,7 @@ final class GrpcUtils {
         } else if (cause instanceof CancellationException) {
             status = new GrpcStatus(CANCELLED, cause);
         } else if (cause instanceof TimeoutException) {
-            // omit cause unless logging configured for debug
-            status = LOGGER.isDebugEnabled() ? new GrpcStatus(DEADLINE_EXCEEDED, cause) : DEADLINE_EXCEEDED.status();
+            status = new GrpcStatus(DEADLINE_EXCEEDED, cause);
         } else {
             // Initialize detail because cause is often lost
             status = new GrpcStatus(UNKNOWN, cause, cause.toString());

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -21,6 +21,8 @@ import io.servicetalk.concurrent.SingleSource.Processor;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.TerminalSignalConsumer;
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.encoding.api.ContentCodec;
 import io.servicetalk.grpc.api.GrpcClientBuilder;
 import io.servicetalk.grpc.api.GrpcExecutionContext;
@@ -42,11 +44,17 @@ import io.servicetalk.grpc.netty.CompatProto.Compat.ServerStreamingCallMetadata;
 import io.servicetalk.grpc.netty.CompatProto.Compat.ServiceFactory;
 import io.servicetalk.grpc.netty.CompatProto.RequestContainer.CompatRequest;
 import io.servicetalk.grpc.netty.CompatProto.ResponseContainer.CompatResponse;
+import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.ServerContext;
@@ -70,27 +78,31 @@ import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 
 import static com.google.protobuf.Any.pack;
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
+import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.DEFAULT_TIMEOUT_SECONDS;
@@ -98,14 +110,20 @@ import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.encoding.netty.ContentCodings.gzipDefault;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
+import static io.servicetalk.grpc.internal.DeadlineUtils.GRPC_TIMEOUT_HEADER_KEY;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
 import static io.servicetalk.test.resources.DefaultTestCerts.loadServerKey;
 import static io.servicetalk.test.resources.DefaultTestCerts.loadServerPem;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static io.servicetalk.transport.api.SslProvider.OPENSSL;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -152,6 +170,8 @@ class ProtocolCompatibilityTest {
     }
 
     private static final String CUSTOM_ERROR_MESSAGE = "custom error message";
+    private static final DeliberateException SERVER_PROCESSED_TOKEN = new DeliberateException();
+    private static final Duration DEFAULT_DEADLINE = ofMillis(100);
 
     private enum ErrorMode {
         NONE,
@@ -569,52 +589,130 @@ class ProtocolCompatibilityTest {
 
     @ParameterizedTest
     @MethodSource("sslStreamingAndCompressionParams")
-    @Disabled("https://github.com/apple/servicetalk/issues/1489")
-    void grpcJavaToGrpcJavaTimeout(final boolean ssl,
-                                   final boolean streaming,
-                                   final String compression) throws Exception {
-        Duration timeout = Duration.ofNanos(1);
+    void grpcJavaToGrpcJavaTimeout(final boolean ssl, final boolean streaming, final String compression)
+            throws Exception {
         final TestServerContext server = grpcJavaServer(ErrorMode.NONE, ssl, compression);
-        final CompatClient client = grpcJavaClient(server.listenAddress(), compression, ssl, timeout);
-        testGrpcError(client, server, false, streaming, compression, GrpcStatusCode.DEADLINE_EXCEEDED, null);
+        try (ServerContext proxyCtx = buildTimeoutProxy(server.listenAddress(), ssl)) {
+            final CompatClient client = grpcJavaClient(proxyCtx.listenAddress(), compression, ssl, DEFAULT_DEADLINE);
+            testGrpcError(client, server, false, streaming, compression, DEADLINE_EXCEEDED, null);
+        }
     }
 
     @ParameterizedTest
     @MethodSource("sslStreamingAndCompressionParams")
-    @Disabled("https://github.com/apple/servicetalk/issues/1489")
-    void serviceTalkToGrpcJavaTimeout(final boolean ssl,
-                                      final boolean streaming,
-                                      final String compression) throws Exception {
-        Duration timeout = Duration.ofNanos(1);
+    void serviceTalkToGrpcJavaTimeout(final boolean ssl, final boolean streaming, final String compression)
+            throws Exception {
         final TestServerContext server = grpcJavaServer(ErrorMode.NONE, ssl, compression);
-        final CompatClient client = serviceTalkClient(server.listenAddress(), ssl, compression, timeout);
-        testGrpcError(client, server, false, streaming, compression, GrpcStatusCode.DEADLINE_EXCEEDED, null);
+        try (ServerContext proxyCtx = buildTimeoutProxy(server.listenAddress(), ssl)) {
+            final CompatClient client = serviceTalkClient(proxyCtx.listenAddress(), ssl, compression, DEFAULT_DEADLINE);
+            testGrpcError(client, server, false, streaming, compression, DEADLINE_EXCEEDED, null);
+        }
     }
 
     @ParameterizedTest
     @MethodSource("sslStreamingAndCompressionParams")
-    @Disabled("https://github.com/apple/servicetalk/issues/1489")
-    void grpcJavaToServiceTalkTimeout(final boolean ssl,
-                                      final boolean streaming,
-                                      final String compression) throws Exception {
-        Duration timeout = Duration.ofNanos(1);
+    void grpcJavaToServiceTalkTimeout(final boolean ssl, final boolean streaming, final String compression)
+            throws Exception {
         final TestServerContext server = serviceTalkServer(ErrorMode.NONE, ssl, compression, null);
-        final CompatClient client = grpcJavaClient(server.listenAddress(), compression, ssl, timeout);
-        testGrpcError(client, server, false, streaming, compression, GrpcStatusCode.DEADLINE_EXCEEDED, null);
+        try (ServerContext proxyCtx = buildTimeoutProxy(server.listenAddress(), ssl)) {
+            final CompatClient client = grpcJavaClient(proxyCtx.listenAddress(), compression, ssl, DEFAULT_DEADLINE);
+            testGrpcError(client, server, false, streaming, compression, DEADLINE_EXCEEDED, null);
+        }
     }
 
     @ParameterizedTest
     @MethodSource("sslStreamingAndCompressionParams")
-    @Disabled("https://github.com/apple/servicetalk/issues/1489")
-    void serviceTalkToServiceTalkTimeout(final boolean ssl,
-                                         final boolean streaming,
-                                         final String compression) throws Exception {
-        Duration timeout = Duration.ofNanos(1);
+    void serviceTalkToServiceTalkTimeout(final boolean ssl, final boolean streaming, final String compression)
+            throws Exception {
         final TestServerContext server = serviceTalkServer(ErrorMode.NONE, ssl, compression, null);
-        final CompatClient client = serviceTalkClient(server.listenAddress(), ssl, compression, timeout);
-        testGrpcError(client, server, false, streaming, compression, GrpcStatusCode.DEADLINE_EXCEEDED, null);
+        try (ServerContext proxyCtx = buildTimeoutProxy(server.listenAddress(), ssl)) {
+            final CompatClient client = serviceTalkClient(proxyCtx.listenAddress(), ssl, compression, DEFAULT_DEADLINE);
+            testGrpcError(client, server, false, streaming, compression, DEADLINE_EXCEEDED, null);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("sslAndStreamingParams")
+    void serviceTalkToGrpcJavaTimeoutBeforeComplete(boolean stClient, boolean proxyRemoveTimeout) throws Exception {
+        BlockingQueue<Throwable> serverErrorQueue = new ArrayBlockingQueue<>(16);
+        final TestServerContext server = serviceTalkServer(ErrorMode.NONE, false, noOffloadsStrategy(), null, null,
+                serverErrorQueue);
+        try (ServerContext proxyCtx = buildTimeoutProxy(server.listenAddress(), false)) {
+            SocketAddress connectAddr = proxyRemoveTimeout ? proxyCtx.listenAddress() : server.listenAddress();
+            final CompatClient client = stClient ?
+                    serviceTalkClient(connectAddr, false, null, DEFAULT_DEADLINE) :
+                    grpcJavaClient(connectAddr, null, false, DEFAULT_DEADLINE);
+            try {
+                PublisherSource.Processor<CompatRequest, CompatRequest> reqPub = newPublisherProcessor();
+                reqPub.onNext(CompatRequest.newBuilder().setId(3).build());
+                validateGrpcErrorInResponse(client.bidirectionalStreamingCall(fromSource(reqPub)).toFuture(), false,
+                        DEADLINE_EXCEEDED, null);
+
+                // It is possible that the timeout on the client occurred before writing the request, in which case the
+                // server will never request the request, and therefore no error is expected.
+                Throwable cause = serverErrorQueue.poll(DEFAULT_DEADLINE.toNanos() * 2, NANOSECONDS);
+                if (cause != null) {
+                    assertThat(cause, is(SERVER_PROCESSED_TOKEN));
+                    cause = serverErrorQueue.take();
+                    assertThat(cause, instanceOf(IOException.class));
+                }
+            } finally {
+                closeAll(server, client);
+            }
+        }
     }
     // </editor-fold>
+
+    private static ServerContext buildTimeoutProxy(SocketAddress serverAddress, boolean ssl) throws Exception {
+        HttpServerBuilder proxyBuilder = HttpServers.forAddress(localAddress(0))
+                .executionStrategy(noOffloadsStrategy())
+                .protocols(h2().build());
+        if (ssl) {
+            proxyBuilder.sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
+                    DefaultTestCerts::loadServerKey).build());
+        }
+        return proxyBuilder.listenStreamingAndAwait(new RemoveTimeoutHeaderProxy(serverAddress, ssl));
+    }
+
+    private static final class RemoveTimeoutHeaderProxy implements StreamingHttpService {
+        private final StreamingHttpClient client;
+
+        RemoveTimeoutHeaderProxy(SocketAddress serverAddress, boolean ssl) {
+            SingleAddressHttpClientBuilder<InetSocketAddress, InetSocketAddress> builder =
+                    HttpClients.forResolvedAddress((InetSocketAddress) serverAddress)
+                            .executionStrategy(noOffloadsStrategy())
+                            .protocols(h2().build());
+            if (ssl) {
+                builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                        .peerHost(serverPemHostname()).build());
+            }
+            client = builder.buildStreaming();
+        }
+
+        @Override
+        public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                    final StreamingHttpRequest request,
+                                                    final StreamingHttpResponseFactory responseFactory) {
+            return Single.defer(() -> {
+                request.headers().remove(GRPC_TIMEOUT_HEADER_KEY);
+                // Make the request, but don't send the response payload body or trailers because we want to force
+                // a timeout on the client.
+                return client.request(request).map(resp ->
+                                resp.transformMessageBody(pub -> pub.ignoreElements().concat(never())))
+                        .subscribeShareContext();
+            });
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return client.closeAsync();
+        }
+
+        @Override
+        public Completable closeAsyncGracefully() {
+            return client.closeAsyncGracefully();
+        }
+    }
 
     private static void testBlockingRequestResponse(final BlockingCompatClient client, final TestServerContext server,
                                                     final boolean streaming,
@@ -1095,19 +1193,29 @@ class ProtocolCompatibilityTest {
                                                        final GrpcExecutionStrategy strategy,
                                                        @Nullable final String compression,
                                                        @Nullable final Duration timeout) throws Exception {
+        return serviceTalkServer(errorMode, ssl, strategy, compression, timeout, new ArrayDeque<>());
+    }
+
+    private static TestServerContext serviceTalkServer(
+            final ErrorMode errorMode, final boolean ssl, final GrpcExecutionStrategy strategy,
+            @Nullable final String compression, @Nullable final Duration timeout,
+            Queue<Throwable> reqStreamError) throws Exception {
         final Compat.CompatService compatService = new Compat.CompatService() {
             @Override
             public Publisher<CompatResponse> bidirectionalStreamingCall(final GrpcServiceContext ctx,
                                                                         final Publisher<CompatRequest> pub) {
+                reqStreamError.add(SERVER_PROCESSED_TOKEN);
                 maybeThrowFromRpc(errorMode);
-                return pub.map(req -> response(req.getId()));
+                return pub.map(req -> response(req.getId())).beforeFinally(errorConsumer());
             }
 
             @Override
             public Single<CompatResponse> clientStreamingCall(final GrpcServiceContext ctx,
                                                               final Publisher<CompatRequest> pub) {
+                reqStreamError.add(SERVER_PROCESSED_TOKEN);
                 maybeThrowFromRpc(errorMode);
-                return pub.collect(() -> 0, (sum, req) -> sum + req.getId()).map(this::response);
+                return pub.collect(() -> 0, (sum, req) -> sum + req.getId()).map(this::response)
+                        .beforeFinally(errorConsumer());
             }
 
             @Override
@@ -1130,6 +1238,26 @@ class ProtocolCompatibilityTest {
                     throwGrpcStatusExceptionWithStatus();
                 }
                 return computeResponse(value);
+            }
+
+            private TerminalSignalConsumer errorConsumer() {
+                return new TerminalSignalConsumer() {
+                    @Override
+                    public void onComplete() {
+                    }
+
+                    @Override
+                    public void onError(final Throwable throwable) {
+                        reqStreamError.add(throwable);
+                    }
+
+                    @Override
+                    public void cancel() {
+                        // todo: server initiated timeout will be seen as a cancel,
+                        //  can we apply the timeout after the service so they se an onError?
+                        reqStreamError.add(new IOException("cancelled"));
+                    }
+                };
             }
         };
 
@@ -1211,7 +1339,7 @@ class ProtocolCompatibilityTest {
         }
 
         if (null != timeout) {
-            stub = stub.withDeadlineAfter(timeout.toNanos(), TimeUnit.NANOSECONDS);
+            stub = stub.withDeadlineAfter(timeout.toNanos(), NANOSECONDS);
         }
 
         final CompatGrpc.CompatStub finalStub = stub;

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelOutboundListener.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelOutboundListener.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+/**
+ * An interface which provides methods that are invoked when outbound channel events occur. The implementors of
+ * this interface are effectively "listening" to these events via method calls.
+ */
+interface ChannelOutboundListener {
+    /**
+     * Notification that the writability of the channel has changed.
+     * <p>
+     * Always called from the event loop thread.
+     */
+    void channelWritable();
+
+    /**
+     * Notification that the channel's outbound side has been closed and will no longer accept writes.
+     * <p>
+     * Always called from the event loop thread.
+     */
+    void channelOutboundClosed();
+
+    /**
+     * Notification that the channel has been closed.
+     * <p>
+     * This may not always be called from the event loop thread. For example if the channel is closed when a new
+     * write happens then this method will be called from the writer thread.
+     *
+     * @param closedException the exception which describes the close rational.
+     */
+    void channelClosed(Throwable closedException);
+
+    /**
+     * Called if there is already a {@link ChannelOutboundListener} active and this listener will be discarded.
+     * @param cause A cause describing the rational.
+     */
+    void listenerDiscard(Throwable cause);
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -421,12 +421,15 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     }
 
     /**
+     * Visible for testing.
+     * <p>
      * This connection does not allow concurrent writes and so this method can determine if there is a writing pending.
      *
      * @return {@code true} if a write is already active.
      */
     boolean isWriteActive() {
-        return channelOutboundListener != NoopChannelOutboundListener.INSTANCE && channelOutboundListener != this;
+        final ChannelOutboundListener listener = channelOutboundListener;
+        return listener != NoopChannelOutboundListener.INSTANCE && listener != this;
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -26,6 +26,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.TerminalSignalConsumer;
 import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
 import io.servicetalk.concurrent.api.internal.SubscribableSingle;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
@@ -95,10 +96,8 @@ import static java.util.function.UnaryOperator.identity;
  * @param <Write> Type of objects written to this connection.
  */
 public final class DefaultNettyConnection<Read, Write> extends NettyChannelListenableAsyncCloseable
-        implements NettyConnection<Read, Write> {
+        implements NettyConnection<Read, Write>, ChannelOutboundListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNettyConnection.class);
-
-    private static final ChannelOutboundListener PLACE_HOLDER_OUTBOUND_LISTENER = new NoopChannelOutboundListener();
 
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<DefaultNettyConnection, ChannelOutboundListener>
@@ -116,7 +115,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     @Nullable
     private final Long idleTimeoutMs;
     private final Protocol protocol;
-    private volatile ChannelOutboundListener channelOutboundListener = PLACE_HOLDER_OUTBOUND_LISTENER;
+    private volatile ChannelOutboundListener channelOutboundListener = NoopChannelOutboundListener.INSTANCE;
     /**
      * Potentially contains more information when a protocol or channel level close event was observed.
      * <p>
@@ -140,6 +139,28 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     private volatile DataObserver dataObserver;
     private final boolean isClient;
     private final UnaryOperator<Throwable> enrichProtocolError;
+    private final TerminalSignalConsumer cleanupStateConsumer = new TerminalSignalConsumer() {
+        @Override
+        public void onComplete() {
+            cleanupOnWriteTerminated();
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+            cleanupOnWriteTerminated();
+        }
+
+        @Override
+        public void cancel() {
+            // If close events happen, we still need to process them, however we should dereference the current
+            // WriteStreamSubscriber and allow another write to be processed.
+            channelOutboundListener = DefaultNettyConnection.this;
+        }
+
+        private void cleanupOnWriteTerminated() {
+            channelOutboundListener = NoopChannelOutboundListener.INSTANCE;
+        }
+    };
 
     private DefaultNettyConnection(Channel channel, BufferAllocator allocator, Executor executor,
                                    Predicate<Read> terminalPredicate, CloseHandler closeHandler,
@@ -371,10 +392,6 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         return closeReason.wrapError(t, channel());
     }
 
-    private void cleanupOnWriteTerminated() {
-        channelOutboundListener = PLACE_HOLDER_OUTBOUND_LISTENER;
-    }
-
     @Override
     public Publisher<Read> read() {
         return readPublisher;
@@ -409,7 +426,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
      * @return {@code true} if a write is already active.
      */
     boolean isWriteActive() {
-        return channelOutboundListener != PLACE_HOLDER_OUTBOUND_LISTENER;
+        return channelOutboundListener != NoopChannelOutboundListener.INSTANCE && channelOutboundListener != this;
     }
 
     @Override
@@ -474,27 +491,57 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
     private Completable cleanupStateWhenDone(Completable completable) {
         // This must happen before we actually trigger the original Subscribers methods so using before* variants.
-        return completable.beforeFinally(this::cleanupOnWriteTerminated);
+        return completable.beforeFinally(cleanupStateConsumer);
     }
 
-    private boolean failIfWriteActive(ChannelOutboundListener newChannelOutboundListener, Subscriber subscriber) {
-        if (writableListenerUpdater.compareAndSet(this, PLACE_HOLDER_OUTBOUND_LISTENER, newChannelOutboundListener)) {
-            // It is possible that we have set the writeSubscriber, then the channel becomes inactive, and we will
-            // never notify the write writeSubscriber of the inactive event. So if the channel is inactive we notify
-            // the writeSubscriber.
-            // It is also possible that Channel is in closing state, we should abort new writes from the client-side
-            // if a closeReason was observed:
-            CloseEvent closeReason = this.closeReason;
-            if ((isClient && closeReason != null) || !channel().isActive()) {
-                final StacklessClosedChannelException e = StacklessClosedChannelException.newInstance(
-                        DefaultNettyConnection.class, "failIfWriteActive(...)");
-                newChannelOutboundListener.channelClosed(closeReason == null ? e : closeReason.wrapError(e, channel()));
+    @Override
+    public void channelWritable() {
+    }
+
+    @Override
+    public void channelOutboundClosed() {
+    }
+
+    @Override
+    public void channelClosed(final Throwable closedException) {
+        // Make sure the channel is closed. If this is from a timeout or non-transport error related cancellation
+        // the transport may not yet have been closed.
+        closeHandler.closeChannelOutbound(channel());
+    }
+
+    @Override
+    public void listenerDiscard(final Throwable cause) {
+    }
+
+    private boolean failIfWriteActive(final ChannelOutboundListener newListener, final Subscriber subscriber) {
+        for (;;) {
+            final ChannelOutboundListener listener = this.channelOutboundListener;
+            if (listener != NoopChannelOutboundListener.INSTANCE && listener != this) {
+                deliverErrorFromSource(subscriber,
+                        new IllegalStateException("A write is already active on this connection."));
                 return false;
+            } else if (writableListenerUpdater.compareAndSet(this, listener, newListener)) {
+                // It is possible that we have set the writeSubscriber, then the channel becomes inactive, and we will
+                // never notify the write writeSubscriber of the inactive event. So if the channel is inactive we notify
+                // the writeSubscriber.
+                // It is also possible that Channel is in closing state, we should abort new writes from the client-side
+                // if a closeReason was observed:
+                CloseEvent closeReason = this.closeReason;
+                boolean channelActive = true;
+                if ((isClient && closeReason != null) || !(channelActive = channel().isActive())) {
+                    final StacklessClosedChannelException e = StacklessClosedChannelException.newInstance(
+                            DefaultNettyConnection.class, "failIfWriteActive(...)");
+                    Throwable cause = closeReason == null ? e : closeReason.wrapError(e, channel());
+                    if (channelActive) {
+                        newListener.listenerDiscard(cause);
+                    } else {
+                        newListener.channelClosed(cause);
+                    }
+                    return false;
+                }
+                return true;
             }
-            return true;
         }
-        deliverErrorFromSource(subscriber, new IllegalStateException("A write is already active on this connection."));
-        return false;
     }
 
     @Override
@@ -512,37 +559,12 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         return fromSource(transportError).publishOn(executionContext().executor());
     }
 
-    /**
-     * An interface which provides methods that are invoked when outbound channel events occur. The implementors of
-     * this interface are effectively "listening" to these events via method calls.
-     */
-    interface ChannelOutboundListener {
-        /**
-         * Notification that the writability of the channel has changed.
-         * <p>
-         * Always called from the event loop thread.
-         */
-        void channelWritable();
-
-        /**
-         * Notification that the channel's outbound side has been closed and will no longer accept writes.
-         * <p>
-         * Always called from the event loop thread.
-         */
-        void channelOutboundClosed();
-
-        /**
-         * Notification that the channel has been closed.
-         * <p>
-         * This may not always be called from the event loop thread. For example if the channel is closed when a new
-         * write happens then this method will be called from the writer thread.
-         *
-         * @param closedException the exception which describes the close rational.
-         */
-        void channelClosed(Throwable closedException);
-    }
-
     private static final class NoopChannelOutboundListener implements ChannelOutboundListener {
+        private static final ChannelOutboundListener INSTANCE = new NoopChannelOutboundListener();
+
+        private NoopChannelOutboundListener() {
+        }
+
         @Override
         public void channelWritable() {
         }
@@ -553,6 +575,10 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
         @Override
         public void channelClosed(Throwable closedException) {
+        }
+
+        @Override
+        public void listenerDiscard(final Throwable cause) {
         }
     }
 


### PR DESCRIPTION
Motivation:
In the event that gRPC client deadine expires it should send a
RST_STREAM to the peer service. There is a scenario where this may not
happen due to common transport code cleaning up internal state before
propagating the error.

Modifications:
- gRPC utiles to propage the TimeoutException so users can see the
  timeout duration.
- DefaultNettyConnection should still propagate channel close events in
  the event that a write is cancelled.
- WriteStreamSubscriber should still let the close handler know that the
  channel outbound close event occurred even if nothing is pending to
  write when a ChannelOutboundListener#channelClosed event happens. This
  method may not always be the result of a transport error and may be a
  local timeout, in which case we should close the outbound side.

Result:
gRPC will send a RST_STREAM on client timeout. HTTP will close the
channel.
Fixes https://github.com/apple/servicetalk/issues/1489.