### PR TITLE
Fix client expected strategies regression

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -37,6 +37,7 @@ import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEI
 import static io.servicetalk.http.api.DefaultPayloadInfo.forTransportReceive;
 import static io.servicetalk.http.api.HeaderUtils.hasContentLength;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpProtocolVersion.h1TrailersSupported;
@@ -52,7 +53,7 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
 
     BlockingStreamingToStreamingService(final BlockingStreamingHttpService original,
                                         final HttpExecutionStrategy strategy) {
-        super(DEFAULT_STRATEGY.merge(strategy));
+        super(defaultStrategy() == strategy ? DEFAULT_STRATEGY : strategy);
         this.original = requireNonNull(original);
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.Single;
 import static io.servicetalk.concurrent.api.Single.fromCallable;
 import static io.servicetalk.http.api.BlockingUtils.blockingToCompletable;
 import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_DATA_STRATEGY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static java.util.Objects.requireNonNull;
 
 final class BlockingToStreamingService extends AbstractServiceAdapterHolder {
@@ -28,7 +29,7 @@ final class BlockingToStreamingService extends AbstractServiceAdapterHolder {
     private final BlockingHttpService original;
 
     BlockingToStreamingService(final BlockingHttpService original, HttpExecutionStrategy strategy) {
-        super(DEFAULT_STRATEGY.merge(strategy));
+        super(defaultStrategy() == strategy ? DEFAULT_STRATEGY : strategy);
         this.original = requireNonNull(original);
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
@@ -145,4 +145,21 @@ public final class ConnectAndHttpExecutionStrategy implements ConnectExecutionSt
     public ConnectExecutionStrategy connectStrategy() {
         return connectStrategy;
     }
+
+    /**
+     * Converts the provided execution strategy to a {@link ConnectExecutionStrategy}. If the provided strategy is
+     * already {@link ConnectExecutionStrategy} it is returned unchanged. For other strategies, if the strategy
+     * {@link ExecutionStrategy#hasOffloads()} then {@link ConnectExecutionStrategy#offload()} is returned otherwise
+     * {@link ConnectExecutionStrategy#anyStrategy()} is returned.
+     *
+     * @param executionStrategy The {@link ExecutionStrategy} to convert
+     * @return converted {@link ConnectExecutionStrategy}.
+     */
+    public static ConnectAndHttpExecutionStrategy from(ExecutionStrategy executionStrategy) {
+        return executionStrategy instanceof ConnectAndHttpExecutionStrategy ?
+                (ConnectAndHttpExecutionStrategy) executionStrategy :
+                    new ConnectAndHttpExecutionStrategy(
+                            ConnectExecutionStrategy.anyStrategy(), HttpExecutionStrategies.defaultStrategy())
+                            .merge(executionStrategy);
+    }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingStrategyInfluencer.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.http.api;
 
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_ALL_REQRESP_STRATEGY;
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_ALL_STRATEGY;
 
 final class DefaultStreamingStrategyInfluencer implements HttpExecutionStrategyInfluencer {
 
@@ -28,6 +28,6 @@ final class DefaultStreamingStrategyInfluencer implements HttpExecutionStrategyI
 
     @Override
     public HttpExecutionStrategy requiredOffloads() {
-        return OFFLOAD_ALL_REQRESP_STRATEGY;
+        return OFFLOAD_ALL_STRATEGY;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
@@ -42,7 +42,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static ReservedHttpConnection toReservedConnection(ReservedStreamingHttpConnection original,
                                                               HttpExecutionStrategyInfluencer influencer) {
-        return new ReservedStreamingHttpConnectionToReservedHttpConnection(original, influencer.requiredOffloads());
+        return toReservedConnection(original, influencer.requiredOffloads());
     }
 
     /**
@@ -69,8 +69,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static ReservedBlockingHttpConnection toReservedBlockingConnection(
             ReservedStreamingHttpConnection original, HttpExecutionStrategyInfluencer influencer) {
-        return new ReservedStreamingHttpConnectionToReservedBlockingHttpConnection(original,
-                                                                                   influencer.requiredOffloads());
+        return toReservedBlockingConnection(original, influencer.requiredOffloads());
     }
 
     /**
@@ -98,7 +97,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static ReservedBlockingStreamingHttpConnection toReservedBlockingStreamingConnection(
             ReservedStreamingHttpConnection original, HttpExecutionStrategyInfluencer influencer) {
-        return new ReservedStreamingHttpConnectionToBlockingStreaming(original, influencer.requiredOffloads());
+        return toReservedBlockingStreamingConnection(original, influencer.requiredOffloads());
     }
 
     /**
@@ -126,7 +125,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static HttpConnection toConnection(StreamingHttpConnection original,
                                               HttpExecutionStrategyInfluencer influencer) {
-        return new StreamingHttpConnectionToHttpConnection(original, influencer.requiredOffloads());
+        return toConnection(original, influencer.requiredOffloads());
     }
 
     /**
@@ -152,7 +151,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static BlockingHttpConnection toBlockingConnection(StreamingHttpConnection original,
                                                               HttpExecutionStrategyInfluencer influencer) {
-        return new StreamingHttpConnectionToBlockingHttpConnection(original, influencer.requiredOffloads());
+        return toBlockingConnection(original, influencer.requiredOffloads());
     }
 
     /**
@@ -179,7 +178,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static BlockingStreamingHttpConnection toBlockingStreamingConnection(
             StreamingHttpConnection original, HttpExecutionStrategyInfluencer influencer) {
-        return new StreamingHttpConnectionToBlockingStreamingHttpConnection(original, influencer.requiredOffloads());
+        return toBlockingStreamingConnection(original, influencer.requiredOffloads());
     }
 
     /**
@@ -206,7 +205,7 @@ public final class HttpApiConversions {
      */
     @Deprecated
     public static HttpClient toClient(StreamingHttpClient original, HttpExecutionStrategyInfluencer influencer) {
-        return new StreamingHttpClientToHttpClient(original, influencer.requiredOffloads());
+        return toClient(original, influencer.requiredOffloads());
     }
 
     /**
@@ -232,7 +231,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static BlockingHttpClient toBlockingClient(StreamingHttpClient original,
                                                       HttpExecutionStrategyInfluencer influencer) {
-        return new StreamingHttpClientToBlockingHttpClient(original, influencer.requiredOffloads());
+        return toBlockingClient(original, influencer.requiredOffloads());
     }
 
     /**
@@ -258,7 +257,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static BlockingStreamingHttpClient toBlockingStreamingClient(StreamingHttpClient original,
                                                                         HttpExecutionStrategyInfluencer influencer) {
-        return new StreamingHttpClientToBlockingStreamingHttpClient(original, influencer.requiredOffloads());
+        return toBlockingStreamingClient(original, influencer.requiredOffloads());
     }
 
     /**
@@ -285,7 +284,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static ServiceAdapterHolder toStreamingHttpService(HttpService service,
                                                               HttpExecutionStrategyInfluencer influencer) {
-        return new ServiceToStreamingService(service, influencer.requiredOffloads());
+        return toStreamingHttpService(service, influencer.requiredOffloads());
     }
 
     /**
@@ -311,7 +310,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static ServiceAdapterHolder toStreamingHttpService(BlockingStreamingHttpService service,
                                                               HttpExecutionStrategyInfluencer influencer) {
-        return new BlockingStreamingToStreamingService(service, influencer.requiredOffloads());
+        return toStreamingHttpService(service, influencer.requiredOffloads());
     }
 
     /**
@@ -338,7 +337,7 @@ public final class HttpApiConversions {
     @Deprecated
     public static ServiceAdapterHolder toStreamingHttpService(BlockingHttpService service,
                                                               HttpExecutionStrategyInfluencer influencer) {
-        return new BlockingToStreamingService(service, influencer.requiredOffloads());
+        return toStreamingHttpService(service, influencer.requiredOffloads());
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ServiceToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ServiceToStreamingService.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 
 import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_DATA_AND_SEND_STRATEGY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static java.util.Objects.requireNonNull;
 
 final class ServiceToStreamingService extends AbstractServiceAdapterHolder {
@@ -29,7 +30,7 @@ final class ServiceToStreamingService extends AbstractServiceAdapterHolder {
     private final HttpService original;
 
     ServiceToStreamingService(final HttpService original, HttpExecutionStrategy strategy) {
-        super(DEFAULT_STRATEGY.merge(strategy));
+        super(defaultStrategy() == strategy ? DEFAULT_STRATEGY : strategy);
         this.original = requireNonNull(original);
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingHttpClient.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.BlockingIterable;
 
 import static io.servicetalk.http.api.BlockingUtils.blockingInvocation;
 import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.RequestResponseFactories.toAggregated;
 import static io.servicetalk.http.api.StreamingHttpConnectionToBlockingHttpConnection.DEFAULT_BLOCKING_CONNECTION_STRATEGY;
 import static java.util.Objects.requireNonNull;
@@ -30,7 +31,8 @@ final class StreamingHttpClientToBlockingHttpClient implements BlockingHttpClien
     private final HttpRequestResponseFactory reqRespFactory;
 
     StreamingHttpClientToBlockingHttpClient(final StreamingHttpClient client, final HttpExecutionStrategy strategy) {
-        this.strategy = DEFAULT_BLOCKING_CONNECTION_STRATEGY.merge(strategy);
+        this.strategy = defaultStrategy() == strategy ?
+                DEFAULT_BLOCKING_CONNECTION_STRATEGY : strategy;
         this.client = client;
         context = new DelegatingHttpExecutionContext(client.executionContext()) {
             @Override
@@ -95,7 +97,8 @@ final class StreamingHttpClientToBlockingHttpClient implements BlockingHttpClien
 
         ReservedStreamingHttpConnectionToReservedBlockingHttpConnection(
                 final ReservedStreamingHttpConnection connection, final HttpExecutionStrategy strategy) {
-            this(connection, DEFAULT_BLOCKING_CONNECTION_STRATEGY.merge(strategy), toAggregated(connection));
+            this(connection, defaultStrategy() == strategy ? DEFAULT_BLOCKING_CONNECTION_STRATEGY : strategy,
+                    toAggregated(connection));
         }
 
         ReservedStreamingHttpConnectionToReservedBlockingHttpConnection(

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.BlockingIterable;
 
 import static io.servicetalk.http.api.BlockingUtils.blockingInvocation;
 import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.RequestResponseFactories.toBlockingStreaming;
 import static io.servicetalk.http.api.StreamingHttpConnectionToBlockingStreamingHttpConnection.DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY;
 import static java.util.Objects.requireNonNull;
@@ -31,7 +32,8 @@ final class StreamingHttpClientToBlockingStreamingHttpClient implements Blocking
 
     StreamingHttpClientToBlockingStreamingHttpClient(final StreamingHttpClient client,
                                                      final HttpExecutionStrategy strategy) {
-        this.strategy = DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY.merge(strategy);
+        this.strategy = defaultStrategy() == strategy ?
+                DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY : strategy;
         this.client = client;
         context = new DelegatingHttpExecutionContext(client.executionContext()) {
             @Override
@@ -98,7 +100,7 @@ final class StreamingHttpClientToBlockingStreamingHttpClient implements Blocking
 
         ReservedStreamingHttpConnectionToBlockingStreaming(final ReservedStreamingHttpConnection connection,
                                                            final HttpExecutionStrategy strategy) {
-            this(connection, DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY.merge(strategy),
+            this(connection, defaultStrategy() == strategy ? DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY : strategy,
                     toBlockingStreaming(connection));
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 
 import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.RequestResponseFactories.toAggregated;
 import static io.servicetalk.http.api.StreamingHttpConnectionToHttpConnection.DEFAULT_CONNECTION_STRATEGY;
 import static java.util.Objects.requireNonNull;
@@ -31,7 +32,8 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
     private final HttpRequestResponseFactory reqRespFactory;
 
     StreamingHttpClientToHttpClient(final StreamingHttpClient client, final HttpExecutionStrategy strategy) {
-        this.strategy = DEFAULT_CONNECTION_STRATEGY.merge(strategy);
+        this.strategy = defaultStrategy() == strategy ?
+                DEFAULT_CONNECTION_STRATEGY : strategy;
         this.client = client;
         context = new DelegatingHttpExecutionContext(client.executionContext()) {
             @Override
@@ -117,7 +119,8 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
 
         ReservedStreamingHttpConnectionToReservedHttpConnection(final ReservedStreamingHttpConnection connection,
                                                                 final HttpExecutionStrategy strategy) {
-            this(connection, DEFAULT_CONNECTION_STRATEGY.merge(strategy), toAggregated(connection));
+            this(connection, defaultStrategy() == strategy ? DEFAULT_CONNECTION_STRATEGY : strategy,
+                    toAggregated(connection));
         }
 
         ReservedStreamingHttpConnectionToReservedHttpConnection(final ReservedStreamingHttpConnection connection,

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingHttpConnection.java
@@ -17,11 +17,12 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.BlockingIterable;
 
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_NONE_STRATEGY;
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_EVENT_STRATEGY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.RequestResponseFactories.toAggregated;
 
 final class StreamingHttpConnectionToBlockingHttpConnection implements BlockingHttpConnection {
-    static final HttpExecutionStrategy DEFAULT_BLOCKING_CONNECTION_STRATEGY = OFFLOAD_NONE_STRATEGY;
+    static final HttpExecutionStrategy DEFAULT_BLOCKING_CONNECTION_STRATEGY = OFFLOAD_EVENT_STRATEGY;
     private final StreamingHttpConnection connection;
     private final HttpExecutionStrategy strategy;
     private final HttpConnectionContext context;
@@ -30,7 +31,7 @@ final class StreamingHttpConnectionToBlockingHttpConnection implements BlockingH
 
     StreamingHttpConnectionToBlockingHttpConnection(final StreamingHttpConnection connection,
                                                     final HttpExecutionStrategy strategy) {
-        this.strategy = DEFAULT_BLOCKING_CONNECTION_STRATEGY.merge(strategy);
+        this.strategy = defaultStrategy() == strategy ? DEFAULT_BLOCKING_CONNECTION_STRATEGY : strategy;
         this.connection = connection;
         final HttpConnectionContext originalCtx = connection.connectionContext();
         executionContext = new DelegatingHttpExecutionContext(connection.executionContext()) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToBlockingStreamingHttpConnection.java
@@ -18,11 +18,12 @@ package io.servicetalk.http.api;
 import io.servicetalk.concurrent.BlockingIterable;
 
 import static io.servicetalk.http.api.BlockingUtils.blockingInvocation;
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_SEND_STRATEGY;
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_SEND_EVENT_STRATEGY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.RequestResponseFactories.toBlockingStreaming;
 
 final class StreamingHttpConnectionToBlockingStreamingHttpConnection implements BlockingStreamingHttpConnection {
-    static final HttpExecutionStrategy DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY = OFFLOAD_SEND_STRATEGY;
+    static final HttpExecutionStrategy DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY = OFFLOAD_SEND_EVENT_STRATEGY;
     private final StreamingHttpConnection connection;
     private final HttpExecutionStrategy strategy;
     private final HttpConnectionContext context;
@@ -31,7 +32,7 @@ final class StreamingHttpConnectionToBlockingStreamingHttpConnection implements 
 
     StreamingHttpConnectionToBlockingStreamingHttpConnection(final StreamingHttpConnection connection,
                                                              final HttpExecutionStrategy strategy) {
-        this.strategy = DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY.merge(strategy);
+        this.strategy = defaultStrategy() == strategy ? DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY : strategy;
         this.connection = connection;
         final HttpConnectionContext originalCtx = connection.connectionContext();
         executionContext = new DelegatingHttpExecutionContext(connection.executionContext()) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
@@ -19,7 +19,8 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 
-import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_DATA_STRATEGY;
+import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_DATA_EVENT_STRATEGY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.RequestResponseFactories.toAggregated;
 
 final class StreamingHttpConnectionToHttpConnection implements HttpConnection {
@@ -27,7 +28,7 @@ final class StreamingHttpConnectionToHttpConnection implements HttpConnection {
      * For aggregation, we invoke the user callback (Single from client#request()) after the payload is completed,
      * hence we need to offload data.
      */
-    static final HttpExecutionStrategy DEFAULT_CONNECTION_STRATEGY = OFFLOAD_RECEIVE_DATA_STRATEGY;
+    static final HttpExecutionStrategy DEFAULT_CONNECTION_STRATEGY = OFFLOAD_RECEIVE_DATA_EVENT_STRATEGY;
     private final StreamingHttpConnection connection;
     private final HttpExecutionStrategy strategy;
     private final HttpConnectionContext context;
@@ -36,7 +37,7 @@ final class StreamingHttpConnectionToHttpConnection implements HttpConnection {
 
     StreamingHttpConnectionToHttpConnection(final StreamingHttpConnection connection,
                                             final HttpExecutionStrategy strategy) {
-        this.strategy = DEFAULT_CONNECTION_STRATEGY.merge(strategy);
+        this.strategy = defaultStrategy() == strategy ? DEFAULT_CONNECTION_STRATEGY : strategy;
         this.connection = connection;
         final HttpConnectionContext originalCtx = connection.connectionContext();
         executionContext = new DelegatingHttpExecutionContext(connection.executionContext()) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClientStrategyInfluencerChainBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClientStrategyInfluencerChainBuilder.java
@@ -67,7 +67,7 @@ final class ClientStrategyInfluencerChainBuilder {
     }
 
     private void add(String purpose, ExecutionStrategyInfluencer<?> influencer, HttpExecutionStrategy strategy) {
-        if (defaultStrategy() == strategy || noOffloadsStrategy() == strategy) {
+        if (noOffloadsStrategy() == strategy) {
             LOGGER.warn("Ignoring illegal {} required strategy ({}) for {}", purpose, strategy, influencer);
             strategy = anyStrategy();
         }
@@ -78,12 +78,12 @@ final class ClientStrategyInfluencerChainBuilder {
 
     void add(ConnectionFactoryFilter<?, FilterableStreamingHttpConnection> connectionFactoryFilter) {
         ExecutionStrategy filterOffloads = connectionFactoryFilter.requiredOffloads();
-        if (defaultStrategy() == filterOffloads || noOffloadsStrategy() == filterOffloads) {
+        if (noOffloadsStrategy() == filterOffloads) {
             LOGGER.warn("Ignoring illegal connection factory required strategy ({}) for {}",
                     filterOffloads, connectionFactoryFilter);
             filterOffloads = anyStrategy();
         }
-        if (defaultStrategy() != filterOffloads && filterOffloads.hasOffloads()) {
+        if (filterOffloads.hasOffloads()) {
             connFactoryChain = null != connFactoryChain ?
                     connFactoryChain.merge(filterOffloads) : ConnectAndHttpExecutionStrategy.from(filterOffloads);
         }
@@ -91,7 +91,7 @@ final class ClientStrategyInfluencerChainBuilder {
 
     void add(StreamingHttpConnectionFilterFactory connectionFilter) {
         HttpExecutionStrategy filterOffloads = connectionFilter.requiredOffloads();
-        if (defaultStrategy() == filterOffloads || noOffloadsStrategy() == filterOffloads) {
+        if (noOffloadsStrategy() == filterOffloads) {
             LOGGER.warn("Ignoring illegal connection filter required strategy ({}) for {}",
                     filterOffloads, connectionFilter);
             filterOffloads = anyStrategy();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -339,9 +339,8 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
         }
 
         return doBind(executionContext, connectionAcceptor, filteredService)
-                .afterOnSuccess(serverContext -> {
-                    LOGGER.debug("Server for address {} uses strategy {}", serverContext.listenAddress(), strategy);
-                });
+                .afterOnSuccess(serverContext -> LOGGER.debug("Server for address {} uses strategy {}",
+                        serverContext.listenAddress(), strategy));
     }
 
     private Single<ServerContext> doBind(final HttpExecutionContext executionContext,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -111,7 +111,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
             urlClient = redirectConfig == null ? urlClient :
                     new RedirectingHttpRequesterFilter(redirectConfig).create(urlClient);
 
-            return new FilterableClientToClient(urlClient, executionContext.executionStrategy(),
+            return new FilterableClientToClient(urlClient,
                     buildContext.builder.computeChainStrategy(executionContext.executionStrategy()));
         } catch (final Throwable t) {
             closeables.closeAsync().subscribe();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -118,7 +118,7 @@ final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttp
                         defaultReqRespFactory(buildContext.httpConfig().asReadOnly(),
                                 executionContext.bufferAllocator()),
                         executionContext, partitionMapFactory);
-        return new FilterableClientToClient(partitionedClient, executionContext.executionStrategy(),
+        return new FilterableClientToClient(partitionedClient,
                 buildContext.builder.computeChainStrategy(executionContext.executionStrategy()));
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -324,7 +324,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                         ctx.builder.autoRetry.newStrategy(lb.eventStream(), ctx.sdStatus));
             }
             return new FilterableClientToClient(currClientFilterFactory != null ?
-                    currClientFilterFactory.create(lbClient) : lbClient, executionStrategy,
+                    currClientFilterFactory.create(lbClient) : lbClient,
                     ctx.builder.strategyComputation.buildForClient(executionStrategy));
         } catch (final Throwable t) {
             closeOnException.closeAsync().subscribe();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
@@ -47,29 +47,26 @@ import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KE
 
 final class FilterableClientToClient implements StreamingHttpClient {
     private final FilterableStreamingHttpClient client;
-    private final HttpExecutionStrategy chainStrategy;
     private final HttpExecutionStrategy strategy;
 
-    FilterableClientToClient(FilterableStreamingHttpClient filteredClient, HttpExecutionStrategy strategyFromBuilder,
-                HttpExecutionStrategy chainStrategy) {
-        strategy = strategyFromBuilder;
+    FilterableClientToClient(FilterableStreamingHttpClient filteredClient, HttpExecutionStrategy strategy) {
         client = filteredClient;
-        this.chainStrategy = chainStrategy;
+        this.strategy = strategy;
     }
 
     @Override
     public HttpClient asClient() {
-        return toClient(this, chainStrategy);
+        return toClient(this, strategy);
     }
 
     @Override
     public BlockingStreamingHttpClient asBlockingStreamingClient() {
-        return toBlockingStreamingClient(this, chainStrategy);
+        return toBlockingStreamingClient(this, strategy);
     }
 
     @Override
     public BlockingHttpClient asBlockingClient() {
-        return toBlockingClient(this, chainStrategy);
+        return toBlockingClient(this, strategy);
     }
 
     @Override
@@ -87,17 +84,17 @@ final class FilterableClientToClient implements StreamingHttpClient {
             return client.reserveConnection(metaData).map(rc -> new ReservedStreamingHttpConnection() {
                 @Override
                 public ReservedHttpConnection asConnection() {
-                    return toReservedConnection(this, chainStrategy);
+                    return toReservedConnection(this, strategy);
                 }
 
                 @Override
                 public ReservedBlockingStreamingHttpConnection asBlockingStreamingConnection() {
-                    return toReservedBlockingStreamingConnection(this, chainStrategy);
+                    return toReservedBlockingStreamingConnection(this, strategy);
                 }
 
                 @Override
                 public ReservedBlockingHttpConnection asBlockingConnection() {
-                    return toReservedBlockingConnection(this, chainStrategy);
+                    return toReservedBlockingConnection(this, strategy);
                 }
 
                 @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -250,15 +250,12 @@ class ClientEffectiveStrategyTest {
         // null means assume default strategy which is, unsurprisingly, defaultStrategy()
         HttpExecutionStrategy computed = null == builderStrategy ?
                 defaultStrategy() : builderStrategy;
-        // null mean no filter
-        computed = null == filterStrategy || anyStrategy() == filterStrategy ||
-                defaultStrategy() == filterStrategy || noOffloadsStrategy() == filterStrategy ?
+        // null means no filter, noOffloadsStrategy() is illegal and replaced.
+        computed = null == filterStrategy || anyStrategy() == filterStrategy || noOffloadsStrategy() == filterStrategy ?
                 computed : computed.merge(filterStrategy);
-        computed = null == lbStrategy || anyStrategy() == lbStrategy ||
-                defaultStrategy() == lbStrategy || noOffloadsStrategy() == lbStrategy ?
+        computed = null == lbStrategy || anyStrategy() == lbStrategy || noOffloadsStrategy() == lbStrategy ?
                 computed : computed.merge(lbStrategy);
-        computed = null == cfStrategy || anyStrategy() == cfStrategy ||
-                defaultStrategy() == cfStrategy || noOffloadsStrategy() == cfStrategy ?
+        computed = null == cfStrategy || anyStrategy() == cfStrategy || noOffloadsStrategy() == cfStrategy ?
                 computed : computed.merge(cfStrategy);
 
         return computed;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -59,6 +59,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Queue;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InvokingThreadsRecorder.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InvokingThreadsRecorder.java
@@ -17,13 +17,13 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.http.api.DelegatingHttpExecutionStrategy;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.IoThreadFactory;
 import io.servicetalk.transport.api.ServerContext;
 
 import java.net.InetSocketAddress;
@@ -38,10 +38,7 @@ import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -67,12 +64,8 @@ final class InvokingThreadsRecorder<T> implements AutoCloseable {
         return new InvokingThreadsRecorder<>(null);
     }
 
-    static <T> InvokingThreadsRecorder<T> userStrategyNoVerify(HttpExecutionStrategy strategy) {
+    static <T> InvokingThreadsRecorder<T> userStrategy(@Nullable HttpExecutionStrategy strategy) {
         return new InvokingThreadsRecorder<>(strategy);
-    }
-
-    static <T> InvokingThreadsRecorder<T> userStrategy(HttpExecutionStrategy strategy) {
-        return new InvokingThreadsRecorder<>(new InstrumentedStrategy(strategy));
     }
 
     void init(BiFunction<IoExecutor, HttpServerBuilder, Single<ServerContext>> serverStarter,
@@ -104,18 +97,13 @@ final class InvokingThreadsRecorder<T> implements AutoCloseable {
     }
 
     void assertNoOffload(final T offloadPoint) {
-        assertThat("Unexpected thread for point: " + offloadPoint, invokingThreads.get(offloadPoint).getName(),
-                startsWith(IO_EXECUTOR_NAME_PREFIX));
+        assertThat("Expected IoThread at point: " + offloadPoint,
+                IoThreadFactory.IoThread.isIoThread(invokingThread(offloadPoint)));
     }
 
     void assertOffload(final T offloadPoint) {
-        assertThat("Unexpected thread for point: " + offloadPoint, invokingThreads.get(offloadPoint).getName(),
-                not(startsWith(IO_EXECUTOR_NAME_PREFIX)));
-    }
-
-    void assertOffload(final T offloadPoint, final String executorNamePrefix) {
-        assertThat("Unexpected thread for point: " + offloadPoint, invokingThreads.get(offloadPoint).getName(),
-                both(not(startsWith(IO_EXECUTOR_NAME_PREFIX))).and(startsWith(executorNamePrefix)));
+        assertThat("Expected non-IoThread at point: " + offloadPoint,
+                !IoThreadFactory.IoThread.isIoThread(invokingThread(offloadPoint)));
     }
 
     Thread invokingThread(final T offloadPoint) {
@@ -138,50 +126,5 @@ final class InvokingThreadsRecorder<T> implements AutoCloseable {
 
     void recordThread(final T offloadPoint) {
         invokingThreads.put(offloadPoint, Thread.currentThread());
-    }
-
-    private static final class InstrumentedStrategy extends DelegatingHttpExecutionStrategy {
-
-        private volatile boolean usedForClientOffloading;
-        private volatile boolean usedForServerOffloading;
-
-        InstrumentedStrategy(HttpExecutionStrategy delegate) {
-            super(delegate);
-        }
-
-        boolean isUsedForClientOffloading() {
-            return usedForClientOffloading;
-        }
-
-        @Override
-        public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
-            return this;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            if (!super.equals(o)) {
-                return false;
-            }
-
-            final InstrumentedStrategy that = (InstrumentedStrategy) o;
-
-            return usedForClientOffloading == that.usedForClientOffloading &&
-                    usedForServerOffloading == that.usedForServerOffloading;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = super.hashCode();
-            result = 31 * result + (usedForClientOffloading ? 1 : 0);
-            result = 31 * result + (usedForServerOffloading ? 1 : 0);
-            return result;
-        }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -48,7 +48,7 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.IO_EXECUTOR_NAME_PREFIX;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.noStrategy;
-import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategyNoVerify;
+import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategy;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Character.isDigit;
 import static java.util.Objects.requireNonNull;
@@ -148,7 +148,7 @@ class ServerEffectiveStrategyTest {
         Params(final ServiceType serviceType, boolean addFilter,
                @Nullable final HttpExecutionStrategy strategy, final Offloads expectedOffloads) {
             this.addFilter = addFilter;
-            this.invokingThreadsRecorder = null == strategy ? noStrategy() : userStrategyNoVerify(strategy);
+            this.invokingThreadsRecorder = null == strategy ? noStrategy() : userStrategy(strategy);
             offloadPoints = expectedOffloads.forServiceType(serviceType);
             nonOffloadPoints = EnumSet.complementOf(offloadPoints);
         }


### PR DESCRIPTION
Motivation:
The computed execution strategy used by the client was different in
some cases than 0.41
Modifications:
Improve `ClientEffectiveStrategyTest` to cover more cases and ensure
that the strategy used matches, where reasonable, the behaviour from
0.41. Some cases, where the strategy from filters or connection factory
was `defaultStrategy()` or `noOffloadsStrategy()` are now ignored with
a warning. Influencers must use a computed strategy rather one of the
special strategies.
Result:
More compatible and consistent client behavior with computed execution
strategy.