### PR TITLE
`publishOn/subscribeOn` take `io.servicetalk.concurrent.Executor`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -481,7 +481,8 @@ public abstract class Completable {
      * {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
      * @param unit The units for {@code duration}.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @param timeoutExecutor The {@link io.servicetalk.concurrent.Executor} to use for managing the timer
+     * notifications.
      * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
@@ -517,7 +518,8 @@ public abstract class Completable {
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onComplete()}.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @param timeoutExecutor The {@link io.servicetalk.concurrent.Executor} to use for managing the timer
+     * notifications.
      * @return a new {@link Completable} that will mimic the signals of this {@link Completable} but will terminate with
      * a {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onComplete()}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
@@ -1419,88 +1421,91 @@ public abstract class Completable {
     }
 
     /**
-     * Creates a new {@link Completable} that will use the passed {@link Executor} to invoke all {@link Subscriber}
-     * methods.
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * Creates a new {@link Completable} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke
+     * all {@link Subscriber} methods.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Completable}. Only subsequent operations, if any, added in this execution chain
+     * will use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #publishOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
-     * passed {@link Executor}.
+     * Note: unlike {@link #publishOn(io.servicetalk.concurrent.Executor, BooleanSupplier)}, current operator always
+     * enforces offloading to the passed {@link io.servicetalk.concurrent.Executor}.
      *
-     * @param executor {@link Executor} to use.
-     * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all {@link Subscriber}
-     * methods.
-     * @see #publishOn(Executor, BooleanSupplier)
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
+     * @return A new {@link Completable} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke
+     * all {@link Subscriber} methods.
+     * @see #publishOn(io.servicetalk.concurrent.Executor, BooleanSupplier)
      */
-    public final Completable publishOn(Executor executor) {
+    public final Completable publishOn(io.servicetalk.concurrent.Executor executor) {
         return PublishAndSubscribeOnCompletables.publishOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Completable} that may use the passed {@link Executor} to invoke all {@link Subscriber}
-     * methods.
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * Creates a new {@link Completable} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke
+     * all {@link Subscriber} methods.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Completable}. Only subsequent operations, if any, added in this execution chain
+     * will use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #publishOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
-     * depending on the result of the {@link BooleanSupplier} hint.
+     * Note: unlike {@link #publishOn(io.servicetalk.concurrent.Executor)}, current operator may skip offloading to the
+     * passed {@link io.servicetalk.concurrent.Executor}, depending on the result of the {@link BooleanSupplier} hint.
      *
-     * @param executor {@link Executor} to use.
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
      * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
      * still occur even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Completable} that may use the passed {@link Executor} to invoke all {@link Subscriber}
-     * methods.
-     * @see #publishOn(Executor)
+     * @return A new {@link Completable} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke
+     * all {@link Subscriber} methods.
+     * @see #publishOn(io.servicetalk.concurrent.Executor)
      */
-    public final Completable publishOn(Executor executor, BooleanSupplier shouldOffload) {
+    public final Completable publishOn(io.servicetalk.concurrent.Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnCompletables.publishOn(this, shouldOffload, executor);
     }
 
     /**
-     * Creates a new {@link Completable} that will use the passed {@link Executor} to invoke the following methods:
+     * Creates a new {@link Completable} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke
+     * the following methods:
      * <ul>
      *     <li>All {@link Cancellable} methods.</li>
      *     <li>The {@link #handleSubscribe(CompletableSource.Subscriber)} method.</li>
      * </ul>
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Completable}. Only subsequent operations, if any, added in this execution chain
+     * will use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #subscribeOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
-     * passed {@link Executor}.
+     * Note: unlike {@link #subscribeOn(io.servicetalk.concurrent.Executor, BooleanSupplier)}, current operator always
+     * enforces offloading to the passed {@link io.servicetalk.concurrent.Executor}.
      *
-     * @param executor {@link Executor} to use.
-     * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods of
-     * {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
-     * @see #subscribeOn(Executor, BooleanSupplier)
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
+     * @return A new {@link Completable} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke
+     * all methods of {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
+     * @see #subscribeOn(io.servicetalk.concurrent.Executor, BooleanSupplier)
      */
-    public final Completable subscribeOn(Executor executor) {
+    public final Completable subscribeOn(io.servicetalk.concurrent.Executor executor) {
         return PublishAndSubscribeOnCompletables.subscribeOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Completable} that may use the passed {@link Executor} to invoke the following methods:
+     * Creates a new {@link Completable} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke
+     * the following methods:
      * <ul>
      *     <li>All {@link Cancellable} methods.</li>
      *     <li>The {@link #handleSubscribe(CompletableSource.Subscriber)} method.</li>
      * </ul>
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Completable}. Only subsequent operations, if any, added in this execution chain
+     * will use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #subscribeOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
-     * depending on the result of the {@link BooleanSupplier} hint.
+     * Note: unlike {@link #subscribeOn(io.servicetalk.concurrent.Executor)}, current operator may skip offloading to =
+     * the passed {@link io.servicetalk.concurrent.Executor}, depending on the result of the {@link BooleanSupplier}
+     * hint.
      *
-     * @param executor {@link Executor} to use.
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
      * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
      * still occur even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Completable} that may use the passed {@link Executor} to invoke all methods of
-     * {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
-     * @see #subscribeOn(Executor)
+     * @return A new {@link Completable} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke
+     * all methods of {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
+     * @see #subscribeOn(io.servicetalk.concurrent.Executor)
      */
-    public final Completable subscribeOn(Executor executor, BooleanSupplier shouldOffload) {
+    public final Completable subscribeOn(io.servicetalk.concurrent.Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnCompletables.subscribeOn(this, shouldOffload, executor);
     }
 
@@ -1674,7 +1679,7 @@ public abstract class Completable {
      * <p>
      * Blocking inside {@link Runnable#run()} will in turn block the subscribe call to the returned {@link Completable}.
      * If this behavior is undesirable then the returned {@link Completable} should be offloaded using
-     * {@link #subscribeOn(Executor)} which offloads the subscribe call.
+     * {@link #subscribeOn(io.servicetalk.concurrent.Executor)} which offloads the subscribe call.
      *
      * @param runnable {@link Runnable} which is invoked before completion.
      * @return A new {@code Completable}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
@@ -61,12 +61,14 @@ final class PublishAndSubscribeOnCompletables {
     }
 
     static Completable publishOn(final Completable original,
-                                 final BooleanSupplier shouldOffload, final Executor executor) {
+                                 final BooleanSupplier shouldOffload,
+                                 final io.servicetalk.concurrent.Executor executor) {
         return executor == immediate() ? original : new PublishOn(original, shouldOffload, executor);
     }
 
     static Completable subscribeOn(final Completable original,
-                                   final BooleanSupplier shouldOffload, final Executor executor) {
+                                   final BooleanSupplier shouldOffload,
+                                   final io.servicetalk.concurrent.Executor executor) {
         return executor == immediate() ? original : new SubscribeOn(original, shouldOffload, executor);
     }
 
@@ -80,7 +82,8 @@ final class PublishAndSubscribeOnCompletables {
     private static final class PublishOn extends TaskBasedAsyncCompletableOperator {
 
         PublishOn(final Completable original,
-                  final BooleanSupplier shouldOffload, final Executor executor) {
+                  final BooleanSupplier shouldOffload,
+                  final io.servicetalk.concurrent.Executor executor) {
             super(original, shouldOffload, executor);
         }
 
@@ -115,7 +118,8 @@ final class PublishAndSubscribeOnCompletables {
     private static final class SubscribeOn extends TaskBasedAsyncCompletableOperator {
 
         SubscribeOn(final Completable original,
-                    final BooleanSupplier shouldOffload, final Executor executor) {
+                    final BooleanSupplier shouldOffload,
+                    final io.servicetalk.concurrent.Executor executor) {
             super(original, shouldOffload, executor);
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
@@ -58,13 +58,13 @@ final class PublishAndSubscribeOnPublishers {
 
     static <T> Publisher<T> publishOn(final Publisher<T> original,
                                       final BooleanSupplier shouldOffload,
-                                      final Executor executor) {
+                                      final io.servicetalk.concurrent.Executor executor) {
         return immediate() == executor ? original : new PublishOn<>(original, shouldOffload, executor);
     }
 
     static <T> Publisher<T> subscribeOn(final Publisher<T> original,
                                         final BooleanSupplier shouldOffload,
-                                        final Executor executor) {
+                                        final io.servicetalk.concurrent.Executor executor) {
         return immediate() == executor ? original : new SubscribeOn<>(original, shouldOffload, executor);
     }
 
@@ -78,7 +78,8 @@ final class PublishAndSubscribeOnPublishers {
     private static final class PublishOn<T> extends TaskBasedAsyncPublisherOperator<T> {
 
         PublishOn(final Publisher<T> original,
-                  final BooleanSupplier shouldOffload, final Executor executor) {
+                  final BooleanSupplier shouldOffload,
+                  final io.servicetalk.concurrent.Executor executor) {
             super(original, shouldOffload, executor);
         }
 
@@ -116,7 +117,8 @@ final class PublishAndSubscribeOnPublishers {
     private static final class SubscribeOn<T> extends TaskBasedAsyncPublisherOperator<T> {
 
         SubscribeOn(final Publisher<T> original,
-                    final BooleanSupplier shouldOffload, final Executor executor) {
+                    final BooleanSupplier shouldOffload,
+                    final io.servicetalk.concurrent.Executor executor) {
             super(original, shouldOffload, executor);
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnSingles.java
@@ -59,12 +59,14 @@ final class PublishAndSubscribeOnSingles {
     }
 
     static <T> Single<T> publishOn(final Single<T> original,
-                                   final BooleanSupplier shouldOffload, final Executor executor) {
+                                   final BooleanSupplier shouldOffload,
+                                   final io.servicetalk.concurrent.Executor executor) {
         return immediate() == executor ? original : new PublishOn<>(original, shouldOffload, executor);
     }
 
     static <T> Single<T> subscribeOn(final Single<T> original,
-                                     final BooleanSupplier shouldOffload, final Executor executor) {
+                                     final BooleanSupplier shouldOffload,
+                                     final io.servicetalk.concurrent.Executor executor) {
         return immediate() == executor ? original : new SubscribeOn<>(original, shouldOffload, executor);
     }
 
@@ -78,7 +80,7 @@ final class PublishAndSubscribeOnSingles {
     private static final class PublishOn<T> extends TaskBasedAsyncSingleOperator<T> {
 
         PublishOn(final Single<T> original,
-                  final BooleanSupplier shouldOffload, final Executor executor) {
+                  final BooleanSupplier shouldOffload, final io.servicetalk.concurrent.Executor executor) {
             super(original, shouldOffload, executor);
         }
 
@@ -113,7 +115,8 @@ final class PublishAndSubscribeOnSingles {
     private static final class SubscribeOn<T> extends TaskBasedAsyncSingleOperator<T> {
 
         SubscribeOn(final Single<T> original,
-                    final BooleanSupplier shouldOffload, final Executor executor) {
+                    final BooleanSupplier shouldOffload,
+                    final io.servicetalk.concurrent.Executor executor) {
             super(original, shouldOffload, executor);
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1536,7 +1536,8 @@ public abstract class Publisher<T> {
      * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
      * @param unit The units for {@code duration}.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @param timeoutExecutor The {@link io.servicetalk.concurrent.Executor} to use for managing the timer
+     * notifications.
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
@@ -1555,7 +1556,8 @@ public abstract class Publisher<T> {
      * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
      * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration which is allowed to elapse between {@link Subscriber#onNext(Object)} calls.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @param timeoutExecutor The {@link io.servicetalk.concurrent.Executor} to use for managing the timer
+     * notifications.
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between {@link Subscriber#onNext(Object)} calls.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
@@ -1590,7 +1592,8 @@ public abstract class Publisher<T> {
      * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} will be {@link Subscription#cancel() cancelled} and
      * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration during which the Publisher must complete.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @param timeoutExecutor The {@link io.servicetalk.concurrent.Executor} to use for managing the timer
+     * notifications.
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
@@ -1627,7 +1630,8 @@ public abstract class Publisher<T> {
      * the associated {@link Subscriber} will be {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration during which the Publisher must complete.
      * @param unit The units for {@code duration}.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @param timeoutExecutor The {@link io.servicetalk.concurrent.Executor} to use for managing the timer
+     * notifications.
      * @return a new {@link Publisher} that will mimic the signals of this {@link Publisher} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses between subscribe and termination.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
@@ -2877,88 +2881,91 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Creates a new {@link Publisher} that will use the passed {@link Executor} to invoke all {@link Subscriber}
-     * methods.
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * Creates a new {@link Publisher} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * {@link Subscriber} methods.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Publisher}. Only subsequent operations, if any, added in this execution chain
+     * will use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #publishOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
-     * passed {@link Executor}.
+     * Note: unlike {@link #publishOn(io.servicetalk.concurrent.Executor, BooleanSupplier)}, current operator always
+     * enforces offloading to the passed {@link io.servicetalk.concurrent.Executor}.
      *
-     * @param executor {@link Executor} to use.
-     * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all {@link Subscriber}
-     * methods.
-     * @see #publishOn(Executor, BooleanSupplier)
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
+     * @return A new {@link Publisher} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * {@link Subscriber} methods.
+     * @see #publishOn(io.servicetalk.concurrent.Executor, BooleanSupplier)
      */
-    public final Publisher<T> publishOn(Executor executor) {
+    public final Publisher<T> publishOn(io.servicetalk.concurrent.Executor executor) {
         return PublishAndSubscribeOnPublishers.publishOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Publisher} that may use the passed {@link Executor} to invoke all {@link Subscriber}
-     * methods.
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * Creates a new {@link Publisher} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * {@link Subscriber} methods.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Publisher}. Only subsequent operations, if any, added in this execution chain
+     * will use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #publishOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
-     * depending on the result of the {@link BooleanSupplier} hint.
+     * Note: unlike {@link #publishOn(io.servicetalk.concurrent.Executor)}, current operator may skip offloading to the
+     * passed {@link io.servicetalk.concurrent.Executor}, depending on the result of the {@link BooleanSupplier} hint.
      *
-     * @param executor {@link Executor} to use.
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
      * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
      * still occur even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Publisher} that may use the passed {@link Executor} to invoke all {@link Subscriber}
-     * methods.
-     * @see #publishOn(Executor)
+     * @return A new {@link Publisher} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * {@link Subscriber} methods.
+     * @see #publishOn(io.servicetalk.concurrent.Executor)
      */
-    public final Publisher<T> publishOn(Executor executor, BooleanSupplier shouldOffload) {
+    public final Publisher<T> publishOn(io.servicetalk.concurrent.Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnPublishers.publishOn(this, shouldOffload, executor);
     }
 
     /**
-     * Creates a new {@link Publisher} that will use the passed {@link Executor} to invoke the following methods:
+     * Creates a new {@link Publisher} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke the
+     * following methods:
      * <ul>
      *     <li>All {@link Subscription} methods.</li>
      *     <li>The {@link #handleSubscribe(PublisherSource.Subscriber)} method.</li>
      * </ul>
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Publisher}. Only subsequent operations, if any, added in this execution chain
+     * will use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #subscribeOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
-     * passed {@link Executor}.
+     * Note: unlike {@link #subscribeOn(io.servicetalk.concurrent.Executor, BooleanSupplier)}, current operator always
+     * enforces offloading to the passed {@link io.servicetalk.concurrent.Executor}.
      *
-     * @param executor {@link Executor} to use.
-     * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods of
-     * {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
-     * @see #subscribeOn(Executor, BooleanSupplier)
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
+     * @return A new {@link Publisher} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * methods of {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
+     * @see #subscribeOn(io.servicetalk.concurrent.Executor, BooleanSupplier)
      */
-    public final Publisher<T> subscribeOn(Executor executor) {
+    public final Publisher<T> subscribeOn(io.servicetalk.concurrent.Executor executor) {
         return PublishAndSubscribeOnPublishers.subscribeOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Publisher} that may use the passed {@link Executor} to invoke the following methods:
+     * Creates a new {@link Publisher} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke the
+     * following methods:
      * <ul>
      *     <li>All {@link Subscription} methods.</li>
      *     <li>The {@link #handleSubscribe(PublisherSource.Subscriber)} method.</li>
      * </ul>
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Publisher}. Only subsequent operations, if any, added in this execution chain
+     * will use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #subscribeOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
-     * depending on the result of the {@link BooleanSupplier} hint.
+     * Note: unlike {@link #subscribeOn(io.servicetalk.concurrent.Executor)}, current operator may skip offloading to
+     * the passed {@link io.servicetalk.concurrent.Executor}, depending on the result of the {@link BooleanSupplier}
+     * hint.
      *
-     * @param executor {@link Executor} to use.
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
      * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
      * still occur even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Publisher} that may use the passed {@link Executor} to invoke all methods of
-     * {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
-     * @see #subscribeOn(Executor)
+     * @return A new {@link Publisher} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * methods of {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
+     * @see #subscribeOn(io.servicetalk.concurrent.Executor)
      */
-    public final Publisher<T> subscribeOn(Executor executor, BooleanSupplier shouldOffload) {
+    public final Publisher<T> subscribeOn(io.servicetalk.concurrent.Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnPublishers.subscribeOn(this, shouldOffload, executor);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -633,7 +633,8 @@ public abstract class Single<T> {
      * {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
      * @param unit The units for {@code duration}.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @param timeoutExecutor The {@link io.servicetalk.concurrent.Executor} to use for managing the timer
+     * notifications.
      * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
@@ -670,7 +671,8 @@ public abstract class Single<T> {
      * {@link Cancellable#cancel() cancelled} and the associated {@link Subscriber} will be
      * {@link Subscriber#onError(Throwable) terminated}.
      * @param duration The time duration which is allowed to elapse before {@link Subscriber#onSuccess(Object)}.
-     * @param timeoutExecutor The {@link Executor} to use for managing the timer notifications.
+     * @param timeoutExecutor The {@link io.servicetalk.concurrent.Executor} to use for managing the timer
+     * notifications.
      * @return a new {@link Single} that will mimic the signals of this {@link Single} but will terminate with a
      * {@link TimeoutException} if time {@code duration} elapses before {@link Subscriber#onSuccess(Object)}.
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX timeout operator.</a>
@@ -1368,84 +1370,91 @@ public abstract class Single<T> {
     }
 
     /**
-     * Creates a new {@link Single} that will use the passed {@link Executor} to invoke all {@link Subscriber} methods.
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * Creates a new {@link Single} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * {@link Subscriber} methods. This method does <strong>not</strong> override preceding {@link Executor}s, if any,
+     * specified for {@code this} {@link Single}. Only subsequent operations, if any, added in this execution chain will
+     * use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #publishOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
-     * passed {@link Executor}.
+     * Note: unlike {@link #publishOn(io.servicetalk.concurrent.Executor, BooleanSupplier)}, current operator always
+     * enforces offloading to the passed {@link io.servicetalk.concurrent.Executor}.
      *
-     * @param executor {@link Executor} to use.
-     * @return A new {@link Single} that will use the passed {@link Executor} to invoke all {@link Subscriber} methods.
-     * @see #publishOn(Executor, BooleanSupplier)
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
+     * @return A new {@link Single} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * {@link Subscriber} methods.
+     * @see #publishOn(io.servicetalk.concurrent.Executor, BooleanSupplier)
      */
-    public final Single<T> publishOn(Executor executor) {
+    public final Single<T> publishOn(io.servicetalk.concurrent.Executor executor) {
         return PublishAndSubscribeOnSingles.publishOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Single} that may use the passed {@link Executor} to invoke all {@link Subscriber} methods.
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * Creates a new {@link Single} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * {@link Subscriber} methods.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Single}. Only subsequent operations, if any, added in this execution chain will
+     * use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #publishOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
+     * Note: unlike {@link #publishOn(io.servicetalk.concurrent.Executor)}, current operator may skip offloading to the
+     * passed {@link io.servicetalk.concurrent.Executor},
      * depending on the result of the {@link BooleanSupplier} hint.
      *
-     * @param executor {@link Executor} to use.
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
      * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
      * still occur even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Single} that may use the passed {@link Executor} to invoke all {@link Subscriber} methods.
-     * @see #publishOn(Executor)
+     * @return A new {@link Single} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * {@link Subscriber} methods.
+     * @see #publishOn(io.servicetalk.concurrent.Executor)
      */
-    public final Single<T> publishOn(Executor executor, BooleanSupplier shouldOffload) {
+    public final Single<T> publishOn(io.servicetalk.concurrent.Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnSingles.publishOn(this, shouldOffload, executor);
     }
 
     /**
-     * Creates a new {@link Single} that will use the passed {@link Executor} to invoke the following methods:
+     * Creates a new {@link Single} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke the
+     * following methods:
      * <ul>
      *     <li>All {@link Cancellable} methods.</li>
      *     <li>The {@link #handleSubscribe(SingleSource.Subscriber)} method.</li>
      * </ul>
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Single}. Only subsequent operations, if any, added in this execution chain will
+     * use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #subscribeOn(Executor, BooleanSupplier)}, current operator always enforces offloading to the
-     * passed{@link Executor}.
+     * Note: unlike {@link #subscribeOn(io.servicetalk.concurrent.Executor, BooleanSupplier)}, current operator always
+     * enforces offloading to the passed {@link io.servicetalk.concurrent.Executor}.
      *
-     * @param executor {@link Executor} to use.
-     * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods of
-     * {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
-     * @see #subscribeOn(Executor, BooleanSupplier)
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
+     * @return A new {@link Single} that will use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * methods of {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
+     * @see #subscribeOn(io.servicetalk.concurrent.Executor, BooleanSupplier)
      */
-    public final Single<T> subscribeOn(Executor executor) {
+    public final Single<T> subscribeOn(io.servicetalk.concurrent.Executor executor) {
         return PublishAndSubscribeOnSingles.subscribeOn(this, Boolean.TRUE::booleanValue, executor);
     }
 
     /**
-     * Creates a new {@link Single} that may use the passed {@link Executor} to invoke the following methods:
+     * Creates a new {@link Single} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke the
+     * following methods:
      * <ul>
      *     <li>All {@link Cancellable} methods.</li>
      *     <li>The {@link #handleSubscribe(SingleSource.Subscriber)} method.</li>
      * </ul>
-     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
-     * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
-     * {@link Executor}.
+     * This method does <strong>not</strong> override preceding {@link io.servicetalk.concurrent.Executor}s, if any,
+     * specified for {@code this} {@link Single}. Only subsequent operations, if any, added in this execution chain will
+     * use this {@link io.servicetalk.concurrent.Executor}.
      * <p>
-     * Note: unlike {@link #subscribeOn(Executor)}, current operator may skip offloading to the passed {@link Executor},
-     * depending on the result of the {@link BooleanSupplier} hint.
+     * Note: unlike {@link #subscribeOn(io.servicetalk.concurrent.Executor)}, current operator may skip offloading to
+     * the passed {@link io.servicetalk.concurrent.Executor}, depending on the result of the {@link BooleanSupplier}
+     * hint.
      *
-     * @param executor {@link Executor} to use.
+     * @param executor {@link io.servicetalk.concurrent.Executor} to use.
      * @param shouldOffload Provides a hint whether offloading to the executor can be omitted or not. Offloading may
      * still occur even if {@code false} is returned in order to preserve signal ordering.
-     * @return A new {@link Single} that may use the passed {@link Executor} to invoke all methods of
-     * {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
-     * @see #subscribeOn(Executor)
+     * @return A new {@link Single} that may use the passed {@link io.servicetalk.concurrent.Executor} to invoke all
+     * methods of {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
+     * @see #subscribeOn(io.servicetalk.concurrent.Executor)
      */
-    public final Single<T> subscribeOn(Executor executor, BooleanSupplier shouldOffload) {
+    public final Single<T> subscribeOn(io.servicetalk.concurrent.Executor executor, BooleanSupplier shouldOffload) {
         return PublishAndSubscribeOnSingles.subscribeOn(this, shouldOffload, executor);
     }
 
@@ -1663,7 +1672,7 @@ public abstract class Single<T> {
      * <p>
      * Blocking inside {@link Callable#call()} will in turn block the subscribe call to the returned {@link Single}. If
      * this behavior is undesirable then the returned {@link Single} should be offloaded using
-     * {@link #subscribeOn(Executor)} which offloads the subscribe call.
+     * {@link #subscribeOn(io.servicetalk.concurrent.Executor)} which offloads the subscribe call.
      *
      * @param callable {@link Callable} which supplies the result of the {@link Single}.
      * @param <T>      Type of the {@link Single}.
@@ -1680,8 +1689,8 @@ public abstract class Single<T> {
      * emitted by the {@link Supplier} will terminate the returned {@link Single} with the same error.
      * <p>
      * Blocking inside {@link Supplier#get()} will in turn block the subscribe call to the returned {@link Single}. If
-     *      * this behavior is undesirable then the returned {@link Single} should be offloaded using
-     *      * {@link #subscribeOn(Executor)} which offloads the subscribe call.
+     * this behavior is undesirable then the returned {@link Single} should be offloaded using
+     * {@link #subscribeOn(io.servicetalk.concurrent.Executor)} which offloads the subscribe call.
      *
      * @param supplier {@link Supplier} which supplies the result of the {@link Single}.
      * @param <T>      Type of the {@link Single}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncCompletableOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncCompletableOperator.java
@@ -21,7 +21,6 @@ import io.servicetalk.context.api.ContextMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
@@ -46,21 +45,21 @@ abstract class TaskBasedAsyncCompletableOperator extends AbstractNoHandleSubscri
 
     private final Completable original;
     private final BooleanSupplier shouldOffload;
-    private final Executor executor;
+    private final io.servicetalk.concurrent.Executor executor;
 
     TaskBasedAsyncCompletableOperator(final Completable original,
                                       final BooleanSupplier shouldOffload,
-                                      final Executor executor) {
+                                      final io.servicetalk.concurrent.Executor executor) {
         this.original = original;
-        this.shouldOffload = Objects.requireNonNull(shouldOffload, "shouldOffload");
-        this.executor = Objects.requireNonNull(executor, "executor");
+        this.shouldOffload = requireNonNull(shouldOffload, "shouldOffload");
+        this.executor = requireNonNull(executor, "executor");
     }
 
     final BooleanSupplier shouldOffload() {
         return shouldOffload;
     }
 
-    final Executor executor() {
+    final io.servicetalk.concurrent.Executor executor() {
         return executor;
     }
 
@@ -83,7 +82,7 @@ abstract class TaskBasedAsyncCompletableOperator extends AbstractNoHandleSubscri
                 newUpdater(AbstractOffloadedSingleValueSubscriber.class, "state");
 
         private final BooleanSupplier shouldOffload;
-        final Executor executor;
+        final io.servicetalk.concurrent.Executor executor;
         @Nullable
         // Visibility: Task submitted to executor happens-before task execution.
         private Cancellable cancellable;
@@ -92,7 +91,8 @@ abstract class TaskBasedAsyncCompletableOperator extends AbstractNoHandleSubscri
         private volatile int state = STATE_INIT;
         private boolean hasOffloaded;
 
-        AbstractOffloadedSingleValueSubscriber(final BooleanSupplier shouldOffload, final Executor executor) {
+        AbstractOffloadedSingleValueSubscriber(final BooleanSupplier shouldOffload,
+                                               final io.servicetalk.concurrent.Executor executor) {
             this.shouldOffload = shouldOffload;
             this.executor = executor;
         }
@@ -239,7 +239,8 @@ abstract class TaskBasedAsyncCompletableOperator extends AbstractNoHandleSubscri
         private final Subscriber subscriber;
 
         CompletableSubscriberOffloadedTerminals(final Subscriber subscriber,
-                                                final BooleanSupplier shouldOffload, final Executor executor) {
+                                                final BooleanSupplier shouldOffload,
+                                                final io.servicetalk.concurrent.Executor executor) {
             super(shouldOffload, executor);
             this.subscriber = requireNonNull(subscriber);
         }
@@ -290,10 +291,11 @@ abstract class TaskBasedAsyncCompletableOperator extends AbstractNoHandleSubscri
     static final class CompletableSubscriberOffloadedCancellable implements Subscriber {
         private final Subscriber subscriber;
         private final BooleanSupplier shouldOffload;
-        private final Executor executor;
+        private final io.servicetalk.concurrent.Executor executor;
 
         CompletableSubscriberOffloadedCancellable(final Subscriber subscriber,
-                                                  final BooleanSupplier shouldOffload, final Executor executor) {
+                                                  final BooleanSupplier shouldOffload,
+                                                  final io.servicetalk.concurrent.Executor executor) {
             this.subscriber = requireNonNull(subscriber);
             this.shouldOffload = shouldOffload;
             this.executor = executor;
@@ -321,10 +323,11 @@ abstract class TaskBasedAsyncCompletableOperator extends AbstractNoHandleSubscri
     static final class OffloadedCancellable implements Cancellable {
         private final Cancellable cancellable;
         private final BooleanSupplier shouldOffload;
-        private final Executor executor;
+        private final io.servicetalk.concurrent.Executor executor;
 
         OffloadedCancellable(final Cancellable cancellable,
-                             final BooleanSupplier shouldOffload, final Executor executor) {
+                             final BooleanSupplier shouldOffload,
+                             final io.servicetalk.concurrent.Executor executor) {
             this.cancellable = requireNonNull(cancellable);
             this.shouldOffload = shouldOffload;
             this.executor = executor;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncPublisherOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncPublisherOperator.java
@@ -23,7 +23,6 @@ import io.servicetalk.context.api.ContextMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -62,21 +61,21 @@ abstract class TaskBasedAsyncPublisherOperator<T> extends AbstractNoHandleSubscr
 
     private final Publisher<T> original;
     private final BooleanSupplier shouldOffload;
-    private final Executor executor;
+    private final io.servicetalk.concurrent.Executor executor;
 
     TaskBasedAsyncPublisherOperator(final Publisher<T> original,
                                     final BooleanSupplier shouldOffload,
-                                    final Executor executor) {
+                                    final io.servicetalk.concurrent.Executor executor) {
         this.original = original;
-        this.shouldOffload = Objects.requireNonNull(shouldOffload, "shouldOffload");
-        this.executor = Objects.requireNonNull(executor, "executor");
+        this.shouldOffload = requireNonNull(shouldOffload, "shouldOffload");
+        this.executor = requireNonNull(executor, "executor");
     }
 
     final BooleanSupplier shouldOffload() {
         return shouldOffload;
     }
 
-    final Executor executor() {
+    final io.servicetalk.concurrent.Executor executor() {
         return executor;
     }
 
@@ -105,7 +104,7 @@ abstract class TaskBasedAsyncPublisherOperator<T> extends AbstractNoHandleSubscr
 
         private final Subscriber<? super T> target;
         private final BooleanSupplier shouldOffload;
-        private final Executor executor;
+        private final io.servicetalk.concurrent.Executor executor;
         private final Queue<Object> signals;
         // Set in onSubscribe before we enqueue the task which provides memory visibility inside the task.
         // Since any further action happens after onSubscribe, we always guarantee visibility of this field inside
@@ -115,12 +114,14 @@ abstract class TaskBasedAsyncPublisherOperator<T> extends AbstractNoHandleSubscr
         private boolean hasOffloaded;
 
         OffloadedSubscriber(final Subscriber<? super T> target,
-                            final BooleanSupplier shouldOffload, final Executor executor) {
+                            final BooleanSupplier shouldOffload,
+                            final io.servicetalk.concurrent.Executor executor) {
             this(target, shouldOffload, executor, 2);
         }
 
         OffloadedSubscriber(final Subscriber<? super T> target,
-                            final BooleanSupplier shouldOffload, final Executor executor,
+                            final BooleanSupplier shouldOffload,
+                            final io.servicetalk.concurrent.Executor executor,
                             final int publisherSignalQueueInitialCapacity) {
             this.target = target;
             this.shouldOffload = shouldOffload;
@@ -301,9 +302,11 @@ abstract class TaskBasedAsyncPublisherOperator<T> extends AbstractNoHandleSubscr
     static final class OffloadedSubscriptionSubscriber<T> implements Subscriber<T> {
         private final Subscriber<T> subscriber;
         private final BooleanSupplier shouldOffload;
-        private final Executor executor;
+        private final io.servicetalk.concurrent.Executor executor;
 
-        OffloadedSubscriptionSubscriber(Subscriber<T> subscriber, BooleanSupplier shouldOffload, Executor executor) {
+        OffloadedSubscriptionSubscriber(final Subscriber<T> subscriber,
+                                        final BooleanSupplier shouldOffload,
+                                        final io.servicetalk.concurrent.Executor executor) {
             this.subscriber = requireNonNull(subscriber);
             this.shouldOffload = shouldOffload;
             this.executor = executor;
@@ -346,14 +349,16 @@ abstract class TaskBasedAsyncPublisherOperator<T> extends AbstractNoHandleSubscr
         private static final AtomicLongFieldUpdater<OffloadedSubscription> requestedUpdater =
                 AtomicLongFieldUpdater.newUpdater(OffloadedSubscription.class, "requested");
 
-        private final Executor executor;
+        private final io.servicetalk.concurrent.Executor executor;
         private final BooleanSupplier shouldOffload;
         private final Subscription target;
         private volatile int state = STATE_IDLE;
         private volatile long requested;
         private boolean hasOffloaded;
 
-        OffloadedSubscription(Executor executor, BooleanSupplier shouldOffload, Subscription target) {
+        OffloadedSubscription(final io.servicetalk.concurrent.Executor executor,
+                              final BooleanSupplier shouldOffload,
+                              final Subscription target) {
             this.executor = executor;
             this.shouldOffload = shouldOffload;
             this.target = requireNonNull(target);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncSingleOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncSingleOperator.java
@@ -24,7 +24,6 @@ import io.servicetalk.context.api.ContextMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 
@@ -57,21 +56,21 @@ abstract class TaskBasedAsyncSingleOperator<T> extends AbstractNoHandleSubscribe
 
     private final Single<T> original;
     private final BooleanSupplier shouldOffload;
-    private final Executor executor;
+    private final io.servicetalk.concurrent.Executor executor;
 
     TaskBasedAsyncSingleOperator(final Single<T> original,
                                  final BooleanSupplier shouldOffload,
-                                 final Executor executor) {
+                                 final io.servicetalk.concurrent.Executor executor) {
         this.original = original;
-        this.shouldOffload = Objects.requireNonNull(shouldOffload, "shouldOffload");
-        this.executor = Objects.requireNonNull(executor, "executor");
+        this.shouldOffload = requireNonNull(shouldOffload, "shouldOffload");
+        this.executor = requireNonNull(executor, "executor");
     }
 
     final BooleanSupplier shouldOffload() {
         return shouldOffload;
     }
 
-    final Executor executor() {
+    final io.servicetalk.concurrent.Executor executor() {
         return executor;
     }
 
@@ -87,7 +86,8 @@ abstract class TaskBasedAsyncSingleOperator<T> extends AbstractNoHandleSubscribe
         private final Subscriber<T> target;
 
         SingleSubscriberOffloadedTerminals(final Subscriber<T> target,
-                                           final BooleanSupplier shouldOffload, final Executor executor) {
+                                           final BooleanSupplier shouldOffload,
+                                           final io.servicetalk.concurrent.Executor executor) {
             super(shouldOffload, executor);
             this.target = requireNonNull(target);
         }
@@ -141,10 +141,11 @@ abstract class TaskBasedAsyncSingleOperator<T> extends AbstractNoHandleSubscribe
     static final class SingleSubscriberOffloadedCancellable<T> implements Subscriber<T> {
         private final Subscriber<? super T> subscriber;
         private final BooleanSupplier shouldOffload;
-        private final Executor executor;
+        private final io.servicetalk.concurrent.Executor executor;
 
         SingleSubscriberOffloadedCancellable(final Subscriber<? super T> subscriber,
-                                             final BooleanSupplier shouldOffload, final Executor executor) {
+                                             final BooleanSupplier shouldOffload,
+                                             final io.servicetalk.concurrent.Executor executor) {
             this.subscriber = requireNonNull(subscriber);
             this.shouldOffload = shouldOffload;
             this.executor = executor;


### PR DESCRIPTION
Motivation:

`publishOn/subscribeOn` does not need any API that
`io.servicetalk.concurrent.api.Executor` define and can work with
`io.servicetalk.concurrent.Executor`.

Modifications:

- Change argument to `io.servicetalk.concurrent.Executor` for
`publishOn/subscribeOn` in `Completable/Single/Publisher`;
- Update javadoc for modified methods;

Result:

`publishOn/subscribeOn` API is less restrictive for the passed executor.