### PR TITLE
Remove `payloadBody(CloseableIterable<Buffer>)` methods

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterable;
-import io.servicetalk.concurrent.CloseableIterable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.CloseableIteratorBufferAsInputStream;
@@ -107,25 +106,6 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body.
      * @return {@code this}
-     * @deprecated Use {@link #payloadBody(Iterable)}.
-     */
-    @Deprecated
-    default BlockingStreamingHttpRequest payloadBody(CloseableIterable<Buffer> payloadBody) {
-        payloadBody((Iterable<Buffer>) payloadBody);
-        return this;
-    }
-
-    /**
-     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
-     * <p>
-     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
-     * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
-     * control.
-     * <p>
-     * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing payload body that is being replaced.
-     * @param payloadBody The new payload body.
-     * @return {@code this}
      */
     BlockingStreamingHttpRequest payloadBody(InputStream payloadBody);
 
@@ -168,27 +148,6 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * @return {@code this}
      */
     <T> BlockingStreamingHttpRequest payloadBody(Iterable<T> payloadBody, HttpStreamingSerializer<T> serializer);
-
-    /**
-     * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to the result of serialization.
-     * <p>
-     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
-     * default policy is not sufficient {@link #payloadBody()} can be used to drain with more fine grain control.
-     * <p>
-     * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing payload body that is being replaced.
-     * @param payloadBody The new payload body, prior to serialization.
-     * @param serializer Used to serialize the payload body.
-     * @param <T> The type of objects to serialize.
-     * @return {@code this}
-     * @deprecated Use {@link #payloadBody(Iterable, HttpStreamingSerializer)}.
-     */
-    @Deprecated
-    default <T> BlockingStreamingHttpRequest payloadBody(CloseableIterable<T> payloadBody,
-                                                         HttpSerializer<T> serializer) {
-        payloadBody((Iterable<T>) payloadBody, serializer);
-        return this;
-    }
 
     /**
      * Set the {@link HttpMessageBodyIterable} for this response.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterable;
-import io.servicetalk.concurrent.CloseableIterable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.CloseableIteratorBufferAsInputStream;
@@ -103,25 +102,6 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * combination with the existing payload body that is being replaced.
      * @param payloadBody The new payload body.
      * @return {@code this}
-     * @deprecated Use {@link #payloadBody(Iterable)}.
-     */
-    @Deprecated
-    default BlockingStreamingHttpResponse payloadBody(CloseableIterable<Buffer> payloadBody) {
-        payloadBody((Iterable<Buffer>) payloadBody);
-        return this;
-    }
-
-    /**
-     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to {@code payloadBody}.
-     * <p>
-     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
-     * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
-     * control.
-     * <p>
-     * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing payload body that is being replaced.
-     * @param payloadBody The new payload body.
-     * @return {@code this}
      */
     BlockingStreamingHttpResponse payloadBody(InputStream payloadBody);
 
@@ -164,28 +144,6 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * @return {@code this}
      */
     <T> BlockingStreamingHttpResponse payloadBody(Iterable<T> payloadBody, HttpStreamingSerializer<T> serializer);
-
-    /**
-     * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to the result of serialization.
-     * <p>
-     * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
-     * default policy is not sufficient you can use {@link #transformPayloadBody(Function, HttpSerializer)} for more
-     * fine grain control.
-     * <p>
-     * This method reserves the right to delay completion/consumption of {@code payloadBody}. This may occur due to the
-     * combination with the existing payload body that is being replaced.
-     * @param payloadBody The new payload body, prior to serialization.
-     * @param serializer Used to serialize the payload body.
-     * @param <T> The type of objects to serialize.
-     * @return {@code this}
-     * @deprecated Use {@link #payloadBody(Iterable, HttpStreamingSerializer)}.
-     */
-    @Deprecated
-    default <T> BlockingStreamingHttpResponse payloadBody(CloseableIterable<T> payloadBody,
-                                                          HttpSerializer<T> serializer) {
-        payloadBody((Iterable<T>) payloadBody, serializer);
-        return this;
-    }
 
     /**
      * Set the {@link HttpMessageBodyIterable} for this response.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterable;
-import io.servicetalk.concurrent.CloseableIterable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.encoding.api.BufferEncoder;
 import io.servicetalk.encoding.api.ContentCodec;
@@ -173,12 +172,6 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
     }
 
     @Override
-    public BlockingStreamingHttpRequest payloadBody(final CloseableIterable<Buffer> payloadBody) {
-        original.payloadBody(fromIterable(payloadBody));
-        return this;
-    }
-
-    @Override
     public BlockingStreamingHttpRequest payloadBody(final InputStream payloadBody) {
         original.payloadBody(fromInputStream(payloadBody)
                 .map(bytes -> original.payloadHolder().allocator().wrap(bytes)));
@@ -219,14 +212,6 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
     @Override
     public <T> BlockingStreamingHttpRequest payloadBody(final Iterable<T> payloadBody,
                                                         final HttpStreamingSerializer<T> serializer) {
-        original.payloadBody(fromIterable(payloadBody), serializer);
-        return this;
-    }
-
-    @Deprecated
-    @Override
-    public <T> BlockingStreamingHttpRequest payloadBody(final CloseableIterable<T> payloadBody,
-                                                        final HttpSerializer<T> serializer) {
         original.payloadBody(fromIterable(payloadBody), serializer);
         return this;
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterable;
-import io.servicetalk.concurrent.CloseableIterable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.encoding.api.ContentCodec;
 
@@ -67,12 +66,6 @@ final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpR
     }
 
     @Override
-    public BlockingStreamingHttpResponse payloadBody(final CloseableIterable<Buffer> payloadBody) {
-        original.payloadBody(fromIterable(payloadBody));
-        return this;
-    }
-
-    @Override
     public BlockingStreamingHttpResponse payloadBody(final InputStream payloadBody) {
         original.payloadBody(fromInputStream(payloadBody)
                 .map(bytes -> original.payloadHolder().allocator().wrap(bytes)));
@@ -113,14 +106,6 @@ final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpR
     @Override
     public <T> BlockingStreamingHttpResponse payloadBody(final Iterable<T> payloadBody,
                                                          final HttpStreamingSerializer<T> serializer) {
-        original.payloadBody(fromIterable(payloadBody), serializer);
-        return this;
-    }
-
-    @Deprecated
-    @Override
-    public <T> BlockingStreamingHttpResponse payloadBody(final CloseableIterable<T> payloadBody,
-                                                         final HttpSerializer<T> serializer) {
         original.payloadBody(fromIterable(payloadBody), serializer);
         return this;
     }


### PR DESCRIPTION
Motivation:

`payloadBody(CloseableIterable<Buffer>)`
and `payloadBody(CloseableIterable<Buffer>, HttpSerializer<T>)` methods
on `BlockingStreamingHttpRequest` and `BlockingStreamingHttpResponse`
were deprecated in 0.41 branch [1], we can safely remove them from the
`main` branch.

1. https://github.com/apple/servicetalk/commit/42688df6c00f229292ba48b30b41a83aa96a1415

Modifications:

- Remove `payloadBody(CloseableIterable<Buffer>)`
and `payloadBody(CloseableIterable<Buffer>, HttpSerializer<T>)` methods
from `BlockingStreamingHttpRequest` and `BlockingStreamingHttpResponse`;

Result:

Less deprecated API.

Follow up for #1797.