### PR TITLE
Deprecate `AwaitUtils#pollUninterruptibly`

### DIFF
--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
@@ -168,13 +168,35 @@ public final class AwaitUtils {
     }
 
     /**
-     * {@link BlockingQueue#poll(long, TimeUnit)} from the queue while suppressing {@link InterruptedException}s.
+     * {@link BlockingQueue#poll(long, TimeUnit)} from the queue, throws unchecked Exception if
+     * thread is interrupted while waiting.
      * @param queue the queue to poll from.
      * @param timeout the timeout duration to poll for.
      * @param unit the units applied to {@code timeout}.
      * @param <T> The types of objects in the queue.
      * @return see {@link BlockingQueue#poll(long, TimeUnit)}.
      */
+    @Nullable
+    public static <T> T poll(BlockingQueue<T> queue, long timeout, TimeUnit unit) {
+        try {
+            return queue.poll(timeout, NANOSECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throwException(e);
+            return null;
+        }
+    }
+
+    /**
+     * {@link BlockingQueue#poll(long, TimeUnit)} from the queue while suppressing {@link InterruptedException}s.
+     * @param queue the queue to poll from.
+     * @param timeout the timeout duration to poll for.
+     * @param unit the units applied to {@code timeout}.
+     * @param <T> The types of objects in the queue.
+     * @return see {@link BlockingQueue#poll(long, TimeUnit)}.
+     * @deprecated use {@link #poll(BlockingQueue, long, TimeUnit)} instead.
+     */
+    @Deprecated
     @Nullable
     public static <T> T pollUninterruptibly(BlockingQueue<T> queue, long timeout, TimeUnit unit) {
         final long startTime = System.nanoTime();

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
@@ -179,7 +179,7 @@ public final class AwaitUtils {
     @Nullable
     public static <T> T poll(BlockingQueue<T> queue, long timeout, TimeUnit unit) {
         try {
-            return queue.poll(timeout, NANOSECONDS);
+            return queue.poll(timeout, unit);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throwException(e);

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.await;
-import static io.servicetalk.concurrent.test.internal.AwaitUtils.pollUninterruptibly;
+import static io.servicetalk.concurrent.test.internal.AwaitUtils.poll;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.take;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -224,7 +224,7 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
      */
     @Nullable
     public Supplier<T> pollOnNext(long timeout, TimeUnit unit) {
-        Object item = pollUninterruptibly(items, timeout, unit);
+        Object item = poll(items, timeout, unit);
         return item == null ? null : () -> unwrapNull(item);
     }
 


### PR DESCRIPTION
Motivation:
The current usage of AwaitUtils catches
InterruptedException and silently discards it. jUnit5 uses
thread interrupt to stop tests after the timeout expires. As a
result, these tests may hang forever as the InterruptedException
is not propagated.

Modifications:

- introduce `AwaitUtils#poll`

Result:
`AwaitUtils#poll` now throws unchecked exception
in the case that the thread is interrupted. Meaning that
JUnit5 will be able to stop the tests by interrupting
when it timeouts.