### PR TITLE
Transportevents offloading

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllers.java
@@ -39,8 +39,7 @@ public final class ReservableRequestConcurrencyControllers {
     public static ReservableRequestConcurrencyController newController(
             final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing,
             final int initialMaxConcurrency) {
-        return new ReservableRequestConcurrencyControllerMulti(maxConcurrency,
-                onClosing, initialMaxConcurrency);
+        return new ReservableRequestConcurrencyControllerMulti(maxConcurrency, onClosing, initialMaxConcurrency);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Processors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Processors.java
@@ -105,7 +105,7 @@ public final class Processors {
      * <p>
      * Only allows for {@code maxBuffer} number of items to be added through
      * {@link PublisherSource.Processor#onNext(Object)} without being delivered to its
-     * {@link PublisherSource.Subscriber}. If more numbers are added without being delivered, subsequent additions will
+     * {@link PublisherSource.Subscriber}. If more items are added without being delivered, subsequent additions will
      * fail.
      *
      * @param maxBuffer Maximum number of items to buffer.
@@ -129,7 +129,7 @@ public final class Processors {
      * <p>
      * Only allows for {@code maxBuffer} number of items to be added through
      * {@link PublisherSource.Processor#onNext(Object)} without being delivered to its
-     * {@link PublisherSource.Subscriber}. If more numbers are added without being delivered, the oldest buffered item
+     * {@link PublisherSource.Subscriber}. If more items are added without being delivered, the oldest buffered item
      * (head) will be dropped.
      *
      * @param maxBuffer Maximum number of items to buffer.
@@ -153,7 +153,7 @@ public final class Processors {
      * <p>
      * Only allows for {@code maxBuffer} number of items to be added through
      * {@link PublisherSource.Processor#onNext(Object)} without being delivered to its
-     * {@link PublisherSource.Subscriber}. If more numbers are added without being delivered, the latest buffered item
+     * {@link PublisherSource.Subscriber}. If more items are added without being delivered, the latest buffered item
      * (tail) will be dropped.
      *
      * @param maxBuffer Maximum number of items to buffer.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionStrategy.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionStrategy.java
@@ -28,8 +28,8 @@ final class DefaultGrpcExecutionStrategy implements GrpcExecutionStrategy {
     }
 
     @Override
-    public boolean hasOffloads() {
-        return delegate.hasOffloads();
+    public boolean isRequestResponseOffloaded() {
+        return delegate.isRequestResponseOffloaded();
     }
 
     @Override
@@ -45,6 +45,11 @@ final class DefaultGrpcExecutionStrategy implements GrpcExecutionStrategy {
     @Override
     public boolean isSendOffloaded() {
         return delegate.isSendOffloaded();
+    }
+
+    @Override
+    public boolean isEventOffloaded() {
+        return delegate.isEventOffloaded();
     }
 
     @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -176,7 +176,7 @@ final class GrpcRouter {
                     HttpExecutionStrategies.noOffloadsStrategy() :
                     executionContext.executionStrategy().missing(routeStrategy);
             verifyNoOverrides(allRoutes.put(path,
-                    null != routeStrategy && missing.hasOffloads() ?
+                    null != routeStrategy && missing.isRequestResponseOffloaded() ?
                               StreamingHttpServiceToOffloadedStreamingHttpService.offloadService(
                                   adapterHolder.serviceInvocationStrategy(),
                                   executionContext.executor(),

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
@@ -84,6 +84,11 @@ public final class ConnectAndHttpExecutionStrategy implements ConnectExecutionSt
     }
 
     @Override
+    public boolean isEventOffloaded() {
+        return httpStrategy.isEventOffloaded();
+    }
+
+    @Override
     public boolean isConnectOffloaded() {
         return connectStrategy.isConnectOffloaded();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import java.util.EnumSet;
 
+import static io.servicetalk.http.api.HttpExecutionStrategies.HttpOffload.OFFLOAD_EVENT;
 import static io.servicetalk.http.api.HttpExecutionStrategies.HttpOffload.OFFLOAD_RECEIVE_DATA;
 import static io.servicetalk.http.api.HttpExecutionStrategies.HttpOffload.OFFLOAD_RECEIVE_META;
 import static io.servicetalk.http.api.HttpExecutionStrategies.HttpOffload.OFFLOAD_SEND;
@@ -38,6 +39,15 @@ enum DefaultHttpExecutionStrategy implements HttpExecutionStrategy {
     OFFLOAD_SEND_STRATEGY(EnumSet.of(OFFLOAD_SEND)),
     OFFLOAD_RECEIVE_META_AND_SEND_STRATEGY(EnumSet.of(OFFLOAD_RECEIVE_META, OFFLOAD_SEND)),
     OFFLOAD_RECEIVE_DATA_AND_SEND_STRATEGY(EnumSet.of(OFFLOAD_RECEIVE_DATA, OFFLOAD_SEND)),
+    OFFLOAD_ALL_REQRESP_STRATEGY(EnumSet.allOf(HttpExecutionStrategies.HttpOffload.class)),
+
+    OFFLOAD_EVENT_STRATEGY(EnumSet.of(OFFLOAD_EVENT)),
+    OFFLOAD_RECEIVE_META_EVENT_STRATEGY(EnumSet.of(OFFLOAD_RECEIVE_META, OFFLOAD_EVENT)),
+    OFFLOAD_RECEIVE_DATA_EVENT_STRATEGY(EnumSet.of(OFFLOAD_RECEIVE_DATA, OFFLOAD_EVENT)),
+    OFFLOAD_RECEIVE_EVENT_STRATEGY(EnumSet.of(OFFLOAD_RECEIVE_META, OFFLOAD_RECEIVE_DATA, OFFLOAD_EVENT)),
+    OFFLOAD_SEND_EVENT_STRATEGY(EnumSet.of(OFFLOAD_SEND, OFFLOAD_EVENT)),
+    OFFLOAD_RECEIVE_META_AND_SEND_EVENT_STRATEGY(EnumSet.of(OFFLOAD_RECEIVE_META, OFFLOAD_SEND, OFFLOAD_EVENT)),
+    OFFLOAD_RECEIVE_DATA_AND_SEND_EVENT_STRATEGY(EnumSet.of(OFFLOAD_RECEIVE_DATA, OFFLOAD_SEND, OFFLOAD_EVENT)),
     OFFLOAD_ALL_STRATEGY(EnumSet.allOf(HttpExecutionStrategies.HttpOffload.class));
 
     private static final DefaultHttpExecutionStrategy[] VALUES = values();
@@ -77,6 +87,11 @@ enum DefaultHttpExecutionStrategy implements HttpExecutionStrategy {
     }
 
     @Override
+    public boolean isEventOffloaded() {
+        return offloaded(OFFLOAD_EVENT);
+    }
+
+    @Override
     public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
         if (this == other) {
             return this;
@@ -100,7 +115,8 @@ enum DefaultHttpExecutionStrategy implements HttpExecutionStrategy {
                 ((DefaultHttpExecutionStrategy) strategy).offloads :
         (byte) ((strategy.isDataReceiveOffloaded() ? OFFLOAD_RECEIVE_DATA.mask() : 0) |
                 (strategy.isMetadataReceiveOffloaded() ? OFFLOAD_RECEIVE_META.mask() : 0) |
-                (strategy.isSendOffloaded() ? OFFLOAD_SEND.mask() : 0));
+                (strategy.isSendOffloaded() ? OFFLOAD_SEND.mask() : 0) |
+                (strategy.isEventOffloaded() ? OFFLOAD_EVENT.mask() : 0));
     }
 
     // Visible for testing

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingStrategyInfluencer.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.http.api;
 
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY;
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_ALL_REQRESP_STRATEGY;
 
 final class DefaultStreamingStrategyInfluencer implements HttpExecutionStrategyInfluencer {
 
@@ -28,6 +28,6 @@ final class DefaultStreamingStrategyInfluencer implements HttpExecutionStrategyI
 
     @Override
     public HttpExecutionStrategy requiredOffloads() {
-        return OFFLOAD_ALL_STRATEGY;
+        return OFFLOAD_ALL_REQRESP_STRATEGY;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.transport.api.ExecutionStrategy;
 
+import static io.servicetalk.http.api.HttpExecutionStrategies.HttpOffload.OFFLOAD_EVENT;
 import static io.servicetalk.http.api.HttpExecutionStrategies.HttpOffload.OFFLOAD_RECEIVE_DATA;
 import static io.servicetalk.http.api.HttpExecutionStrategies.HttpOffload.OFFLOAD_RECEIVE_META;
 import static io.servicetalk.http.api.HttpExecutionStrategies.HttpOffload.OFFLOAD_SEND;
@@ -30,6 +31,15 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
 
     @Override
     default boolean hasOffloads() {
+        return isRequestResponseOffloaded();
+    }
+
+    /**
+     * Returns {@code true} if any portion of request/response path is offloaded for this {@link HttpExecutionStrategy}.
+     *
+     * @return {@code true} if any portion of request/response path is offloaded for this {@link HttpExecutionStrategy}.
+     */
+    default boolean isRequestResponseOffloaded() {
         return isSendOffloaded() || isMetadataReceiveOffloaded() || isDataReceiveOffloaded();
     }
 
@@ -53,6 +63,13 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
      * @return {@code true} if send offloading is enabled for this {@link HttpExecutionStrategy}.
      */
     boolean isSendOffloaded();
+
+    /**
+     * Returns {@code true} if event offloading is enabled for this {@link HttpExecutionStrategy}.
+     *
+     * @return {@code true} if event offloading is enabled for this {@link HttpExecutionStrategy}.
+     */
+    boolean isEventOffloaded();
 
     /**
      * Merges the passed {@link HttpExecutionStrategy} with {@code this} {@link HttpExecutionStrategy} and return the
@@ -86,6 +103,9 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
         }
         if (other.isDataReceiveOffloaded() && !this.isDataReceiveOffloaded()) {
             effectiveOffloads |= OFFLOAD_RECEIVE_DATA.mask();
+        }
+        if (other.isEventOffloaded() && !this.isEventOffloaded()) {
+            effectiveOffloads |= OFFLOAD_EVENT.mask();
         }
 
         return DefaultHttpExecutionStrategy.fromMask(effectiveOffloads);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
@@ -48,6 +48,11 @@ enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
             return false;
         }
 
+        @Override
+        public boolean isEventOffloaded() {
+            return false;
+        }
+
         /**
          * Always returns itself, the {@link #OFFLOAD_NEVER_STRATEGY} strategy.
          *
@@ -81,6 +86,11 @@ enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
 
         @Override
         public boolean isSendOffloaded() {
+            return true;
+        }
+
+        @Override
+        public boolean isEventOffloaded() {
             return true;
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToOffloadedStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToOffloadedStreamingHttpService.java
@@ -60,7 +60,7 @@ public class StreamingHttpServiceToOffloadedStreamingHttpService implements Stre
         final HttpServiceContext wrappedCtx =
                 new ExecutionContextOverridingServiceContext(ctx, strategy, useExecutor);
 
-        if (!additionalOffloads.hasOffloads()) {
+        if (!additionalOffloads.isRequestResponseOffloaded()) {
             // No additional offloading needed.
             return delegate.handle(wrappedCtx, request, responseFactory);
         } else {
@@ -114,7 +114,7 @@ public class StreamingHttpServiceToOffloadedStreamingHttpService implements Stre
                                                       @Nullable final Executor executor,
                                                       final BooleanSupplier shouldOffload,
                                                       final StreamingHttpService service) {
-        return strategy.hasOffloads() ?
+        return strategy.isRequestResponseOffloaded() ?
                 new StreamingHttpServiceToOffloadedStreamingHttpService(strategy, executor, shouldOffload, service) :
                 new StreamingHttpService() {
                     @Override

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/DelegatingHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/DelegatingHttpExecutionStrategy.java
@@ -49,6 +49,11 @@ public class DelegatingHttpExecutionStrategy implements HttpExecutionStrategy {
     }
 
     @Override
+    public boolean isEventOffloaded() {
+        return delegate.isEventOffloaded();
+    }
+
+    @Override
     public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
         // Since any methods can be overridden to change behavior, we leverage the other strategy to also account for
         // the overridden methods here.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -41,6 +41,7 @@ import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.defer;
@@ -78,8 +79,11 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
         this.connectionContext = new DefaultNettyHttpConnectionContext(conn, executionContext);
         this.reqRespFactory = requireNonNull(reqRespFactory);
         maxConcurrencySetting = from(new IgnoreConsumedEvent<>(maxPipelinedRequests))
-                .concat(connection.onClosing().publishOn(executionContext.executor()))
-                .concat(succeeded(ZERO_MAX_CONCURRENCY_EVENT));
+                .concat(connection.onClosing())
+                .concat(succeeded(ZERO_MAX_CONCURRENCY_EVENT))
+                .publishOn(executionContext.executionStrategy().isEventOffloaded() ?
+                        executionContext.executor() : immediate(),
+                        IoThreadFactory.IoThread::currentThreadIsIoThread);
         this.headersFactory = headersFactory;
         this.allowDropTrailersReadFromTransport = allowDropTrailersReadFromTransport;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -16,8 +16,10 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
+import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.client.api.internal.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
@@ -40,7 +42,6 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.concurrent.api.Single.failed;
-import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_1_1;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_2;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
@@ -101,11 +102,11 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
     }
 
     @Override
-    ReservableRequestConcurrencyController newConcurrencyController(final FilterableStreamingHttpConnection connection,
-                                                                    final Completable onClosing) {
+    ReservableRequestConcurrencyController newConcurrencyController(
+            final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing) {
         // We set initialMaxConcurrency to 1 here because we don't know what type of connection will be created when
         // ALPN completes. The actual maxConcurrency value will be updated by the MAX_CONCURRENCY stream,
         // when we create a connection.
-        return newController(connection.transportEventStream(MAX_CONCURRENCY), onClosing, 1);
+        return newController(maxConcurrency, onClosing, 1);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClientStrategyInfluencerChainBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClientStrategyInfluencerChainBuilder.java
@@ -36,7 +36,7 @@ final class ClientStrategyInfluencerChainBuilder {
         connFactoryChain = new ConnectAndHttpExecutionStrategy(ConnectExecutionStrategy.anyStrategy(),
                 HttpExecutionStrategies.defaultStrategy());
         connFilterChain = HttpExecutionStrategies.anyStrategy();
-        clientChain = HttpExecutionStrategies.anyStrategy();
+        clientChain = HttpExecutionStrategies.customStrategyBuilder().offloadEvent().build();
     }
 
     private ClientStrategyInfluencerChainBuilder(ClientStrategyInfluencerChainBuilder from) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -16,8 +16,10 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
+import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.client.api.internal.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
@@ -35,7 +37,6 @@ import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS;
 import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newController;
-import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 
@@ -70,9 +71,8 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
     }
 
     @Override
-    ReservableRequestConcurrencyController newConcurrencyController(final FilterableStreamingHttpConnection connection,
-                                                                    final Completable onClosing) {
-        return newController(connection.transportEventStream(MAX_CONCURRENCY), onClosing,
-                SMALLEST_MAX_CONCURRENT_STREAMS);
+    ReservableRequestConcurrencyController newConcurrencyController(
+            final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing) {
+        return newController(maxConcurrency, onClosing, SMALLEST_MAX_CONCURRENT_STREAMS);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -180,6 +180,13 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
 
         abstract void tryFailSubscriber(Throwable cause);
 
+        /**
+         * Receive a settings frame and optionally handle the acknowledgement of the frame.
+         *
+         * @param ctx the channel context
+         * @param settingsFrame the received settings frame
+         * @return true if caller should send ack or false if receiver has or will send ack.
+         */
         abstract boolean ackSettings(ChannelHandlerContext ctx, Http2SettingsFrame settingsFrame);
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -16,8 +16,10 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
+import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.client.api.internal.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
@@ -31,7 +33,6 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newController;
-import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.buildStreaming;
 
@@ -58,10 +59,9 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
     }
 
     @Override
-    ReservableRequestConcurrencyController newConcurrencyController(final FilterableStreamingHttpConnection connection,
-                                                                    Completable onClosing) {
+    ReservableRequestConcurrencyController newConcurrencyController(
+            final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, Completable onClosing) {
         assert config.h1Config() != null;
-        return newController(connection.transportEventStream(MAX_CONCURRENCY), onClosing,
-                config.h1Config().maxPipelinedRequests());
+        return newController(maxConcurrency, onClosing, config.h1Config().maxPipelinedRequests());
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
@@ -113,7 +113,7 @@ class ExecutionStrategyInContextTest {
         clientAsCloseable = client;
         if (!customStrategy) {
             assert expectedClientStrategy == null;
-            expectedClientStrategy = customStrategyBuilder().offloadReceiveData().build();
+            expectedClientStrategy = customStrategyBuilder().offloadReceiveData().offloadEvent().build();
             assert expectedServerStrategy == null;
             expectedServerStrategy = customStrategyBuilder().offloadReceiveData().offloadSend().build();
         }
@@ -141,7 +141,7 @@ class ExecutionStrategyInContextTest {
         clientAsCloseable = client;
         if (!customStrategy) {
             assert expectedClientStrategy == null;
-            expectedClientStrategy = customStrategyBuilder().offloadNone().build();
+            expectedClientStrategy = customStrategyBuilder().offloadNone().offloadEvent().build();
             assert expectedServerStrategy == null;
             expectedServerStrategy = customStrategyBuilder().offloadReceiveData().build();
         }
@@ -175,7 +175,7 @@ class ExecutionStrategyInContextTest {
         clientAsCloseable = client;
         if (!customStrategy) {
             assert expectedClientStrategy == null;
-            expectedClientStrategy = customStrategyBuilder().offloadSend().build();
+            expectedClientStrategy = customStrategyBuilder().offloadSend().offloadEvent().build();
             assert expectedServerStrategy == null;
             expectedServerStrategy = customStrategyBuilder().offloadReceiveMetadata().build();
         }

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/JerseyRouteExecutionStrategy.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/JerseyRouteExecutionStrategy.java
@@ -36,8 +36,8 @@ class JerseyRouteExecutionStrategy implements HttpExecutionStrategy {
     }
 
     @Override
-    public boolean hasOffloads() {
-        return delegate.hasOffloads();
+    public boolean isRequestResponseOffloaded() {
+        return delegate.isRequestResponseOffloaded();
     }
 
     @Override
@@ -53,6 +53,11 @@ class JerseyRouteExecutionStrategy implements HttpExecutionStrategy {
     @Override
     public boolean isSendOffloaded() {
         return delegate.isSendOffloaded();
+    }
+
+    @Override
+    public boolean isEventOffloaded() {
+        return delegate.isEventOffloaded();
     }
 
     @Override


### PR DESCRIPTION
Motivation:
Current offloading for transport is inconsistent, some events are offloaded, others are
not. To make it easier to support additional transport event receivers the offloading
should be configurable.
Modifications:
Apply consistent signal delivery with either no offloading or offloading to the context
executor for transport events. Extend `HttpExecutionStrategy` to provide configuration of
transport event offloading.
Result:
More flexible transport event offloading. By default, transport events will be offloaded.
