### PR TITLE
Update to PITest 1.7.3 and matching plugins

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,7 @@ testngVersion=7.4.0
 hamcrestVersion=2.2
 mockitoCoreVersion=3.12.4
 spotbugsPluginVersion=4.7.5
-pitestPluginVersion=1.6.0
+pitestPluginVersion=1.7.0
 
 apacheDirectoryServerVersion=1.5.7
 commonsLangVersion=2.6

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
@@ -23,7 +23,7 @@ final class Versions {
   static final String CHECKSTYLE_VERSION = "9.0"
   static final String PMD_VERSION = "6.38.0"
   static final String SPOTBUGS_VERSION = "4.4.1"
-  static final String PITEST_VERSION = "1.6.7"
-  static final String PITEST_JUNIT5_PLUGIN_VERSION = "0.12"
+  static final String PITEST_VERSION = "1.7.3"
+  static final String PITEST_JUNIT5_PLUGIN_VERSION = "0.15"
   static final JavaVersion TARGET_VERSION = VERSION_1_8
 }


### PR DESCRIPTION
Motivation:
PITest plugin version 1.7.0 fixes deprecations for Gradle 8.0
Modifications:
Update PITest and associated plugin versions
Result:
Improved compatibility with upcoming Gradle by removing deprecations