### PR TITLE
Ensure `ChannelSet.closeAsyncGracefully()` callbacks are offloaded

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelSet.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelSet.java
@@ -141,14 +141,14 @@ public final class ChannelSet implements ListenableAsyncCloseable {
                     return;
                 }
 
-                CompositeCloseable closeable = newCompositeCloseable().appendAll(() -> onClose);
+                CompositeCloseable closeable = newCompositeCloseable();
 
                 for (final Channel channel : channelMap.values()) {
                     Attribute<PrivilegedListenableAsyncCloseable> closeableAttribute =
                             channel.attr(CHANNEL_CLOSEABLE_KEY);
                     PrivilegedListenableAsyncCloseable channelCloseable = closeableAttribute.getAndSet(null);
                     if (null != channelCloseable) {
-                        // Upon shutdown of the set, we will close all live channels. If close of individual hannels
+                        // Upon shutdown of the set, we will close all live channels. If close of individual channels
                         // are offloaded, then this would trigger a surge in threads required to offload these closures.
                         // Here we assume that if there is any offloading required, it is done by offloading the
                         // Completable returned by closeAsyncGracefully() hence offloading each channel is not required.
@@ -169,6 +169,7 @@ public final class ChannelSet implements ListenableAsyncCloseable {
                         channel.close();
                     }
                 }
+                closeable.append(() -> onClose);
                 toSource(closeable.closeAsyncGracefully()).subscribe(subscriber);
             }
         };


### PR DESCRIPTION
Motivation:
The terminal signal for the `Completable` returned by `asyncClose` or
`asyncCloseGracefully` should be offloaded.
Modifications:
Re-order the steps of the `CompositeCloseable` so that the offloaded
onClose is the source of the terminal signal. Prior to #1585 the order
did not matter as all of the `Completable` were offloaded.
Result:
`Completable` result of `HttpServer.closeAsyncGracefully()` no longer
invokes `onComplete()` on the IoThread.

Resolves #1630.