### PR TITLE
Reduce SSLSession cache misses

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcSslAndNonSslConnectionsTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcSslAndNonSslConnectionsTest.java
@@ -161,11 +161,10 @@ class GrpcSslAndNonSslConnectionsTest {
              BlockingTesterClient client = GrpcClients.forAddress(
                      getLoopbackAddress().getHostName(), serverHostAndPort(serverContext).port())
                      .initializeHttp(builder -> builder
-                             .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
-                                     .peerHost(serverPemHostname()).build())
+                             .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build())
+                     .inferPeerHost(false)
                      .inferSniHostname(false))
-                     .buildBlocking(clientFactory());
-        ) {
+                     .buildBlocking(clientFactory())) {
             final TesterProto.TestResponse response = client.test(REQUEST);
             assertThat(response, is(notNullValue()));
             assertThat(response.getMessage(), is(notNullValue()));
@@ -183,11 +182,10 @@ class GrpcSslAndNonSslConnectionsTest {
              BlockingTesterClient client = GrpcClients.forAddress(
                      getLoopbackAddress().getHostName(), serverHostAndPort(serverContext).port())
                      .initializeHttp(builder -> builder
-                             .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
-                                     .peerHost(serverPemHostname()).build())
+                             .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build())
+                             .inferPeerHost(false)
                              .inferSniHostname(false))
-                     .buildBlocking(clientFactory());
-        ) {
+                     .buildBlocking(clientFactory())) {
             GrpcStatusException e = assertThrows(GrpcStatusException.class, () -> client.test(REQUEST));
             assertThat(e.getCause(), instanceOf(SSLHandshakeException.class));
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -37,6 +37,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.SMALLEST_MAX_CONCURREN
 import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 
 final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
     H2LBHttpConnectionFactory(
@@ -56,14 +57,13 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
             final ResolvedAddress resolvedAddress, final TransportObserver observer) {
         assert config.h2Config() != null;
         // This state is read only, so safe to keep a copy across Subscribers
-        final ReadOnlyTcpClientConfig roTcpClientConfig = config.tcpConfig();
+        final ReadOnlyTcpClientConfig tcpConfig = withSslConfigPeerHost(resolvedAddress, config.tcpConfig());
         // Auto read is required for h2
-        return TcpConnector.connect(null, resolvedAddress, roTcpClientConfig, true, executionContext,
+        return TcpConnector.connect(null, resolvedAddress, tcpConfig, true, executionContext,
                 (channel, connectionObserver) -> H2ClientParentConnectionContext.initChannel(channel,
-                        executionContext,
-                        config.h2Config(), reqRespFactoryFunc.apply(HTTP_2_0), roTcpClientConfig.flushStrategy(),
-                        roTcpClientConfig.idleTimeoutMs(),
-                        new TcpClientChannelInitializer(roTcpClientConfig, connectionObserver).andThen(
+                        executionContext, config.h2Config(), reqRespFactoryFunc.apply(HTTP_2_0),
+                        tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(),
+                        new TcpClientChannelInitializer(tcpConfig, connectionObserver).andThen(
                                 new H2ClientParentChannelInitializer(config.h2Config())), connectionObserver,
                         config.allowDropTrailersReadFromTransport()), observer);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.tcp.netty.internal.TcpClientConfig;
 import io.servicetalk.transport.api.ClientSslConfig;
+import io.servicetalk.transport.api.DelegatingClientSslConfig;
 
 import java.util.List;
 import javax.annotation.Nullable;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServerConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServerConfig.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.tcp.netty.internal.TcpServerConfig;
+import io.servicetalk.transport.api.DelegatingServerSslConfig;
 import io.servicetalk.transport.api.ServerSslConfig;
 
 import java.util.LinkedHashMap;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -17,8 +17,10 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpConnector;
+import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
@@ -28,10 +30,15 @@ import io.servicetalk.transport.netty.internal.NettyConnection;
 
 import io.netty.channel.Channel;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import javax.net.ssl.SNIHostName;
+
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
+import static java.util.Objects.requireNonNull;
 
 final class StreamingConnectionFactory {
     private StreamingConnectionFactory() {
@@ -41,24 +48,78 @@ final class StreamingConnectionFactory {
     static <ResolvedAddress> Single<? extends NettyConnection<Object, Object>> buildStreaming(
             final HttpExecutionContext executionContext, final ResolvedAddress resolvedAddress,
             final ReadOnlyHttpClientConfig roConfig, final TransportObserver observer) {
+        final ReadOnlyTcpClientConfig tcpConfig = withSslConfigPeerHost(resolvedAddress, roConfig.tcpConfig());
+        final H1ProtocolConfig h1Config = roConfig.h1Config();
+        assert h1Config != null;
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
-        return TcpConnector.connect(null, resolvedAddress, roConfig.tcpConfig(), false, executionContext,
-                (channel, connectionObserver) -> createConnection(channel, executionContext, roConfig,
-                        new TcpClientChannelInitializer(roConfig.tcpConfig(), connectionObserver, roConfig.hasProxy()),
+        return TcpConnector.connect(null, resolvedAddress, tcpConfig, false, executionContext,
+                (channel, connectionObserver) -> createConnection(channel, executionContext, h1Config, tcpConfig,
+                        new TcpClientChannelInitializer(tcpConfig, connectionObserver, roConfig.hasProxy()),
                         connectionObserver),
                 observer);
     }
 
     static Single<? extends DefaultNettyConnection<Object, Object>> createConnection(final Channel channel,
-            final HttpExecutionContext executionContext, final ReadOnlyHttpClientConfig config,
-            final ChannelInitializer initializer, final ConnectionObserver connectionObserver) {
+            final HttpExecutionContext executionContext, final H1ProtocolConfig h1Config,
+            final ReadOnlyTcpClientConfig tcpConfig, final ChannelInitializer initializer,
+            final ConnectionObserver connectionObserver) {
         final CloseHandler closeHandler = forPipelinedRequestResponse(true, channel.config());
-        assert config.h1Config() != null;
         return showPipeline(DefaultNettyConnection.initChannel(channel, executionContext.bufferAllocator(),
                 executionContext.executor(), executionContext.ioExecutor(), closeHandler,
-                config.tcpConfig().flushStrategy(), config.tcpConfig().idleTimeoutMs(),
+                tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(),
                 initializer.andThen(new HttpClientChannelInitializer(
-                        getByteBufAllocator(executionContext.bufferAllocator()), config.h1Config(), closeHandler)),
+                        getByteBufAllocator(executionContext.bufferAllocator()), h1Config, closeHandler)),
                 executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true), HTTP_1_1, channel);
+    }
+
+    static ReadOnlyTcpClientConfig withSslConfigPeerHost(Object resolvedRemoteAddress,
+                                                         ReadOnlyTcpClientConfig config) {
+        requireNonNull(resolvedRemoteAddress);
+        requireNonNull(config);
+        ClientSslConfig sslConfig = config.sslConfig();
+        if (sslConfig != null && resolvedRemoteAddress instanceof InetSocketAddress) {
+            // Get the InetAddress for hostname+IP, port will be appended elsewhere to the SSLSession cache key.
+            final InetSocketAddress socketAddress = (InetSocketAddress) resolvedRemoteAddress;
+            final InetAddress inetAddress = socketAddress.getAddress();
+            final String sniHostname = sslConfig.sniHostname();
+            final String peerHost = sslConfig.peerHost();
+            final String newPeerHost;
+            final String newSniHostname;
+            final String hostnameVerificationAlgorithm;
+            if (sniHostname == null) {
+                if (peerHost == null) {
+                    newPeerHost = inetAddress.getHostAddress();
+                    newSniHostname = hostnameVerificationAlgorithm = null;
+                } else {
+                    newPeerHost = peerHost + '-' + inetAddress.getHostAddress();
+                    // We are overriding the peerHost to make it qualified with the resolved address. If sniHostname is
+                    // not set and the hostnameVerificationAlgorithm is set, the SSLEngine will take the peerHost value
+                    // for validation, which will fail to match now that we have changed the value.
+                    if (isValidSniHostname(peerHost)) {
+                        newSniHostname = peerHost;
+                        hostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
+                    } else {
+                        newSniHostname = hostnameVerificationAlgorithm = null;
+                    }
+                }
+            } else {
+                newPeerHost = sniHostname + '-' + inetAddress.getHostAddress();
+                newSniHostname = sniHostname;
+                hostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
+            }
+
+            return config.withSslConfigPeerHost(newPeerHost, socketAddress.getPort(), newSniHostname,
+                    hostnameVerificationAlgorithm);
+        }
+        return config;
+    }
+
+    private static boolean isValidSniHostname(String peerHost) {
+        try {
+            new SNIHostName(peerHost);
+            return true;
+        } catch (Throwable cause) {
+            return false;
+        }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilderTest.java
@@ -24,11 +24,14 @@ import io.servicetalk.transport.api.ServerSslConfigBuilder;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.forResolvedAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -91,12 +94,9 @@ class DefaultSingleAddressHttpClientBuilderTest {
             try {
                 SSLSession sslSession = conn.connectionContext().sslSession();
                 assertNotNull(sslSession);
-                assertEquals(hostName, sslSession.getPeerHost());
-                if (port == null) {
-                    assertEquals(-1, sslSession.getPeerPort());
-                } else {
-                    assertEquals(port.intValue(), sslSession.getPeerPort());
-                }
+                assertThat(sslSession.getPeerHost(), startsWith(hostName));
+                InetSocketAddress socketAddress = (InetSocketAddress) conn.connectionContext().remoteAddress();
+                assertEquals(socketAddress.getPort(), sslSession.getPeerPort());
             } finally {
                 conn.release();
             }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
@@ -51,7 +51,7 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig> {
     }
 
     AbstractReadOnlyTcpConfig(final AbstractReadOnlyTcpConfig<SecurityConfig> from) {
-        options = nonNullOptions(from.options());
+        options = from.options();
         idleTimeoutMs = from.idleTimeoutMs();
         flushStrategy = from.flushStrategy();
         wireLoggerConfig = from.wireLoggerConfig();

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
@@ -50,6 +50,13 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig> {
         wireLoggerConfig = from.wireLoggerConfig();
     }
 
+    AbstractReadOnlyTcpConfig(final AbstractReadOnlyTcpConfig<SecurityConfig> from) {
+        options = nonNullOptions(from.options());
+        idleTimeoutMs = from.idleTimeoutMs();
+        flushStrategy = from.flushStrategy();
+        wireLoggerConfig = from.wireLoggerConfig();
+    }
+
     @SuppressWarnings("rawtypes")
     static Map<ChannelOption, Object> nonNullOptions(@Nullable Map<ChannelOption, Object> options) {
         return options == null ? emptyMap() : unmodifiableMap(new HashMap<>(options));

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
@@ -98,7 +98,6 @@ public final class TcpConnector {
             protected void handleSubscribe(final Subscriber<? super C> subscriber) {
                 ConnectHandler<C> connectHandler = new ConnectHandler<>(subscriber, connectionFactory, observer);
                 try {
-
                     Future<?> connectFuture = connect0(localAddress, resolvedRemoteAddress, config, autoRead,
                             executionContext, connectHandler);
                     connectHandler.connectFuture(connectFuture);

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
@@ -98,6 +98,7 @@ public final class TcpConnector {
             protected void handleSubscribe(final Subscriber<? super C> subscriber) {
                 ConnectHandler<C> connectHandler = new ConnectHandler<>(subscriber, connectionFactory, observer);
                 try {
+
                     Future<?> connectFuture = connect0(localAddress, resolvedRemoteAddress, config, autoRead,
                             executionContext, connectHandler);
                     connectHandler.connectFuture(connectFuture);

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingClientSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingClientSslConfig.java
@@ -13,14 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
-
-import io.servicetalk.transport.api.ClientSslConfig;
+package io.servicetalk.transport.api;
 
 import javax.annotation.Nullable;
 
-class DelegatingClientSslConfig extends DelegatingSslConfig<ClientSslConfig> implements ClientSslConfig {
-    DelegatingClientSslConfig(final ClientSslConfig delegate) {
+/**
+ * Wrap a {@link ClientSslConfig} and delegate all methods to it.
+ */
+public class DelegatingClientSslConfig extends DelegatingSslConfig<ClientSslConfig> implements ClientSslConfig {
+    /**
+     * Create a new instance.
+     * @param delegate The instance to delegate to.
+     */
+    protected DelegatingClientSslConfig(final ClientSslConfig delegate) {
         super(delegate);
     }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingServerSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingServerSslConfig.java
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
+package io.servicetalk.transport.api;
 
-import io.servicetalk.transport.api.ServerSslConfig;
-import io.servicetalk.transport.api.SslClientAuthMode;
-
-class DelegatingServerSslConfig extends DelegatingSslConfig<ServerSslConfig> implements ServerSslConfig {
-    DelegatingServerSslConfig(final ServerSslConfig delegate) {
+/**
+ * Wrap a {@link ServerSslConfig} and delegate all methods to it.
+ */
+public class DelegatingServerSslConfig extends DelegatingSslConfig<ServerSslConfig> implements ServerSslConfig {
+    /**
+     * Create a new instance.
+     * @param delegate The instance to delegate to.
+     */
+    protected DelegatingServerSslConfig(final ServerSslConfig delegate) {
         super(delegate);
     }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingSslConfig.java
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
-
-import io.servicetalk.transport.api.SslConfig;
-import io.servicetalk.transport.api.SslProvider;
+package io.servicetalk.transport.api;
 
 import java.io.InputStream;
 import java.util.List;
@@ -27,13 +24,25 @@ import javax.net.ssl.TrustManagerFactory;
 
 import static java.util.Objects.requireNonNull;
 
-abstract class DelegatingSslConfig<T extends SslConfig> implements SslConfig {
+/**
+ * Wrap a {@link SslConfig} and delegate all methods to it.
+ * @param <T> The type of {@link SslConfig} to delegate to.
+ */
+public abstract class DelegatingSslConfig<T extends SslConfig> implements SslConfig {
     private final T delegate;
 
-    DelegatingSslConfig(final T delegate) {
+    /**
+     * Create a new instance.
+     * @param delegate The instance to delegate to.
+     */
+    protected DelegatingSslConfig(final T delegate) {
         this.delegate = requireNonNull(delegate);
     }
 
+    /**
+     * Get the {@link T} to delegate to.
+     * @return the {@link T} to delegate to.
+     */
     protected T delegate() {
         return delegate;
     }


### PR DESCRIPTION
Motivation:
The key for SSLSession is `peerHost+peerPort`. Our builders current
set the peerHost before resolution is complete. This may result in
cache misses if the hostname resolves to multiple IPs.

Modifications:
- The peerHost should be set after resolution, when the IP address
  is known. The cache key will then be specific to a host and more
  likely to have a cache hit. The peerHost is not authoritative so
  overriding should be safe.

Result:
SSLSession cache hits are more likely to happen in practice.