### PR TITLE
`SingleThreadedScheduler` should fallback execution upon offloading failure

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultExecutor.java
@@ -258,8 +258,9 @@ final class DefaultExecutor extends AbstractExecutor implements Consumer<Runnabl
                         try {
                             offloadExecutor.execute(task);
                         } catch (Throwable t) {
-                            LOGGER.error("Unexpected exception while offloading scheduled task: {} to executor: {}.",
-                                    task, offloadExecutor, t);
+                            LOGGER.error("Unexpected exception while offloading scheduled task: {} to executor: {}. " +
+                                            "Will execute the task on {} thread.",
+                                    task, offloadExecutor, Thread.currentThread().getName(), t);
                             // If the offloadExecutor failed to execute, we fallback to the scheduler thread for
                             // best-effort attempt at actually executing the task.
                             try {


### PR DESCRIPTION
Motivation:

When the `Executor` provided by the user fails to accept the task
executed by the `SingleThreadedScheduler`, the exception is ignored and
the scheduler is no longer usable. The exceptions from the user land
should not surface to the global scheduler and the implementation should
do its' best to run the task even at the cost of skipping offloading.

Modification:

`DefaultExecutor.SingleThreadedScheduler#schedule` is guarded against
rejections from the user's `offloadExecutor` and triest to fallback
and execute the task on its' own thread.

Result:

User error does not prevent the `SingleThreadedScheduler` from executing
future tasks.