### PR TITLE
Rename subscribeShareContext to shareContextOnSubscribe

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/OffloadingTest.java
@@ -102,7 +102,7 @@ class OffloadingTest extends AbstractCompletableOffloadingTest {
         PUBLISH_ON_CONDITIONAL_SECOND(1, "onComplete",
                 (c, e) -> Completable.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
-                    return c.publishOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
+                    return c.publishOn(e, () -> countdown.decrementAndGet() < 0).shareContextOnSubscribe();
                 }), TerminalOperation.COMPLETE,
                 EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
                         ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/OffloadingTest.java
@@ -96,7 +96,7 @@ class OffloadingTest extends AbstractPublisherOffloadingTest {
         SUBSCRIBE_ON_CONDITIONAL_SECOND(1, "request",
                 (p, e) -> Publisher.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
-                    return p.subscribeOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
+                    return p.subscribeOn(e, () -> countdown.decrementAndGet() < 0).shareContextOnSubscribe();
                 }), TerminalOperation.COMPLETE,
                 EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
                         ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,
@@ -141,7 +141,7 @@ class OffloadingTest extends AbstractPublisherOffloadingTest {
         PUBLISH_ON_CONDITIONAL_SECOND(2, "onNext, onComplete",
                 (p, e) -> Publisher.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
-                    return p.publishOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
+                    return p.publishOn(e, () -> countdown.decrementAndGet() < 0).shareContextOnSubscribe();
                 }), TerminalOperation.COMPLETE,
                 EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
                         ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/OffloadingTest.java
@@ -101,7 +101,7 @@ class OffloadingTest extends AbstractSingleOffloadingTest {
         PUBLISH_ON_CONDITIONAL_SECOND(1, "onComplete",
                 (s, e) -> Single.defer(() -> {
                     AtomicInteger countdown = new AtomicInteger(1);
-                    return s.publishOn(e, () -> countdown.decrementAndGet() < 0).subscribeShareContext();
+                    return s.publishOn(e, () -> countdown.decrementAndGet() < 0).shareContextOnSubscribe();
                 }), TerminalOperation.COMPLETE,
                 EnumSet.of(ORIGINAL_SUBSCRIBE, OFFLOADED_SUBSCRIBE,
                         ORIGINAL_ON_SUBSCRIBE, OFFLOADED_ON_SUBSCRIBE,

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1514,8 +1514,24 @@ public abstract class Completable {
      * @return A {@link Completable} that will share the {@link AsyncContext} instead of making a
      * {@link ContextMap#copy() copy} when subscribed to.
      */
+    public final Completable shareContextOnSubscribe() {
+        return new CompletableShareContextOnSubscribe(this);
+    }
+
+    /**
+     * Signifies that when the returned {@link Completable} is subscribed to, the {@link AsyncContext} will be shared
+     * instead of making a {@link ContextMap#copy() copy}.
+     * <p>
+     * This operator only impacts behavior if the returned {@link Completable} is subscribed directly after this
+     * operator, that means this must be the "last operator" in the chain for this to have an impact.
+     *
+     * @return A {@link Completable} that will share the {@link AsyncContext} instead of making a
+     * {@link ContextMap#copy() copy} when subscribed to.
+     * @deprecated Use {@link #shareContextOnSubscribe()}.
+     */
+    @Deprecated
     public final Completable subscribeShareContext() {
-        return new CompletableSubscribeShareContext(this);
+        return shareContextOnSubscribe();
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableShareContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableShareContextOnSubscribe.java
@@ -17,10 +17,10 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.context.api.ContextMap;
 
-final class CompletableSubscribeShareContext extends AbstractNoHandleSubscribeCompletable {
+final class CompletableShareContextOnSubscribe extends AbstractNoHandleSubscribeCompletable {
     private final Completable original;
 
-    CompletableSubscribeShareContext(final Completable original) {
+    CompletableShareContextOnSubscribe(final Completable original) {
         this.original = original;
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2972,8 +2972,24 @@ public abstract class Publisher<T> {
      * @return A {@link Publisher} that will share the {@link AsyncContext} instead of making a
      * {@link ContextMap#copy() copy} when subscribed to.
      */
+    public final Publisher<T> shareContextOnSubscribe() {
+        return new PublisherShareContextOnSubscribe<>(this);
+    }
+
+    /**
+     * Signifies that when the returned {@link Publisher} is subscribed to, the {@link AsyncContext} will be shared
+     * instead of making a {@link ContextMap#copy() copy}.
+     * <p>
+     * This operator only impacts behavior if the returned {@link Publisher} is subscribed directly after this operator,
+     * that means this must be the "last operator" in the chain for this to have an impact.
+     *
+     * @return A {@link Publisher} that will share the {@link AsyncContext} instead of making a
+     * {@link ContextMap#copy() copy} when subscribed to.
+     * @deprecated Use {@link #shareContextOnSubscribe()}.
+     */
+    @Deprecated
     public final Publisher<T> subscribeShareContext() {
-        return new PublisherSubscribeShareContext<>(this);
+        return shareContextOnSubscribe();
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherShareContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherShareContextOnSubscribe.java
@@ -17,10 +17,10 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.context.api.ContextMap;
 
-final class SingleSubscribeShareContext<T> extends AbstractNoHandleSubscribeSingle<T> {
-    private final Single<T> original;
+final class PublisherShareContextOnSubscribe<T> extends AbstractNoHandleSubscribePublisher<T> {
+    private final Publisher<T> original;
 
-    SingleSubscribeShareContext(Single<T> original) {
+    PublisherShareContextOnSubscribe(final Publisher<T> original) {
         this.original = original;
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1459,8 +1459,24 @@ public abstract class Single<T> {
      * @return A {@link Single} that will share the {@link AsyncContext} instead of making a
      * {@link ContextMap#copy() copy} when subscribed to.
      */
+    public final Single<T> shareContextOnSubscribe() {
+        return new SingleShareContextOnSubscribe<>(this);
+    }
+
+    /**
+     * Signifies that when the returned {@link Single} is subscribed to, the {@link AsyncContext} will be shared
+     * instead of making a {@link ContextMap#copy() copy}.
+     * <p>
+     * This operator only impacts behavior if the returned {@link Single} is subscribed directly after this operator,
+     * that means this must be the "last operator" in the chain for this to have an impact.
+     *
+     * @return A {@link Single} that will share the {@link AsyncContext} instead of making a
+     * {@link ContextMap#copy() copy} when subscribed to.
+     * @deprecated Use {@link #shareContextOnSubscribe()}.
+     */
+    @Deprecated
     public final Single<T> subscribeShareContext() {
-        return new SingleSubscribeShareContext<>(this);
+        return shareContextOnSubscribe();
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleShareContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleShareContextOnSubscribe.java
@@ -17,10 +17,10 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.context.api.ContextMap;
 
-final class PublisherSubscribeShareContext<T> extends AbstractNoHandleSubscribePublisher<T> {
-    private final Publisher<T> original;
+final class SingleShareContextOnSubscribe<T> extends AbstractNoHandleSubscribeSingle<T> {
+    private final Single<T> original;
 
-    PublisherSubscribeShareContext(final Publisher<T> original) {
+    SingleShareContextOnSubscribe(Single<T> original) {
         this.original = original;
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/ShareContextOnSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/ShareContextOnSubscribeTest.java
@@ -31,14 +31,14 @@ import static io.servicetalk.context.api.ContextMap.Key.newKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-class SubscribeShareContextTest {
+class ShareContextOnSubscribeTest {
 
     static final ContextMap.Key<String> KEY = newKey("share-context-key", String.class);
 
     @Test
     void contextIsShared() throws Exception {
         AsyncContext.put(KEY, "v1");
-        awaitTermination(completed().beforeOnComplete(() -> AsyncContext.put(KEY, "v2")).subscribeShareContext());
+        awaitTermination(completed().beforeOnComplete(() -> AsyncContext.put(KEY, "v2")).shareContextOnSubscribe());
         assertThat("Unexpected value found in the context.", AsyncContext.get(KEY), is("v2"));
     }
 
@@ -46,7 +46,7 @@ class SubscribeShareContextTest {
     void contextIsNotSharedIfNotLastOperator() throws Exception {
         // When we support this feature, then we can change this test
         AsyncContext.put(KEY, "v1");
-        awaitTermination(completed().beforeOnComplete(() -> AsyncContext.put(KEY, "v2")).subscribeShareContext()
+        awaitTermination(completed().beforeOnComplete(() -> AsyncContext.put(KEY, "v2")).shareContextOnSubscribe()
                 .beforeOnComplete(() -> { }));
         assertThat("Unexpected value found in the context.", AsyncContext.get(KEY), is("v1"));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ShareContextOnSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/ShareContextOnSubscribeTest.java
@@ -31,7 +31,7 @@ import static io.servicetalk.context.api.ContextMap.Key.newKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-class SubscribeShareContextTest {
+class ShareContextOnSubscribeTest {
 
     static final ContextMap.Key<String> KEY = newKey("share-context-key", String.class);
 
@@ -40,7 +40,7 @@ class SubscribeShareContextTest {
         AsyncContext.put(KEY, "v1");
         // publisher.toFuture() will use the toSingle() conversion and share context operator will not be effective
         // since it isn't the last operator. So we directly subscribe to the publisher.
-        awaitTermination(from(1).beforeOnNext(__ -> AsyncContext.put(KEY, "v2")).subscribeShareContext());
+        awaitTermination(from(1).beforeOnNext(__ -> AsyncContext.put(KEY, "v2")).shareContextOnSubscribe());
         assertThat("Unexpected value found in the context.", AsyncContext.get(KEY), is("v2"));
     }
 
@@ -50,7 +50,7 @@ class SubscribeShareContextTest {
         AsyncContext.put(KEY, "v1");
         // publisher.toFuture() will use the toSingle() conversion and share context operator will not be effective
         // since it isn't the last operator. So we directly subscribe to the publisher.
-        awaitTermination(from(1).beforeOnNext(__ -> AsyncContext.put(KEY, "v2")).subscribeShareContext()
+        awaitTermination(from(1).beforeOnNext(__ -> AsyncContext.put(KEY, "v2")).shareContextOnSubscribe()
                 .beforeOnNext(__ -> { }));
         assertThat("Unexpected value found in the context.", AsyncContext.get(KEY), is("v1"));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ShareContextOnSubscribeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ShareContextOnSubscribeTest.java
@@ -25,14 +25,14 @@ import static io.servicetalk.context.api.ContextMap.Key.newKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-class SubscribeShareContextTest {
+class ShareContextOnSubscribeTest {
 
     static final ContextMap.Key<String> KEY = newKey("share-context-key", String.class);
 
     @Test
     void contextIsShared() throws Exception {
         AsyncContext.put(KEY, "v1");
-        succeeded(1).beforeOnSuccess(__ -> AsyncContext.put(KEY, "v2")).subscribeShareContext().toFuture().get();
+        succeeded(1).beforeOnSuccess(__ -> AsyncContext.put(KEY, "v2")).shareContextOnSubscribe().toFuture().get();
         assertThat("Unexpected value found in the context.", AsyncContext.get(KEY), is("v2"));
     }
 
@@ -41,7 +41,7 @@ class SubscribeShareContextTest {
         // When we support this feature, then we can change this test
         AsyncContext.put(KEY, "v1");
         succeeded(1).beforeOnSuccess(__ -> AsyncContext.put(KEY, "v2"))
-                .subscribeShareContext().beforeOnSuccess(__ -> { }).toFuture().get();
+                .shareContextOnSubscribe().beforeOnSuccess(__ -> { }).toFuture().get();
         assertThat("Unexpected value found in the context.", AsyncContext.get(KEY), is("v1"));
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -674,7 +674,7 @@ class ProtocolCompatibilityTest {
                 // a timeout on the client.
                 return client.request(request).map(resp ->
                                 resp.transformMessageBody(pub -> pub.ignoreElements().concat(never())))
-                        .subscribeShareContext();
+                        .shareContextOnSubscribe();
             });
         }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/SingleRequestOrResponseApiTest.java
@@ -94,7 +94,7 @@ class SingleRequestOrResponseApiTest {
                         // and generates requested number of response items:
                         return defer(() -> {
                             request.requestTarget(BlockingTestResponseStreamRpc.PATH);
-                            return delegate.request(request).subscribeShareContext();
+                            return delegate.request(request).shareContextOnSubscribe();
                         });
                     }
                 }));

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingUtils.java
@@ -62,7 +62,7 @@ final class BlockingUtils {
         // It is assumed that users will always apply timeouts at the StreamingHttpService layer (e.g. via filter). So
         // we don't apply any explicit timeout here and just wait forever.
         return blockingInvocation(requester.request(request.toStreamingRequest())
-                .flatMap(response -> response.toResponse().subscribeShareContext()));
+                .flatMap(response -> response.toResponse().shareContextOnSubscribe()));
     }
 
     static <T> T blockingInvocation(Single<T> source) throws Exception {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
@@ -66,7 +66,7 @@ public final class ContentCodingHttpRequesterFilter
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                             final StreamingHttpRequest request) {
                 return Single.defer(() -> codecTransformBidirectionalIfNeeded(delegate(), request)
-                        .subscribeShareContext());
+                        .shareContextOnSubscribe());
             }
         };
     }
@@ -77,7 +77,7 @@ public final class ContentCodingHttpRequesterFilter
             @Override
             public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
                 return Single.defer(() -> codecTransformBidirectionalIfNeeded(delegate(), request)
-                        .subscribeShareContext());
+                        .shareContextOnSubscribe());
             }
         };
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
@@ -116,11 +116,11 @@ public final class ContentCodingHttpServiceFilter implements StreamingHttpServic
                             encodePayloadContentIfAvailable(request.headers(), request.method(), responseCodings,
                                     response, allocator);
                             return response;
-                        }).subscribeShareContext();
+                        }).shareContextOnSubscribe();
                     } catch (UnsupportedContentEncodingException cause) {
                         LOGGER.error("Request failed for service={}, connection={}", service, this, cause);
                         // see https://tools.ietf.org/html/rfc7231#section-3.1.2.2
-                        return succeeded(responseFactory.unsupportedMediaType()).subscribeShareContext();
+                        return succeeded(responseFactory.unsupportedMediaType()).shareContextOnSubscribe();
                     }
                 });
             }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpRequesterFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpRequesterFilter.java
@@ -117,7 +117,7 @@ public final class ContentEncodingHttpRequesterFilter implements
 
                 return response.transformPayloadBody(pub -> decoder.streamingDecoder().deserialize(pub,
                         delegate.executionContext().bufferAllocator()));
-            }) : respSingle).subscribeShareContext();
+            }) : respSingle).shareContextOnSubscribe();
         });
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
@@ -96,7 +96,7 @@ public final class ContentEncodingHttpServiceFilter implements StreamingHttpServ
                         BufferDecoder decoder = matchAndRemoveEncoding(decompressors.decoders(),
                                 BufferDecoder::encodingName, contentEncodingItr, request.headers());
                         if (decoder == null) {
-                            return succeeded(responseFactory.unsupportedMediaType()).subscribeShareContext();
+                            return succeeded(responseFactory.unsupportedMediaType()).shareContextOnSubscribe();
                         }
 
                         requestDecompressed = request.transformPayloadBody(pub ->
@@ -121,7 +121,7 @@ public final class ContentEncodingHttpServiceFilter implements StreamingHttpServ
                         addContentEncoding(response.headers(), encoder.encodingName());
                         return response.transformPayloadBody(bufPub ->
                                 encoder.streamingEncoder().serialize(bufPub, ctx.executionContext().bufferAllocator()));
-                    }).subscribeShareContext();
+                    }).shareContextOnSubscribe();
                 });
             }
         };

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
@@ -47,8 +47,8 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
         return Single.defer(() -> {
             request.context().putIfAbsent(HTTP_EXECUTION_STRATEGY_KEY, strategy);
             return client.request(request.toStreamingRequest())
-                    .flatMap(response -> response.toResponse().subscribeShareContext())
-                    .subscribeShareContext();
+                    .flatMap(response -> response.toResponse().shareContextOnSubscribe())
+                    .shareContextOnSubscribe();
         });
     }
 
@@ -59,7 +59,7 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
             return client.reserveConnection(metaData)
                     .map(c -> new ReservedStreamingHttpConnectionToReservedHttpConnection(c, this.strategy,
                             reqRespFactory))
-                    .subscribeShareContext();
+                    .shareContextOnSubscribe();
         });
     }
 
@@ -164,7 +164,7 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
         @Override
         public Single<HttpResponse> request(final HttpRequest request) {
             return connection.request(request.toStreamingRequest())
-                    .flatMap(response -> response.toResponse().subscribeShareContext());
+                    .flatMap(response -> response.toResponse().shareContextOnSubscribe());
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
@@ -72,7 +72,7 @@ final class StreamingHttpConnectionToHttpConnection implements HttpConnection {
     @Override
     public Single<HttpResponse> request(final HttpRequest request) {
         return connection.request(request.toStreamingRequest())
-                .flatMap(response -> response.toResponse().subscribeShareContext());
+                .flatMap(response -> response.toResponse().shareContextOnSubscribe());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
@@ -91,7 +91,7 @@ final class StreamingHttpPayloadHolder implements PayloadInfo {
                 Processor<HttpHeaders, HttpHeaders> trailersProcessor = newSingleProcessor();
                 return merge(payloadBody.liftSync(new BridgeFlowControlAndDiscardOperator(
                                 oldMessageBody.liftSync(new PreserveTrailersBufferOperator(trailersProcessor)))),
-                        fromSource(trailersProcessor)).subscribeShareContext();
+                        fromSource(trailersProcessor)).shareContextOnSubscribe();
             });
         } else {
             messageBody = payloadBody.liftSync(new BridgeFlowControlAndDiscardOperator(messageBody));
@@ -130,7 +130,7 @@ final class StreamingHttpPayloadHolder implements PayloadInfo {
                 final Publisher<Buffer> transformedPayloadBody = transformer.apply(oldMessageBody.liftSync(
                         new PreserveTrailersBufferOperator(trailersProcessor)));
                 payloadInfo.setEmpty(transformedPayloadBody == EMPTY);
-                return merge(transformedPayloadBody, fromSource(trailersProcessor)).subscribeShareContext();
+                return merge(transformedPayloadBody, fromSource(trailersProcessor)).shareContextOnSubscribe();
             });
         } else {
             final Publisher<Buffer> transformedPayloadBody = transformer.apply(payloadBody());
@@ -154,7 +154,7 @@ final class StreamingHttpPayloadHolder implements PayloadInfo {
             return merge(serializer.deserialize(headers, transformedPayloadBody, allocator),
                     fromSource(trailersProcessor)).scanWith(() ->
                             new TrailersMapper<>(trailersTransformer, headersFactory))
-                    .subscribeShareContext();
+                    .shareContextOnSubscribe();
         }));
     }
 
@@ -168,7 +168,7 @@ final class StreamingHttpPayloadHolder implements PayloadInfo {
         if (messageBody == null) {
             messageBody = defer(() ->
                     from(trailersTransformer.payloadComplete(trailersTransformer.newState(),
-                            headersFactory.newEmptyTrailers())).subscribeShareContext());
+                            headersFactory.newEmptyTrailers())).shareContextOnSubscribe());
         } else {
             payloadInfo.setEmpty(false); // transformer may add payload content
             messageBody = internalTransformer.apply(messageBody);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToOffloadedStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToOffloadedStreamingHttpService.java
@@ -72,7 +72,7 @@ public class StreamingHttpServiceToOffloadedStreamingHttpService implements Stre
             if (additionalOffloads.isMetadataReceiveOffloaded() && shouldOffload.getAsBoolean()) {
                 final StreamingHttpRequest r = request;
                 resp = useExecutor.submit(
-                                () -> delegate.handle(wrappedCtx, r, responseFactory).subscribeShareContext())
+                                () -> delegate.handle(wrappedCtx, r, responseFactory).shareContextOnSubscribe())
                         // exec.submit() returns a Single<Single<response>>, so flatten nested Single.
                         .flatMap(identity());
             } else {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
@@ -468,7 +468,7 @@ class BlockingStreamingToStreamingServiceTest {
         Publisher<Object> resp;
         if (strategy.isMetadataReceiveOffloaded()) {
             final StreamingHttpRequest r = request;
-            resp = executor.submit(() -> service.apply(r).subscribeShareContext())
+            resp = executor.submit(() -> service.apply(r).shareContextOnSubscribe())
                     .onErrorReturn(cause -> errorHandler.apply(cause, executor))
                     // exec.submit() returns a Single<Publisher<Object>>, so flatten the nested Publisher.
                     .flatMapPublisher(identity());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
@@ -86,7 +86,7 @@ final class AbsoluteAddressHttpRequesterFilter implements StreamingHttpClientFil
         return defer(() -> {
             final String effectiveRequestUri = getEffectiveRequestUri(request, scheme, authority, false);
             request.requestTarget(effectiveRequestUri);
-            return delegate.request(request).subscribeShareContext();
+            return delegate.request(request).shareContextOnSubscribe();
         });
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
@@ -139,7 +139,7 @@ abstract class AbstractLifecycleObserverHttpFilter implements ExecutionStrategyI
                 responseSingle = responseFunction.apply(transformed);
             } catch (Throwable t) {
                 onExchange.onResponseError(t);
-                return Single.<StreamingHttpResponse>failed(t).subscribeShareContext();
+                return Single.<StreamingHttpResponse>failed(t).shareContextOnSubscribe();
             }
             return responseSingle
                     .liftSync(new BeforeFinallyHttpOperator(exchangeContext, /* discardEventsAfterCancel */ true))
@@ -151,7 +151,7 @@ abstract class AbstractLifecycleObserverHttpFilter implements ExecutionStrategyI
                     .map(resp -> {
                         exchangeContext.onResponse(resp);
                         return resp.transformMessageBody(p -> p.beforeOnNext(exchangeContext::onResponseBody));
-                    }).subscribeShareContext();
+                    }).shareContextOnSubscribe();
         });
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -143,7 +143,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
                                 IoThreadFactory.IoThread::currentThreadIsIoThread)));
             }
 
-            return resp.subscribeShareContext();
+            return resp.shareContextOnSubscribe();
         });
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -273,9 +273,9 @@ final class DefaultMultiAddressUrlHttpClientBuilder
                 final HttpRequestMetaData metaData) {
             return defer(() -> {
                 try {
-                    return selectClient(metaData).reserveConnection(metaData).subscribeShareContext();
+                    return selectClient(metaData).reserveConnection(metaData).shareContextOnSubscribe();
                 } catch (Throwable t) {
-                    return Single.<FilterableReservedStreamingHttpConnection>failed(t).subscribeShareContext();
+                    return Single.<FilterableReservedStreamingHttpConnection>failed(t).shareContextOnSubscribe();
                 }
             });
         }
@@ -284,9 +284,9 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
             return defer(() -> {
                 try {
-                    return selectClient(request).request(request).subscribeShareContext();
+                    return selectClient(request).request(request).shareContextOnSubscribe();
                 } catch (Throwable t) {
-                    return Single.<StreamingHttpResponse>failed(t).subscribeShareContext();
+                    return Single.<StreamingHttpResponse>failed(t).shareContextOnSubscribe();
                 }
             });
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -158,12 +158,12 @@ final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttp
         @Override
         public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
                 final HttpRequestMetaData metaData) {
-            return defer(() -> selectClient(metaData).reserveConnection(metaData).subscribeShareContext());
+            return defer(() -> selectClient(metaData).reserveConnection(metaData).shareContextOnSubscribe());
         }
 
         @Override
         public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-            return defer(() -> selectClient(request).request(request).subscribeShareContext());
+            return defer(() -> selectClient(request).request(request).shareContextOnSubscribe());
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
@@ -76,7 +76,7 @@ final class FilterableClientToClient implements StreamingHttpClient {
     public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
         return Single.defer(() -> {
             request.context().putIfAbsent(HTTP_EXECUTION_STRATEGY_KEY, strategy);
-            return client.request(request).subscribeShareContext();
+            return client.request(request).shareContextOnSubscribe();
         });
     }
 
@@ -113,7 +113,7 @@ final class FilterableClientToClient implements StreamingHttpClient {
                     return Single.defer(() -> {
                         request.context().putIfAbsent(HTTP_EXECUTION_STRATEGY_KEY,
                                 FilterableClientToClient.this.strategy);
-                        return rc.request(request).subscribeShareContext();
+                        return rc.request(request).shareContextOnSubscribe();
                     });
                 }
 
@@ -156,7 +156,7 @@ final class FilterableClientToClient implements StreamingHttpClient {
                 public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
                     return rc.newRequest(method, requestTarget);
                 }
-            }).subscribeShareContext();
+            }).shareContextOnSubscribe();
         });
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
@@ -86,7 +86,7 @@ final class HostHeaderHttpRequesterFilter implements StreamingHttpClientFilterFa
             if (!HTTP_1_0.equals(request.version()) && !request.headers().contains(HOST)) {
                 request.setHeader(HOST, fallbackHost);
             }
-            return delegate.request(request).subscribeShareContext();
+            return delegate.request(request).shareContextOnSubscribe();
         });
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -120,10 +120,10 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
                                 }
                             }
                         }))
-                        // subscribeShareContext is used because otherwise the AsyncContext modified during response
+                        // shareContextOnSubscribe is used because otherwise the AsyncContext modified during response
                         // meta data processing will not be visible during processing of the response payload for
                         // ConnectionFilters (it already is visible on ClientFilters).
-                        .subscribeShareContext();
+                        .shareContextOnSubscribe();
             });
     }
 
@@ -136,7 +136,7 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
                     executionContext().executionStrategy());
             return (strategy.isMetadataReceiveOffloaded() || strategy.isDataReceiveOffloaded() ?
                     connection.publishOn(executionContext.executor(), IoThread::currentThreadIsIoThread) : connection)
-                    .subscribeShareContext();
+                    .shareContextOnSubscribe();
         });
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -163,7 +163,7 @@ abstract class AbstractHttpServiceAsyncContextTest {
             public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                         final StreamingHttpRequest request,
                                                         final StreamingHttpResponseFactory factory) {
-                return asyncFilter ? defer(() -> doHandle(ctx, request, factory).subscribeShareContext()) :
+                return asyncFilter ? defer(() -> doHandle(ctx, request, factory).shareContextOnSubscribe()) :
                         doHandle(ctx, request, factory);
             }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentEncodingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentEncodingTest.java
@@ -109,7 +109,7 @@ class ServiceTalkContentEncodingTest extends BaseContentEncodingTest {
                                     request.headers().get(CONTENT_ENCODING), true);
                             assertHeader(clientDecoder.group::advertisedMessageEncoding,
                                     request.headers().get(ACCEPT_ENCODING), false);
-                            return delegate.request(request).subscribeShareContext();
+                            return delegate.request(request).shareContextOnSubscribe();
                         });
                      }
                  })

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
@@ -119,7 +119,7 @@ class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncConte
             public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                         final StreamingHttpRequest request,
                                                         final StreamingHttpResponseFactory responseFactory) {
-                return asyncService ? defer(() -> doHandle(request, responseFactory).subscribeShareContext()) :
+                return asyncService ? defer(() -> doHandle(request, responseFactory).shareContextOnSubscribe()) :
                         doHandle(request, responseFactory);
             }
 

--- a/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/AsyncContextHttpFilterVerifier.java
+++ b/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/AsyncContextHttpFilterVerifier.java
@@ -173,7 +173,7 @@ public final class AsyncContextHttpFilterVerifier {
                             assertAsyncContext(K1, V1, errorQueue);
                             assertAsyncContext(K2, V2, errorQueue);
                             assertAsyncContext(K3, V3, errorQueue);
-                        })).subscribeShareContext();
+                        })).shareContextOnSubscribe();
             }
         };
     }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
@@ -106,14 +106,14 @@ abstract class AbstractTimeoutHttpFilter implements ExecutionStrategyInfluencer<
                                 .onErrorMap(TimeoutException.class, t ->
                                         new MappedTimeoutException("message body timeout after " + timeout.toMillis() +
                                                 "ms", t))
-                                .subscribeShareContext();
+                                .shareContextOnSubscribe();
                     })));
                 } else {
                     response = timeoutResponse;
                 }
             }
 
-            return response.subscribeShareContext();
+            return response.shareContextOnSubscribe();
         });
     }
 

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/EnforceSequentialModeRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/EnforceSequentialModeRequesterFilter.java
@@ -61,7 +61,7 @@ public final class EnforceSequentialModeRequesterFilter implements StreamingHttp
             StreamingHttpRequest r = request.transformMessageBody(messageBody -> messageBody
                     .whenFinally(requestSent::onComplete));
             return fromSource(requestSent).merge(delegate.request(r).toPublisher()).firstOrError()
-                    .subscribeShareContext();
+                    .shareContextOnSubscribe();
         });
     }
 

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetDecoderHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetDecoderHttpServiceFilter.java
@@ -62,7 +62,7 @@ public final class RequestTargetDecoderHttpServiceFilter implements StreamingHtt
                                                         final StreamingHttpResponseFactory responseFactory) {
                 return defer(() -> {
                     request.requestTarget(request.requestTarget(charset));
-                    return delegate().handle(ctx, request, responseFactory).subscribeShareContext();
+                    return delegate().handle(ctx, request, responseFactory).shareContextOnSubscribe();
                 });
             }
         };

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetEncoderHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetEncoderHttpRequesterFilter.java
@@ -60,7 +60,7 @@ public final class RequestTargetEncoderHttpRequesterFilter implements
                                                   final StreamingHttpRequest request) {
         return Single.defer(() -> {
            request.requestTarget(request.requestTarget(), charset);
-           return delegate.request(request).subscribeShareContext();
+           return delegate.request(request).shareContextOnSubscribe();
         });
     }
 

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetEncoderHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetEncoderHttpServiceFilter.java
@@ -66,7 +66,7 @@ public final class RequestTargetEncoderHttpServiceFilter implements StreamingHtt
                                                         final StreamingHttpResponseFactory responseFactory) {
                 return defer(() -> {
                     request.requestTarget(request.requestTarget(), charset);
-                    return delegate().handle(ctx, request, responseFactory).subscribeShareContext();
+                    return delegate().handle(ctx, request, responseFactory).shareContextOnSubscribe();
                 });
             }
         };

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/auth/BasicAuthHttpServiceFilter.java
@@ -346,7 +346,7 @@ public final class BasicAuthHttpServiceFilter<UserInfo> implements StreamingHttp
                     userIdAndPassword.substring(colonIdx + 1);
 
             return config.credentialsVerifier.apply(userId, password)
-                    .flatMap(userInfo -> onAuthenticated(ctx, request, factory, userInfo).subscribeShareContext())
+                    .flatMap(userInfo -> onAuthenticated(ctx, request, factory, userInfo).shareContextOnSubscribe())
                     .onErrorResume(t -> {
                         if (t instanceof AuthenticationException) {
                             return onAccessDenied(request, factory);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -415,7 +415,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
 
     @Override
     public Single<C> selectConnection(Predicate<C> selector) {
-        return defer(() -> selectConnection0(selector).subscribeShareContext());
+        return defer(() -> selectConnection0(selector).shareContextOnSubscribe());
     }
 
     @Override

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
@@ -107,7 +107,7 @@ public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
             @Override
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                             final StreamingHttpRequest request) {
-                return Single.defer(() -> trackRequest(delegate, request).subscribeShareContext());
+                return Single.defer(() -> trackRequest(delegate, request).shareContextOnSubscribe());
             }
        };
     }
@@ -118,7 +118,7 @@ public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
 
             @Override
             public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-                return Single.defer(() -> trackRequest(delegate(), request).subscribeShareContext());
+                return Single.defer(() -> trackRequest(delegate(), request).shareContextOnSubscribe());
             }
        };
     }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
@@ -245,7 +245,7 @@ public final class TcpConnector {
         @Override
         public void accept(final Channel channel) {
             toSource(connectionFactory.apply(channel, connectionObserver)
-                    .subscribeShareContext())
+                    .shareContextOnSubscribe())
                     .subscribe(new Subscriber<C>() {
                         @Override
                         public void onSubscribe(final Cancellable cancellable) {


### PR DESCRIPTION
Motivation:

`subscribeShareContext` method may confuse users to think it actually
subscribes.

Modifications:

- Deprecated `subscribeShareContext` in `Single`, `Completable`, and
  `Publisher`,
- Added `shareContextOnSubscribe` and replaced all calls to the old
  variant in the codebase.

Result:

New method name which is more intuitive to use.