### PR TITLE
Remove default impl from `ConnectionObserver`

### DIFF
--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -50,9 +50,7 @@ public interface ConnectionObserver {
      * Transport protocols that require a handshake in order to connect. Example:
      * <a href="https://datatracker.ietf.org/doc/html/rfc793.html#section-3.4">TCP "three-way handshake"</a>.
      */
-    default void onTransportHandshakeComplete() {
-        // FIXME: 0.42 - remove default impl
-    }
+    void onTransportHandshakeComplete();
 
     /**
      * Callback when a security handshake is initiated.
@@ -173,9 +171,7 @@ public interface ConnectionObserver {
          *
          * @param streamId assigned stream identifier
          */
-        default void streamIdAssigned(long streamId) {  // Use long to comply with HTTP/3 requirements
-            // FIXME: 0.42 - remove default impl
-        }
+        void streamIdAssigned(long streamId);   // Use long to comply with HTTP/3 requirements
 
         /**
          * Callback when the stream is established and ready to be used. It may or may not have an already assigned


### PR DESCRIPTION
Motivation:

#1969 and #1970 introduced two new callbacks for `ConnectionObserver`
and added default impl for backward compatibility. We can clean up API
in 0.42.

Modifications:

- Remove default impl for `onTransportHandshakeComplete()` and
`streamIdAssigned`;

Result:

No default callback impls.