### PR TITLE
NettyHttpServerTest.testErrorBeforeRead handle exception

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
@@ -606,7 +606,11 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
         } catch (Throwable cause) {
             // The server intentionally triggers an error when it writes, if this happens before all content is read
             // the client may fail to write the request due to premature connection closure.
-            assertThat(cause, instanceOf(ClosedChannelException.class));
+            if (cause instanceof ExecutionException) {
+                assertThat(cause.getCause(), instanceOf(IOException.class));
+            } else {
+                assertThat(cause, instanceOf(IOException.class));
+            }
         } finally {
             assertConnectionClosed();
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
@@ -584,12 +584,6 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
     void testErrorBeforeRead(ExecutorSupplier clientExecutorSupplier,
                              ExecutorSupplier serverExecutorSupplier) throws Exception {
         setUp(clientExecutorSupplier, serverExecutorSupplier);
-        // Flaky test: https://github.com/apple/servicetalk/issues/245
-        ignoreTestWhen(IMMEDIATE, IMMEDIATE);
-        ignoreTestWhen(IMMEDIATE, CACHED);
-        ignoreTestWhen(CACHED, IMMEDIATE);
-        ignoreTestWhen(CACHED, CACHED);
-
         final StreamingHttpRequest request = reqRespFactory.newRequest(GET, SVC_ERROR_BEFORE_READ).payloadBody(
             getChunkPublisherFromStrings("Goodbye", "cruel", "world!"));
 
@@ -601,7 +595,7 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
 
             final BlockingIterator<Buffer> httpPayloadChunks = response.payloadBody().toIterable().iterator();
 
-            Exception e = assertThrows(Exception.class, () -> httpPayloadChunks.next());
+            Exception e = assertThrows(Exception.class, httpPayloadChunks::next);
             assertThat(e, either(instanceOf(RuntimeException.class)).or(instanceOf(ExecutionException.class)));
             // Due to a race condition, the exception cause here can vary.
             // If the socket closure is delayed slightly
@@ -609,6 +603,10 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
             // then the client throws ClosedChannelException. However if the socket closure happens quickly enough,
             // the client throws NativeIoException (KQueue) or IOException (NIO).
             assertThat(e.getCause(), instanceOf(IOException.class));
+        } catch (Throwable cause) {
+            // The server intentionally triggers an error when it writes, if this happens before all content is read
+            // the client may fail to write the request due to premature connection closure.
+            assertThat(cause, instanceOf(ClosedChannelException.class));
         } finally {
             assertConnectionClosed();
         }


### PR DESCRIPTION
Motivation:
NettyHttpServerTest.testErrorBeforeRead has the server intentionally
write an error without first consuming the request content. The server
may close the connection before the client is done writting and if that
is the case a ClosedChannelException may be observed and fail the test.

Modifications:
- Allow ClosedChannelException when making a request

Result:
Fixes https://github.com/apple/servicetalk/issues/245