### PR TITLE
Add Netty BOM as platform for test fixtures

### DIFF
--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -19,6 +19,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   testImplementation enforcedPlatform("io.netty:netty-bom:$nettyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testFixturesImplementation platform("io.netty:netty-bom:$nettyVersion")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-client-api")


### PR DESCRIPTION
Motivation:
Several Netty components are used as runtime dependencies by the
`tcp-netty-internal` test fixtures. The current Maven POM does not
include versions for these components.
Modifications:
The Netty BOM is imported as a platform to ensure that the versions are
available in the published Maven POM file for this module.
Result:
Maven builds including `servicetalk-tcp-netty-internal` module have the
versions they need.