### PR TITLE
Build improvements from Gradle Enterprise testing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           languages: ${{ matrix.language }}
       - name: Execute gradle build
+        with:
+          CI: true
         run: ./gradlew --parallel clean assemble
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1

--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ shadowPluginVersion=7.0.0
 jmhCoreVersion=1.33
 jmhPluginVersion=0.6.6
 
-junitPlatformVersion=1.7.2
+junitPlatformVersion=1.8.0
 junit5Version=5.8.0
 testngVersion=7.4.0
 hamcrestVersion=2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,8 @@
 #
 
 org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xms2g -Xmx4g -dsa -da -ea:io.servicetalk... -XX:+HeapDumpOnOutOfMemoryError
 
 group=io.servicetalk


### PR DESCRIPTION
I did an evaluation of the service talk build using gradle enterprise, and found a few improvements that could be made.

There are three main changes:
* Enable local build caching.  Doesn't do much for CI builds unless you set up a remote build cache, but will make repeated local builds significantly faster.
* Enable configure-on-demand.  This means gradle will only configure the projects participating in the build, rather than all of them.  With the amount of projects you have, this is a noticeable speedup, especially for short, single project tasks.  **Note that this is an incubating feature**, if you don't want that in your builds I can remove it from the PR.
* Update the specified junit platform version to 1.8.0.  This is what was being used anyways, due to transitive dependencies, but having the specified version be lower caused extraneous dependency resolve requests, adding 1-3s to just about every task (including IntelliJ sync).

I also set the CI environment variable on one of the CI workflows that was missing it, but that's just bookkeeping, I don't expect it to affect anything.