### PR TITLE
Restore `ServiceDiscovererUtils` methods and mark them as deprecated

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ServiceDiscovererUtils.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ServiceDiscovererUtils.java
@@ -30,11 +30,105 @@ import static java.util.Collections.binarySearch;
 
 /**
  * A set of utility functions for {@link ServiceDiscoverer}.
+ *
+ * @deprecated This is an internal class and will be removed in 0.42. If you depend on it, consider replicating its
+ * logic.
  */
+@Deprecated
 public final class ServiceDiscovererUtils {
 
     private ServiceDiscovererUtils() {
         // no instances
+    }
+
+    /**
+     * Given a sorted list of currently active addresses, and a new set of unsorted active address calculate the
+     * {@link ServiceDiscovererEvent}s.
+     * <p>
+     * {@code newActiveAddresses} will be sorted in this method.
+     * @param currentActiveAddresses The currently active addresses.
+     * @param newActiveAddresses The new list of active addresses.<b>This list must be modifiable</b> as it will be
+     * sorted with {@link List#sort(Comparator)}.
+     * @param comparator A comparator for the addresses and to use for binary searches.
+     * @param reporter A reporter for the numbers of available and unavailable events.
+     * @param <T> The type of address.
+     * @return A list of {@link ServiceDiscovererEvent}s which represents the changes between
+     * {@code currentActiveAddresses} and {@code newActiveAddresses}, or {@code null} if there are no changes.
+     * @deprecated This is an internal class and will be removed in 0.42. If you depend on it, consider replicating its
+     * logic.
+     */
+    @Deprecated
+    @Nullable
+    public static <T> List<ServiceDiscovererEvent<T>> calculateDifference(List<? extends T> currentActiveAddresses,
+                                                                          List<? extends T> newActiveAddresses,
+                                                                          Comparator<T> comparator,
+                                                                          @Nullable TwoIntsConsumer reporter) {
+        // First sort the newAddresses so we can use binary search.
+        newActiveAddresses.sort(comparator);
+
+        // Calculate additions (in newAddresses, not in activeAddresses).
+        List<ServiceDiscovererEvent<T>> availableEvents =
+                relativeComplement(true, currentActiveAddresses, newActiveAddresses, comparator, null);
+        // Store nAvailable now because the List may be updated on the next step.
+        final int nAvailable = availableEvents == null ? 0 : availableEvents.size();
+        // Calculate removals (in activeAddresses, not in newAddresses).
+        List<ServiceDiscovererEvent<T>> allEvents =
+                relativeComplement(false, newActiveAddresses, currentActiveAddresses, comparator, availableEvents);
+
+        reportEvents(reporter, allEvents, nAvailable);
+        return allEvents;
+    }
+
+    /**
+     * Calculate the relative complement of {@code sortedA} and {@code sortedB} (elements in {@code sortedB} and not in
+     * {@code sortedA}).
+     * <p>
+     * See <a href="https://en.wikipedia.org/wiki/Venn_diagram#Overview">Set Mathematics</a>.
+     * @param available Will be used for {@link ServiceDiscovererEvent#isAvailable()} for each
+     * {@link ServiceDiscovererEvent} in the returned {@link List}.
+     * @param sortedA A sorted {@link List} of which no elements be present in the return value.
+     * @param sortedB A sorted {@link List} of which elements in this set that are not in {@code sortedA} will be in the
+     * return value.
+     * @param comparator Used for binary searches on {@code sortedA} for each element in {@code sortedB}.
+     * @param result List to append new results to.
+     * @param <T> The type of resolved address.
+     * @return the relative complement of {@code sortedA} and {@code sortedB} (elements in {@code sortedB} and not in
+     * {@code sortedA}).
+     */
+    @Deprecated
+    @Nullable
+    private static <T> List<ServiceDiscovererEvent<T>> relativeComplement(
+            boolean available, List<? extends T> sortedA, List<? extends T> sortedB, Comparator<T> comparator,
+            @Nullable List<ServiceDiscovererEvent<T>> result) {
+        if (sortedB instanceof RandomAccess) {
+            for (int i = 0; i < sortedB.size(); ++i) {
+                final T valueB = sortedB.get(i);
+                if (binarySearch(sortedA, valueB, comparator) < 0) {
+                    if (result == null) {
+                        result = new ArrayList<>(4);
+                        result.add(new DefaultServiceDiscovererEvent<>(valueB, available));
+                    } else if (comparator.compare(valueB, result.get(result.size() - 1).address()) != 0) {
+                        // make sure we don't include duplicates. the input lists are sorted and we process in order so
+                        // we verify the previous entry is not a duplicate.
+                        result.add(new DefaultServiceDiscovererEvent<>(valueB, available));
+                    }
+                }
+            }
+        } else {
+            for (T valueB : sortedB) {
+                if (binarySearch(sortedA, valueB, comparator) < 0) {
+                    if (result == null) {
+                        result = new ArrayList<>(4);
+                        result.add(new DefaultServiceDiscovererEvent<>(valueB, available));
+                    } else if (comparator.compare(valueB, result.get(result.size() - 1).address()) != 0) {
+                        // make sure we don't include duplicates. the input lists are sorted and we process in order so
+                        // we verify the previous entry is not a duplicate.
+                        result.add(new DefaultServiceDiscovererEvent<>(valueB, available));
+                    }
+                }
+            }
+        }
+        return result;
     }
 
     /**
@@ -52,7 +146,10 @@ public final class ServiceDiscovererUtils {
      * {@link ServiceDiscovererEvent} when address present in current list but not in the new one.
      * @return A list of {@link ServiceDiscovererEvent}s which represents the changes between
      * {@code currentActiveAddresses} and {@code newActiveAddresses}, or {@code null} if there are no changes.
+     * @deprecated This is an internal class and will be removed in 0.42. If you depend on it, consider replicating its
+     * logic.
      */
+    @Deprecated
     @Nullable
     public static <T> List<ServiceDiscovererEvent<T>> calculateDifference(
             List<? extends T> currentActiveAddresses,
@@ -143,7 +240,11 @@ public final class ServiceDiscovererUtils {
 
     /**
      * Represents an operation that accepts two {@code int}-valued arguments and returns no result.
+     *
+     * @deprecated This interface is defined by an internal class and will be removed in 0.42. If you depend on it,
+     * consider replicating it.
      */
+    @Deprecated
     @FunctionalInterface
     public interface TwoIntsConsumer {
 

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ServiceDiscovererUtils.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ServiceDiscovererUtils.java
@@ -31,8 +31,8 @@ import static java.util.Collections.binarySearch;
 /**
  * A set of utility functions for {@link ServiceDiscoverer}.
  *
- * @deprecated This is an internal class and will be removed in 0.42. If you depend on it, consider replicating its
- * logic.
+ * @deprecated This is an internal class and will be removed in a future release. If you depend on it, consider
+ * replicating its logic.
  */
 @Deprecated
 public final class ServiceDiscovererUtils {
@@ -54,8 +54,8 @@ public final class ServiceDiscovererUtils {
      * @param <T> The type of address.
      * @return A list of {@link ServiceDiscovererEvent}s which represents the changes between
      * {@code currentActiveAddresses} and {@code newActiveAddresses}, or {@code null} if there are no changes.
-     * @deprecated This is an internal class and will be removed in 0.42. If you depend on it, consider replicating its
-     * logic.
+     * @deprecated This is an internal class and will be removed in a future release. If you depend on it, consider
+     * replicating its logic.
      */
     @Deprecated
     @Nullable
@@ -94,6 +94,8 @@ public final class ServiceDiscovererUtils {
      * @param <T> The type of resolved address.
      * @return the relative complement of {@code sortedA} and {@code sortedB} (elements in {@code sortedB} and not in
      * {@code sortedA}).
+     * @deprecated This is an internal class and will be removed in a future release. If you depend on it, consider
+     * replicating its logic.
      */
     @Deprecated
     @Nullable
@@ -146,8 +148,8 @@ public final class ServiceDiscovererUtils {
      * {@link ServiceDiscovererEvent} when address present in current list but not in the new one.
      * @return A list of {@link ServiceDiscovererEvent}s which represents the changes between
      * {@code currentActiveAddresses} and {@code newActiveAddresses}, or {@code null} if there are no changes.
-     * @deprecated This is an internal class and will be removed in 0.42. If you depend on it, consider replicating its
-     * logic.
+     * @deprecated This is an internal class and will be removed in a future release. If you depend on it, consider
+     * replicating its logic.
      */
     @Deprecated
     @Nullable
@@ -241,8 +243,8 @@ public final class ServiceDiscovererUtils {
     /**
      * Represents an operation that accepts two {@code int}-valued arguments and returns no result.
      *
-     * @deprecated This interface is defined by an internal class and will be removed in 0.42. If you depend on it,
-     * consider replicating it.
+     * @deprecated This interface is defined by an internal class and will be removed in a future release. If you depend
+     * on it, consider replicating it.
      */
     @Deprecated
     @FunctionalInterface


### PR DESCRIPTION
Motivation:

`japicmp.sh` highlights `ServiceDiscovererUtils#calculateDifference` as
removed method. For 0.41 branch we should be backward compatible even
for internal classes.

Modifications:

- Restore `ServiceDiscovererUtils#calculateDifference(List, List, Comparator, TwoIntsConsumer)`
overload;
- Mark the whole utility class, `calculateDifference`, and
`TwoIntsConsumer` interface as `@Deprecated`;

Result:

`ServiceDiscovererUtils` is backward compatible with 0.41.11.