### PR TITLE
Make `GlobalExecutor` part of `concurrent-api` module

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -42,7 +42,7 @@ import java.util.function.Supplier;
 import static io.servicetalk.concurrent.api.CompletableDoOnUtils.doOnCompleteSupplier;
 import static io.servicetalk.concurrent.api.CompletableDoOnUtils.doOnErrorSupplier;
 import static io.servicetalk.concurrent.api.CompletableDoOnUtils.doOnSubscribeSupplier;
-import static io.servicetalk.concurrent.api.Executors.immediate;
+import static io.servicetalk.concurrent.api.Executors.global;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
@@ -468,7 +468,7 @@ public abstract class Completable {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
     public final Completable timeout(long duration, TimeUnit unit) {
-        return timeout(duration, unit, immediate());
+        return timeout(duration, unit, global());
     }
 
     /**
@@ -505,7 +505,7 @@ public abstract class Completable {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
     public final Completable timeout(Duration duration) {
-        return timeout(duration, immediate());
+        return timeout(duration, global());
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
@@ -54,11 +54,6 @@ public final class Executors {
      * are expected to happen concurrently.
      * It creates as many threads as required but reuses threads when possible. It is therefore 'safe to block' when
      * using it.
-     * <p>
-     * <strong>Be cautious</strong> though, and prefer creating dedicated {@link Executor executors}
-     * with proper limits that match the profile of your application and use case
-     * (e.g. specific instance handling a database). This {@link Executor} also executes core and critical tasks and is
-     * used internally by ServiceTalk network library.
      * @return An {@link Executor} which serves as a global mechanism for executing concurrent operations.
      */
     public static Executor global() {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import static io.servicetalk.concurrent.api.GlobalExecutor.GLOBAL_EXECUTOR;
 import static io.servicetalk.concurrent.api.ImmediateExecutor.IMMEDIATE_EXECUTOR;
 
 /**
@@ -46,6 +47,22 @@ public final class Executors {
      */
     public static Executor immediate() {
         return IMMEDIATE_EXECUTOR;
+    }
+
+    /**
+     * Returns a global {@link Executor} instance, which should be used for operations that do not involve I/O and
+     * are expected to happen concurrently.
+     * It creates as many threads as required but reuses threads when possible. It is therefore 'safe to block' when
+     * using it.
+     * <p>
+     * <strong>Be cautious</strong> though, and prefer creating dedicated {@link Executor executors}
+     * with proper limits that match the profile of your application and use case
+     * (e.g. specific instance handling a database). This {@link Executor} also executes core and critical tasks and is
+     * used internally by ServiceTalk network library.
+     * @return An {@link Executor} which serves as a global mechanism for executing concurrent operations.
+     */
+    public static Executor global() {
+        return GLOBAL_EXECUTOR;
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
+
+final class GlobalExecutor extends DelegatingExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExecutor.class);
+
+    static final String NAME_PREFIX = "servicetalk-global-executor";
+
+    static final Executor GLOBAL_EXECUTOR = new GlobalExecutor(newCachedThreadExecutor(
+            new DefaultThreadFactory(GlobalExecutor.NAME_PREFIX)));
+
+    private GlobalExecutor(final Executor delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "{delegate=" + delegate() + "}";
+    }
+
+    @Override
+    public Completable closeAsync() {
+        return delegate().closeAsync()
+                .beforeOnSubscribe(__ -> log(LOGGER, NAME_PREFIX, "closeAsync()"));
+    }
+
+    @Override
+    public Completable closeAsyncGracefully() {
+        return delegate().closeAsyncGracefully()
+                .beforeOnSubscribe(__ -> log(LOGGER, NAME_PREFIX, "closeAsyncGracefully()"));
+    }
+
+    private static void log(final Logger logger, final String name, final String methodName) {
+        logger.debug("Closure of \"{}\" was initiated using {} method. Closing the global instance before " +
+                "closing all resources that use it may result in unexpected behavior.", name, methodName);
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -53,7 +53,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.EmptyPublisher.emptyPublisher;
-import static io.servicetalk.concurrent.api.Executors.immediate;
+import static io.servicetalk.concurrent.api.Executors.global;
 import static io.servicetalk.concurrent.api.NeverPublisher.neverPublisher;
 import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnCancelSupplier;
 import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnCompleteSupplier;
@@ -1505,7 +1505,7 @@ public abstract class Publisher<T> {
      * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
      */
     public final Publisher<T> timeout(long duration, TimeUnit unit) {
-        return timeout(duration, unit, immediate());
+        return timeout(duration, unit, global());
     }
 
     /**
@@ -1523,7 +1523,7 @@ public abstract class Publisher<T> {
      * @see #timeout(long, TimeUnit, io.servicetalk.concurrent.Executor)
      */
     public final Publisher<T> timeout(Duration duration) {
-        return timeout(duration, immediate());
+        return timeout(duration, global());
     }
 
     /**
@@ -1578,7 +1578,7 @@ public abstract class Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
     public final Publisher<T> timeoutTerminal(Duration duration) {
-        return timeoutTerminal(duration, immediate());
+        return timeoutTerminal(duration, global());
     }
 
     /**
@@ -1614,7 +1614,7 @@ public abstract class Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
     public final Publisher<T> timeoutTerminal(long duration, TimeUnit unit) {
-        return timeoutTerminal(duration, unit, immediate());
+        return timeoutTerminal(duration, unit, global());
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -42,7 +42,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Executors.immediate;
+import static io.servicetalk.concurrent.api.Executors.global;
 import static io.servicetalk.concurrent.api.NeverSingle.neverSingle;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
@@ -606,7 +606,7 @@ public abstract class Single<T> {
     }
 
     /**
-     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate
      * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
      * termination. The timer starts when the returned {@link Single} is subscribed.
      * <p>
@@ -620,11 +620,11 @@ public abstract class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
     public final Single<T> timeout(long duration, TimeUnit unit) {
-        return timeout(duration, unit, immediate());
+        return timeout(duration, unit, global());
     }
 
     /**
-     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate
      * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
      * termination. The timer starts when the returned {@link Single} is subscribed.
      * <p>
@@ -644,7 +644,7 @@ public abstract class Single<T> {
     }
 
     /**
-     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
+     * Creates a new {@link Single} that will mimic the signals of this {@link Single} but will terminate
      * with a {@link TimeoutException} if time {@code duration} elapses between subscribe and
      * termination. The timer starts when the returned {@link Single} is subscribed.
      * <p>
@@ -658,7 +658,7 @@ public abstract class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
      */
     public final Single<T> timeout(Duration duration) {
-        return timeout(duration, immediate());
+        return timeout(duration, global());
     }
 
     /**


### PR DESCRIPTION
Motivation:

`Executors.immediate()` was used in time sensitive operators, which
don't accept an `Executor` instance. When the `ImmediateExecutor` was
used to offload a scheduled task, such as a timeout, it would have been
executed on the global
`io.servicetalk.concurrent.api.DefaultExecutor.SingleThreadedScheduler`
which is used for all future executions internally. When the actual
termination happened, if it blocked, it would have stalled all following
scheduled delayed tasks.

Modifications:

- Moved `GlobalExecutor` from `transport-netty-internal` module to
  `concurrent-api`,
- Introduced `Executors.global()` `Executor`, which uses a singleton of
  `GlobalExecutor`,
- Using `Executors.global()` in all `timeout(...)` operators that do not
  accept `Executor` as an argument.

Result:

The offloading of terminating a `Timeout*` operators happens on the
`GlobalExecutor`, which is the default concurrent instance also used for
reactive chain processing in all transport related operations.