### PR TITLE
RoundRobinLoadBalancer: reduce number of operators in health check chain

### DIFF
--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -80,6 +80,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.DEFAULT_TIMEOUT_SECONDS;
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
+import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerTest.UnhealthyHostConnectionFactory.UNHEALTHY_HOST_EXCEPTION;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
@@ -412,7 +413,7 @@ abstract class RoundRobinLoadBalancerTest {
                 final TestLoadBalancedConnection selectedConnection = lb.selectConnection(any()).toFuture().get();
                 assertThat(selectedConnection, equalTo(properConnection.toFuture().get()));
             } catch (Exception e) {
-                assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
+                assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
             }
         }
 
@@ -456,7 +457,7 @@ abstract class RoundRobinLoadBalancerTest {
 
         for (int i = 0; i < DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD; ++i) {
             Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any()).toFuture().get());
-            assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
+            assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
         }
 
         assertThat(testExecutor.scheduledTasksPending(), equalTo(0));
@@ -464,7 +465,7 @@ abstract class RoundRobinLoadBalancerTest {
         for (int i = 0; i < timeAdvancementsTillHealthy - 1; ++i) {
             unhealthyHostConnectionFactory.advanceTime(testExecutor);
             Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any()).toFuture().get());
-            assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
+            assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
         }
 
         unhealthyHostConnectionFactory.advanceTime(testExecutor);
@@ -489,7 +490,7 @@ abstract class RoundRobinLoadBalancerTest {
 
         for (int i = 0; i < DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD; ++i) {
             Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any()).toFuture().get());
-            assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
+            assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
         }
 
         for (int i = 0; i < timeAdvancementsTillHealthy; ++i) {
@@ -535,7 +536,7 @@ abstract class RoundRobinLoadBalancerTest {
 
         // Trigger first health check:
         Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any()).toFuture().get());
-        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
+        assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
         // Execute two health checks: first will fail due to connectionFactory,
         // second - due to an unexpected error from executor:
         for (int i = 0; i < 2; ++i) {
@@ -544,7 +545,7 @@ abstract class RoundRobinLoadBalancerTest {
 
         // Trigger yet another health check:
         e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any()).toFuture().get());
-        assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
+        assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
         // Execute two health checks: first will fail due to connectionFactory, second succeeds:
         for (int i = 0; i < 2; ++i) {
             unhealthyHostConnectionFactory.advanceTime(testExecutor);
@@ -756,6 +757,8 @@ abstract class RoundRobinLoadBalancerTest {
     }
 
     static class UnhealthyHostConnectionFactory {
+        // Create a new instance of DeliberateException to avoid "Self-suppression not permitted"
+        static final DeliberateException UNHEALTHY_HOST_EXCEPTION = new DeliberateException();
         private final String failingHost;
         private final AtomicInteger momentInTime = new AtomicInteger();
         final AtomicInteger requests = new AtomicInteger();
@@ -784,7 +787,7 @@ abstract class RoundRobinLoadBalancerTest {
                                        Single<TestLoadBalancedConnection> properConnection) {
             this.failingHost = failingHost;
             this.connections = IntStream.range(0, timeAdvancementsTillHealthy)
-                    .<Single<TestLoadBalancedConnection>>mapToObj(__ -> failed(DELIBERATE_EXCEPTION))
+                    .<Single<TestLoadBalancedConnection>>mapToObj(__ -> failed(UNHEALTHY_HOST_EXCEPTION))
                     .collect(Collectors.toList());
             this.properConnection = properConnection;
         }


### PR DESCRIPTION
Motivation:

`Completable.retryWhen` actually does
`toSingle().retryWhen(...).ignoreElement()`. We can avoid it by retrying
the `Single` directly.
We can also skip `onErrorMap` and log inside a retry predicate.

Modifications:

- Avoid premature conversion of a `Single` to `Completable`;
- Use retry predicate instead of `onErrorMap` to log an attempt failure;
- Use the original cause instead of `RESCHEDULE_SIGNAL`;

Result:

Less operators in the health check execution chain.