### PR TITLE
Clean up deprecated API after changes for redirects in #1792

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -83,19 +83,6 @@ public interface MultiAddressHttpClientBuilder<U, R> extends HttpClientBuilder<U
     MultiAddressHttpClientBuilder<U, R> initializer(SingleAddressInitializer<U, R> initializer);
 
     /**
-     * Sets a maximum number of redirects to follow.
-     *
-     * @param maxRedirects A maximum number of redirects to follow. {@code 0} disables redirects.
-     * @return {@code this}.
-     * @deprecated Use {@link #followRedirects(RedirectConfig)} with {@link RedirectConfigBuilder#maxRedirects(int)}.
-     */
-    @Deprecated
-    default MultiAddressHttpClientBuilder<U, R> maxRedirects(int maxRedirects) {
-        return followRedirects(new RedirectConfigBuilder().maxRedirects(maxRedirects)
-                .allowNonRelativeRedirects(true).build());
-    }
-
-    /**
      * Enables <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4">redirection</a>.
      * <p>
      * Note: For backward compatibility with 0.41.x versions redirects are enabled by default. Starting from version
@@ -107,8 +94,5 @@ public interface MultiAddressHttpClientBuilder<U, R> extends HttpClientBuilder<U
      * @return {@code this}.
      * @see RedirectConfigBuilder
      */
-    default MultiAddressHttpClientBuilder<U, R> followRedirects(RedirectConfig config) {
-        throw new UnsupportedOperationException("followRedirects(RedirectConfig) not yet supported by " +
-                getClass().getName());
-    }
+    MultiAddressHttpClientBuilder<U, R> followRedirects(RedirectConfig config);
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -32,7 +32,6 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.MultiAddressHttpClientBuilder;
 import io.servicetalk.http.api.RedirectConfig;
-import io.servicetalk.http.api.RedirectConfigBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
@@ -73,13 +72,11 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         implements MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> {
 
     private static final String HTTPS_SCHEME = HTTPS.toString();
-    private static final RedirectConfig DEFAULT_REDIRECT_CONFIG = new RedirectConfigBuilder()
-            .allowNonRelativeRedirects(true).build();   // FIXME: remove for 0.42 branch to make redirects opt-in
 
     private final DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builderTemplate;
 
     @Nullable
-    private RedirectConfig redirectConfig = DEFAULT_REDIRECT_CONFIG;
+    private RedirectConfig redirectConfig;
     @Nullable
     private Function<HostAndPort, CharSequence> unresolvedAddressToHostFunction;
     @Nullable


### PR DESCRIPTION
Motivation:

#1792 introduced new API for configuring redirects and deprecated old
`RedirectingHttpRequesterFilter` ctors and
`MultiAddressHttpClientBuilder#maxRedirects`. We can remove all
deprecated API for 0.42.

Modifications:

- Remove deprecated ctors for `RedirectingHttpRequesterFilter`;
- Remove `BackwardCompatibleRedirectConfig`;
- Remove `MultiAddressHttpClientBuilder#maxRedirects` method;
- Remove default impl of `MultiAddressHttpClientBuilder#followRedirects`;
- Make redirects opt-in for multi-address client;

Result:

No deprecated API for redirects.