### PR TITLE
Deprecate `ExecutionContext` related methods in `GrpcServerBuilder`

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -349,32 +349,60 @@ public abstract class GrpcServerBuilder {
      *
      * @param executor {@link Executor} to use.
      * @return {@code this}.
+     * @deprecated Call {@link #initializeHttp(HttpInitializer)} and use
+     * {@link HttpServerBuilder#executor(Executor)}
+     * on the {@code builder} instance by implementing {@link HttpInitializer#initialize(HttpServerBuilder)}
+     * functional interface.
      */
-    public abstract GrpcServerBuilder executor(Executor executor);
+    @Deprecated
+    public GrpcServerBuilder executor(Executor executor) {
+        throw new UnsupportedOperationException("Method executor is not supported by " + getClass().getName());
+    }
 
     /**
      * Sets the {@link IoExecutor} to be used by this server.
      *
      * @param ioExecutor {@link IoExecutor} to use.
      * @return {@code this}.
+     * @deprecated Call {@link #initializeHttp(HttpInitializer)} and use
+     * {@link HttpServerBuilder#ioExecutor(IoExecutor)}
+     * on the {@code builder} instance by implementing {@link HttpInitializer#initialize(HttpServerBuilder)}
+     * functional interface.
      */
-    public abstract GrpcServerBuilder ioExecutor(IoExecutor ioExecutor);
+    @Deprecated
+    public GrpcServerBuilder ioExecutor(IoExecutor ioExecutor) {
+        throw new UnsupportedOperationException("Method ioExecutor is not supported by " + getClass().getName());
+    }
 
     /**
      * Sets the {@link BufferAllocator} to be used by this server.
      *
      * @param allocator {@link BufferAllocator} to use.
      * @return {@code this}.
+     * @deprecated Call {@link #initializeHttp(HttpInitializer)} and use
+     * {@link HttpServerBuilder#bufferAllocator(BufferAllocator)}
+     * on the {@code builder} instance by implementing {@link HttpInitializer#initialize(HttpServerBuilder)}
+     * functional interface.
      */
-    public abstract GrpcServerBuilder bufferAllocator(BufferAllocator allocator);
+    @Deprecated
+    public GrpcServerBuilder bufferAllocator(BufferAllocator allocator) {
+        throw new UnsupportedOperationException("Method bufferAllocator is not supported by " + getClass().getName());
+    }
 
     /**
      * Sets the {@link HttpExecutionStrategy} to be used by this server.
      *
      * @param strategy {@link HttpExecutionStrategy} to use by this server.
      * @return {@code this}.
+     * @deprecated Call {@link #initializeHttp(HttpInitializer)} and use
+     * {@link HttpServerBuilder#executionStrategy(HttpExecutionStrategy)}
+     * on the {@code builder} instance by implementing {@link HttpInitializer#initialize(HttpServerBuilder)}
+     * functional interface.
      */
-    public abstract GrpcServerBuilder executionStrategy(GrpcExecutionStrategy strategy);
+    @Deprecated
+    public GrpcServerBuilder executionStrategy(GrpcExecutionStrategy strategy) {
+        throw new UnsupportedOperationException("Method executionStrategy is not supported by " + getClass().getName());
+    }
 
     /**
      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -27,6 +27,7 @@ import io.servicetalk.grpc.api.GrpcServiceFactory.ServerBinder;
 import io.servicetalk.http.api.BlockingHttpService;
 import io.servicetalk.http.api.BlockingStreamingHttpService;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpServerBuilder;
@@ -73,10 +74,9 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
     private GrpcServerBuilder.HttpInitializer directCallInitializer = builder -> {
         // no-op
     };
-    private final ExecutionContextBuilder contextBuilder = new ExecutionContextBuilder()
-            // Make sure we always set a strategy so that ExecutionContextBuilder does not create a strategy which is
-            // not compatible with gRPC.
-            .executionStrategy(defaultStrategy());
+
+    @Nullable
+    private ExecutionContextInterceptorHttpServerBuilder interceptorBuilder;
 
     /**
      * A duration greater than zero or null for no timeout.
@@ -167,35 +167,32 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
 
     @Override
     public GrpcServerBuilder executor(final Executor executor) {
-        contextBuilder.executor(executor);
         directCallInitializer = directCallInitializer.append(builder -> builder.executor(executor));
         return this;
     }
 
     @Override
     public GrpcServerBuilder ioExecutor(final IoExecutor ioExecutor) {
-        contextBuilder.ioExecutor(ioExecutor);
         directCallInitializer = directCallInitializer.append(builder -> builder.ioExecutor(ioExecutor));
         return this;
     }
 
     @Override
     public GrpcServerBuilder bufferAllocator(final BufferAllocator allocator) {
-        contextBuilder.bufferAllocator(allocator);
         directCallInitializer = directCallInitializer.append(builder -> builder.bufferAllocator(allocator));
         return this;
     }
 
     @Override
     public GrpcServerBuilder executionStrategy(final GrpcExecutionStrategy strategy) {
-        contextBuilder.executionStrategy(strategy);
         directCallInitializer = directCallInitializer.append(builder -> builder.executionStrategy(strategy));
         return this;
     }
 
     @Override
     protected Single<ServerContext> doListen(final GrpcServiceFactory<?, ?, ?> serviceFactory) {
-        return serviceFactory.bind(this, contextBuilder.build());
+        interceptorBuilder = preBuild();
+        return serviceFactory.bind(this, interceptorBuilder.contextBuilder.build());
     }
 
     @Override
@@ -210,17 +207,18 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
                 builder.appendServiceFilter(predicate, factory));
     }
 
-    private HttpServerBuilder preBuild() {
-        final HttpServerBuilder httpServerBuilder = httpServerBuilderSupplier.get();
+    private ExecutionContextInterceptorHttpServerBuilder preBuild() {
+        final ExecutionContextInterceptorHttpServerBuilder interceptor =
+                new ExecutionContextInterceptorHttpServerBuilder(httpServerBuilderSupplier.get());
 
-        appendCatchAllFilter(httpServerBuilder);
+        appendCatchAllFilter(interceptor);
 
-        directCallInitializer.initialize(httpServerBuilder);
-        initializer.initialize(httpServerBuilder);
+        directCallInitializer.initialize(interceptor);
+        initializer.initialize(interceptor);
 
-        httpServerBuilder.appendServiceFilter(
+        interceptor.appendServiceFilter(
                 new TimeoutHttpServiceFilter(grpcDetermineTimeout(defaultTimeout), true));
-        return httpServerBuilder;
+        return interceptor;
     }
 
     private static TimeoutFromRequest grpcDetermineTimeout(@Nullable Duration defaultTimeout) {
@@ -265,21 +263,176 @@ final class DefaultGrpcServerBuilder extends GrpcServerBuilder implements Server
 
     @Override
     public Single<ServerContext> bind(final HttpService service) {
-        return preBuild().listen(service);
+        return interceptorBuilder.listen(service);
     }
 
     @Override
     public Single<ServerContext> bindStreaming(final StreamingHttpService service) {
-        return preBuild().listenStreaming(service);
+        return interceptorBuilder.listenStreaming(service);
     }
 
     @Override
     public Single<ServerContext> bindBlocking(final BlockingHttpService service) {
-        return preBuild().listenBlocking(service);
+        return interceptorBuilder.listenBlocking(service);
     }
 
     @Override
     public Single<ServerContext> bindBlockingStreaming(final BlockingStreamingHttpService service) {
-        return preBuild().listenBlockingStreaming(service);
+        return interceptorBuilder.listenBlockingStreaming(service);
+    }
+
+    private static class ExecutionContextInterceptorHttpServerBuilder implements HttpServerBuilder {
+        private final HttpServerBuilder delegate;
+        private final ExecutionContextBuilder contextBuilder = new ExecutionContextBuilder()
+                // Make sure we always set a strategy so that ExecutionContextBuilder does not create a strategy
+                // which is not compatible with gRPC.
+                .executionStrategy(defaultStrategy());
+
+        ExecutionContextInterceptorHttpServerBuilder(final HttpServerBuilder delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public HttpServerBuilder ioExecutor(final IoExecutor ioExecutor) {
+            contextBuilder.ioExecutor(ioExecutor);
+            delegate.ioExecutor(ioExecutor);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder executor(final Executor executor) {
+            contextBuilder.executor(executor);
+            delegate.executor(executor);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder bufferAllocator(final BufferAllocator allocator) {
+            contextBuilder.bufferAllocator(allocator);
+            delegate.bufferAllocator(allocator);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder executionStrategy(final HttpExecutionStrategy strategy) {
+            contextBuilder.executionStrategy(strategy);
+            delegate.executionStrategy(strategy);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder protocols(final HttpProtocolConfig... protocols) {
+            delegate.protocols(protocols);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder sslConfig(final ServerSslConfig config) {
+            delegate.sslConfig(config);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder sslConfig(final ServerSslConfig defaultConfig,
+                                           final Map<String, ServerSslConfig> sniMap) {
+            delegate.sslConfig(defaultConfig, sniMap);
+            return this;
+        }
+
+        @Override
+        public <T> HttpServerBuilder socketOption(final SocketOption<T> option, final T value) {
+            delegate.socketOption(option, value);
+            return this;
+        }
+
+        @Override
+        public <T> HttpServerBuilder listenSocketOption(final SocketOption<T> option, final T value) {
+            delegate.listenSocketOption(option, value);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder enableWireLogging(final String loggerName,
+                                                   final LogLevel logLevel,
+                                                   final BooleanSupplier logUserData) {
+            delegate.enableWireLogging(loggerName, logLevel, logUserData);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder transportObserver(final TransportObserver transportObserver) {
+            delegate.transportObserver(transportObserver);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder lifecycleObserver(final HttpLifecycleObserver lifecycleObserver) {
+            delegate.lifecycleObserver(lifecycleObserver);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder drainRequestPayloadBody(final boolean enable) {
+            delegate.drainRequestPayloadBody(enable);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder allowDropRequestTrailers(final boolean allowDrop) {
+            delegate.allowDropRequestTrailers(allowDrop);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder appendConnectionAcceptorFilter(final ConnectionAcceptorFactory factory) {
+            delegate.appendConnectionAcceptorFilter(factory);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder appendNonOffloadingServiceFilter(final StreamingHttpServiceFilterFactory factory) {
+            delegate.appendNonOffloadingServiceFilter(factory);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder appendNonOffloadingServiceFilter(final Predicate<StreamingHttpRequest> predicate,
+                                                                  final StreamingHttpServiceFilterFactory factory) {
+            delegate.appendNonOffloadingServiceFilter(predicate, factory);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder appendServiceFilter(final StreamingHttpServiceFilterFactory factory) {
+            delegate.appendServiceFilter(factory);
+            return this;
+        }
+
+        @Override
+        public HttpServerBuilder appendServiceFilter(final Predicate<StreamingHttpRequest> predicate,
+                                                     final StreamingHttpServiceFilterFactory factory) {
+            delegate.appendServiceFilter(predicate, factory);
+            return this;
+        }
+
+        @Override
+        public Single<ServerContext> listen(final HttpService service) {
+            return delegate.listen(service);
+        }
+
+        @Override
+        public Single<ServerContext> listenStreaming(final StreamingHttpService service) {
+            return delegate.listenStreaming(service);
+        }
+
+        @Override
+        public Single<ServerContext> listenBlocking(final BlockingHttpService service) {
+            return delegate.listenBlocking(service);
+        }
+
+        @Override
+        public Single<ServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
+            return delegate.listenBlockingStreaming(service);
+        }
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
@@ -263,8 +263,10 @@ class ErrorHandlingTest {
         this.requestPublisher = requestPublisher;
         final StreamingHttpServiceFilterFactory filterFactory = serviceFilterFactory;
         serverContext = GrpcServers.forAddress(localAddress(0))
-                .initializeHttp(builder -> builder.appendServiceFilter(filterFactory))
-                .executionStrategy(serverStrategy).listenAndAwait(serviceFactory);
+                .initializeHttp(builder -> builder
+                        .appendServiceFilter(filterFactory)
+                        .executionStrategy(serverStrategy))
+                .listenAndAwait(serviceFactory);
         final StreamingHttpClientFilterFactory pickedClientFilterFactory = clientFilterFactory;
         GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
                 GrpcClients.forAddress(serverHostAndPort(serverContext))

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
@@ -109,27 +109,27 @@ class ExecutionStrategyTest {
         CUSTOM_STRATEGY {
             @Override
             void configureContextExecutionStrategy(GrpcServerBuilder builder) {
-                builder.executionStrategy(customStrategyBuilder().offloadAll().build());
+                builder.initializeHttp(b -> b.executionStrategy(customStrategyBuilder().offloadAll().build()));
             }
         },
         CUSTOM_EXECUTOR {
             @Override
             void configureContextExecutionStrategy(GrpcServerBuilder builder) {
-                builder.executor(CONTEXT_EXEC.executor());
+                builder.initializeHttp(b -> b.executor(CONTEXT_EXEC.executor()));
             }
         },
         CUSTOM_EXECUTOR_STRATEGY {
             @Override
             void configureContextExecutionStrategy(GrpcServerBuilder builder) {
-                builder
+                builder.initializeHttp(b -> b
                         .executor(CONTEXT_EXEC.executor())
-                        .executionStrategy(customStrategyBuilder().offloadAll().build());
+                        .executionStrategy(customStrategyBuilder().offloadAll().build()));
             }
         },
         NO_OFFLOADS {
             @Override
             void configureContextExecutionStrategy(GrpcServerBuilder builder) {
-                builder.executionStrategy(noOffloadsStrategy());
+                builder.initializeHttp(b -> b.executionStrategy(noOffloadsStrategy()));
             }
         };
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
@@ -141,9 +141,9 @@ class GrpcLifecycleObserverTest {
         serverRequestInOrder = inOrder(serverRequestObserver);
 
         server = forAddress(localAddress(0))
-                .ioExecutor(SERVER_CTX.ioExecutor())
-                .executor(SERVER_CTX.executor())
                 .initializeHttp(builder -> builder
+                        .ioExecutor(SERVER_CTX.ioExecutor())
+                        .executor(SERVER_CTX.executor())
                         .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true)
                         .protocols(h2().enableFrameLogging("servicetalk-tests-h2-frame-logger", TRACE, () -> true)
                                 .build())

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
@@ -59,7 +59,7 @@ class GrpcUdsTest {
         String name = "foo";
         String expectedResponse = greetingPrefix + name;
         try (ServerContext serverContext = forAddress(newSocketAddress())
-                .ioExecutor(ioExecutor)
+                .initializeHttp(builder -> builder.ioExecutor(ioExecutor))
                 .listenAndAwait((GreeterService) (ctx, request) ->
                         succeeded(HelloReply.newBuilder().setMessage(greetingPrefix + request.getName()).build()));
              BlockingGreeterClient client = forResolvedAddress(serverContext.listenAddress())

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
@@ -84,10 +84,10 @@ class KeepAliveTest {
                        final Duration idleTimeout) throws Exception {
         this.idleTimeoutMillis = idleTimeout.toMillis();
         GrpcServerBuilder serverBuilder = forAddress(localAddress(0))
-                .executor(SERVER_CTX.executor())
-                .ioExecutor(SERVER_CTX.ioExecutor())
-                .executionStrategy(defaultStrategy())
                 .initializeHttp(builder -> {
+                    builder.executor(SERVER_CTX.executor())
+                            .ioExecutor(SERVER_CTX.ioExecutor())
+                            .executionStrategy(defaultStrategy());
                     if (!keepAlivesFromClient) {
                         builder.protocols(h2Config(keepAliveIdleFor));
                     } else {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -1061,9 +1061,18 @@ class ProtocolCompatibilityTest {
     private static GrpcServerBuilder serviceTalkServerBuilder(final ErrorMode errorMode,
                                                               final boolean ssl,
                                                               @Nullable final Duration timeout) {
+        return serviceTalkServerBuilder(errorMode, ssl, timeout, b -> {
+            // no-op
+        });
+    }
+
+    private static GrpcServerBuilder serviceTalkServerBuilder(final ErrorMode errorMode,
+                                                              final boolean ssl,
+                                                              @Nullable final Duration timeout,
+                                                              GrpcServerBuilder.HttpInitializer initializer) {
 
         final GrpcServerBuilder serverBuilder = GrpcServers.forAddress(localAddress(0))
-                .initializeHttp(builder -> {
+                .initializeHttp(((GrpcServerBuilder.HttpInitializer) builder -> {
                     builder.appendServiceFilter(service -> new StreamingHttpServiceFilter(service) {
                         @Override
                         public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
@@ -1081,7 +1090,7 @@ class ProtocolCompatibilityTest {
                         builder.sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
                                 DefaultTestCerts::loadServerKey).provider(OPENSSL).build());
                     }
-                });
+                }).append(initializer));
         if (null != timeout) {
             serverBuilder.defaultTimeout(timeout);
         }
@@ -1317,9 +1326,9 @@ class ProtocolCompatibilityTest {
             }
         });
 
-        final ServerContext serverContext = serviceTalkServerBuilder(errorMode, ssl, timeout)
-                .executionStrategy(strategy)
-                .listenAndAwait(serviceFactory);
+        final ServerContext serverContext =
+                serviceTalkServerBuilder(errorMode, ssl, timeout, b -> b.executionStrategy(strategy))
+                        .listenAndAwait(serviceFactory);
         return TestServerContext.fromServiceTalkServerContext(serverContext);
     }
 


### PR DESCRIPTION
Motivation:

Recent changes to `GrpcServerBuilder` attempted decoupling the gRPC
layer from the underlying HTTP transport in terms of the builder
APIs. Methods that serve the purpose of configuring the
`ExecutionContext` have not been deprecated due to the way the actual
`ServerContext` is created with regards to `GrpcRoutes`. This change
deprecates four methods and introduces a mechanism to transport the
underlying `HttpServerBuilder`'s `ExecutionContext` to populate the
context in routes.

Modifications:

- Deprecated `ioExecutor`, `executor`, `bufferAllocator`, and
  `executionStrategy` methods in `GrpcServerBuilder`,
- Introduced an internal `ExecutionContextInterceptorHttpServerBuilder`
  to capture the configured `ExecutionContext` via the
  `GrpcServerBuilder.HttpInitializer`,
- Adjusted test cases to use the new APIs.

Result:

All of the `GrpcServerBuilder` methods that served as a facade to
`HttpServerBuilder` have now been deprecated and there is a single way
to configure the underlying transport using
`initializeHttp(HttpServerBuilder)` method.