### PR TITLE
`HttpLoadBalancerFactory` should override `newLoadBalancer` with 3 args

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -21,6 +21,10 @@ import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Publisher;
 
+import java.util.Collection;
+
+import static java.util.function.Function.identity;
+
 /**
  * A {@link LoadBalancerFactory} for HTTP clients.
  *
@@ -29,10 +33,19 @@ import io.servicetalk.concurrent.api.Publisher;
 public interface HttpLoadBalancerFactory<ResolvedAddress>
         extends LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> {
 
+    @Deprecated
     @Override
     <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
             Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
             ConnectionFactory<ResolvedAddress, T> cf);
+
+    @Override
+    default <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
+            String targetResource,
+            Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
+            ConnectionFactory<ResolvedAddress, T> cf) {
+        return newLoadBalancer(eventPublisher.flatMapConcatIterable(identity()), cf);
+    }
 
     /**
      * Converts the passed {@link FilterableStreamingHttpConnection} to a


### PR DESCRIPTION
Motivation:

#1831 added a new
`LoadBalancerFactory#newLoadBalancer(String, Publisher, ConnectionFactory)`
overload, but didn't override it in `HttpLoadBalancerFactory`.

Modifications:

- Add `HttpLoadBalancerFactory.newLoadBalancer(...)` overload with 3
arguments;

Result:

`HttpLoadBalancerFactory` follows `LoadBalancerFactory` contract with
http-specific types.