### PR TITLE
Handle `InterruptedException` in tests consistently

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
@@ -46,6 +46,7 @@ import static io.servicetalk.concurrent.api.internal.ConnectablePayloadWriterTes
 import static io.servicetalk.concurrent.api.internal.ConnectablePayloadWriterTest.toRunnable;
 import static io.servicetalk.concurrent.api.internal.ConnectablePayloadWriterTest.verifyCheckedRunnableException;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Runtime.getRuntime;
@@ -97,7 +98,10 @@ class ConnectableBufferOutputStreamTest {
             })));
             try {
                 barrier.await();
-            } catch (InterruptedException | BrokenBarrierException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throwException(e);
+            } catch (BrokenBarrierException e) {
                 throw new RuntimeException(e);
             }
         })).subscribe(subscriber);
@@ -122,7 +126,10 @@ class ConnectableBufferOutputStreamTest {
             })));
             try {
                 barrier.await();
-            } catch (InterruptedException | BrokenBarrierException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throwException(e);
+            } catch (BrokenBarrierException e) {
                 throw new RuntimeException(e);
             }
         })).subscribe(subscriber);

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Runtime.getRuntime;
@@ -93,7 +94,10 @@ class ConnectablePayloadWriterTest {
             })));
             try {
                 barrier.await();
-            } catch (InterruptedException | BrokenBarrierException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throwException(e);
+            } catch (BrokenBarrierException e) {
                 throw new RuntimeException(e);
             }
         })).subscribe(subscriber);
@@ -118,7 +122,10 @@ class ConnectablePayloadWriterTest {
             })));
             try {
                 barrier.await();
-            } catch (InterruptedException | BrokenBarrierException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throwException(e);
+            } catch (BrokenBarrierException e) {
                 throw new RuntimeException(e);
             }
         })).subscribe(subscriber);

--- a/servicetalk-concurrent-api-test/build.gradle
+++ b/servicetalk-concurrent-api-test/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-concurrent-test-internal")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/CompletableStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/CompletableStepVerifierTest.java
@@ -35,6 +35,7 @@ import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofNanos;
@@ -68,7 +69,8 @@ class CompletableStepVerifierTest {
                         try {
                             latch.await();
                         } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
+                            Thread.currentThread().interrupt();
+                            throwException(e);
                         }
                     })
                     .expectComplete()

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
@@ -40,6 +40,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofNanos;
@@ -84,7 +85,8 @@ class PublisherStepVerifierTest {
                         try {
                             latch.await();
                         } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
+                            Thread.currentThread().interrupt();
+                            throwException(e);
                         }
                     })
                     .expectNext("foo")

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/SingleStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/SingleStepVerifierTest.java
@@ -37,6 +37,7 @@ import static io.servicetalk.concurrent.api.Single.never;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofNanos;
@@ -71,7 +72,8 @@ class SingleStepVerifierTest {
                         try {
                             latch.await();
                         } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
+                            Thread.currentThread().interrupt();
+                            throwException(e);
                         }
                     })
                     .expectSuccess("foo")

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithMapper.java
@@ -71,5 +71,5 @@ public interface ScanWithMapper<T, R> {
      * {@link #mapOnError(Throwable)} nor {@link #mapOnComplete()} will be invoked and any terminal signal will be
      * passed through directly (no mapping, no additional {@link Subscriber#onNext(Object)}).
      */
-    boolean mapTerminal();
+    boolean mapTerminal() throws InterruptedException;
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractToFutureTest.java
@@ -108,6 +108,7 @@ public abstract class AbstractToFutureTest<T> {
                 latch.await();
                 completeSource();
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throwException(e);
             }
         });

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
@@ -398,7 +398,8 @@ class CompletableMergeWithPublisherTest {
             try {
                 Thread.sleep(10);
             } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+                Thread.currentThread().interrupt();
+                throwException(e);
             }
         }).whenOnComplete(latch::countDown)).subscribe(subscriber);
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
@@ -31,6 +31,7 @@ import static io.servicetalk.concurrent.api.Completable.failed;
 import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.time.Duration.ofMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.function.UnaryOperator.identity;
@@ -39,7 +40,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class PublisherBufferConcurrencyTest {
     private static final String THREAD_NAME_PREFIX = "buffer-concurrency-test";
@@ -97,7 +97,8 @@ class PublisherBufferConcurrencyTest {
                     }
                     added = integer;
                 } catch (InterruptedException e) {
-                    fail();
+                    Thread.currentThread().interrupt();
+                    throwException(e);
                 }
             }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapMergeTest.java
@@ -296,6 +296,7 @@ class PublisherFlatMapMergeTest {
                     try {
                         cancelledLatch.await();
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throwException(e);
                     }
                     subscriber1.onError(new IllegalStateException("shouldn't reach the Subscriber!"));
@@ -895,6 +896,7 @@ class PublisherFlatMapMergeTest {
                 try {
                     onNextWaitLatch.await();
                 } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     throwException(e);
                 }
             }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -251,6 +251,7 @@ class PublisherFlatMapSingleTest {
                     try {
                         cancelledLatch.await();
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throwException(e);
                     }
                     subscriber1.onError(new IllegalStateException("shouldn't reach the Subscriber!"));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ScanWithPublisherTest.java
@@ -390,13 +390,14 @@ class ScanWithPublisherTest {
                         }
 
                         @Override
-                        public boolean mapTerminal() {
+                        public boolean mapTerminal() throws InterruptedException {
                             if (interleaveCancellation) {
                                 checkpoint.countDown();
                                 try {
                                     resume.await();
                                 } catch (InterruptedException e) {
-                                    e.printStackTrace();
+                                    Thread.currentThread().interrupt();
+                                    throw e;
                                 }
                             }
                             return true;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Executors.from;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -64,7 +65,7 @@ class SchedulerOffloadTest {
                 invoker.exchange(Thread.currentThread());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new AssertionError("Exchange interrupted.");
+                throwException(e);
             }
         }, 1, TimeUnit.MILLISECONDS);
         Thread taskInvoker = invoker.exchange(Thread.currentThread());

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RunnableCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/RunnableCompletableTest.java
@@ -85,6 +85,8 @@ class RunnableCompletableTest {
                 latch.await();
             } catch (InterruptedException e) {
                 latch.countDown();
+                Thread.currentThread().interrupt();
+                throw e;
             }
             return 1;
         }).when(factory).run();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
@@ -94,6 +94,8 @@ class CallableSingleTest {
                 latch.await();
             } catch (InterruptedException e) {
                 latch.countDown();
+                Thread.currentThread().interrupt();
+                throw e;
             }
             return 1;
         });

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -41,6 +41,7 @@ import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -258,7 +259,8 @@ class SingleConcatWithPublisherTest {
                 // Simulate the a blocking operation on demand, like ConnectablePayloadWriter.
                 subscription.awaitRequestN(1);
             } catch (InterruptedException e) {
-                throw new AssertionError(e);
+                Thread.currentThread().interrupt();
+                throwException(e);
             }
             return sub1;
         });

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SupplierSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SupplierSingleTest.java
@@ -93,6 +93,8 @@ class SupplierSingleTest {
                 latch.await();
             } catch (InterruptedException e) {
                 latch.countDown();
+                Thread.currentThread().interrupt();
+                throw e;
             }
             return 1;
         });

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
@@ -233,7 +233,8 @@ class ConcurrentTerminalSubscriberTest {
                 onNextEnterBarrier.await();
                 onNextLatch.await();
             } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+                Thread.currentThread().interrupt();
+                throw e;
             }
             return null;
         }).when(mockSubscriber).onNext(any());
@@ -281,7 +282,8 @@ class ConcurrentTerminalSubscriberTest {
             try {
                 onSubscribeLatch.await();
             } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+                Thread.currentThread().interrupt();
+                throw e;
             }
             return null;
         }).when(mockSubscriber).onSubscribe(any());

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -347,7 +348,10 @@ public final class TestCompletable extends Completable implements CompletableSou
         private Subscriber waitForSubscriber() {
             try {
                 return realSubscriberSingle.toFuture().get();
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return throwException(e);
+            } catch (ExecutionException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -415,7 +416,10 @@ public final class TestPublisher<T> extends Publisher<T> implements PublisherSou
         private Subscriber<? super T> waitForSubscriber() {
             try {
                 return realSubscriberSingle.toFuture().get();
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return throwException(e);
+            } catch (ExecutionException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ConcurrentUtilsSourceRequestedTest.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ConcurrentUtilsSourceRequestedTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.calculateSourceRequested;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Math.min;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -166,7 +167,10 @@ class ConcurrentUtilsSourceRequestedTest {
             futures.add(executorService.submit(() -> {
                 try {
                     barrier.await();
-                } catch (InterruptedException | BrokenBarrierException e) {
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throwException(e);
+                } catch (BrokenBarrierException e) {
                     throw new IllegalStateException("unexpected exception", e);
                 }
                 int produced = 0;
@@ -192,7 +196,10 @@ class ConcurrentUtilsSourceRequestedTest {
                 futures.add(executorService.submit(() -> {
                     try {
                         barrier.await();
-                    } catch (InterruptedException | BrokenBarrierException e) {
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throwException(e);
+                    } catch (BrokenBarrierException e) {
                         throw new IllegalStateException("unexpected exception", e);
                     }
                     final Random random = ThreadLocalRandom.current();

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
@@ -37,6 +37,7 @@ import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.await;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.poll;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.take;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -198,6 +199,7 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
         } finally {
             if (interrupted) {
                 Thread.currentThread().interrupt();
+                throwException(new InterruptedException());
             }
         }
         return list;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RequestResponseFactories.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RequestResponseFactories.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import java.util.concurrent.ExecutionException;
 
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Thread.currentThread;
 
 final class RequestResponseFactories {
@@ -127,7 +128,7 @@ final class RequestResponseFactories {
             return requestFactory.newRequest(method, requestTarget).toRequest().toFuture().get();
         } catch (InterruptedException e) {
             currentThread().interrupt(); // Reset the interrupted flag.
-            throw new RuntimeException(e);
+            return throwException(e);
         } catch (ExecutionException e) {
             throw new RuntimeException(e);
         }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
@@ -46,10 +46,10 @@ import static io.servicetalk.http.api.StreamingHttpRequests.newRequest;
 import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
 import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Thread.currentThread;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class DefaultHttpExecutionStrategyTest {
 
@@ -161,8 +161,11 @@ class DefaultHttpExecutionStrategyTest {
                 analyzer.instrumentedResponseForServer(svc.handle(ctx, req, ctx.streamingResponseFactory()))
                         .flatMapPublisher(StreamingHttpResponse::payloadBody)
                     .toFuture().get();
-            } catch (InterruptedException | ExecutionException e) {
-                fail("Unexepected exception", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throwException(e);
+            } catch (ExecutionException e) {
+                throwException(e);
             }
         };
         if (params.offloadSend || params.offloadReceiveMeta || params.offloadReceiveData) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -81,6 +81,7 @@ import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Thread.NORM_PRIORITY;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -367,8 +368,11 @@ abstract class AbstractNettyHttpServerTest {
     static <T> T awaitSingleIndefinitelyNonNull(Single<T> single) {
         try {
             return requireNonNull(single.toFuture().get());
-        } catch (InterruptedException | ExecutionException e) {
-            throw new AssertionError(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return throwException(e);
+        } catch (ExecutionException e) {
+            return throwException(e);
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -189,8 +189,10 @@ final class ConnectionCloseHeaderHandlingTest {
                                     try {
                                         responseReceived.await();
                                         done = true;
-                                    } catch (InterruptedException interruptedException) {
+                                    } catch (InterruptedException e) {
                                         // ignored
+                                        Thread.currentThread().interrupt();
+                                        throw e;
                                     }
                                 } while (!done);
                             }
@@ -302,6 +304,7 @@ final class ConnectionCloseHeaderHandlingTest {
                     try {
                         responseReceived.await();
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throwException(e);
                     }
                 }).concat(from(content)), RAW_STRING_SERIALIZER);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyForClientApiTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyForClientApiTest.java
@@ -44,6 +44,7 @@ import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -69,7 +70,8 @@ class FlushStrategyForClientApiTest extends AbstractNettyHttpServerTest {
                 try {
                     payloadBuffersReceived.put(buffer);
                 } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                    Thread.currentThread().interrupt();
+                    throwException(e);
                 }
             });
             return Single.succeeded(responseFactory.ok());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -522,6 +522,7 @@ class GracefulConnectionClosureHandlingTest {
                     try {
                         payloadBodyLatch.await();
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throwException(e);
                     }
                 }).concat(from(REQUEST_CONTENT)), RAW_STRING_SERIALIZER);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
@@ -55,6 +55,7 @@ import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupp
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
@@ -165,7 +166,8 @@ class H2ResponseCancelTest extends AbstractNettyHttpServerTest {
                         secondRequestReceivedLatch.await();
                         cancellable.get().cancel(); // If I use thenCancel() the current then(Runnable) does not run
                     } catch (InterruptedException e) {
-                        // ignore
+                        Thread.currentThread().interrupt();
+                        throwException(e);
                     }
                 })
                 // FIXME: use thenCancel() after await() instead of cancelling from inside then(...) + expectError()

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -114,7 +114,8 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
                 try {
                     processRequest.await();
                 } catch (InterruptedException e) {
-                    return throwException(e);
+                    Thread.currentThread().interrupt();
+                    throwException(e);
                 }
                 return delegate().handle(ctx, request, responseFactory);
             }
@@ -333,7 +334,8 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
                             try {
                                 requestReceived.await();
                             } catch (InterruptedException interruptedException) {
-                                return throwException(interruptedException);
+                                Thread.currentThread().interrupt();
+                                throwException(interruptedException);
                             }
                             return failed(DELIBERATE_EXCEPTION);
                         }))));

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporterTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporterTest.java
@@ -48,6 +48,7 @@ import static io.servicetalk.opentracing.zipkin.publisher.reporter.SpanUtils.new
 import static io.servicetalk.opentracing.zipkin.publisher.reporter.SpanUtils.verifySpan;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -170,7 +171,10 @@ class HttpReporterTest {
         responseGenerator = (httpServiceContext, factory) -> {
             try {
                 httpServiceContext.closeAsync().toFuture().get();
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throwException(e);
+            } catch (ExecutionException e) {
                 throw new RuntimeException(e);
             }
             return factory.ok();


### PR DESCRIPTION
Motivation:
There are some test files where thread's interrupted
flag is not reset after InterruptedException is caught,
as well as where InterruptedException is being wrapped
into RuntimeException, which JUnit5 may not recognize,
when stopping the tests after a timeout.

This does not concern any non-test files.

Modifications:

- Use `Thread.currentThread().interrupt();` where it was forgotten
- Use unchecked exception with `throwException` instead of `RuntimeException`
- Where possibly simply rethrow the caught exception.

Result:
That did not work out as nicely as expected. Some tests are failing
locally, which I am still trying to figure out how to fix.

some questions:
- how to handle this in HttpOffloadingTest.java:345?
I don't really see how the errors in the errors queue are handled, 
so had no idea if there is anything I could fix here.

- Is it okay how I handle InterruptedException in `TestPublisherSubscriber#takeOnNext(int n)`?
as I understand if the exception was thrown we should propagate it at
some point, but wouldn't that break the current method?

That's about it, if I forgot something I will add it as a comment
to the PR.