### PR TITLE
MalformedDataAfterHttpMessageTest.afterResponseNextClientRequestSucceeds fix

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
@@ -53,8 +53,8 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import static io.netty.buffer.ByteBufUtil.writeAscii;
 import static io.netty.util.ReferenceCountUtil.release;
@@ -126,7 +126,7 @@ class MalformedDataAfterHttpMessageTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void afterResponseNextClientRequestSucceeds(boolean doOffloading) throws Exception {
-        Queue<ConnectionContext> contextQueue = new ArrayBlockingQueue<>(4);
+        Queue<ConnectionContext> contextQueue = new LinkedBlockingQueue<>();
         ServerSocketChannel server = nettyServer(RESPONSE_MSG);
         try (BlockingHttpClient client = stClientBuilder(server.localAddress())
                 .executionStrategy(doOffloading ? defaultStrategy() : noOffloadsStrategy())

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
@@ -131,8 +131,8 @@ class MalformedDataAfterHttpMessageTest {
         try (BlockingHttpClient client = stClientBuilder(server.localAddress())
                 .executionStrategy(doOffloading ? defaultStrategy() : noOffloadsStrategy())
                 // ClosedChannelException maybe observed on the second request if write is done before read of the
-                // garbage data, which won't be a RetryableExcepton. We may also see an exception from flush if the read
-                // closed the connection and then attempt to write on the same connection.
+                // garbage data, which won't be a RetryableException. We may also see an exception from flush if the
+                // read closed the connection and then attempt to write on the same connection.
                 .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
                         .maxRetries(MAX_VALUE)
                         .retryFor((req, cause) -> true)


### PR DESCRIPTION
Motivation:
afterResponseNextClientRequestSucceeds attempts to validate that
NettyChannelPublisher preemptively closes the channel after request
processing concluded if there is an error pending to prevent subsequent
requests from using this connection. This condition may not be hit in
all scenarios due to sequencing of offloading as well as when bytes are
read from the network and the error condition is observed. This results
in the test being flaky and failing.

Modifications:
- Make afterResponseNextClientRequestSucceeds more robust by inserting a
  RetryingHttpRequesterFilter and adjusting the assertions to expect
  retry may happen.

Result:
Fixes https://github.com/apple/servicetalk/issues/1889.