### PR TITLE
Use connection execution context in proxy connect

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
@@ -15,9 +15,12 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.netty.internal.ExecutionContextBuilder;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
@@ -29,6 +32,30 @@ final class HttpExecutionContextBuilder extends ExecutionContextBuilder<HttpExec
 
     HttpExecutionContextBuilder(final HttpExecutionContextBuilder from) {
         super(from);
+    }
+
+    @Override
+    public HttpExecutionContextBuilder ioExecutor(final IoExecutor ioExecutor) {
+        super.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public HttpExecutionContextBuilder executor(final Executor executor) {
+        super.executor(executor);
+        return this;
+    }
+
+    @Override
+    public HttpExecutionContextBuilder bufferAllocator(final BufferAllocator allocator) {
+        super.bufferAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public HttpExecutionContextBuilder executionStrategy(final HttpExecutionStrategy strategy) {
+        super.executionStrategy(strategy);
+        return this;
     }
 
     /**

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
@@ -159,7 +159,7 @@ class ProxyConnectConnectionFactoryFilterTest {
     }
 
     private void subscribeToProxyConnectionFactory() {
-        subscribeToProxyConnectionFactory(c -> {});
+        subscribeToProxyConnectionFactory(c -> { });
     }
 
     private void subscribeToProxyConnectionFactory(Consumer<FilterableStreamingHttpConnection> onSuccess) {
@@ -315,12 +315,13 @@ class ProxyConnectConnectionFactoryFilterTest {
     void noOffloadingStrategy() {
         ChannelPipeline pipeline = configurePipeline(SslHandshakeCompletionEvent.SUCCESS);
         configureDeferSslHandler(pipeline);
-        configureConnectionContext(pipeline, HttpExecutionStrategies.offloadAll());
+        configureConnectionContext(pipeline, HttpExecutionStrategies.noOffloadsStrategy());
         configureRequestSend();
         configureConnectRequest();
         Queue<Throwable> errors = new LinkedBlockingQueue<>();
+        Thread testThread = Thread.currentThread();
         subscribeToProxyConnectionFactory(c -> {
-            if (true) {
+            if (Thread.currentThread() != testThread) {
                 errors.add(new AssertionError("Unexpected Thread for success " + Thread.currentThread()));
             }
         });


### PR DESCRIPTION
Motivation:
Currently default execution strategy is always used for the connect
request but the connection/client may be using a different strategy.
Modifications:
Use the connection execution strategy so as not to introduce unexpected
offloading.
Result:
Proxy connect uses same strategy as the rest of the client operations.