### PR TITLE
`ConnectionAcceptor` `ConnectionFactory` offloading control

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
@@ -16,6 +16,7 @@
 package io.servicetalk.client.api;
 
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.transport.api.ConnectExecutionStrategy;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
@@ -76,6 +77,8 @@ public interface ConnectionFactoryFilter<ResolvedAddress, C extends ListenableAs
     /**
      * {@inheritDoc}
      *
+     * <p>If the returned strategy extends {@link ConnectExecutionStrategy} then the connection creation or accept may
+     * be offloaded.
      * <p>If the returned strategy extends {@code HttpExecutionStrategy} then the HTTP execution strategy will be
      * applied to the connections created.</p>
      * <p>A utility class provides the ability to combine connect and HTTP execution strategies,
@@ -83,8 +86,8 @@ public interface ConnectionFactoryFilter<ResolvedAddress, C extends ListenableAs
      */
     @Override
     default ExecutionStrategy requiredOffloads() {
-        // safe default--implementations are expected to override
-        return ExecutionStrategy.offloadAll();
+        // safe default--implementations are expected to override if offloading is required.
+        return ConnectExecutionStrategy.anyStrategy();
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.transport.api.ConnectExecutionStrategy;
+import io.servicetalk.transport.api.ExecutionStrategy;
+
+import java.util.Objects;
+
+/**
+ * Combines a {@link ConnectExecutionStrategy} and an {@link HttpExecutionStrategy}.
+ */
+public final class ConnectAndHttpExecutionStrategy implements ConnectExecutionStrategy, HttpExecutionStrategy {
+
+    final ConnectExecutionStrategy connectStrategy;
+    final HttpExecutionStrategy httpStrategy;
+
+    public ConnectAndHttpExecutionStrategy(ConnectExecutionStrategy connectStrategy) {
+        this(connectStrategy, HttpExecutionStrategies.anyStrategy());
+    }
+
+    public ConnectAndHttpExecutionStrategy(HttpExecutionStrategy httpStrategy) {
+        this(ConnectExecutionStrategy.anyStrategy(), httpStrategy);
+    }
+
+    public ConnectAndHttpExecutionStrategy(ConnectExecutionStrategy connect, HttpExecutionStrategy http) {
+        this.connectStrategy = connect;
+        this.httpStrategy = http;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ConnectAndHttpExecutionStrategy that = (ConnectAndHttpExecutionStrategy) o;
+        return connectStrategy.equals(that.connectStrategy) && httpStrategy.equals(that.httpStrategy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectStrategy, httpStrategy);
+    }
+
+    @Override
+    public String toString() {
+        return connectStrategy + " " + httpStrategy;
+    }
+
+    @Override
+    public boolean hasOffloads() {
+        return connectStrategy.hasOffloads() || httpStrategy.hasOffloads();
+    }
+
+    @Override
+    public boolean isMetadataReceiveOffloaded() {
+        return httpStrategy.isMetadataReceiveOffloaded();
+    }
+
+    @Override
+    public boolean isDataReceiveOffloaded() {
+        return httpStrategy.isDataReceiveOffloaded();
+    }
+
+    @Override
+    public boolean isSendOffloaded() {
+        return httpStrategy.isSendOffloaded();
+    }
+
+    @Override
+    public boolean isConnectOffloaded() {
+        return connectStrategy.isConnectOffloaded();
+    }
+
+    @Override
+    public ConnectAndHttpExecutionStrategy merge(final ExecutionStrategy other) {
+        if (other instanceof ConnectAndHttpExecutionStrategy) {
+            return merge((ConnectAndHttpExecutionStrategy) other);
+        } else if (other instanceof HttpExecutionStrategy) {
+            return merge((HttpExecutionStrategy) other);
+        } else if (other instanceof ConnectExecutionStrategy) {
+            return merge((ConnectExecutionStrategy) other);
+        } else {
+            return other.hasOffloads() ?
+                    new ConnectAndHttpExecutionStrategy(
+                            ConnectExecutionStrategy.offload(),
+                            HttpExecutionStrategies.offloadAll())
+                    : this;
+        }
+    }
+
+    private ConnectAndHttpExecutionStrategy merge(final ConnectExecutionStrategy other) {
+        ConnectExecutionStrategy merged = connectStrategy.merge(other);
+        return merged == connectStrategy ? this : new ConnectAndHttpExecutionStrategy(merged, httpStrategy);
+    }
+
+    @Override
+    public ConnectAndHttpExecutionStrategy merge(final HttpExecutionStrategy other) {
+        HttpExecutionStrategy merged = httpStrategy.merge(other);
+        return merged == httpStrategy ? this : new ConnectAndHttpExecutionStrategy(connectStrategy, merged);
+    }
+
+    private ConnectAndHttpExecutionStrategy merge(final ConnectAndHttpExecutionStrategy other) {
+        ConnectExecutionStrategy mergedConnect = connectStrategy.merge(other);
+        HttpExecutionStrategy mergedHttp = httpStrategy.merge(other);
+        return mergedConnect == connectStrategy && mergedHttp == httpStrategy ?
+                this : new ConnectAndHttpExecutionStrategy(mergedConnect, mergedHttp);
+    }
+
+    /**
+     * Returns the {@link HttpExecutionStrategy} portion of this strategy.
+     *
+     * @return the {@link HttpExecutionStrategy} portion of this strategy.
+     */
+    public HttpExecutionStrategy httpStrategy() {
+        return httpStrategy;
+    }
+
+    /**
+     * Returns the {@link ConnectExecutionStrategy} portion of this strategy.
+     *
+     * @return the {@link ConnectExecutionStrategy} portion of this strategy.
+     */
+    public ConnectExecutionStrategy connectStrategy() {
+        return connectStrategy;
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
@@ -38,9 +38,11 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
     }
 
     /**
-     * Return the {@link HttpExecutionStrategy} describing offloads required by this instance.
+     * {@inheritDoc}
      *
-     * @return the {@link HttpExecutionStrategy} describing offloads required by this instance
+     * <p>The provided default implementation requests offloading of all operations. Implementations that require no
+     * offloading should be careful to return {@link HttpExecutionStrategies#anyStrategy()} rather than
+     * {@link HttpExecutionStrategies#noOffloadsStrategy()}.
      */
     @Override
     default HttpExecutionStrategy requiredOffloads() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -19,8 +19,11 @@ import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.logging.api.LogLevel;
+import io.servicetalk.transport.api.ConnectExecutionStrategy;
 import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionAcceptorFactory;
+import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfig;
@@ -164,6 +167,11 @@ public interface HttpServerBuilder {
      * <pre>
      *     filter1 ⇒ filter2 ⇒ filter3
      * </pre>
+     *
+     * <p>The connection acceptor will, by default, not be offloaded. If your filter requires the
+     * {@link ConnectionAcceptor#accept(ConnectionContext)} to be offloaded then your
+     * {@link ConnectionAcceptorFactory} will need to return {@link ConnectExecutionStrategy#offloadAll()} from the
+     * {@link ExecutionStrategyInfluencer#requiredOffloads()}.
      *
      * @param factory {@link ConnectionAcceptorFactory} to append. Lifetime of this
      * {@link ConnectionAcceptorFactory} is managed by this builder and the server started thereof.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -22,7 +22,6 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
-import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
@@ -31,6 +30,7 @@ import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpConnector;
 import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.TransportObserver;
 
 import io.netty.channel.Channel;
@@ -51,12 +51,13 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
             final ReadOnlyHttpClientConfig config, final HttpExecutionContext executionContext,
             @Nullable final StreamingHttpConnectionFilterFactory connectionFilterFunction,
             final Function<HttpProtocolVersion, StreamingHttpRequestResponseFactory> reqRespFactoryFunc,
-            final HttpExecutionStrategy chainStrategy,
+            final ExecutionStrategy connectStrategy,
             final ConnectionFactoryFilter<ResolvedAddress, FilterableStreamingHttpConnection> connectionFactoryFilter,
             final Function<FilterableStreamingHttpConnection,
                     FilterableStreamingHttpLoadBalancedConnection> protocolBinding) {
-        super(config, executionContext, connectionFilterFunction, reqRespFactoryFunc, chainStrategy,
-                connectionFactoryFilter, protocolBinding);
+        super(config, executionContext, reqRespFactoryFunc,
+                connectStrategy, connectionFactoryFilter, connectionFilterFunction,
+                protocolBinding);
         assert config.h1Config() != null && config.h2Config() != null;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -39,7 +39,6 @@ import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.serializer.api.SerializationException;
-import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionAcceptorFactory;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
@@ -47,6 +46,7 @@ import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,6 +124,15 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
             throw new IllegalArgumentException(desc + " required offloading : " + requires);
         }
         return obj;
+    }
+
+    private static HttpExecutionStrategy requiredOffloads(Object anything, HttpExecutionStrategy defaultOffloads) {
+        if (anything instanceof ExecutionStrategyInfluencer) {
+            ExecutionStrategy requiredOffloads = ((ExecutionStrategyInfluencer<?>) anything).requiredOffloads();
+            return HttpExecutionStrategy.from(requiredOffloads);
+        } else {
+            return defaultOffloads;
+        }
     }
 
     @Override
@@ -275,26 +284,6 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
         return executionContextBuilder.build();
     }
 
-    private Single<ServerContext> doListen(@Nullable final ConnectionAcceptor connectionAcceptor,
-                                           final HttpExecutionContext context,
-                                           StreamingHttpService service,
-                                           final boolean drainRequestPayloadBody) {
-        final ReadOnlyHttpServerConfig roConfig = this.config.asReadOnly();
-        service = applyInternalFilters(service, roConfig.lifecycleObserver());
-
-        if (roConfig.tcpConfig().isAlpnConfigured()) {
-            return DeferredServerChannelBinder.bind(context, roConfig, address, connectionAcceptor,
-                    service, drainRequestPayloadBody, false);
-        } else if (roConfig.tcpConfig().sniMapping() != null) {
-            return DeferredServerChannelBinder.bind(context, roConfig, address, connectionAcceptor,
-                    service, drainRequestPayloadBody, true);
-        } else if (roConfig.isH2PriorKnowledge()) {
-            return H2ServerParentConnectionContext.bind(context, roConfig, address, connectionAcceptor,
-                    service, drainRequestPayloadBody);
-        }
-        return NettyHttpServer.bind(context, roConfig, address, connectionAcceptor, service, drainRequestPayloadBody);
-    }
-
     private Single<ServerContext> listenForAdapter(HttpApiConversions.ServiceAdapterHolder adapterHolder) {
         return listenForService(adapterHolder.adaptor(), adapterHolder.serviceInvocationStrategy());
     }
@@ -318,8 +307,9 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
      * the server could not be started.
      */
     private Single<ServerContext> listenForService(StreamingHttpService rawService, HttpExecutionStrategy strategy) {
-        ConnectionAcceptor connectionAcceptor = connectionAcceptorFactory == null ? null :
-           connectionAcceptorFactory.create(ACCEPT_ALL);
+        InfluencerConnectionAcceptor connectionAcceptor = connectionAcceptorFactory == null ? null :
+                InfluencerConnectionAcceptor.withStrategy(connectionAcceptorFactory.create(ACCEPT_ALL),
+                        connectionAcceptorFactory.requiredOffloads());
 
         final StreamingHttpService filteredService;
         HttpExecutionContext serviceContext;
@@ -351,19 +341,31 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
                 });
     }
 
+    private Single<ServerContext> doListen(@Nullable final InfluencerConnectionAcceptor connectionAcceptor,
+                                           final HttpExecutionContext serviceContext,
+                                           StreamingHttpService service,
+                                           final boolean drainRequestPayloadBody) {
+        final ReadOnlyHttpServerConfig roConfig = this.config.asReadOnly();
+        service = applyInternalFilters(service, roConfig.lifecycleObserver());
+
+        if (roConfig.tcpConfig().isAlpnConfigured()) {
+            return DeferredServerChannelBinder.bind(serviceContext, roConfig, address, connectionAcceptor,
+                    service, drainRequestPayloadBody, false);
+        } else if (roConfig.tcpConfig().sniMapping() != null) {
+            return DeferredServerChannelBinder.bind(serviceContext, roConfig, address, connectionAcceptor,
+                    service, drainRequestPayloadBody, true);
+        } else if (roConfig.isH2PriorKnowledge()) {
+            return H2ServerParentConnectionContext.bind(serviceContext, roConfig, address, connectionAcceptor,
+                    service, drainRequestPayloadBody);
+        }
+        return NettyHttpServer.bind(serviceContext, roConfig, address, connectionAcceptor,
+                service, drainRequestPayloadBody);
+    }
+
     private HttpExecutionStrategy computeServiceStrategy(Object service) {
         HttpExecutionStrategy serviceStrategy = requiredOffloads(service, defaultStrategy());
         HttpExecutionStrategy filterStrategy = computeRequiredStrategy(serviceFilters, serviceStrategy);
         return defaultStrategy() == strategy ? filterStrategy : strategy.merge(filterStrategy);
-    }
-
-    private static HttpExecutionStrategy requiredOffloads(Object anything, HttpExecutionStrategy defaultOffloads) {
-        if (anything instanceof ExecutionStrategyInfluencer) {
-            ExecutionStrategy requiredOffloads = ((ExecutionStrategyInfluencer<?>) anything).requiredOffloads();
-            return HttpExecutionStrategy.from(requiredOffloads);
-        } else {
-            return defaultOffloads;
-        }
     }
 
     private static StreamingHttpService applyInternalFilters(StreamingHttpService service,
@@ -381,8 +383,7 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
     /**
      * Internal filter that makes sure we handle all exceptions from user-defined service and filters.
      */
-    private static final class ExceptionMapperServiceFilter
-            implements StreamingHttpServiceFilterFactory {
+    private static final class ExceptionMapperServiceFilter implements StreamingHttpServiceFilterFactory {
 
         static final StreamingHttpServiceFilterFactory INSTANCE = new ExceptionMapperServiceFilter();
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
@@ -23,9 +23,9 @@ import io.servicetalk.http.netty.NettyHttpServer.NettyHttpServerConnection;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
 import io.servicetalk.tcp.netty.internal.TcpServerBinder;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
-import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
 import io.netty.channel.Channel;
@@ -51,7 +51,7 @@ final class DeferredServerChannelBinder {
     static Single<ServerContext> bind(final HttpExecutionContext executionContext,
                                       final ReadOnlyHttpServerConfig config,
                                       final SocketAddress listenAddress,
-                                      @Nullable final ConnectionAcceptor connectionAcceptor,
+                                      @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
                                       final StreamingHttpService service,
                                       final boolean drainRequestPayloadBody,
                                       final boolean sniOnly) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -22,12 +22,12 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
-import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpConnector;
+import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.TransportObserver;
 
 import java.util.function.Function;
@@ -44,12 +44,13 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
             final ReadOnlyHttpClientConfig config, final HttpExecutionContext executionContext,
             @Nullable final StreamingHttpConnectionFilterFactory connectionFilterFunction,
             final StreamingHttpRequestResponseFactory reqRespFactory,
-            final HttpExecutionStrategy chainStrategy,
+            final ExecutionStrategy connectStrategy,
             final ConnectionFactoryFilter<ResolvedAddress, FilterableStreamingHttpConnection> connectionFactoryFilter,
             final Function<FilterableStreamingHttpConnection,
                     FilterableStreamingHttpLoadBalancedConnection> protocolBinding) {
-        super(config, executionContext, connectionFilterFunction, version -> reqRespFactory, chainStrategy,
-                connectionFactoryFilter, protocolBinding);
+        super(config, executionContext, version -> reqRespFactory,
+                connectStrategy, connectionFactoryFilter, connectionFilterFunction,
+                protocolBinding);
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -25,7 +25,6 @@ import io.servicetalk.http.netty.NettyHttpServer.NettyHttpServerConnection;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
 import io.servicetalk.tcp.netty.internal.TcpServerBinder;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
-import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
@@ -35,6 +34,7 @@ import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
+import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 import io.servicetalk.transport.netty.internal.NettyPipelineSslUtils;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopMultiplexedObserver;
 
@@ -82,7 +82,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
     static Single<ServerContext> bind(final HttpExecutionContext executionContext,
                                       final ReadOnlyHttpServerConfig config,
                                       final SocketAddress listenAddress,
-                                      @Nullable final ConnectionAcceptor connectionAcceptor,
+                                      @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
                                       final StreamingHttpService service,
                                       final boolean drainRequestPayloadBody) {
         if (config.h2Config() == null) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
@@ -54,16 +54,16 @@ final class LoadBalancedStreamingHttpConnection implements FilterableStreamingHt
     private final ReservableRequestConcurrencyController limiter;
     private final FilterableStreamingHttpLoadBalancedConnection filteredConnection;
     private final HttpExecutionStrategy streamingStrategy;
-    private final HttpExecutionStrategy chainStrategy;
+    private final HttpExecutionStrategy connectStrategy;
 
     LoadBalancedStreamingHttpConnection(FilterableStreamingHttpLoadBalancedConnection filteredConnection,
                                         ReservableRequestConcurrencyController limiter,
                                         HttpExecutionStrategy streamingStrategy,
-                                        HttpExecutionStrategy chainStrategy) {
+                                        HttpExecutionStrategy connectStrategy) {
         this.filteredConnection = filteredConnection;
         this.limiter = requireNonNull(limiter);
         this.streamingStrategy = streamingStrategy;
-        this.chainStrategy = chainStrategy;
+        this.connectStrategy = connectStrategy;
     }
 
     @Override
@@ -133,22 +133,22 @@ final class LoadBalancedStreamingHttpConnection implements FilterableStreamingHt
 
     @Override
     public ReservedHttpConnection asConnection() {
-        return toReservedConnection(this, chainStrategy);
+        return toReservedConnection(this, connectStrategy);
     }
 
     @Override
     public ReservedBlockingStreamingHttpConnection asBlockingStreamingConnection() {
-        return toReservedBlockingStreamingConnection(this, chainStrategy);
+        return toReservedBlockingStreamingConnection(this, connectStrategy);
     }
 
     @Override
     public ReservedBlockingHttpConnection asBlockingConnection() {
-        return toReservedBlockingConnection(this, chainStrategy);
+        return toReservedBlockingConnection(this, connectStrategy);
     }
 
     @Override
     public HttpExecutionStrategy requiredOffloads() {
-        return chainStrategy;
+        return connectStrategy;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -46,7 +46,6 @@ import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
 import io.servicetalk.tcp.netty.internal.TcpServerBinder;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
-import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ServerContext;
@@ -56,6 +55,7 @@ import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedEx
 import io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
+import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 import io.servicetalk.transport.netty.internal.SplittingFlushStrategy;
@@ -119,7 +119,7 @@ final class NettyHttpServer {
     static Single<ServerContext> bind(final HttpExecutionContext executionContext,
                                       final ReadOnlyHttpServerConfig config,
                                       final SocketAddress address,
-                                      @Nullable final ConnectionAcceptor connectionAcceptor,
+                                      @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
                                       final StreamingHttpService service,
                                       final boolean drainRequestPayloadBody) {
         if (config.h1Config() == null) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -22,9 +22,9 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
-import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.TransportObserver;
 
 import java.util.function.Function;
@@ -40,12 +40,12 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
             final ReadOnlyHttpClientConfig config, final HttpExecutionContext executionContext,
             @Nullable final StreamingHttpConnectionFilterFactory connectionFilterFunction,
             final StreamingHttpRequestResponseFactory reqRespFactory,
-            final HttpExecutionStrategy chainStrategy,
+            final ExecutionStrategy connectStrategy,
             final ConnectionFactoryFilter<ResolvedAddress, FilterableStreamingHttpConnection> connectionFactoryFilter,
             final Function<FilterableStreamingHttpConnection,
                     FilterableStreamingHttpLoadBalancedConnection> protocolBinding) {
-        super(config, executionContext, connectionFilterFunction, version -> reqRespFactory, chainStrategy,
-                connectionFactoryFilter, protocolBinding);
+        super(config, executionContext, version -> reqRespFactory, connectStrategy, connectionFactoryFilter,
+                connectionFilterFunction, protocolBinding);
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptorOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptorOffloadingTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseFactory;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.transport.api.ConnectExecutionStrategy;
+import io.servicetalk.transport.api.ConnectionAcceptorFactory;
+import io.servicetalk.transport.api.IoThreadFactory;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+class ConnectionAcceptorOffloadingTest {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testAcceptorOffloading(boolean offload) throws Exception {
+        AtomicReference<Boolean> offloaded = new AtomicReference<>();
+        ConnectionAcceptorFactory factory = ConnectionAcceptorFactory.withStrategy(original ->
+                        context -> {
+                            boolean isIoThread = IoThreadFactory.IoThread.currentThreadIsIoThread();
+                            offloaded.set(!isIoThread);
+                            return original.accept(context);
+                        },
+                offload ? ConnectExecutionStrategy.offload() : ConnectExecutionStrategy.anyStrategy());
+
+        try (ServerContext server = HttpServers.forPort(0)
+                .appendConnectionAcceptorFilter(factory)
+                .listenAndAwait(this::helloWorld)) {
+            SocketAddress serverAddress = server.listenAddress();
+
+            try (BlockingHttpClient client = HttpClients.forResolvedAddress(serverAddress).buildBlocking()) {
+                HttpResponse response = client.request(client.get("/sayHello"));
+                assertThat("unexpected status", response.status(), is(HttpResponseStatus.OK));
+            }
+        }
+        assertThat("factory was not invoked", offloaded.get(), is(notNullValue()));
+        assertThat("incorrect offloading", offloaded.get(), is(offload));
+    }
+
+    private Single<HttpResponse> helloWorld(HttpServiceContext ctx,
+                                            HttpRequest request,
+                                            HttpResponseFactory responseFactory) {
+        return succeeded(responseFactory.ok().payloadBody("Hello World!", textSerializerUtf8()));
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryOffloadingTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionFactoryFilter;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.ConnectAndHttpExecutionStrategy;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategies;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseFactory;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.transport.api.ConnectExecutionStrategy;
+import io.servicetalk.transport.api.IoThreadFactory;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.TransportObserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConnectionFactoryOffloadingTest {
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> testCases() {
+        return Stream.of(
+                Arguments.of(false, HttpExecutionStrategies.anyStrategy()),
+                Arguments.of(false, HttpExecutionStrategies.offloadAll()),
+                Arguments.of(true, HttpExecutionStrategies.anyStrategy()),
+                Arguments.of(true, HttpExecutionStrategies.offloadAll())
+        );
+    }
+
+    @ParameterizedTest(name = "offload={0} httpStrategy={1}")
+    @MethodSource("testCases")
+    void testFactoryOffloading(boolean offload, HttpExecutionStrategy httpStrategy) throws Exception {
+        AtomicReference<Thread> factoryThread = new AtomicReference<>();
+
+        Thread appThread = Thread.currentThread();
+
+        try (ServerContext server = HttpServers.forPort(0)
+                .listenAndAwait(this::helloWorld)) {
+            SocketAddress serverAddress = server.listenAddress();
+
+            ConnectionFactoryFilter<SocketAddress, FilterableStreamingHttpConnection> factory =
+                    ConnectionFactoryFilter.withStrategy(original ->
+                                    new ConnectionFactory<SocketAddress, FilterableStreamingHttpConnection>() {
+                                private final ListenableAsyncCloseable close = emptyAsyncCloseable();
+
+                                @Override
+                                public Single<FilterableStreamingHttpConnection> newConnection(
+                                        final SocketAddress socketAddress, @Nullable final TransportObserver observer) {
+                                    factoryThread.set(Thread.currentThread());
+                                    return original.newConnection(socketAddress, observer);
+                                }
+
+                                @Override
+                                public Completable onClose() {
+                                    return close.onClose();
+                                }
+
+                                @Override
+                                public Completable closeAsync() {
+                                    return close.closeAsync();
+                                }
+
+                                @Override
+                                public Completable closeAsyncGracefully() {
+                                    return close.closeAsyncGracefully();
+                                }
+                            },
+                            new ConnectAndHttpExecutionStrategy(offload ?
+                                    ConnectExecutionStrategy.offload() : ConnectExecutionStrategy.anyStrategy(),
+                                    httpStrategy));
+
+            try (HttpClient client = HttpClients.forResolvedAddress(serverAddress)
+                    .appendConnectionFactoryFilter(factory)
+                    .build()) {
+                assertThat(client.executionContext().executionStrategy().missing(httpStrategy),
+                        is(HttpExecutionStrategies.anyStrategy()));
+                Single<HttpResponse> single = client.request(client.get("/sayHello"));
+                HttpResponse response = single.toFuture().get();
+                assertThat("unexpected status", response.status(), is(HttpResponseStatus.OK));
+            }
+        }
+        assertTrue((offload && !IoThreadFactory.IoThread.isIoThread(factoryThread.get())) ||
+                        (!offload && factoryThread.get() == appThread),
+                "incorrect offloading, offload=" + offload + " thread=" + factoryThread.get());
+    }
+
+    private Single<HttpResponse> helloWorld(HttpServiceContext ctx,
+                                            HttpRequest request,
+                                            HttpResponseFactory responseFactory) {
+        return succeeded(responseFactory.ok().payloadBody("Hello World!", textSerializerUtf8()));
+    }
+}

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
@@ -25,6 +25,7 @@ import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.BuilderUtils;
 import io.servicetalk.transport.netty.internal.ChannelSet;
 import io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutor;
+import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 import io.servicetalk.transport.netty.internal.NettyServerContext;
 
@@ -46,6 +47,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.toNettyAddress;
@@ -83,7 +85,7 @@ public final class TcpServerBinder {
      */
     public static <CC extends ConnectionContext> Single<ServerContext> bind(SocketAddress listenAddress,
             final ReadOnlyTcpServerConfig config, final boolean autoRead, final ExecutionContext<?> executionContext,
-            @Nullable final ConnectionAcceptor connectionAcceptor,
+            @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
             final BiFunction<Channel, ConnectionObserver, Single<CC>> connectionFunction,
             final Consumer<CC> connectionConsumer) {
         requireNonNull(connectionFunction);
@@ -131,7 +133,9 @@ public final class TcpServerBinder {
                             // of connection processing.
                             defer(() -> connectionAcceptor.accept(conn).concat(succeeded(conn)))
                                     // subscribeOn is required to offload calls to connectionAcceptor#accept
-                                    .subscribeOn(executionContext.executor()));
+                                    .subscribeOn(connectionAcceptor.requiredOffloads().isConnectOffloaded() ?
+                                        executionContext.executor() : immediate())
+                    );
                 }
                 connectionSingle.beforeOnError(cause -> {
                     // Getting the remote-address may involve volatile reads and potentially a syscall, so guard it.

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -19,12 +19,13 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
-import io.servicetalk.transport.api.ConnectionAcceptor;
+import io.servicetalk.transport.api.ConnectExecutionStrategy;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
+import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 
 import org.junit.jupiter.api.AfterEach;
@@ -48,7 +49,8 @@ public abstract class AbstractTcpServerTest {
     public static final ExecutionContextExtension CLIENT_CTX =
             ExecutionContextExtension.cached("client-io", "client-executor");
 
-    private ConnectionAcceptor connectionAcceptor = ACCEPT_ALL;
+    private InfluencerConnectionAcceptor connectionAcceptor =
+            InfluencerConnectionAcceptor.withStrategy(ACCEPT_ALL, ConnectExecutionStrategy.anyStrategy());
     private Function<NettyConnection<Buffer, Buffer>, Completable> service =
         conn -> conn.write(conn.read());
     private boolean sslEnabled;
@@ -57,7 +59,7 @@ public abstract class AbstractTcpServerTest {
     InetSocketAddress serverAddress;
     TcpClient client;
 
-    void connectionAcceptor(final ConnectionAcceptor connectionAcceptor) {
+    void connectionAcceptor(final InfluencerConnectionAcceptor connectionAcceptor) {
         this.connectionAcceptor = connectionAcceptor;
     }
 

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -17,13 +17,13 @@ package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.transport.api.ConnectionAcceptor;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.BufferHandler;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
+import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 
 import org.slf4j.Logger;
@@ -78,7 +78,7 @@ public class TcpServer {
      * @throws InterruptedException If the calling thread was interrupted waiting for the server to start.
      */
     public ServerContext bind(ExecutionContext<?> executionContext, int port,
-                              @Nullable ConnectionAcceptor connectionAcceptor,
+                              @Nullable InfluencerConnectionAcceptor connectionAcceptor,
                               Function<NettyConnection<Buffer, Buffer>, Completable> service,
                               ExecutionStrategy executionStrategy)
             throws ExecutionException, InterruptedException {

--- a/servicetalk-transport-api/build.gradle
+++ b/servicetalk-transport-api/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectExecutionStrategy.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+/**
+ * An execution strategy for creating or accepting connections.
+ */
+public interface ConnectExecutionStrategy extends ExecutionStrategy {
+
+    /**
+     * Returns {@code true} if the instance has offloading for any operation.
+     *
+     * @return {@code true} if the instance has offloading for any operation.
+     */
+    @Override
+    default boolean hasOffloads() {
+        return isConnectOffloaded();
+    }
+
+    /**
+     * Returns true if connection creation or accept requires offloading.
+     *
+     * @return true if connection creation or accept requires offloading
+     */
+    boolean isConnectOffloaded();
+
+    /**
+     * Combines this execution strategy with another execution strategy.
+     *
+     * @param other The other execution strategy to combine. This is converted to a {@link ConnectExecutionStrategy}
+     * using {@link #from(ExecutionStrategy)}.
+     * @return The combined execution strategy.
+     */
+    @Override
+    default ConnectExecutionStrategy merge(ExecutionStrategy other) {
+        ConnectExecutionStrategy asCES = from(other);
+        return hasOffloads() ?
+                asCES.hasOffloads() ? ConnectExecutionStrategy.offload() : this :
+                asCES.hasOffloads() ? asCES : ConnectExecutionStrategy.anyStrategy();
+    }
+
+    /**
+     * Returns an {@link ConnectExecutionStrategy} that requires no offloading.
+     *
+     * @return an {@link ConnectExecutionStrategy} that requires no offloading.
+     */
+    static ConnectExecutionStrategy anyStrategy() {
+        return DefaultConnectExecutionStrategy.CONNECT_NOT_OFFLOADED;
+    }
+
+    /**
+     * Returns an {@link ConnectExecutionStrategy} that requires offloading for all actions.
+     *
+     * @return an {@link ConnectExecutionStrategy} that requires offloading.
+     */
+    static ConnectExecutionStrategy offload() {
+        return DefaultConnectExecutionStrategy.CONNECT_OFFLOADED;
+    }
+
+    /**
+     * Converts the provided execution strategy to a {@link ConnectExecutionStrategy}. If the provided strategy is
+     * already {@link ConnectExecutionStrategy} it is returned unchanged. For other strategies, if the strategy
+     * {@link ExecutionStrategy#hasOffloads()} then {@link ConnectExecutionStrategy#offload()} is returned otherwise
+     * {@link ConnectExecutionStrategy#anyStrategy()} is returned.
+     *
+     * @param executionStrategy The {@link ExecutionStrategy} to convert
+     * @return converted {@link ConnectExecutionStrategy}.
+     */
+    static ConnectExecutionStrategy from(ExecutionStrategy executionStrategy) {
+        return executionStrategy instanceof ConnectExecutionStrategy ?
+                (ConnectExecutionStrategy) executionStrategy :
+                    executionStrategy.hasOffloads() ?
+                        ConnectExecutionStrategy.offload() :
+                        ConnectExecutionStrategy.anyStrategy();
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
  * A factory of {@link ConnectionAcceptor}.
  */
 @FunctionalInterface
-public interface ConnectionAcceptorFactory extends ExecutionStrategyInfluencer<ExecutionStrategy> {
+public interface ConnectionAcceptorFactory extends ExecutionStrategyInfluencer<ConnectExecutionStrategy> {
 
     /**
      * Create a {@link ConnectionAcceptor} using the provided {@link ConnectionAcceptor}.
@@ -63,10 +63,17 @@ public interface ConnectionAcceptorFactory extends ExecutionStrategyInfluencer<E
         return original -> original;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The strategy returned will be applied to the connection acceptor instance returned by
+     * {@link #create(ConnectionAcceptor)}. If offloading is not required then override to return
+     * {@link ConnectExecutionStrategy#anyStrategy()}
+     */
     @Override
-    default ExecutionStrategy requiredOffloads() {
+    default ConnectExecutionStrategy requiredOffloads() {
         // safe default--implementations are expected to override
-        return ExecutionStrategy.offloadAll();
+        return ConnectExecutionStrategy.offload();
     }
 
     /**
@@ -76,7 +83,8 @@ public interface ConnectionAcceptorFactory extends ExecutionStrategyInfluencer<E
      * @param strategy execution strategy for the wrapped factory
      * @return wrapped {@link ConnectionAcceptorFactory}
      */
-    static ConnectionAcceptorFactory withStrategy(ConnectionAcceptorFactory original, ExecutionStrategy strategy) {
+    static ConnectionAcceptorFactory withStrategy(ConnectionAcceptorFactory original,
+                                                  ConnectExecutionStrategy strategy) {
         return new ConnectionAcceptorFactory() {
 
             @Override
@@ -85,7 +93,7 @@ public interface ConnectionAcceptorFactory extends ExecutionStrategyInfluencer<E
             }
 
             @Override
-            public ExecutionStrategy requiredOffloads() {
+            public ConnectExecutionStrategy requiredOffloads() {
                 return strategy;
             }
         };

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DefaultConnectExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DefaultConnectExecutionStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+/**
+ * Implements the built-in {@link ConnectExecutionStrategy} instances.
+ */
+enum DefaultConnectExecutionStrategy implements ConnectExecutionStrategy {
+    /**
+     * Does not require connect offloads
+     */
+    CONNECT_NOT_OFFLOADED {
+        @Override
+        public boolean isConnectOffloaded() {
+            return false;
+        }
+    },
+    /**
+     * Offload all connect invocations
+     */
+    CONNECT_OFFLOADED {
+        @Override
+        public boolean isConnectOffloaded() {
+            return true;
+        }
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategyInfluencer.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategyInfluencer.java
@@ -24,8 +24,7 @@ package io.servicetalk.transport.api;
 public interface ExecutionStrategyInfluencer<S extends ExecutionStrategy> {
 
     /**
-     * Return an {@link ExecutionStrategy} that describes the offloads required by the influencer. The provided
-     * default implementation requests offloading of all operations.
+     * Return an {@link ExecutionStrategy} that describes the offloads required by the influencer.
      *
      * @return the {@link ExecutionStrategy} required by the influencer.
      */

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/InfluencerConnectionAcceptor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/InfluencerConnectionAcceptor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.transport.api.ConnectExecutionStrategy;
+import io.servicetalk.transport.api.ConnectionAcceptor;
+import io.servicetalk.transport.api.ConnectionAcceptorFactory;
+import io.servicetalk.transport.api.DelegatingConnectionAcceptor;
+import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.transport.api.ConnectExecutionStrategy.anyStrategy;
+
+/**
+ * A contract that defines the connection acceptance criterion.
+ *
+ * @see ConnectionAcceptorFactory
+ */
+@FunctionalInterface
+public interface InfluencerConnectionAcceptor extends ConnectionAcceptor,
+                                                      ExecutionStrategyInfluencer<ConnectExecutionStrategy> {
+
+    /**
+     * ACCEPT all connections.
+     */
+    InfluencerConnectionAcceptor ACCEPT_ALL = withStrategy((context) -> completed(), anyStrategy());
+
+    @Override
+    default Completable closeAsync() {
+        return completed();
+    }
+
+    @Override
+    default ConnectExecutionStrategy requiredOffloads() {
+        // "safe" default -- implementations are expected to override
+        return ConnectExecutionStrategy.offload();
+    }
+
+    /**
+     * Wraps a {@link InfluencerConnectionAcceptor} to return a specific execution strategy.
+     *
+     * @param original connection ConnectionAcceptor to be wrapped.
+     * @param strategy execution strategy for the wrapped ConnectionAcceptor
+     * @return wrapped {@link InfluencerConnectionAcceptor}
+     */
+    static InfluencerConnectionAcceptor withStrategy(ConnectionAcceptor original, ConnectExecutionStrategy strategy) {
+        class InfluencedConnectionAcceptor extends DelegatingConnectionAcceptor
+                implements InfluencerConnectionAcceptor {
+
+            InfluencedConnectionAcceptor() {
+                super(original);
+            }
+
+            @Override
+            public ConnectExecutionStrategy requiredOffloads() {
+                return strategy;
+            }
+        }
+
+        return new InfluencedConnectionAcceptor();
+    }
+}

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/InfluencerConnectionAcceptorTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/InfluencerConnectionAcceptorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.ConnectExecutionStrategy;
+import io.servicetalk.transport.api.ConnectionAcceptorFactory;
+
+import org.junit.jupiter.api.Test;
+
+import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
+import static io.servicetalk.transport.api.ConnectionAcceptorFactory.withStrategy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+class InfluencerConnectionAcceptorTest {
+
+    @Test
+    void defaultRequiredOffloads() {
+        ConnectionAcceptorFactory factory = ConnectionAcceptorFactory.identity();
+        assertThat("Default should be safe", factory.requiredOffloads().hasOffloads());
+
+        InfluencerConnectionAcceptor acceptor =
+                InfluencerConnectionAcceptor.withStrategy(factory.create(ACCEPT_ALL), factory.requiredOffloads());
+        assertThat("acceptor should have same strategy", acceptor.requiredOffloads(), is(factory.requiredOffloads()));
+    }
+
+    @Test
+    void withStrategyRequiredOffloads() {
+        ConnectionAcceptorFactory factory = withStrategy(original -> original, ConnectExecutionStrategy.offload());
+        assertThat("unexpected strategy", factory.requiredOffloads(), is(ConnectExecutionStrategy.offload()));
+
+        InfluencerConnectionAcceptor acceptor =
+                InfluencerConnectionAcceptor.withStrategy(factory.create(ACCEPT_ALL), factory.requiredOffloads());
+        assertThat("acceptor should have same strategy", acceptor.requiredOffloads(), is(factory.requiredOffloads()));
+    }
+}


### PR DESCRIPTION
Motivation:
Currently `ConnectionAcceptor::accept` and
`ConnectionFactory::newConnection` are always offloaded. This may
be unnecessary.
Modifications:
By implementing `ExecutionStrategyInfluencer` and conditionally
offloading only when the required strategy of the acceptor or factory
is not `anyStrategy()` unnecessary offloading is avoided.
Result:
Potentially less offloading for connection acceptors and factories.