### PR TITLE
HTTP/2 messages with empty body should not have empty trailers

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -195,8 +195,9 @@ final class HeaderUtils {
         assert emptyMessageBody(metadata, messageBody);
         // HTTP/2 and above can write meta-data as a single frame with endStream=true flag. To check the version, use
         // HttpProtocolVersion from ConnectionInfo because HttpMetaData may have different version.
-        final Publisher<Object> flatMessage = shouldAppendTrailers(protocolVersion, metadata) ?
-                from(metadata, EmptyHttpHeaders.INSTANCE) : from(metadata);
+        final Publisher<Object> flatMessage =
+                protocolVersion.major() > 1 || !shouldAppendTrailers(protocolVersion, metadata) ? from(metadata) :
+                        from(metadata, EmptyHttpHeaders.INSTANCE);
         return messageBody == empty() ? flatMessage :
                 // Subscribe to the messageBody publisher to trigger any applied transformations, but ignore its
                 // content because the PayloadInfo indicated it's effectively empty and does not contain trailers


### PR DESCRIPTION
`AbstractH2DuplexHandler` expects a single `metadata` item when it
observes a message with empty body. Recent change #1850 added an
empty trailers at the end, which may cause errors because h2 stream
closes right after writing a frame with `endStream=true` flag.

Modifications:

- Never add empty trailers for HTTP/2 messages with empty body;

Result:

Correct flat HTTP/2 messages for `AbstractH2DuplexHandler`.