### PR TITLE
Fix how `CI` env variable is set for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
       - name: Execute gradle build
-        with:
+        env:
           CI: true
         run: ./gradlew --parallel clean assemble
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
Motivation:

`with` is an incorrect property, `env` should be used instead.

Modifications:

- `with` -> `env`;

Result:

CodeQL workflow starts working.

---
Example: https://github.com/github/codeql-action/blob/ef3290ce11a0bf44196019ab9c650d50b69232da/.github/workflows/codeql.yml#L41-L44
Failed workflow: https://github.com/apple/servicetalk/actions/runs/1287548318