### PR TITLE
Update Jackson 2.12.5 -> 2.13

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,8 +40,8 @@ jerseyVersion=2.34
 
 reactiveStreamsVersion=1.0.3
 jcToolsVersion=3.3.0
-# backward compatible with jackson 2.9+, we do not depend on any new features from later versions:
 jacksonVersion=2.13.0
+# backward compatible with jackson 2.9+, we do not depend on any new features from later versions.
 
 openTracingVersion=0.33.0
 zipkinReporterVersion=2.16.3


### PR DESCRIPTION
This is only for the main branch, no plans to cherry-pick into 0.41.