### PR TITLE
Converting `GrpcClientBuilder` to interface

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -25,7 +25,7 @@ import java.time.Duration;
  * @param <U> the type of address before resolution (unresolved address)
  * @param <R> the type of address after resolution (resolved address)
  */
-public abstract class GrpcClientBuilder<U, R> {
+public interface GrpcClientBuilder<U, R> {
 
     /**
      * Initializes the underlying {@link SingleAddressHttpClientBuilder} used for the transport layer.
@@ -33,7 +33,7 @@ public abstract class GrpcClientBuilder<U, R> {
      * @param <R> resolved address
      */
     @FunctionalInterface
-    public interface HttpInitializer<U, R> {
+    interface HttpInitializer<U, R> {
 
         /**
          * Configures the underlying {@link SingleAddressHttpClientBuilder}.
@@ -61,10 +61,7 @@ public abstract class GrpcClientBuilder<U, R> {
      * @param initializer Initializes the underlying HTTP transport builder.
      * @return {@code this}.
      */
-    public GrpcClientBuilder<U, R> initializeHttp(HttpInitializer<U, R> initializer) {
-        throw new UnsupportedOperationException("Initializing the GrpcClientBuilder using this method is not yet" +
-                " supported by " + getClass().getName());
-    }
+    GrpcClientBuilder<U, R> initializeHttp(HttpInitializer<U, R> initializer);
 
     /**
      * Set default timeout during which gRPC calls are expected to complete. This default will be used only if the
@@ -73,7 +70,7 @@ public abstract class GrpcClientBuilder<U, R> {
      * @param defaultTimeout {@link Duration} of default timeout which must be positive non-zero.
      * @return {@code this}.
      */
-    public abstract GrpcClientBuilder<U, R> defaultTimeout(Duration defaultTimeout);
+    GrpcClientBuilder<U, R> defaultTimeout(Duration defaultTimeout);
 
     /**
      * Builds a <a href="https://www.grpc.io">gRPC</a> client.
@@ -84,9 +81,7 @@ public abstract class GrpcClientBuilder<U, R> {
      *
      * @return A <a href="https://www.grpc.io">gRPC</a> client.
      */
-    public final <Client extends GrpcClient<?>> Client build(GrpcClientFactory<Client, ?> clientFactory) {
-        return clientFactory.newClientForCallFactory(newGrpcClientCallFactory());
-    }
+    <Client extends GrpcClient<?>> Client build(GrpcClientFactory<Client, ?> clientFactory);
 
     /**
      * Builds a blocking <a href="https://www.grpc.io">gRPC</a> client.
@@ -97,15 +92,6 @@ public abstract class GrpcClientBuilder<U, R> {
      *
      * @return A blocking <a href="https://www.grpc.io">gRPC</a> client.
      */
-    public final <BlockingClient extends BlockingGrpcClient<?>> BlockingClient
-    buildBlocking(GrpcClientFactory<?, BlockingClient> clientFactory) {
-        return clientFactory.newBlockingClientForCallFactory(newGrpcClientCallFactory());
-    }
-
-    /**
-     * Create a new {@link GrpcClientCallFactory}.
-     *
-     * @return A new {@link GrpcClientCallFactory}.
-     */
-    protected abstract GrpcClientCallFactory newGrpcClientCallFactory();
+    <BlockingClient extends BlockingGrpcClient<?>> BlockingClient buildBlocking(
+            GrpcClientFactory<?, BlockingClient> clientFactory);
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
@@ -52,7 +52,7 @@ public abstract class GrpcClientFactory<Client extends GrpcClient<BlockingClient
      * @return A new <a href="https://www.grpc.io">gRPC</a> client following the specified
      * <a href="https://www.grpc.io">gRPC</a> {@link Client} contract.
      */
-    final Client newClientForCallFactory(GrpcClientCallFactory clientCallFactory) {
+    public final Client newClientForCallFactory(GrpcClientCallFactory clientCallFactory) {
         return newClient(clientCallFactory);
     }
 
@@ -65,7 +65,7 @@ public abstract class GrpcClientFactory<Client extends GrpcClient<BlockingClient
      * @return A new <a href="https://www.grpc.io">gRPC</a> client following the specified
      * <a href="https://www.grpc.io">gRPC</a> {@link BlockingClient} contract.
      */
-    final BlockingClient newBlockingClientForCallFactory(GrpcClientCallFactory clientCallFactory) {
+    public final BlockingClient newBlockingClientForCallFactory(GrpcClientCallFactory clientCallFactory) {
             return newBlockingClient(clientCallFactory);
     }
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -16,8 +16,11 @@
 package io.servicetalk.grpc.netty;
 
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.api.BlockingGrpcClient;
+import io.servicetalk.grpc.api.GrpcClient;
 import io.servicetalk.grpc.api.GrpcClientBuilder;
 import io.servicetalk.grpc.api.GrpcClientCallFactory;
+import io.servicetalk.grpc.api.GrpcClientFactory;
 import io.servicetalk.grpc.api.GrpcStatusException;
 import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
@@ -47,7 +50,7 @@ import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static io.servicetalk.utils.internal.DurationUtils.isInfinite;
 import static java.util.Objects.requireNonNull;
 
-final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
+final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
 
     /**
      * A function which determines the timeout for a given request.
@@ -96,7 +99,17 @@ final class DefaultGrpcClientBuilder<U, R> extends GrpcClientBuilder<U, R> {
     }
 
     @Override
-    protected GrpcClientCallFactory newGrpcClientCallFactory() {
+    public <Client extends GrpcClient<?>> Client build(GrpcClientFactory<Client, ?> clientFactory) {
+        return clientFactory.newClientForCallFactory(newGrpcClientCallFactory());
+    }
+
+    @Override
+    public <BlockingClient extends BlockingGrpcClient<?>> BlockingClient buildBlocking(
+            GrpcClientFactory<?, BlockingClient> clientFactory) {
+        return clientFactory.newBlockingClientForCallFactory(newGrpcClientCallFactory());
+    }
+
+    private GrpcClientCallFactory newGrpcClientCallFactory() {
         SingleAddressHttpClientBuilder<U, R> builder = httpClientBuilderSupplier.get().protocols(h2Default());
         builder.appendClientFilter(CatchAllHttpClientFilter.INSTANCE);
         httpInitializer.initialize(builder);


### PR DESCRIPTION
Motivation:

In an effort to unify the various server and client builders, the
`GrpcClientBuilder` should become an interface and the entire
implementation logic should reside in the `servicetalk-grpc-netty`
module.

Modifications:

- `GrpcClientBuilder` converted to an interface,
- `GrpcClientBuilder#build` and `GrpcClientBuilder#buildBlocking` method
  implementations moved to `DefaultGrpcClientBuilder`,
- `DefaultGrpcClientBuilder#newGrpcClientCallFactory` method made
  private, while the protected abstract base method was removed from
  `GrpcClientBuilder`,
- `GrpcClientFactory#newClientForCallFactory` and
  `GrpcClientFactory#newBlockingClientForCallFactory` methods were made
  public to allow access from the `servicetalk-grpc-netty` module.

Result:

`GrpcClientBuilder` is now an interface which makes it consistent with
the `HttpClientBuilder` interface.