### PR TITLE
Give visibility to the assigned HTTP/2 Stream ID

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
@@ -47,7 +47,7 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
     final BufferAllocator allocator;
     final HttpHeadersFactory headersFactory;
     final CloseHandler closeHandler;
-    private final StreamObserver observer;
+    final StreamObserver observer;
 
     AbstractH2DuplexHandler(BufferAllocator allocator, HttpHeadersFactory headersFactory, CloseHandler closeHandler,
                             StreamObserver observer) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -149,6 +149,8 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                 connection.trackActiveStream(streamChannel);
                                 StreamObserver streamObserver =
                                         parentChannelInitializer.multiplexedObserver.onNewStream();
+                                assert streamChannel.stream().id() > 0;
+                                streamObserver.streamIdAssigned(streamChannel.stream().id());
 
                                 // Netty To ServiceTalk type conversion
                                 final CloseHandler closeHandler = forNonPipelined(false, streamChannel.config());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -149,8 +149,9 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                 connection.trackActiveStream(streamChannel);
                                 StreamObserver streamObserver =
                                         parentChannelInitializer.multiplexedObserver.onNewStream();
-                                assert streamChannel.stream().id() > 0;
-                                streamObserver.streamIdAssigned(streamChannel.stream().id());
+                                final int streamId = streamChannel.stream().id();
+                                assert streamId > 0;
+                                streamObserver.streamIdAssigned(streamId);
 
                                 // Netty To ServiceTalk type conversion
                                 final CloseHandler closeHandler = forNonPipelined(false, streamChannel.config());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -31,6 +31,7 @@ import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http2.Http2DataFrame;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
 
 import javax.annotation.Nullable;
 
@@ -85,7 +86,15 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 h2Headers.scheme(scheme.name());
                 h2Headers.path(metaData.requestTarget());
             }
-            writeMetaData(ctx, metaData, h2Headers, promise);
+            try {
+                writeMetaData(ctx, metaData, h2Headers, promise);
+            } finally {
+                final Http2StreamChannel streamChannel = (Http2StreamChannel) ctx.channel();
+                final int streamId = streamChannel.stream().id();
+                if (streamId > 0) {
+                    observer.streamIdAssigned(streamId);
+                }
+            }
         } else if (msg instanceof Buffer) {
             writeBuffer(ctx, (Buffer) msg, promise);
         } else if (msg instanceof HttpHeaders) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
@@ -34,8 +34,10 @@ import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
 import io.netty.handler.codec.http2.Http2DataFrame;
+import io.netty.handler.codec.http2.Http2FrameStream;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -69,6 +71,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class AbstractH2DuplexHandlerTest {
 
@@ -119,7 +122,7 @@ class AbstractH2DuplexHandlerTest {
         abstract Http2Headers setHeaders(Http2Headers headers);
     }
 
-    private final EmbeddedChannel channel = new EmbeddedChannel();
+    private final EmbeddedChannel channel = new EmbeddedHttp2StreamChannel();
     private final CloseHandler closeHandler = mock(CloseHandler.class);
 
     void setUp(Variant variant) {
@@ -412,5 +415,15 @@ class AbstractH2DuplexHandlerTest {
         Http2DataFrame dataFrame = channel.readOutbound();
         assertThat(dataFrame.content().readableBytes(), is(0));
         dataFrame.release();
+    }
+
+    private static final class EmbeddedHttp2StreamChannel extends EmbeddedChannel implements Http2StreamChannel {
+
+        @Override
+        public Http2FrameStream stream() {
+            Http2FrameStream streamMock = mock(Http2FrameStream.class);
+            when(streamMock.id()).thenReturn(3);
+            return streamMock;
+        }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -233,6 +233,11 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
         private class AsyncContextCaptureStreamObserver implements StreamObserver {
 
             @Override
+            public void streamIdAssigned(final long streamId) {
+                // AsyncContext may be unknown at this point if the streamId is assigned by the transport
+            }
+
+            @Override
             public DataObserver streamEstablished() {
                 storageMap.put("streamEstablished", valueOf(AsyncContext.get(key)));
                 return new AsyncContextCaptureDataObserver();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -66,6 +66,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.lenient;
@@ -399,6 +400,8 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
             verify(serverMultiplexedObserver).onNewStream();
 
             verify(clientStreamObserver).streamEstablished();
+            verify(clientStreamObserver).streamIdAssigned(eq(3L));
+            verify(serverStreamObserver).streamIdAssigned(eq(3L));
             verify(serverStreamObserver).streamEstablished();
 
             verify(clientDataObserver).onNewRead();

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -170,6 +170,12 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void streamIdAssigned(final long streamId) {
+            first.streamIdAssigned(streamId);
+            second.streamIdAssigned(streamId);
+        }
+
+        @Override
         public DataObserver streamEstablished() {
             return new BiDataObserver(first.streamEstablished(), second.streamEstablished());
         }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -174,6 +174,11 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void streamIdAssigned(final long streamId) {
+            safeReport(() -> observer.streamIdAssigned(streamId), observer, "streamId assigned");
+        }
+
+        @Override
         public DataObserver streamEstablished() {
             return safeReport(observer::streamEstablished, observer, "stream established",
                     CatchAllDataObserver::new, NoopDataObserver.INSTANCE);

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -152,8 +152,6 @@ public interface ConnectionObserver {
          */
         default void streamIdAssigned(long streamId) {  // Use long to comply with HTTP/3 requirements
             // FIXME: 0.42 - remove default impl
-            throw new UnsupportedOperationException("Method streamIdAssigned(long) is not yet implemented by "
-                    + getClass().getName());
         }
 
         /**

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -156,7 +156,7 @@ public interface ConnectionObserver {
 
         /**
          * Callback when the stream is established and ready to be used. It may or may not have an already assigned
-         * {@code streamId} at this time.
+         * {@code streamId} at the time.
          *
          * @return a new {@link DataObserver} that provides visibility into read and write events
          * @see #streamIdAssigned(long)

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -144,9 +144,24 @@ public interface ConnectionObserver {
     interface StreamObserver {
 
         /**
-         * Callback when the stream is established and ready.
+         * Callback when a {@code streamId} is assigned.
+         * <p>
+         * Stream identifier may be deferred until after the first write is made on a newly established stream.
+         *
+         * @param streamId assigned stream identifier
+         */
+        default void streamIdAssigned(long streamId) {  // Use long to comply with HTTP/3 requirementsc
+            // FIXME: 0.42 - remove default impl
+            throw new UnsupportedOperationException("Method streamIdAssigned(int) is not yet implemented by "
+                    + getClass().getName());
+        }
+
+        /**
+         * Callback when the stream is established and ready to be used. It may or may not have an already assigned
+         * {@code streamId} at this time.
          *
          * @return a new {@link DataObserver} that provides visibility into read and write events
+         * @see #streamIdAssigned(long)
          */
         DataObserver streamEstablished();
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -152,7 +152,7 @@ public interface ConnectionObserver {
          */
         default void streamIdAssigned(long streamId) {  // Use long to comply with HTTP/3 requirements
             // FIXME: 0.42 - remove default impl
-            throw new UnsupportedOperationException("Method streamIdAssigned(int) is not yet implemented by "
+            throw new UnsupportedOperationException("Method streamIdAssigned(long) is not yet implemented by "
                     + getClass().getName());
         }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -150,7 +150,7 @@ public interface ConnectionObserver {
          *
          * @param streamId assigned stream identifier
          */
-        default void streamIdAssigned(long streamId) {  // Use long to comply with HTTP/3 requirementsc
+        default void streamIdAssigned(long streamId) {  // Use long to comply with HTTP/3 requirements
             // FIXME: 0.42 - remove default impl
             throw new UnsupportedOperationException("Method streamIdAssigned(int) is not yet implemented by "
                     + getClass().getName());

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -140,6 +140,10 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void streamIdAssigned(final long streamId) {
+        }
+
+        @Override
         public DataObserver streamEstablished() {
             return NoopDataObserver.INSTANCE;
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -161,6 +161,10 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void streamIdAssigned(final long streamId) {
+        }
+
+        @Override
         public DataObserver streamEstablished() {
             return NoopDataObserver.INSTANCE;
         }


### PR DESCRIPTION
Motivation:

`HttpServerContext` always has an HTTP/2 stream id as part of the
`ctx.toString()`. On the client-side, the identifier is assigned only
after the first write of `HEADERS` frame is made. We can give visibility
into the assigned stream id through the `StreamObserver`.

Modifications:

- Add `StreamObserver#streamIdAssigned(long)` callback;
- Invoke the new callback when the steam id is known;
- Test new behavior;

Result:

Users have visibility into the assigned HTTP/2 stream id and when it's
assigned.