### PR TITLE
Completable#concat(Completable...)

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -546,6 +546,31 @@ public abstract class Completable {
     }
 
     /**
+     * Once this {@link Completable} is terminated successfully, subscribe to each {@link Completable} in {@code nexts}
+     * in a sequential fashion after termination, and the final terminal signals is propagated to the returned
+     * {@link Completable}. Any error from this {@link Completable} or from {@code nexts} {@link Completable} are
+     * propagated to the returned {@link Completable}.
+     * <p>
+     * This method provide equivalent functionality as:
+     * <pre>{@code
+     *   Completable original = ...;
+     *   Completable[] nexts  = ...;
+     *   Completable result = original;
+     *   for (int i = 0; i < nexts.length; ++i) {
+     *       result = result.concat(nexts[i]);
+     *   }
+     *   return result;
+     * }</pre>
+     *
+     * @param nexts {@link Completable}s to subscribe after this {@link Completable} terminates successfully.
+     * @return A {@link Completable} that emits the terminal signal of {@code nexts} {@link Completable}s, after this
+     * {@link Completable} has terminated successfully.
+     */
+    public final Completable concat(Completable... nexts) {
+        return new CompletableConcatWithCompletables(this, nexts);
+    }
+
+    /**
      * Once this {@link Completable} is terminated successfully, subscribe to {@code next} {@link Single}
      * and propagate the result to the returned {@link Single}. Any error from this {@link Completable} or {@code next}
      * {@link Single} are propagated to the returned {@link Single}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -567,7 +567,7 @@ public abstract class Completable {
      * {@link Completable} has terminated successfully.
      */
     public final Completable concat(Completable... nexts) {
-        return new CompletableConcatWithCompletables(this, nexts);
+        return nexts.length == 0 ? this : new CompletableConcatWithCompletables(this, nexts);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableConcatWithCompletables.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.internal.SequentialCancellable;
+
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * As returned by {@link Completable#concat(Completable)}.
+ */
+final class CompletableConcatWithCompletables extends AbstractNoHandleSubscribeCompletable {
+    private static final int MAX_STACK_DEPTH = 8;
+    private final Completable original;
+    private final Completable[] nexts;
+
+    CompletableConcatWithCompletables(Completable original, Completable... nexts) {
+        this.original = original;
+        this.nexts = requireNonNull(nexts);
+    }
+
+    @Override
+    protected void handleSubscribe(Subscriber subscriber, AsyncContextMap contextMap,
+                                   AsyncContextProvider contextProvider) {
+        Subscriber wrappedSubscriber = contextProvider.wrapCompletableSubscriber(subscriber, contextMap);
+        original.delegateSubscribe(new ConcatWithSubscriber(wrappedSubscriber, nexts), contextMap, contextProvider);
+    }
+
+    private static final class ConcatWithSubscriber implements Subscriber {
+        private final Subscriber target;
+        private final Completable[] nexts;
+        @Nullable
+        private SequentialCancellable sequentialCancellable;
+        private int nextIndex;
+        private int onCompleteDepth;
+
+        ConcatWithSubscriber(Subscriber target, Completable... nexts) {
+            this.target = target;
+            this.nexts = nexts;
+        }
+
+        @Override
+        public void onSubscribe(Cancellable cancellable) {
+            if (sequentialCancellable == null) {
+                sequentialCancellable = new SequentialCancellable(cancellable);
+                target.onSubscribe(sequentialCancellable);
+            } else {
+                sequentialCancellable.nextCancellable(cancellable);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (++onCompleteDepth < MAX_STACK_DEPTH) {
+                do {
+                    if (nextIndex == nexts.length) {
+                        target.onComplete();
+                    } else {
+                        // Asynchronous boundary we should recapture the AsyncContext instead of propagating it.
+                        nexts[nextIndex++].subscribeInternal(this);
+                    }
+                } while (onCompleteDepth-- >= MAX_STACK_DEPTH);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            target.onError(t);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithCompletablesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableConcatWithCompletablesTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.completable;
+
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.TestCancellable;
+import io.servicetalk.concurrent.api.TestCompletable;
+import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.stubbing.Answer;
+
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+class CompletableConcatWithCompletablesTest {
+    private TestCompletableSubscriber subscriber;
+    private TestCompletable source;
+    private TestCompletable[] nexts;
+
+    @BeforeEach
+    void setUp() {
+        subscriber = new TestCompletableSubscriber();
+        source = new TestCompletable();
+    }
+
+    private void initNexts(int num) {
+        nexts = new TestCompletable[num];
+        for (int i = 0; i < nexts.length; ++i) {
+            nexts[i] = new TestCompletable();
+        }
+    }
+
+    @Test
+    void testSourceSuccessNextEmpty() {
+        initNexts(0);
+        toSource(source.concat(nexts)).subscribe(subscriber);
+        source.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void testSourceSuccessNextSuccess(int num) {
+        initNexts(num);
+        toSource(source.concat(nexts)).subscribe(subscriber);
+        source.onComplete();
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        for (final TestCompletable next : nexts) {
+            next.onComplete();
+        }
+        subscriber.awaitOnComplete();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10000})
+    void testSourceSuccessReentrant(int num) {
+        Completable[] mockCompletables = new Completable[num];
+        for (int i = 0; i < mockCompletables.length; ++i) {
+            CompletableSource mockCompletable = mock(CompletableSource.class);
+            doAnswer((Answer<Void>) invocation -> {
+                CompletableSource.Subscriber sub = invocation.getArgument(0);
+                sub.onSubscribe(IGNORE_CANCEL);
+                sub.onComplete();
+                return null;
+            }).when(mockCompletable).subscribe(any());
+            mockCompletables[i] = fromSource(mockCompletable);
+        }
+        toSource(source.concat(mockCompletables)).subscribe(subscriber);
+        source.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void testSourceSuccessNextError(int num) {
+        initNexts(num);
+        toSource(source.concat(nexts)).subscribe(subscriber);
+        source.onComplete();
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        nexts[0].onError(DELIBERATE_EXCEPTION);
+        assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void testSourceError(int num) {
+        initNexts(num);
+        toSource(source.concat(nexts)).subscribe(subscriber);
+        source.onError(DELIBERATE_EXCEPTION);
+        assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        for (final TestCompletable next : nexts) {
+            assertFalse(next.isSubscribed());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void testCancelSource(int num) {
+        initNexts(num);
+        toSource(source.concat(nexts)).subscribe(subscriber);
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        subscriber.awaitSubscription().cancel();
+        TestCancellable cancellable = new TestCancellable();
+        source.onSubscribe(cancellable);
+        assertTrue(cancellable.isCancelled());
+        for (final TestCompletable next : nexts) {
+            assertFalse(next.isSubscribed());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void testCancelNext(int num) {
+        initNexts(num);
+        toSource(source.concat(nexts)).subscribe(subscriber);
+        source.onComplete();
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        subscriber.awaitSubscription().cancel();
+
+        TestCancellable sourceCancellable = new TestCancellable();
+        source.onSubscribe(sourceCancellable);
+        assertFalse(sourceCancellable.isCancelled());
+
+        TestCancellable nextCancellable = new TestCancellable();
+        source.onSubscribe(nextCancellable);
+        assertTrue(nextCancellable.isCancelled());
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableConcatWithCompletablesTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableConcatWithCompletablesTckTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Completable;
+
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+
+@Test
+public class CompletableConcatWithCompletablesTckTest extends AbstractCompletableOperatorTckTest {
+    @Override
+    protected Completable composeCompletable(Completable completable) {
+        return completable.concat(completed(), completed());
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableConcatWithCompletablesTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableConcatWithCompletablesTckTest.java
@@ -19,12 +19,19 @@ import io.servicetalk.concurrent.api.Completable;
 
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+
 import static io.servicetalk.concurrent.api.Completable.completed;
 
 @Test
 public class CompletableConcatWithCompletablesTckTest extends AbstractCompletableOperatorTckTest {
+    private static final Completable[] COMPLETABLES = new Completable[100];
+    static {
+        Arrays.fill(COMPLETABLES, completed());
+    }
+
     @Override
     protected Completable composeCompletable(Completable completable) {
-        return completable.concat(completed(), completed());
+        return completable.concat(COMPLETABLES);
     }
 }


### PR DESCRIPTION
Motivation:
There are some use cases (DefaultCompositeCloseable) that dynamically
build a large chain of Completable#concat(Completable) operations. These
large chains may result in a StackOverflowException.

Modifications:
- Introduce a `Completable#concat(Completable...)` operator that has stack
  overflow protection.

Result:
Completable concat operator exists with stack overflow protection.