### PR TITLE
Removal of deprecated one-way builder methods

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -284,10 +284,7 @@ public abstract class GrpcClientBuilder<U, R> {
      * @return {@code this}
      * @see #unresolvedAddressToHost(Function)
      */
-    public GrpcClientBuilder<U, R> hostHeaderFallback(boolean enable) {
-        throw new UnsupportedOperationException("Setting automatic host header fallback using this method" +
-                " is not yet supported by " + getClass().getSimpleName());
-    }
+    public abstract GrpcClientBuilder<U, R> hostHeaderFallback(boolean enable);
 
     /**
      * Set a {@link ServiceDiscoverer} to resolve addresses of remote servers to connect to.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -275,20 +275,6 @@ public abstract class GrpcClientBuilder<U, R> {
             Function<U, CharSequence> unresolvedAddressToHostFunction);
 
     /**
-     * Disables automatically setting {@code Host} headers by inferring from the address or {@link HttpMetaData}.
-     * <p>
-     * This setting disables the default filter such that no {@code Host} header will be manipulated.
-     *
-     * @return {@code this}
-     * @see #unresolvedAddressToHost(Function)
-     * @deprecated Use {@link #hostHeaderFallback(boolean)}.
-     */
-    @Deprecated
-    public GrpcClientBuilder<U, R> disableHostHeaderFallback() {
-        return hostHeaderFallback(false);
-    }
-
-    /**
      * Configures automatically setting {@code Host} headers by inferring from the address or {@link HttpMetaData}.
      * <p>
      * When {@code false} is passed, this setting disables the default filter such that no {@code Host} header will be

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -143,10 +143,7 @@ public abstract class GrpcServerBuilder {
      * @param lifecycleObserver A {@link GrpcLifecycleObserver} that provides visibility into gRPC lifecycle events.
      * @return {@code this}.
      */
-    public GrpcServerBuilder lifecycleObserver(GrpcLifecycleObserver lifecycleObserver) {
-        throw new UnsupportedOperationException(
-                "Setting GrpcLifecycleObserver using this method is not yet supported by " + getClass().getName());
-    }
+    public abstract GrpcServerBuilder lifecycleObserver(GrpcLifecycleObserver lifecycleObserver);
 
     /**
      * Configures automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is
@@ -164,10 +161,7 @@ public abstract class GrpcServerBuilder {
      * {@link StreamingHttpRequest#payloadBody()}.
      * @return {@code this}.
      */
-    public GrpcServerBuilder drainRequestPayloadBody(boolean enable) {
-        throw new UnsupportedOperationException("Setting automatic request draining using this method is not yet " +
-                "supported by " + getClass().getSimpleName());
-    }
+    public abstract GrpcServerBuilder drainRequestPayloadBody(boolean enable);
 
     /**
      * Append the filter to the chain of filters used to decorate the {@link ConnectionAcceptor} used by this builder.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -149,26 +149,6 @@ public abstract class GrpcServerBuilder {
     }
 
     /**
-     * Disables automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is not
-     * consumed by the service.
-     * <p>
-     * For <a href="https://tools.ietf.org/html/rfc7230#section-6.3">persistent HTTP connections</a> it is required to
-     * eventually consume the entire request payload to enable reading of the next request. This is required because
-     * requests are pipelined for HTTP/1.1, so if the previous request is not completely read, next request can not be
-     * read from the socket. For cases when there is a possibility that user may forget to consume request payload,
-     * ServiceTalk automatically consumes request payload body. This automatic consumption behavior may create some
-     * overhead and can be disabled using this method when it is guaranteed that all request paths consumes all request
-     * payloads eventually. An example of guaranteed consumption are {@link HttpRequest non-streaming APIs}.
-     *
-     * @return {@code this}.
-     * @deprecated Use {@link #drainRequestPayloadBody(boolean)}.
-     */
-    @Deprecated
-    public GrpcServerBuilder disableDrainingRequestPayloadBody() {
-        return drainRequestPayloadBody(false);
-    }
-
-    /**
      * Configures automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is
      * not consumed by the service.
      * <p>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -151,27 +151,6 @@ public abstract class HttpServerBuilder {
     }
 
     /**
-     * Disables automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is not
-     * consumed by the service.
-     * <p>
-     * For <a href="https://tools.ietf.org/html/rfc7230#section-6.3">persistent HTTP connections</a> it is required to
-     * eventually consume the entire request payload to enable reading of the next request. This is required because
-     * requests are pipelined for HTTP/1.1, so if the previous request is not completely read, next request can not be
-     * read from the socket. For cases when there is a possibility that user may forget to consume request payload,
-     * ServiceTalk automatically consumes request payload body. This automatic consumption behavior may create some
-     * overhead and can be disabled using this method when it is guaranteed that all request paths consumes all request
-     * payloads eventually. An example of guaranteed consumption are {@link HttpRequest non-streaming APIs}.
-     *
-     * @return {@code this}.
-     * @deprecated Use {@link #drainRequestPayloadBody(boolean)}.
-     */
-    @Deprecated
-    public final HttpServerBuilder disableDrainingRequestPayloadBody() {
-        this.drainRequestPayloadBody = false;
-        return this;
-    }
-
-    /**
      * Configure automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is not
      * consumed by the service.
      * <p>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -145,10 +145,7 @@ public abstract class HttpServerBuilder {
      * @param lifecycleObserver A {@link HttpLifecycleObserver} that provides visibility into HTTP lifecycle events.
      * @return {@code this}.
      */
-    public HttpServerBuilder lifecycleObserver(HttpLifecycleObserver lifecycleObserver) {
-        throw new UnsupportedOperationException(
-                "Setting HttpLifecycleObserver using this method is not yet supported by " + getClass().getName());
-    }
+    public abstract HttpServerBuilder lifecycleObserver(HttpLifecycleObserver lifecycleObserver);
 
     /**
      * Configure automatic consumption of request {@link StreamingHttpRequest#payloadBody() payload body} when it is not

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -97,10 +97,7 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
      * @return {@code this}
      * @see #unresolvedAddressToHost(Function)
      */
-    public SingleAddressHttpClientBuilder<U, R> hostHeaderFallback(boolean enable) {
-        throw new UnsupportedOperationException("Setting automatic host header fallback using this method is not" +
-                " yet supported by " + getClass().getSimpleName());
-    }
+    public abstract SingleAddressHttpClientBuilder<U, R> hostHeaderFallback(boolean enable);
 
     /**
      * Provide a hint if response <a href="https://tools.ietf.org/html/rfc7230#section-4.1.2">trailers</a> are allowed

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -88,20 +88,6 @@ public abstract class SingleAddressHttpClientBuilder<U, R>
     public abstract SingleAddressHttpClientBuilder<U, R> protocols(HttpProtocolConfig... protocols);
 
     /**
-     * Disables automatically setting {@code Host} headers by inferring from the address or {@link HttpMetaData}.
-     * <p>
-     * This setting disables the default filter such that no {@code Host} header will be manipulated.
-     *
-     * @return {@code this}
-     * @see #unresolvedAddressToHost(Function)
-     * @deprecated Use {@link #hostHeaderFallback(boolean)}.
-     */
-    @Deprecated
-    public SingleAddressHttpClientBuilder<U, R> disableHostHeaderFallback() {
-        return hostHeaderFallback(false);
-    }
-
-    /**
      * Configures automatically setting {@code Host} headers by inferring from the address or {@link HttpMetaData}.
      * <p>
      * When {@code false} is passed, this setting disables the default filter such that no {@code Host} header will be

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -288,7 +288,7 @@ public final class HttpClients {
      * This address will also be used for the {@link HttpHeaderNames#HOST} using a best effort conversion.
      * Use {@link PartitionedHttpClientBuilder#initializer(PartitionedHttpClientBuilder.SingleAddressInitializer)}
      * and {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
-     * or {@link SingleAddressHttpClientBuilder#disableHostHeaderFallback()} if you want to disable this behavior.
+     * or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you want to disable this behavior.
      * @param partitionAttributesBuilderFactory The factory {@link Function} used to build {@link PartitionAttributes}
      * from {@link HttpRequestMetaData}.
      * @param <U> the type of address before resolution (unresolved address)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
@@ -79,7 +79,7 @@ class FlushStrategyOverrideTest {
                 .toFuture().get();
         InetSocketAddress serverAddr = (InetSocketAddress) serverCtx.listenAddress();
         client = forSingleAddress(new NoopSD(serverAddr), serverAddr)
-                .disableHostHeaderFallback()
+                .hostHeaderFallback(false)
                 .ioExecutor(ctx.ioExecutor())
                 .executionStrategy(noOffloadsStrategy())
                 .unresolvedAddressToHost(InetSocketAddress::getHostString)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
@@ -129,7 +129,7 @@ class HostHeaderHttpRequesterFilterTest {
         try (ServerContext context = buildServer();
              BlockingHttpClient client = forSingleAddress(serverHostAndPort(context))
                      .protocols(httpVersionConfig.config())
-                     .disableHostHeaderFallback() // turn off the default
+                     .hostHeaderFallback(false) // turn off the default
                      .appendClientFilter(new HostHeaderHttpRequesterFilter("foo.bar:-1"))
                      .buildBlocking()) {
             assertResponse(client, null, "foo.bar:-1");
@@ -143,7 +143,7 @@ class HostHeaderHttpRequesterFilterTest {
         try (ServerContext context = buildServer();
              BlockingHttpClient client = forSingleAddress(serverHostAndPort(context))
                      .protocols(httpVersionConfig.config())
-                     .disableHostHeaderFallback() // turn off the default
+                     .hostHeaderFallback(false) // turn off the default
                      .appendConnectionFilter(new HostHeaderHttpRequesterFilter("foo.bar:-1"))
                      .buildBlocking()) {
             assertResponse(client, null, "foo.bar:-1");
@@ -157,7 +157,7 @@ class HostHeaderHttpRequesterFilterTest {
         try (ServerContext context = buildServer();
              BlockingHttpClient client = HttpClients.forResolvedAddress(serverHostAndPort(context))
                      .protocols(httpVersionConfig.config())
-                     .disableHostHeaderFallback() // turn off the default
+                     .hostHeaderFallback(false) // turn off the default
                      .appendConnectionFilter(new HostHeaderHttpRequesterFilter("foo.bar:-1"))
                      .buildBlocking();
              ReservedBlockingHttpConnection conn = client.reserveConnection(client.get("/"))) {
@@ -173,7 +173,7 @@ class HostHeaderHttpRequesterFilterTest {
         try (ServerContext context = buildServer();
              BlockingHttpClient client = forSingleAddress(serverHostAndPort(context))
                      .protocols(httpVersionConfig.config())
-                     .disableHostHeaderFallback() // turn off the default
+                     .hostHeaderFallback(false) // turn off the default
                      .appendClientFilter(new HostHeaderHttpRequesterFilter("foo.bar:-1"))
                      .buildBlocking()) {
             assertResponse(client, "bar.only:-1", "bar.only:-1");

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
@@ -257,17 +257,6 @@ public final class HttpReporter extends Component implements Reporter<Span>, Asy
         }
 
         /**
-         * Disable batching of spans before sending them to the zipkin collector.
-         *
-         * @return {@code this}.
-         * @deprecated Use {@link #spansBatchingEnabled(boolean)}.
-         */
-        @Deprecated
-        public Builder disableSpanBatching() {
-            return spansBatchingEnabled(false);
-        }
-
-        /**
          * Configure batching of spans before sending them to the zipkin collector.
          * @param enable When {@code false} batching will be disabled.
          * @return {@code this}.


### PR DESCRIPTION
Motivation:

Previously deprecated methods in various builders have now been removed
making the API cleaner.

Modifications:

- Removed deprecated one-way builder methods from `GrpcClientBuilder`,
  `GrpcServerBuilder`, `HttpServerBuilder`,
  `SingleAddressHttpClientBuilder`, and `HttpReporter`,
- Removed the usage of these methods from code and javadocs.

Result:

Cleaner API without deprecations in the main branch.