### PR TITLE
Use internal NettyIoExecutors for public NettyIoExecutors

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
@@ -62,6 +62,16 @@ public final class NettyIoExecutors {
      * Create a new {@link NettyIoExecutor}.
      *
      * @param ioThreads number of threads.
+     * @return The created {@link IoExecutor}
+     */
+    public static EventLoopAwareNettyIoExecutor createIoExecutor(int ioThreads) {
+        return createIoExecutor(ioThreads, newIoThreadFactory());
+    }
+
+    /**
+     * Create a new {@link NettyIoExecutor}.
+     *
+     * @param ioThreads number of threads.
      * @param threadNamePrefix the name prefix used for the created {@link Thread}s.
      * @return The created {@link IoExecutor}
      */
@@ -173,10 +183,21 @@ public final class NettyIoExecutors {
         }
     }
 
+    /**
+     * Creates a new {@link NettyIoThreadFactory} instance with the default thread name prefix.
+     *
+     * @return a new {@link NettyIoThreadFactory} instance.
+     */
     private static NettyIoThreadFactory newIoThreadFactory() {
         return newIoThreadFactory(NettyIoExecutor.class.getSimpleName());
     }
 
+    /**
+     * Creates a new {@link NettyIoThreadFactory} instance.
+     *
+     * @param prefix The prefix for thread names created by the factory.
+     * @return a new {@link NettyIoThreadFactory} instance.
+     */
     private static NettyIoThreadFactory newIoThreadFactory(String prefix) {
         return new NettyIoThreadFactory(prefix);
     }

--- a/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
+++ b/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
@@ -18,8 +18,6 @@ package io.servicetalk.transport.netty;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.IoThreadFactory;
 import io.servicetalk.transport.api.IoThreadFactory.IoThread;
-import io.servicetalk.transport.netty.internal.NettyIoExecutor;
-import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
 /**
  * Factory methods to create {@link IoExecutor}s using Netty as the transport.
@@ -50,15 +48,14 @@ public final class NettyIoExecutors {
      * @return The created {@link IoExecutor}
      */
     public static IoExecutor createIoExecutor(int ioThreads) {
-        return createIoExecutor(ioThreads, newIoThreadFactory());
+        return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor(ioThreads);
     }
 
     /**
      * Creates a new {@link IoExecutor} with the default number of {@code ioThreads}.
      *
      * @param <T> Type of threads created by {@link IoThreadFactory}
-     * @param threadFactory the {@link IoThreadFactory} to use. If possible you should use an instance
-     * of {@link NettyIoThreadFactory} as it allows internal optimizations.
+     * @param threadFactory the {@link IoThreadFactory} to use.
      * @return The created {@link IoExecutor}
      */
     public static <T extends Thread & IoThread> IoExecutor createIoExecutor(IoThreadFactory<T> threadFactory) {
@@ -92,14 +89,6 @@ public final class NettyIoExecutors {
      * @return The created {@link IoExecutor}
      */
     public static IoExecutor createIoExecutor() {
-        return createIoExecutor(newIoThreadFactory());
-    }
-
-    private static NettyIoThreadFactory newIoThreadFactory() {
-        return newIoThreadFactory(NettyIoExecutor.class.getSimpleName());
-    }
-
-    private static NettyIoThreadFactory newIoThreadFactory(String prefix) {
-        return new NettyIoThreadFactory(prefix);
+        return io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor();
     }
 }


### PR DESCRIPTION
Motivation:
Review of #1814 suggested some improvements to expose less
implementation in the public `NettyIoExecutors` utility class by better
isolating the implementation in the internal `NettyIoExecutors`.
Modifications:
Public API in `NettyIoExecutors` now relies entirely on immplementation
from internal `NettyIoExecutors`.
Result:
Cleaner and simpler public API.