### PR TITLE
Remove `grpc` and `http` modules from BOM

### DIFF
--- a/servicetalk-bom/build.gradle
+++ b/servicetalk-bom/build.gradle
@@ -17,7 +17,8 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-core"
 apply plugin: "java-platform"
 
-rootProject.subprojects.findAll { !it.name.contains("bom") && !it.name.contains("examples") }.each {
+rootProject.subprojects.findAll { !it.name.contains("bom") && !it.name.contains("examples") &&
+                                          !it.name.equals("grpc") && !it.name.equals("http") }.each {
   dependencies.constraints.add("api", it)
 }
 


### PR DESCRIPTION
Motivation:
The ServiceTalk BOM file currently contains references to two modules,
`grpc` and `http` which do not exist. These modules are generated from
the examples parent directories but have no artifacts.
Modifications:
Exclude the `grpc` and `http` examples parent modules when building
BOM.
Result:
Non-existant modules no longer included in BOM.