### PR TITLE
(cherry-pick) Untangling `GrpcClientBuilder` from `SingleAddressHttpClientBuilder` (#1867)

### DIFF
--- a/servicetalk-examples/grpc/observer/src/main/java/io/servicetalk/examples/grpc/observer/LifecycleObserverClient.java
+++ b/servicetalk-examples/grpc/observer/src/main/java/io/servicetalk/examples/grpc/observer/LifecycleObserverClient.java
@@ -34,8 +34,8 @@ public final class LifecycleObserverClient {
         try (BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)
                 // Append this filter first for most cases to maximize visibility!
                 // See javadocs on GrpcLifecycleObserverRequesterFilter for more details on filter ordering.
-                .appendHttpClientFilter(new GrpcLifecycleObserverRequesterFilter(
-                        GrpcLifecycleObservers.logging("servicetalk-examples-grpc-observer-logger", TRACE)))
+                .initializeHttp(builder -> builder.appendClientFilter(new GrpcLifecycleObserverRequesterFilter(
+                        GrpcLifecycleObservers.logging("servicetalk-examples-grpc-observer-logger", TRACE))))
                 .buildBlocking(new ClientFactory())) {
             client.sayHello(HelloRequest.newBuilder().setName("LifecycleObserver").build());
             // Ignore the response for this example. See logs for GrpcLifecycleObserver results.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcLifecycleObserver.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcLifecycleObserver.java
@@ -33,9 +33,10 @@ import io.servicetalk.transport.api.IoExecutor;
  * offload publications to another {@link Executor} <b>after</b> capturing timing of events. If blocking code is
  * executed inside callbacks without offloading, it will negatively impact {@link IoExecutor}.
  * <p>
- * To install this observer for the server use {@link GrpcServerBuilder#lifecycleObserver(GrpcLifecycleObserver)}, for
- * the client use {@link GrpcClientBuilder#appendHttpClientFilter(StreamingHttpClientFilterFactory)} with
- * {@code io.servicetalk.grpc.netty.GrpcLifecycleObserverRequesterFilter}.
+ * To install this observer for the server use {@link GrpcServerBuilder#lifecycleObserver(GrpcLifecycleObserver)}.
+ * For the client use {@code io.servicetalk.grpc.netty.GrpcLifecycleObserverRequesterFilter} as argument to
+ * {@link io.servicetalk.http.api.SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)}
+ * which can be configured using {@link GrpcClientBuilder#initializeHttp(GrpcClientBuilder.HttpInitializer)}.
  */
 @FunctionalInterface
 public interface GrpcLifecycleObserver extends HttpLifecycleObserver {

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
@@ -45,7 +45,7 @@ public final class GrpcClients {
      * @return new builder for the address
      */
     public static GrpcClientBuilder<HostAndPort, InetSocketAddress> forAddress(final String host, final int port) {
-        return new DefaultGrpcClientBuilder<>(HttpClients.forSingleAddress(host, port));
+        return new DefaultGrpcClientBuilder<>(() -> HttpClients.forSingleAddress(host, port));
     }
 
     /**
@@ -57,7 +57,7 @@ public final class GrpcClients {
      * @return new builder for the address
      */
     public static GrpcClientBuilder<HostAndPort, InetSocketAddress> forAddress(final HostAndPort address) {
-        return new DefaultGrpcClientBuilder<>(HttpClients.forSingleAddress(address));
+        return new DefaultGrpcClientBuilder<>(() -> HttpClients.forSingleAddress(address));
     }
 
     /**
@@ -68,7 +68,7 @@ public final class GrpcClients {
      * @return new builder for the address
      */
     public static GrpcClientBuilder<String, InetSocketAddress> forServiceAddress(final String serviceName) {
-        return new DefaultGrpcClientBuilder<>(HttpClients.forServiceAddress(serviceName));
+        return new DefaultGrpcClientBuilder<>(() -> HttpClients.forServiceAddress(serviceName));
     }
 
     /**
@@ -80,7 +80,7 @@ public final class GrpcClients {
      */
     public static GrpcClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddress(final String host,
                                                                                        final int port) {
-        return new DefaultGrpcClientBuilder<>(HttpClients.forResolvedAddress(host, port));
+        return new DefaultGrpcClientBuilder<>(() -> HttpClients.forResolvedAddress(host, port));
     }
 
     /**
@@ -90,7 +90,7 @@ public final class GrpcClients {
      * @return new builder for the address
      */
     public static GrpcClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddress(final HostAndPort address) {
-        return new DefaultGrpcClientBuilder<>(HttpClients.forResolvedAddress(address));
+        return new DefaultGrpcClientBuilder<>(() -> HttpClients.forResolvedAddress(address));
     }
 
     /**
@@ -101,21 +101,24 @@ public final class GrpcClients {
      */
     public static GrpcClientBuilder<InetSocketAddress, InetSocketAddress> forResolvedAddress(
             final InetSocketAddress address) {
-        return new DefaultGrpcClientBuilder<>(HttpClients.forResolvedAddress(address));
+        return new DefaultGrpcClientBuilder<>(() -> HttpClients.forResolvedAddress(address));
     }
 
     /**
      * Creates a {@link GrpcClientBuilder} for an address with default {@link LoadBalancer}.
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
-     * {@link HttpHeaderNames#HOST}. Use {@link GrpcClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link GrpcClientBuilder#hostHeaderFallback(boolean)} if you
-     * want to disable this behavior.
+     * {@link HttpHeaderNames#HOST}.
+     * Use {@link io.servicetalk.http.api.SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
+     * via {@link GrpcClientBuilder#initializeHttp(GrpcClientBuilder.HttpInitializer)}
+     * if you want to override that value or
+     * {@link io.servicetalk.http.api.SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)}
+     * if you want to disable this behavior.
      * @param <T> The type of {@link SocketAddress}.
      * @return new builder for the address
      */
     public static <T extends SocketAddress> GrpcClientBuilder<T, T> forResolvedAddress(final T address) {
-        return new DefaultGrpcClientBuilder<>(HttpClients.forResolvedAddress(address));
+        return new DefaultGrpcClientBuilder<>(() -> HttpClients.forResolvedAddress(address));
     }
 
     /**
@@ -132,6 +135,6 @@ public final class GrpcClients {
     public static <U, R>
     GrpcClientBuilder<U, R> forAddress(final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer,
                                        final U address) {
-        return new DefaultGrpcClientBuilder<>(HttpClients.forSingleAddress(serviceDiscoverer, address));
+        return new DefaultGrpcClientBuilder<>(() -> HttpClients.forSingleAddress(serviceDiscoverer, address));
     }
 }

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverRequesterFilter.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverRequesterFilter.java
@@ -18,6 +18,7 @@ package io.servicetalk.grpc.netty;
 import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.grpc.api.GrpcClientBuilder;
 import io.servicetalk.grpc.api.GrpcLifecycleObserver;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.netty.HttpLifecycleObserverRequesterFilter;
@@ -28,13 +29,14 @@ import io.servicetalk.http.utils.RetryingHttpRequesterFilter;
  * An HTTP requester filter that tracks events during gRPC request/response lifecycle.
  * <p>
  * This filter is recommended to be appended as the first filter at the
- * {@link GrpcClientBuilder#appendHttpClientFilter(StreamingHttpClientFilterFactory) client builder} to account
- * for all work done by other filters. If it's preferred to get visibility in all retried or redirected requests,
- * consider adding it after {@link RetryingHttpRequesterFilter} or {@link RedirectingHttpRequesterFilter}.
+ * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory) client builder}
+ * (which can be configured using {@link GrpcClientBuilder#initializeHttp(GrpcClientBuilder.HttpInitializer)})
+ * to account for all work done by other filters. If it's preferred to get visibility in all retried or redirected
+ * requests, consider adding it after {@link RetryingHttpRequesterFilter} or {@link RedirectingHttpRequesterFilter}.
  * Alternatively, it can be applied as the first filter at
- * {@link GrpcClientBuilder#appendConnectionFilter(StreamingHttpConnectionFilterFactory) connection level}
+ * {@link SingleAddressHttpClientBuilder#appendConnectionFilter(StreamingHttpConnectionFilterFactory) connection level}
  * to also get visibility into
- * {@link GrpcClientBuilder#autoRetryStrategy(AutoRetryStrategyProvider) automatic retries}.
+ * {@link SingleAddressHttpClientBuilder#autoRetryStrategy(AutoRetryStrategyProvider) automatic retries}.
  */
 public final class GrpcLifecycleObserverRequesterFilter extends HttpLifecycleObserverRequesterFilter {
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
@@ -265,9 +265,12 @@ class ErrorHandlingTest {
         this.requestPublisher = requestPublisher;
         serverContext = GrpcServers.forAddress(localAddress(0)).appendHttpServiceFilter(serviceFilterFactory)
                 .executionStrategy(serverStrategy).listenAndAwait(serviceFactory);
+        final StreamingHttpClientFilterFactory pickedClientFilterFactory = clientFilterFactory;
         GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                GrpcClients.forAddress(serverHostAndPort(serverContext)).appendHttpClientFilter(clientFilterFactory)
-                .executionStrategy(clientStrategy);
+                GrpcClients.forAddress(serverHostAndPort(serverContext))
+                        .initializeHttp(builder -> builder
+                                .appendClientFilter(pickedClientFilterFactory)
+                                .executionStrategy(clientStrategy));
         client = clientBuilder.build(new ClientFactory());
         blockingClient = clientBuilder.buildBlocking(new ClientFactory());
     }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
@@ -29,6 +29,7 @@ import io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
 import io.servicetalk.grpc.netty.TesterProto.Tester.ServiceFactory;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterServiceFilter;
+import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.router.api.RouteExecutionStrategyFactory;
 import io.servicetalk.transport.api.ServerContext;
 
@@ -302,7 +303,7 @@ class ExecutionStrategyTest {
         filterConfiguration.appendServiceFilter(serviceFactory);
         serverContext = builder.listenAndAwait(serviceFactory);
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .executionStrategy(noOffloadsStrategy())
+                .initializeHttp(b -> b.executionStrategy(HttpExecutionStrategies.noOffloadsStrategy()))
                 .buildBlocking(new ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientRequiresTrailersTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientRequiresTrailersTest.java
@@ -94,7 +94,7 @@ class GrpcClientRequiresTrailersTest {
                 serverBuilder.listenAndAwait(toHttpService(streamingService));
 
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .executionStrategy(noOffloadsStrategy())
+                .initializeHttp(builder -> builder.executionStrategy(noOffloadsStrategy()))
                 .buildBlocking(new TesterProto.Tester.ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientValidatesContentTypeTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientValidatesContentTypeTest.java
@@ -138,7 +138,7 @@ final class GrpcClientValidatesContentTypeTest {
                 serverBuilder.listenAndAwait(toHttpService(streamingService));
 
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .executionStrategy(noOffloadsStrategy())
+                .initializeHttp(builder -> builder.executionStrategy(noOffloadsStrategy()))
                 .buildBlocking(new TesterProto.Tester.ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
@@ -149,12 +149,14 @@ class GrpcLifecycleObserverTest {
                 .listenAndAwait(new EchoService(error));
 
         client = GrpcClients.forAddress(serverHostAndPort(server))
-                .ioExecutor(CLIENT_CTX.ioExecutor())
-                .executor(CLIENT_CTX.executor())
-                .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true)
-                .protocols(h2().enableFrameLogging("servicetalk-tests-h2-frame-logger", TRACE, () -> true).build())
-                .appendHttpClientFilter(
-                        new GrpcLifecycleObserverRequesterFilter(combine(clientLifecycleObserver, LOGGING)))
+                .initializeHttp(builder ->
+                    builder.ioExecutor(CLIENT_CTX.ioExecutor())
+                            .executor(CLIENT_CTX.executor())
+                            .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true)
+                            .protocols(h2().enableFrameLogging("servicetalk-tests-h2-frame-logger",
+                                    TRACE, () -> true).build())
+                            .appendClientFilter(new GrpcLifecycleObserverRequesterFilter(
+                                    combine(clientLifecycleObserver, LOGGING))))
                 .buildBlocking(new ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceContextProtocolTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceContextProtocolTest.java
@@ -73,7 +73,7 @@ class GrpcServiceContextProtocolTest {
                         new ServiceFactory(new BlockingTesterServiceImpl()));
 
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .protocols(protocolConfig(httpProtocol))
+                .initializeHttp(builder -> builder.protocols(protocolConfig(httpProtocol)))
                 .buildBlocking(new ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
@@ -94,14 +94,17 @@ class KeepAliveTest {
         }
         ctx = serverBuilder.listenAndAwait(new ServiceFactory(new InfiniteStreamsService()));
         GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-            GrpcClients.forAddress(serverHostAndPort(ctx))
-                .ioExecutor(CLIENT_CTX.ioExecutor())
-                .executionStrategy(defaultStrategy(CLIENT_CTX.executor()));
+                GrpcClients.forAddress(serverHostAndPort(ctx))
+                        .initializeHttp(builder ->
+                                builder.executor(CLIENT_CTX.executor())
+                                        .ioExecutor(CLIENT_CTX.ioExecutor())
+                                        .executionStrategy(defaultStrategy(CLIENT_CTX.executor())));
         if (keepAlivesFromClient) {
-            clientBuilder.protocols(h2Config(keepAliveIdleFor));
+            clientBuilder.initializeHttp(builder -> builder.protocols(h2Config(keepAliveIdleFor)));
         } else {
-            clientBuilder.socketOption(IDLE_TIMEOUT, idleTimeoutMillis)
-                .protocols(h2Config(null));
+            clientBuilder.initializeHttp(builder -> builder
+                    .socketOption(IDLE_TIMEOUT, idleTimeoutMillis)
+                    .protocols(h2Config(null)));
         }
         client = clientBuilder.build(new ClientFactory());
     }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -1061,8 +1061,8 @@ class ProtocolCompatibilityTest {
         final GrpcClientBuilder<InetSocketAddress, InetSocketAddress> builder =
                 GrpcClients.forResolvedAddress((InetSocketAddress) serverAddress);
         if (ssl) {
-            builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
-                    .peerHost(serverPemHostname()).build());
+            builder.initializeHttp(b -> b.sslConfig(new ClientSslConfigBuilder(
+                    DefaultTestCerts::loadServerCAPem).peerHost(serverPemHostname()).build()));
         }
         if (null != timeout) {
             builder.defaultTimeout(timeout);

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
@@ -87,7 +87,7 @@ class SingleRequestOrResponseApiTest {
 
         clientBuilder = GrpcClients.forAddress(serverHostAndPort(serverContext))
                 // HTTP filter that modifies path to workaround gRPC API constraints:
-                .appendHttpClientFilter(origin -> new StreamingHttpClientFilter(origin) {
+                .initializeHttp(builder -> builder.appendClientFilter(origin -> new StreamingHttpClientFilter(origin) {
                     @Override
                     protected Single<StreamingHttpResponse> request(StreamingHttpRequester delegate,
                                                                     HttpExecutionStrategy strategy,
@@ -99,7 +99,7 @@ class SingleRequestOrResponseApiTest {
                             return delegate.request(strategy, request).subscribeShareContext();
                         });
                     }
-                });
+                }));
     }
 
     private static Stream<Arguments> params() {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
@@ -80,8 +80,8 @@ class TrailersOnlyErrorTest {
                 .listenAndAwait(new Tester.ServiceFactory(mockTesterService()))) {
 
             final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                    GrpcClients.forAddress(serverHostAndPort(serverContext))
-                            .appendHttpClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors));
+                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> builder
+                            .appendClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors)));
 
             // The server only binds on Tester service, but the client sends a HelloRequest (Greeter service),
             // thus no route is found and it should result in UNIMPLEMENTED.
@@ -102,8 +102,8 @@ class TrailersOnlyErrorTest {
                 .listenAndAwait(new Tester.ServiceFactory(service))) {
 
             final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                    GrpcClients.forAddress(serverHostAndPort(serverContext))
-                            .appendHttpClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors));
+                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> builder
+                            .appendClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors)));
 
             try (TesterClient client = clientBuilder.build(new Tester.ClientFactory())) {
                 verifyException(client.test(TestRequest.newBuilder()
@@ -135,8 +135,8 @@ class TrailersOnlyErrorTest {
                 .listenAndAwait(new Tester.ServiceFactory(service))) {
 
             final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                    GrpcClients.forAddress(serverHostAndPort(serverContext))
-                            .appendHttpClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors));
+                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> builder
+                            .appendClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors)));
 
             try (TesterClient client = clientBuilder.build(new Tester.ClientFactory())) {
                 verifyException(client.test(TestRequest.newBuilder().build()).toFuture(), UNKNOWN);
@@ -163,8 +163,8 @@ class TrailersOnlyErrorTest {
         try (ServerContext serverContext = serverBuilder.listenAndAwait(new Tester.ServiceFactory(service))) {
 
             final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                    GrpcClients.forAddress(serverHostAndPort(serverContext))
-                            .appendHttpClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors));
+                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> builder
+                            .appendClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors)));
 
             try (TesterClient client = clientBuilder.build(new Tester.ClientFactory())) {
                 verifyException(client.test(TestRequest.newBuilder()


### PR DESCRIPTION
Motivation:

The methods in `GrpcClientBuilder` are often only delegating to the
underlying HTTP transport builder. It will be beneficial if the API can
be simplified and have only gRPC specific settings. The first step is to
deprecate the methods which can be called directly on the underlying
`SingleAddressHttpClientBuilder` and to introduce a method for configuring that
builder.

Modifications:

- Introduce a `GrpcClientBuilder.HttpInitializer` interface and a
  corresponding `GrpcClientBuilder#initializeHttp` method which accepts the
  initializer for the underlying `SingleAddressHttpClientBuilder` instance,
- Deprecate methods which have only served the purpose of delegating to
  the underlying HTTP transport builder,
- Made builder reusable and added implementations for deprecated methods,
- Refactor tests to use the new approach to showcase it works.

Result:

The API of `GrpcClientBuilder` is prepared for removal of the deprecated
methods in 0.42 release and the API is more specific, while maintaining
the same level of configurability.