### PR TITLE
Add missing subscribeShareContext to missing static sources

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
@@ -67,7 +67,8 @@ public final class ContentCodingHttpRequesterFilter
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                             final HttpExecutionStrategy strategy,
                                                             final StreamingHttpRequest request) {
-                return Single.defer(() -> codecTransformBidirectionalIfNeeded(delegate(), strategy, request));
+                return Single.defer(() -> codecTransformBidirectionalIfNeeded(delegate(), strategy, request)
+                        .subscribeShareContext());
             }
         };
     }
@@ -78,7 +79,8 @@ public final class ContentCodingHttpRequesterFilter
             @Override
             public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                          final StreamingHttpRequest request) {
-                return Single.defer(() -> codecTransformBidirectionalIfNeeded(delegate(), strategy, request));
+                return Single.defer(() -> codecTransformBidirectionalIfNeeded(delegate(), strategy, request)
+                        .subscribeShareContext());
             }
         };
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
@@ -121,7 +121,7 @@ public final class ContentCodingHttpServiceFilter
                     } catch (UnsupportedContentEncodingException cause) {
                         LOGGER.error("Request failed for service={}, connection={}", service, this, cause);
                         // see https://tools.ietf.org/html/rfc7231#section-3.1.2.2
-                        return succeeded(responseFactory.unsupportedMediaType());
+                        return succeeded(responseFactory.unsupportedMediaType()).subscribeShareContext();
                     }
                 });
             }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
@@ -97,7 +97,7 @@ public final class ContentEncodingHttpServiceFilter
                         BufferDecoder decoder = matchAndRemoveEncoding(decompressors.decoders(),
                                 BufferDecoder::encodingName, contentEncodingItr, request.headers());
                         if (decoder == null) {
-                            return succeeded(responseFactory.unsupportedMediaType());
+                            return succeeded(responseFactory.unsupportedMediaType()).subscribeShareContext();
                         }
 
                         requestDecompressed = request.transformPayloadBody(pub ->

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
@@ -109,7 +109,7 @@ public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                             final HttpExecutionStrategy strategy,
                                                             final StreamingHttpRequest request) {
-                return Single.defer(() -> trackRequest(delegate, strategy, request));
+                return Single.defer(() -> trackRequest(delegate, strategy, request).subscribeShareContext());
             }
        };
     }
@@ -121,7 +121,7 @@ public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
             @Override
             public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
                                                          final StreamingHttpRequest request) {
-                return Single.defer(() -> trackRequest(delegate(), strategy, request));
+                return Single.defer(() -> trackRequest(delegate(), strategy, request).subscribeShareContext());
             }
        };
     }
@@ -143,7 +143,7 @@ public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
             tracker.onError(t);
             return Single.failed(t);
         }
-        return tracker.track(response).subscribeShareContext();
+        return tracker.track(response);
     }
 
     private ScopeTracker newTracker(final HttpRequestMetaData request) {

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
@@ -119,7 +119,7 @@ public class TracingHttpServiceFilter extends AbstractTracingHttpFilter implemen
             tracker.onError(t);
             return Single.failed(t);
         }
-        return tracker.track(response).subscribeShareContext();
+        return tracker.track(response);
     }
 
     private ScopeTracker newTracker(final StreamingHttpRequest request) {


### PR DESCRIPTION
Motivation:
The subscribeShareContext was added in a few cases when defer was used
but not added to all return paths. It should also be added to static
sources like succeed and failed for consistency.

Modifications:
- Update deprecated ContentCoding filters to use subscribeShareContext
  on static succeeded operators.
- Move subscribeShareContext in tracing filters to the usage of defer,
  to make the need for subscribeShareContext more clear.

Result:
More consistent usage of subscribeShareContext on static sources when
control flow otherwise expects sharing context.