### PR TITLE
Deprecate unused exception types

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/MaxRequestLimitExceededRejectedSubscribeException.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/MaxRequestLimitExceededRejectedSubscribeException.java
@@ -20,7 +20,11 @@ import io.servicetalk.concurrent.internal.RejectedSubscribeError;
 
 /**
  * Exception raised when more concurrent requests have been issued on a connection than is allowed.
+ *
+ * @deprecated There is no code that can throw this exception. We will remove it and create a new exception type if
+ * there is a use-case in future releases.
  */
+@Deprecated
 public final class MaxRequestLimitExceededRejectedSubscribeException extends MaxRequestLimitExceededException
         implements RejectedSubscribeError {
 

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionClosedException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionClosedException.java
@@ -17,7 +17,11 @@ package io.servicetalk.client.api;
 
 /**
  * Thrown when the connection is no longer available.
+ *
+ * @deprecated There is no code that can throw this exception. We will remove it and create a new exception type if
+ * there is a use-case in future releases.
  */
+@Deprecated
 public class ConnectionClosedException extends RuntimeException {
     private static final long serialVersionUID = -2133048420662985692L;
 

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/MaxRequestLimitExceededException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/MaxRequestLimitExceededException.java
@@ -17,7 +17,11 @@ package io.servicetalk.client.api;
 
 /**
  * Exception raised when more concurrent requests have been issued on a connection than is allowed.
+ *
+ * @deprecated There is no code that can throw this exception. We will remove it and create a new exception type if
+ * there is a use-case in future releases.
  */
+@Deprecated
 public class MaxRequestLimitExceededException extends RuntimeException {
     private static final long serialVersionUID = 9114515334374632438L;
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionAcceptorTest.java
@@ -15,9 +15,6 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.client.api.ConnectionClosedException;
-import io.servicetalk.client.api.MaxRequestLimitExceededException;
-import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.internal.DeliberateException;
@@ -50,8 +47,8 @@ import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupp
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.IMMEDIATE;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class NettyHttpServerConnectionAcceptorTest extends AbstractNettyHttpServerTest {
@@ -151,10 +148,7 @@ class NettyHttpServerConnectionAcceptorTest extends AbstractNettyHttpServerTest 
             if (filterMode.expectAccept) {
                 throw new AssertionError("Unexpected exception while reading/writing request/response", e);
             }
-            MatcherAssert.assertThat(e.getCause(), anyOf(instanceOf(IOException.class),
-                                                         instanceOf(MaxRequestLimitExceededException.class),
-                                                         instanceOf(NoAvailableHostException.class),
-                                                         instanceOf(ConnectionClosedException.class)));
+            MatcherAssert.assertThat(e.getCause(), is(instanceOf(IOException.class)));
         }
 
         if (isSslEnabled()) {

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/InvalidRedirectException.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/InvalidRedirectException.java
@@ -17,7 +17,11 @@ package io.servicetalk.http.utils;
 
 /**
  * Throws when redirect could not be performed.
+ *
+ * @deprecated There is no code that can throw this exception. We will remove it and create a new exception type if
+ * there is a use-case in future releases.
  */
+@Deprecated
 public final class InvalidRedirectException extends RuntimeException {
     private static final long serialVersionUID = -3339327100606339327L;
 


### PR DESCRIPTION
Motivation:

There are a few custom exception types that were used in the past, but
became unusable after some refactoring. It's safe to deprecate them and
remove in future releases.

Modifications:

- Deprecate `ConnectionClosedException`, `InvalidRedirectException`
`MaxRequestLimitExceededException`,
`MaxRequestLimitExceededRejectedSubscribeException`;

Result:

All unused exception types are deprecated now.