### PR TITLE
Enhance javadoc to clarify StackOverflowError possibility

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -867,7 +867,6 @@ public abstract class Completable {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to retry an operation under certain failure conditions and in sequential programming
      * is similar to:
      * <pre>{@code
@@ -909,7 +908,6 @@ public abstract class Completable {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
      * and in sequential programming is similar to:
      * <pre>{@code
@@ -953,7 +951,6 @@ public abstract class Completable {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
      * <pre>{@code
      *     int i = 0;
@@ -982,7 +979,6 @@ public abstract class Completable {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in
      * sequential programming is similar to:
      * <pre>{@code

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -862,6 +862,11 @@ public abstract class Completable {
     /**
      * Re-subscribes to this {@link Completable} if an error is emitted and the passed {@link BiIntPredicate} returns
      * {@code true}.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to retry an operation under certain failure conditions and in sequential programming
      * is similar to:
@@ -899,6 +904,11 @@ public abstract class Completable {
      * Re-subscribes to this {@link Completable} if an error is emitted and the {@link Completable} returned by the
      * supplied {@link BiIntFunction} completes successfully. If the returned {@link Completable} emits an error, the
      * returned {@link Completable} terminates with that error.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
      * and in sequential programming is similar to:
@@ -938,6 +948,11 @@ public abstract class Completable {
     /**
      * Re-subscribes to this {@link Completable} when it completes and the passed {@link IntPredicate} returns
      * {@code true}.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
      * <pre>{@code
@@ -962,6 +977,11 @@ public abstract class Completable {
      * Re-subscribes to this {@link Completable} when it completes and the {@link Completable} returned by the supplied
      * {@link IntFunction} completes successfully. If the returned {@link Completable} emits an error, the returned
      * {@link Completable} emits an error.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in
      * sequential programming is similar to:

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -864,7 +864,7 @@ public abstract class Completable {
      * {@code true}.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to retry an operation under certain failure conditions and in sequential programming
@@ -905,7 +905,7 @@ public abstract class Completable {
      * returned {@link Completable} terminates with that error.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
@@ -948,7 +948,7 @@ public abstract class Completable {
      * {@code true}.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
@@ -976,7 +976,7 @@ public abstract class Completable {
      * {@link Completable} emits an error.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1712,7 +1712,6 @@ public abstract class Publisher<T> {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to retry an operation under certain failure conditions and in sequential programming
      * is similar to:
      * <pre>{@code
@@ -1763,7 +1762,6 @@ public abstract class Publisher<T> {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
      * and in sequential programming is similar to:
      * <pre>{@code
@@ -1850,7 +1848,6 @@ public abstract class Publisher<T> {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in
      * sequential programming is similar to:
      * <pre>{@code

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1707,6 +1707,11 @@ public abstract class Publisher<T> {
     /**
      * Re-subscribes to this {@link Publisher} if an error is emitted and the passed {@link BiIntPredicate} returns
      * {@code true}.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to retry an operation under certain failure conditions and in sequential programming
      * is similar to:
@@ -1753,6 +1758,11 @@ public abstract class Publisher<T> {
      * Re-subscribes to this {@link Publisher} if an error is emitted and the {@link Completable} returned by the
      * supplied {@link BiIntFunction} completes successfully. If the returned {@link Completable} emits an error, the
      * returned {@link Publisher} terminates with that error.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
      * and in sequential programming is similar to:
@@ -1802,7 +1812,11 @@ public abstract class Publisher<T> {
     /**
      * Re-subscribes to this {@link Publisher} when it completes and the passed {@link IntPredicate} returns
      * {@code true}.
-     * <p>
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
      * <pre>{@code
      *     List<T> results = new ...;
@@ -1831,6 +1845,11 @@ public abstract class Publisher<T> {
      * Re-subscribes to this {@link Publisher} when it completes and the {@link Completable} returned by the supplied
      * {@link IntFunction} completes successfully. If the returned {@link Completable} emits an error, the returned
      * {@link Publisher} is completed.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in
      * sequential programming is similar to:

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1709,7 +1709,7 @@ public abstract class Publisher<T> {
      * {@code true}.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to retry an operation under certain failure conditions and in sequential programming
@@ -1759,7 +1759,7 @@ public abstract class Publisher<T> {
      * returned {@link Publisher} terminates with that error.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
@@ -1812,7 +1812,7 @@ public abstract class Publisher<T> {
      * {@code true}.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
@@ -1845,7 +1845,7 @@ public abstract class Publisher<T> {
      * {@link Publisher} is completed.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -829,7 +829,7 @@ public abstract class Single<T> {
      * {@code true}.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to retry an operation under certain failure conditions and in sequential programming
@@ -869,7 +869,7 @@ public abstract class Single<T> {
      * {@link Single} terminates with that error.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
@@ -910,7 +910,7 @@ public abstract class Single<T> {
      * Re-subscribes to this {@link Single} when it completes and the passed {@link IntPredicate} returns {@code true}.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
@@ -939,7 +939,7 @@ public abstract class Single<T> {
      * {@link Single} emits an error.
      * <pre>
      * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
-     * avoided by trampolining the call stack onto an Executor. For example:
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
      * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -832,7 +832,6 @@ public abstract class Single<T> {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to retry an operation under certain failure conditions and in sequential programming
      * is similar to:
      * <pre>{@code
@@ -873,7 +872,6 @@ public abstract class Single<T> {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
      * and in sequential programming is similar to:
      * <pre>{@code
@@ -915,7 +913,6 @@ public abstract class Single<T> {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
      * <pre>{@code
      *     List<T> results = new ...;
@@ -945,7 +942,6 @@ public abstract class Single<T> {
      * avoided by trampolining the call stack onto an Executor. For example:
      *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
      * </pre>
-     * <p>
      * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in
      * sequential programming is similar to:
      * <pre>{@code

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -827,6 +827,11 @@ public abstract class Single<T> {
     /**
      * Re-subscribes to this {@link Single} if an error is emitted and the passed {@link BiIntPredicate} returns
      * {@code true}.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to retry an operation under certain failure conditions and in sequential programming
      * is similar to:
@@ -863,6 +868,11 @@ public abstract class Single<T> {
      * Re-subscribes to this {@link Single} if an error is emitted and the {@link Completable} returned by the supplied
      * {@link BiIntFunction} completes successfully. If the returned {@link Completable} emits an error, the returned
      * {@link Single} terminates with that error.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
      * and in sequential programming is similar to:
@@ -900,6 +910,11 @@ public abstract class Single<T> {
 
     /**
      * Re-subscribes to this {@link Single} when it completes and the passed {@link IntPredicate} returns {@code true}.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
      * <pre>{@code
@@ -925,6 +940,11 @@ public abstract class Single<T> {
      * Re-subscribes to this {@link Single} when it completes and the {@link Completable} returned by the supplied
      * {@link IntFunction} completes successfully. If the returned {@link Completable} emits an error, the returned
      * {@link Single} emits an error.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an Executor. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
      * <p>
      * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in
      * sequential programming is similar to:


### PR DESCRIPTION
Motivation:
Publisher [repeat | retry] operators may cause StackOverflowError if too
many recovery operations are done consecutively on the same thread. This
condition can be difficult to detect as the onError recovery path is
unlikely to be called. We should highlight this possibility in the
javadocs for these methods.

Modifications:
- Publisher, Single, Completable repeat* and retry* operators have
  javadoc that clarifies the risk of StackOverflowError and mitigation
  technique.

Result:
Javadocs highlight risks of StackOverflowError and how it can be
avoided.