### PR TITLE
Extend `japicmp.sh` to compare versus local build

### DIFF
--- a/scripts/japicmp.sh
+++ b/scripts/japicmp.sh
@@ -18,11 +18,11 @@
 SCRIPT=$(basename "${BASH_SOURCE:-stidn}")
 
 if [ $# -lt 1 ] || [ $# -gt 3 ]; then
-	echo "# This script compares versions for binary backward compatibility."
-	echo "# Usage: ${SCRIPT} <old_version> (<new_version> (<group_id>))"
-	echo "# if <new_version> unspecified then comparison will be made againt local build"
-	echo "# if <group_id> unspecified then local dir gradle 'group' property will be used"
-	exit 1
+  echo "# This script compares versions for binary backward compatibility."
+  echo "# Usage: ${SCRIPT} <old_version> (<new_version> (<group_id>))"
+  echo "# if <new_version> unspecified then comparison will be made againt local build"
+  echo "# if <group_id> unspecified then local dir gradle 'group' property will be used"
+  exit 1
 fi
 
 MVN_REPO="$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)"
@@ -31,9 +31,9 @@ JAPICMP_VERSION="0.15.3"
 JAR_DIR="${MVN_REPO}/com/github/siom79/japicmp/japicmp/${JAPICMP_VERSION}"
 JAR_FILE="${JAR_DIR}/japicmp-${JAPICMP_VERSION}-jar-with-dependencies.jar"
 if ! test -e "${JAR_FILE}"; then
-	mvn -N dependency:get \
-		-DgroupId=com.github.siom79.japicmp -DartifactId=japicmp -Dversion="${JAPICMP_VERSION}" \
-		-Dtransitive=false -Dclassifier=jar-with-dependencies 1>&2 || exit 1
+  mvn -N dependency:get \
+    -DgroupId=com.github.siom79.japicmp -DartifactId=japicmp -Dversion="${JAPICMP_VERSION}" \
+    -Dtransitive=false -Dclassifier=jar-with-dependencies 1>&2 || exit 1
 fi
 
 OLD_ST_VERSION="${1}"
@@ -45,24 +45,24 @@ BASEPATH="$MVN_REPO/$GROUP_PATH/"
 # All servicetalk modules except:
 # servicetalk-benchmarks, servicetalk-bom, servicetalk-examples, servicetalk-gradle-plugin-internal
 ARTIFACTS="$(find servicetalk-* -type d -maxdepth 0 |
-	grep -v -- '-\(benchmarks\|bom\|examples\|gradle-plugin-internal\)$')"
+  grep -v -- '-\(benchmarks\|bom\|examples\|gradle-plugin-internal\)$')"
 
 for ARTIFACT_ID in ${ARTIFACTS}; do
-	mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
-		-Dversion="${OLD_ST_VERSION}" -Dtransitive=false >/dev/null || continue
+  mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
+    -Dversion="${OLD_ST_VERSION}" -Dtransitive=false >/dev/null || continue
 
-	if [[ ${NEW_ST_VERSION} =~ .+-SNAPSHOT$ ]]; then
-		NEWPATH="${ARTIFACT_ID}/build/libs"
-	else
-		mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
-			-Dversion="${NEW_ST_VERSION}" -Dtransitive=false >/dev/null
-		NEWPATH="${BASEPATH}/${ARTIFACT_ID}/${NEW_ST_VERSION}"
-	fi
+  if [[ ${NEW_ST_VERSION} =~ .+-SNAPSHOT$ ]]; then
+    NEWPATH="${ARTIFACT_ID}/build/libs"
+  else
+    mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
+      -Dversion="${NEW_ST_VERSION}" -Dtransitive=false >/dev/null
+    NEWPATH="${BASEPATH}/${ARTIFACT_ID}/${NEW_ST_VERSION}"
+  fi
 
-	java -jar "$JAR_FILE" --no-error-on-exclusion-incompatibility --report-only-filename \
-		-a protected -b --ignore-missing-classes --include-synthetic \
-		--old "${BASEPATH}/${ARTIFACT_ID}/${OLD_ST_VERSION}/${ARTIFACT_ID}-${OLD_ST_VERSION}.jar" \
-		--new "${NEWPATH}/${ARTIFACT_ID}-${NEW_ST_VERSION}.jar" |
-		grep -v -- '--ignore-missing-classes'
-	echo ""
+  java -jar "$JAR_FILE" --no-error-on-exclusion-incompatibility --report-only-filename \
+    -a protected -b --ignore-missing-classes --include-synthetic \
+    --old "${BASEPATH}/${ARTIFACT_ID}/${OLD_ST_VERSION}/${ARTIFACT_ID}-${OLD_ST_VERSION}.jar" \
+    --new "${NEWPATH}/${ARTIFACT_ID}-${NEW_ST_VERSION}.jar" |
+    grep -v -- '--ignore-missing-classes'
+  echo ""
 done

--- a/scripts/japicmp.sh
+++ b/scripts/japicmp.sh
@@ -20,8 +20,8 @@ SCRIPT=$(basename "${BASH_SOURCE:-stidn}")
 if [ $# -lt 1 ] || [ $# -gt 3 ]; then
   echo "# This script compares versions for binary backward compatibility."
   echo "# Usage: ${SCRIPT} <old_version> (<new_version> (<group_id>))"
-  echo "# if <new_version> unspecified then comparison will be made againt local build"
-  echo "# if <group_id> unspecified then local dir gradle 'group' property will be used"
+  echo "# if optional <new_version> unspecified then comparison will be made againt local build"
+  echo "# if optional <group_id> unspecified then local dir gradle 'group' property will be used"
   exit 1
 fi
 
@@ -30,17 +30,23 @@ MVN_REPO="$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceSt
 JAPICMP_VERSION="0.15.3"
 JAR_DIR="${MVN_REPO}/com/github/siom79/japicmp/japicmp/${JAPICMP_VERSION}"
 JAR_FILE="${JAR_DIR}/japicmp-${JAPICMP_VERSION}-jar-with-dependencies.jar"
-if ! test -e "${JAR_FILE}"; then
+if [ ! -f "${JAR_FILE}" ]; then
   mvn -N dependency:get \
     -DgroupId=com.github.siom79.japicmp -DartifactId=japicmp -Dversion="${JAPICMP_VERSION}" \
-    -Dtransitive=false -Dclassifier=jar-with-dependencies 1>&2 || exit 1
+    -Dtransitive=false -Dclassifier=jar-with-dependencies 2>&1 || exit 1
 fi
 
-OLD_ST_VERSION="${1}"
+OLD_ST_VERSION="${1:-}"
+LOCAL="${2:-local}"
 NEW_ST_VERSION="${2:-$(./gradlew properties | grep '^version: ' | cut -f 2 -d ' ')}"
 GROUP_ID="${3:-$(./gradlew properties | grep '^group: ' | cut -f 2 -d ' ')}"
-GROUP_PATH=$(echo "$GROUP_ID" | tr '.' '/')
-BASEPATH="$MVN_REPO/$GROUP_PATH/"
+GROUP_PATH=$(echo "${GROUP_ID}" | tr '.' '/')
+BASEPATH="${MVN_REPO}/${GROUP_PATH}/"
+
+if [ -z "${OLD_ST_VERSION}" ]; then
+  echo "# Error: Old version not specified."
+  exit 1
+fi
 
 # All servicetalk modules except:
 # servicetalk-benchmarks, servicetalk-bom, servicetalk-examples, servicetalk-gradle-plugin-internal
@@ -48,21 +54,35 @@ ARTIFACTS="$(find servicetalk-* -type d -maxdepth 0 |
   grep -v -- '-\(benchmarks\|bom\|examples\|gradle-plugin-internal\)$')"
 
 for ARTIFACT_ID in ${ARTIFACTS}; do
-  mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
-    -Dversion="${OLD_ST_VERSION}" -Dtransitive=false >/dev/null || continue
+  OLD_JAR="${BASEPATH}/${ARTIFACT_ID}/${OLD_ST_VERSION}/${ARTIFACT_ID}-${OLD_ST_VERSION}.jar"
 
-  if [[ ${NEW_ST_VERSION} =~ .+-SNAPSHOT$ ]]; then
-    NEWPATH="${ARTIFACT_ID}/build/libs"
+  FOUND_OLD=$( (mvn -N -U dependency:get \
+    -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
+    -Dversion="${OLD_ST_VERSION}" -Dtransitive=false 1>&2 >/dev/null && echo true) ||
+    echo false)
+
+  if [ "${FOUND_OLD}" = "false" ] || [ ! -f "${OLD_JAR}" ]; then
+    echo "# Skipping ${ARTIFACT_ID} : old artifact (${OLD_ST_VERSION}) not found"
+    echo ""
+    continue
+  fi
+
+  if [ "${LOCAL}" = "local" ]; then
+    NEW_JAR="${ARTIFACT_ID}/build/libs/${ARTIFACT_ID}-${NEW_ST_VERSION}.jar"
   else
     mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
       -Dversion="${NEW_ST_VERSION}" -Dtransitive=false >/dev/null
-    NEWPATH="${BASEPATH}/${ARTIFACT_ID}/${NEW_ST_VERSION}"
+    NEW_JAR="${BASEPATH}/${ARTIFACT_ID}/${NEW_ST_VERSION}/${ARTIFACT_ID}-${NEW_ST_VERSION}.jar"
+  fi
+
+  if [ ! -f "${NEW_JAR}" ]; then
+    echo "# Skipping ${ARTIFACT_ID} : new artifact (${NEW_ST_VERSION}) not found"
+    echo ""
+    continue
   fi
 
   java -jar "$JAR_FILE" --no-error-on-exclusion-incompatibility --report-only-filename \
     -a protected -b --ignore-missing-classes --include-synthetic \
-    --old "${BASEPATH}/${ARTIFACT_ID}/${OLD_ST_VERSION}/${ARTIFACT_ID}-${OLD_ST_VERSION}.jar" \
-    --new "${NEWPATH}/${ARTIFACT_ID}-${NEW_ST_VERSION}.jar" |
-    grep -v -- '--ignore-missing-classes'
+    --old "${OLD_JAR}" --new "${NEW_JAR}" | grep -v -- '--ignore-missing-classes'
   echo ""
 done

--- a/scripts/japicmp.sh
+++ b/scripts/japicmp.sh
@@ -18,10 +18,14 @@
 SCRIPT=$(basename "${BASH_SOURCE:-stidn}")
 
 if [ $# -lt 1 ] || [ $# -gt 3 ]; then
+  echo "# Usage"
+  echo "#    ${SCRIPT} <old_version> (<new_version> (<group_id>))"
+  echo "# Description"
   echo "# This script compares versions for binary backward compatibility."
-  echo "# Usage: ${SCRIPT} <old_version> (<new_version> (<group_id>))"
-  echo "# if optional <new_version> unspecified then comparison will be made againt local build"
+  echo "# It must be run from a directory containing a clone of ServiceTalk"
+  echo "# if optional <new_version> unspecified or string 'local' then compare to local build"
   echo "# if optional <group_id> unspecified then local dir gradle 'group' property will be used"
+  echo "# Comparisons against local build assume that './gradlew build' has been run."
   exit 1
 fi
 

--- a/scripts/japicmp.sh
+++ b/scripts/japicmp.sh
@@ -15,43 +15,54 @@
 # limitations under the License.
 #
 
-if [ $# -lt 2 ] || [ $# -gt 3 ]; then
-  echo "This script compares versions for binary backward compatibility."
-  echo "Usage: $0 old_version new_version [group_id]"
-  exit 1
+SCRIPT=$(basename "${BASH_SOURCE:-stidn}")
+
+if [ $# -lt 1 ] || [ $# -gt 3 ]; then
+	echo "# This script compares versions for binary backward compatibility."
+	echo "# Usage: ${SCRIPT} <old_version> (<new_version> (<group_id>))"
+	echo "# if <new_version> unspecified then comparison will be made againt local build"
+	echo "# if <group_id> unspecified then local dir gradle 'group' property will be used"
+	exit 1
 fi
 
-MVN_REPO=$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
+MVN_REPO="$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)"
 
-JAPICMP_VERSION=0.15.3
-JAR_FILE=$MVN_REPO/com/github/siom79/japicmp/japicmp/$JAPICMP_VERSION/japicmp-$JAPICMP_VERSION-jar-with-dependencies.jar
-if ! test -e "$JAR_FILE"; then
-    mvn -N dependency:get -DgroupId=com.github.siom79.japicmp -DartifactId=japicmp -Dversion=$JAPICMP_VERSION \
-        -Dtransitive=false -Dclassifier=jar-with-dependencies 1>&2
+JAPICMP_VERSION="0.15.3"
+JAR_DIR="${MVN_REPO}/com/github/siom79/japicmp/japicmp/${JAPICMP_VERSION}"
+JAR_FILE="${JAR_DIR}/japicmp-${JAPICMP_VERSION}-jar-with-dependencies.jar"
+if ! test -e "${JAR_FILE}"; then
+	mvn -N dependency:get \
+		-DgroupId=com.github.siom79.japicmp -DartifactId=japicmp -Dversion="${JAPICMP_VERSION}" \
+		-Dtransitive=false -Dclassifier=jar-with-dependencies 1>&2 || exit 1
 fi
 
-OLD_ST_VERSION=$1
-NEW_ST_VERSION=$2
-GROUP_ID=$3
-if [ -z "$GROUP_ID" ]; then
-  GROUP_ID=io.servicetalk
-fi
+OLD_ST_VERSION="${1}"
+NEW_ST_VERSION="${2:-$(./gradlew properties | grep '^version: ' | cut -f 2 -d ' ')}"
+GROUP_ID="${3:-$(./gradlew properties | grep '^group: ' | cut -f 2 -d ' ')}"
 GROUP_PATH=$(echo "$GROUP_ID" | tr '.' '/')
-BASEPATH=$MVN_REPO/$GROUP_PATH/
+BASEPATH="$MVN_REPO/$GROUP_PATH/"
 
 # All servicetalk modules except:
 # servicetalk-benchmarks, servicetalk-bom, servicetalk-examples, servicetalk-gradle-plugin-internal
-ARTIFACTS="$(ls -d -- */ | grep '^servicetalk-' | sed 's/.$//' | \
-  grep -v 'benchmark' | grep -v 'bom' | grep -v 'examples' | grep -v 'gradle-plugin-internal')"
+ARTIFACTS="$(find servicetalk-* -type d -maxdepth 0 |
+	grep -v -- '-\(benchmarks\|bom\|examples\|gradle-plugin-internal\)$')"
 
-for ARTIFACT_ID in $ARTIFACTS
-do
-  mvn -N -U dependency:get -DgroupId=$GROUP_ID -DartifactId=$ARTIFACT_ID -Dversion=$OLD_ST_VERSION \
-      -Dtransitive=false >/dev/null
-  mvn -N -U dependency:get -DgroupId=$GROUP_ID -DartifactId=$ARTIFACT_ID -Dversion=$NEW_ST_VERSION \
-      -Dtransitive=false >/dev/null
-  java -jar "$JAR_FILE" -b --ignore-missing-classes \
-      --old $BASEPATH/$ARTIFACT_ID/$OLD_ST_VERSION/$ARTIFACT_ID-$OLD_ST_VERSION.jar \
-      --new $BASEPATH/$ARTIFACT_ID/$NEW_ST_VERSION/$ARTIFACT_ID-$NEW_ST_VERSION.jar
-  echo ""
+for ARTIFACT_ID in ${ARTIFACTS}; do
+	mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
+		-Dversion="${OLD_ST_VERSION}" -Dtransitive=false >/dev/null || continue
+
+	if [[ ${NEW_ST_VERSION} =~ .+-SNAPSHOT$ ]]; then
+		NEWPATH="${ARTIFACT_ID}/build/libs"
+	else
+		mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
+			-Dversion="${NEW_ST_VERSION}" -Dtransitive=false >/dev/null
+		NEWPATH="${BASEPATH}/${ARTIFACT_ID}/${NEW_ST_VERSION}"
+	fi
+
+	java -jar "$JAR_FILE" --no-error-on-exclusion-incompatibility --report-only-filename \
+		-a protected -b --ignore-missing-classes --include-synthetic \
+		--old "${BASEPATH}/${ARTIFACT_ID}/${OLD_ST_VERSION}/${ARTIFACT_ID}-${OLD_ST_VERSION}.jar" \
+		--new "${NEWPATH}/${ARTIFACT_ID}-${NEW_ST_VERSION}.jar" |
+		grep -v -- '--ignore-missing-classes'
+	echo ""
 done


### PR DESCRIPTION
Motivation:
It is useful to be able to compare the Java API compatibility of a
local build against a prior release.
Modifications:
Extend `japicmp.sh` to provide capability to compare an old version
of ServiceTalk against a local build.
Result:
Additional API compatibility comparison capability.