### PR TITLE
Add missed `serialVersionUID` for exceptions

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionClosedException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionClosedException.java
@@ -19,6 +19,7 @@ package io.servicetalk.client.api;
  * Thrown when the connection is no longer available.
  */
 public class ConnectionClosedException extends RuntimeException {
+    private static final long serialVersionUID = -2133048420662985692L;
 
     /**
      * Creates a new instance.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyResponseException.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyResponseException.java
@@ -24,6 +24,8 @@ import java.io.IOException;
  * A proxy response exception, that indicates an unexpected response status from a proxy.
  */
 public final class ProxyResponseException extends IOException implements RetryableException {
+    private static final long serialVersionUID = -1021287419155443499L;
+
     private final HttpResponseStatus status;
 
     ProxyResponseException(final String message, final HttpResponseStatus status) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
@@ -24,6 +24,7 @@ import java.nio.channels.ClosedChannelException;
  * limited stacktrace details for the user.
  */
 public final class StacklessClosedChannelException extends ClosedChannelException {
+    private static final long serialVersionUID = -5021225720136487769L;
 
     private StacklessClosedChannelException() { }
 


### PR DESCRIPTION
Motivation:

`Serializable` interface requires `serialVersionUID`.

Modifications:

- Add `serialVersionUID` for `ConnectionClosedException`,
`ProxyResponseException`, `StacklessClosedChannelException`;

Result:

Exceptions are aligned with `Serializable` contract.