### PR TITLE
Fix javadoc warnings for JDK17

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -153,7 +153,7 @@ public abstract class GrpcServerBuilder {
 
     /**
      * Enable wire-logging for this server.
-     * <p>
+     *
      * @deprecated Use {@link #enableWireLogging(String, LogLevel, BooleanSupplier)} instead.
      * @param loggerName The name of the logger to log wire events.
      * @return {@code this}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseHttpBuilder.java
@@ -82,7 +82,7 @@ abstract class BaseHttpBuilder<ResolvedAddress> {
 
     /**
      * Enables wire-logging for connections created by this builder.
-     * <p>
+     *
      * @deprecated Use {@link #enableWireLogging(String, LogLevel, BooleanSupplier)} instead.
      * @param loggerName The name of the logger to log wire events.
      * @return {@code this}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -135,7 +135,7 @@ public abstract class HttpServerBuilder {
 
     /**
      * Enables wire-logging for this server.
-     * <p>
+     *
      * @deprecated Use {@link #enableWireLogging(String, LogLevel, BooleanSupplier)} instead.
      * @param loggerName The name of the logger to log wire events.
      * @return {@code this}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionHttpClientBuilderConfigurator.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionHttpClientBuilderConfigurator.java
@@ -20,7 +20,7 @@ import io.servicetalk.client.api.partition.PartitionAttributes;
 /**
  * If different clients used by a partitioned client created by a {@link PartitionedHttpClientBuilder} have different
  * builder configuration, this configurator helps to configure them differently.
- * <p>
+ *
  * @deprecated Use {@link PartitionedHttpClientBuilder.SingleAddressInitializer}.
  * @param <U> the type of address before resolution (unresolved address)
  * @param <R> the type of address after resolution (resolved address)


### PR DESCRIPTION
Motivation:

JDK17 warning: empty <p> tag.

Modifications:

- Remove empty `<p>` tags.

Result:

Successful JDK17 build.