### PR TITLE
Deprecate remaining disable* methods in builder APIs

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProvider.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProvider.java
@@ -70,9 +70,22 @@ public final class DefaultAutoRetryStrategyProvider implements AutoRetryStrategy
          * instead of failing fast. This method disables the default behavior.
          *
          * @return {@code this}.
+         * @deprecated Use {@link #waitForLoadBalancer(boolean)}.
          */
+        @Deprecated
         public Builder disableWaitForLoadBalancer() {
-            waitForLb = false;
+            return waitForLoadBalancer(false);
+        }
+
+        /**
+         * By default, automatic retries wait for the associated {@link LoadBalancer} to be ready before triggering a
+         * retry for requests. This behavior may add latency to requests till the time the load balancer is ready
+         * instead of failing fast. This method allows controlling that behavior.
+         * @param waitForLb Whether to wait for the {@link LoadBalancer} to be ready before retrying requests.
+         * @return {@code this}.
+         */
+        public Builder waitForLoadBalancer(final boolean waitForLb) {
+            this.waitForLb = waitForLb;
             return this;
         }
 
@@ -95,9 +108,24 @@ public final class DefaultAutoRetryStrategyProvider implements AutoRetryStrategy
          * This method disables the default behavior.
          *
          * @return {@code this}.
+         * @deprecated Use {@link #retryAllRetryableExceptions(boolean)}.
          */
+        @Deprecated
         public Builder disableRetryAllRetryableExceptions() {
-            retryAllRetryableExceptions = false;
+            return retryAllRetryableExceptions(false);
+        }
+
+        /**
+         * Connection closures (by the peer or locally) and new requests may happen concurrently. This means that it is
+         * possible for a {@link LoadBalancer} to select a connection which is already closed (concurrently) but the
+         * close signal has not yet been seen by the {@link LoadBalancer}. In such cases, requests fail with a
+         * {@link RetryableException}. By default, automatic retries always retries these {@link RetryableException}s.
+         * This method allows controlling that behaviour.
+         * @param retryAllRetryableExceptions Whether to retry all {@link RetryableException}s.
+         * @return {@code this}.
+         */
+        public Builder retryAllRetryableExceptions(final boolean retryAllRetryableExceptions) {
+            this.retryAllRetryableExceptions = retryAllRetryableExceptions;
             return this;
         }
 

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProviderTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProviderTest.java
@@ -57,7 +57,7 @@ class DefaultAutoRetryStrategyProviderTest {
 
     @Test
     void disableWaitForLb() {
-        AutoRetryStrategy strategy = newStrategy(Builder::disableWaitForLoadBalancer);
+        AutoRetryStrategy strategy = newStrategy(b -> b.waitForLoadBalancer(false));
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
         verifyRetryResultCompleted();
@@ -65,7 +65,7 @@ class DefaultAutoRetryStrategyProviderTest {
 
     @Test
     void disableRetryAllRetryableExWithRetryable() {
-        AutoRetryStrategy strategy = newStrategy(Builder::disableRetryAllRetryableExceptions);
+        AutoRetryStrategy strategy = newStrategy(b -> b.retryAllRetryableExceptions(false));
         Completable retry = strategy.apply(1, RETRYABLE_EXCEPTION);
         toSource(retry).subscribe(retrySubscriber);
         verifyRetryResultError(RETRYABLE_EXCEPTION);
@@ -73,7 +73,7 @@ class DefaultAutoRetryStrategyProviderTest {
 
     @Test
     void disableRetryAllRetryableExWithNoAvailableHost() {
-        AutoRetryStrategy strategy = newStrategy(Builder::disableRetryAllRetryableExceptions);
+        AutoRetryStrategy strategy = newStrategy(b -> b.retryAllRetryableExceptions(false));
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
         assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -83,7 +83,7 @@ class DefaultAutoRetryStrategyProviderTest {
 
     @Test
     void disableRetryAllRetryableExWithNoAvailableHostAndUnknownHostException() {
-        AutoRetryStrategy strategy = newStrategy(Builder::disableRetryAllRetryableExceptions);
+        AutoRetryStrategy strategy = newStrategy(b -> b.retryAllRetryableExceptions(false));
         Completable retry = strategy.apply(1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
         assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
@@ -94,8 +94,7 @@ class DefaultAutoRetryStrategyProviderTest {
     @Test
     void disableAll() {
         AutoRetryStrategy strategy = newStrategy(builder ->
-                builder.disableWaitForLoadBalancer()
-                        .disableRetryAllRetryableExceptions());
+                builder.waitForLoadBalancer(false).retryAllRetryableExceptions(false));
         Completable retry = strategy.apply(1, RETRYABLE_EXCEPTION);
         toSource(retry).subscribe(retrySubscriber);
         verifyRetryResultError(RETRYABLE_EXCEPTION);

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
@@ -109,7 +109,7 @@ public final class GrpcClients {
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link GrpcClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link GrpcClientBuilder#disableHostHeaderFallback()} if you
+     * if you want to override that value or {@link GrpcClientBuilder#hostHeaderFallback(boolean)} if you
      * want to disable this behavior.
      * @param <T> The type of {@link SocketAddress}.
      * @return new builder for the address

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -94,7 +94,7 @@ public final class HttpClients {
      * @param host host to connect to, resolved by default using a DNS {@link ServiceDiscoverer}. This will also be
      * used for the {@link HttpHeaderNames#HOST} together with the {@code port}. Use
      * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
-     * or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
+     * or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)}} if you want to disable this behavior.
      * @param port port to connect to
      * @return new builder for the address
      */
@@ -110,7 +110,7 @@ public final class HttpClients {
      * @param host host to connect to via the proxy. This will also be used for the {@link HttpHeaderNames#HOST}
      * together with the {@code port}. Use
      * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
-     * or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
+     * or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you want to disable this behavior.
      * @param port port to connect to
      * @param proxyHost the proxy host to connect to, resolved by default using a DNS {@link ServiceDiscoverer}.
      * @param proxyPort The proxy port to connect.
@@ -128,7 +128,7 @@ public final class HttpClients {
      * @param address the {@code UnresolvedAddress} to connect to, resolved by default using a DNS {@link
      * ServiceDiscoverer}. This address will also be used for the {@link HttpHeaderNames#HOST}.
      * Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that
-     * value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
+     * value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you want to disable this behavior.
      * @return new builder for the address
      */
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forSingleAddress(
@@ -155,7 +155,7 @@ public final class HttpClients {
      *
      * @param address the {@code UnresolvedAddress} to connect to via the proxy. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
+     * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you
      * want to disable this behavior.
      * @param proxyAddress the proxy {@code UnresolvedAddress} to connect to, resolved by default using a DNS {@link
      * ServiceDiscoverer}.
@@ -171,7 +171,7 @@ public final class HttpClients {
      *
      * @param host resolved host address to connect. This will also be used for the {@link HttpHeaderNames#HOST}
      * together with the {@code port}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()}
+     * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)}
      * if you want to disable this behavior.
      * @param port port to connect to
      * @return new builder for the address
@@ -188,7 +188,7 @@ public final class HttpClients {
      * @param host resolved host address to connect via the proxy. This will also be used for the
      * {@link HttpHeaderNames#HOST} together with the {@code port}. Use
      * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
-     * or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
+     * or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you want to disable this behavior.
      * @param port port to connect to via the proxy
      * @param proxyHost The proxy resolved host address to connect.
      * @param proxyPort The proxy port to connect.
@@ -204,7 +204,7 @@ public final class HttpClients {
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
+     * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you
      * want to disable this behavior.
      * @return new builder for the address
      */
@@ -218,7 +218,7 @@ public final class HttpClients {
      *
      * @param address the {@code ResolvedAddress} to connect to via the proxy. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
+     * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you
      * want to disable this behavior.
      * @param proxyAddress The proxy {@code ResolvedAddress} to connect.
      * @return new builder for the address
@@ -234,7 +234,7 @@ public final class HttpClients {
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
+     * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you
      * want to disable this behavior.
      * @param <T> The type of {@link SocketAddress}.
      * @return new builder for the address
@@ -248,7 +248,7 @@ public final class HttpClients {
      *
      * @param address the {@code ResolvedAddress} to connect to via the proxy. This address will also be used for the
      * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you
+     * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you
      * want to disable this behavior.
      * @param proxyAddress The proxy {@code ResolvedAddress} to connect.
      * @return new builder for the address
@@ -267,7 +267,7 @@ public final class HttpClients {
      * @param address the {@code UnresolvedAddress} to connect to resolved using the provided {@code serviceDiscoverer}.
      * This address will also be used for the {@link HttpHeaderNames#HOST} using a best effort conversion. Use {@link
      * SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value or
-     * {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
+     * {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you want to disable this behavior.
      * @param <U> the type of address before resolution (unresolved address)
      * @param <R> the type of address after resolution (resolved address)
      * @return new builder with provided configuration


### PR DESCRIPTION
Motivation:

To keep the API consistent across the codebase, builder API
methods changing a boolean value should take a boolean
as a parameter.

Modifications:

- Deprecated `DefaultAutoRetryStrategyProvider#disableWaitForLoadBalancer`
  in favor of `DefaultAutoRetryStrategyProvider#waitForLoadBalancer(boolean)`,
- Deprecated
  `DefaultAutoRetryStrategyProvider#disableRetryAllRetryableExceptions`
  in favor of
  `DefaultAutoRetryStrategyProvider#retryAllRetryableExceptions(boolean)`,
- Changed references to previously deprecated methods in javadocs to new
  methods that accept boolean.

Result:

More consistent builders' APIs.