### PR TITLE
Avoid appSerializerUtf8FixLen in tests if content-length is byte length

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthAndTrailersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentLengthAndTrailersTest.java
@@ -404,7 +404,7 @@ class ContentLengthAndTrailersTest extends AbstractNettyHttpServerTest {
         return sb;
     }
 
-    static int addFixedLengthFramingOverhead(int length) {
+    private static int addFixedLengthFramingOverhead(int length) {
         return length == 0 ? 0 : length + Integer.BYTES;
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -105,8 +105,7 @@ class GracefulConnectionClosureHandlingTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(GracefulConnectionClosureHandlingTest.class);
     private static final Collection<Boolean> TRUE_FALSE = asList(true, false);
 
-    static final HttpStreamingSerializer<String> RAW_STRING_SERIALIZER =
-            stringStreamingSerializer(UTF_8, headers -> { });
+    static final HttpStreamingSerializer<String> RAW_STRING_SERIALIZER = stringStreamingSerializer(UTF_8, hdr -> { });
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -56,7 +56,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -92,6 +91,7 @@ import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.GR
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.valueOf;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -106,7 +106,7 @@ class GracefulConnectionClosureHandlingTest {
     private static final Collection<Boolean> TRUE_FALSE = asList(true, false);
 
     static final HttpStreamingSerializer<String> RAW_STRING_SERIALIZER =
-            stringStreamingSerializer(StandardCharsets.UTF_8, headers -> { });
+            stringStreamingSerializer(UTF_8, headers -> { });
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -21,15 +21,14 @@ import io.servicetalk.transport.api.HostAndPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
@@ -40,7 +39,6 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 final class ProxyTunnel implements AutoCloseable {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyTunnel.class);
     private static final String CONNECT_PREFIX = "CONNECT ";
 
@@ -51,6 +49,7 @@ final class ProxyTunnel implements AutoCloseable {
     private ServerSocket serverSocket;
     private ProxyRequestHandler handler = this::handleRequest;
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public void close() throws Exception {
         try {
@@ -61,6 +60,7 @@ final class ProxyTunnel implements AutoCloseable {
         }
     }
 
+    @SuppressWarnings("StatementWithEmptyBody")
     HostAndPort startProxy() throws IOException {
         serverSocket = new ServerSocket(0, 50, getLoopbackAddress());
         final InetSocketAddress serverSocketAddress = (InetSocketAddress) serverSocket.getLocalSocketAddress();
@@ -72,17 +72,17 @@ final class ProxyTunnel implements AutoCloseable {
                         final InputStream in = socket.getInputStream();
                         final String initialLine = readLine(in);
                         while (readLine(in).length() > 0) {
-                            // ignore headers
+                            // Ignore headers.
                         }
 
-                        handler.handle(socket, in, initialLine);
+                        handler.handle(socket, initialLine);
                     } catch (Exception e) {
-                        LOGGER.debug("Error from proxy", e);
+                        LOGGER.debug("Error from proxy {}", socket, e);
                     } finally {
                         try {
                             socket.close();
                         } catch (IOException e) {
-                            LOGGER.debug("Error from proxy server socket close", e);
+                            LOGGER.debug("Error from proxy server socket {} close", socket, e);
                         }
                     }
                 });
@@ -94,9 +94,10 @@ final class ProxyTunnel implements AutoCloseable {
     }
 
     void badResponseProxy() {
-        handler = (socket, in, initialLine) -> {
-            socket.getOutputStream().write("HTTP/1.1 500 Internal Server Error\r\n\r\n".getBytes(UTF_8));
-            socket.getOutputStream().flush();
+        handler = (socket, initialLine) -> {
+            final OutputStream os = socket.getOutputStream();
+            os.write("HTTP/1.1 500 Internal Server Error\r\n\r\n".getBytes(UTF_8));
+            os.flush();
         };
     }
 
@@ -105,72 +106,65 @@ final class ProxyTunnel implements AutoCloseable {
     }
 
     private static String readLine(final InputStream in) throws IOException {
-        byte[] bytes = new byte[1024];
-        int i = 0;
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(512);
         int b;
         while ((b = in.read()) >= 0) {
             if (b == '\n') {
                 break;
             }
             if (b != '\r') {
-                bytes[i++] = (byte) b;
+                bos.write((byte) b);
             }
         }
-        return new String(bytes, 0, i, UTF_8);
+        return bos.toString(UTF_8.name());
     }
 
-    private void handleRequest(final Socket socket, final InputStream in, final String initialLine) throws IOException,
-            ExecutionException, InterruptedException {
-        try {
-            if (initialLine.startsWith(CONNECT_PREFIX)) {
-                final int end = initialLine.indexOf(' ', CONNECT_PREFIX.length());
-                final String authority = initialLine.substring(CONNECT_PREFIX.length(), end);
-                final String protocol = initialLine.substring(end + 1);
-                final int colon = authority.indexOf(':');
-                final String host = authority.substring(0, colon);
-                final int port = Integer.parseInt(authority.substring(colon + 1));
+    private void handleRequest(final Socket socket, final String initialLine) throws IOException {
+        if (initialLine.startsWith(CONNECT_PREFIX)) {
+            final int end = initialLine.indexOf(' ', CONNECT_PREFIX.length());
+            final String authority = initialLine.substring(CONNECT_PREFIX.length(), end);
+            final String protocol = initialLine.substring(end + 1);
+            final int colon = authority.indexOf(':');
+            final String host = authority.substring(0, colon);
+            final int port = Integer.parseInt(authority.substring(colon + 1));
 
-                try (Socket clientSocket = new Socket(host, port)) {
-                    connectCount.incrementAndGet();
-                    final OutputStream out = socket.getOutputStream();
-                    out.write((protocol + " 200 Connection established\r\n\r\n").getBytes(UTF_8));
-                    out.flush();
+            try (Socket clientSocket = new Socket(host, port)) {
+                connectCount.incrementAndGet();
+                final OutputStream out = socket.getOutputStream();
+                out.write((protocol + " 200 Connection established\r\n\r\n").getBytes(UTF_8));
+                out.flush();
 
-                    final InputStream cin = clientSocket.getInputStream();
-                    Future<Void> f = executor.submit(() -> {
-                        copyStream(out, cin);
-                        return null;
-                    });
-                    copyStream(clientSocket.getOutputStream(), in);
-                    f.get(); // wait for the copy of proxy client input to server output to finish copying.
-                }
-            } else {
-                throw new RuntimeException("Unrecognized initial line: " + initialLine);
+                executor.submit(() -> {
+                    try {
+                        copyStream(out, clientSocket.getInputStream());
+                    } finally {
+                        // We are simulating a proxy that doesn't do half closure. The proxy should close the server
+                        // socket as soon as the server read is done.
+                        socket.close();
+                    }
+                    return null;
+                });
+                copyStream(clientSocket.getOutputStream(), socket.getInputStream());
             }
-        } finally {
-            in.close();
+        } else {
+            throw new IllegalArgumentException("Unrecognized initial line: " + initialLine);
         }
+        // The Socket is closed outside the scope of this method.
     }
 
     private static void copyStream(final OutputStream out, final InputStream cin) throws IOException {
-        try {
-            int b;
-            while ((b = cin.read()) >= 0) {
-                out.write(b);
-            }
+        int read;
+        final byte[] bytes = new byte[256];
+        while ((read = cin.read(bytes)) >= 0) {
+            out.write(bytes, 0, read);
             out.flush();
-        } finally {
-            try {
-                cin.close();
-            } finally {
-                out.close();
-            }
         }
+        // Don't close either Stream! We are simulating a proxy that doesn't do half closure, and close the socket
+        // outside the scope of this method.
     }
 
     @FunctionalInterface
     private interface ProxyRequestHandler {
-        void handle(Socket socket, InputStream in, String initialLine) throws IOException,
-                ExecutionException, InterruptedException;
+        void handle(Socket socket, String initialLine) throws IOException;
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -144,7 +144,7 @@ final class ProxyTunnel implements AutoCloseable {
                         try {
                             // We are simulating a proxy that doesn't do half closure. The proxy should close the server
                             // socket as soon as the server read is done. ServiceTalk's CloseHandler is expected to
-                            // handle this gracefully (and delay FIN/RST until requests/responses are completed).
+                            // handle this gracefully (and delay FIN/RST until requests/responses complete).
                             serverSocket.close();
                         } catch (IOException e) {
                             LOGGER.debug("Error closing serverSocket", e);
@@ -155,8 +155,7 @@ final class ProxyTunnel implements AutoCloseable {
 
                 // Don't wait on the clientSocket input to serverSocket output copy to complete. We want to simulate a
                 // proxy that doesn't do half closure and that means we should close as soon as possible. ServiceTalk's
-                // CloseHandler should handle this scenario gracefully (and delay FIN/RST until requests/responses are
-                // completed).
+                // CloseHandler should handle this gracefully (and delay FIN/RST until requests/responses complete).
             }
         } else {
             throw new IllegalArgumentException("Unrecognized initial line: " + initialLine);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -106,17 +106,18 @@ final class ProxyTunnel implements AutoCloseable {
     }
 
     private static String readLine(final InputStream in) throws IOException {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream(512);
-        int b;
-        while ((b = in.read()) >= 0) {
-            if (b == '\n') {
-                break;
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream(512)) {
+            int b;
+            while ((b = in.read()) >= 0) {
+                if (b == '\n') {
+                    break;
+                }
+                if (b != '\r') {
+                    bos.write((byte) b);
+                }
             }
-            if (b != '\r') {
-                bos.write((byte) b);
-            }
+            return bos.toString(UTF_8.name());
         }
-        return bos.toString(UTF_8.name());
     }
 
     private void handleRequest(final Socket serverSocket, final String initialLine) throws IOException {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -142,7 +142,8 @@ final class ProxyTunnel implements AutoCloseable {
                     } finally {
                         try {
                             // We are simulating a proxy that doesn't do half closure. The proxy should close the server
-                            // socket as soon as the server read is done.
+                            // socket as soon as the server read is done. ServiceTalk's CloseHandler is expected to
+                            // handle this gracefully (and delay FIN/RST until requests/responses are completed).
                             serverSocket.close();
                         } catch (IOException e) {
                             LOGGER.debug("Error closing serverSocket", e);


### PR DESCRIPTION
Motivation:
Some tests use appSerializerUtf8FixLen but also rely upon content-length
header being the same quantity as the number of bytes to terminate
gracefully. In these cases we may get spurious errors due to
content-length being larger than the actual payload length because the
http protocol doesn't think we are done, but the socket closes anyways.

Motivation:
- Restore ProxyTunnel behavior which was intended to simulate proxies
  that don't support half closure.
- ConnectionCloseHeaderHandlingTest and
  GracefulConnectionClosureHandlingTest just count total bytes, and
  don't need to restore the exact String contents. In this case we can
  just use a raw string serializer and count bytes manually.

Result:
ConnectionCloseHeaderHandlingTest and
GracefulConnectionClosureHandlingTest should fail less frequently due to
premature closures. ProxyTunnel again replicates behavior of a proxy
that doesn't do half closure.