### PR TITLE
`RoundRobinLoadBalancerFactory#EAGER_CONNECTION_SHUTDOWN_ENABLED` false by default

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -66,7 +66,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
         implements LoadBalancerFactory<ResolvedAddress, C> {
 
     static final AtomicInteger FACTORY_COUNT = new AtomicInteger();
-    static final boolean EAGER_CONNECTION_SHUTDOWN_ENABLED = true;
+    static final boolean EAGER_CONNECTION_SHUTDOWN_ENABLED = false;
     static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = Duration.ofSeconds(1);
     static final int DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD = 5; // higher than default for AutoRetryStrategy
 


### PR DESCRIPTION
Motivation:

`RoundRobinLoadBalancer` can maintain connections to hosts which
`ServiceDiscoverer` marks as `UNAVAILABLE` via a boolean flag. This
improves overall performance by reusing existing connections if the
backend is still available. We should make it the default behaviour.

Modifications:

- `RoundRobinLoadBalancerFactory#EAGER_CONNECTION_SHUTDOWN_ENABLED` is
  `false` by default.

Result:

The default behaviour of `RoundRobinLoadBalancer` will provide better
connection reuse for most cases.