### PR TITLE
`MessageEncodingException` should take an encoding name only

### DIFF
--- a/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
+++ b/servicetalk-grpc-protobuf/src/main/java/io/servicetalk/grpc/protobuf/ProtoBufSerializationProviderBuilder.java
@@ -172,7 +172,7 @@ public final class ProtoBufSerializationProviderBuilder {
             @SuppressWarnings("unchecked")
             HttpSerializer<T> httpSerializer = serializersForType.get(codec);
             if (httpSerializer == null) {
-                throw new MessageEncodingException("Unknown encoding: " + codec.name());
+                throw new MessageEncodingException(codec.name().toString());
             }
             return httpSerializer;
         }
@@ -186,7 +186,7 @@ public final class ProtoBufSerializationProviderBuilder {
             @SuppressWarnings("unchecked")
             HttpDeserializer<T> httpSerializer = deserializersForType.get(codec);
             if (httpSerializer == null) {
-                throw new MessageEncodingException("Unknown encoding: " + codec.name());
+                throw new MessageEncodingException(codec.name().toString());
             }
             return httpSerializer;
         }


### PR DESCRIPTION
Motivation:

`MessageEncodingException` expects an encoding name only, not a cause.
It already has a prepared cause inside a ctor.

Modifications:

- Pass encoding to the `MessageEncodingException` ctor instead of a
cause;

Result:

Users see a correct cause message for `MessageEncodingException`.