### PR TITLE
DefaultCompositeCloseable StackOverflowException

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
@@ -18,7 +18,12 @@ package io.servicetalk.concurrent.api;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
@@ -27,11 +32,13 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 
 final class DefaultCompositeCloseable implements CompositeCloseable {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCompositeCloseable.class);
 
-    private Completable closeAsync = completed();
-    private Completable closeAsyncGracefully = completed();
+    private final Deque<Operand> operands = new ArrayDeque<>(2);
+    @Nullable
+    private Completable closeAsync;
+    @Nullable
+    private Completable closeAsyncGracefully;
 
     @Override
     public <T extends AsyncCloseable> T merge(final T closeable) {
@@ -93,11 +100,17 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
 
     @Override
     public Completable closeAsync() {
+        if (closeAsync == null) {
+            closeAsync = buildCompletable(AsyncCloseable::closeAsync);
+        }
         return closeAsync;
     }
 
     @Override
     public Completable closeAsyncGracefully() {
+        if (closeAsyncGracefully == null) {
+            closeAsyncGracefully = buildCompletable(AsyncCloseable::closeAsyncGracefully);
+        }
         return closeAsyncGracefully;
     }
 
@@ -112,39 +125,85 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
     }
 
     private void mergeCloseableDelayError(final AsyncCloseable closeable) {
-        closeAsync = closeAsync.mergeDelayError(closeable.closeAsync());
-        closeAsyncGracefully = closeAsyncGracefully.mergeDelayError(closeable.closeAsyncGracefully());
+        final Operand operand = getOrAddMergeOperand();
+        operand.closables.add(closeable);
+        resetState();
     }
 
     private void mergeCloseableDelayError(final List<AsyncCloseable> closeables) {
-        closeAsync = closeAsync.mergeDelayError(closeables.stream().map(AsyncCloseable::closeAsync).collect(toList()));
-        closeAsyncGracefully = closeAsyncGracefully.mergeDelayError(
-                closeables.stream().map(AsyncCloseable::closeAsyncGracefully).collect(toList()));
+        final Operand operand = getOrAddMergeOperand();
+        operand.closables.addAll(closeables);
+        resetState();
+    }
+
+    private void resetState() {
+        closeAsync = closeAsyncGracefully = null;
+    }
+
+    private Operand getOrAddMergeOperand() {
+        return getOrAddOperand(true, true);
+    }
+
+    private Operand getOrAddConcatOperand(boolean append) {
+        return getOrAddOperand(append, false);
+    }
+
+    private Operand getOrAddOperand(boolean append, boolean isMerge) {
+        final Operand operand;
+        if (operands.isEmpty()) {
+            operand = new Operand(isMerge);
+            operands.add(operand);
+        } else {
+            Operand rawOperand = append ? operands.getLast() : operands.getFirst();
+            if (isMerge == rawOperand.isMerge) {
+                operand = rawOperand;
+            } else {
+                operand = new Operand(isMerge);
+                if (append) {
+                    operands.add(operand);
+                } else {
+                    operands.addFirst(operand);
+                }
+            }
+        }
+        return operand;
     }
 
     private void concatCloseableDelayError(final AsyncCloseable closeable) {
-        closeAsync = closeAsync.concat(closeable.closeAsync().onErrorComplete(th -> {
-            //TODO: This should use concatDelayError when available.
-            LOGGER.debug("Ignored failure to close {}.", closeable, th);
-            return true;
-        }));
-        closeAsyncGracefully = closeAsyncGracefully.concat(closeable.closeAsyncGracefully().onErrorComplete(th -> {
-            //TODO: This should use concatDelayError when available.
-            LOGGER.debug("Ignored failure to close {}.", closeable, th);
-            return true;
-        }));
+        final Operand operand = getOrAddConcatOperand(true);
+        operand.closables.add(closeable);
+        resetState();
     }
 
     private void prependCloseableDelayError(final AsyncCloseable closeable) {
-        closeAsync = closeable.closeAsync().onErrorComplete(th -> {
-            //TODO: This should use prependDelayError when available.
-            LOGGER.debug("Ignored failure to close {}.", closeable, th);
-            return true;
-        }).concat(closeAsync);
-        closeAsyncGracefully = closeable.closeAsyncGracefully().onErrorComplete(th -> {
-            //TODO: This should use prependDelayError when available.
-            LOGGER.debug("Ignored failure to close {}.", closeable, th);
-            return true;
-        }).concat(closeAsyncGracefully);
+        final Operand operand = getOrAddConcatOperand(false);
+        operand.closables.add(closeable);
+        resetState();
+    }
+
+    private Completable buildCompletable(Function<AsyncCloseable, Completable> closerFunc) {
+        Completable result = completed();
+        for (Operand operand : operands) {
+            if (operand.isMerge) {
+                result = result.mergeDelayError(operand.closables.stream().map(closerFunc).toArray(Completable[]::new));
+            } else {
+                result = result.concat(operand.closables.stream().map(closerFunc).map(completable ->
+                        completable.onErrorComplete(th -> {
+                            // TODO: This should use concatDelayError when available.
+                            LOGGER.debug("Ignored failure to close", th);
+                            return true;
+                        })).toArray(Completable[]::new));
+            }
+        }
+        return result;
+    }
+
+    private static final class Operand {
+        private final List<AsyncCloseable> closables = new ArrayList<>(4);
+        private final boolean isMerge;
+
+        Operand(boolean isMerge) {
+            this.isMerge = isMerge;
+        }
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeClosableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeClosableTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class CompositeClosableTest {
+    @ParameterizedTest
+    @CsvSource(value = {"true,true", "true,false", "false, true", "false,false"})
+    void sameOperationDoesNotSOOE(boolean merge, boolean gracefully) throws Exception {
+        AsyncCloseable mockClosable = mock(AsyncCloseable.class);
+        when(mockClosable.closeAsync()).thenReturn(completed());
+        when(mockClosable.closeAsyncGracefully()).thenReturn(completed());
+
+        CompositeCloseable compositeCloseable = newCompositeCloseable();
+        for (int i = 0; i < 10000; ++i) {
+            if (merge) {
+                compositeCloseable.merge(mockClosable);
+            } else {
+                compositeCloseable.append(mockClosable);
+            }
+        }
+
+        if (gracefully) {
+            compositeCloseable.closeGracefully();
+        } else {
+            compositeCloseable.close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void alternatingOperationSOOE(boolean gracefully) {
+        AsyncCloseable mockClosable = mock(AsyncCloseable.class);
+        when(mockClosable.closeAsync()).thenReturn(completed());
+        when(mockClosable.closeAsyncGracefully()).thenReturn(completed());
+
+        CompositeCloseable compositeCloseable = newCompositeCloseable();
+        for (int i = 0; i < 10000; ++i) {
+            if ((i & 1) == 0) {
+                compositeCloseable.merge(mockClosable);
+            } else {
+                compositeCloseable.append(mockClosable);
+            }
+        }
+
+        // We currently don't offer protection across different operations. Large cardinality mixed operations is not
+        // common but could be addressed in the future if it becomes common.
+        assertThrows(StackOverflowError.class, () -> {
+            if (gracefully) {
+                compositeCloseable.closeGracefully();
+            } else {
+                compositeCloseable.close();
+            }
+        });
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeClosableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeClosableTest.java
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.when;
 
 final class CompositeClosableTest {
     @ParameterizedTest
-    @CsvSource(value = {"true,true", "true,false", "false, true", "false,false"})
-    void sameOperationDoesNotSOOE(boolean merge, boolean gracefully) throws Exception {
+    @CsvSource(value = {"true,true", "true,false", "false,true", "false,false"})
+    void sameOperationDoesNotSOE(boolean merge, boolean gracefully) throws Exception {
         AsyncCloseable mockClosable = mock(AsyncCloseable.class);
         when(mockClosable.closeAsync()).thenReturn(completed());
         when(mockClosable.closeAsyncGracefully()).thenReturn(completed());
@@ -49,9 +49,9 @@ final class CompositeClosableTest {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "gracefully={0}")
     @ValueSource(booleans = {true, false})
-    void alternatingOperationSOOE(boolean gracefully) {
+    void alternatingOperationSOE(boolean gracefully) {
         AsyncCloseable mockClosable = mock(AsyncCloseable.class);
         when(mockClosable.closeAsync()).thenReturn(completed());
         when(mockClosable.closeAsyncGracefully()).thenReturn(completed());

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ClosureTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ClosureTest.java
@@ -171,9 +171,11 @@ class ClosureTest {
     }
 
     private void verifyClosure(AsyncCloseable closeable, int times) {
-        // Async mode both methods are called but one is subscribed.
-        verify(closeable, times(times)).closeAsyncGracefully();
-        verify(closeable, times(times)).closeAsync();
+        if (closeGracefully) {
+            verify(closeable, times(times)).closeAsyncGracefully();
+        } else {
+            verify(closeable, times(times)).closeAsync();
+        }
         verifyNoMoreInteractions(closeable);
     }
 


### PR DESCRIPTION
Motivation:
DefaultCompositeCloseable uses operator composition when merging or
appending AsyncClosables. When a close operation is invoked on the
closable that means the stack must have enough depth in order to
cascade invocations of subscribe and signal notification. There are
scenarios where the number of operations is proportional to the number
of channels (ChannelSet, RRLB) which are more likely to result in
StackOverflowException as the number of channels grow.

Modifications:
- Update DefaultCompositeCloseable to avoid composing individual
  operators and instead use bulk array based operators.

Result:
Less likely to get SOOE from DefaultCompositeCloseable during
client/server shutdown.