### PR TITLE
Add missed transition between new and deprecated filters

### DIFF
--- a/servicetalk-http-api/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-http-api/gradle/spotbugs/test-exclusions.xml
@@ -44,4 +44,9 @@
     <Class name="io.servicetalk.http.api.InvalidMetadataValuesTest"/>
     <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
   </Match>
+  <!-- Not interested in returned values -->
+  <Match>
+    <Source name="~.*Test\.java"/>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
@@ -45,6 +45,7 @@ import static io.servicetalk.http.api.AbstractHttpRequesterFilterTest.SecurityTy
 import static io.servicetalk.http.api.FilterFactoryUtils.appendClientFilterFactory;
 import static io.servicetalk.http.api.FilterFactoryUtils.appendConnectionFilterFactory;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.NewToDeprecatedFilter.NEW_TO_DEPRECATED_FILTER;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
@@ -371,7 +372,7 @@ public abstract class AbstractHttpRequesterFilterTest {
                     }
                 };
 
-        return TestStreamingHttpClient.from(REQ_RES_FACTORY, mockExecutionContext,
-                appendClientFilterFactory(filterFactory, handlerFilter));
+        return TestStreamingHttpClient.from(REQ_RES_FACTORY, mockExecutionContext, appendClientFilterFactory(
+                appendClientFilterFactory(filterFactory, NEW_TO_DEPRECATED_FILTER), handlerFilter));
     }
 }


### PR DESCRIPTION
Motivation:

#1956 introduced `NEW_TO_DEPRECATED_FILTER` which helps to glue a
new filter API to deprecated filter API. This glue was missed in
`AbstractHttpRequesterFilterTest`.

Modifications:

- Add `NEW_TO_DEPRECATED_FILTER` in
`AbstractHttpRequesterFilterTest#newClient`;

Result:

Implementations of `AbstractHttpRequesterFilterTest` work correctly.