### PR TITLE
Fix protoc caching, re-enable gradle caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 org.gradle.parallel=true
-org.gradle.caching=false
+org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xms2g -Xmx4g -dsa -da -ea:io.servicetalk... -XX:+HeapDumpOnOutOfMemoryError
 

--- a/servicetalk-examples/grpc/compression/build.gradle
+++ b/servicetalk-examples/grpc/compression/build.gradle
@@ -39,12 +39,17 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
   plugins {
     servicetalk_grpc {
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
       //// "path" is used only because we want to use the gradle project local version of the plugin.
-      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      path = pluginJar.path
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
 
       // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
@@ -54,6 +59,13 @@ protobuf {
     all().each { task ->
       //// REMOVE if outside of ServiceTalk gradle project
       task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+      // you may need to manually add the artifact name as an input
+      task.inputs
+              .file(pluginJar)
+              .withNormalizer(ClasspathNormalizer)
+              .withPropertyName("servicetalkPluginJar")
+              .withPathSensitivity(PathSensitivity.RELATIVE)
       //// REMOVE if outside of ServiceTalk gradle project
 
       task.plugins {

--- a/servicetalk-examples/grpc/deadline/build.gradle
+++ b/servicetalk-examples/grpc/deadline/build.gradle
@@ -37,12 +37,17 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
   plugins {
     servicetalk_grpc {
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
       //// "path" is used only because we want to use the gradle project local version of the plugin.
-      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      path = pluginJar.path
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
 
       // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
@@ -52,6 +57,13 @@ protobuf {
     all().each { task ->
       //// REMOVE if outside of ServiceTalk gradle project
       task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+      // you may need to manually add the artifact name as an input
+      task.inputs
+              .file(pluginJar)
+              .withNormalizer(ClasspathNormalizer)
+              .withPropertyName("servicetalkPluginJar")
+              .withPathSensitivity(PathSensitivity.RELATIVE)
       //// REMOVE if outside of ServiceTalk gradle project
 
       task.plugins {

--- a/servicetalk-examples/grpc/errors/build.gradle
+++ b/servicetalk-examples/grpc/errors/build.gradle
@@ -38,12 +38,17 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
   plugins {
     servicetalk_grpc {
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
       //// "path" is used only because we want to use the gradle project local version of the plugin.
-      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      path = pluginJar.path
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
 
       // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
@@ -53,6 +58,13 @@ protobuf {
     all().each { task ->
       //// REMOVE if outside of ServiceTalk gradle project
       task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+      // you may need to manually add the artifact name as an input
+      task.inputs
+              .file(pluginJar)
+              .withNormalizer(ClasspathNormalizer)
+              .withPropertyName("servicetalkPluginJar")
+              .withPathSensitivity(PathSensitivity.RELATIVE)
       //// REMOVE if outside of ServiceTalk gradle project
 
       task.plugins {

--- a/servicetalk-examples/grpc/helloworld/build.gradle
+++ b/servicetalk-examples/grpc/helloworld/build.gradle
@@ -38,12 +38,17 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
   plugins {
     servicetalk_grpc {
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
       //// "path" is used only because we want to use the gradle project local version of the plugin.
-      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      path = pluginJar.path
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
 
       // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
@@ -53,6 +58,13 @@ protobuf {
     all().each { task ->
       //// REMOVE if outside of ServiceTalk gradle project
       task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+      // you may need to manually add the artifact name as an input
+      task.inputs
+              .file(pluginJar)
+              .withNormalizer(ClasspathNormalizer)
+              .withPropertyName("servicetalkPluginJar")
+              .withPathSensitivity(PathSensitivity.RELATIVE)
       //// REMOVE if outside of ServiceTalk gradle project
 
       task.plugins {

--- a/servicetalk-examples/grpc/observer/build.gradle
+++ b/servicetalk-examples/grpc/observer/build.gradle
@@ -38,12 +38,17 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
   plugins {
     servicetalk_grpc {
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
       //// "path" is used only because we want to use the gradle project local version of the plugin.
-      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      path = pluginJar.path
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
 
       // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
@@ -53,6 +58,13 @@ protobuf {
     all().each { task ->
       //// REMOVE if outside of ServiceTalk gradle project
       task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+      // you may need to manually add the artifact name as an input
+      task.inputs
+              .file(pluginJar)
+              .withNormalizer(ClasspathNormalizer)
+              .withPropertyName("servicetalkPluginJar")
+              .withPathSensitivity(PathSensitivity.RELATIVE)
       //// REMOVE if outside of ServiceTalk gradle project
 
       task.plugins {

--- a/servicetalk-examples/grpc/protoc-options/build.gradle
+++ b/servicetalk-examples/grpc/protoc-options/build.gradle
@@ -38,12 +38,17 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
   plugins {
     servicetalk_grpc {
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
       //// "path" is used only because we want to use the gradle project local version of the plugin.
-      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      path = pluginJar.path
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
 
       // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
@@ -53,6 +58,13 @@ protobuf {
     all().each { task ->
       //// REMOVE if outside of ServiceTalk gradle project
       task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+      // you may need to manually add the artifact name as an input
+      task.inputs
+              .file(pluginJar)
+              .withNormalizer(ClasspathNormalizer)
+              .withPropertyName("servicetalkPluginJar")
+              .withPathSensitivity(PathSensitivity.RELATIVE)
       //// REMOVE if outside of ServiceTalk gradle project
 
       task.plugins {

--- a/servicetalk-examples/grpc/routeguide/build.gradle
+++ b/servicetalk-examples/grpc/routeguide/build.gradle
@@ -39,12 +39,17 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
   plugins {
     servicetalk_grpc {
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
       //// "path" is used only because we want to use the gradle project local version of the plugin.
-      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      path = pluginJar.path
       //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
 
       // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
@@ -54,6 +59,13 @@ protobuf {
     all().each { task ->
       //// REMOVE if outside of ServiceTalk gradle project
       task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+      // you may need to manually add the artifact name as an input
+      task.inputs
+              .file(pluginJar)
+              .withNormalizer(ClasspathNormalizer)
+              .withPropertyName("servicetalkPluginJar")
+              .withPathSensitivity(PathSensitivity.RELATIVE)
       //// REMOVE if outside of ServiceTalk gradle project
 
       task.plugins {

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -76,20 +76,31 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+          "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
   plugins {
     grpc {
       artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
     }
     servicetalk_grpc {
       // use gradle project local grpc-protoc dependency
-      path = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
-                  "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar").path
+      path = pluginJar.path
     }
   }
   generateProtoTasks {
     all().each { task ->
       if (task.isTest) {
         task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+        task.inputs
+                .file(pluginJar)
+                .withNormalizer(ClasspathNormalizer)
+                .withPropertyName("servicetalkPluginJar")
+                .withPathSensitivity(PathSensitivity.RELATIVE)
       }
 
       task.plugins {

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -73,17 +73,17 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"
   }
-  def pluginFile = file("${buildExecutable.destinationDir}/$grpcPluginUberJarName")
+  def pluginJar = file("${buildExecutable.destinationDir}/$grpcPluginUberJarName")
   // Used for testing
   plugins {
     servicetalk_grpc {
-      path = pluginFile
+      path = pluginJar
     }
   }
   generateProtoTasks {
     all().each { task ->
       task.inputs
-          .file(pluginFile)
+          .file(pluginJar)
           .withNormalizer(ClasspathNormalizer)
           .withPropertyName("servicetalkPluginJar")
           .withPathSensitivity(PathSensitivity.RELATIVE)


### PR DESCRIPTION
Fixes the issues with caching that led to #1907, by extending #1895 to all places the servicetalk protoc plugin is used.

I've tested this by making changes to `Generator`, it does force re-running of `:servicetalk-grpc-netty:generateTestProto`.  Is there anything else I should test this for?