### PR TITLE
Use internal NettyIoExecutors for public NettyIoExecutors (#1815)

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
@@ -64,6 +64,16 @@ public final class NettyIoExecutors {
      * Create a new {@link NettyIoExecutor}.
      *
      * @param ioThreads number of threads.
+     * @return The created {@link IoExecutor}
+     */
+    public static EventLoopAwareNettyIoExecutor createIoExecutor(int ioThreads) {
+        return createIoExecutor(ioThreads, newIoThreadFactory());
+    }
+
+    /**
+     * Create a new {@link NettyIoExecutor}.
+     *
+     * @param ioThreads number of threads.
      * @param threadNamePrefix the name prefix used for the created {@link Thread}s.
      * @return The created {@link IoExecutor}
      */
@@ -195,10 +205,21 @@ public final class NettyIoExecutors {
         }
     }
 
+    /**
+     * Creates a new {@link NettyIoThreadFactory} instance with the default thread name prefix.
+     *
+     * @return a new {@link NettyIoThreadFactory} instance.
+     */
     private static NettyIoThreadFactory newIoThreadFactory() {
         return newIoThreadFactory(NettyIoExecutor.class.getSimpleName());
     }
 
+    /**
+     * Creates a new {@link NettyIoThreadFactory} instance.
+     *
+     * @param prefix The prefix for thread names created by the factory.
+     * @return a new {@link NettyIoThreadFactory} instance.
+     */
     private static NettyIoThreadFactory newIoThreadFactory(String prefix) {
         return new NettyIoThreadFactory(prefix);
     }

--- a/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
+++ b/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
@@ -18,8 +18,6 @@ package io.servicetalk.transport.netty;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.IoThreadFactory;
 import io.servicetalk.transport.api.IoThreadFactory.IoThread;
-import io.servicetalk.transport.netty.internal.NettyIoExecutor;
-import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 import java.util.concurrent.ThreadFactory;
 
@@ -65,13 +63,13 @@ public final class NettyIoExecutors {
      * @return The created {@link IoExecutor}
      */
     public static IoExecutor createIoExecutor(int ioThreads) {
-        return createIoExecutor(ioThreads, newIoThreadFactory());
+        return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor(ioThreads);
     }
 
     /**
      * Creates a new {@link IoExecutor} with the default number of {@code ioThreads}.
      *
-     * @param <T> Type of the IO thread instances created by factory.
+     * @param <T> Type of threads created by {@link IoThreadFactory}
      * @param threadFactory the {@link IoThreadFactory} to use.
      * @return The created {@link IoExecutor}
      */
@@ -112,14 +110,6 @@ public final class NettyIoExecutors {
      * @return The created {@link IoExecutor}
      */
     public static IoExecutor createIoExecutor() {
-        return createIoExecutor(newIoThreadFactory());
-    }
-
-    private static NettyIoThreadFactory newIoThreadFactory() {
-        return newIoThreadFactory(NettyIoExecutor.class.getSimpleName());
-    }
-
-    private static NettyIoThreadFactory newIoThreadFactory(String prefix) {
-        return new NettyIoThreadFactory(prefix);
+        return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor();
     }
 }


### PR DESCRIPTION
Motivation:
Some javadoc was missed when bringing #1811 in to 0.41 branch.
Modifications:
Add missing javadoc
Result:
More complete javadoc.