### PR TITLE
Clarify `ServiceDiscovererEvent` contract related to address and status

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
@@ -27,6 +27,10 @@ import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.UNAVAILABL
 public interface ServiceDiscovererEvent<ResolvedAddress> {
     /**
      * Get the resolved address which is the subject of this event.
+     * <p>
+     * Note: all subsequent events for the same address override its {@link #status()} or any additional meta-data
+     * associated with the address.
+     *
      * @return a resolved address that can be used for connecting.
      */
     ResolvedAddress address();


### PR DESCRIPTION
Motivation:

Add a note that clarifies how subsequent events are treated by SD
contract.