### PR TITLE
Deprecate `FilterableGrpcClient`

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/FilterableGrpcClient.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/FilterableGrpcClient.java
@@ -19,7 +19,15 @@ import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
 /**
  * A client to a <a href="https://www.grpc.io">gRPC</a> service that supports filtering.
+ * @deprecated gRPC Client Filters will be removed in future release of ServiceTalk. We encourage the use of
+ * {@link io.servicetalk.http.api.StreamingHttpClientFilterFactory} and if the access to the decoded payload is
+ * necessary, then performing that logic can be done in the particular {@link GrpcClient client implementation}.
+ * Please use {@link io.servicetalk.http.api.SingleAddressHttpClientBuilder#appendClientFilter(
+ * io.servicetalk.http.api.StreamingHttpClientFilterFactory)} upon the {@code builder} obtained using
+ * {@link io.servicetalk.grpc.api.GrpcClientBuilder#initializeHttp(GrpcClientBuilder.HttpInitializer)}
+ * if HTTP filters are acceptable in your use case.
  */
+@Deprecated
 public interface FilterableGrpcClient extends ListenableAsyncCloseable {
 
     /**

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
@@ -220,7 +220,15 @@ public abstract class GrpcClientFactory<Client extends GrpcClient<BlockingClient
      * @param filterableClient {@link FilterableClient} to create a {@link Client} from.
      * @return A new <a href="https://www.grpc.io">gRPC</a> client following the specified
      * <a href="https://www.grpc.io">gRPC</a> {@link Client} contract.
+     * @deprecated gRPC Client Filters will be removed in future release of ServiceTalk. We encourage the use of
+     * {@link io.servicetalk.http.api.StreamingHttpClientFilterFactory} and if the access to the decoded payload is
+     * necessary, then performing that logic can be done in the particular {@link GrpcClient client implementation}.
+     * Please use {@link io.servicetalk.http.api.SingleAddressHttpClientBuilder#appendClientFilter(
+     * io.servicetalk.http.api.StreamingHttpClientFilterFactory)} upon the {@code builder} obtained using
+     * {@link io.servicetalk.grpc.api.GrpcClientBuilder#initializeHttp(GrpcClientBuilder.HttpInitializer)}
+     * if HTTP filters are acceptable in your use case.
      */
+    @Deprecated
     protected abstract Client newClient(FilterableClient filterableClient);
 
     /**

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -885,6 +885,17 @@ final class Generator {
                 .addSuperinterface(ParameterizedTypeName.get(GrpcClient, state.blockingClientClass));
 
         final TypeSpec.Builder filterableClientSpecBuilder = interfaceBuilder(state.filterableClientClass)
+                .addJavadoc(JAVADOC_DEPRECATED +
+                                " gRPC Client Filters will be removed in future release of ServiceTalk." +
+                                " We encourage the use of {@link $T} and if the access to the decoded payload" +
+                                " is necessary, then performing that logic can be done in the particular" +
+                                " {@link $T client implementation}. Please use" +
+                                " {@link $T#appendClientFilter($T)} upon the {@code builder} obtained using" +
+                                " {@link $T#initializeHttp($T)} if HTTP filters are acceptable in your" +
+                                " use case." + lineSeparator(),
+                        StreamingHttpClientFilterFactory, GrpcClient, SingleAddressHttpClientBuilder,
+                        StreamingHttpClientFilterFactory, GrpcClientBuilder, GrpcClientBuilderHttpInitializer)
+                .addAnnotation(Deprecated.class)
                 .addModifiers(PUBLIC)
                 .addSuperinterface(FilterableGrpcClient);
 
@@ -983,7 +994,8 @@ final class Generator {
     private TypeSpec.Builder addClientFilter(final State state, final TypeSpec.Builder serviceClassBuilder) {
         final TypeSpec.Builder classSpecBuilder = newFilterDelegateCommonMethods(state.clientFilterClass,
                 state.filterableClientClass)
-                .addJavadoc("gRPC Client Filters will be removed in future release of ServiceTalk." +
+                .addJavadoc(JAVADOC_DEPRECATED +
+                                " gRPC Client Filters will be removed in future release of ServiceTalk." +
                                 " We encourage the use of {@link $T} and if the access to the decoded payload" +
                                 " is necessary, then performing that logic can be done in the particular" +
                                 " {@link $T client implementation}. Please use" +
@@ -1017,7 +1029,8 @@ final class Generator {
     private static TypeSpec.Builder addClientFilterFactory(final State state,
                                                            final TypeSpec.Builder serviceClassBuilder) {
         serviceClassBuilder.addType(interfaceBuilder(state.clientFilterFactoryClass)
-                .addJavadoc("gRPC Client Filters will be removed in future release of ServiceTalk." +
+                .addJavadoc(JAVADOC_DEPRECATED +
+                                " gRPC Client Filters will be removed in future release of ServiceTalk." +
                                 " We encourage the use of {@link $T} and if the access to the decoded payload" +
                                 " is necessary, then performing that logic can be done in the particular" +
                                 " {@link $T client implementation}. Please use" +
@@ -1050,7 +1063,8 @@ final class Generator {
                 .superclass(ParameterizedTypeName.get(GrpcClientFactory, state.clientClass, state.blockingClientClass,
                         state.clientFilterClass, state.filterableClientClass, state.clientFilterFactoryClass))
                 .addMethod(methodBuilder("appendClientFilterFactory")
-                        .addJavadoc("gRPC Client Filters will be removed in future release of ServiceTalk." +
+                        .addJavadoc(JAVADOC_DEPRECATED +
+                                        " gRPC Client Filters will be removed in future release of ServiceTalk." +
                                         " We encourage the use of {@link $T} and if the access to the decoded payload" +
                                         " is necessary, then performing that logic can be done in the particular" +
                                         " {@link $T client implementation}. Please use" +
@@ -1076,7 +1090,8 @@ final class Generator {
                                 supportedMessageCodings, bufferDecoderGroup)
                         .build())
                 .addMethod(methodBuilder("newFilter")
-                        .addJavadoc("gRPC Client Filters will be removed in future release of ServiceTalk." +
+                        .addJavadoc(JAVADOC_DEPRECATED +
+                                        " gRPC Client Filters will be removed in future release of ServiceTalk." +
                                         " We encourage the use of {@link $T} and if the access to the decoded payload" +
                                         " is necessary, then performing that logic can be done in the particular" +
                                         " {@link $T client implementation}. Please use" +
@@ -1094,6 +1109,17 @@ final class Generator {
                         .addStatement("return $L.create($L)", factory, client)
                         .build())
                 .addMethod(methodBuilder("newClient")
+                        .addJavadoc(JAVADOC_DEPRECATED +
+                                        " gRPC Client Filters will be removed in future release of ServiceTalk." +
+                                        " We encourage the use of {@link $T} and if the access to the decoded payload" +
+                                        " is necessary, then performing that logic can be done in the particular" +
+                                        " {@link $T client implementation}. Please use" +
+                                        " {@link $T#appendClientFilter($T)} upon the {@code builder} obtained using" +
+                                        " {@link $T#initializeHttp($T)} if HTTP filters are acceptable in your" +
+                                        " use case." + lineSeparator(),
+                                StreamingHttpClientFilterFactory, GrpcClient, SingleAddressHttpClientBuilder,
+                                StreamingHttpClientFilterFactory, GrpcClientBuilder, GrpcClientBuilderHttpInitializer)
+                        .addAnnotation(Deprecated.class)
                         .addModifiers(PROTECTED)
                         .addAnnotation(Override.class)
                         .returns(state.clientClass)
@@ -1409,6 +1435,17 @@ final class Generator {
                                                           final ClassName filterableClientToClientClass,
                                                           final ClassName clientToBlockingClientClass) {
         final TypeSpec.Builder typeSpecBuilder = classBuilder(filterableClientToClientClass)
+                .addJavadoc(JAVADOC_DEPRECATED +
+                                " gRPC Client Filters will be removed in future release of ServiceTalk." +
+                                " We encourage the use of {@link $T} and if the access to the decoded payload" +
+                                " is necessary, then performing that logic can be done in the particular" +
+                                " {@link $T client implementation}. Please use" +
+                                " {@link $T#appendClientFilter($T)} upon the {@code builder} obtained using" +
+                                " {@link $T#initializeHttp($T)} if HTTP filters are acceptable in your" +
+                                " use case." + lineSeparator(),
+                        StreamingHttpClientFilterFactory, GrpcClient, SingleAddressHttpClientBuilder,
+                        StreamingHttpClientFilterFactory, GrpcClientBuilder, GrpcClientBuilderHttpInitializer)
+                .addAnnotation(Deprecated.class)
                 .addModifiers(PRIVATE, STATIC, FINAL)
                 .addSuperinterface(state.clientClass)
                 .addField(state.filterableClientClass, client, PRIVATE, FINAL)


### PR DESCRIPTION
Motivation:

gRPC filters will be removed in 0.42. `FilterableGrpcClient` can be
deprecated now.

Modifications:

- Deprecated `FilterableGrpcClient`,
- Deprecated `GrpcClientFactory#newClient(FilterableClient)`,
- `Generator` produces corresponding dreprecations for generated
  classes.

Result:

The gRPC API is prepared for removal of filters.