### PR TITLE
Unifying `ServiceDiscoverer` and `LoadBalancerFactory` APIs

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
@@ -33,7 +33,8 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
     /**
      * Create a new {@link LoadBalancer}.
      * @param eventPublisher A stream of {@link ServiceDiscovererEvent}s which the {@link LoadBalancer} can use to
-     * connect to physical hosts. Typically generated from a {@link ServiceDiscoverer}.
+     * connect to physical hosts. Typically generated from a
+     * {@link ServiceDiscoverer#discover(Object) ServiceDiscoverer}.
      * @param connectionFactory {@link ConnectionFactory} that the returned {@link LoadBalancer} will use to generate
      * new connections. Returned {@link LoadBalancer} will own the responsibility for this {@link ConnectionFactory}
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
@@ -59,7 +60,7 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * a merged collection.
      * @param eventPublisher A stream of {@link Collection}&lt;{@link ServiceDiscovererEvent}&gt;
      * which the {@link LoadBalancer} can use to connect to physical hosts. Typically generated
-     * from a {@link ServiceDiscoverer}.
+     * from {@link ServiceDiscoverer#discover(Object) ServiceDiscoverer}.
      * @param connectionFactory {@link ConnectionFactory} that the returned {@link LoadBalancer} will use to generate
      * new connections. Returned {@link LoadBalancer} will own the responsibility for this {@link ConnectionFactory}
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
@@ -17,6 +17,10 @@ package io.servicetalk.client.api;
 
 import io.servicetalk.concurrent.api.Publisher;
 
+import java.util.Collection;
+
+import static java.util.function.Function.identity;
+
 /**
  * A factory for creating {@link LoadBalancer} instances.
  *
@@ -53,8 +57,9 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * will perform load balancing. Bear in mind, load balancing is performed over the a collection of hosts provided
      * via the {@code eventPublisher} which may not correspond directly to a single unresolved address, but potentially
      * a merged collection.
-     * @param eventPublisher A stream of {@link ServiceDiscovererEvent}s which the {@link LoadBalancer} can use to
-     * connect to physical hosts. Typically generated from a {@link ServiceDiscoverer}.
+     * @param eventPublisher A stream of {@link Collection}&lt;{@link ServiceDiscovererEvent}&gt;
+     * which the {@link LoadBalancer} can use to connect to physical hosts. Typically generated
+     * from a {@link ServiceDiscoverer}.
      * @param connectionFactory {@link ConnectionFactory} that the returned {@link LoadBalancer} will use to generate
      * new connections. Returned {@link LoadBalancer} will own the responsibility for this {@link ConnectionFactory}
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
@@ -63,8 +68,8 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      */
     default <T extends C> LoadBalancer<T> newLoadBalancer(
             String targetResource,
-            Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
+            Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-        return newLoadBalancer(eventPublisher, connectionFactory);
+        return newLoadBalancer(eventPublisher.flatMapConcatIterable(identity()), connectionFactory);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -37,6 +37,8 @@ import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.loadbalancer.RoundRobinLoadBalancer;
 import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
 
+import java.util.Collection;
+
 import static io.servicetalk.http.api.HttpExecutionStrategyInfluencer.defaultStreamingInfluencer;
 import static java.lang.Integer.MAX_VALUE;
 import static java.util.Objects.requireNonNull;
@@ -68,7 +70,7 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
     @Override
     public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
             final String targetResource,
-            final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
+            final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
         return rawFactory.newLoadBalancer(targetResource, eventPublisher, connectionFactory);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -82,7 +82,6 @@ import static java.lang.Integer.parseInt;
 import static java.time.Duration.ofSeconds;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
 
 /**
  * A builder of {@link StreamingHttpClient} instances which call a single server based on the provided address.
@@ -278,8 +277,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         // Track resources that potentially need to be closed when an exception is thrown during buildStreaming
         final CompositeCloseable closeOnException = newCompositeCloseable();
         try {
-            final Publisher<ServiceDiscovererEvent<R>> sdEvents =
-                    ctx.serviceDiscoverer(executionContext).discover(ctx.address()).flatMapConcatIterable(identity());
+            // final Publisher<ServiceDiscovererEvent<R>> sdEvents =
+            final Publisher<? extends Collection<? extends ServiceDiscovererEvent<R>>> sdEvents =
+                    ctx.serviceDiscoverer(executionContext).discover(ctx.address());
 
             ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> connectionFactoryFilter =
                     ctx.builder.connectionFactoryFilter;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -277,7 +277,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         // Track resources that potentially need to be closed when an exception is thrown during buildStreaming
         final CompositeCloseable closeOnException = newCompositeCloseable();
         try {
-            // final Publisher<ServiceDiscovererEvent<R>> sdEvents =
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<R>>> sdEvents =
                     ctx.serviceDiscoverer(executionContext).discover(ctx.address());
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -187,7 +187,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
      * @see io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory
      */
     RoundRobinLoadBalancer(
-            String targetResource,
+            final String targetResource,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
             final boolean eagerConnectionShutdown,

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -44,6 +44,8 @@ import java.time.Duration;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadLocalRandom;
@@ -164,7 +166,8 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                            final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
                            final boolean eagerConnectionShutdown,
                            @Nullable final HealthCheckConfig healthCheckConfig) {
-        this("unknown", eventPublisher, connectionFactory, eagerConnectionShutdown, healthCheckConfig);
+        this("unknown", eventPublisher.map(Collections::singletonList), connectionFactory,
+                eagerConnectionShutdown, healthCheckConfig);
     }
 
     /**
@@ -183,17 +186,19 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
      * continues being eligible for connecting on the request path).
      * @see io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory
      */
-    RoundRobinLoadBalancer(String targetResource,
-                           final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-                           final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
-                           final boolean eagerConnectionShutdown,
-                           @Nullable final HealthCheckConfig healthCheckConfig) {
+    RoundRobinLoadBalancer(
+            String targetResource,
+            final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
+            final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
+            final boolean eagerConnectionShutdown,
+            @Nullable final HealthCheckConfig healthCheckConfig) {
         this.targetResource = requireNonNull(targetResource);
         Processor<Object, Object> eventStreamProcessor = newPublisherProcessorDropHeadOnOverflow(32);
         this.eventStream = fromSource(eventStreamProcessor);
         this.connectionFactory = requireNonNull(connectionFactory);
 
-        toSource(eventPublisher).subscribe(new Subscriber<ServiceDiscovererEvent<ResolvedAddress>>() {
+        toSource(eventPublisher).subscribe(
+                new Subscriber<Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>>() {
 
             @Override
             public void onSubscribe(final Subscription s) {
@@ -206,50 +211,53 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
             }
 
             @Override
-            public void onNext(final ServiceDiscovererEvent<ResolvedAddress> event) {
-                LOGGER.debug("Load balancer {}: Received new ServiceDiscoverer event {}.",
-                        RoundRobinLoadBalancer.this, event);
+            public void onNext(final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
+                for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
+                    LOGGER.debug("Load balancer {}: Received new ServiceDiscoverer event {}.",
+                            RoundRobinLoadBalancer.this, event);
 
-                @SuppressWarnings("unchecked")
-                final List<Host<ResolvedAddress, C>> usedAddresses =
-                    usedHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, oldHosts -> {
-                        if (oldHosts == CLOSED_LIST) {
-                            return oldHosts;
-                        }
-                        final ResolvedAddress addr = requireNonNull(event.address());
-                        @SuppressWarnings("unchecked")
-                        final List<Host<ResolvedAddress, C>> oldHostsTyped = (List<Host<ResolvedAddress, C>>) oldHosts;
+                    @SuppressWarnings("unchecked")
+                    final List<Host<ResolvedAddress, C>> usedAddresses =
+                            usedHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, oldHosts -> {
+                                if (oldHosts == CLOSED_LIST) {
+                                    return oldHosts;
+                                }
+                                final ResolvedAddress addr = requireNonNull(event.address());
+                                @SuppressWarnings("unchecked")
+                                final List<Host<ResolvedAddress, C>> oldHostsTyped =
+                                        (List<Host<ResolvedAddress, C>>) oldHosts;
 
-                        if (eagerConnectionShutdown) {
-                            if (event.isAvailable()) {
-                                return addHostToList(oldHostsTyped, addr, false);
-                            } else {
-                                return listWithHostRemoved(oldHostsTyped, host -> {
-                                    boolean match = host.address.equals(addr);
-                                    if (match) {
-                                        host.markClosed();
+                                if (eagerConnectionShutdown) {
+                                    if (event.isAvailable()) {
+                                        return addHostToList(oldHostsTyped, addr, false);
+                                    } else {
+                                        return listWithHostRemoved(oldHostsTyped, host -> {
+                                            boolean match = host.address.equals(addr);
+                                            if (match) {
+                                                host.markClosed();
+                                            }
+                                            return match;
+                                        });
                                     }
-                                    return match;
-                                });
-                            }
-                        } else if (event.isAvailable()) {
-                            return addHostToList(oldHostsTyped, addr, true);
-                        } else if (oldHostsTyped.isEmpty()) {
-                            return emptyList();
-                        } else {
-                            return markHostAsExpired(oldHostsTyped, addr);
+                                } else if (event.isAvailable()) {
+                                    return addHostToList(oldHostsTyped, addr, true);
+                                } else if (oldHostsTyped.isEmpty()) {
+                                    return emptyList();
+                                } else {
+                                    return markHostAsExpired(oldHostsTyped, addr);
+                                }
+                            });
+
+                    LOGGER.debug("Load balancer {}: Now using {} addresses: {}.",
+                            RoundRobinLoadBalancer.this, usedAddresses.size(), usedAddresses);
+
+                    if (event.isAvailable()) {
+                        if (usedAddresses.size() == 1) {
+                            eventStreamProcessor.onNext(LOAD_BALANCER_READY_EVENT);
                         }
-                    });
-
-                LOGGER.debug("Load balancer {}: Now using {} addresses: {}.",
-                        RoundRobinLoadBalancer.this, usedAddresses.size(), usedAddresses);
-
-                if (event.isAvailable()) {
-                    if (usedAddresses.size() == 1) {
-                        eventStreamProcessor.onNext(LOAD_BALANCER_READY_EVENT);
+                    } else if (usedAddresses.isEmpty()) {
+                        eventStreamProcessor.onNext(LOAD_BALANCER_NOT_READY_EVENT);
                     }
-                } else if (usedAddresses.isEmpty()) {
-                    eventStreamProcessor.onNext(LOAD_BALANCER_NOT_READY_EVENT);
                 }
             }
 
@@ -512,7 +520,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
         @Override
         public <T extends C> LoadBalancer<T> newLoadBalancer(
                 final String targetResource,
-                final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
+                final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
                 final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
             return new RoundRobinLoadBalancer<>(targetResource, eventPublisher, connectionFactory,
                     EAGER_CONNECTION_SHUTDOWN_ENABLED,

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -27,6 +27,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.loadbalancer.RoundRobinLoadBalancer.HealthCheckConfig;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -88,7 +89,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
     @Override
     public <T extends C> LoadBalancer<T> newLoadBalancer(
             final String targetResource,
-            final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
+            final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
         return new RoundRobinLoadBalancer<>(
                 targetResource, eventPublisher, connectionFactory, eagerConnectionShutdown, healthCheckConfig);


### PR DESCRIPTION
Motivation:

`ServiceDiscoverer#discover` method returns a `Publisher<Collection<E>>`
while `LoadBalancerFactory#newLoadBalancer` takes `Publisher<E>` as an
argument. Those interfaces should be aligned.

Modifications:

Recently introduced `LoadBalancerFactory#newLoadBalancer` default method
now takes a `Publisher<Collection<E>>` as an argument. Implementations
in `DefaultHttpLoadBalancerFactory` and `RoundRobinLoadBalancerFactory`
implement that properly and `RoundRobinLoadBalancer` iterates over the
events.

Result:

A more aligned API that can allow acting upon a fixed collection
returned from the `ServiceDiscoverer` allowing more sophisticated usages
of the fact that these items come as one update.