### PR TITLE
`RoundRobinLoadBalancer`: further logging enhancements

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -28,6 +28,7 @@ import io.servicetalk.loadbalancer.RoundRobinLoadBalancer.HealthCheckConfig;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -63,6 +64,7 @@ import static java.util.Objects.requireNonNull;
 public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConnection>
         implements LoadBalancerFactory<ResolvedAddress, C> {
 
+    static final AtomicInteger FACTORY_COUNT = new AtomicInteger();
     static final boolean EAGER_CONNECTION_SHUTDOWN_ENABLED = true;
     static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = Duration.ofSeconds(1);
     static final int DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD = 5; // higher than default for AutoRetryStrategy
@@ -91,8 +93,8 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
             final String targetResource,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-        return new RoundRobinLoadBalancer<>(
-                targetResource, eventPublisher, connectionFactory, eagerConnectionShutdown, healthCheckConfig);
+        return new RoundRobinLoadBalancer<>(requireNonNull(targetResource) + '#' + FACTORY_COUNT.incrementAndGet(),
+                eventPublisher, connectionFactory, eagerConnectionShutdown, healthCheckConfig);
     }
 
     /**


### PR DESCRIPTION
Motivation:

There are still a few gaps in RRLB logging.

Modifications:

- Add a counter for `targetResource` to distinguish different clients
for the same target host;
- Enhance `RoundRobinLoadBalancer#toString()` to include all hosts;
- Use consistent "Load balancer for" pattern for all log events;
- Avoid double logging when health check passes (it also logs that it
cancelled);
- Log the full `host` state when health check is cancelled to let us
know its new state;
- Log connection id if we close a new connection when health check
finishes;
- Log if the health check terminated with an unexpected error;
- Fix order of log arguments when we observe connect failure;

Result:

Better visibility into RRLB execution.