### PR TITLE
Make static final buffers unreleasable and read-only

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
@@ -76,9 +76,10 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelOutbound
     private static final int ZERO_CRLF_MEDIUM = ('0' << 16) | CRLF_SHORT;
     private static final int COLON_AND_SPACE_SHORT = (COLON << 8) | SP;
     private static final byte[] ZERO_CRLF_CRLF = {'0', CR, LF, CR, LF};
-    private static final ByteBuf CRLF_BUF = unreleasableBuffer(directBuffer(2).writeByte(CR).writeByte(LF));
+    private static final ByteBuf CRLF_BUF = unreleasableBuffer(directBuffer(2).writeByte(CR).writeByte(LF)
+            .asReadOnly());
     private static final ByteBuf ZERO_CRLF_CRLF_BUF = unreleasableBuffer(directBuffer(ZERO_CRLF_CRLF.length)
-            .writeBytes(ZERO_CRLF_CRLF));
+            .writeBytes(ZERO_CRLF_CRLF).asReadOnly());
     private static final float HEADERS_WEIGHT_NEW = 1 / 5f;
     private static final float HEADERS_WEIGHT_HISTORICAL = 1 - HEADERS_WEIGHT_NEW;
     private static final float TRAILERS_WEIGHT_NEW = HEADERS_WEIGHT_NEW;

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -75,7 +75,7 @@ import static org.mockito.Mockito.when;
 class DefaultNettyConnectionTest {
 
     private static final String TRAILER_MSG = "Trailer";
-    private static final Buffer TRAILER = DEFAULT_ALLOCATOR.fromAscii(TRAILER_MSG);
+    private static final Buffer TRAILER = DEFAULT_ALLOCATOR.fromAscii(TRAILER_MSG).asReadOnly();
     private TestPublisher<Buffer> publisher;
     private TestCompletableSubscriber writeListener = new TestCompletableSubscriber();
     private final TestCompletableSubscriber secondWriteListener = new TestCompletableSubscriber();


### PR DESCRIPTION
Motivation:
`HttpObjectEncoder` writes static final ByteBufs to encode HTTP chunks.
Some handlers (e.g. SslHandler) may attempt to aggregate data into
existing buffers if they can be expanded. If static buffers are not
marked as ReadOnly then data maybe appended to these static buffers over
time which may lead to data corruption.

Modification:
- Make static ByteBuf/Buffer objects ReadOnly in `HttpObjectEncoder` and
  elsewhere.

Result:
Static buffers will not be used to aggregate data.