### PR TITLE
Enhance GrpcStatus.fromCodeValue static factories to include actual status code when it maps to UNKNOWN

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatus.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatus.java
@@ -17,7 +17,6 @@ package io.servicetalk.grpc.api;
 
 import com.google.rpc.Status;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
@@ -89,7 +88,7 @@ public final class GrpcStatus {
         try {
             return fromCodeValue(parseInt(codeValue));
         } catch (NumberFormatException e) {
-            return UNKNOWN.status().withDescription("Status code value not a number: " + codeValue);
+            return new GrpcStatus(UNKNOWN, null, "Status code value not a number: " + codeValue);
         }
     }
 
@@ -101,7 +100,7 @@ public final class GrpcStatus {
      */
     public static GrpcStatus fromCodeValue(int codeValue) {
         return codeValue < 0 || codeValue >= INT_TO_GRPC_STATUS_MAP.length ?
-                UNKNOWN.status().withDescription("Unknown code: " + codeValue) : INT_TO_GRPC_STATUS_MAP[codeValue];
+                new GrpcStatus(UNKNOWN, null, "Unknown code: " + codeValue) : INT_TO_GRPC_STATUS_MAP[codeValue];
     }
 
     /**
@@ -177,13 +176,6 @@ public final class GrpcStatus {
     @Nullable
     public String description() {
         return description;
-    }
-
-    public GrpcStatus withDescription(String description) {
-        if (Objects.equals(this.description, description)) {
-            return this;
-        }
-        return new GrpcStatus(this.code, this.cause, description);
     }
 
     @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatus.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatus.java
@@ -17,6 +17,7 @@ package io.servicetalk.grpc.api;
 
 import com.google.rpc.Status;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
@@ -88,7 +89,7 @@ public final class GrpcStatus {
         try {
             return fromCodeValue(parseInt(codeValue));
         } catch (NumberFormatException e) {
-            return UNKNOWN.status();
+            return UNKNOWN.status().withDescription("Status code value not a number: " + codeValue);
         }
     }
 
@@ -100,7 +101,7 @@ public final class GrpcStatus {
      */
     public static GrpcStatus fromCodeValue(int codeValue) {
         return codeValue < 0 || codeValue >= INT_TO_GRPC_STATUS_MAP.length ?
-                UNKNOWN.status() : INT_TO_GRPC_STATUS_MAP[codeValue];
+                UNKNOWN.status().withDescription("Unknown code: " + codeValue) : INT_TO_GRPC_STATUS_MAP[codeValue];
     }
 
     /**
@@ -176,6 +177,13 @@ public final class GrpcStatus {
     @Nullable
     public String description() {
         return description;
+    }
+
+    public GrpcStatus withDescription(String description) {
+        if (Objects.equals(this.description, description)) {
+            return this;
+        }
+        return new GrpcStatus(this.code, this.cause, description);
     }
 
     @Override

--- a/servicetalk-grpc-api/test/java/io/servicetalk/grpc/api/GrpcStatusTest.java
+++ b/servicetalk-grpc-api/test/java/io/servicetalk/grpc/api/GrpcStatusTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GrpcStatusTest {
+
+    @Test
+    public void testGrpcStatusFromIntCodeValue() {
+        final GrpcStatus grpcStatus = GrpcStatus.fromCodeValue(0);
+        assertEquals(GrpcStatusCode.OK, grpcStatus.code());
+    }
+
+    @Test
+    public void testGrpcStatusFromStringCodeValue() {
+        final GrpcStatus grpcStatus = GrpcStatus.fromCodeValue("0");
+        assertEquals(GrpcStatusCode.OK, grpcStatus.code());
+    }
+
+    @Test
+    public void testGrpcStatusUnknownFromIntCodeValue() {
+        int unknownCode = 255;
+        final GrpcStatus grpcStatus = GrpcStatus.fromCodeValue(unknownCode);
+        assertEquals(GrpcStatusCode.UNKNOWN, grpcStatus.code());
+        assertEquals("Unknown code: " + unknownCode, grpcStatus.description());
+    }
+
+    @Test
+    public void testGrpcStatusUnknownFromStringCodeValue() {
+        final String unknownCode = "255";
+        final GrpcStatus grpcStatus = GrpcStatus.fromCodeValue(unknownCode);
+        assertEquals(GrpcStatusCode.UNKNOWN, grpcStatus.code());
+        assertEquals("Unknown code: " + unknownCode, grpcStatus.description());
+    }
+
+    @Test
+    public void testGrpcStatusUnknownFromUnparsableStringCodeValue() {
+        final String unknownCode = "1f";
+        final GrpcStatus grpcStatus = GrpcStatus.fromCodeValue(unknownCode);
+        assertEquals(GrpcStatusCode.UNKNOWN, grpcStatus.code());
+        assertEquals("Status code value not a number: " + unknownCode, grpcStatus.description());
+    }
+}


### PR DESCRIPTION
Motivation:
Preserving the original code value in the description when the code is not recognized. This is also consistent with grpc-java.

Modifications:
Pass in the original error code to `GrpcStatus` in the static factories.

Result:
GrpcStatus with UNKNOWN status code preserves the ogirinal code value.