### PR TITLE
Test utility ProxyTunnel full duplex

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
@@ -252,6 +253,7 @@ final class ConnectionCloseHeaderHandlingTest {
             CharSequence contentLengthHeader = response.headers().get(CONTENT_LENGTH);
             assertThat(contentLengthHeader, is(notNullValue()));
             int actualContentLength = response.payloadBody().map(Buffer::readableBytes)
+                    .onErrorResume(cause -> Publisher.empty())
                     .collect(() -> 0, Integer::sum).toFuture().get();
             assertThat(valueOf(actualContentLength), contentEqualTo(contentLengthHeader));
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -21,6 +21,7 @@ import io.servicetalk.client.api.DelegatingConnectionFactory;
 import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpPayloadWriter;
@@ -509,6 +510,7 @@ class GracefulConnectionClosureHandlingTest {
         CharSequence contentLengthHeader = response.headers().get(CONTENT_LENGTH);
         assertThat(contentLengthHeader, is(notNullValue()));
         int actualContentLength = response.payloadBody().map(Buffer::readableBytes)
+                .onErrorResume(cause -> Publisher.empty())
                 .collect(() -> 0, Integer::sum).toFuture().get();
         assertThat(valueOf(actualContentLength), contentEqualTo(contentLengthHeader));
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -150,7 +150,7 @@ final class ProxyTunnel implements AutoCloseable {
                 } finally {
                     clientSocket.shutdownOutput();
                     socket.shutdownInput();
-                    f.get(); // Wait for the copy of proxy client input to server output to finish.
+                    f.get(); // Wait for copy of proxy client input to server output to finish.
                 }
             }
         } else {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -154,7 +154,7 @@ final class ProxyTunnel implements AutoCloseable {
         } else {
             throw new RuntimeException("Unrecognized initial line: " + initialLine);
         }
-        // The socket will be closed outside the scope of this method.
+        // The Socket is closed outside the scope of this method.
     }
 
     private static void copyStream(final OutputStream out, final InputStream cin) throws IOException {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -95,8 +95,9 @@ final class ProxyTunnel implements AutoCloseable {
 
     void badResponseProxy() {
         handler = (socket, initialLine) -> {
-            socket.getOutputStream().write("HTTP/1.1 500 Internal Server Error\r\n\r\n".getBytes(UTF_8));
-            socket.getOutputStream().flush();
+            final OutputStream os = socket.getOutputStream();
+            os.write("HTTP/1.1 500 Internal Server Error\r\n\r\n".getBytes(UTF_8));
+            os.flush();
         };
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -78,7 +78,7 @@ final class ProxyTunnel implements AutoCloseable {
 
                         handler.handle(socket, initialLine);
                     } catch (Exception e) {
-                        LOGGER.debug("Error from proxy", e);
+                        LOGGER.debug("Error from proxy {}", socket, e);
                     } finally {
                         try {
                             socket.close();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -21,6 +21,7 @@ import io.servicetalk.transport.api.HostAndPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -106,18 +107,17 @@ final class ProxyTunnel implements AutoCloseable {
     }
 
     private static String readLine(final InputStream in) throws IOException {
-        byte[] bytes = new byte[1024];
-        int i = 0;
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(512);
         int b;
         while ((b = in.read()) >= 0) {
             if (b == '\n') {
                 break;
             }
             if (b != '\r') {
-                bytes[i++] = (byte) b;
+                bos.write((byte) b);
             }
         }
-        return new String(bytes, 0, i, UTF_8);
+        return bos.toString(UTF_8.name());
     }
 
     private void handleRequest(final Socket socket, final String initialLine) throws IOException, ExecutionException,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -164,8 +164,8 @@ final class ProxyTunnel implements AutoCloseable {
             out.write(bytes, 0, read);
             out.flush();
         }
-        // Don't close either Stream as we need full duplex behavior and closing a Stream of a Socket will close
-        // the entire Socket. Shutting down the input/outputs done outside the scope of this method.
+        // Don't close either Stream as we need full duplex behavior and closing a Stream of a Socket will close the
+        // entire Socket. Shutting down the input/outputs done outside the scope of this method.
     }
 
     @FunctionalInterface

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -148,8 +148,6 @@ final class ProxyTunnel implements AutoCloseable {
                 try {
                     copyStream(clientSocket.getOutputStream(), socket.getInputStream());
                 } finally {
-                    clientSocket.shutdownOutput();
-                    socket.shutdownInput();
                     f.get(); // Wait for copy of proxy client input to server output to finish.
                 }
             }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -74,7 +74,7 @@ final class ProxyTunnel implements AutoCloseable {
                         final InputStream in = socket.getInputStream();
                         final String initialLine = readLine(in);
                         while (readLine(in).length() > 0) {
-                            // ignore headers
+                            // Ignore headers.
                         }
 
                         handler.handle(socket, initialLine);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -166,7 +166,7 @@ final class ProxyTunnel implements AutoCloseable {
             out.flush();
         }
         // Don't close either Stream as we need full duplex behavior and closing a Stream of a Socket will close the
-        // entire Socket. Shutting down the input/outputs done outside the scope of this method.
+        // entire Socket. Shutting down the input/output done outside the scope of this method.
     }
 
     @FunctionalInterface

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -149,8 +149,8 @@ final class ProxyTunnel implements AutoCloseable {
                 } finally {
                     clientSocket.shutdownOutput();
                     socket.shutdownInput();
+                    f.get(); // wait for the copy of proxy client input to server output to finish copying.
                 }
-                f.get(); // wait for the copy of proxy client input to server output to finish copying.
             }
         } else {
             throw new RuntimeException("Unrecognized initial line: " + initialLine);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -160,7 +160,7 @@ final class ProxyTunnel implements AutoCloseable {
 
     private static void copyStream(final OutputStream out, final InputStream cin) throws IOException {
         int read;
-        final byte[] bytes = new byte[2048];
+        final byte[] bytes = new byte[1024];
         while ((read = cin.read(bytes)) >= 0) {
             out.write(bytes, 0, read);
             out.flush();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -41,7 +41,6 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 final class ProxyTunnel implements AutoCloseable {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyTunnel.class);
     private static final String CONNECT_PREFIX = "CONNECT ";
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -148,6 +148,7 @@ final class ProxyTunnel implements AutoCloseable {
                 try {
                     copyStream(clientSocket.getOutputStream(), socket.getInputStream());
                 } finally {
+                    // Always let the copy from proxy client input to server output initiate close.
                     f.get(); // Wait for copy of proxy client input to server output to finish.
                 }
             }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -165,7 +165,7 @@ final class ProxyTunnel implements AutoCloseable {
             out.write(bytes, 0, read);
             out.flush();
         }
-        // Don't close either Stream as we need full duplex behavior and closing a Stream of a Socket will close the
+        // Don't close either Stream! We need full duplex behavior and closing a Stream of a Socket will close the
         // entire Socket. Shutting down the input/output done outside the scope of this method.
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -141,8 +141,8 @@ final class ProxyTunnel implements AutoCloseable {
                     try {
                         copyStream(out, clientSocket.getInputStream());
                     } finally {
-                        clientSocket.shutdownInput();
                         socket.shutdownOutput();
+                        clientSocket.shutdownInput();
                     }
                     return null;
                 });

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -166,7 +166,7 @@ final class ProxyTunnel implements AutoCloseable {
             out.write(bytes, 0, read);
             out.flush();
         }
-        // Don't close either stream as we need full duplex behavior and closing a stream of a Socket will close
+        // Don't close either Stream as we need full duplex behavior and closing a Stream of a Socket will close
         // the entire Socket. Shutting down the input/output is done outside the scope of this method.
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -154,7 +154,7 @@ final class ProxyTunnel implements AutoCloseable {
                 }
             }
         } else {
-            throw new RuntimeException("Unrecognized initial line: " + initialLine);
+            throw new IllegalArgumentException("Unrecognized initial line: " + initialLine);
         }
         // The Socket is closed outside the scope of this method.
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -137,14 +137,20 @@ final class ProxyTunnel implements AutoCloseable {
 
                 final InputStream cin = clientSocket.getInputStream();
                 Future<Void> f = executor.submit(() -> {
-                    copyStream(out, cin);
-                    clientSocket.shutdownInput();
-                    socket.shutdownOutput();
+                    try {
+                        copyStream(out, cin);
+                    } finally {
+                        clientSocket.shutdownInput();
+                        socket.shutdownOutput();
+                    }
                     return null;
                 });
-                copyStream(clientSocket.getOutputStream(), in);
-                clientSocket.shutdownOutput();
-                socket.shutdownInput();
+                try {
+                    copyStream(clientSocket.getOutputStream(), in);
+                } finally {
+                    clientSocket.shutdownOutput();
+                    socket.shutdownInput();
+                }
                 f.get(); // wait for the copy of proxy client input to server output to finish copying.
             }
         } else {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -83,7 +83,7 @@ final class ProxyTunnel implements AutoCloseable {
                         try {
                             socket.close();
                         } catch (IOException e) {
-                            LOGGER.debug("Error from proxy server socket close", e);
+                            LOGGER.debug("Error from proxy server socket {} close", socket, e);
                         }
                     }
                 });

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -165,7 +165,7 @@ final class ProxyTunnel implements AutoCloseable {
             out.flush();
         }
         // Don't close either Stream as we need full duplex behavior and closing a Stream of a Socket will close
-        // the entire Socket. Shutting down the input/output is done outside the scope of this method.
+        // the entire Socket. Shutting down the input/outputs done outside the scope of this method.
     }
 
     @FunctionalInterface

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -135,10 +135,9 @@ final class ProxyTunnel implements AutoCloseable {
                 out.write((protocol + " 200 Connection established\r\n\r\n").getBytes(UTF_8));
                 out.flush();
 
-                final InputStream cin = clientSocket.getInputStream();
                 Future<Void> f = executor.submit(() -> {
                     try {
-                        copyStream(out, cin);
+                        copyStream(out, clientSocket.getInputStream());
                     } finally {
                         clientSocket.shutdownInput();
                         socket.shutdownOutput();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -62,6 +62,7 @@ final class ProxyTunnel implements AutoCloseable {
         }
     }
 
+    @SuppressWarnings("StatementWithEmptyBody")
     HostAndPort startProxy() throws IOException {
         serverSocket = new ServerSocket(0, 50, getLoopbackAddress());
         final InetSocketAddress serverSocketAddress = (InetSocketAddress) serverSocket.getLocalSocketAddress();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -148,7 +148,8 @@ final class ProxyTunnel implements AutoCloseable {
                 try {
                     copyStream(clientSocket.getOutputStream(), socket.getInputStream());
                 } finally {
-                    // Always let the copy from proxy client input to server output initiate close.
+                    clientSocket.shutdownOutput();
+                    socket.shutdownInput();
                     f.get(); // Wait for copy of proxy client input to server output to finish.
                 }
             }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -150,7 +150,7 @@ final class ProxyTunnel implements AutoCloseable {
                 } finally {
                     clientSocket.shutdownOutput();
                     socket.shutdownInput();
-                    f.get(); // wait for the copy of proxy client input to server output to finish.
+                    f.get(); // Wait for the copy of proxy client input to server output to finish.
                 }
             }
         } else {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -150,7 +150,7 @@ final class ProxyTunnel implements AutoCloseable {
                 } finally {
                     clientSocket.shutdownOutput();
                     socket.shutdownInput();
-                    f.get(); // wait for the copy of proxy client input to server output to finish copying.
+                    f.get(); // wait for the copy of proxy client input to server output to finish.
                 }
             }
         } else {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -51,6 +51,7 @@ final class ProxyTunnel implements AutoCloseable {
     private ServerSocket serverSocket;
     private ProxyRequestHandler handler = this::handleRequest;
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public void close() throws Exception {
         try {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -167,7 +167,7 @@ final class ProxyTunnel implements AutoCloseable {
             out.flush();
         }
         // Don't close either Stream! We need full duplex behavior and closing a Stream of a Socket will close the
-        // entire Socket. Shutting down the input/output done outside the scope of this method.
+        // entire Socket. Shutting down the input/output is done outside the scope of this method.
     }
 
     @FunctionalInterface


### PR DESCRIPTION
Motivation:
The ProxyTunnel test utility uses java.io Socket APIs to proxy traffic.
It also closes each InputStream and OutputStream, but this will close
the underlying Socket which leads to test failures due to premature
closures.

Motivation:
- Use Socket.shutdownInput() and Socket.shutdownInput() so the proxy is
  full duplex.

Result:
Less likely that the ProxyTunnel will prematurely close.