### PR TITLE
Deprecate `AwaitUtils#takeUninterruptibly`

### DIFF
--- a/servicetalk-concurrent-test-internal/build.gradle
+++ b/servicetalk-concurrent-test-internal/build.gradle
@@ -19,9 +19,6 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   api project(":servicetalk-concurrent")
 
-  compileOnly 'net.jcip:jcip-annotations:1.0'
-  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.3'
-
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")

--- a/servicetalk-concurrent-test-internal/build.gradle
+++ b/servicetalk-concurrent-test-internal/build.gradle
@@ -19,6 +19,9 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   api project(":servicetalk-concurrent")
 
+  compileOnly 'net.jcip:jcip-annotations:1.0'
+  compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.3'
+
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
@@ -123,11 +123,34 @@ public final class AwaitUtils {
     }
 
     /**
-     * {@link BlockingQueue#take()} from the queue while suppressing {@link InterruptedException}s.
+     * {@link BlockingQueue#take()} from the queue or throws unchecked exception in the case
+     * of InterruptedException.
      * @param queue The queue to take from.
      * @param <T> The types of objects in the queue.
      * @return see {@link BlockingQueue#take()}.
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+            value = "NP_NONNULL_RETURN_VIOLATION",
+            justification = "return null statement is never reached"
+    )
+    public static <T> T take(BlockingQueue<T> queue) {
+        try {
+            return queue.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throwException(e);
+            return null;
+        }
+    }
+
+    /**
+     * {@link BlockingQueue#take()} from the queue while suppressing {@link InterruptedException}s.
+     * @param queue The queue to take from.
+     * @param <T> The types of objects in the queue.
+     * @return see {@link BlockingQueue#take()}.
+     * @deprecated use {@link #take(BlockingQueue)} instead.
+     */
+    @Deprecated
     public static <T> T takeUninterruptibly(BlockingQueue<T> queue) {
         boolean interrupted = false;
         try {

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
@@ -129,17 +129,16 @@ public final class AwaitUtils {
      * @param <T> The types of objects in the queue.
      * @return see {@link BlockingQueue#take()}.
      */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-            value = "NP_NONNULL_RETURN_VIOLATION",
-            justification = "return null statement is never reached"
-    )
+    @SuppressWarnings("unchecked")
     public static <T> T take(BlockingQueue<T> queue) {
         try {
             return queue.take();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throwException(e);
-            return null;
+            // Returning Object cast to type T is not necessary as the method will either return or throw exception
+            // before even reaching this statement. However, this is necessary to compile successfully.
+            return (T) new Object();
         }
     }
 

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
@@ -36,7 +36,7 @@ import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.await;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.pollUninterruptibly;
-import static io.servicetalk.concurrent.test.internal.AwaitUtils.takeUninterruptibly;
+import static io.servicetalk.concurrent.test.internal.AwaitUtils.take;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -168,7 +168,7 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
      */
     @Nullable
     public T takeOnNext() {
-        Object item = takeUninterruptibly(items);
+        Object item = take(items);
         return unwrapNull(item);
     }
 


### PR DESCRIPTION
Motivation:
The current usage of AwaitUtils catches
InterruptedException and silently discards it. jUnit5 uses
thread interrupt to stop tests after the timeout expires. As a
result, these tests may hang forever as the InterruptedException
is not propagated.

Modifications:
- Rewrite `takeUninterruptibly` to `take` in `AwaitUtils`

Result:
Deprecated `takeUninterruptibly`. `take` now throws unchecked
exception in the case when `queue.take()` throws `InterruptedException`.

The only problem here is that  I use `return null` to compile
successfully. `spotBugs` does not like that because 
I return null for a method that has `@NonNullByDefault`.

I don't understand where it is coming from since there is no
`@NonNullByDefault` for the method, could someone explain?

I tried putting `@Nullable`, but that did not fix the build, so
the workaround was to use `@SupressFBWarnings`, which is
not ideal, because it introduces new dependencies, is there a
smarter way to handle this?