### PR TITLE
Convert `BlockingStreamingHttpServerResponse` to an interface

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.GracefulAutoCloseable;
-import io.servicetalk.oio.api.PayloadWriter;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
 import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_META_STRATEGY;
@@ -32,8 +31,8 @@ public interface BlockingStreamingHttpService extends
      *
      * @param ctx Context of the service.
      * @param request to handle.
-     * @param response to send to the client. The implementation of this method is responsible for calling
-     * {@link PayloadWriter#close()} on the {@link BlockingStreamingHttpServerResponse#payloadWriter()}.
+     * @param response to send to the client. The implementation of this method is responsible for closing
+     * {@link HttpPayloadWriter} or {@link HttpOutputStream} after meta-data is sent and payload body is written.
      * @throws Exception If an exception occurs during request processing.
      */
     void handle(HttpServiceContext ctx, BlockingStreamingHttpRequest request,

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpServerResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpServerResponse.java
@@ -164,4 +164,30 @@ final class DefaultBlockingStreamingHttpServerResponse extends DefaultHttpRespon
     private static void throwMetaAlreadySent() {
         throw new IllegalStateException("Response meta-data is already sent");
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        final DefaultBlockingStreamingHttpServerResponse that = (DefaultBlockingStreamingHttpServerResponse) o;
+        return metaSent == that.metaSent && sendMeta.equals(that.sendMeta) && payloadWriter.equals(that.payloadWriter)
+                && allocator.equals(that.allocator);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + metaSent;
+        result = 31 * result + sendMeta.hashCode();
+        result = 31 * result + payloadWriter.hashCode();
+        result = 31 * result + allocator.hashCode();
+        return result;
+    }
 }


### PR DESCRIPTION
Motivation:

`BlockingStreamingHttpServerResponse` is the only response type that is
an abstract class, not an interface. It limits users ability to wrap it
to intercept the methods because its ctor is pkg-private.

Modifications:

- Convert `BlockingStreamingHttpServerResponse` to an interface;
- Update `DefaultBlockingStreamingHttpServerResponse` to take full
implementation responsibility;

Result:

`BlockingStreamingHttpServerResponse` is consistent with other response
types and users can wrap it now.