### PR TITLE
Rename default logger name for LifecycleObserver(s)

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
@@ -87,7 +87,7 @@ class GrpcLifecycleObserverTest {
             ExecutionContextExtension.cached("client-io", "client-executor");
 
     private static final String CONTENT = "content";
-    private static final GrpcLifecycleObserver LOGGING = logging("servicetalk-tests-http-lifecycle-logger", TRACE);
+    private static final GrpcLifecycleObserver LOGGING = logging("servicetalk-tests-lifecycle-observer-logger", TRACE);
 
     // To avoid flaky behavior await for both exchanges to terminate before starting verification:
     private final CountDownLatch bothTerminate = new CountDownLatch(2);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpLifecycleObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpLifecycleObserverTest.java
@@ -87,7 +87,7 @@ import static org.mockito.Mockito.when;
 class HttpLifecycleObserverTest extends AbstractNettyHttpServerTest {
 
     private static final Buffer CONTENT = DEFAULT_RO_ALLOCATOR.fromAscii("content");
-    private static final HttpLifecycleObserver LOGGING = logging("servicetalk-tests-http-lifecycle-logger", TRACE);
+    private static final HttpLifecycleObserver LOGGING = logging("servicetalk-tests-lifecycle-observer-logger", TRACE);
 
     // To avoid flaky behavior await for both exchanges to terminate before starting verification:
     private final CountDownLatch bothTerminate = new CountDownLatch(2);

--- a/servicetalk-test-resources/src/main/resources/log4j2.xml
+++ b/servicetalk-test-resources/src/main/resources/log4j2.xml
@@ -19,7 +19,7 @@
     <Property name="rootLevel">${sys:servicetalk.logger.rootLevel:-INFO}</Property>
     <Property name="wireLogLevel">${sys:servicetalk.logger.wireLogLevel:-OFF}</Property>
     <Property name="h2FrameLogLevel">${sys:servicetalk.logger.h2FrameLogLevel:-OFF}</Property>
-    <Property name="httpLifecycleLogger">${sys:servicetalk.logger.httpLifecycleLogger:-OFF}</Property>
+    <Property name="lifecycleObserverLogLevel">${sys:servicetalk.logger.lifecycleObserverLogLevel:-OFF}</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
@@ -29,7 +29,7 @@
   <Loggers>
     <Logger name="servicetalk-tests-wire-logger" level="${wireLogLevel}"/>
     <Logger name="servicetalk-tests-h2-frame-logger" level="${h2FrameLogLevel}"/>
-    <Logger name="servicetalk-tests-http-lifecycle-logger" level="${httpLifecycleLogger}"/>
+    <Logger name="servicetalk-tests-lifecycle-observer-logger" level="${lifecycleObserverLogLevel}"/>
     <Root level="${rootLevel}">
       <AppenderRef ref="Console"/>
     </Root>


### PR DESCRIPTION
Motivation:

We recently added a new logger name in `servicetalk-test-resources`
for debugging LifecycleObserver tests, but it has inconsistent system
property name and mentions HTTP protocol in the name, while it is used
for gRPC as well.

Modifications:

- Rename system property `servicetalk.logger.httpLifecycleLogger` ->
`servicetalk.logger.lifecycleObserverLogLevel`;
- Rename logger `servicetalk-tests-http-lifecycle-logger` ->
`servicetalk-tests-lifecycle-observer-logger`;

Result:

Consistency with other test loggers.