### PR TITLE
Use bom to determine modules to compare

### DIFF
--- a/scripts/japicmp.sh
+++ b/scripts/japicmp.sh
@@ -29,6 +29,40 @@ if [ $# -lt 1 ] || [ $# -gt 3 ]; then
   exit 1
 fi
 
+function bom_artifacts() {
+  local GROUP_ID=${1}
+  local VERSION=${2}
+  mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="servicetalk-bom" \
+    -Dversion="${VERSION}" -Dpackaging=pom -Dtransitive=false >/dev/null
+  (xsltproc - \
+    "${BASEPATH}/servicetalk-bom/${VERSION}/servicetalk-bom-${VERSION}.pom" |
+    grep '^servicetalk-' |
+    sort -) <<"XSLTDOC"
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+	xmlns:p="http://maven.apache.org/POM/4.0.0" 
+	xmlns:exslt="http://exslt.org/common" version="1.0" extension-element-prefixes="exslt">
+  <xsl:output omit-xml-declaration="yes" indent="no" method="text"/>
+  <xsl:template match="/">
+    <xsl:for-each select="//p:dependencyManagement/p:dependencies/p:dependency">
+      <xsl:call-template name="value-of-template">
+        <xsl:with-param name="select" select="p:artifactId"/>
+      </xsl:call-template>
+      <xsl:value-of select="'&#10;'"/>
+    </xsl:for-each>
+  </xsl:template>
+  <xsl:template name="value-of-template">
+    <xsl:param name="select"/>
+    <xsl:value-of select="$select"/>
+    <xsl:for-each select="exslt:node-set($select)[position()&gt;1]">
+      <xsl:value-of select="'&#10;'"/>
+      <xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:template>
+</xsl:stylesheet>
+XSLTDOC
+}
+
 MVN_REPO="$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)"
 
 JAPICMP_VERSION="0.15.3"
@@ -52,9 +86,19 @@ if [ -z "${OLD_ST_VERSION}" ]; then
   exit 1
 fi
 
+OLD_ARTIFACTS="$(bom_artifacts "${GROUP_ID}" "${OLD_ST_VERSION}")"
+
+if [ "${LOCAL}" = "local" ]; then
+  NEW_ARTIFACTS="$(find servicetalk-* -type d -maxdepth 0 | sort -)"
+else
+  NEW_ARTIFACTS="$(bom_artifacts "${GROUP_ID}" "${NEW_ST_VERSION}")"
+fi
+
 # All servicetalk modules except:
 # servicetalk-benchmarks, servicetalk-bom, servicetalk-examples, servicetalk-gradle-plugin-internal
-ARTIFACTS="$(find servicetalk-* -type d -maxdepth 0 |
+ARTIFACTS="$(comm -1 -2 \
+  <(echo "${OLD_ARTIFACTS}" | tr ' ' '\n') \
+  <(echo "${NEW_ARTIFACTS}" | tr ' ' '\n') |
   grep -v -- '-\(benchmarks\|bom\|examples\|gradle-plugin-internal\)$')"
 
 for ARTIFACT_ID in ${ARTIFACTS}; do
@@ -66,23 +110,24 @@ for ARTIFACT_ID in ${ARTIFACTS}; do
     echo false)
 
   if [ "${FOUND_OLD}" = "false" ] || [ ! -f "${OLD_JAR}" ]; then
-    echo "# Skipping ${ARTIFACT_ID} : old artifact (${OLD_ST_VERSION}) not found"
+    echo "# Error  : old artifact (${ARTIFACT_ID}::${OLD_ST_VERSION}) not found"
     echo ""
-    continue
+    exit 1
   fi
 
   if [ "${LOCAL}" = "local" ]; then
     NEW_JAR="${ARTIFACT_ID}/build/libs/${ARTIFACT_ID}-${NEW_ST_VERSION}.jar"
   else
-    mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
-      -Dversion="${NEW_ST_VERSION}" -Dtransitive=false >/dev/null
+    FOUND_NEW=$( (mvn -N -U dependency:get -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" \
+      -Dversion="${NEW_ST_VERSION}" -Dtransitive=false 1>&2 >/dev/null && echo true) ||
+      echo false)
     NEW_JAR="${BASEPATH}/${ARTIFACT_ID}/${NEW_ST_VERSION}/${ARTIFACT_ID}-${NEW_ST_VERSION}.jar"
   fi
 
-  if [ ! -f "${NEW_JAR}" ]; then
-    echo "# Skipping ${ARTIFACT_ID} : new artifact (${NEW_ST_VERSION}) not found"
+  if [ "${FOUND_NEW:-}" = "false" ] || [ ! -f "${NEW_JAR}" ]; then
+    echo "# Error : new artifact (${ARTIFACT_ID}::${NEW_ST_VERSION}) not found"
     echo ""
-    continue
+    exit 1
   fi
 
   java -jar "$JAR_FILE" --no-error-on-exclusion-incompatibility --report-only-filename \

--- a/scripts/japicmp.sh
+++ b/scripts/japicmp.sh
@@ -39,9 +39,9 @@ function bom_artifacts() {
     grep '^servicetalk-' |
     sort -) <<"XSLTDOC"
 <?xml version="1.0"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:p="http://maven.apache.org/POM/4.0.0" 
-	xmlns:exslt="http://exslt.org/common" version="1.0" extension-element-prefixes="exslt">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:p="http://maven.apache.org/POM/4.0.0"
+    xmlns:exslt="http://exslt.org/common" version="1.0" extension-element-prefixes="exslt">
   <xsl:output omit-xml-declaration="yes" indent="no" method="text"/>
   <xsl:template match="/">
     <xsl:for-each select="//p:dependencyManagement/p:dependencies/p:dependency">


### PR DESCRIPTION
Motivation:
The japicmp script used the local directory to determine the modules to
compare, even if that local directory had nothing to do with the
versions being compared.
Modifications:
Use the bom files from the versions being compared to determine which
modules to compare. The local directory will be used rather than bom
file if doing a local compare. The modules compared is the intersection
of the modules present in both versions.
Result:
Smarter comparison