### PR TITLE
Remove enforcedPlatform from test fixtures

### DIFF
--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -18,7 +18,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-concurrent")
 

--- a/servicetalk-concurrent-internal/build.gradle
+++ b/servicetalk-concurrent-internal/build.gradle
@@ -18,7 +18,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-concurrent")
 

--- a/servicetalk-http-api/build.gradle
+++ b/servicetalk-http-api/build.gradle
@@ -18,7 +18,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-buffer-api")
   api project(":servicetalk-client-api")

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -18,9 +18,9 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   implementation platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
-  testFixturesImplementation enforcedPlatform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
+  testFixturesImplementation platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-http-api")
   api project(":servicetalk-router-api")

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -19,7 +19,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   testImplementation enforcedPlatform("io.netty:netty-bom:$nettyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-client-api")
   api project(":servicetalk-logging-api")

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -19,7 +19,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   api platform("io.netty:netty-bom:$nettyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-buffer-netty")
   api project(":servicetalk-concurrent-api")


### PR DESCRIPTION
Motivation:
In #1827 `enforcedPlatform` was used for importing several BOM files
related to tests. For the modules which publish artifacts to be used by
other modules the use of `enforcedPlatform` is incorrect and Maven
Java publish tasks fail.
Modifications:
All `testFixtures` imports of BOM files use `platform` rather than
`enforcedPlatform`. For dependencies for test execution
`enforcedPlatform` is still appropriate and continues to be used.
Result:
Maven publish tasks succeed.