### PR TITLE
Replace deprecated Gradle 7 features

### DIFF
--- a/docs/generation/gradle/validateSite.gradle
+++ b/docs/generation/gradle/validateSite.gradle
@@ -82,7 +82,7 @@ for (location in ["local", "remote"]) {
     outputs.file outputFile
 
     classpath = configurations.nuValidator
-    main = "nu.validator.client.SimpleCommandLineValidator"
+    mainClass = "nu.validator.client.SimpleCommandLineValidator"
     args "--also-check-css"
     args "--also-check-svg"
     args "--filterpattern", '(.*)Consider adding “lang=(.*)'

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -133,7 +133,7 @@ final class ProjectUtils {
     return createTask(project, sourceSet.getTaskName(null, "sourcesJar"), Jar) {
       description = "Assembles a Jar archive containing the $sourceSet.name sources."
       group = JavaBasePlugin.DOCUMENTATION_GROUP
-      appendix = sourceSet.name == "main" ? null : sourceSet.name
+      archiveAppendix = sourceSet.name == "main" ? null : sourceSet.name
       classifier = "sources"
       addManifestAttributes(project, manifest)
       from sourceSet.allSource
@@ -164,7 +164,7 @@ final class ProjectUtils {
     createTask(project, sourceSet.getTaskName(null, "javadocJar"), Jar) {
       description = "Assembles a Jar archive containing the $sourceSet.name Javadoc."
       group = JavaBasePlugin.DOCUMENTATION_GROUP
-      appendix = sourceSet.name == "main" ? null : sourceSet.name
+      archiveAppendix = sourceSet.name == "main" ? null : sourceSet.name
       classifier = "javadoc"
       addManifestAttributes(project, manifest)
       from javadocTask


### PR DESCRIPTION
Motivation:

To ensure compatibility with an eventual upgrade to Gradle 8

Modifications:

- Replace JavaExec.main with mainClass
- Replace appendix with archiveAppendix

Result:

Gradle deprecation warnings go away!