### PR TITLE
`BeforeFinallyHttpOperator`: add option to discard signals after cancelation

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TerminalNotification.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TerminalNotification.java
@@ -18,6 +18,7 @@ package io.servicetalk.concurrent.internal;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource;
 
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
@@ -152,5 +153,22 @@ public final class TerminalNotification {
     @Override
     public String toString() {
         return "TerminalNotification{" + (this.cause == null ? "COMPLETE" : cause) + "}";
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TerminalNotification that = (TerminalNotification) o;
+        return Objects.equals(cause, that.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return cause == null ? 0 : cause.hashCode();
     }
 }

--- a/servicetalk-http-utils/build.gradle
+++ b/servicetalk-http-utils/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-http-api"))
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-concurrent-api-test")
+  testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
   testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -357,9 +357,9 @@ public final class BeforeFinallyHttpOperator implements SingleOperator<Streaming
                                                         PROCESSING_PAYLOAD, TERMINATED)) {
                                                     return state;
                                                 }
-                                            } else {
+                                            } else if (stateUpdater.compareAndSet(ResponseCompletionSubscriber.this,
+                                                    state, TERMINATED)) {
                                                 // re-entry, but we can terminate because this is a final event:
-                                                stateUpdater.set(ResponseCompletionSubscriber.this, TERMINATED);
                                                 return state;
                                             }
                                         }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Motivation:

After `cancel`, async sources can stop propagating more signals. Therefore,
"beforeFinally" operators consider cancellation as a terminal event. However,
cancellation is the best effort and more signals can be delivered later or it may
race with other signals. In some scenarios, like observability, it may be confusing
to receive more signals after a terminal event. For those use-cases, a new option
is added for `BeforeFinallyHttpOperator` to discard further signals after cancel.

Modifications:

- Add a new ctor for `BeforeFinallyHttpOperator` that takes `discardEventsAfterCancel`;
- Enhance internal state machine to accommodate the new features;
- Add tests to verify new behavior;

Result:

Users can configure `BeforeFinallyHttpOperator` to discard further signals after
cancellation.