### PR TITLE
ConnectionCloseHeaderHandlingTest don't write empty payload

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -200,7 +200,9 @@ final class ConnectionCloseHeaderHandlingTest {
                                     }
                                 } while (!done);
                             }
-                            writer.write(content);
+                            if (!content.isEmpty()) {
+                                writer.write(content);
+                            }
                         }
                     });
 


### PR DESCRIPTION
Motivation:
ConnectionCloseHeaderHandlingTest$NonPipelinedRequestsTest with
noResponseContent=true has been observed to fail [1]. This is because
the test assumes there will be no payload content however the serializer
always appends a fixed 4 byte length onto every write (even if the
payload is empty). This may result in the payload not being empty.

[1]
```
java.lang.AssertionError:
Expected: "0"
     but: was "15"
```

Motiviations:
- ConnectionCloseHeaderHandlingTest server will not write empty content
  to the PayloadWriter for serialization.

Result:
Less test failures in ConnectionCloseHeaderHandlingTest.