### PR TITLE
Implement `toString()` for our `ThreadFactory` variants

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultThreadFactory.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultThreadFactory.java
@@ -36,7 +36,6 @@ public final class DefaultThreadFactory implements ThreadFactory {
     private final String namePrefix;
     private final boolean daemon;
     private final int priority;
-    @SuppressWarnings("unused")
     private final AtomicInteger threadCount = new AtomicInteger();
 
     /**
@@ -106,6 +105,16 @@ public final class DefaultThreadFactory implements ThreadFactory {
             t.setPriority(priority);
         }
         return t;
+    }
+
+    @Override
+    public String toString() {
+        return DefaultThreadFactory.class.getSimpleName() +
+                "{namePrefix='" + namePrefix + '\'' +
+                ", daemon=" + daemon +
+                ", priority=" + priority +
+                ", threadCount=" + threadCount +
+                '}';
     }
 
     private static final class AsyncContextHolderThread extends Thread implements AsyncContextMapHolder {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoThreadFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoThreadFactory.java
@@ -31,6 +31,7 @@ import static java.util.Objects.requireNonNull;
  */
 public final class NettyIoThreadFactory implements IoThreadFactory<NettyIoThreadFactory.NettyIoThread> {
     private static final AtomicInteger factoryCount = new AtomicInteger();
+
     private final AtomicInteger threadCount = new AtomicInteger();
     private final String namePrefix;
     private final boolean daemon;
@@ -81,6 +82,16 @@ public final class NettyIoThreadFactory implements IoThreadFactory<NettyIoThread
             t.setPriority(NORM_PRIORITY);
         }
         return t;
+    }
+
+    @Override
+    public String toString() {
+        return NettyIoThreadFactory.class.getSimpleName() +
+                "{namePrefix='" + namePrefix + '\'' +
+                ", daemon=" + daemon +
+                ", threadGroup=" + threadGroup +
+                ", threadCount=" + threadCount +
+                '}';
     }
 
     static final class NettyIoThread extends FastThreadLocalThread implements IoThreadFactory.IoThread {


### PR DESCRIPTION
Motivation:

Users can see what thread name prefix a `ThreadFactory` uses and other
info.

Modifications:

- Add `DefaultThreadFactory#toString()`;
- Add `NettyIoThreadFactory#toString()`;

Result:

Users can get visibility into `DefaultThreadFactory` and
`NettyIoThreadFactory` internal state.