### PR TITLE
Deprecated GrpcClientBuilder#MultiClientBuilder

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -391,9 +391,12 @@ public abstract class GrpcClientBuilder<U, R> {
      * instance.
      *
      * @return A blocking <a href="https://www.grpc.io">gRPC</a> client.
+     * @deprecated Use {@link GrpcClientFactory#newClient(GrpcClientCallFactory)}
+     * or {@link GrpcClientFactory#newBlockingClient(GrpcClientCallFactory)}
+     * and provide a custom {@link GrpcClientCallFactory} instead.
      */
+    @Deprecated
     public final MultiClientBuilder buildMulti() {
-
         GrpcClientCallFactory callFactory = newGrpcClientCallFactory();
         return new MultiClientBuilder() {
             @Override
@@ -484,7 +487,11 @@ public abstract class GrpcClientBuilder<U, R> {
     /**
      * An interface to create multiple <a href="https://www.grpc.io">gRPC</a> clients sharing the
      * same underlying transport instance.
+     * @deprecated Use {@link GrpcClientFactory#newClient(GrpcClientCallFactory)}
+     * or {@link GrpcClientFactory#newBlockingClient(GrpcClientCallFactory)}
+     * and provide a custom {@link GrpcClientCallFactory} instead.
      */
+    @Deprecated
     public interface MultiClientBuilder {
 
         /**


### PR DESCRIPTION
Motivation:

`GrpcClientBuilder#MultiClientBuilder` is no longer necessary, as the
`GrpcClientFactory` contains methods that allow providing a custom
`GrpcClientCallFactory` to build multiple clients.

Modifications:

- Deprecated `GrpcClientBuilder#MultiClientBuilder`,
- Deprecated `GrpcClientBuilder#buildMulti` method,
- Enriched Javadoc to provide alternatives
  (`GrpcClientFactory#newClient(GrpcClientCallFactory)` and
  `GrpcClientFactory#newBlockingClient(GrpcClientCallFactory)`).

Result:

Unnecessary means to create multiple `GrpcClient`s has been removed and
there is one way to build `GrpcClient`s.