### PR TITLE
Remove deprecated `HttpClients` factories for proxy

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.forUnknownHostAndPort;
-import static io.servicetalk.transport.netty.internal.BuilderUtils.toResolvedInetSocketAddress;
 import static java.util.function.Function.identity;
 
 /**
@@ -106,27 +105,6 @@ public final class HttpClients {
     }
 
     /**
-     * Creates a {@link SingleAddressHttpClientBuilder} for an address via a proxy, with default {@link LoadBalancer}
-     * and DNS {@link ServiceDiscoverer}.
-     *
-     * @param host host to connect to via the proxy. This will also be used for the {@link HttpHeaderNames#HOST}
-     * together with the {@code port}. Use
-     * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
-     * or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you want to disable this behavior.
-     * @param port port to connect to
-     * @param proxyHost the proxy host to connect to, resolved by default using a DNS {@link ServiceDiscoverer}.
-     * @param proxyPort The proxy port to connect.
-     * @return new builder for the address
-     * @deprecated Use {@link SingleAddressHttpClientBuilder#proxyAddress(Object)} on the instance returned from
-     * {@link #forSingleAddress(String, int)}.
-     */
-    @Deprecated
-    public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forSingleAddressViaProxy(
-            final String host, final int port, final String proxyHost, final int proxyPort) {
-        return forSingleAddressViaProxy(HostAndPort.of(host, port), HostAndPort.of(proxyHost, proxyPort));
-    }
-
-    /**
      * Creates a {@link SingleAddressHttpClientBuilder} for an address with default {@link LoadBalancer} and DNS {@link
      * ServiceDiscoverer}.
      *
@@ -155,26 +133,6 @@ public final class HttpClients {
     }
 
     /**
-     * Creates a {@link SingleAddressHttpClientBuilder} for an address via a proxy, with default {@link LoadBalancer}
-     * and DNS {@link ServiceDiscoverer}.
-     *
-     * @param address the {@code UnresolvedAddress} to connect to via the proxy. This address will also be used for the
-     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you
-     * want to disable this behavior.
-     * @param proxyAddress the proxy {@code UnresolvedAddress} to connect to, resolved by default using a DNS {@link
-     * ServiceDiscoverer}.
-     * @return new builder for the address
-     * @deprecated Use {@link SingleAddressHttpClientBuilder#proxyAddress(Object)} on the instance returned from
-     * {@link #forSingleAddress(HostAndPort)}.
-     */
-    @Deprecated
-    public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forSingleAddressViaProxy(
-            final HostAndPort address, final HostAndPort proxyAddress) {
-        return DefaultSingleAddressHttpClientBuilder.forHostAndPort(address).proxyAddress(proxyAddress);
-    }
-
-    /**
      * Creates a {@link SingleAddressHttpClientBuilder} for a resolved address with default {@link LoadBalancer}.
      *
      * @param host resolved host address to connect. This will also be used for the {@link HttpHeaderNames#HOST}
@@ -191,27 +149,6 @@ public final class HttpClients {
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddress(
             final String host, final int port) {
         return forResolvedAddress(HostAndPort.of(host, port));
-    }
-
-    /**
-     * Creates a {@link SingleAddressHttpClientBuilder} for a resolved address via a proxy, with default
-     * {@link LoadBalancer}.
-     *
-     * @param host resolved host address to connect via the proxy. This will also be used for the
-     * {@link HttpHeaderNames#HOST} together with the {@code port}. Use
-     * {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)} if you want to override that value
-     * or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you want to disable this behavior.
-     * @param port port to connect to via the proxy
-     * @param proxyHost The proxy resolved host address to connect.
-     * @param proxyPort The proxy port to connect.
-     * @return new builder for the address
-     * @deprecated Use {@link SingleAddressHttpClientBuilder#proxyAddress(Object)} on the instance returned from
-     * {@link #forResolvedAddress(String, int)}.
-     */
-    @Deprecated
-    public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddressViaProxy(
-            final String host, final int port, final String proxyHost, final int proxyPort) {
-        return forResolvedAddressViaProxy(HostAndPort.of(host, port), HostAndPort.of(proxyHost, proxyPort));
     }
 
     /**
@@ -234,26 +171,6 @@ public final class HttpClients {
     }
 
     /**
-     * Creates a {@link SingleAddressHttpClientBuilder} for an address via a proxy, with default {@link LoadBalancer}.
-     *
-     * @param address the {@code ResolvedAddress} to connect to via the proxy. This address will also be used for the
-     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you
-     * want to disable this behavior.
-     * @param proxyAddress The proxy {@code ResolvedAddress} to connect.
-     * @return new builder for the address
-     * @deprecated Use {@link SingleAddressHttpClientBuilder#proxyAddress(Object)} on the instance returned from
-     * {@link #forResolvedAddress(HostAndPort)}.
-     */
-    @Deprecated
-    public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forResolvedAddressViaProxy(
-            final HostAndPort address, final HostAndPort proxyAddress) {
-        return DefaultSingleAddressHttpClientBuilder
-                .forResolvedAddress(address, BuilderUtils::toResolvedInetSocketAddress)
-                .proxyAddress(proxyAddress);
-    }
-
-    /**
      * Creates a {@link SingleAddressHttpClientBuilder} for an address with default {@link LoadBalancer}.
      *
      * @param address the {@code ResolvedAddress} to connect. This address will also be used for the
@@ -265,24 +182,6 @@ public final class HttpClients {
      */
     public static <T extends SocketAddress> SingleAddressHttpClientBuilder<T, T> forResolvedAddress(final T address) {
         return DefaultSingleAddressHttpClientBuilder.forResolvedAddress(address, identity());
-    }
-
-    /**
-     * Creates a {@link SingleAddressHttpClientBuilder} for an address via a proxy, with default {@link LoadBalancer}.
-     *
-     * @param address the {@code ResolvedAddress} to connect to via the proxy. This address will also be used for the
-     * {@link HttpHeaderNames#HOST}. Use {@link SingleAddressHttpClientBuilder#unresolvedAddressToHost(Function)}
-     * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you
-     * want to disable this behavior.
-     * @param proxyAddress The proxy {@code ResolvedAddress} to connect.
-     * @return new builder for the address
-     * @deprecated Use {@link SingleAddressHttpClientBuilder#proxyAddress(Object)} on the instance returned from
-     * {@link #forResolvedAddress(SocketAddress)}
-     */
-    @Deprecated
-    public static SingleAddressHttpClientBuilder<InetSocketAddress, InetSocketAddress> forResolvedAddressViaProxy(
-            final InetSocketAddress address, final InetSocketAddress proxyAddress) {
-        return DefaultSingleAddressHttpClientBuilder.forResolvedAddress(address, identity()).proxyAddress(proxyAddress);
     }
 
     /**


### PR DESCRIPTION
Motivation:

`HttpClients` factories that are related to proxy were deprecated in
#1751 and deprecations were announced in one of 0.41.x releases.
It’s safe to remove these methods from the main branch now.

Modifications:

- Remove `forSingleAddressViaProxy` and `forResolvedAddressViaProxy`;

Result:

No deprecated API in `HttpClients`.