### PR TITLE
Prevent response publisher from being cancelled before `onComplete`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -366,6 +366,8 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             }
             this.failureCause = cause;
             setFlag(SOURCE_TERMINATED);
+            // Mark the subscription as CANCELLED to prevent propagating cancel from channelClosed
+            subscriptionUpdater.getAndSet(WriteStreamSubscriber.this, CANCELLED);
             if (activeWrites == 0) {
                 try {
                     setFlag(SUBSCRIBER_TERMINATED);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -366,8 +366,9 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             }
             this.failureCause = cause;
             setFlag(SOURCE_TERMINATED);
-            // Mark the subscription as CANCELLED to prevent propagating cancel from channelClosed
-            subscriptionUpdater.getAndSet(WriteStreamSubscriber.this, CANCELLED);
+            // Mark the subscription as CANCELLED to prevent propagating cancel from channelClosed. At this point we
+            // always have a non-null subscription because this is reachable only if publisher emitted some signals.
+            WriteStreamSubscriber.this.subscription = CANCELLED;
             if (activeWrites == 0) {
                 try {
                     setFlag(SUBSCRIBER_TERMINATED);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopWriteObserver;
 import io.servicetalk.transport.netty.internal.WriteStreamSubscriber.AbortedFirstWriteException;
 
+import io.netty.channel.Channel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -40,6 +41,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class WriteStreamSubscriberTest extends AbstractWriteTest {
@@ -188,6 +190,24 @@ class WriteStreamSubscriberTest extends AbstractWriteTest {
         verifyListenerSuccessful();
         verifyWriteSuccessful("Hello");
         verifyNoInteractions(closeHandler);
+    }
+
+    @Test
+    void channelClosedDoesNotCancelAfterOutboundEnd() {
+        WriteInfo info = writeAndFlush("Hello");
+        subscriber.channelOutboundClosed();
+        verify(subscription, never()).cancel();
+
+        verifyListenerSuccessful();
+        verifyWriteSuccessful("Hello");
+        verifyWrite(info);
+
+        subscriber.channelClosed(DELIBERATE_EXCEPTION); // simulate channelInactive event
+        verify(closeHandler).closeChannelOutbound(any(Channel.class));
+        verify(subscription, never()).cancel();
+
+        subscriber.onComplete();
+        verifyNoMoreInteractions(closeHandler);
     }
 
     private void failingWriteClosesChannel(Runnable enableWriteFailure) throws InterruptedException {


### PR DESCRIPTION
If netty `Channel` closes after writing the last item of the outbound
publisher (like HTTP/2 stream closes after sending `endStream=true` flag),
`channelInactive` event may race with `onComplete`. If it comes first,
`WriteStreamSubscriber#channelClosed(Throwable)` will be invoked,
triggering cancellation on the subscription that is already effectively
terminated (because we saw `OutboundDataEndEvent` ->
`WriteStreamSubscriber#channelOutboundClosed` -> `SOURCE_TERMINATED`
flag is already set).
This may result in observing response cancellation from filters instead
of successful completion.

Modifications:

- Swap current `subscription` with `CANCELLED` after
`SOURCE_TERMINATED` flag is set in `WriteStreamSubscriber#AllPromise`;

Result:

Cancel is not propagated and filters see the successful completion of the
outbound publisher instead of a cancellation.