### PR TITLE
Improve POM/BOM publication metadata

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,14 +14,21 @@
 # limitations under the License.
 #
 
+# build configuration
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xms2g -Xmx4g -dsa -da -ea:io.servicetalk... -XX:+HeapDumpOnOutOfMemoryError
 
+# project metadata used for publications
 group=io.servicetalk
 version=0.42.0-SNAPSHOT
+scmHost=github.com
+scmPath=apple/servicetalk
+issueManagementUrl=https://github.com/apple/servicetalk/issues
+ciManagementUrl=https://github.com/apple/servicetalk/actions
 
+# dependency versions
 nettyVersion=4.1.69.Final
 
 jsr305Version=3.0.2

--- a/servicetalk-bom/build.gradle
+++ b/servicetalk-bom/build.gradle
@@ -46,9 +46,17 @@ publishing {
           }
         }
         scm {
-          connection = 'scm:git:git://github.com/apple/servicetalk.git'
-          developerConnection = 'scm:git:ssh://github.com:apple/servicetalk.git'
-          url = 'https://github.com/apple/servicetalk'
+          connection = "scm:git:git://${scmHost}/${scmPath}.git"
+          developerConnection = "scm:git:ssh://${scmHost}:${scmPath}.git"
+          url = "https://${scmHost}/${scmPath}"
+        }
+        issueManagement {
+          system = 'ServiceTalk Issues'
+          url = "${issueManagementUrl}"
+        }
+        ciManagement {
+          system = 'ServiceTalk CI'
+          url = "${ciManagementUrl}"
         }
       }
     }

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -21,8 +21,6 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
-import org.gradle.external.javadoc.JavadocOptionFileOption
-import org.gradle.external.javadoc.internal.JavadocOptionFileWriterContext
 
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addManifestAttributes
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addQualityTask
@@ -106,9 +104,17 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
                 }
               }
               scm {
-                connection = 'scm:git:git://github.com/apple/servicetalk.git'
-                developerConnection = 'scm:git:ssh://github.com:apple/servicetalk.git'
-                url = 'https://github.com/apple/servicetalk'
+                connection = "scm:git:git://${scmHost}/${scmPath}.git"
+                developerConnection = "scm:git:ssh://${scmHost}:${scmPath}.git"
+                url = "https://${scmHost}/${scmPath}"
+              }
+              issueManagement {
+                system = 'ServiceTalk Issues'
+                url = "${issueManagementUrl}"
+              }
+              ciManagement {
+                system = 'ServiceTalk CI'
+                url = "${ciManagementUrl}"
               }
             }
           }


### PR DESCRIPTION
Motivation:
Some additional POM sections can be added and we can improve the
configurability of the `scm`, `issueManagement` and `ciManagement`
sections.
Modifications:
Add `issueManagement` and `ciManagement` sections to POM/BOM
definition. Add new `gradle.properties` definitions for the
values of the metadata.
Result:
Richer BOM/POM file metadata