### PR TITLE
Remove `subscribeShareContext` method

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1519,22 +1519,6 @@ public abstract class Completable {
     }
 
     /**
-     * Signifies that when the returned {@link Completable} is subscribed to, the {@link AsyncContext} will be shared
-     * instead of making a {@link ContextMap#copy() copy}.
-     * <p>
-     * This operator only impacts behavior if the returned {@link Completable} is subscribed directly after this
-     * operator, that means this must be the "last operator" in the chain for this to have an impact.
-     *
-     * @return A {@link Completable} that will share the {@link AsyncContext} instead of making a
-     * {@link ContextMap#copy() copy} when subscribed to.
-     * @deprecated Use {@link #shareContextOnSubscribe()}.
-     */
-    @Deprecated
-    public final Completable subscribeShareContext() {
-        return shareContextOnSubscribe();
-    }
-
-    /**
      * Creates a new {@link Completable} that terminates with the result (either success or error) of either this
      * {@link Completable} or the passed {@code other} {@link Completable}, whichever terminates first. Therefore the
      * result is said to be <strong>ambiguous</strong> relative to which source it originated from. After the first

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2977,22 +2977,6 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Signifies that when the returned {@link Publisher} is subscribed to, the {@link AsyncContext} will be shared
-     * instead of making a {@link ContextMap#copy() copy}.
-     * <p>
-     * This operator only impacts behavior if the returned {@link Publisher} is subscribed directly after this operator,
-     * that means this must be the "last operator" in the chain for this to have an impact.
-     *
-     * @return A {@link Publisher} that will share the {@link AsyncContext} instead of making a
-     * {@link ContextMap#copy() copy} when subscribed to.
-     * @deprecated Use {@link #shareContextOnSubscribe()}.
-     */
-    @Deprecated
-    public final Publisher<T> subscribeShareContext() {
-        return shareContextOnSubscribe();
-    }
-
-    /**
      * <strong>This method requires advanced knowledge of building operators. Before using this method please attempt
      * to compose existing operator(s) to satisfy your use case.</strong>
      * <p>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1464,22 +1464,6 @@ public abstract class Single<T> {
     }
 
     /**
-     * Signifies that when the returned {@link Single} is subscribed to, the {@link AsyncContext} will be shared
-     * instead of making a {@link ContextMap#copy() copy}.
-     * <p>
-     * This operator only impacts behavior if the returned {@link Single} is subscribed directly after this operator,
-     * that means this must be the "last operator" in the chain for this to have an impact.
-     *
-     * @return A {@link Single} that will share the {@link AsyncContext} instead of making a
-     * {@link ContextMap#copy() copy} when subscribed to.
-     * @deprecated Use {@link #shareContextOnSubscribe()}.
-     */
-    @Deprecated
-    public final Single<T> subscribeShareContext() {
-        return shareContextOnSubscribe();
-    }
-
-    /**
      * <strong>This method requires advanced knowledge of building operators. Before using this method please attempt
      * to compose existing operator(s) to satisfy your use case.</strong>
      * <p>


### PR DESCRIPTION
Motivation:

Recently, `subscribeShareContext` method from `Completable`, `Single`,
and `Publisher` were renamed to `shareContextOnSubscribe` and the
previous variant was deprecated.

Modification:

`subscribeShareContext` removed from the API.

Result:

Only recent variant - `shareContextOnSubscribe` to achieve the
functionality exists.