### PR TITLE
Add support for nonOffloading HTTP Server Filters (#1710)

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ClearAsyncContextHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ClearAsyncContextHttpServiceFilter.java
@@ -18,8 +18,19 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.Single;
 
-final class AsyncContextAwareHttpServiceFilter implements
+/**
+ * Clears the {@link AsyncContext} for a new request.
+ */
+final class ClearAsyncContextHttpServiceFilter implements
                                                StreamingHttpServiceFilterFactory, HttpExecutionStrategyInfluencer {
+
+    static final ClearAsyncContextHttpServiceFilter CLEAR_ASYNC_CONTEXT_HTTP_SERVICE_FILTER =
+            new ClearAsyncContextHttpServiceFilter();
+
+    private ClearAsyncContextHttpServiceFilter() {
+        // singleton
+    }
+
     @Override
     public StreamingHttpServiceFilter create(final StreamingHttpService service) {
         return new StreamingHttpServiceFilter(service) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
@@ -40,6 +40,15 @@ public class DelegatingHttpServiceContext extends HttpServiceContext {
         this.delegate = other;
     }
 
+    /**
+     * Returns the delegate {@link HttpServiceContext}.
+     *
+     * @return the delegate {@link HttpServiceContext}.
+     */
+    public HttpServiceContext delegate() {
+        return delegate;
+    }
+
     @Override
     public String toString() {
         return delegate.toString();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpApiConversions.ServiceAdapterHolder;
@@ -31,14 +30,18 @@ import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.BlockingUtils.blockingInvocation;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategyInfluencer.defaultStreamingInfluencer;
 import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toConditionalServiceFilterFactory;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
@@ -51,11 +54,18 @@ public abstract class HttpServerBuilder {
 
     @Nullable
     private ConnectionAcceptorFactory connectionAcceptorFactory;
-    @Nullable
-    private StreamingHttpServiceFilterFactory serviceFilter;
+    private final List<StreamingHttpServiceFilterFactory> noOffloadServiceFilters = new ArrayList<>();
+    private final List<StreamingHttpServiceFilterFactory> serviceFilters = new ArrayList<>();
     private HttpExecutionStrategy strategy = defaultStrategy();
-    private final StrategyInfluencerChainBuilder influencerChainBuilder = new StrategyInfluencerChainBuilder();
     private boolean drainRequestPayloadBody = true;
+
+    /**
+     * Create a new instance.
+     */
+    protected HttpServerBuilder() {
+        // Async context clear goes before everything else.
+        appendNonOffloadingServiceFilter(ClearAsyncContextHttpServiceFilter.CLEAR_ASYNC_CONTEXT_HTTP_SERVICE_FILTER);
+    }
 
     /**
      * Configurations of various HTTP protocol versions.
@@ -222,8 +232,10 @@ public abstract class HttpServerBuilder {
      * <p>
      * The order of execution of these filters are in order of append. If 3 filters are added as follows:
      * <pre>
-     *     builder.appendConnectionAcceptorFilter(filter1).appendConnectionAcceptorFilter(filter2).
-     *     appendConnectionAcceptorFilter(filter3)
+     *     builder
+     *          .appendConnectionAcceptorFilter(filter1)
+     *          .appendConnectionAcceptorFilter(filter2)
+     *          .appendConnectionAcceptorFilter(filter3)
      * </pre>
      * accepting a connection by a filter wrapped by this filter chain, the order of invocation of these filters will
      * be:
@@ -245,6 +257,65 @@ public abstract class HttpServerBuilder {
     }
 
     /**
+     * Appends a non-offloading filter to the chain of filters used to decorate the {@link StreamingHttpService} used
+     * by this builder.
+     * <p>
+     * Note this method will be used to decorate the {@link StreamingHttpService} passed to
+     * {@link #listenStreaming(StreamingHttpService)} before it is used by the server.
+     * <p>
+     * The order of execution of these filters are in order of append, before the filters added with
+     * {@link #appendServiceFilter(StreamingHttpServiceFilterFactory)}. If 3 filters are added as follows:
+     * <pre>
+     *     builder.appendServiceFilter(filter1).appendNonOffloadingServiceFilter(filter2).appendServiceFilter(filter3)
+     * </pre>
+     * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
+     * <pre>
+     *     filter2 ⇒ filter1 ⇒ filter3 ⇒ service
+     * </pre>
+     *
+     * @param factory {@link StreamingHttpServiceFilterFactory} to append.
+     * @return {@code this}
+     * @throws IllegalArgumentException if the provided filter requires offloading.
+     */
+    public final HttpServerBuilder appendNonOffloadingServiceFilter(final StreamingHttpServiceFilterFactory factory) {
+        noOffloadServiceFilters.add(checkNonOffloading("Non-offloading filter",
+                HttpExecutionStrategies.defaultStrategy(), factory));
+        return this;
+    }
+
+    /**
+     * Appends a non-offloading filter to the chain of filters used to decorate the {@link StreamingHttpService} used
+     * by this builder, for every request that passes the provided {@link Predicate}. Filters added via this method
+     * will be executed before offloading occurs and before filters appended via
+     * {@link #appendServiceFilter(StreamingHttpServiceFilterFactory)}.
+     * <p>
+     * Note this method will be used to decorate the {@link StreamingHttpService} passed to
+     * {@link #listenStreaming(StreamingHttpService)} before it is used by the server.
+     * The order of execution of these filters are in order of append, before the filters added with
+     * {@link #appendServiceFilter(StreamingHttpServiceFilterFactory)}. If 3 filters are added as follows:
+     * <pre>
+     *     builder.appendServiceFilter(filter1).appendNonOffloadingServiceFilter(filter2).appendServiceFilter(filter3)
+     * </pre>
+     * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
+     * <pre>
+     *     filter2 ⇒ filter1 ⇒ filter3 ⇒ service
+     * </pre>
+     *
+     * @param predicate the {@link Predicate} to test if the filter must be applied. This must not block.
+     * @param factory {@link StreamingHttpServiceFilterFactory} to append.
+     * @return {@code this}
+     * @throws IllegalArgumentException if the provided filter or predicate requires offloading.
+     */
+    public final HttpServerBuilder appendNonOffloadingServiceFilter(final Predicate<StreamingHttpRequest> predicate,
+                                                                    final StreamingHttpServiceFilterFactory factory) {
+        checkNonOffloading("Non-offloading predicate", noOffloadsStrategy(), predicate);
+        checkNonOffloading("Non-offloading filter", HttpExecutionStrategies.defaultStrategy(), factory);
+        noOffloadServiceFilters.add(
+                service -> new ConditionalHttpServiceFilter(predicate, factory.create(service), service));
+        return this;
+    }
+
+    /**
      * Appends the filter to the chain of filters used to decorate the {@link StreamingHttpService} used by this
      * builder.
      * <p>
@@ -257,7 +328,7 @@ public abstract class HttpServerBuilder {
      * </pre>
      * accepting a request by a service wrapped by this filter chain, the order of invocation of these filters will be:
      * <pre>
-     *     filter1 ⇒ filter2 ⇒ filter3 ⇒ service
+     *      filter1 ⇒ filter2 ⇒ filter3 ⇒ service
      * </pre>
      *
      * @param factory {@link StreamingHttpServiceFilterFactory} to append.
@@ -265,10 +336,7 @@ public abstract class HttpServerBuilder {
      */
     public final HttpServerBuilder appendServiceFilter(final StreamingHttpServiceFilterFactory factory) {
         requireNonNull(factory);
-        serviceFilter = appendFilter(serviceFilter, factory);
-        if (!influencerChainBuilder.appendIfInfluencer(factory)) {
-            influencerChainBuilder.append(defaultStreamingInfluencer());
-        }
+        serviceFilters.add(factory);
         return this;
     }
 
@@ -288,7 +356,7 @@ public abstract class HttpServerBuilder {
      *     filter1 ⇒ filter2 ⇒ filter3 ⇒ service
      * </pre>
      *
-     * @param predicate the {@link Predicate} to test if the filter must be applied.
+     * @param predicate the {@link Predicate} to test if the filter must be applied. This must not block.
      * @param factory {@link StreamingHttpServiceFilterFactory} to append.
      * @return {@code this}
      */
@@ -331,14 +399,14 @@ public abstract class HttpServerBuilder {
      * @return {@code this}.
      */
     public final HttpServerBuilder executionStrategy(HttpExecutionStrategy strategy) {
-        this.strategy = strategy;
+        this.strategy = requireNonNull(strategy);
         return this;
     }
 
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
      * <p>
-     * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
      * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
@@ -353,7 +421,7 @@ public abstract class HttpServerBuilder {
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
      * <p>
-     * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param handler Service invoked for every request received by this server. The returned {@link ServerContext}
      * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
@@ -368,7 +436,7 @@ public abstract class HttpServerBuilder {
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
      * <p>
-     * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
      * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
@@ -383,7 +451,7 @@ public abstract class HttpServerBuilder {
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
      * <p>
-     * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param handler Service invoked for every request received by this server. The returned {@link ServerContext}
      * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
@@ -399,7 +467,7 @@ public abstract class HttpServerBuilder {
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
      * <p>
-     * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
      * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
@@ -407,14 +475,13 @@ public abstract class HttpServerBuilder {
      * the server could not be started.
      */
     public final Single<ServerContext> listen(final HttpService service) {
-        influencerChainBuilder.prependIfInfluencer(service);
-        return listenForAdapter(toStreamingHttpService(service, influencerChainBuilder.build(strategy)));
+        return listenForAdapter(toStreamingHttpService(service, strategyInfluencer(service)));
     }
 
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
      * <p>
-     * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
      * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
@@ -428,7 +495,7 @@ public abstract class HttpServerBuilder {
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
      * <p>
-     * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
      * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
@@ -436,14 +503,13 @@ public abstract class HttpServerBuilder {
      * the server could not be started.
      */
     public final Single<ServerContext> listenBlocking(final BlockingHttpService service) {
-        influencerChainBuilder.prependIfInfluencer(service);
-        return listenForAdapter(toStreamingHttpService(service, influencerChainBuilder.build(strategy)));
+        return listenForAdapter(toStreamingHttpService(service, strategyInfluencer(service)));
     }
 
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
      * <p>
-     * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
      * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
@@ -451,14 +517,13 @@ public abstract class HttpServerBuilder {
      * the server could not be started.
      */
     public final Single<ServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
-        influencerChainBuilder.prependIfInfluencer(service);
-        return listenForAdapter(toStreamingHttpService(service, influencerChainBuilder.build(strategy)));
+        return listenForAdapter(toStreamingHttpService(service, strategyInfluencer(service)));
     }
 
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
      * <p>
-     * If the underlying protocol (eg. TCP) supports it this should result in a socket bind/listen on {@code address}.
+     * If the underlying protocol (e.g. TCP) supports it this should result in a socket bind/listen on {@code address}.
      *
      * @param connectionAcceptor {@link ConnectionAcceptor} to use for the server.
      * @param service {@link StreamingHttpService} to use for the server.
@@ -467,11 +532,7 @@ public abstract class HttpServerBuilder {
      * ignore the {@link StreamingHttpRequest#payloadBody() payload body} of incoming requests.
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
-     * @deprecated This method will be removed. If you depend upon it consider copying the implementation from
-     * {@code DefaultHttpServerBuilder#doListen(ConnectionAcceptor, StreamingHttpService, HttpExecutionStrategy,
-     * boolean)}
      */
-    @Deprecated
     protected abstract Single<ServerContext> doListen(@Nullable ConnectionAcceptor connectionAcceptor,
                                                       StreamingHttpService service,
                                                       HttpExecutionStrategy strategy,
@@ -481,23 +542,106 @@ public abstract class HttpServerBuilder {
         return listenForService(adapterHolder.adaptor(), adapterHolder.serviceInvocationStrategy());
     }
 
+    /**
+     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * <p>
+     * If the underlying protocol (e.g. TCP) supports it this should result in a socket bind/listen on {@code address}.
+     * <p>/p>
+     * The execution path for a request will be offloaded from the IO thread as required to ensure safety. The
+     * <dl>
+     *     <dt>read side</dt>
+     *     <dd>IO thread → request → non-offload filters → offload filters → raw service</dd>
+     *     <dt>subscribe/request side</dt>
+     *     <dd>IO thread → subscribe/request/cancel → non-offload filters → offload filters → raw service</dd>
+     * </dl>
+     *
+     * @param rawService {@link StreamingHttpService} to use for the server.
+     * @param strategy the {@link HttpExecutionStrategy} to use for the service.
+     * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
+     * the server could not be started.
+
+     */
     private Single<ServerContext> listenForService(StreamingHttpService rawService, HttpExecutionStrategy strategy) {
         ConnectionAcceptor connectionAcceptor = connectionAcceptorFactory == null ? null :
                 connectionAcceptorFactory.create(ACCEPT_ALL);
-        StreamingHttpServiceFilterFactory currServiceFilter = serviceFilter;
-        if (!AsyncContext.isDisabled()) {
-            StreamingHttpServiceFilterFactory asyncContextFilter = new AsyncContextAwareHttpServiceFilter();
-            currServiceFilter = currServiceFilter == null ? asyncContextFilter :
-                    appendFilter(asyncContextFilter, currServiceFilter);
+
+        final StreamingHttpService filteredService;
+
+        if (noOffloadServiceFilters.isEmpty()) {
+            filteredService = serviceFilters.isEmpty() ? rawService : buildService(serviceFilters.stream(), rawService);
+        } else {
+            boolean anyOffloads = strategy.isSendOffloaded() ||
+                    strategy.isMetadataReceiveOffloaded() ||
+                    strategy.isDataReceiveOffloaded();
+
+            Stream<StreamingHttpServiceFilterFactory> nonOffloadingFilters = noOffloadServiceFilters.stream();
+
+            if (anyOffloads) {
+                // We are going to have to offload, even if just to the raw service
+                nonOffloadingFilters = Stream.concat(nonOffloadingFilters,
+                        Stream.of(new OffloadingFilter(strategy, buildFactory(serviceFilters))));
+                strategy = null != strategy.executor() ?
+                        HttpExecutionStrategies.customStrategyBuilder()
+                                .offloadNone().executor(strategy.executor()).build() :
+                        noOffloadsStrategy();
+            } else {
+                // All the filters can be appended.
+                nonOffloadingFilters = Stream.concat(nonOffloadingFilters, serviceFilters.stream());
+            }
+            filteredService = buildService(nonOffloadingFilters, rawService);
         }
-        StreamingHttpService filteredService = currServiceFilter != null ?
-                currServiceFilter.create(rawService) : rawService;
+
         return doListen(connectionAcceptor, filteredService, strategy, drainRequestPayloadBody);
     }
 
-    private static StreamingHttpServiceFilterFactory appendFilter(
-            @Nullable final StreamingHttpServiceFilterFactory current,
-            final StreamingHttpServiceFilterFactory next) {
-        return current == null ? next : service -> current.create(next.create(service));
+    private HttpExecutionStrategyInfluencer strategyInfluencer(Object service) {
+        HttpExecutionStrategyInfluencer influencer =
+                buildInfluencer(serviceFilters, strategy -> influenceStrategy(service, strategy));
+        HttpExecutionStrategy useStrategy = influencer.influenceStrategy(strategy);
+
+        return s -> s.merge(useStrategy);
+    }
+
+    private static StreamingHttpServiceFilterFactory buildFactory(List<StreamingHttpServiceFilterFactory> filters) {
+        return filters.stream()
+                .reduce((prev, filter) -> strategy -> prev.create(filter.create(strategy)))
+                .orElse(StreamingHttpServiceFilter::new); // unfortunate that we need extra layer
+    }
+
+    private static StreamingHttpService buildService(Stream<StreamingHttpServiceFilterFactory> filters,
+                                                     StreamingHttpService service) {
+        return filters
+                .reduce((prev, filter) -> svc -> prev.create(filter.create(svc)))
+                .map(factory -> (StreamingHttpService) factory.create(service))
+                .orElse(service);
+    }
+
+    private static HttpExecutionStrategyInfluencer buildInfluencer(List<StreamingHttpServiceFilterFactory> filters,
+                                                                   HttpExecutionStrategyInfluencer defaultInfluence) {
+        return filters.stream()
+                .map(filter -> filter instanceof HttpExecutionStrategyInfluencer ?
+                        (HttpExecutionStrategyInfluencer) filter :
+                        defaultStreamingInfluencer())
+                .distinct()
+                .reduce(defaultInfluence,
+                        (prev, influencer) -> strategy -> influencer.influenceStrategy(prev.influenceStrategy(strategy))
+                );
+    }
+
+    private static HttpExecutionStrategy influenceStrategy(Object anything, HttpExecutionStrategy strategy) {
+        return anything instanceof HttpExecutionStrategyInfluencer ?
+                ((HttpExecutionStrategyInfluencer) anything).influenceStrategy(strategy) :
+                strategy;
+    }
+
+    private static <T> T checkNonOffloading(String desc, HttpExecutionStrategy assumeStrategy, T obj) {
+        requireNonNull(obj);
+        HttpExecutionStrategy requires = obj instanceof HttpExecutionStrategyInfluencer ?
+                ((HttpExecutionStrategyInfluencer) obj).influenceStrategy(noOffloadsStrategy()) :
+                assumeStrategy;
+        if (requires.isMetadataReceiveOffloaded() || requires.isDataReceiveOffloaded() || requires.isSendOffloaded()) {
+            throw new IllegalArgumentException(desc + " required offloading : " + requires);
+        }
+        return obj;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/OffloadingFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/OffloadingFilter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Single;
+
+import static java.util.function.Function.identity;
+
+/**
+ * An {@link StreamingHttpServiceFilterFactory} implementation which offloads filters using a provided strategy.
+ */
+final class OffloadingFilter implements StreamingHttpServiceFilterFactory, HttpExecutionStrategyInfluencer {
+
+    private final HttpExecutionStrategy strategy;
+    private final StreamingHttpServiceFilterFactory offloaded;
+
+    /**
+     * @param strategy Execution strategy for the offloaded filters
+     * @param offloaded Filters to be offloaded
+     */
+    OffloadingFilter(HttpExecutionStrategy strategy, StreamingHttpServiceFilterFactory offloaded) {
+        this.strategy = strategy;
+        this.offloaded = offloaded;
+    }
+
+    @Override
+    public StreamingHttpServiceFilter create(StreamingHttpService service) {
+        return new StreamingHttpServiceFilter(offloaded.create(service)) {
+
+            @Override
+            public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                        StreamingHttpRequest request,
+                                                        final StreamingHttpResponseFactory responseFactory) {
+                Executor se = strategy.executor();
+                Executor e = null != se ? se : ctx.executionContext().executor();
+
+                // The service should see our ExecutionStrategy inside the ExecutionContext:
+                final HttpServiceContext wrappedCtx =
+                        new ExecutionContextOverridingServiceContext(ctx, strategy, e);
+
+                if (strategy.isDataReceiveOffloaded()) {
+                    request = request.transformMessageBody(p -> p.publishOn(e));
+                }
+                final Single<StreamingHttpResponse> resp;
+                if (strategy.isMetadataReceiveOffloaded()) {
+                    final StreamingHttpRequest r = request;
+                    resp = e.submit(() -> delegate().handle(wrappedCtx, r, responseFactory).subscribeShareContext())
+                            // exec.submit() returns a Single<Single<response>>, so flatten the nested Single.
+                            .flatMap(identity());
+                } else {
+                    resp = delegate().handle(wrappedCtx, request, responseFactory);
+                }
+                return strategy.isSendOffloaded() ?
+                        // This is different from invokeService() where we just offload once on the  flattened
+                        // (meta + data) stream. In this case, we need to preserve the service contract and hence
+                        // have to offload both meta and data separately.
+                        resp.map(r -> r.transformMessageBody(p -> p.subscribeOn(e))).subscribeOn(e) : resp;
+            }
+        };
+    }
+
+    @Override
+    public HttpExecutionStrategy influenceStrategy(final HttpExecutionStrategy strategy) {
+        // no influence
+        return strategy;
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InvokingThreadsRecorder.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InvokingThreadsRecorder.java
@@ -26,8 +26,8 @@ import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
-import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
@@ -37,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
@@ -53,6 +52,9 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
+/**
+ * @param <T> Type of the keys used in thread recorder map.
+ */
 final class InvokingThreadsRecorder<T> {
     static final String IO_EXECUTOR_NAME_PREFIX = "io-executor";
 
@@ -138,23 +140,21 @@ final class InvokingThreadsRecorder<T> {
 
     void verifyOffloadCount() {
         assert invokingThreads != null;
-        assertThat("Unexpected offload points recorded.", invokingThreads.size(), is(3));
+        assertThat("Unexpected offload points recorded. " + invokingThreads, invokingThreads.size(), is(3));
     }
 
     void assertStrategyUsedForClient() {
         assertThat("No user specified strategy found.", strategy, is(notNullValue()));
         assertThat("Unknown user specified strategy.", strategy, instanceOf(InstrumentedStrategy.class));
         InstrumentedStrategy instrumentedStrategy = (InstrumentedStrategy) strategy;
-        assertThat("User specified strategy not used.", instrumentedStrategy.isUsedForClientOffloading(),
-                is(true));
+        assertThat("User specified strategy not used.", instrumentedStrategy.isUsedForClientOffloading());
     }
 
     void assertStrategyUsedForServer() {
         assertThat("No user specified strategy found.", strategy, is(notNullValue()));
         assertThat("Unknown user specified strategy.", strategy, instanceOf(InstrumentedStrategy.class));
         InstrumentedStrategy instrumentedStrategy = (InstrumentedStrategy) strategy;
-        assertThat("User specified strategy not used.", instrumentedStrategy.isUsedForServerOffloading(),
-                is(true));
+        assertThat("User specified strategy not used.", instrumentedStrategy.isUsedForServerOffloading());
     }
 
     StreamingHttpClient client() {
@@ -190,11 +190,9 @@ final class InvokingThreadsRecorder<T> {
         }
 
         @Override
-        public Publisher<Object> invokeService(final Executor fallback, final StreamingHttpRequest request,
-                                               final Function<StreamingHttpRequest, Publisher<Object>> service,
-                                               final BiFunction<Throwable, Executor, Publisher<Object>> errorHandler) {
+        public StreamingHttpService offloadService(final Executor fallback, final StreamingHttpService handler) {
             usedForServerOffloading = true;
-            return super.invokeService(fallback, request, service, errorHandler);
+            return super.offloadService(fallback, handler);
         }
 
         boolean isUsedForClientOffloading() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
@@ -21,30 +21,23 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
-import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
-import io.servicetalk.http.api.HttpResponse;
-import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.DelegatingHttpServiceContext;
 import io.servicetalk.http.api.HttpServiceContext;
-import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
-import io.servicetalk.transport.api.HostAndPort;
-import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -56,7 +49,6 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.closeAsyncGracefully
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
@@ -81,8 +73,6 @@ import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ROT13;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_SINGLE_ERROR;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_TEST_PUBLISHER;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_THROW_ERROR;
-import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
-import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -156,35 +146,6 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
         request.headers().set(CONTENT_LENGTH, "5");
         final StreamingHttpResponse response = makeRequest(request);
         assertResponse(response, HTTP_1_1, OK, "hello");
-    }
-
-    @ParameterizedTest(name = "{displayName} [{index}] disableOffloading={0}")
-    @ValueSource(booleans = {true, false})
-    void testServiceThrowsReturnsErrorResponse(boolean disableOffloading) throws Exception {
-        // the test suite state isn't used by this individual test, but cleanup code requires it is initialized.
-        setUp(IMMEDIATE, IMMEDIATE);
-
-        HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
-        if (disableOffloading) {
-            serverBuilder.executionStrategy(noOffloadsStrategy());
-        }
-        try (ServerContext serverCtx = serverBuilder.listenStreamingAndAwait((ctx, request, responseFactory) -> {
-                    throw DELIBERATE_EXCEPTION;
-                });
-             BlockingHttpClient client = disableOffloading(HttpClients.forResolvedAddress(serverHostAndPort(serverCtx)),
-                     disableOffloading)
-                     .buildBlocking()) {
-            HttpResponse resp = client.request(client.get("/"));
-            assertThat(resp.status(), is(INTERNAL_SERVER_ERROR));
-        }
-    }
-
-    private static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> disableOffloading(
-            SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder, boolean disableOffloading) {
-        if (disableOffloading) {
-            clientBuilder.executionStrategy(noOffloadsStrategy());
-        }
-        return clientBuilder;
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] client={0} server={1}")
@@ -669,8 +630,14 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
             public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                         final StreamingHttpRequest request,
                                                         final StreamingHttpResponseFactory responseFactory) {
+                HttpServiceContext checkCtx = ctx instanceof DelegatingHttpServiceContext ?
+                    ((DelegatingHttpServiceContext) ctx).delegate() : ctx;
                 // Capture for future assertions on the transport errors
-                capturedServiceTransportErrorRef.set(((NettyConnectionContext) ctx).transportError());
+                NettyConnectionContext asNCC;
+                if (checkCtx instanceof NettyConnectionContext) {
+                    asNCC = (NettyConnectionContext) checkCtx;
+                    capturedServiceTransportErrorRef.set(asNCC.transportError());
+                }
                 return delegate().handle(ctx, request, responseFactory)
                     .afterOnSubscribe(c -> serviceHandleLatch.countDown());
             }

--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/InOrderRouter.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/InOrderRouter.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.router.predicate;
 
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServiceContext;
@@ -67,7 +68,9 @@ final class InOrderRouter implements StreamingHttpService {
                 StreamingHttpService service = pair.service();
                 final HttpExecutionStrategy strategy = pair.routeStrategy();
                 if (strategy != null) {
-                    service = strategy.offloadService(ctx.executionContext().executor(), service);
+                    Executor se = strategy.executor();
+                    Executor executor = null == se ? ctx.executionContext().executor() : se;
+                    service = strategy.offloadService(executor, service);
                 }
                 return service.handle(ctx, request, factory);
             }

--- a/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/GlobalBindingBasicAuthSecurityContextFilterTest.java
+++ b/servicetalk-http-security-jersey/src/test/java/io/servicetalk/http/security/auth/basic/jersey/GlobalBindingBasicAuthSecurityContextFilterTest.java
@@ -43,7 +43,7 @@ class GlobalBindingBasicAuthSecurityContextFilterTest extends AbstractBasicAuthS
         };
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "withUserInfo={0}")
     @ValueSource(booleans = {true, false})
     void authenticated(final boolean withUserInfo) throws Exception {
         setUp(withUserInfo);
@@ -51,7 +51,7 @@ class GlobalBindingBasicAuthSecurityContextFilterTest extends AbstractBasicAuthS
         assertBasicAuthSecurityContextPresent(NameBindingResource.PATH);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "withUserInfo={0}")
     @ValueSource(booleans = {true, false})
     void notAuthenticated(final boolean withUserInfo) throws Exception {
         setUp(withUserInfo);


### PR DESCRIPTION
Motivation:
Some filters may wish to run early in the request process before the
request has been offloaded.
Modifications:
A new API,
`HttpServerBuilder.appendNonOffloadingServiceFilter(StreamingHttpServiceFilterFactory)`
is provided for registering filters which will not be offloaded.
Offloading will be handled in the filter chain by the new
`OffloadingFilter` which is logically inserted between the
non-offloading and offloading filters. The new offloading filter also replaces
one of the `HttpExecutionStrategy.invokeService` methods.
Result:
New options for filters.