### PR TITLE
Cleanup default methods from `HttpMetaData`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -335,8 +335,5 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     }
 
     @Override
-    default BlockingStreamingHttpRequest context(ContextMap context) {
-        HttpRequestMetaData.super.context(context);
-        return this;
-    }
+    BlockingStreamingHttpRequest context(ContextMap context);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -285,8 +285,5 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     }
 
     @Override
-    default BlockingStreamingHttpResponse context(ContextMap context) {
-        HttpResponseMetaData.super.context(context);
-        return this;
-    }
+    BlockingStreamingHttpResponse context(ContextMap context);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java
@@ -214,9 +214,7 @@ public interface HttpMetaData extends ContextMapHolder {
      */
     @Nonnull
     @Override
-    default ContextMap context() {  // FIXME: remove `default` impl after cherry-pick for 0.41
-        throw new UnsupportedOperationException("Method context() is not supported by " + getClass().getName());
-    }
+    ContextMap context();
 
     /**
      * Sets a context for this {@link HttpMetaData}.
@@ -228,8 +226,5 @@ public interface HttpMetaData extends ContextMapHolder {
      * @return {@code this}.
      */
     @Override
-    default HttpMetaData context(ContextMap context) {  // FIXME: remove `default` impl after cherry-pick for 0.41
-        throw new UnsupportedOperationException("Method context(ContextMap) is not supported by " +
-                getClass().getName());
-    }
+    HttpMetaData context(ContextMap context);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
@@ -223,8 +223,5 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
     }
 
     @Override
-    default HttpRequest context(ContextMap context) {
-        HttpRequestMetaData.super.context(context);
-        return this;
-    }
+    HttpRequest context(ContextMap context);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
@@ -492,8 +492,5 @@ public interface HttpRequestMetaData extends HttpMetaData {
     }
 
     @Override
-    default HttpRequestMetaData context(ContextMap context) {
-        HttpMetaData.super.context(context);
-        return this;
-    }
+    HttpRequestMetaData context(ContextMap context);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
@@ -172,8 +172,5 @@ public interface HttpResponse extends HttpResponseMetaData, TrailersHolder {
     }
 
     @Override
-    default HttpResponse context(ContextMap context) {
-        HttpResponseMetaData.super.context(context);
-        return this;
-    }
+    HttpResponse context(ContextMap context);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponseMetaData.java
@@ -90,8 +90,5 @@ public interface HttpResponseMetaData extends HttpMetaData {
     }
 
     @Override
-    default HttpResponseMetaData context(ContextMap context) {
-        HttpMetaData.super.context(context);
-        return this;
-    }
+    HttpResponseMetaData context(ContextMap context);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
@@ -336,8 +336,5 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     }
 
     @Override
-    default StreamingHttpRequest context(ContextMap context) {
-        HttpRequestMetaData.super.context(context);
-        return this;
-    }
+    StreamingHttpRequest context(ContextMap context);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
@@ -289,8 +289,5 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
     }
 
     @Override
-    default StreamingHttpResponse context(ContextMap context) {
-        HttpResponseMetaData.super.context(context);
-        return this;
-    }
+    StreamingHttpResponse context(ContextMap context);
 }


### PR DESCRIPTION
#1904 added two `context` methods on `HttpMetaData`, but had to use
`default` implementations to make it backward compatible with 0.41. We
can remove those `default` implementations now.

Modifications:

- Remove default impl for `HttpMetaData#context()` and
`HttpMetaData#context(ContextMap)`;
- Adjust all interfaces that extend `HttpMetaData`;

Result:

0.42 won't have `default` implementations for `context` methods.