### PR TITLE
Fix build caching for protoc plugin

### DIFF
--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -84,6 +84,7 @@ protobuf {
     all().each { task ->
       task.inputs
           .file(pluginFile)
+          .withNormalizer(ClasspathNormalizer)
           .withPropertyName("servicetalkPluginJar")
           .withPathSensitivity(PathSensitivity.RELATIVE)
 


### PR DESCRIPTION
Fixes the issue brought up in https://github.com/apple/servicetalk/pull/1853#issuecomment-944131061.

It does this by manually adding the plugin jar as a task input to the protoc tasks, ensuring that if the plugin sources (and thus jar) change the task will have a new cache key.