### PR TITLE
`StatelessTrailersTransformer`: Object -> Void state

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -39,7 +39,6 @@ import io.servicetalk.http.api.HttpSerializer;
 import io.servicetalk.http.api.StatelessTrailersTransformer;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
-import io.servicetalk.http.api.TrailersTransformer;
 import io.servicetalk.serializer.api.Deserializer;
 import io.servicetalk.serializer.api.SerializationException;
 import io.servicetalk.serializer.api.Serializer;
@@ -96,7 +95,7 @@ final class GrpcUtils {
     private static final GrpcStatus STATUS_OK = GrpcStatus.fromCodeValue(GrpcStatusCode.OK.value());
     private static final BufferDecoderGroup EMPTY_BUFFER_DECODER_GROUP = new BufferDecoderGroupBuilder().build();
 
-    private static final TrailersTransformer<Object, Buffer> ENSURE_GRPC_STATUS_RECEIVED =
+    private static final StatelessTrailersTransformer<Buffer> ENSURE_GRPC_STATUS_RECEIVED =
             new StatelessTrailersTransformer<Buffer>() {
                 @Override
                 protected HttpHeaders payloadComplete(final HttpHeaders trailers) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfigBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfigBuilder.java
@@ -302,7 +302,7 @@ public final class RedirectConfigBuilder {
 
     private static final class DefaultRedirectRequestTransformer implements RedirectRequestTransformer {
 
-        private static final TrailersTransformer<Object, Buffer> NOOP_TRAILERS_TRANSFORMER =
+        private static final StatelessTrailersTransformer<Buffer> NOOP_TRAILERS_TRANSFORMER =
                 new StatelessTrailersTransformer<>();
 
         private final boolean changePostToGet;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StatelessTrailersTransformer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StatelessTrailersTransformer.java
@@ -20,30 +20,30 @@ package io.servicetalk.http.api;
  *
  * @param <Payload> Type of payload this transformer receives.
  */
-public class StatelessTrailersTransformer<Payload> implements TrailersTransformer<Object, Payload> {
+public class StatelessTrailersTransformer<Payload> implements TrailersTransformer<Void, Payload> {
     @Override
-    public final Object newState() {
+    public final Void newState() {
         return null;
     }
 
     @Override
-    public final Payload accept(final Object __, final Payload payload) {
+    public final Payload accept(final Void __, final Payload payload) {
         return accept(payload);
     }
 
     @Override
-    public final HttpHeaders payloadComplete(final Object __, final HttpHeaders trailers) {
+    public final HttpHeaders payloadComplete(final Void __, final HttpHeaders trailers) {
         return payloadComplete(trailers);
     }
 
     @Override
-    public final HttpHeaders catchPayloadFailure(final Object __, final Throwable cause, final HttpHeaders trailers)
+    public final HttpHeaders catchPayloadFailure(final Void __, final Throwable cause, final HttpHeaders trailers)
             throws Throwable {
         return payloadFailed(cause, trailers);
     }
 
     /**
-     * Same as {@link #accept(Object, Object)} but without the state.
+     * Same as {@link #accept(Void, Object)} but without the state.
      *
      * @param payload {@link Payload} to accept.
      * @return Potentially transformed {@link Payload} instance.
@@ -53,7 +53,7 @@ public class StatelessTrailersTransformer<Payload> implements TrailersTransforme
     }
 
     /**
-     * Same as {@link #payloadComplete(Object, HttpHeaders)} but without the state.
+     * Same as {@link #payloadComplete(Void, HttpHeaders)} but without the state.
      *
      * @param trailers Trailer for the streaming HTTP request/response that is transformed.
      * @return Potentially transformed trailers.
@@ -63,7 +63,7 @@ public class StatelessTrailersTransformer<Payload> implements TrailersTransforme
     }
 
     /**
-     * Same as {@link #catchPayloadFailure(Object, Throwable, HttpHeaders)} but without the state.
+     * Same as {@link #catchPayloadFailure(Void, Throwable, HttpHeaders)} but without the state.
      *
      * @param cause of the payload stream failure.
      * @param trailers Trailer for the streaming HTTP request/response that is transformed.


### PR DESCRIPTION
Motivation:

`StatelessTrailersTransformer` does not have a state. `Void` type is
more appropriate.

Modifications:

- Change the state type from `Object` to `Void`;

Result:

Correct contract for `StatelessTrailersTransformer`.