### PR TITLE
Adjust changes to http-api related to `ExecutionStrategyInfluencer`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_NONE_STRATEGY;
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_DATA_STRATEGY;
 
 /**
  * The equivalent of {@link HttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
@@ -40,7 +40,8 @@ public interface BlockingHttpService extends ExecutionStrategyInfluencer<HttpExe
 
     @Override
     default HttpExecutionStrategy requiredOffloads() {
-        return OFFLOAD_NONE_STRATEGY;
+        // safe default--implementations are expected to override
+        return OFFLOAD_RECEIVE_DATA_STRATEGY;
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
@@ -19,7 +19,7 @@ import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.oio.api.PayloadWriter;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_NONE_STRATEGY;
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_META_STRATEGY;
 
 /**
  * The equivalent of {@link StreamingHttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
@@ -41,7 +41,8 @@ public interface BlockingStreamingHttpService extends
 
     @Override
     default HttpExecutionStrategy requiredOffloads() {
-        return OFFLOAD_NONE_STRATEGY;
+        // safe default--implementations are expected to override
+        return OFFLOAD_RECEIVE_META_STRATEGY;
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyInfluencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,11 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY;
-
-/**
- * A factory for HTTP filters.
- */
-public interface HttpFilterFactory extends ExecutionStrategyInfluencer<HttpExecutionStrategy> {
+interface DefaultHttpExecutionStrategyInfluencer extends ExecutionStrategyInfluencer<HttpExecutionStrategy> {
 
     @Override
     default HttpExecutionStrategy requiredOffloads() {
-        // "safe" default strategy -- implementations are expected to override
-        return OFFLOAD_ALL_STRATEGY;
+        // safe default--implementations are expected to override
+        return HttpExecutionStrategies.offloadAll();
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FilterableStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FilterableStreamingHttpClient.java
@@ -18,8 +18,6 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY;
-
 /**
  * A {@link StreamingHttpClient} that supports filtering.
  */
@@ -39,7 +37,7 @@ public interface FilterableStreamingHttpClient extends
 
     @Override
     default HttpExecutionStrategy requiredOffloads() {
-        // safe default--implementations are expected to ovrride
-        return OFFLOAD_ALL_STRATEGY;
+        // safe default--implementations are expected to override
+        return HttpExecutionStrategies.offloadAll();
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
@@ -17,17 +17,14 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY;
 
 /**
  * Provides a means to issue requests against HTTP service. The implementation is free to maintain a collection of
  * {@link HttpConnection} instances and distribute calls to {@link #request(HttpRequest)} amongst this collection.
  */
-public interface HttpClient extends
-                            HttpRequester, GracefulAutoCloseable, ExecutionStrategyInfluencer<HttpExecutionStrategy> {
+public interface HttpClient extends HttpRequester, GracefulAutoCloseable {
     /**
      * Send a {@code request}.
      *
@@ -92,11 +89,5 @@ public interface HttpClient extends
     @Override
     default void closeGracefully() throws Exception {
         awaitTermination(closeAsyncGracefully().toFuture());
-    }
-
-    @Override
-    default HttpExecutionStrategy requiredOffloads() {
-        // safe default--implementations are expected to override
-        return OFFLOAD_ALL_STRATEGY;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
@@ -39,6 +39,7 @@ public interface HttpService extends AsyncCloseable, ExecutionStrategyInfluencer
 
     @Override
     default HttpExecutionStrategy requiredOffloads() {
+        // safe default--implementations are expected to override
         return OFFLOAD_RECEIVE_DATA_AND_SEND_STRATEGY;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilterFactory.java
@@ -19,7 +19,7 @@ package io.servicetalk.http.api;
  * A factory for {@link StreamingHttpClientFilter}.
  */
 @FunctionalInterface
-public interface StreamingHttpClientFilterFactory extends HttpFilterFactory {
+public interface StreamingHttpClientFilterFactory extends DefaultHttpExecutionStrategyInfluencer {
 
     /**
      * Creates a {@link StreamingHttpClientFilter} using the provided {@link StreamingHttpClientFilter}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilterFactory.java
@@ -19,7 +19,7 @@ package io.servicetalk.http.api;
  * A factory for {@link StreamingHttpConnectionFilter}.
  */
 @FunctionalInterface
-public interface StreamingHttpConnectionFilterFactory extends HttpFilterFactory {
+public interface StreamingHttpConnectionFilterFactory extends DefaultHttpExecutionStrategyInfluencer {
 
     /**
      * Create a {@link StreamingHttpConnectionFilter} using the provided {@link FilterableStreamingHttpConnection}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
@@ -21,7 +21,6 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY;
 
 /**
  * A service contract for the HTTP protocol.
@@ -51,7 +50,7 @@ public interface StreamingHttpService extends AsyncCloseable, ExecutionStrategyI
 
     @Override
     default HttpExecutionStrategy requiredOffloads() {
-        // "safe" default -- implementations are expected to override
-        return OFFLOAD_ALL_STRATEGY;
+        // safe default--implementations are expected to override
+        return HttpExecutionStrategies.offloadAll();
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceFilterFactory.java
@@ -15,13 +15,11 @@
  */
 package io.servicetalk.http.api;
 
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_META_STRATEGY;
-
 /**
  * A factory for {@link StreamingHttpServiceFilter}.
  */
 @FunctionalInterface
-public interface StreamingHttpServiceFilterFactory extends HttpFilterFactory {
+public interface StreamingHttpServiceFilterFactory extends DefaultHttpExecutionStrategyInfluencer {
 
     /**
      * Create a {@link StreamingHttpServiceFilter} using the provided {@link StreamingHttpService}.
@@ -30,9 +28,4 @@ public interface StreamingHttpServiceFilterFactory extends HttpFilterFactory {
      * @return {@link StreamingHttpServiceFilter} using the provided {@link StreamingHttpService}.
      */
     StreamingHttpServiceFilter create(StreamingHttpService service);
-
-    @Override
-    default HttpExecutionStrategy requiredOffloads() {
-        return OFFLOAD_RECEIVE_META_STRATEGY;
-    }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilter.java
@@ -94,6 +94,7 @@ public final class BasicAuthHttpServiceFilter<UserInfo> implements StreamingHttp
 
         @Override
         default HttpExecutionStrategy requiredOffloads() {
+            // safe default--implementations are expected to override
             return HttpExecutionStrategies.offloadAll();
         }
     }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
@@ -65,7 +65,7 @@ public interface ConnectionAcceptorFactory extends ExecutionStrategyInfluencer<E
 
     @Override
     default ExecutionStrategy requiredOffloads() {
-        // "safe" default -- implementations are expected to override
+        // safe default--implementations are expected to override
         return ExecutionStrategy.offloadAll();
     }
 


### PR DESCRIPTION
Motivation:

1. There is no much value in making `HttpFilterFactory` public,
hard to think of a use-case for users.
2. Inconsistencies in default `requiredOffloads()` implementations.
3. Incorrect `requiredOffloads()` impl for some service API.
4. No need to implement `ExecutionStrategyInfluencer` for `HttpClient`,
it already has a strategy in `HttpExecutionContext` associated with the
client. No other client API implement `ExecutionStrategyInfluencer`.

Modifications:

- Rename `HttpFilterFactory` to `DefaultHttpExecutionStrategyInfluencer`
and make it pkg-private;
- Make all default `requiredOffloads()` implementations consistent;
- Use `HttpExecutionStrategies.offloadAll()` instead of a pkg-private
`OFFLOAD_ALL_STRATEGY` constant because users will read the default
impl, better to have something that has javadoc;
- `BlockingHttpService#requiredOffloads()` have to be
`OFFLOAD_RECEIVE_DATA_STRATEGY` as it's defined in
`BlockingToStreamingService`;
- `BlockingStreamingHttpService#requiredOffloads()` have to be
`OFFLOAD_RECEIVE_META_STRATEGY` as it's defined in
`BlockingStreamingToStreamingService`;
- `StreamingHttpServiceFilterFactory` should not override the default
`offloadAll()` strategy;
- Remove `ExecutionStrategyInfluencer` interface from `HttpClient`;

Result:

Less public API, more consistency, correct default implementations.