### PR TITLE
Fixes for `EmptyBuffer` implementation

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AbstractBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AbstractBuffer.java
@@ -33,6 +33,7 @@ package io.servicetalk.buffer.api;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
+import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER_HASH_CODE;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Short.reverseBytes;
@@ -590,7 +591,7 @@ abstract class AbstractBuffer implements Buffer {
         final int longCount = aLen >>> 3;
         final int byteCount = aLen & 3;
 
-        int hashCode = 1;
+        int hashCode = EMPTY_BUFFER_HASH_CODE;
         int arrayIndex = readerIndex;
         // TODO(scott): take into account endianness? we currently don't have order() on Buffer.
         for (int i = longCount; i > 0; --i) {

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/EmptyBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/EmptyBuffer.java
@@ -805,7 +805,7 @@ public final class EmptyBuffer implements Buffer {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof Buffer && ((Buffer) obj).readableBytes() == 0;
+        return this == obj || (obj instanceof Buffer && ((Buffer) obj).readableBytes() == 0);
     }
 
     private static void checkIndex(int index) {

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/EmptyBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/EmptyBuffer.java
@@ -31,8 +31,10 @@ public final class EmptyBuffer implements Buffer {
      */
     public static final EmptyBuffer EMPTY_BUFFER = new EmptyBuffer();
 
-    private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocateDirect(0);
+    private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocateDirect(0).asReadOnlyBuffer();
     private static final byte[] EMPTY_BYTES = {};
+
+    static final int EMPTY_BUFFER_HASH_CODE = 1;
 
     private EmptyBuffer() {
         // No instances, use the static instance.
@@ -759,6 +761,11 @@ public final class EmptyBuffer implements Buffer {
     }
 
     @Override
+    public String toString() {
+        return EmptyBuffer.class.getSimpleName();
+    }
+
+    @Override
     public String toString(Charset charset) {
         return "";
     }
@@ -789,6 +796,16 @@ public final class EmptyBuffer implements Buffer {
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
         checkIndex(index, length);
         return -1;
+    }
+
+    @Override
+    public int hashCode() {
+        return EMPTY_BUFFER_HASH_CODE;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof Buffer && ((Buffer) obj).readableBytes() != 0;
     }
 
     private static void checkIndex(int index) {

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/EmptyBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/EmptyBuffer.java
@@ -805,7 +805,7 @@ public final class EmptyBuffer implements Buffer {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof Buffer && ((Buffer) obj).readableBytes() != 0;
+        return obj instanceof Buffer && ((Buffer) obj).readableBytes() == 0;
     }
 
     private static void checkIndex(int index) {


### PR DESCRIPTION
Motivation:

`EmptyBuffer` has a few minor issues.

Modifications:

- Return a read-only view of `ByteBuffer` from `toNioBuffer()`;
- Implement `toString()`, `equals(Object)`, and `hashCode()`;

Result:

`EmptyBuffer` correctly implements methods from `Object` and is
consistent with netty's `EmptyByteBuf` implementation.