### PR TITLE
Deprecate `AwaitUtils#awaitUninterruptibly`

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
@@ -82,7 +82,7 @@ public final class TestCompletable extends Completable implements CompletableSou
      * {@link Thread#isInterrupted()} will be set upon return.
      */
     public void awaitSubscribed() {
-        AwaitUtils.awaitUninterruptibly(subscriberLatch);
+        AwaitUtils.await(subscriberLatch);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
@@ -84,7 +84,7 @@ public final class TestPublisher<T> extends Publisher<T> implements PublisherSou
      * {@link Thread#isInterrupted()} will be set upon return.
      */
     public void awaitSubscribed() {
-        AwaitUtils.awaitUninterruptibly(subscriberLatch);
+        AwaitUtils.await(subscriberLatch);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.test.internal.AwaitUtils.awaitUninterruptibly;
+import static io.servicetalk.concurrent.test.internal.AwaitUtils.await;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -83,7 +83,7 @@ public final class TestSingle<T> extends Single<T> implements SingleSource<T> {
      * will be set upon return.
      */
     public void awaitSubscribed() {
-        awaitUninterruptibly(subscriberLatch);
+        await(subscriberLatch);
     }
 
     @Override

--- a/servicetalk-concurrent-test-internal/build.gradle
+++ b/servicetalk-concurrent-test-internal/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
@@ -84,9 +84,8 @@ public final class AwaitUtils {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throwException(e);
+            return false;
         }
-
-        return false;
     }
 
     /**

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
-import static io.servicetalk.concurrent.test.internal.AwaitUtils.awaitUninterruptibly;
+import static io.servicetalk.concurrent.test.internal.AwaitUtils.await;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.pollUninterruptibly;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.takeUninterruptibly;
 import static java.util.Objects.requireNonNull;
@@ -156,7 +156,7 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
      * @return The {@link Subscription} from {@link PublisherSource.Subscriber#onSubscribe(Subscription)}.
      */
     public Subscription awaitSubscription() {
-        awaitUninterruptibly(onSubscribeLatch);
+        await(onSubscribeLatch);
         assert subscription != null;
         return subscription;
     }
@@ -248,7 +248,7 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
      * @return the exception received by {@link #onError(Throwable)}.
      */
     Throwable awaitOnError(boolean verifyOnNextConsumed) {
-        awaitUninterruptibly(onTerminalLatch);
+        await(onTerminalLatch);
         assert onTerminal != null;
         if (onTerminal == complete()) {
             throw new IllegalStateException("wanted onError but Subscriber terminated with onComplete");
@@ -276,7 +276,7 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
      * and throw if not. {@code false} to ignore if {@link #onNext(Object)} signals have been consumed or not.
      */
     void awaitOnComplete(boolean verifyOnNextConsumed) {
-        awaitUninterruptibly(onTerminalLatch);
+        await(onTerminalLatch);
         assert onTerminal != null;
         if (onTerminal != complete()) {
             throw new IllegalStateException("wanted onComplete but Subscriber terminated with onError",
@@ -298,7 +298,7 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
      */
     @Nullable
     public Supplier<Throwable> pollTerminal(long timeout, TimeUnit unit) {
-        if (awaitUninterruptibly(onTerminalLatch, timeout, unit)) {
+        if (await(onTerminalLatch, timeout, unit)) {
             assert onTerminal != null;
             return onTerminal == complete() ? () -> null : onTerminal::cause;
         }


### PR DESCRIPTION
Motivation:

The current usage of `awaitUtils` catches
`InterruptedException` and silently discards it. jUnit5 uses
thread interrupt to stop tests after the timeout expires. As a
result, these tests may hang forever as the `InterruptedException`
is not propagated.

Modifications:
- Rewrite `awaitUninterruptibly` to await in `awaitUtils`

Result:
Deprecated awaitUninterruptibly. await now throws unchecked
Exception with the help of PlatformDependent.throwException.

It has been verified that a test that takes more than 10 seconds
and uses `awaitUtils.await` will fail with `java.util.concurrent.TimeoutException.`
