### PR TITLE
Rename special execution strategies

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
@@ -48,7 +48,7 @@ public interface ConnectionFactoryFilter<ResolvedAddress, C extends ListenableAs
      * @return a function that always returns its input {@link ConnectionFactory}.
      */
     static <RA, C extends ListenableAsyncCloseable> ConnectionFactoryFilter<RA, C> identity() {
-        return withStrategy(original -> original, ExecutionStrategy.anyStrategy());
+        return withStrategy(original -> original, ExecutionStrategy.offloadNone());
     }
 
     /**
@@ -87,7 +87,7 @@ public interface ConnectionFactoryFilter<ResolvedAddress, C extends ListenableAs
     @Override
     default ExecutionStrategy requiredOffloads() {
         // safe default--implementations are expected to override if offloading is required.
-        return ConnectExecutionStrategy.anyStrategy();
+        return ConnectExecutionStrategy.offloadNone();
     }
 
     /**

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
@@ -51,7 +51,7 @@ public final class LimitingConnectionFactoryFilter<ResolvedAddress, C extends Li
 
     @Override
     public ExecutionStrategy requiredOffloads() {
-        return ExecutionStrategy.anyStrategy();
+        return ExecutionStrategy.offloadNone();
     }
 
     /**

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
@@ -80,6 +80,6 @@ public final class TransportObserverConnectionFactoryFilter<ResolvedAddress, C e
 
     @Override
     public ExecutionStrategy requiredOffloads() {
-        return ExecutionStrategy.anyStrategy();
+        return ExecutionStrategy.offloadNone();
     }
 }

--- a/servicetalk-examples/grpc/execution-strategy/src/main/java/io/servicetalk/examples/grpc/strategies/ExecutionStrategyServer.java
+++ b/servicetalk-examples/grpc/execution-strategy/src/main/java/io/servicetalk/examples/grpc/strategies/ExecutionStrategyServer.java
@@ -35,7 +35,7 @@ import io.grpc.examples.strategies.HelloRequest;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 
 /**
  * Extends the async "Hello World" example to demonstrate support for alternative execution strategies and executors.
@@ -67,7 +67,7 @@ public final class ExecutionStrategyServer {
             // -> no offloading, route executed on IoExecutor
             System.out.printf("\n%d : no offloading server, async route\n", port);
             ServerContext asyncServer = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(noOffloadsStrategy()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
                     .listenAndAwait((GreeterService)
                             (ctx, request) -> getReplySingle(request, "no offloading server, async route"));
             closeEverything.prepend(asyncServer);
@@ -76,7 +76,7 @@ public final class ExecutionStrategyServer {
             // -> no offloading, route executed on IoExecutor
             System.out.printf("\n%d : no offloading server, blocking route\n", port);
             ServerContext blockingServer = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(noOffloadsStrategy()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
                     .listenAndAwait((Greeter.BlockingGreeterService)
                             (ctx, request) -> getReply(request, "no offloading server, blocking route"));
             closeEverything.prepend(blockingServer);
@@ -85,7 +85,7 @@ public final class ExecutionStrategyServer {
             // -> route offloaded to global executor
             System.out.printf("\n%d : no offloading server, default offloading for the route\n", port);
             ServerContext noOffloadsServerRouteOffloads = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(noOffloadsStrategy()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
                     .listenAndAwait(new Greeter.ServiceFactory.Builder()
                             .sayHello(defaultStrategy(),
                                     (ctx, request) -> getReplySingle(request,
@@ -97,7 +97,7 @@ public final class ExecutionStrategyServer {
             // -> route offloaded to global executor
             System.out.printf("\n%d: no offloading server, custom offloading for the route\n", port);
             ServerContext noOffloadsServerRouteOffloadCustom = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(noOffloadsStrategy()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
                     .listenAndAwait(new Greeter.ServiceFactory.Builder().sayHello(CUSTOM_STRATEGY,
                                     (ctx, request) -> getReplySingle(request,
                                             "no offloading server, custom offloading for the route"))
@@ -118,7 +118,7 @@ public final class ExecutionStrategyServer {
             // -> route offloaded to global executor
             System.out.printf("\n%d : default server, no offloading route\n", port);
             ServerContext noOffloadsRoute = GrpcServers.forPort(port++)
-                    .listenAndAwait(new Greeter.ServiceFactory.Builder().sayHello(noOffloadsStrategy(),
+                    .listenAndAwait(new Greeter.ServiceFactory.Builder().sayHello(offloadNever(),
                                     (ctx, request) -> getReplySingle(request, "default server, no offloading route"))
                             .build());
             closeEverything.prepend(noOffloadsRoute);
@@ -136,9 +136,9 @@ public final class ExecutionStrategyServer {
             // -> no offloading, route executed on IoExecutor
             System.out.printf("\n%d : no offloading server, no offloading route\n", port);
             ServerContext noOffloadsServerRoute = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(noOffloadsStrategy()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
                     .listenAndAwait(new Greeter.ServiceFactory.Builder()
-                            .sayHello(noOffloadsStrategy(),
+                            .sayHello(offloadNever(),
                                     (ctx, request) ->
                                             getReplySingle(request, "no offloading server, no offloading route"))
                             .build());

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -16,6 +16,8 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.http.api.HttpExecutionStrategies;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
 
 /**
  * A factory to create different {@link GrpcExecutionStrategy}.
@@ -23,7 +25,7 @@ import io.servicetalk.http.api.HttpExecutionStrategies;
 public final class GrpcExecutionStrategies {
 
     private static final GrpcExecutionStrategy NEVER_OFFLOAD_STRATEGY =
-            new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.noOffloadsStrategy());
+            new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.offloadNever());
 
     private static final GrpcExecutionStrategy DEFAULT_GRPC_EXECUTION_STRATEGY =
             new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.defaultStrategy());
@@ -33,7 +35,11 @@ public final class GrpcExecutionStrategies {
     }
 
     /**
-     * The default {@link GrpcExecutionStrategy}.
+     * A special default {@link GrpcExecutionStrategy} that offloads all actions unless merged with another strategy
+     * that requires less offloading. The intention of this strategy is to provide a safe default if no strategy is
+     * specified; it should not be returned by
+     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()}, which should return
+     * {@link HttpExecutionStrategy#offloadNone()} or {@link HttpExecutionStrategy#offloadAll()} instead.
      *
      * @return Default {@link GrpcExecutionStrategy}.
      */
@@ -42,11 +48,29 @@ public final class GrpcExecutionStrategies {
     }
 
     /**
-     * A {@link GrpcExecutionStrategy} that disables all offloads.
+     * A special {@link GrpcExecutionStrategy} that disables all offloads on the request-response and transport event
+     * paths. This strategy is intended to be used only for client and server builders; it should not be returned by
+     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()}, which should return a custom strategy instead.
+     * When merged with another execution strategy the result is always this strategy.
      *
-     * @return {@link GrpcExecutionStrategy} that disables all offloads.
+     * @return {@link GrpcExecutionStrategy} that disables all request-response path offloads.
+     * @see #offloadNever()
+     * @deprecated Replaced with more descriptive {@link #offloadNever()}.
      */
+    @Deprecated
     public static GrpcExecutionStrategy noOffloadsStrategy() {
+        return NEVER_OFFLOAD_STRATEGY;
+    }
+
+    /**
+     * A special {@link HttpExecutionStrategy} that disables all offloads on the request-response and transport event
+     * paths. This strategy is intended to be used only for client and server builders; it should not be returned by
+     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()}, which should return a custom strategy instead.
+     * When merged with another execution strategy the result is always this strategy.
+     *
+     * @return {@link GrpcExecutionStrategy} that disables all request-response path offloads.
+     */
+    public static GrpcExecutionStrategy offloadNever() {
         return NEVER_OFFLOAD_STRATEGY;
     }
 
@@ -93,6 +117,16 @@ public final class GrpcExecutionStrategies {
          */
         public Builder offloadSend() {
             httpBuilder.offloadSend();
+            return this;
+        }
+
+        /**
+         * Enables offloading of events.
+         *
+         * @return {@code this}.
+         */
+        public Builder offloadEvent() {
+            httpBuilder.offloadEvent();
             return this;
         }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategy.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategy.java
@@ -34,8 +34,8 @@ public interface GrpcExecutionStrategy extends HttpExecutionStrategy {
         GrpcExecutionStrategy result;
         if (httpExecutionStrategy instanceof GrpcExecutionStrategy) {
             result = (GrpcExecutionStrategy) httpExecutionStrategy;
-        } else if (HttpExecutionStrategies.noOffloadsStrategy() == httpExecutionStrategy) {
-            result = GrpcExecutionStrategies.noOffloadsStrategy();
+        } else if (HttpExecutionStrategies.offloadNever() == httpExecutionStrategy) {
+            result = GrpcExecutionStrategies.offloadNever();
         } else if (HttpExecutionStrategies.defaultStrategy() == httpExecutionStrategy) {
             result = GrpcExecutionStrategies.defaultStrategy();
         } else {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -173,7 +173,7 @@ final class GrpcRouter {
             final StreamingHttpService route = closeable.append(adapterHolder.adaptor());
             final GrpcExecutionStrategy routeStrategy = executionStrategies.getOrDefault(path, null);
             final HttpExecutionStrategy missing = null == routeStrategy ?
-                    HttpExecutionStrategies.noOffloadsStrategy() :
+                    HttpExecutionStrategies.offloadNever() :
                     executionContext.executionStrategy().missing(routeStrategy);
             verifyNoOverrides(allRoutes.put(path,
                     null != routeStrategy && missing.isRequestResponseOffloaded() ?

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -40,7 +40,7 @@ import java.util.TreeSet;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.grpc.api.GrpcHeaderValues.GRPC_CONTENT_TYPE_PROTO_SUFFIX;
 import static io.servicetalk.grpc.api.GrpcUtils.compressors;
 import static io.servicetalk.grpc.api.GrpcUtils.decompressors;
@@ -57,7 +57,7 @@ import static io.servicetalk.utils.internal.ReflectionUtils.retrieveMethod;
  */
 public abstract class GrpcRoutes<Service extends GrpcService> {
     private static final GrpcExecutionStrategy NULL = new DefaultGrpcExecutionStrategy(
-            HttpExecutionStrategies.noOffloadsStrategy());
+            HttpExecutionStrategies.offloadNever());
 
     private final GrpcRouter.Builder routeBuilder;
     private final Set<String> errors;
@@ -197,7 +197,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             return saved;
         }
         return getAndValidateRouteExecutionStrategyAnnotationIfPresent(method, clazz, strategyFactory, errors,
-                noOffloadsStrategy());
+                offloadNever());
     }
 
     /**

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/CatchAllHttpServiceFilter.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/CatchAllHttpServiceFilter.java
@@ -64,6 +64,6 @@ final class CatchAllHttpServiceFilter implements StreamingHttpServiceFilterFacto
 
     @Override
     public HttpExecutionStrategy requiredOffloads() {
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -154,7 +154,7 @@ final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
         @Override
         public HttpExecutionStrategy requiredOffloads() {
             // no influence since we do not block
-            return HttpExecutionStrategies.anyStrategy();
+            return HttpExecutionStrategies.offloadNone();
         }
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
@@ -94,7 +94,7 @@ final class Utils {
 
         @Override
         public GrpcExecutionStrategy executionStrategy() {
-            return GrpcExecutionStrategies.noOffloadsStrategy();
+            return GrpcExecutionStrategies.offloadNever();
         }
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
@@ -70,7 +70,7 @@ import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
@@ -418,7 +418,7 @@ class ErrorHandlingTest {
     }
 
     static Collection<Arguments> data() {
-        GrpcExecutionStrategy noopStrategy = noOffloadsStrategy();
+        GrpcExecutionStrategy noopStrategy = offloadNever();
         GrpcExecutionStrategy[] strategies =
                 new GrpcExecutionStrategy[]{noopStrategy, defaultStrategy()};
         List<Arguments> data = new ArrayList<>(strategies.length * 2 * TestMode.values().length);

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyConfigurationFailuresTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyConfigurationFailuresTest.java
@@ -30,7 +30,7 @@ import io.servicetalk.router.api.RouteExecutionStrategyFactory;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.router.utils.internal.DefaultRouteExecutionStrategyFactory.getUsingDefaultStrategyFactory;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -109,7 +109,7 @@ class ExecutionStrategyConfigurationFailuresTest {
     private static final TesterService MISCONFIGURED_SERVICE = new MisconfiguredService();
     private static final BlockingTesterService MISCONFIGURED_BLOCKING_SERVICE = new MisconfiguredBlockingService();
     private static final RouteExecutionStrategyFactory<GrpcExecutionStrategy> STRATEGY_FACTORY =
-            id -> "test".equals(id) ? noOffloadsStrategy() : getUsingDefaultStrategyFactory(id);
+            id -> "test".equals(id) ? offloadNever() : getUsingDefaultStrategyFactory(id);
 
     @Test
     void usingServiceFactoryAsyncService() {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
@@ -47,7 +47,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_EXEC_ID_STRATEGY_ASYNC_SERVICE;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_EXEC_ID_STRATEGY_BLOCKING_SERVICE;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE;
@@ -126,7 +126,7 @@ class ExecutionStrategyTest {
         NO_OFFLOADS {
             @Override
             void configureContextExecutionStrategy(GrpcServerBuilder builder) {
-                builder.initializeHttp(b -> b.executionStrategy(noOffloadsStrategy()));
+                builder.initializeHttp(b -> b.executionStrategy(offloadNever()));
             }
         };
 
@@ -162,10 +162,10 @@ class ExecutionStrategyTest {
             @Override
             ServiceFactory getServiceFactory() {
                 return new ServiceFactory.Builder(STRATEGY_FACTORY)
-                        .test(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
-                        .testBiDiStream(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
-                        .testResponseStream(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
-                        .testRequestStream(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .test(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .testBiDiStream(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .testResponseStream(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .testRequestStream(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
                         .build();
             }
         },
@@ -197,10 +197,10 @@ class ExecutionStrategyTest {
             @Override
             ServiceFactory getServiceFactory() {
                 return new ServiceFactory.Builder(STRATEGY_FACTORY)
-                        .testBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
-                        .testBiDiStreamBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
-                        .testResponseStreamBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
-                        .testRequestStreamBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testBiDiStreamBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testResponseStreamBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testRequestStreamBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
                         .build();
             }
         };
@@ -269,7 +269,7 @@ class ExecutionStrategyTest {
         ServiceFactory serviceFactory = routeStrategy.getServiceFactory();
         serverContext = builder.listenAndAwait(serviceFactory);
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .initializeHttp(b -> b.executionStrategy(HttpExecutionStrategies.noOffloadsStrategy()))
+                .initializeHttp(b -> b.executionStrategy(HttpExecutionStrategies.offloadNever()))
                 .buildBlocking(new ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientRequiresTrailersTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientRequiresTrailersTest.java
@@ -44,7 +44,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.grpc.api.GrpcHeaderNames.GRPC_STATUS;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.util.Collections.singletonList;
@@ -106,7 +106,7 @@ class GrpcClientRequiresTrailersTest {
                 });
 
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .initializeHttp(builder -> builder.executionStrategy(noOffloadsStrategy()))
+                .initializeHttp(builder -> builder.executionStrategy(offloadNever()))
                 .buildBlocking(new TesterProto.Tester.ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientValidatesContentTypeTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientValidatesContentTypeTest.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -87,7 +87,7 @@ final class GrpcClientValidatesContentTypeTest {
                 });
 
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .initializeHttp(builder -> builder.executionStrategy(noOffloadsStrategy()))
+                .initializeHttp(builder -> builder.executionStrategy(offloadNever()))
                 .buildBlocking(new TesterProto.Tester.ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcRouterConfigurationTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcRouterConfigurationTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_NO_OFFLOADS_STRATEGY_BLOCKING_SERVICE;
@@ -143,36 +143,36 @@ class GrpcRouterConfigurationTest {
         final TesterService asyncService = DEFAULT_STRATEGY_ASYNC_SERVICE;
         testCanNotOverrideAlreadyRegisteredPath(TestRpc.PATH, builder -> builder
                 .test(asyncService)
-                .test(noOffloadsStrategy(), asyncService));
+                .test(offloadNever(), asyncService));
 
         testCanNotOverrideAlreadyRegisteredPath(TestBiDiStreamRpc.PATH, builder -> builder
                 .testBiDiStream(asyncService)
-                .testBiDiStream(noOffloadsStrategy(), asyncService));
+                .testBiDiStream(offloadNever(), asyncService));
 
         testCanNotOverrideAlreadyRegisteredPath(TestResponseStreamRpc.PATH, builder -> builder
                 .testResponseStream(asyncService)
-                .testResponseStream(noOffloadsStrategy(), asyncService));
+                .testResponseStream(offloadNever(), asyncService));
 
         testCanNotOverrideAlreadyRegisteredPath(TestRequestStreamRpc.PATH, builder -> builder
                 .testRequestStream(asyncService)
-                .testRequestStream(noOffloadsStrategy(), asyncService));
+                .testRequestStream(offloadNever(), asyncService));
 
         final BlockingTesterService blockingService = DEFAULT_STRATEGY_BLOCKING_SERVICE;
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestRpc.PATH, builder -> builder
                 .testBlocking(blockingService)
-                .testBlocking(noOffloadsStrategy(), blockingService));
+                .testBlocking(offloadNever(), blockingService));
 
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestBiDiStreamRpc.PATH, builder -> builder
                 .testBiDiStreamBlocking(blockingService)
-                .testBiDiStreamBlocking(noOffloadsStrategy(), blockingService));
+                .testBiDiStreamBlocking(offloadNever(), blockingService));
 
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestResponseStreamRpc.PATH, builder -> builder
                 .testResponseStreamBlocking(blockingService)
-                .testResponseStreamBlocking(noOffloadsStrategy(), blockingService));
+                .testResponseStreamBlocking(offloadNever(), blockingService));
 
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestRequestStreamRpc.PATH, builder -> builder
                 .testRequestStreamBlocking(blockingService)
-                .testRequestStreamBlocking(noOffloadsStrategy(), blockingService));
+                .testRequestStreamBlocking(offloadNever(), blockingService));
     }
 
     @Test

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -116,7 +116,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.DEFAULT_TIMEOUT_SECONDS;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.grpc.api.GrpcStatusCode.CANCELLED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
 import static io.servicetalk.grpc.internal.DeadlineUtils.GRPC_TIMEOUT_HEADER_KEY;
@@ -403,7 +403,7 @@ class ProtocolCompatibilityTest {
                                                        final String compression)
             throws Exception {
         final TestServerContext server = serviceTalkServer(ErrorMode.SIMPLE_IN_RESPONSE, ssl,
-                noOffloadsStrategy(), compression, null);
+                offloadNever(), compression, null);
         final CompatClient client = grpcJavaClient(server.listenAddress(), compression, ssl, null);
         testGrpcError(client, server, false, streaming, compression);
     }
@@ -457,7 +457,7 @@ class ProtocolCompatibilityTest {
         final boolean streaming,
         final String compression) throws Exception {
         final TestServerContext server = serviceTalkServer(ErrorMode.STATUS_IN_RESPONSE, ssl,
-                noOffloadsStrategy(), compression, null);
+                offloadNever(), compression, null);
         final CompatClient client = grpcJavaClient(server.listenAddress(), compression, ssl, null);
         testGrpcError(client, server, true, streaming, compression);
     }
@@ -602,7 +602,7 @@ class ProtocolCompatibilityTest {
         Duration serverTimeout = clientInitiatedTimeout ? null : DEFAULT_DEADLINE;
         BlockingQueue<Throwable> serverErrorQueue = new ArrayBlockingQueue<>(16);
         final TestServerContext server = stServer ?
-                serviceTalkServer(ErrorMode.NONE, false, noOffloadsStrategy(), null, null, serverErrorQueue) :
+                serviceTalkServer(ErrorMode.NONE, false, offloadNever(), null, null, serverErrorQueue) :
                 grpcJavaServer(ErrorMode.NONE, false, null);
         try (ServerContext proxyCtx = buildTimeoutProxy(server.listenAddress(), serverTimeout, false)) {
             final CompatClient client = stClient ?
@@ -632,7 +632,7 @@ class ProtocolCompatibilityTest {
     private static ServerContext buildTimeoutProxy(SocketAddress serverAddress, @Nullable Duration forcedTimeout,
                                                    boolean ssl) throws Exception {
         HttpServerBuilder proxyBuilder = HttpServers.forAddress(localAddress(0))
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .protocols(h2().build());
         if (ssl) {
             proxyBuilder.sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
@@ -650,7 +650,7 @@ class ProtocolCompatibilityTest {
                                  boolean ssl) {
             SingleAddressHttpClientBuilder<InetSocketAddress, InetSocketAddress> builder =
                     HttpClients.forResolvedAddress((InetSocketAddress) serverAddress)
-                            .executionStrategy(noOffloadsStrategy())
+                            .executionStrategy(offloadNever())
                             .protocols(h2().build());
             if (ssl) {
                 builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
@@ -29,11 +29,11 @@ public final class ConnectAndHttpExecutionStrategy implements ConnectExecutionSt
     final HttpExecutionStrategy httpStrategy;
 
     public ConnectAndHttpExecutionStrategy(ConnectExecutionStrategy connectStrategy) {
-        this(connectStrategy, HttpExecutionStrategies.anyStrategy());
+        this(connectStrategy, HttpExecutionStrategies.offloadNone());
     }
 
     public ConnectAndHttpExecutionStrategy(HttpExecutionStrategy httpStrategy) {
-        this(ConnectExecutionStrategy.anyStrategy(), httpStrategy);
+        this(ConnectExecutionStrategy.offloadNone(), httpStrategy);
     }
 
     public ConnectAndHttpExecutionStrategy(ConnectExecutionStrategy connect, HttpExecutionStrategy http) {
@@ -104,7 +104,7 @@ public final class ConnectAndHttpExecutionStrategy implements ConnectExecutionSt
         } else {
             return other.hasOffloads() ?
                     new ConnectAndHttpExecutionStrategy(
-                            ConnectExecutionStrategy.offload(),
+                            ConnectExecutionStrategy.offloadAll(),
                             HttpExecutionStrategies.offloadAll())
                     : this;
         }
@@ -149,8 +149,8 @@ public final class ConnectAndHttpExecutionStrategy implements ConnectExecutionSt
     /**
      * Converts the provided execution strategy to a {@link ConnectExecutionStrategy}. If the provided strategy is
      * already {@link ConnectExecutionStrategy} it is returned unchanged. For other strategies, if the strategy
-     * {@link ExecutionStrategy#hasOffloads()} then {@link ConnectExecutionStrategy#offload()} is returned otherwise
-     * {@link ConnectExecutionStrategy#anyStrategy()} is returned.
+     * {@link ExecutionStrategy#hasOffloads()} then {@link ConnectExecutionStrategy#offloadAll()} is returned otherwise
+     * {@link ConnectExecutionStrategy#offloadNone()} is returned.
      *
      * @param executionStrategy The {@link ExecutionStrategy} to convert
      * @return converted {@link ConnectExecutionStrategy}.
@@ -159,7 +159,7 @@ public final class ConnectAndHttpExecutionStrategy implements ConnectExecutionSt
         return executionStrategy instanceof ConnectAndHttpExecutionStrategy ?
                 (ConnectAndHttpExecutionStrategy) executionStrategy :
                     new ConnectAndHttpExecutionStrategy(
-                            ConnectExecutionStrategy.anyStrategy(), HttpExecutionStrategies.defaultStrategy())
+                            ConnectExecutionStrategy.offloadNone(), HttpExecutionStrategies.defaultStrategy())
                             .merge(executionStrategy);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
@@ -85,7 +85,7 @@ public final class ContentCodingHttpRequesterFilter
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     private Single<StreamingHttpResponse> codecTransformBidirectionalIfNeeded(final StreamingHttpRequester delegate,

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
@@ -130,7 +130,7 @@ public final class ContentCodingHttpServiceFilter implements StreamingHttpServic
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     private static void encodePayloadContentIfAvailable(final HttpHeaders requestHeaders,

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpRequesterFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpRequesterFilter.java
@@ -78,7 +78,7 @@ public final class ContentEncodingHttpRequesterFilter implements
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     private Single<StreamingHttpResponse> applyEncodingAndDecoding(final StreamingHttpRequester delegate,

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
@@ -130,7 +130,7 @@ public final class ContentEncodingHttpServiceFilter implements StreamingHttpServ
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     private static boolean isPassThrough(final HttpRequestMethod method, final StreamingHttpResponse response) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -37,10 +37,11 @@ public final class HttpExecutionStrategies {
     /**
      * A special default {@link HttpExecutionStrategy} that offloads all actions unless merged with another strategy
      * that requires less offloading. The intention of this strategy is to provide a safe default if no strategy is
-     * specified.
+     * specified; it should not be returned by
+     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()}, which should return {@link #offloadNone()} or
+     * {@link #offloadAll()} instead.
      *
      * @return Default {@link HttpExecutionStrategy}.
-     * @see #offloadAll()
      */
     public static HttpExecutionStrategy defaultStrategy() {
         return DEFAULT_HTTP_EXECUTION_STRATEGY;
@@ -48,23 +49,42 @@ public final class HttpExecutionStrategies {
 
     /**
      * A special {@link HttpExecutionStrategy} that disables all offloads on the request-response and transport event
-     * paths. When merged with another execution strategy the result is always this strategy.
+     * paths. This strategy is intended to be used only for client and server builders; it should not be returned by
+     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()}, which should return {@link #offloadNone()} instead.
+     * When merged with another execution strategy the result is always this strategy.
      *
      * @return {@link HttpExecutionStrategy} that disables all request-response path offloads.
-     * @see #anyStrategy()
+     * @see #offloadNever()
+     * @deprecated Replaced with more descriptive {@link #offloadNever()}.
      */
-    public static HttpExecutionStrategy noOffloadsStrategy() {
+    @Deprecated
+    public static HttpExecutionStrategy noOffloadStrategy() {
+        return OFFLOAD_NEVER_STRATEGY;
+    }
+
+    /**
+     * A special {@link HttpExecutionStrategy} that disables all offloads on the request-response and transport event
+     * paths. This strategy is intended to be used only for client and server builders; it should not be returned by
+     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()}, which should return {@link #offloadNone()} instead.
+     * When merged with another execution strategy the result is always this strategy.
+     *
+     * @return {@link HttpExecutionStrategy} that disables all request-response path offloads.
+     * @see #offloadNone()
+     */
+    public static HttpExecutionStrategy offloadNever() {
         return OFFLOAD_NEVER_STRATEGY;
     }
 
     /**
      * An {@link HttpExecutionStrategy} that requires no offloads on the request-response path or transport event path.
-     * Unlike {@link #noOffloadsStrategy()}, this strategy merges normally with other execution strategy instances.
+     * For {@link HttpExecutionStrategyInfluencer}s that do not block, the
+     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()} method should return this value. Unlike
+     * {@link #offloadNever()}, this strategy merges normally with other execution strategy instances.
      *
      * @return {@link HttpExecutionStrategy} that requires no request-response path offloads.
-     * @see #noOffloadsStrategy()
+     * @see #offloadNever()
      */
-    public static HttpExecutionStrategy anyStrategy() {
+    public static HttpExecutionStrategy offloadNone() {
         return DefaultHttpExecutionStrategy.OFFLOAD_NONE_STRATEGY;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategy.java
@@ -122,6 +122,6 @@ public interface HttpExecutionStrategy extends ExecutionStrategy {
                 ((HttpExecutionStrategy) strategy) :
                 strategy.hasOffloads() ?
                         HttpExecutionStrategyInfluencer.defaultStreamingInfluencer().requiredOffloads() :
-                        HttpExecutionStrategies.anyStrategy();
+                        HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
@@ -41,8 +41,8 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
      * {@inheritDoc}
      *
      * <p>The provided default implementation requests offloading of all operations. Implementations that require no
-     * offloading should be careful to return {@link HttpExecutionStrategies#anyStrategy()} rather than
-     * {@link HttpExecutionStrategies#noOffloadsStrategy()}.
+     * offloading should be careful to return {@link HttpExecutionStrategies#offloadNone()} rather than
+     * {@link HttpExecutionStrategies#offloadNever()}.
      */
     @Override
     default HttpExecutionStrategy requiredOffloads() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerChainBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerChainBuilder.java
@@ -151,7 +151,7 @@ public final class StrategyInfluencerChainBuilder implements ExecutionStrategyIn
         HttpExecutionStrategy strategy = influencers.stream()
                 .map(ExecutionStrategyInfluencer::requiredOffloads)
                 .map(HttpExecutionStrategy::from)
-                .reduce(HttpExecutionStrategies.anyStrategy(), HttpExecutionStrategy::merge);
+                .reduce(HttpExecutionStrategies.offloadNone(), HttpExecutionStrategy::merge);
         return HttpExecutionStrategyInfluencer.newInfluencer(strategy);
     }
 
@@ -166,6 +166,6 @@ public final class StrategyInfluencerChainBuilder implements ExecutionStrategyIn
                 .map(ExecutionStrategyInfluencer::requiredOffloads)
                 .map(HttpExecutionStrategy::from)
                 .reduce(HttpExecutionStrategy::merge)
-                .orElse(HttpExecutionStrategies.anyStrategy());
+                .orElse(HttpExecutionStrategies.offloadNone());
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
@@ -28,7 +28,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpApiConversions.toBlockingClient;
 import static io.servicetalk.http.api.HttpApiConversions.toBlockingStreamingClient;
 import static io.servicetalk.http.api.HttpApiConversions.toClient;
-import static io.servicetalk.http.api.HttpExecutionStrategies.anyStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static java.util.Objects.requireNonNull;
 
 public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHttpRequesterTest {
@@ -108,17 +108,17 @@ public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHt
 
         @Override
         public HttpClient asClient() {
-            return toClient(this, anyStrategy());
+            return toClient(this, offloadNone());
         }
 
         @Override
         public BlockingStreamingHttpClient asBlockingStreamingClient() {
-            return toBlockingStreamingClient(this, anyStrategy());
+            return toBlockingStreamingClient(this, offloadNone());
         }
 
         @Override
         public BlockingHttpClient asBlockingClient() {
-            return toBlockingClient(this, anyStrategy());
+            return toBlockingClient(this, offloadNone());
         }
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionTest.java
@@ -28,7 +28,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpApiConversions.toBlockingConnection;
 import static io.servicetalk.http.api.HttpApiConversions.toBlockingStreamingConnection;
 import static io.servicetalk.http.api.HttpApiConversions.toConnection;
-import static io.servicetalk.http.api.HttpExecutionStrategies.anyStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -117,17 +117,17 @@ public class BlockingStreamingHttpConnectionTest extends AbstractBlockingStreami
 
         @Override
         public HttpConnection asConnection() {
-            return toConnection(this, anyStrategy());
+            return toConnection(this, offloadNone());
         }
 
         @Override
         public BlockingStreamingHttpConnection asBlockingStreamingConnection() {
-            return toBlockingStreamingConnection(this, anyStrategy());
+            return toBlockingStreamingConnection(this, offloadNone());
         }
 
         @Override
         public BlockingHttpConnection asBlockingConnection() {
-            return toBlockingConnection(this, anyStrategy());
+            return toBlockingConnection(this, offloadNone());
         }
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
@@ -54,7 +54,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
-import static io.servicetalk.http.api.HttpExecutionStrategies.anyStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpHeaderNames.TRAILER;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
@@ -229,7 +229,7 @@ class BlockingStreamingToStreamingServiceTest {
                 closedCalled.set(true);
             }
         };
-        StreamingHttpService asyncService = toStreamingHttpService(syncService, anyStrategy()).adaptor();
+        StreamingHttpService asyncService = toStreamingHttpService(syncService, offloadNone()).adaptor();
         asyncService.closeAsync().toFuture().get();
         assertThat(closedCalled.get(), is(true));
     }
@@ -250,7 +250,7 @@ class BlockingStreamingToStreamingServiceTest {
                 onErrorLatch.countDown();
             }
         };
-        StreamingHttpService asyncService = toStreamingHttpService(syncService, anyStrategy()).adaptor();
+        StreamingHttpService asyncService = toStreamingHttpService(syncService, offloadNone()).adaptor();
         toSource(asyncService.handle(mockCtx, reqRespFactory.get("/"), reqRespFactory)
                 // Use subscribeOn(Executor) instead of HttpExecutionStrategy#invokeService which returns a flatten
                 // Publisher<Object> to verify that cancellation of Single<StreamingHttpResponse> interrupts the thread
@@ -297,7 +297,7 @@ class BlockingStreamingToStreamingServiceTest {
                 serviceTerminationLatch.countDown();
             }
         };
-        StreamingHttpService asyncService = toStreamingHttpService(syncService, anyStrategy()).adaptor();
+        StreamingHttpService asyncService = toStreamingHttpService(syncService, offloadNone()).adaptor();
         StreamingHttpResponse asyncResponse = asyncService.handle(mockCtx, reqRespFactory.get("/"), reqRespFactory)
                 // Use subscribeOn(Executor) instead of HttpExecutionStrategy#invokeService which returns a flatten
                 // Publisher<Object> to verify that cancellation of Publisher<Buffer> interrupts the thread of handle
@@ -368,7 +368,7 @@ class BlockingStreamingToStreamingServiceTest {
         BlockingStreamingHttpService syncService = (ctx, request, response) -> {
             throw DELIBERATE_EXCEPTION;
         };
-        StreamingHttpService asyncService = toStreamingHttpService(syncService, anyStrategy()).adaptor();
+        StreamingHttpService asyncService = toStreamingHttpService(syncService, offloadNone()).adaptor();
         toSource(asyncService.handle(mockCtx, reqRespFactory.get("/"), reqRespFactory)
                 // Use subscribeOn(Executor) instead of HttpExecutionStrategy#invokeService which returns a flatten
                 // Publisher<Object> to verify that the Single<StreamingHttpResponse> of response meta-data terminates
@@ -403,7 +403,7 @@ class BlockingStreamingToStreamingServiceTest {
             response.sendMetaData();
             throw DELIBERATE_EXCEPTION;
         };
-        StreamingHttpService asyncService = toStreamingHttpService(syncService, anyStrategy()).adaptor();
+        StreamingHttpService asyncService = toStreamingHttpService(syncService, offloadNone()).adaptor();
         StreamingHttpResponse asyncResponse = asyncService.handle(mockCtx, reqRespFactory.get("/"), reqRespFactory)
                 // Use subscribeOn(Executor) instead of HttpExecutionStrategy#invokeService which returns a flatten
                 // Publisher<Object> to verify that the Publisher<Buffer> of payload body terminates with an error
@@ -445,7 +445,7 @@ class BlockingStreamingToStreamingServiceTest {
 
     private List<Object> invokeService(BlockingStreamingHttpService syncService,
                                        StreamingHttpRequest request) throws Exception {
-        ServiceAdapterHolder holder = toStreamingHttpService(syncService, anyStrategy());
+        ServiceAdapterHolder holder = toStreamingHttpService(syncService, offloadNone());
 
         Collection<Object> responseCollection =
                 invokeService(holder.serviceInvocationStrategy(), executorExtension.executor(), request,

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
@@ -39,7 +39,7 @@ import static io.servicetalk.concurrent.api.Single.never;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.StreamingHttpRequests.newRequest;
@@ -154,7 +154,7 @@ class DefaultHttpExecutionStrategyTest {
                 new TestHttpServiceContext(INSTANCE, respFactory,
                         // Use noOffloadsStrategy() for the ctx to indicate that there was no offloading before.
                         // So, the difference function inside #offloadService will return the tested strategy.
-                        new ExecutionContextToHttpExecutionContext(contextRule, noOffloadsStrategy()));
+                        new ExecutionContextToHttpExecutionContext(contextRule, offloadNever()));
         Callable<?> runHandle = () -> {
                 return analyzer.instrumentedResponseForServer(svc.handle(ctx, req, ctx.streamingResponseFactory()))
                         .flatMapPublisher(StreamingHttpResponse::payloadBody)
@@ -346,7 +346,7 @@ class DefaultHttpExecutionStrategyTest {
         }
 
         void verifyThread(final boolean offloadedPath, final String errMsg) {
-            if (strategy == noOffloadsStrategy() && testThread != currentThread()) {
+            if (strategy == offloadNever() && testThread != currentThread()) {
                 addError(errMsg);
             } else if (offloadedPath && testThread == currentThread()) {
                 addError(errMsg);

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategiesTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategiesTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.difference;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -58,14 +58,14 @@ class HttpExecutionStrategiesTest {
     @Test
     void diffRightNoOffload() {
         HttpExecutionStrategy strat1 = customStrategyBuilder().offloadReceiveData().build();
-        HttpExecutionStrategy strat2 = noOffloadsStrategy();
+        HttpExecutionStrategy strat2 = offloadNever();
         HttpExecutionStrategy result = difference(strat1, strat2);
         assertThat("Unexpected diff.", result, is(nullValue()));
     }
 
     @Test
     void diffLeftNoOffload() {
-        HttpExecutionStrategy strat1 = noOffloadsStrategy();
+        HttpExecutionStrategy strat1 = offloadNever();
         HttpExecutionStrategy strat2 = customStrategyBuilder().offloadReceiveData().build();
         HttpExecutionStrategy result = difference(strat1, strat2);
         assertThat("Unexpected diff.", result, is(sameInstance(strat2)));
@@ -104,14 +104,14 @@ class HttpExecutionStrategiesTest {
     @Test
     void missingRightNoOffload() {
         HttpExecutionStrategy strat1 = customStrategyBuilder().offloadReceiveData().build();
-        HttpExecutionStrategy strat2 = noOffloadsStrategy();
+        HttpExecutionStrategy strat2 = offloadNever();
         HttpExecutionStrategy result = strat1.missing(strat2);
-        assertThat("Unexpected diff.", result, is(sameInstance(HttpExecutionStrategies.anyStrategy())));
+        assertThat("Unexpected diff.", result, is(sameInstance(HttpExecutionStrategies.offloadNone())));
     }
 
     @Test
     void missingLeftNoOffload() {
-        HttpExecutionStrategy strat1 = noOffloadsStrategy();
+        HttpExecutionStrategy strat1 = offloadNever();
         HttpExecutionStrategy strat2 = customStrategyBuilder().offloadReceiveData().build();
         HttpExecutionStrategy result = strat1.missing(strat2);
         assertThat("Unexpected diff.", result, is(sameInstance(strat2)));

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StrategyInfluencerChainBuilderTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StrategyInfluencerChainBuilderTest.java
@@ -95,7 +95,7 @@ class StrategyInfluencerChainBuilderTest {
     @Nonnull
     private HttpExecutionStrategyInfluencer newNoInfluenceInfluencer() {
         HttpExecutionStrategyInfluencer influencer1 = mock(HttpExecutionStrategyInfluencer.class);
-        when(influencer1.requiredOffloads()).thenReturn(HttpExecutionStrategies.anyStrategy());
+        when(influencer1.requiredOffloads()).thenReturn(HttpExecutionStrategies.offloadNone());
         when(influencer1.influenceStrategy(any(HttpExecutionStrategy.class)))
                 .then(invocation -> invocation.getArgument(0));
         return influencer1;

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
@@ -95,18 +95,18 @@ public final class TestStreamingHttpClient {
                         .map(rc -> new ReservedStreamingHttpConnection() {
                             @Override
                             public ReservedHttpConnection asConnection() {
-                                return toReservedConnection(this, HttpExecutionStrategies.anyStrategy());
+                                return toReservedConnection(this, HttpExecutionStrategies.offloadNone());
                             }
 
                             @Override
                             public ReservedBlockingStreamingHttpConnection asBlockingStreamingConnection() {
                                 return toReservedBlockingStreamingConnection(this,
-                                        HttpExecutionStrategies.anyStrategy());
+                                        HttpExecutionStrategies.offloadNone());
                             }
 
                             @Override
                             public ReservedBlockingHttpConnection asBlockingConnection() {
-                                return toReservedBlockingConnection(this, HttpExecutionStrategies.anyStrategy());
+                                return toReservedBlockingConnection(this, HttpExecutionStrategies.offloadNone());
                             }
 
                             @Override
@@ -199,17 +199,17 @@ public final class TestStreamingHttpClient {
 
             @Override
             public HttpClient asClient() {
-                return toClient(this, HttpExecutionStrategies.anyStrategy());
+                return toClient(this, HttpExecutionStrategies.offloadNone());
             }
 
             @Override
             public BlockingStreamingHttpClient asBlockingStreamingClient() {
-                return toBlockingStreamingClient(this, HttpExecutionStrategies.anyStrategy());
+                return toBlockingStreamingClient(this, HttpExecutionStrategies.offloadNone());
             }
 
             @Override
             public BlockingHttpClient asBlockingClient() {
-                return toBlockingClient(this, HttpExecutionStrategies.anyStrategy());
+                return toBlockingClient(this, HttpExecutionStrategies.offloadNone());
             }
         };
     }

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpConnection.java
@@ -138,17 +138,17 @@ public final class TestStreamingHttpConnection {
 
             @Override
             public HttpConnection asConnection() {
-                return toConnection(this, HttpExecutionStrategies.anyStrategy());
+                return toConnection(this, HttpExecutionStrategies.offloadNone());
             }
 
             @Override
             public BlockingStreamingHttpConnection asBlockingStreamingConnection() {
-                return toBlockingStreamingConnection(this, HttpExecutionStrategies.anyStrategy());
+                return toBlockingStreamingConnection(this, HttpExecutionStrategies.offloadNone());
             }
 
             @Override
             public BlockingHttpConnection asBlockingConnection() {
-                return toBlockingConnection(this, HttpExecutionStrategies.anyStrategy());
+                return toBlockingConnection(this, HttpExecutionStrategies.offloadNone());
             }
         };
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
@@ -78,7 +78,7 @@ final class AbsoluteAddressHttpRequesterFilter implements StreamingHttpClientFil
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
@@ -135,7 +135,7 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
                     return new LoadBalancedStreamingHttpConnection(protocolBinding.apply(filteredConnection),
                             concurrencyController, executionContext.executionStrategy(),
                             connectStrategy instanceof HttpExecutionStrategy ?
-                                    (HttpExecutionStrategy) connectStrategy : HttpExecutionStrategies.anyStrategy());
+                                    (HttpExecutionStrategy) connectStrategy : HttpExecutionStrategies.offloadNone());
                 });
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
@@ -158,7 +158,7 @@ abstract class AbstractLifecycleObserverHttpFilter implements ExecutionStrategyI
     @Override
     public final HttpExecutionStrategy requiredOffloads() {
         // no influence since we do not block and the observer is not expected to block either
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     private static final class ExchangeContext implements TerminalSignalConsumer {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClearAsyncContextHttpServiceFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClearAsyncContextHttpServiceFilter.java
@@ -55,6 +55,6 @@ final class ClearAsyncContextHttpServiceFilter implements StreamingHttpServiceFi
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -65,7 +65,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
@@ -163,7 +163,7 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
     @Override
     public HttpServerBuilder appendNonOffloadingServiceFilter(final Predicate<StreamingHttpRequest> predicate,
                                                               final StreamingHttpServiceFilterFactory factory) {
-        checkNonOffloading("Non-offloading predicate", noOffloadsStrategy(), predicate);
+        checkNonOffloading("Non-offloading predicate", offloadNever(), predicate);
         checkNonOffloading("Non-offloading filter", defaultStrategy(), factory);
         noOffloadServiceFilters.add(toConditionalServiceFilterFactory(predicate, factory));
         return this;
@@ -437,7 +437,7 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
 
         @Override
         public HttpExecutionStrategy requiredOffloads() {
-            return HttpExecutionStrategies.anyStrategy();    // no influence since we do not block
+            return HttpExecutionStrategies.offloadNone();    // no influence since we do not block
         }
     }
 
@@ -474,7 +474,7 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
         @Override
         public HttpExecutionStrategy requiredOffloads() {
             // no influence since we do not block
-            return HttpExecutionStrategies.anyStrategy();
+            return HttpExecutionStrategies.offloadNone();
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilter.java
@@ -76,7 +76,7 @@ final class HostHeaderHttpRequesterFilter implements StreamingHttpClientFilterFa
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -268,7 +268,7 @@ final class NettyHttpServer {
             this.headersFactory = headersFactory;
             executionContext = new DefaultHttpExecutionContext(connection.executionContext().bufferAllocator(),
                     connection.executionContext().ioExecutor(), connection.executionContext().executor(),
-                    HttpExecutionStrategies.noOffloadsStrategy());
+                    HttpExecutionStrategies.offloadNever());
             this.service = service;
             // H2 uses child channels, doesn't support pipelining, and doesn't repeat the write operation on the same
             // channel. We therefore don't need the splitting flush in this case.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OffloadingFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OffloadingFilter.java
@@ -55,6 +55,6 @@ final class OffloadingFilter implements StreamingHttpServiceFilterFactory {
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // We do our own offloading
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -122,6 +122,6 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
@@ -38,7 +38,7 @@ import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitelyN
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffFullJitter;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
@@ -64,7 +64,7 @@ abstract class AbstractEchoServerBasedHttpRequesterTest {
     void startServer() throws Exception {
         serverContext = forAddress(localAddress(0))
             .ioExecutor(CTX.ioExecutor())
-            .executionStrategy(noOffloadsStrategy())
+            .executionStrategy(offloadNever())
             .listenStreamingAndAwait(new EchoServiceStreaming());
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -52,7 +52,7 @@ import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.netty.HttpClients.forResolvedAddress;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
@@ -105,7 +105,7 @@ abstract class AbstractHttpServiceAsyncContextTest {
                             forResolvedAddress(serverHostAndPort(ctx))
                                     .protocols(h1().maxPipelinedRequests(numRequests).build());
                     try (StreamingHttpClient client = (!useImmediate ? clientBuilder :
-                            clientBuilder.executionStrategy(noOffloadsStrategy())).buildStreaming()) {
+                            clientBuilder.executionStrategy(offloadNever())).buildStreaming()) {
                         try (StreamingHttpConnection connection = client.reserveConnection(client.get("/"))
                                 .toFuture().get()) {
                             barrier.await();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AutoRetryTest.java
@@ -127,7 +127,7 @@ class AutoRetryTest {
 
         @Override
         public ExecutionStrategy requiredOffloads() {
-            return ExecutionStrategy.anyStrategy();
+            return ExecutionStrategy.offloadNone();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
@@ -55,7 +55,7 @@ import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.AUTHORIZATION;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -134,8 +134,8 @@ class BasicAuthStrategyInfluencerTest {
         CredentialsVerifier<String> verifier = credentialsVerifier;
         if (noOffloadsInfluence) {
             verifier = new InfluencingVerifier(verifier,
-                    HttpExecutionStrategyInfluencer.newInfluencer(HttpExecutionStrategies.anyStrategy()));
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+                    HttpExecutionStrategyInfluencer.newInfluencer(HttpExecutionStrategies.offloadNone()));
+            serverBuilder.executionStrategy(offloadNever());
         }
         serverBuilder.appendServiceFilter(new BasicAuthHttpServiceFilter.Builder<>(verifier, "dummy")
                 .buildServer());
@@ -195,7 +195,7 @@ class BasicAuthStrategyInfluencerTest {
         @Override
         public HttpExecutionStrategy requiredOffloads() {
             // No influence since we do not block.
-            return HttpExecutionStrategies.anyStrategy();
+            return HttpExecutionStrategies.offloadNone();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -71,10 +71,10 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.http.api.HttpExecutionStrategies.anyStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.netty.ClientEffectiveStrategyTest.ClientOffloadPoint.RequestPayloadSubscription;
 import static io.servicetalk.http.netty.ClientEffectiveStrategyTest.ClientOffloadPoint.ResponseData;
 import static io.servicetalk.http.netty.ClientEffectiveStrategyTest.ClientOffloadPoint.ResponseMeta;
@@ -91,8 +91,8 @@ class ClientEffectiveStrategyTest {
 
     private static final HttpExecutionStrategy[] BUILDER_STRATEGIES = {
             null, // unspecified
-            noOffloadsStrategy(),
-            anyStrategy(),
+            offloadNever(),
+            offloadNone(),
             defaultStrategy(),
             HttpExecutionStrategies.customStrategyBuilder().offloadSend().build(),
             offloadAll(),
@@ -100,27 +100,27 @@ class ClientEffectiveStrategyTest {
 
     private static final HttpExecutionStrategy[] FILTER_STRATEGIES = {
             null, // absent
-            noOffloadsStrategy(), // treated as "anyStrategy"
-            anyStrategy(),
-            defaultStrategy(), // treated as "anyStrategy"
+            offloadNever(), // treated as "offloadNoneStrategy"
+            offloadNone(),
+            defaultStrategy(), // treated as "offloadNoneStrategy"
             HttpExecutionStrategies.customStrategyBuilder().offloadSend().build(),
             offloadAll(),
     };
 
     private static final HttpExecutionStrategy[] LB_STRATEGIES = {
             null, // absent
-            noOffloadsStrategy(), // treated as "anyStrategy"
-            anyStrategy(),
-            defaultStrategy(), // treated as "anyStrategy"
+            offloadNever(), // treated as "offloadNoneStrategy"
+            offloadNone(),
+            defaultStrategy(), // treated as "offloadNoneStrategy"
             HttpExecutionStrategies.customStrategyBuilder().offloadSend().build(),
             offloadAll(),
     };
 
     private static final HttpExecutionStrategy[] CF_STRATEGIES = {
             null, // absent
-            noOffloadsStrategy(), // treated as "anyStrategy"
-            anyStrategy(),
-            defaultStrategy(), // treated as "anyStrategy"
+            offloadNever(), // treated as "offloadNoneStrategy"
+            offloadNone(),
+            defaultStrategy(), // treated as "offloadNoneStrategy"
             HttpExecutionStrategies.customStrategyBuilder().offloadSend().build(),
             offloadAll(),
     };
@@ -251,11 +251,13 @@ class ClientEffectiveStrategyTest {
         HttpExecutionStrategy computed = null == builderStrategy ?
                 defaultStrategy() : builderStrategy;
         // null means no filter, noOffloadsStrategy() is illegal and replaced.
-        computed = null == filterStrategy || anyStrategy() == filterStrategy || noOffloadsStrategy() == filterStrategy ?
+        computed = null == filterStrategy || offloadNone() == filterStrategy || offloadNever() == filterStrategy ?
                 computed : computed.merge(filterStrategy);
-        computed = null == lbStrategy || anyStrategy() == lbStrategy || noOffloadsStrategy() == lbStrategy ?
+        computed = null == lbStrategy || offloadNone() == lbStrategy ||
+                defaultStrategy() == lbStrategy || offloadNever() == lbStrategy ?
                 computed : computed.merge(lbStrategy);
-        computed = null == cfStrategy || anyStrategy() == cfStrategy || noOffloadsStrategy() == cfStrategy ?
+        computed = null == cfStrategy || offloadNone() == cfStrategy ||
+                defaultStrategy() == cfStrategy || offloadNever() == cfStrategy ?
                 computed : computed.merge(cfStrategy);
 
         return computed;
@@ -321,7 +323,7 @@ class ClientEffectiveStrategyTest {
         @Override
         public HttpExecutionStrategy requiredOffloads() {
             // No influence since we do not block.
-            return HttpExecutionStrategies.anyStrategy();
+            return HttpExecutionStrategies.offloadNone();
         }
 
         @Override
@@ -380,7 +382,7 @@ class ClientEffectiveStrategyTest {
 
         @Override
         public ExecutionStrategy requiredOffloads() {
-            return ExecutionStrategy.anyStrategy();
+            return ExecutionStrategy.offloadNone();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptorOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptorOffloadingTest.java
@@ -50,7 +50,7 @@ class ConnectionAcceptorOffloadingTest {
                             offloaded.set(!isIoThread);
                             return original.accept(context);
                         },
-                offload ? ConnectExecutionStrategy.offload() : ConnectExecutionStrategy.anyStrategy());
+                offload ? ConnectExecutionStrategy.offloadAll() : ConnectExecutionStrategy.offloadNone());
 
         try (ServerContext server = HttpServers.forPort(0)
                 .appendConnectionAcceptorFilter(factory)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
@@ -45,7 +45,7 @@ class ConnectionContextToStringTest extends AbstractNettyHttpServerTest {
     void service(final StreamingHttpService service) {
         super.service((toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) ->
                         responseFactory.ok().payloadBody(ctx.toString(), textSerializerUtf8()),
-                HttpExecutionStrategies.anyStrategy())).adaptor());
+                HttpExecutionStrategies.offloadNone())).adaptor());
     }
 
     @ParameterizedTest(name = "protocol={0}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
@@ -164,7 +164,7 @@ class ConnectionFactoryFilterTest {
                             final InetSocketAddress inetSocketAddress, @Nullable final TransportObserver observer) {
                         return delegate().newConnection(inetSocketAddress, observer).map(filter);
                     }
-                }, ExecutionStrategy.anyStrategy());
+                }, ExecutionStrategy.offloadNone());
     }
 
     private static class AddResponseHeaderConnectionFilter extends StreamingHttpConnectionFilter {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryOffloadingTest.java
@@ -56,9 +56,9 @@ class ConnectionFactoryOffloadingTest {
     @SuppressWarnings("unused")
     static Stream<Arguments> testCases() {
         return Stream.of(
-                Arguments.of(false, HttpExecutionStrategies.anyStrategy()),
+                Arguments.of(false, HttpExecutionStrategies.offloadNone()),
                 Arguments.of(false, HttpExecutionStrategies.offloadAll()),
-                Arguments.of(true, HttpExecutionStrategies.anyStrategy()),
+                Arguments.of(true, HttpExecutionStrategies.offloadNone()),
                 Arguments.of(true, HttpExecutionStrategies.offloadAll())
         );
     }
@@ -102,14 +102,14 @@ class ConnectionFactoryOffloadingTest {
                                 }
                             },
                             new ConnectAndHttpExecutionStrategy(offload ?
-                                    ConnectExecutionStrategy.offload() : ConnectExecutionStrategy.anyStrategy(),
+                                    ConnectExecutionStrategy.offloadAll() : ConnectExecutionStrategy.offloadNone(),
                                     httpStrategy));
 
             try (HttpClient client = HttpClients.forResolvedAddress(serverAddress)
                     .appendConnectionFactoryFilter(factory)
                     .build()) {
                 assertThat(client.executionContext().executionStrategy().missing(httpStrategy),
-                        is(HttpExecutionStrategies.anyStrategy()));
+                        is(HttpExecutionStrategies.offloadNone()));
                 Single<HttpResponse> single = client.request(client.get("/sayHello"));
                 HttpResponse response = single.toFuture().get();
                 assertThat("unexpected status", response.status(), is(HttpResponseStatus.OK));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionInfoTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionInfoTest.java
@@ -91,7 +91,7 @@ class ConnectionInfoTest extends AbstractNettyHttpServerTest {
         @Override
         public HttpExecutionStrategy requiredOffloads() {
             // No influence since we do not block.
-            return HttpExecutionStrategies.anyStrategy();
+            return HttpExecutionStrategies.offloadNone();
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.cached;
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.immediate;
@@ -138,7 +138,7 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
         assertThat(CTX.ioExecutor(), not(equalTo(INTERNAL_CLIENT_CTX.ioExecutor())));
 
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .listenStreamingAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()))) {
             AtomicReference<BufferAllocator> actualInternalBufferAllocator = new AtomicReference<>();
             AtomicReference<IoExecutor> actualInternalIoExecutor = new AtomicReference<>();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -50,7 +50,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
@@ -81,7 +81,7 @@ class FlushStrategyOnServerTest {
     private BlockingHttpClient client;
 
     private enum Param {
-        NO_OFFLOAD(noOffloadsStrategy()),
+        NO_OFFLOAD(offloadNever()),
         DEFAULT(defaultStrategy()),
         OFFLOAD_ALL(customStrategyBuilder().offloadAll().build());
         private final HttpExecutionStrategy executionStrategy;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
@@ -52,7 +52,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.immediate;
@@ -76,14 +76,14 @@ class FlushStrategyOverrideTest {
         service = new FlushingService();
         serverCtx = HttpServers.forAddress(localAddress(0))
                 .ioExecutor(ctx.ioExecutor())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .listenStreaming(service)
                 .toFuture().get();
         InetSocketAddress serverAddr = (InetSocketAddress) serverCtx.listenAddress();
         client = forSingleAddress(new NoopSD(serverAddr), serverAddr)
                 .hostHeaderFallback(false)
                 .ioExecutor(ctx.ioExecutor())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .unresolvedAddressToHost(InetSocketAddress::getHostString)
                 .buildStreaming();
         conn = client.reserveConnection(client.get("/")).toFuture().get();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -229,7 +229,7 @@ class GracefulConnectionClosureHandlingTest {
                 .enableWireLogging("servicetalk-tests-wire-logger", TRACE, Boolean.TRUE::booleanValue)
                 .appendConnectionFactoryFilter(ConnectionFactoryFilter.withStrategy(
                         cf -> initiateClosureFromClient ? new OnClosingConnectionFactoryFilter<>(cf, onClosing) : cf,
-                        ExecutionStrategy.anyStrategy()))
+                        ExecutionStrategy.offloadNone()))
                 .buildStreaming();
         connection = client.reserveConnection(client.get("/")).toFuture().get();
         connection.onClose().whenFinally(clientConnectionClosed::countDown).subscribe();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
@@ -110,7 +110,7 @@ class H2ResponseCancelTest extends AbstractNettyHttpServerTest {
                             return delegate().newConnection(inetSocketAddress, observer);
                         });
                     }
-                }, ExecutionStrategy.anyStrategy()));
+                }, ExecutionStrategy.offloadNone()));
         setUp(CACHED, CACHED_SERVER);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
@@ -72,13 +72,13 @@ class HttpAuthConnectionFactoryClientTest {
     void simulateAuth() throws Exception {
         serverContext = forAddress(localAddress(0))
             .ioExecutor(CTX.ioExecutor())
-            .executionStrategy(noOffloadsStrategy())
+            .executionStrategy(offloadNever())
             .listenStreamingAndAwait((ctx, request, factory) -> succeeded(newTestResponse(factory)));
 
         client = forSingleAddress(serverHostAndPort(serverContext))
             .appendConnectionFactoryFilter(TestHttpAuthConnectionFactory::new)
             .ioExecutor(CTX.ioExecutor())
-            .executionStrategy(noOffloadsStrategy())
+            .executionStrategy(offloadNever())
             .buildStreaming();
 
         StreamingHttpResponse response = client.request(newTestRequest(client, "/foo")).toFuture().get();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
@@ -81,7 +81,7 @@ class HttpClientAsyncContextTest {
                 .appendClientFilter(c -> new TestStreamingHttpClientFilter(c, errorQueue))
                 .appendClientFilter(c -> new TestStreamingHttpClientFilter(c, errorQueue));
         if (useImmediate) {
-            clientBuilder.executionStrategy(HttpExecutionStrategies.noOffloadsStrategy());
+            clientBuilder.executionStrategy(HttpExecutionStrategies.offloadNever());
         }
         return clientBuilder;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;
 import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mockito.ArgumentMatchers.any;
@@ -80,7 +80,7 @@ class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterTest {
                 .appendConnectionFactoryFilter(factoryFilter(factory1))
                 .appendConnectionFactoryFilter(factoryFilter(factory2))
                 .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .buildStreaming();
         makeRequestValidateResponseAndClose(requester);
 
@@ -96,7 +96,7 @@ class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterTest {
                     .thenAnswer(invocation -> orig.newConnection(invocation.getArgument(0),
                             invocation.getArgument(1)));
             return factory;
-        }, HttpExecutionStrategies.anyStrategy());
+        }, HttpExecutionStrategies.offloadNone());
     }
 
     @SuppressWarnings("unchecked")
@@ -118,7 +118,7 @@ class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterTest {
         StreamingHttpClient requester = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
                 .serviceDiscoverer(disco)
                 .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .buildStreaming();
         makeRequestValidateResponseAndClose(requester);
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientOverrideOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientOverrideOffloadingTest.java
@@ -38,7 +38,7 @@ import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -78,9 +78,9 @@ class HttpClientOverrideOffloadingTest {
     }
 
     enum Params {
-        OVERRIDE_NO_OFFLOAD(th -> !isInClientEventLoop(th), noOffloadsStrategy(), null),
+        OVERRIDE_NO_OFFLOAD(th -> !isInClientEventLoop(th), offloadNever(), null),
         DEFAULT_NO_OFFLOAD(HttpClientOverrideOffloadingTest::isInClientEventLoop, null,
-                noOffloadsStrategy()),
+                offloadNever()),
         BOTH_OFFLOADS(HttpClientOverrideOffloadingTest::isInClientEventLoop, null, null);
 
         final Predicate<Thread> isInvalidThread;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
@@ -35,7 +35,7 @@ import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitelyN
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
@@ -62,7 +62,7 @@ class HttpConnectionEmptyPayloadTest {
             ServerContext serverContext = closeable.merge(HttpServers
                     .forAddress(localAddress(0))
                     .ioExecutor(executionContextRule.ioExecutor())
-                    .executionStrategy(noOffloadsStrategy())
+                    .executionStrategy(offloadNever())
                     .listenStreamingAndAwait(
                             (ctx, req, factory) -> {
                                 StreamingHttpResponse resp = factory.ok().payloadBody(from(

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerFilterOrderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServerFilterOrderTest.java
@@ -172,7 +172,7 @@ class HttpServerFilterOrderTest {
         @Override
         public HttpExecutionStrategy requiredOffloads() {
             // No influence since we do not block.
-            return HttpExecutionStrategies.anyStrategy();
+            return HttpExecutionStrategies.offloadNone();
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpStreamingClientOverrideOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpStreamingClientOverrideOffloadingTest.java
@@ -39,7 +39,7 @@ import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -77,9 +77,9 @@ class HttpStreamingClientOverrideOffloadingTest {
     }
 
     enum Params {
-        OVERRIDE_NO_OFFLOAD(th -> !isInClientEventLoop(th), noOffloadsStrategy(), null),
+        OVERRIDE_NO_OFFLOAD(th -> !isInClientEventLoop(th), offloadNever(), null),
         DEFAULT_NO_OFFLOAD(HttpStreamingClientOverrideOffloadingTest::isInClientEventLoop, null,
-                noOffloadsStrategy()),
+                offloadNever()),
         BOTH_OFFLOADS(HttpStreamingClientOverrideOffloadingTest::isInClientEventLoop, null, null);
 
         final Predicate<Thread> isInvalidThread;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTestExecutionStrategy.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTestExecutionStrategy.java
@@ -21,7 +21,7 @@ import io.servicetalk.http.api.HttpExecutionStrategy;
 import java.util.function.Supplier;
 
 public enum HttpTestExecutionStrategy {
-    NO_OFFLOAD(HttpExecutionStrategies::noOffloadsStrategy),
+    NO_OFFLOAD(HttpExecutionStrategies::offloadNever),
     DEFAULT(HttpExecutionStrategies::defaultStrategy);
 
     final Supplier<HttpExecutionStrategy> executorSupplier;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
@@ -59,7 +59,7 @@ import static io.netty.buffer.ByteBufUtil.writeAscii;
 import static io.netty.util.ReferenceCountUtil.release;
 import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
@@ -128,7 +128,7 @@ class MalformedDataAfterHttpMessageTest {
         Queue<ConnectionContext> contextQueue = new LinkedBlockingQueue<>();
         ServerSocketChannel server = nettyServer(RESPONSE_MSG);
         try (BlockingHttpClient client = stClientBuilder(server.localAddress())
-                .executionStrategy(doOffloading ? defaultStrategy() : noOffloadsStrategy())
+                .executionStrategy(doOffloading ? defaultStrategy() : offloadNever())
                 // ClosedChannelException maybe observed on the second request if write is done before read of the
                 // garbage data, which won't be a RetryableException. We may also see an exception from flush if the
                 // read closed the connection and then attempt to write on the same connection.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
@@ -43,7 +43,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -69,9 +69,9 @@ class NettyHttpServerConnectionTest {
     private static Stream<Arguments> executionStrategies() {
         return Stream.of(
                 Arguments.of(defaultStrategy(), defaultStrategy()),
-                Arguments.of(noOffloadsStrategy(), defaultStrategy()),
-                Arguments.of(defaultStrategy(), noOffloadsStrategy()),
-                Arguments.of(noOffloadsStrategy(), noOffloadsStrategy()));
+                Arguments.of(offloadNever(), defaultStrategy()),
+                Arguments.of(defaultStrategy(), offloadNever()),
+                Arguments.of(offloadNever(), offloadNever()));
     }
 
     @AfterEach

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
@@ -57,7 +57,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.closeAsyncGracefully
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
@@ -167,7 +167,7 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
 
         HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
         if (disableOffloading) {
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+            serverBuilder.executionStrategy(offloadNever());
         }
         try (ServerContext serverCtx = serverBuilder.listenStreamingAndAwait((ctx, request, responseFactory) -> {
                     throw DELIBERATE_EXCEPTION;
@@ -183,7 +183,7 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
     private static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> disableOffloading(
             SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder, boolean disableOffloading) {
         if (disableOffloading) {
-            clientBuilder.executionStrategy(noOffloadsStrategy());
+            clientBuilder.executionStrategy(offloadNever());
         }
         return clientBuilder;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
@@ -315,7 +315,7 @@ class ProxyConnectConnectionFactoryFilterTest {
     void noOffloadingStrategy() {
         ChannelPipeline pipeline = configurePipeline(SslHandshakeCompletionEvent.SUCCESS);
         configureDeferSslHandler(pipeline);
-        configureConnectionContext(pipeline, HttpExecutionStrategies.noOffloadsStrategy());
+        configureConnectionContext(pipeline, HttpExecutionStrategies.offloadNever());
         configureRequestSend();
         configureConnectRequest();
         Queue<Throwable> errors = new LinkedBlockingQueue<>();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestResponseContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestResponseContextTest.java
@@ -51,7 +51,7 @@ import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
-import static io.servicetalk.http.api.HttpExecutionStrategies.anyStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
@@ -137,7 +137,7 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                     HttpResponse response = responseFactory.ok().payloadBody(request.payloadBody());
                     transferContext(request, response);
                     return succeeded(response);
-                }, anyStrategy()).adaptor();
+                }, offloadNone()).adaptor();
                 break;
             case AsyncStreaming:
                 newService = (ctx, request, responseFactory) -> {
@@ -151,7 +151,7 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                     HttpResponse response = responseFactory.ok().payloadBody(request.payloadBody());
                     transferContext(request, response);
                     return response;
-                }, anyStrategy()).adaptor();
+                }, offloadNone()).adaptor();
                 break;
             case BlockingStreaming:
                 newService = toStreamingHttpService((ctx, request, response) -> {
@@ -161,7 +161,7 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                             writer.write(chunk);
                         }
                     }
-                }, anyStrategy()).adaptor();
+                }, offloadNone()).adaptor();
                 break;
             default:
                 throw new IllegalStateException("Unknown api: " + api);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
@@ -100,7 +100,7 @@ class ResponseCancelTest {
                 })
                 .appendConnectionFactoryFilter(ConnectionFactoryFilter.withStrategy(
                         original -> new CountingConnectionFactory(original, connectionCount),
-                        HttpExecutionStrategies.anyStrategy()))
+                        HttpExecutionStrategies.offloadNone()))
                 .build();
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryRequestWithNonRepeatablePayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryRequestWithNonRepeatablePayloadTest.java
@@ -106,7 +106,7 @@ class RetryRequestWithNonRepeatablePayloadTest extends AbstractNettyHttpServerTe
                     };
                 });
             }
-        }, ExecutionStrategy.anyStrategy()));
+        }, ExecutionStrategy.offloadNone()));
         setUp(offloading ? CACHED : IMMEDIATE, offloading ? CACHED_SERVER : IMMEDIATE);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -44,8 +44,8 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.IO_EXECUTOR_NAME_PREFIX;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.noStrategy;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategy;
@@ -70,9 +70,9 @@ class ServerEffectiveStrategyTest {
         userStrategyWithFilter(serviceType ->
                 new Params(serviceType, true, defaultStrategy(), Offloads.ALL)),
         userStrategyNoOffloadsNoFilter(serviceType ->
-                new Params(serviceType, false, noOffloadsStrategy(), Offloads.NONE)),
+                new Params(serviceType, false, offloadNever(), Offloads.NONE)),
         userStrategyNoOffloadsWithFilter(serviceType ->
-                new Params(serviceType, true, noOffloadsStrategy(), Offloads.NONE)),
+                new Params(serviceType, true, offloadNever(), Offloads.NONE)),
         customUserStrategyNoFilter(serviceType ->
                 new Params(serviceType, false, customStrategyBuilder().offloadAll().build(), Offloads.ALL)),
         customUserStrategyWithFilter(serviceType ->
@@ -297,7 +297,7 @@ class ServerEffectiveStrategyTest {
         @Override
         public HttpExecutionStrategy requiredOffloads() {
             // No influence since we do not block.
-            return HttpExecutionStrategies.anyStrategy();
+            return HttpExecutionStrategies.offloadNone();
         }
 
         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerGracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerGracefulConnectionClosureHandlingTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpSerializers.stringStreamingSerializer;
 import static io.servicetalk.http.netty.HttpServers.forAddress;
@@ -73,7 +73,7 @@ class ServerGracefulConnectionClosureHandlingTest {
         serverContext = forAddress(localAddress(0))
             .ioExecutor(SERVER_CTX.ioExecutor())
             .executor(SERVER_CTX.executor())
-            .executionStrategy(noOffloadsStrategy())
+            .executionStrategy(offloadNever())
             .appendConnectionAcceptorFilter(original -> new DelegatingConnectionAcceptor(original) {
                 @Override
                 public Completable accept(final ConnectionContext context) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -42,8 +42,8 @@ import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
-import static io.servicetalk.http.api.HttpExecutionStrategies.anyStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
@@ -72,7 +72,7 @@ class ServerRespondsOnClosingTest {
     ServerRespondsOnClosingTest() throws Exception {
         channel = new EmbeddedDuplexChannel(false);
         DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR,
-                fromNettyEventLoop(channel.eventLoop()), immediate(), noOffloadsStrategy());
+                fromNettyEventLoop(channel.eventLoop()), immediate(), offloadNever());
         final HttpServerConfig httpServerConfig = new HttpServerConfig();
         httpServerConfig.tcpConfig().enableWireLogging("servicetalk-tests-wire-logger", TRACE,
                 Boolean.TRUE::booleanValue);
@@ -85,7 +85,7 @@ class ServerRespondsOnClosingTest {
         };
         serverConnection = initChannel(channel, httpExecutionContext, config, new TcpServerChannelInitializer(
                 config.tcpConfig(), connectionObserver),
-                toStreamingHttpService(service, anyStrategy()).adaptor(), true,
+                toStreamingHttpService(service, offloadNone()).adaptor(), true,
                 connectionObserver).toFuture().get();
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
@@ -43,7 +43,7 @@ import javax.net.ssl.SSLHandshakeException;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
@@ -91,7 +91,7 @@ class SslAndNonSslConnectionsTest {
         when(STREAMING_HTTP_SERVICE.closeAsync()).thenReturn(completed());
         when(STREAMING_HTTP_SERVICE.closeAsyncGracefully()).thenReturn(completed());
         serverCtx = HttpServers.forAddress(localAddress(0))
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .listenStreamingAndAwait(STREAMING_HTTP_SERVICE);
         final String serverHostHeader = hostHeader(serverHostAndPort(serverCtx));
         requestTarget = "http://" + serverHostHeader + "/";
@@ -109,7 +109,7 @@ class SslAndNonSslConnectionsTest {
         secureServerCtx = HttpServers.forAddress(localAddress(0))
                 .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
                         DefaultTestCerts::loadServerKey).build())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .listenStreamingAndAwait(SECURE_STREAMING_HTTP_SERVICE);
         final String secureServerHostHeader = hostHeader(serverHostAndPort(secureServerCtx));
         secureRequestTarget = "https://" + secureServerHostHeader + "/";

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
 import static java.lang.Thread.currentThread;
 
@@ -80,7 +80,7 @@ class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncConte
     protected ServerContext serverWithEmptyAsyncContextService(HttpServerBuilder serverBuilder,
                                                      boolean useImmediate) throws Exception {
         if (useImmediate) {
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+            serverBuilder.executionStrategy(offloadNever());
         }
         return serverBuilder.listenStreamingAndAwait(newEmptyAsyncContextService());
     }
@@ -108,7 +108,7 @@ class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncConte
     protected ServerContext serverWithService(HttpServerBuilder serverBuilder,
                                     boolean useImmediate, boolean asyncService) throws Exception {
         if (useImmediate) {
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+            serverBuilder.executionStrategy(offloadNever());
         }
         return serverBuilder.listenStreamingAndAwait(service(useImmediate, asyncService));
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SupportedBufferAllocatorsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SupportedBufferAllocatorsTest.java
@@ -33,7 +33,7 @@ import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_DIRECT_ALLOCAT
 import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_HEAP_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
-import static io.servicetalk.http.api.HttpExecutionStrategies.anyStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
@@ -68,7 +68,7 @@ class SupportedBufferAllocatorsTest extends AbstractNettyHttpServerTest {
     void service(final StreamingHttpService service) {
         super.service((toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) ->
                         responseFactory.ok().payloadBody(allocator.fromAscii(request.payloadBody().toString(US_ASCII))),
-                anyStrategy())).adaptor());
+                offloadNone())).adaptor());
     }
 
     @ParameterizedTest(name = "{index}: protocol={0}, allocator={1}")

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/JerseyRouteExecutionStrategyUtils.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/JerseyRouteExecutionStrategyUtils.java
@@ -50,8 +50,8 @@ import java.util.concurrent.CompletionStage;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.router.utils.internal.RouteExecutionStrategyUtils.getRouteExecutionStrategyAnnotation;
 import static java.util.Collections.emptyMap;
 import static org.glassfish.jersey.model.Parameter.Source.ENTITY;
@@ -171,7 +171,7 @@ final class JerseyRouteExecutionStrategyUtils {
         }
 
         if (annotation instanceof NoOffloadsRouteExecutionStrategy) {
-            return noOffloadsStrategy();
+            return offloadNever();
         }
 
         // This can never be null because we have pre-validated that all route strategy IDs exist at startup

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractResourceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractResourceTest.java
@@ -42,7 +42,7 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.ext.Provider;
 
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
@@ -134,7 +134,7 @@ public abstract class AbstractResourceTest extends AbstractJerseyStreamingHttpSe
                            final HttpJerseyRouterBuilder jerseyRouterBuilder) {
         super.configureBuilders(serverBuilder, jerseyRouterBuilder);
         if (serverNoOffloads) {
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+            serverBuilder.executionStrategy(offloadNever());
         }
     }
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyTest.java
@@ -44,7 +44,7 @@ import java.util.Set;
 import javax.ws.rs.core.Application;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.router.jersey.AbstractJerseyStreamingHttpServiceTest.RouterApi.BLOCKING_STREAMING;
@@ -106,7 +106,7 @@ final class ExecutionStrategyTest extends AbstractJerseyStreamingHttpServiceTest
         NO_OFFLOADS {
             @Override
             void configureRouterBuilder(final HttpServerBuilder builder, final Executor ignored) {
-                builder.executionStrategy(noOffloadsStrategy());
+                builder.executionStrategy(offloadNever());
             }
         };
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/MixedModeResourceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/MixedModeResourceTest.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import javax.ws.rs.core.Application;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.router.jersey.AbstractResourceTest.assumeSafeToDisableOffloading;
@@ -59,7 +59,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
     void configureBuilders(final HttpServerBuilder serverBuilder,
                            final HttpJerseyRouterBuilder jerseyRouterBuilder) {
         super.configureBuilders(serverBuilder, jerseyRouterBuilder);
-        serverBuilder.executionStrategy(noOffloadsStrategy());
+        serverBuilder.executionStrategy(offloadNever());
     }
 
     @Override
@@ -73,7 +73,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
                 .executionStrategy(defaultStrategy())
                 .thenRouteTo(route)
                 .when(__ -> true)
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .thenRouteTo(route)
                 .buildStreaming();
         return httpServerBuilder.listenStreamingAndAwait(router);
@@ -90,7 +90,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
                 .executionStrategy(defaultStrategy())
                 .thenRouteTo(route)
                 .when(__ -> true)
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .thenRouteTo(route)
                 .buildStreaming();
         return httpServerBuilder.listenStreamingAndAwait(router);
@@ -107,7 +107,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
                 .executionStrategy(defaultStrategy())
                 .thenRouteTo(route)
                 .when(__ -> true)
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .thenRouteTo(route)
                 .buildStreaming();
         return httpServerBuilder.listenStreamingAndAwait(router);
@@ -124,7 +124,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
                 .executionStrategy(defaultStrategy())
                 .thenRouteTo(route)
                 .when(__ -> true)
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .thenRouteTo(route)
                 .buildStreaming();
         return httpServerBuilder.listenStreamingAndAwait(router);

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
@@ -51,7 +51,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
 import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -64,10 +64,10 @@ class HttpServerOverrideOffloadingTest {
     private static final String IO_EXECUTOR_THREAD_NAME_PREFIX = "http-server-io-executor";
     private static final String EXECUTOR_THREAD_NAME_PREFIX = "http-server-executor";
     private static final HttpExecutionStrategy[] SERVER_STRATEGIES = new HttpExecutionStrategy[] {
-            defaultStrategy(), noOffloadsStrategy() };
+            defaultStrategy(), offloadNever() };
 
     private static final HttpExecutionStrategy[] ROUTE_STRATEGIES = new HttpExecutionStrategy[] {
-            null, defaultStrategy(), noOffloadsStrategy(), customStrategyBuilder().offloadSend().build() };
+            null, defaultStrategy(), offloadNever(), customStrategyBuilder().offloadSend().build() };
 
     @RegisterExtension
     private static final ExecutionContextExtension EXECUTION_CONTEXT =
@@ -134,7 +134,7 @@ class HttpServerOverrideOffloadingTest {
         @Override
         public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx, final StreamingHttpRequest request,
                                                     final StreamingHttpResponseFactory responseFactory) {
-            boolean offloading = ctx.executionContext().executionStrategy() != noOffloadsStrategy() ||
+            boolean offloading = ctx.executionContext().executionStrategy() != offloadNever() ||
                     defaultStrategy() != usingStrategy;
             boolean expectReadMetaOffload = offloading &&
                     (ctx.executionContext().executionStrategy().isMetadataReceiveOffloaded() ||

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/PredicateRouterOffloadingTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/PredicateRouterOffloadingTest.java
@@ -61,7 +61,7 @@ import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.router.predicate.PredicateRouterOffloadingTest.RouteServiceType.ASYNC_AGGREGATED;
 import static io.servicetalk.http.router.predicate.PredicateRouterOffloadingTest.RouteServiceType.BLOCKING_AGGREGATED;
@@ -134,7 +134,7 @@ class PredicateRouterOffloadingTest {
         final HttpPredicateRouterBuilder routerBuilder = newRouterBuilder();
         serverBuilder.executor(executionContextRule.executor());
         routeServiceType.addThreadRecorderService(
-                routerBuilder.when(this::recordRouterThread).executionStrategy(noOffloadsStrategy()),
+                routerBuilder.when(this::recordRouterThread).executionStrategy(offloadNever()),
                 this::recordThread);
         final BlockingHttpClient client = buildServerAndClient(routerBuilder.buildStreaming());
         client.request(client.get("/"));
@@ -148,7 +148,7 @@ class PredicateRouterOffloadingTest {
     void routeOffloadedAndNotPredicate(RouteServiceType routeServiceType) throws Exception {
         this.routeServiceType = routeServiceType;
         final HttpPredicateRouterBuilder routerBuilder = newRouterBuilder();
-        serverBuilder.executionStrategy(noOffloadsStrategy()).executor(executionContextRule.executor());
+        serverBuilder.executionStrategy(offloadNever()).executor(executionContextRule.executor());
         routeServiceType.addThreadRecorderService(
                 routerBuilder.when(this::recordRouterThread)
                         .executionStrategy(defaultStrategy()),
@@ -164,7 +164,7 @@ class PredicateRouterOffloadingTest {
     void routeDefaultAndPredicateNotOffloaded(RouteServiceType routeServiceType) throws Exception {
         this.routeServiceType = routeServiceType;
         final HttpPredicateRouterBuilder routerBuilder = newRouterBuilder();
-        serverBuilder.executionStrategy(noOffloadsStrategy());
+        serverBuilder.executionStrategy(offloadNever());
         routeServiceType.addThreadRecorderService(
                 routerBuilder.when(this::recordRouterThread),
                 this::recordThread);
@@ -180,9 +180,9 @@ class PredicateRouterOffloadingTest {
         this.routeServiceType = routeServiceType;
         assumeSafeToDisableOffloading(routeServiceType);
         final HttpPredicateRouterBuilder routerBuilder = newRouterBuilder();
-        serverBuilder.executionStrategy(noOffloadsStrategy());
+        serverBuilder.executionStrategy(offloadNever());
         routeServiceType.addThreadRecorderService(
-                routerBuilder.when(this::recordRouterThread).executionStrategy(noOffloadsStrategy()),
+                routerBuilder.when(this::recordRouterThread).executionStrategy(offloadNever()),
                 this::recordThread);
         final BlockingHttpClient client = buildServerAndClient(routerBuilder.buildStreaming());
         client.request(client.get("/"));

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
@@ -89,7 +89,7 @@ abstract class AbstractTimeoutHttpFilter implements ExecutionStrategyInfluencer<
 
     @Override
     public final HttpExecutionStrategy requiredOffloads() {
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     /**

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/EnforceSequentialModeRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/EnforceSequentialModeRequesterFilter.java
@@ -89,6 +89,6 @@ public final class EnforceSequentialModeRequesterFilter implements StreamingHttp
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
@@ -138,6 +138,6 @@ public final class RedirectingHttpRequesterFilter implements StreamingHttpClient
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetDecoderHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetDecoderHttpServiceFilter.java
@@ -71,6 +71,6 @@ public final class RequestTargetDecoderHttpServiceFilter implements StreamingHtt
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetEncoderHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetEncoderHttpRequesterFilter.java
@@ -88,6 +88,6 @@ public final class RequestTargetEncoderHttpRequesterFilter implements
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetEncoderHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RequestTargetEncoderHttpServiceFilter.java
@@ -75,6 +75,6 @@ public final class RequestTargetEncoderHttpServiceFilter implements StreamingHtt
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpRequesterFilter.java
@@ -107,7 +107,7 @@ public final class RetryingHttpRequesterFilter implements StreamingHttpClientFil
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     /**

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -97,7 +97,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
     @Override
     public ExecutionStrategy requiredOffloads() {
         // We do not block
-        return ExecutionStrategy.anyStrategy();
+        return ExecutionStrategy.offloadNone();
     }
 
     /**

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
@@ -126,7 +126,7 @@ public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         // No influence since we do not block.
-        return HttpExecutionStrategies.anyStrategy();
+        return HttpExecutionStrategies.offloadNone();
     }
 
     private Single<StreamingHttpResponse> trackRequest(final StreamingHttpRequester delegate,

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractTcpServerTest {
             ExecutionContextExtension.cached("client-io", "client-executor");
 
     private InfluencerConnectionAcceptor connectionAcceptor =
-            InfluencerConnectionAcceptor.withStrategy(ACCEPT_ALL, ConnectExecutionStrategy.anyStrategy());
+            InfluencerConnectionAcceptor.withStrategy(ACCEPT_ALL, ConnectExecutionStrategy.offloadNone());
     private Function<NettyConnection<Buffer, Buffer>, Completable> service =
         conn -> conn.write(conn.read());
     private boolean sslEnabled;

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpServerBinderConnectionAcceptorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpServerBinderConnectionAcceptorTest.java
@@ -73,7 +73,7 @@ class TcpServerBinderConnectionAcceptorTest extends AbstractTcpServerTest {
             @Override
             InfluencerConnectionAcceptor getContextFilter(final Executor executor) {
                 return InfluencerConnectionAcceptor.withStrategy(ConnectionAcceptor.ACCEPT_ALL,
-                        ConnectExecutionStrategy.anyStrategy());
+                        ConnectExecutionStrategy.offloadNone());
             }
         };
 
@@ -93,7 +93,7 @@ class TcpServerBinderConnectionAcceptorTest extends AbstractTcpServerTest {
 
         InfluencerConnectionAcceptor getContextFilter(Executor executor) {
             return InfluencerConnectionAcceptor.withStrategy(context -> contextFilterFunction.apply(executor, context),
-                    offload ? ConnectExecutionStrategy.offload() : ConnectExecutionStrategy.anyStrategy());
+                    offload ? ConnectExecutionStrategy.offloadAll() : ConnectExecutionStrategy.offloadNone());
         }
     }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectExecutionStrategy.java
@@ -48,8 +48,8 @@ public interface ConnectExecutionStrategy extends ExecutionStrategy {
     default ConnectExecutionStrategy merge(ExecutionStrategy other) {
         ConnectExecutionStrategy asCES = from(other);
         return hasOffloads() ?
-                asCES.hasOffloads() ? ConnectExecutionStrategy.offload() : this :
-                asCES.hasOffloads() ? asCES : ConnectExecutionStrategy.anyStrategy();
+                asCES.hasOffloads() ? ConnectExecutionStrategy.offloadAll() : this :
+                asCES.hasOffloads() ? asCES : ConnectExecutionStrategy.offloadNone();
     }
 
     /**
@@ -57,7 +57,7 @@ public interface ConnectExecutionStrategy extends ExecutionStrategy {
      *
      * @return an {@link ConnectExecutionStrategy} that requires no offloading.
      */
-    static ConnectExecutionStrategy anyStrategy() {
+    static ConnectExecutionStrategy offloadNone() {
         return DefaultConnectExecutionStrategy.CONNECT_NOT_OFFLOADED;
     }
 
@@ -66,15 +66,15 @@ public interface ConnectExecutionStrategy extends ExecutionStrategy {
      *
      * @return an {@link ConnectExecutionStrategy} that requires offloading.
      */
-    static ConnectExecutionStrategy offload() {
+    static ConnectExecutionStrategy offloadAll() {
         return DefaultConnectExecutionStrategy.CONNECT_OFFLOADED;
     }
 
     /**
      * Converts the provided execution strategy to a {@link ConnectExecutionStrategy}. If the provided strategy is
      * already {@link ConnectExecutionStrategy} it is returned unchanged. For other strategies, if the strategy
-     * {@link ExecutionStrategy#hasOffloads()} then {@link ConnectExecutionStrategy#offload()} is returned otherwise
-     * {@link ConnectExecutionStrategy#anyStrategy()} is returned.
+     * {@link ExecutionStrategy#hasOffloads()} then {@link ConnectExecutionStrategy#offloadAll()} is returned otherwise
+     * {@link ConnectExecutionStrategy#offloadNone()} is returned.
      *
      * @param executionStrategy The {@link ExecutionStrategy} to convert
      * @return converted {@link ConnectExecutionStrategy}.
@@ -83,7 +83,7 @@ public interface ConnectExecutionStrategy extends ExecutionStrategy {
         return executionStrategy instanceof ConnectExecutionStrategy ?
                 (ConnectExecutionStrategy) executionStrategy :
                     executionStrategy.hasOffloads() ?
-                        ConnectExecutionStrategy.offload() :
-                        ConnectExecutionStrategy.anyStrategy();
+                        ConnectExecutionStrategy.offloadAll() :
+                        ConnectExecutionStrategy.offloadNone();
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionAcceptorFactory.java
@@ -68,12 +68,12 @@ public interface ConnectionAcceptorFactory extends ExecutionStrategyInfluencer<C
      *
      * <p>The strategy returned will be applied to the connection acceptor instance returned by
      * {@link #create(ConnectionAcceptor)}. If offloading is not required then override to return
-     * {@link ConnectExecutionStrategy#anyStrategy()}
+     * {@link ConnectExecutionStrategy#offloadNone()}
      */
     @Override
     default ConnectExecutionStrategy requiredOffloads() {
         // safe default--implementations are expected to override
-        return ConnectExecutionStrategy.offload();
+        return ConnectExecutionStrategy.offloadAll();
     }
 
     /**

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionStrategy.java
@@ -37,7 +37,7 @@ public interface ExecutionStrategy {
      *
      * @return an {@link ExecutionStrategy} that requires no offloading.
      */
-    static ExecutionStrategy anyStrategy() {
+    static ExecutionStrategy offloadNone() {
         return SpecialExecutionStrategy.NO_OFFLOADS;
     }
 
@@ -59,6 +59,6 @@ public interface ExecutionStrategy {
     default ExecutionStrategy merge(ExecutionStrategy other) {
         return hasOffloads() ?
                 other.hasOffloads() ? ExecutionStrategy.offloadAll() : this :
-                other.hasOffloads() ? other : ExecutionStrategy.anyStrategy();
+                other.hasOffloads() ? other : ExecutionStrategy.offloadNone();
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoThreadFactory.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoThreadFactory.java
@@ -45,6 +45,7 @@ public interface IoThreadFactory<T extends Thread & IoThread> extends ThreadFact
         /**
          * Returns {@code true} if the specified thread is an {@link IoThread} otherwise {code false}.
          *
+         * @param thread the thread to be examined.
          * @return {@code true} if the specified thread is an {@link IoThread} otherwise {code false}.
          */
         static boolean isIoThread(Thread thread) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/InfluencerConnectionAcceptor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/InfluencerConnectionAcceptor.java
@@ -23,7 +23,7 @@ import io.servicetalk.transport.api.DelegatingConnectionAcceptor;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.transport.api.ConnectExecutionStrategy.anyStrategy;
+import static io.servicetalk.transport.api.ConnectExecutionStrategy.offloadNone;
 
 /**
  * A contract that defines the connection acceptance criterion.
@@ -37,7 +37,7 @@ public interface InfluencerConnectionAcceptor extends ConnectionAcceptor,
     /**
      * ACCEPT all connections.
      */
-    InfluencerConnectionAcceptor ACCEPT_ALL = withStrategy((context) -> completed(), anyStrategy());
+    InfluencerConnectionAcceptor ACCEPT_ALL = withStrategy((context) -> completed(), offloadNone());
 
     @Override
     default Completable closeAsync() {
@@ -47,7 +47,7 @@ public interface InfluencerConnectionAcceptor extends ConnectionAcceptor,
     @Override
     default ConnectExecutionStrategy requiredOffloads() {
         // "safe" default -- implementations are expected to override
-        return ConnectExecutionStrategy.offload();
+        return ConnectExecutionStrategy.offloadAll();
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -76,7 +76,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
                         }
                         ctx.write(msg, promise);
                     }
-                })), ExecutionStrategy.anyStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, isClient)
+                })), ExecutionStrategy.offloadNone(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, isClient)
                 .toFuture().get();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/InfluencerConnectionAcceptorTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/InfluencerConnectionAcceptorTest.java
@@ -39,8 +39,8 @@ class InfluencerConnectionAcceptorTest {
 
     @Test
     void withStrategyRequiredOffloads() {
-        ConnectionAcceptorFactory factory = withStrategy(original -> original, ConnectExecutionStrategy.offload());
-        assertThat("unexpected strategy", factory.requiredOffloads(), is(ConnectExecutionStrategy.offload()));
+        ConnectionAcceptorFactory factory = withStrategy(original -> original, ConnectExecutionStrategy.offloadAll());
+        assertThat("unexpected strategy", factory.requiredOffloads(), is(ConnectExecutionStrategy.offloadAll()));
 
         InfluencerConnectionAcceptor acceptor =
                 InfluencerConnectionAcceptor.withStrategy(factory.create(ACCEPT_ALL), factory.requiredOffloads());


### PR DESCRIPTION
Motivation:
The naming of the special execution strategies, particularly
`anyStrategy` and `noOffloadStrategy` are confusing and leading to
potential and actual misuse.
Modifications:
Deprecate `noOffloadStrategy` and rename several of the special
execution strategies introduced since 0.41
    
`noOffloadStrategy` → `offloadNever`
`anyStrategy` → `offloadNone`
Result:
More obvious offloading behaviour and execution strategy interactions.
