### PR TITLE
Removing default implementations from `HttpClientBuilder`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -37,9 +37,6 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toConditionalClientFilterFactory;
-import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toConditionalConnectionFilterFactory;
-
 /**
  * A builder of {@link StreamingHttpClient} instances which call a single server based on the provided unresolved
  * address.
@@ -166,10 +163,8 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * purpose of filtering.
      * @return {@code this}
      */
-    default SingleAddressHttpClientBuilder<U, R> appendConnectionFilter(
-            Predicate<StreamingHttpRequest> predicate, StreamingHttpConnectionFilterFactory factory) {
-        return appendConnectionFilter(toConditionalConnectionFilterFactory(predicate, factory));
-    }
+    SingleAddressHttpClientBuilder<U, R> appendConnectionFilter(
+            Predicate<StreamingHttpRequest> predicate, StreamingHttpConnectionFilterFactory factory);
 
     @Override
     SingleAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
@@ -249,10 +244,8 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * filtering.
      * @return {@code this}
      */
-    default SingleAddressHttpClientBuilder<U, R> appendClientFilter(Predicate<StreamingHttpRequest> predicate,
-                                                                    StreamingHttpClientFilterFactory factory) {
-        return appendClientFilter(toConditionalClientFilterFactory(predicate, factory));
-    }
+    SingleAddressHttpClientBuilder<U, R> appendClientFilter(Predicate<StreamingHttpRequest> predicate,
+                                                                    StreamingHttpClientFilterFactory factory);
 
     /**
      * Provides a means to convert {@link U} unresolved address type into a {@link CharSequence}.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConditionalHttpClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConditionalHttpClientFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.api;
+package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
 
 import java.util.function.Predicate;
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConditionalHttpConnectionFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConditionalHttpConnectionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.api;
+package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
 
 import java.util.function.Predicate;
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -70,6 +70,7 @@ import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static io.servicetalk.http.api.HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
+import static io.servicetalk.http.netty.StrategyInfluencerAwareConversions.toConditionalServiceFilterFactory;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
 import static java.util.Objects.requireNonNull;
 
@@ -131,32 +132,6 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
             throw new IllegalArgumentException(desc + " required offloading : " + requires);
         }
         return obj;
-    }
-
-    private static StreamingHttpServiceFilterFactory toConditionalServiceFilterFactory(
-            final Predicate<StreamingHttpRequest> predicate, final StreamingHttpServiceFilterFactory original) {
-        requireNonNull(predicate);
-        requireNonNull(original);
-
-        if (original instanceof HttpExecutionStrategyInfluencer) {
-            HttpExecutionStrategyInfluencer influencer = (HttpExecutionStrategyInfluencer) original;
-            return new StrategyInfluencingStreamingServiceFilterFactory() {
-                @Override
-                public StreamingHttpServiceFilter create(final StreamingHttpService service) {
-                    return new ConditionalHttpServiceFilter(predicate, original.create(service), service);
-                }
-
-                @Override
-                public HttpExecutionStrategy influenceStrategy(final HttpExecutionStrategy strategy) {
-                    return influencer.influenceStrategy(strategy);
-                }
-            };
-        }
-        return service -> new ConditionalHttpServiceFilter(predicate, original.create(service), service);
-    }
-
-    private interface StrategyInfluencingStreamingServiceFilterFactory
-            extends StreamingHttpServiceFilterFactory, HttpExecutionStrategyInfluencer {
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -48,6 +48,7 @@ import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ClientSslConfig;
@@ -63,6 +64,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import static io.netty.util.NetUtil.toSocketAddressString;
@@ -76,6 +78,8 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_2;
 import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
 import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalSrvDnsServiceDiscoverer;
+import static io.servicetalk.http.netty.StrategyInfluencerAwareConversions.toConditionalClientFilterFactory;
+import static io.servicetalk.http.netty.StrategyInfluencerAwareConversions.toConditionalConnectionFilterFactory;
 import static java.lang.Integer.parseInt;
 import static java.time.Duration.ofSeconds;
 import static java.util.Collections.singletonList;
@@ -453,6 +457,12 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         return this;
     }
 
+    @Override
+    public SingleAddressHttpClientBuilder<U, R> appendConnectionFilter(
+            final Predicate<StreamingHttpRequest> predicate, final StreamingHttpConnectionFilterFactory factory) {
+        return appendConnectionFilter(toConditionalConnectionFilterFactory(predicate, factory));
+    }
+
     // Use another method to keep final references and avoid StackOverflowError
     private static StreamingHttpConnectionFilterFactory appendConnectionFilter(
             @Nullable final StreamingHttpConnectionFilterFactory current,
@@ -493,6 +503,12 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         autoRetry = autoRetryStrategyProvider == DISABLE_AUTO_RETRIES ? null :
                 requireNonNull(autoRetryStrategyProvider);
         return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientBuilder<U, R> appendClientFilter(final Predicate<StreamingHttpRequest> predicate,
+                                                                   final StreamingHttpClientFilterFactory factory) {
+        return appendClientFilter(toConditionalClientFilterFactory(predicate, factory));
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractConditionalHttpFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractConditionalHttpFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.api;
+package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.SingleSource;
@@ -22,6 +22,15 @@ import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.AsyncContextMap;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.DefaultHttpExecutionContext;
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import org.junit.jupiter.api.Test;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConditionalHttpClientFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConditionalHttpClientFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.api;
+package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.TestStreamingHttpClient;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConditionalHttpConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConditionalHttpConnectionFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.api;
+package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpConnectionContext;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.TestStreamingHttpConnection;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConditionalHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConditionalHttpServiceFilterTest.java
@@ -19,7 +19,6 @@ import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.http.api.AbstractConditionalHttpFilterTest;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
@@ -17,12 +17,11 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.AbstractHttpRequesterFilterTest;
 import io.servicetalk.http.api.BlockingHttpRequester;
-import io.servicetalk.http.api.ConditionalFilterFactory;
-import io.servicetalk.http.api.ConditionalFilterFactory.FilterFactory;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpConnection;
 import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.netty.ConditionalFilterFactory.FilterFactory;
 import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
 import io.servicetalk.transport.api.HostAndPort;
 

--- a/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/ConditionalFilterFactory.java
+++ b/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/ConditionalFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.api;
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
 
 import java.util.function.Predicate;
 
-import static io.servicetalk.http.api.FilterFactoryUtils.appendClientFilterFactory;
-import static io.servicetalk.http.api.FilterFactoryUtils.appendConnectionFilterFactory;
+import static java.util.Objects.requireNonNull;
 
 public final class ConditionalFilterFactory
         implements StreamingHttpConnectionFilterFactory, StreamingHttpClientFilterFactory {
@@ -73,5 +80,19 @@ public final class ConditionalFilterFactory
                 }
             };
         }
+    }
+
+    private static StreamingHttpConnectionFilterFactory appendConnectionFilterFactory(
+            StreamingHttpConnectionFilterFactory first, StreamingHttpConnectionFilterFactory second) {
+        requireNonNull(first);
+        requireNonNull(second);
+        return connection -> first.create(second.create(connection));
+    }
+
+    private static StreamingHttpClientFilterFactory appendClientFilterFactory(
+            StreamingHttpClientFilterFactory first, StreamingHttpClientFilterFactory second) {
+        requireNonNull(first);
+        requireNonNull(second);
+        return client -> first.create(second.create(client));
     }
 }


### PR DESCRIPTION
Motivation:

In order to unify the way methods in `HttpClientBuilder`
and `HttpServerBuilder` are implemented, the default methods from
`HttpClientBuilder` have been removed and implemented in
`SingleAddressHttpClientBuilder`.

Modifications:

- Removed default methods from `HttpClientBuilder`,
- Added implementations to `SingleAddressHttpClientBuilder`,
- Moved utilities to servicetalk-http-netty package,
- Moved tests around,
- Copied methods from `FilterFactoryUtils` to `ConditionalFilterFactory`
  as they are inaccessible from the netty module's testFixtures
  directory.

Result:

The API is consistent with the `HttpServerBuilder`.