### PR TITLE
Restore `BaseSingleAddressHttpClientBuilder#retryServiceDiscoveryErrors`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BaseSingleAddressHttpClientBuilder.java
@@ -95,6 +95,12 @@ abstract class BaseSingleAddressHttpClientBuilder<U, R, SDE extends ServiceDisco
             ServiceDiscoverer<U, R, SDE> serviceDiscoverer);
 
     @Override
+    public BaseSingleAddressHttpClientBuilder<U, R, SDE> retryServiceDiscoveryErrors(
+            ServiceDiscoveryRetryStrategy<R, SDE> retryStrategy) {
+        return (BaseSingleAddressHttpClientBuilder<U, R, SDE>) super.retryServiceDiscoveryErrors(retryStrategy);
+    }
+
+    @Override
     public abstract BaseSingleAddressHttpClientBuilder<U, R, SDE> loadBalancerFactory(
             HttpLoadBalancerFactory<R> loadBalancerFactory);
 


### PR DESCRIPTION
Motivation:

`japicmp.sh` highlights this method as removed. For 0.41 branch we
should be extra cautious for any changes, even for internal or
pkg-private changes. For extra safety, let's recover this method.

Modifications:

- Restore `BaseSingleAddressHttpClientBuilder#retryServiceDiscoveryErrors(ServiceDiscoveryRetryStrategy)`;
- Add default impl;

Result:

Less changes for `BaseSingleAddressHttpClientBuilder` in 0.41.