### PR TITLE
Correctly report TLS handshake when TCP Fast Open is enabled

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -193,6 +193,11 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
+            public void onTcpHandshakeComplete() {
+                // AsyncContext is unknown at this point because this event is triggered by network
+            }
+
+            @Override
             public SecurityHandshakeObserver onSecurityHandshake() {
                 // AsyncContext is unknown at this point because this event is triggered by network
                 return NoopSecurityHandshakeObserver.INSTANCE;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -193,7 +193,7 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
-            public void onTcpHandshakeComplete() {
+            public void onTransportHandshakeComplete() {
                 // AsyncContext is unknown at this point because this event is triggered by network
             }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -168,8 +168,8 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
 
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
-        verify(clientConnectionObserver).onTcpHandshakeComplete();
-        verify(serverConnectionObserver, await()).onTcpHandshakeComplete();
+        verify(clientConnectionObserver).onTransportHandshakeComplete();
+        verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
         if (protocol == HTTP_1) {
             verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
             verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -168,6 +168,8 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
 
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
+        verify(clientConnectionObserver).onTcpHandshakeComplete();
+        verify(serverConnectionObserver, await()).onTcpHandshakeComplete();
         if (protocol == HTTP_1) {
             verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
             verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -72,8 +72,6 @@ class SecurityHandshakeObserverTest {
     static final ExecutionContextExtension CLIENT_CTX =
         ExecutionContextExtension.cached("client-io", "client-executor");
 
-
-
     private final TransportObserver clientTransportObserver;
     private final ConnectionObserver clientConnectionObserver;
     private final SecurityHandshakeObserver clientSecurityHandshakeObserver;

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -63,7 +63,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {
         final SslContext sslContext = config.sslContext();
         if (observer != NoopConnectionObserver.INSTANCE) {
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
-                    sslContext != null && !deferSslHandler));
+                    sslContext != null && !deferSslHandler, true));
         }
 
         if (config.idleTimeoutMs() != null) {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -47,7 +47,8 @@ public class TcpServerChannelInitializer implements ChannelInitializer {
         ChannelInitializer delegate = ChannelInitializer.defaultInitializer();
 
         if (observer != NoopConnectionObserver.INSTANCE) {
-            delegate = delegate.andThen(new ConnectionObserverInitializer(observer, config.sslContext() != null));
+            delegate = delegate.andThen(
+                    new ConnectionObserverInitializer(observer, config.sslContext() != null, false));
         }
 
         if (config.idleTimeoutMs() != null) {

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -127,7 +127,7 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
     static void verifyWriteObserver(DataObserver dataObserver, WriteObserver writeObserver,
                                     boolean completeExpected) {
         verify(dataObserver).onNewWrite();
-        verify(writeObserver).requestedToWrite(anyLong());
+        verify(writeObserver, atLeastOnce()).requestedToWrite(anyLong());
         verify(writeObserver).itemReceived();
         verify(writeObserver).onFlushRequest();
         verify(writeObserver).itemWritten();

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
@@ -76,9 +76,9 @@ class SecureTcpTransportObserverTest extends AbstractTransportObserverTest {
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
 
-        verify(clientConnectionObserver).onTcpHandshakeComplete();
+        verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
-        verify(serverConnectionObserver, await()).onTcpHandshakeComplete();
+        verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
         // handshake starts

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
@@ -76,7 +76,9 @@ class SecureTcpTransportObserverTest extends AbstractTransportObserverTest {
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
 
+        verify(clientConnectionObserver).onTcpHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
+        verify(serverConnectionObserver, await()).onTcpHandshakeComplete();
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
         // handshake starts

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
@@ -118,7 +118,9 @@ final class TcpTransportObserverErrorsTest extends AbstractTransportObserverTest
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
+        verify(clientConnectionObserver).onTcpHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
+        verify(serverConnectionObserver, await()).onTcpHandshakeComplete();
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
         switch (errorSource) {
             case CONNECTION_ACCEPTOR:

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
@@ -118,9 +118,9 @@ final class TcpTransportObserverErrorsTest extends AbstractTransportObserverTest
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
-        verify(clientConnectionObserver).onTcpHandshakeComplete();
+        verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
-        verify(serverConnectionObserver, await()).onTcpHandshakeComplete();
+        verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
         switch (errorSource) {
             case CONNECTION_ACCEPTOR:

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
@@ -48,7 +48,9 @@ class TcpTransportObserverTest extends AbstractTransportObserverTest {
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
+        verify(clientConnectionObserver).onTcpHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
+        verify(serverConnectionObserver, await()).onTcpHandshakeComplete();
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
         Buffer content = connection.executionContext().bufferAllocator().fromAscii("Hello");

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
@@ -48,9 +48,9 @@ class TcpTransportObserverTest extends AbstractTransportObserverTest {
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
         verify(clientTransportObserver).onNewConnection();
         verify(serverTransportObserver, await()).onNewConnection();
-        verify(clientConnectionObserver).onTcpHandshakeComplete();
+        verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
-        verify(serverConnectionObserver, await()).onTcpHandshakeComplete();
+        verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
         Buffer content = connection.executionContext().bufferAllocator().fromAscii("Hello");

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -70,9 +70,9 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onTcpHandshakeComplete() {
-            first.onTcpHandshakeComplete();
-            second.onTcpHandshakeComplete();
+        public void onTransportHandshakeComplete() {
+            first.onTransportHandshakeComplete();
+            second.onTransportHandshakeComplete();
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -70,6 +70,12 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void onTcpHandshakeComplete() {
+            first.onTcpHandshakeComplete();
+            second.onTcpHandshakeComplete();
+        }
+
+        @Override
         public SecurityHandshakeObserver onSecurityHandshake() {
             return new BiSecurityHandshakeObserver(first.onSecurityHandshake(), second.onSecurityHandshake());
         }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -81,8 +81,8 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onTcpHandshakeComplete() {
-            safeReport(observer::onTcpHandshakeComplete, observer, "flush");
+        public void onTransportHandshakeComplete() {
+            safeReport(observer::onTransportHandshakeComplete, observer, "flush");
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -81,6 +81,11 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void onTcpHandshakeComplete() {
+            safeReport(observer::onTcpHandshakeComplete, observer, "flush");
+        }
+
+        @Override
         public SecurityHandshakeObserver onSecurityHandshake() {
             return safeReport(observer::onSecurityHandshake, observer, "security handshake",
                     CatchAllSecurityHandshakeObserver::new, NoopSecurityHandshakeObserver.INSTANCE);

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -55,10 +55,14 @@ public interface ConnectionObserver {
      * Callback when a security handshake is initiated.
      * <p>
      * For the typical TCP connection, this callback is invoked after {@link #onTcpHandshakeComplete()}. When
-     * {@link ServiceTalkSocketOptions#TCP_FASTOPEN_CONNECT} option is used and the Fast Open feature is supported by
-     * the OS, this callback may be invoked earlier.
+     * {@link ServiceTalkSocketOptions#TCP_FASTOPEN_CONNECT} option is configured and the Fast Open feature is supported
+     * by the OS, this callback may be invoked earlier. Note, even if the Fast Open is available and configured, it may
+     * not actually happen if the
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7413#section-4.1">Fast Open Cookie</a> is {@code null} or
+     * rejected by the server.
      *
      * @return a new {@link SecurityHandshakeObserver} that provides visibility into security handshake events
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7413">RFC7413: TCP Fast Open</a>
      */
     SecurityHandshakeObserver onSecurityHandshake();
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -45,7 +45,18 @@ public interface ConnectionObserver {
     void onFlush();
 
     /**
+     * Callback when a TCP handshake completes.
+     */
+    default void onTcpHandshakeComplete() {
+        // FIXME: 0.42 - remove default impl
+    }
+
+    /**
      * Callback when a security handshake is initiated.
+     * <p>
+     * For the typical TCP connection, this callback is invoked after {@link #onTcpHandshakeComplete()}. When
+     * {@link ServiceTalkSocketOptions#TCP_FASTOPEN_CONNECT} option is used and the Fast Open feature is supported by
+     * the OS, this callback may be invoked earlier.
      *
      * @return a new {@link SecurityHandshakeObserver} that provides visibility into security handshake events
      */

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -45,21 +45,29 @@ public interface ConnectionObserver {
     void onFlush();
 
     /**
-     * Callback when a TCP handshake completes.
+     * Callback when a transport handshake completes.
+     * <p>
+     * Transport protocols that require a handshake in order to connect. Example:
+     * <a href="https://datatracker.ietf.org/doc/html/rfc793.html#section-3.4">TCP "three-way handshake"</a>.
      */
-    default void onTcpHandshakeComplete() {
+    default void onTransportHandshakeComplete() {
         // FIXME: 0.42 - remove default impl
     }
 
     /**
      * Callback when a security handshake is initiated.
      * <p>
-     * For the typical TCP connection, this callback is invoked after {@link #onTcpHandshakeComplete()}. When
-     * {@link ServiceTalkSocketOptions#TCP_FASTOPEN_CONNECT} option is configured and the Fast Open feature is supported
-     * by the OS, this callback may be invoked earlier. Note, even if the Fast Open is available and configured, it may
-     * not actually happen if the
-     * <a href="https://datatracker.ietf.org/doc/html/rfc7413#section-4.1">Fast Open Cookie</a> is {@code null} or
-     * rejected by the server.
+     * For a typical connection, this callback is invoked after {@link #onTransportHandshakeComplete()}. There are may
+     * be exceptions:
+     * <ol>
+     *     <li>For a TCP connection, when {@link ServiceTalkSocketOptions#TCP_FASTOPEN_CONNECT} option is configured and
+     *     the Fast Open feature is supported by the OS, this callback may be invoked earlier. Note, even if the Fast
+     *     Open is available and configured, it may not actually happen if the
+     *     <a href="https://datatracker.ietf.org/doc/html/rfc7413#section-4.1">Fast Open Cookie</a> is {@code null} or
+     *     rejected by the server.</li>
+     *     <li>For a proxy connections, the handshake may happen after the
+     *     {@link #connectionEstablished(ConnectionInfo)}.</li>
+     * </ol>
      *
      * @return a new {@link SecurityHandshakeObserver} that provides visibility into security handshake events
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc7413">RFC7413: TCP Fast Open</a>

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -58,7 +58,7 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onTcpHandshakeComplete() {
+        public void onTransportHandshakeComplete() {
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -58,6 +58,10 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void onTcpHandshakeComplete() {
+        }
+
+        @Override
         public SecurityHandshakeObserver onSecurityHandshake() {
             return NoopSecurityHandshakeObserver.INSTANCE;
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -25,9 +25,12 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.kqueue.KQueue;
 
 import javax.annotation.Nullable;
 
+import static io.netty.channel.ChannelOption.TCP_FASTOPEN_CONNECT;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.channelError;
 import static java.util.Objects.requireNonNull;
 
@@ -38,16 +41,20 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
     private final ConnectionObserver observer;
     private final boolean secure;
+    private final boolean client;
 
     /**
      * Creates a new instance.
      *
      * @param observer {@link ConnectionObserver} to report network events.
      * @param secure {@code true} if the observed connection is secure
+     * @param client {@code true} if this initializer is used on the client-side
      */
-    public ConnectionObserverInitializer(final ConnectionObserver observer, final boolean secure) {
+    public ConnectionObserverInitializer(final ConnectionObserver observer, final boolean secure,
+                                         final boolean client) {
         this.observer = requireNonNull(observer);
         this.secure = secure;
+        this.client = client;
     }
 
     @Override
@@ -60,34 +67,54 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
                 observer.connectionClosed(t);
             }
         });
-        channel.pipeline().addLast(new ConnectionObserverHandler(observer, secure));
+        channel.pipeline().addLast(new ConnectionObserverHandler(observer, secure, isFastOpen(channel)));
+    }
+
+    private boolean isFastOpen(final Channel channel) {
+        return client && secure && Boolean.TRUE.equals(channel.config().getOption(TCP_FASTOPEN_CONNECT)) &&
+                (Epoll.isTcpFastOpenClientSideAvailable() || KQueue.isTcpFastOpenClientSideAvailable());
     }
 
     static final class ConnectionObserverHandler extends ChannelDuplexHandler {
 
         private final ConnectionObserver observer;
         private final boolean secure;
+        private boolean tcpHandshakeComplete;
         @Nullable
         private SecurityHandshakeObserver handshakeObserver;
 
-        ConnectionObserverHandler(final ConnectionObserver observer, final boolean secure) {
+        ConnectionObserverHandler(final ConnectionObserver observer, final boolean secure, final boolean fastOpen) {
             this.observer = observer;
             this.secure = secure;
+            if (fastOpen) {
+                reportSecurityHandshakeStarting();
+            }
         }
 
         @Override
         public void handlerAdded(final ChannelHandlerContext ctx) {
-            if (secure && ctx.channel().isActive()) {
-                reportSecurityHandshakeStarting();
+            if (ctx.channel().isActive()) {
+                reportTcpHandshakeComplete();
+                if (secure) {
+                    reportSecurityHandshakeStarting();
+                }
             }
         }
 
         @Override
         public void channelActive(final ChannelHandlerContext ctx) {
+            reportTcpHandshakeComplete();
             if (secure) {
                 reportSecurityHandshakeStarting();
             }
             ctx.fireChannelActive();
+        }
+
+        void reportTcpHandshakeComplete() {
+            if (!tcpHandshakeComplete) {
+                tcpHandshakeComplete = true;
+                observer.onTcpHandshakeComplete();
+            }
         }
 
         void reportSecurityHandshakeStarting() {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -113,7 +113,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         void reportTcpHandshakeComplete() {
             if (!tcpHandshakeComplete) {
                 tcpHandshakeComplete = true;
-                observer.onTcpHandshakeComplete();
+                observer.onTransportHandshakeComplete();
             }
         }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -67,7 +67,7 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onTcpHandshakeComplete() {
+        public void onTransportHandshakeComplete() {
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -67,6 +67,10 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void onTcpHandshakeComplete() {
+        }
+
+        @Override
         public SecurityHandshakeObserver onSecurityHandshake() {
             return NoopSecurityHandshakeObserver.INSTANCE;
         }


### PR DESCRIPTION
Motivation:

When TCP Fast Open socket option is enabled and available by the OS,
client sends `ClientHello` message with the initial TCP handshake. We
should trigger `onSecurityHandshake()` earlier in this case and give
users another callback to see when the TCP handshake completes.

Modifications:

- Add `ConnectionObserver#onTransportHandshakeComplete()`;
- Improve tests to verity new callback;
- Adjust `ConnectionObserverInitializer` to trigger
`onSecurityHandshake()` earlier when TCP Fast Open is enabled and
available;

Result:

Users can observe TCP and TLS handshake behavior correctly when
Fast Open is used.