### PR TITLE
Cleanup LoadBalancer APIs

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
@@ -20,8 +20,7 @@ import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
 import java.util.Collection;
-
-import static java.util.function.Function.identity;
+import java.util.Collections;
 
 /**
  * A factory for creating {@link LoadBalancer} instances.
@@ -47,9 +46,12 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * please use that method instead.
      */
     @Deprecated
-    <T extends C> LoadBalancer<T> newLoadBalancer(
+    default <T extends C> LoadBalancer<T> newLoadBalancer(
             Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-            ConnectionFactory<ResolvedAddress, T> connectionFactory);
+            ConnectionFactory<ResolvedAddress, T> connectionFactory) {
+        return newLoadBalancer("UNKNOWN",
+                eventPublisher.map(Collections::singletonList), connectionFactory);
+    }
 
     /**
      * Create a new {@link LoadBalancer}.
@@ -70,12 +72,10 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * @param <T> Type of connections created by the passed {@link ConnectionFactory}.
      * @return a new {@link LoadBalancer}.
      */
-    default <T extends C> LoadBalancer<T> newLoadBalancer(
+    <T extends C> LoadBalancer<T> newLoadBalancer(
             String targetResource,
             Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
-            ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-        return newLoadBalancer(eventPublisher.flatMapConcatIterable(identity()), connectionFactory);
-    }
+            ConnectionFactory<ResolvedAddress, T> connectionFactory);
 
     @Override
     default ExecutionStrategy requiredOffloads() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -15,15 +15,7 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.client.api.ConnectionFactory;
-import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
-import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.Publisher;
-
-import java.util.Collection;
-
-import static java.util.function.Function.identity;
 
 /**
  * A {@link LoadBalancerFactory} for HTTP clients.
@@ -32,20 +24,6 @@ import static java.util.function.Function.identity;
  */
 public interface HttpLoadBalancerFactory<ResolvedAddress>
         extends LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> {
-
-    @Deprecated
-    @Override
-    <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
-            Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-            ConnectionFactory<ResolvedAddress, T> cf);
-
-    @Override
-    default <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
-            String targetResource,
-            Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
-            ConnectionFactory<ResolvedAddress, T> cf) {
-        return newLoadBalancer(eventPublisher.flatMapConcatIterable(identity()), cf);
-    }
 
     /**
      * Converts the passed {@link FilterableStreamingHttpConnection} to a

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -59,13 +59,6 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
 
     @Override
     public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
-            final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-            final ConnectionFactory<ResolvedAddress, T> cf) {
-        return rawFactory.newLoadBalancer(eventPublisher, cf);
-    }
-
-    @Override
-    public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
             final String targetResource,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
@@ -117,9 +118,11 @@ class AutoRetryTest {
 
         @Override
         public <T extends C> LoadBalancer<T> newLoadBalancer(
-                final Publisher<? extends ServiceDiscovererEvent<InetSocketAddress>> eventPublisher,
+                final String targetResource,
+                final Publisher<? extends Collection<? extends ServiceDiscovererEvent<InetSocketAddress>>>
+                        eventPublisher,
                 final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
-            return new InspectingLoadBalancer<>(rr.newLoadBalancer(eventPublisher, connectionFactory));
+            return new InspectingLoadBalancer<>(rr.newLoadBalancer(targetResource, eventPublisher, connectionFactory));
         }
 
         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -342,13 +342,16 @@ class ClientEffectiveStrategyTest {
 
     private static class LoadBalancerFactoryImpl
             implements LoadBalancerFactory<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection> {
+
         @Override
-        public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T>
-        newLoadBalancer(final Publisher<? extends ServiceDiscovererEvent<InetSocketAddress>> eventPublisher,
-                        final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
+        public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
+                final String targetResource,
+                final Publisher<? extends Collection<? extends ServiceDiscovererEvent<InetSocketAddress>>>
+                        eventPublisher,
+                final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
             return new RoundRobinLoadBalancerFactory
                     .Builder<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>().build()
-                    .newLoadBalancer(eventPublisher, connectionFactory);
+                    .newLoadBalancer(targetResource, eventPublisher, connectionFactory);
         }
 
         @Override

--- a/servicetalk-loadbalancer/build.gradle
+++ b/servicetalk-loadbalancer/build.gradle
@@ -34,7 +34,6 @@ dependencies {
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -19,7 +19,6 @@ import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.ConnectionRejectedException;
 import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.client.api.LoadBalancer;
-import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.PublisherSource.Processor;
@@ -35,8 +34,6 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
 import io.servicetalk.concurrent.internal.ThrowableUtils;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.SharedExecutor;
-import io.servicetalk.transport.api.ExecutionStrategy;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +43,6 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadLocalRandom;
@@ -74,10 +70,6 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
-import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
-import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.DEFAULT_HEALTH_CHECK_INTERVAL;
-import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.EAGER_CONNECTION_SHUTDOWN_ENABLED;
-import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.FACTORY_COUNT;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -90,11 +82,8 @@ import static java.util.stream.Collectors.toList;
  *
  * @param <ResolvedAddress> The resolved address type.
  * @param <C> The type of connection.
- * @deprecated Use {@link io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory} to provide instances of this
- * {@link LoadBalancer}. This class will become package-private in the future.
  */
-@Deprecated
-public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnection>
+final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnection>
         implements LoadBalancer<C> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RoundRobinLoadBalancer.class);
@@ -138,67 +127,10 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
     /**
      * Creates a new instance.
      *
-     * @param eventPublisher provides a stream of addresses to connect to.
-     * @param connectionFactory a function which creates new connections.
-     * @deprecated Use {@link io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory} to build instances
-     * of this {@link LoadBalancer}.
-     */
-    @Deprecated
-    public RoundRobinLoadBalancer(final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-                                  final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory) {
-        this(eventPublisher, connectionFactory, EAGER_CONNECTION_SHUTDOWN_ENABLED,
-                new HealthCheckConfig(SharedExecutor.getInstance(),
-                        DEFAULT_HEALTH_CHECK_INTERVAL, DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD));
-    }
-
-    /**
-     * Creates a new instance.
-     *
-     * @param eventPublisher provides a stream of addresses to connect to.
-     * @param connectionFactory a function which creates new connections.
-     * @param eagerConnectionShutdown setting controlling whether {@link ServiceDiscovererEvent events}
-     * with {@link ServiceDiscovererEvent.Status#UNAVAILABLE} or {@link ServiceDiscovererEvent.Status#EXPIRED} statuses
-     * should be eagerly closed.
-     * When {@code false}, {@link ServiceDiscovererEvent.Status#UNAVAILABLE} addresses
-     * will be treated as {@link ServiceDiscovererEvent.Status#EXPIRED} and established connections will be used
-     * for sending requests, but new connections will not be requested, allowing the server to drive
-     * the connection closure and shifting traffic to other addresses.
-     * When {@code true}, {@link ServiceDiscovererEvent.Status#EXPIRED} addresses will be treated as
-     * {@link ServiceDiscovererEvent.Status#UNAVAILABLE} and connections will be immediately terminated.
-     * {@code null} disables the mapping.
-     * @param healthCheckConfig configuration for the health checking mechanism, which monitors hosts that
-     * are unable to have a connection established. Providing {@code null} disables this mechanism (meaning the host
-     * continues being eligible for connecting on the request path).
-     * @see io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory
-     * @deprecated Use
-     * {@link #RoundRobinLoadBalancer(String, Publisher, ConnectionFactory, Boolean, HealthCheckConfig)}.
-     */
-    @Deprecated
-    RoundRobinLoadBalancer(final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-                           final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
-                           @Nullable final Boolean eagerConnectionShutdown,
-                           @Nullable final HealthCheckConfig healthCheckConfig) {
-        this("unknown#" + FACTORY_COUNT.incrementAndGet(), eventPublisher.map(Collections::singletonList),
-                connectionFactory, eagerConnectionShutdown, healthCheckConfig);
-    }
-
-    /**
-     * Creates a new instance.
-     *
      * @param targetResource {@link String} representation of the target resource for which this instance
      * is performing load balancing.
      * @param eventPublisher provides a stream of addresses to connect to.
      * @param connectionFactory a function which creates new connections.
-     * @param eagerConnectionShutdown setting controlling whether {@link ServiceDiscovererEvent events}
-     * with {@link ServiceDiscovererEvent.Status#UNAVAILABLE} or {@link ServiceDiscovererEvent.Status#EXPIRED} statuses
-     * should be eagerly closed.
-     * When {@code false}, {@link ServiceDiscovererEvent.Status#UNAVAILABLE} addresses
-     * will be treated as {@link ServiceDiscovererEvent.Status#EXPIRED} and established connections will be used
-     * for sending requests, but new connections will not be requested, allowing the server to drive
-     * the connection closure and shifting traffic to other addresses.
-     * When {@code true}, {@link ServiceDiscovererEvent.Status#EXPIRED} addresses will be treated as
-     * {@link ServiceDiscovererEvent.Status#UNAVAILABLE} and connections will be immediately terminated.
-     * {@code null} disables the mapping.
      * @param healthCheckConfig configuration for the health checking mechanism, which monitors hosts that
      * are unable to have a connection established. Providing {@code null} disables this mechanism (meaning the host
      * continues being eligible for connecting on the request path).
@@ -208,7 +140,6 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
             final String targetResource,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
-            @Nullable final Boolean eagerConnectionShutdown,
             @Nullable final HealthCheckConfig healthCheckConfig) {
         this.targetResource = requireNonNull(targetResource);
         Processor<Object, Object> eventStreamProcessor = newPublisherProcessorDropHeadOnOverflow(32);
@@ -231,9 +162,9 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
             @Override
             public void onNext(final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
                 for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
-                    final ServiceDiscovererEvent.Status actualStatus = inferStatus(event);
+                    final ServiceDiscovererEvent.Status eventStatus = event.status();
                     LOGGER.debug("Load balancer for {}: received new ServiceDiscoverer event {}. Inferred status: {}.",
-                            targetResource, event, actualStatus);
+                            targetResource, event, eventStatus);
 
                     @SuppressWarnings("unchecked")
                     final List<Host<ResolvedAddress, C>> usedAddresses =
@@ -246,15 +177,15 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                                 final List<Host<ResolvedAddress, C>> oldHostsTyped =
                                         (List<Host<ResolvedAddress, C>>) oldHosts;
 
-                                if (AVAILABLE.equals(actualStatus)) {
+                                if (AVAILABLE.equals(eventStatus)) {
                                     return addHostToList(oldHostsTyped, addr);
-                                } else if (EXPIRED.equals(actualStatus)) {
+                                } else if (EXPIRED.equals(eventStatus)) {
                                     if (oldHostsTyped.isEmpty()) {
                                         return emptyList();
                                     } else {
                                         return markHostAsExpired(oldHostsTyped, addr);
                                     }
-                                } else if (UNAVAILABLE.equals(actualStatus)) {
+                                } else if (UNAVAILABLE.equals(eventStatus)) {
                                     return listWithHostRemoved(oldHostsTyped, host -> {
                                         boolean match = host.address.equals(addr);
                                         if (match) {
@@ -265,7 +196,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                                 } else {
                                     LOGGER.error("Load balancer for {}: Unexpected Status in event:" +
                                             " {} (mapped to {}). Leaving usedHosts unchanged: {}",
-                                            targetResource, event, actualStatus, oldHosts);
+                                            targetResource, event, eventStatus, oldHosts);
                                     return oldHosts;
                                 }
                             });
@@ -273,7 +204,7 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                     LOGGER.debug("Load balancer for {}: now using {} addresses: {}.",
                             targetResource, usedAddresses.size(), usedAddresses);
 
-                    if (AVAILABLE.equals(actualStatus)) {
+                    if (AVAILABLE.equals(eventStatus)) {
                         if (usedAddresses.size() == 1) {
                             eventStreamProcessor.onNext(LOAD_BALANCER_READY_EVENT);
                         }
@@ -281,18 +212,6 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
                         eventStreamProcessor.onNext(LOAD_BALANCER_NOT_READY_EVENT);
                     }
                 }
-            }
-
-            private ServiceDiscovererEvent.Status inferStatus(final ServiceDiscovererEvent<ResolvedAddress> event) {
-                ServiceDiscovererEvent.Status status = event.status();
-                if (eagerConnectionShutdown != null) {
-                    if (eagerConnectionShutdown && EXPIRED.equals(status)) {
-                        status = UNAVAILABLE;
-                    } else if (!eagerConnectionShutdown && UNAVAILABLE.equals(status)) {
-                        status = EXPIRED;
-                    }
-                }
-                return status;
             }
 
             private List<Host<ResolvedAddress, C>> markHostAsExpired(
@@ -392,21 +311,6 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
             CompositeCloseable cc = newCompositeCloseable().appendAll(currentList).appendAll(connectionFactory);
             return graceful ? cc.closeAsyncGracefully() : cc.closeAsync();
         });
-    }
-
-    /**
-     * Please use {@link io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory} instead of this factory.
-     *
-     * @param <ResolvedAddress> The resolved address type.
-     * @param <C> The type of connection.
-     * @return a {@link LoadBalancerFactory} that creates instances of this class.
-     * @deprecated Use {@link io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory} to build instances
-     * of this {@link LoadBalancer}.
-     */
-    @Deprecated
-    public static <ResolvedAddress, C extends LoadBalancedConnection>
-    RoundRobinLoadBalancerFactory<ResolvedAddress, C> newRoundRobinFactory() {
-        return new RoundRobinLoadBalancerFactory<>();
     }
 
     private static <T> Single<T> failedLBClosed(String targetResource) {
@@ -527,45 +431,6 @@ public final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalance
     // Visible for testing
     List<Entry<ResolvedAddress, List<C>>> usedAddresses() {
         return usedHosts.stream().map(Host::asEntry).collect(toList());
-    }
-
-    /**
-     * Please use {@link io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory} instead of this factory.
-     *
-     * @param <ResolvedAddress> The resolved address type.
-     * @param <C> The type of connection.
-     * @deprecated Use {@link io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory} to build instances
-     * of this {@link LoadBalancer}
-     */
-    @Deprecated
-    public static final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConnection>
-            implements LoadBalancerFactory<ResolvedAddress, C> {
-
-        @Override
-        public <T extends C> LoadBalancer<T> newLoadBalancer(
-                final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-                final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-            return new RoundRobinLoadBalancer<>(eventPublisher, connectionFactory, EAGER_CONNECTION_SHUTDOWN_ENABLED,
-                    new HealthCheckConfig(SharedExecutor.getInstance(),
-                            DEFAULT_HEALTH_CHECK_INTERVAL, DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD));
-        }
-
-        @Override
-        public <T extends C> LoadBalancer<T> newLoadBalancer(
-                final String targetResource,
-                final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
-                final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-            return new RoundRobinLoadBalancer<>(requireNonNull(targetResource) + '#' + FACTORY_COUNT.incrementAndGet(),
-                    eventPublisher, connectionFactory, EAGER_CONNECTION_SHUTDOWN_ENABLED,
-                    new HealthCheckConfig(SharedExecutor.getInstance(),
-                            DEFAULT_HEALTH_CHECK_INTERVAL, DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD));
-        }
-
-        @Override
-        public ExecutionStrategy requiredOffloads() {
-            // We do not block
-            return ExecutionStrategy.anyStrategy();
-        }
     }
 
     static final class HealthCheckConfig {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -60,11 +60,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * {@link ServiceDiscovererEvent#address()} are used for requests, but no new connections are created.
  * In case the address' connections are busy, another host is tried. If all hosts are busy, selection fails with a
  * {@link io.servicetalk.client.api.ConnectionRejectedException}.</li>
- * <li>If {@link Builder#eagerConnectionShutdown(boolean)} is called with {@code true} as argument,
- * the {@link ServiceDiscovererEvent.Status#EXPIRED} status is treated like
- * {@link ServiceDiscovererEvent.Status#UNAVAILABLE} status and connections are immediately terminated.
- * When {@code false} is provided, {@link ServiceDiscovererEvent.Status#UNAVAILABLE} is treated like
- * {@link ServiceDiscovererEvent.Status#EXPIRED} and connections are not terminated.</li>
  * <li>For hosts to which consecutive connection attempts fail, a background health checking task is created and
  * the host is not considered for opening new connections until the background check succeeds to create a connection.
  * Upon such event, the connection can immediately be reused and future attempts will again consider this host.
@@ -80,29 +75,14 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
         implements LoadBalancerFactory<ResolvedAddress, C> {
 
     static final AtomicInteger FACTORY_COUNT = new AtomicInteger();
-    @Nullable
-    static final Boolean EAGER_CONNECTION_SHUTDOWN_ENABLED = null;
     static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = Duration.ofSeconds(1);
     static final int DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD = 5; // higher than default for AutoRetryStrategy
 
     @Nullable
-    private final Boolean eagerConnectionShutdown;
-
-    @Nullable
     private final HealthCheckConfig healthCheckConfig;
 
-    private RoundRobinLoadBalancerFactory(@Nullable Boolean eagerConnectionShutdown,
-                                          @Nullable HealthCheckConfig healthCheckConfig) {
-        this.eagerConnectionShutdown = eagerConnectionShutdown;
+    private RoundRobinLoadBalancerFactory(@Nullable HealthCheckConfig healthCheckConfig) {
         this.healthCheckConfig = healthCheckConfig;
-    }
-
-    @Override
-    public <T extends C> LoadBalancer<T> newLoadBalancer(
-            final Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
-            final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-        return new RoundRobinLoadBalancer<>(
-                eventPublisher, connectionFactory, eagerConnectionShutdown, healthCheckConfig);
     }
 
     @Override
@@ -111,7 +91,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
         return new RoundRobinLoadBalancer<>(requireNonNull(targetResource) + '#' + FACTORY_COUNT.incrementAndGet(),
-                eventPublisher, connectionFactory, eagerConnectionShutdown, healthCheckConfig);
+                eventPublisher, connectionFactory, healthCheckConfig);
     }
 
     @Override
@@ -128,8 +108,6 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
      */
     public static final class Builder<ResolvedAddress, C extends LoadBalancedConnection> {
         @Nullable
-        private Boolean eagerConnectionShutdown = EAGER_CONNECTION_SHUTDOWN_ENABLED;
-        @Nullable
         private Executor backgroundExecutor;
         private Duration healthCheckInterval = DEFAULT_HEALTH_CHECK_INTERVAL;
         private int healthCheckFailedConnectionsThreshold = DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
@@ -138,30 +116,6 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
          * Creates a new instance with default settings.
          */
         public Builder() {
-        }
-
-        /**
-         * Configures the {@link RoundRobinLoadBalancerFactory} to produce a {@link LoadBalancer} with
-         * a setting driving eagerness of connection shutdown.
-         * When configured with {@code false} as the argument, the created {@link LoadBalancer} does not close
-         * connections upon receiving {@link ServiceDiscovererEvent.Status#UNAVAILABLE} or
-         * {@link ServiceDiscovererEvent.Status#EXPIRED} {@link ServiceDiscovererEvent events}.
-         * If the value is {@code true}, the connections will be closed gracefully for both
-         * {@link ServiceDiscovererEvent.Status#UNAVAILABLE} and {@link ServiceDiscovererEvent.Status#EXPIRED} events.
-         *
-         * @param eagerConnectionShutdown controls the eagerness of connection shutdown.
-         * @return {@code this}.
-         * @deprecated To control the behaviour, configure the
-         * {@link io.servicetalk.client.api.ServiceDiscoverer} of your choice to deliver appropriate
-         * {@link ServiceDiscovererEvent#status()}. In order to avoid connection shutdown use
-         * {@link ServiceDiscovererEvent.Status#EXPIRED}. Use {@link ServiceDiscovererEvent.Status#UNAVAILABLE} when the
-         * connections should be eagerly closed upon such event.
-         */
-        @Deprecated
-        public RoundRobinLoadBalancerFactory.Builder<ResolvedAddress, C> eagerConnectionShutdown(
-                boolean eagerConnectionShutdown) {
-            this.eagerConnectionShutdown = eagerConnectionShutdown;
-            return this;
         }
 
         /**
@@ -233,14 +187,14 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
          */
         public RoundRobinLoadBalancerFactory<ResolvedAddress, C> build() {
             if (this.healthCheckFailedConnectionsThreshold < 0) {
-                return new RoundRobinLoadBalancerFactory<>(eagerConnectionShutdown, null);
+                return new RoundRobinLoadBalancerFactory<>(null);
             }
 
             HealthCheckConfig healthCheckConfig = new HealthCheckConfig(
                             this.backgroundExecutor == null ? SharedExecutor.getInstance() : this.backgroundExecutor,
                     healthCheckInterval, healthCheckFailedConnectionsThreshold);
 
-            return new RoundRobinLoadBalancerFactory<>(eagerConnectionShutdown, healthCheckConfig);
+            return new RoundRobinLoadBalancerFactory<>(healthCheckConfig);
         }
     }
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerRoundRobinLoadBalancerTest.java
@@ -15,14 +15,8 @@
  */
 package io.servicetalk.loadbalancer;
 
-import io.servicetalk.client.api.ServiceDiscovererEvent;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
-import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.EXPIRED;
-import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.UNAVAILABLE;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -48,34 +42,32 @@ class EagerRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest {
         assertThat(lb.usedAddresses(), hasSize(0));
     }
 
-    @ParameterizedTest(name = "down-status-expired={0}")
-    @ValueSource(booleans = {true, false})
-    void handleDiscoveryEvents(boolean downStatusExpired) {
-        ServiceDiscovererEvent.Status downStatus = downStatusExpired ? EXPIRED : UNAVAILABLE;
+    @Test
+    void handleDiscoveryEvents() {
         assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
 
         sendServiceDiscoveryEvents(upEvent("address-1"));
         assertAddresses(lb.usedAddresses(), "address-1");
 
-        sendServiceDiscoveryEvents(downEvent("address-1", downStatus));
+        sendServiceDiscoveryEvents(downEvent("address-1"));
         assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
 
         sendServiceDiscoveryEvents(upEvent("address-2"));
         assertAddresses(lb.usedAddresses(), "address-2");
 
-        sendServiceDiscoveryEvents(downEvent("address-3", downStatus));
+        sendServiceDiscoveryEvents(downEvent("address-3"));
         assertAddresses(lb.usedAddresses(), "address-2");
 
         sendServiceDiscoveryEvents(upEvent("address-1"));
         assertAddresses(lb.usedAddresses(), "address-2", "address-1");
 
-        sendServiceDiscoveryEvents(downEvent("address-1", downStatus));
+        sendServiceDiscoveryEvents(downEvent("address-1"));
         assertAddresses(lb.usedAddresses(), "address-2");
 
-        sendServiceDiscoveryEvents(downEvent("address-2", downStatus));
+        sendServiceDiscoveryEvents(downEvent("address-2"));
         assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
 
-        sendServiceDiscoveryEvents(downEvent("address-3", downStatus));
+        sendServiceDiscoveryEvents(downEvent("address-3"));
         assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
 
         // Let's make sure that an SD failure doesn't compromise LB's internal state


### PR DESCRIPTION
Motivation:

We deprecated some APIs in the load balancing area: `LoadBalancerFactory`,
`RoundRobinLoadBalancer`, and `RoundRobinLoadBalancerFactory`.

Modifications:

- `LoadBalancerFactory` default methods swapped,
- `RoundRobinLoadBalancer` is no longer public and the constructors have
  been cleaned up,
- `RoundRobinLoadBalancerFactory` removed configuration for
  `RoundRobinLoadBalancer` eagerness configuration,
- Adjusted tests.

Result:

Old APIs have been removed and it's more obvious how to use
`RoundRobinLoadBalancerFactory` to obtain a `LoadBalancer` that performs
round-robin strategy.