### PR TITLE
ExecutionStrategy simplification deprecations for gRPC builders

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BaseGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/BaseGrpcClientBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
@@ -31,6 +32,14 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 interface BaseGrpcClientBuilder<U, R> {
+
+    /**
+     * Sets the {@link Executor} for all connections created from this builder.
+     *
+     * @param executor {@link Executor} to use.
+     * @return {@code this}.
+     */
+    BaseGrpcClientBuilder<U, R> executor(Executor executor);
 
     /**
      * Sets the {@link IoExecutor} for all clients created from this builder.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -21,6 +21,7 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.AsyncContextMap;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.internal.DeadlineUtils;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
@@ -65,6 +66,11 @@ public abstract class GrpcClientBuilder<U, R>
     protected static final AsyncContextMap.Key<Long> GRPC_DEADLINE_KEY = DeadlineUtils.GRPC_DEADLINE_KEY;
 
     private boolean appendedCatchAllFilter;
+
+    @Override
+    public GrpcClientBuilder<U, R> executor(Executor executor) {
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
+    }
 
     @Override
     public abstract GrpcClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -17,11 +17,13 @@ package io.servicetalk.grpc.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.AsyncContextMap;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.internal.DeadlineUtils;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
@@ -265,6 +267,16 @@ public abstract class GrpcServerBuilder {
      * @return {@code this}.
      */
     public abstract GrpcServerBuilder ioExecutor(IoExecutor ioExecutor);
+
+    /**
+     * Sets the {@link Executor} to use.
+     *
+     * @param executor {@link Executor} to use.
+     * @return {@code this}.
+     */
+    public GrpcServerBuilder executor(Executor executor) {
+        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
+    }
 
     /**
      * Sets the {@link BufferAllocator} to be used by this server.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -23,7 +23,6 @@ import io.servicetalk.grpc.internal.DeadlineUtils;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpRequest;
-import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/SingleAddressGrpcClientBuilder.java
@@ -23,6 +23,7 @@ import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.BiIntPredicate;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpLoadBalancerFactory;
@@ -43,6 +44,9 @@ import java.util.function.Predicate;
 
 interface SingleAddressGrpcClientBuilder<U, R,
         SDE extends ServiceDiscovererEvent<R>> extends BaseGrpcClientBuilder<U, R> {
+
+    @Override
+    SingleAddressGrpcClientBuilder<U, R, SDE> executor(Executor executor);
 
     @Override
     SingleAddressGrpcClientBuilder<U, R, SDE> ioExecutor(IoExecutor ioExecutor);

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.grpc.api.GrpcClientBuilder;
 import io.servicetalk.grpc.api.GrpcClientCallFactory;
 import io.servicetalk.grpc.api.GrpcClientSecurityConfigurator;
@@ -93,6 +94,12 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
             throw new IllegalStateException("default timeout cannot be modified after build, create a new builder");
         }
         this.defaultTimeout = ensurePositive(defaultTimeout, "defaultTimeout");
+        return this;
+    }
+
+    @Override
+    public GrpcClientBuilder<U, R> executor(Executor executor) {
+        httpClientBuilder.executor(executor);
         return this;
     }
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -17,6 +17,7 @@ package io.servicetalk.grpc.netty;
 
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.api.GrpcExecutionStrategy;
 import io.servicetalk.grpc.api.GrpcServerBuilder;
@@ -163,6 +164,13 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
     public GrpcServerBuilder ioExecutor(final IoExecutor ioExecutor) {
         contextBuilder.ioExecutor(ioExecutor);
         httpServerBuilder.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public GrpcServerBuilder executor(final Executor executor) {
+        contextBuilder.executor(executor);
+        httpServerBuilder.executor(executor);
         return this;
     }
 


### PR DESCRIPTION
Motivation:
9a605c294fe9092d602084313c1efd64bf31ef93 introduced methods on the Http
Client/Server builders to set the executor in preparation for removal of
the Executor from the ExecutionStrategy. These same changes need to be
made for the gRPC builders.

Modifications:
- Add the `executor(Executor)` setters to the gRPC client/serveer
  builders.

Result:
Methods exist to set the Executor on the gRPC builders.