### PR TITLE
Http executor builder methods abstract

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -327,9 +327,7 @@ public abstract class HttpServerBuilder {
      * @param executor {@link Executor} to use.
      * @return {@code this}.
      */
-    public HttpServerBuilder executor(Executor executor) {
-        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
-    }
+    public abstract HttpServerBuilder executor(Executor executor);
 
     /**
      * Sets the {@link BufferAllocator} to be used by this server.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -68,9 +68,7 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     public abstract MultiAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
     @Override
-    public MultiAddressHttpClientBuilder<U, R> executor(Executor executor) {
-        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
-    }
+    public abstract MultiAddressHttpClientBuilder<U, R> executor(Executor executor);
 
     @Override
     public abstract MultiAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -71,9 +71,7 @@ public abstract class PartitionedHttpClientBuilder<U, R> implements HttpClientBu
     public abstract PartitionedHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
     @Override
-    public PartitionedHttpClientBuilder<U, R> executor(Executor executor) {
-        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
-    }
+    public abstract PartitionedHttpClientBuilder<U, R> executor(Executor executor);
 
     @Override
     public abstract PartitionedHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -165,9 +165,7 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
     public abstract SingleAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> executor(Executor executor) {
-        throw new UnsupportedOperationException("Setting Executor not yet supported by " + getClass().getSimpleName());
-    }
+    public abstract SingleAddressHttpClientBuilder<U, R> executor(Executor executor);
 
     @Override
     public abstract SingleAddressHttpClientBuilder<U, R> executionStrategy(HttpExecutionStrategy strategy);


### PR DESCRIPTION
Motivation:
0.42 release will break some APIs, and the builder methods that throw
UnsupportedOperationException can be made abstract to force
implementing.

Modifications:
- Remove UnsupportedOperationException and make methods abstract

Result:
Http builder executor methods are now abstract.