### PR TITLE
Deprecate and replace `noOffloadsStrategy()`

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -25,7 +25,7 @@ import io.servicetalk.http.api.HttpExecutionStrategy;
 public final class GrpcExecutionStrategies {
 
     private static final DefaultGrpcExecutionStrategy NO_OFFLOADS =
-            new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.noOffloadsStrategy());
+            new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.offloadNever());
 
     private GrpcExecutionStrategies() {
         // No instances
@@ -57,8 +57,19 @@ public final class GrpcExecutionStrategies {
      * A {@link GrpcExecutionStrategy} that disables all offloads.
      *
      * @return {@link GrpcExecutionStrategy} that disables all offloads.
+     * @deprecated Replaced with the more descriptive {@link #offloadNever()}.
      */
+    @Deprecated
     public static GrpcExecutionStrategy noOffloadsStrategy() {
+        return NO_OFFLOADS;
+    }
+
+    /**
+     * A {@link GrpcExecutionStrategy} that disables all offloads.
+     *
+     * @return {@link GrpcExecutionStrategy} that disables all offloads.
+     */
+    public static GrpcExecutionStrategy offloadNever() {
         return NO_OFFLOADS;
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -35,7 +35,7 @@ import java.util.TreeSet;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.router.utils.internal.DefaultRouteExecutionStrategyFactory.defaultStrategyFactory;
 import static io.servicetalk.router.utils.internal.RouteExecutionStrategyUtils.getAndValidateRouteExecutionStrategyAnnotationIfPresent;
 import static io.servicetalk.utils.internal.ReflectionUtils.retrieveMethod;
@@ -48,7 +48,7 @@ import static io.servicetalk.utils.internal.ReflectionUtils.retrieveMethod;
 public abstract class GrpcRoutes<Service extends GrpcService> {
 
     private static final GrpcExecutionStrategy NULL = new DefaultGrpcExecutionStrategy(
-            HttpExecutionStrategies.noOffloadsStrategy());
+            HttpExecutionStrategies.offloadNever());
 
     private final GrpcRouter.Builder routeBuilder;
     private final Set<String> errors;
@@ -188,7 +188,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             return saved;
         }
         return getAndValidateRouteExecutionStrategyAnnotationIfPresent(method, clazz, strategyFactory, errors,
-                noOffloadsStrategy());
+                offloadNever());
     }
 
     /**

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
@@ -74,7 +74,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
@@ -452,7 +452,7 @@ class ErrorHandlingTest {
     }
 
     static Collection<Arguments> data() {
-        GrpcExecutionStrategy noopStrategy = noOffloadsStrategy();
+        GrpcExecutionStrategy noopStrategy = offloadNever();
         GrpcExecutionStrategy immediateStrategy = customStrategyBuilder().executor(immediate()).build();
         GrpcExecutionStrategy[] strategies =
                 new GrpcExecutionStrategy[]{noopStrategy, immediateStrategy, defaultStrategy()};

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyConfigurationFailuresTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyConfigurationFailuresTest.java
@@ -30,7 +30,7 @@ import io.servicetalk.router.api.RouteExecutionStrategyFactory;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.router.utils.internal.DefaultRouteExecutionStrategyFactory.getUsingDefaultStrategyFactory;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -109,7 +109,7 @@ class ExecutionStrategyConfigurationFailuresTest {
     private static final TesterService MISCONFIGURED_SERVICE = new MisconfiguredService();
     private static final BlockingTesterService MISCONFIGURED_BLOCKING_SERVICE = new MisconfiguredBlockingService();
     private static final RouteExecutionStrategyFactory<GrpcExecutionStrategy> STRATEGY_FACTORY =
-            id -> "test".equals(id) ? noOffloadsStrategy() : getUsingDefaultStrategyFactory(id);
+            id -> "test".equals(id) ? offloadNever() : getUsingDefaultStrategyFactory(id);
 
     @Test
     void usingServiceFactoryAsyncService() {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
@@ -47,7 +47,7 @@ import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_EXEC_ID_STRATEGY_ASYNC_SERVICE;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_EXEC_ID_STRATEGY_BLOCKING_SERVICE;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE;
@@ -123,7 +123,7 @@ class ExecutionStrategyTest {
         NO_OFFLOADS {
             @Override
             void configureBuilderExecutionStrategy(GrpcServerBuilder builder) {
-                builder.initializeHttp(b -> b.executionStrategy(noOffloadsStrategy()));
+                builder.initializeHttp(b -> b.executionStrategy(offloadNever()));
             }
         };
 
@@ -159,10 +159,10 @@ class ExecutionStrategyTest {
             @Override
             ServiceFactory getServiceFactory() {
                 return new ServiceFactory.Builder(STRATEGY_FACTORY)
-                        .test(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
-                        .testBiDiStream(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
-                        .testResponseStream(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
-                        .testRequestStream(noOffloadsStrategy(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .test(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .testBiDiStream(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .testResponseStream(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .testRequestStream(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
                         .build();
             }
         },
@@ -194,10 +194,10 @@ class ExecutionStrategyTest {
             @Override
             ServiceFactory getServiceFactory() {
                 return new ServiceFactory.Builder(STRATEGY_FACTORY)
-                        .testBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
-                        .testBiDiStreamBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
-                        .testResponseStreamBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
-                        .testRequestStreamBlocking(noOffloadsStrategy(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testBiDiStreamBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testResponseStreamBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testRequestStreamBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
                         .build();
             }
         };
@@ -303,7 +303,7 @@ class ExecutionStrategyTest {
         filterConfiguration.appendServiceFilter(serviceFactory);
         serverContext = builder.listenAndAwait(serviceFactory);
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .initializeHttp(b -> b.executionStrategy(HttpExecutionStrategies.noOffloadsStrategy()))
+                .initializeHttp(b -> b.executionStrategy(HttpExecutionStrategies.offloadNever()))
                 .buildBlocking(new ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientRequiresTrailersTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientRequiresTrailersTest.java
@@ -44,7 +44,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.encoding.api.Identity.identity;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpApiConversions.toHttpService;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
@@ -94,7 +94,7 @@ class GrpcClientRequiresTrailersTest {
                 serverBuilder.listenAndAwait(toHttpService(streamingService));
 
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .initializeHttp(builder -> builder.executionStrategy(noOffloadsStrategy()))
+                .initializeHttp(builder -> builder.executionStrategy(offloadNever()))
                 .buildBlocking(new TesterProto.Tester.ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientValidatesContentTypeTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientValidatesContentTypeTest.java
@@ -44,7 +44,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.encoding.api.Identity.identity;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.grpc.api.GrpcStatusCode.OK;
 import static io.servicetalk.http.api.HttpApiConversions.toHttpService;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
@@ -138,7 +138,7 @@ final class GrpcClientValidatesContentTypeTest {
                 serverBuilder.listenAndAwait(toHttpService(streamingService));
 
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .initializeHttp(builder -> builder.executionStrategy(noOffloadsStrategy()))
+                .initializeHttp(builder -> builder.executionStrategy(offloadNever()))
                 .buildBlocking(new TesterProto.Tester.ClientFactory());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcRouterConfigurationTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcRouterConfigurationTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_NO_OFFLOADS_STRATEGY_BLOCKING_SERVICE;
@@ -162,36 +162,36 @@ class GrpcRouterConfigurationTest {
         final TesterService asyncService = DEFAULT_STRATEGY_ASYNC_SERVICE;
         testCanNotOverrideAlreadyRegisteredPath(TestRpc.PATH, builder -> builder
                 .test(asyncService)
-                .test(noOffloadsStrategy(), asyncService));
+                .test(offloadNever(), asyncService));
 
         testCanNotOverrideAlreadyRegisteredPath(TestBiDiStreamRpc.PATH, builder -> builder
                 .testBiDiStream(asyncService)
-                .testBiDiStream(noOffloadsStrategy(), asyncService));
+                .testBiDiStream(offloadNever(), asyncService));
 
         testCanNotOverrideAlreadyRegisteredPath(TestResponseStreamRpc.PATH, builder -> builder
                 .testResponseStream(asyncService)
-                .testResponseStream(noOffloadsStrategy(), asyncService));
+                .testResponseStream(offloadNever(), asyncService));
 
         testCanNotOverrideAlreadyRegisteredPath(TestRequestStreamRpc.PATH, builder -> builder
                 .testRequestStream(asyncService)
-                .testRequestStream(noOffloadsStrategy(), asyncService));
+                .testRequestStream(offloadNever(), asyncService));
 
         final BlockingTesterService blockingService = DEFAULT_STRATEGY_BLOCKING_SERVICE;
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestRpc.PATH, builder -> builder
                 .testBlocking(blockingService)
-                .testBlocking(noOffloadsStrategy(), blockingService));
+                .testBlocking(offloadNever(), blockingService));
 
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestBiDiStreamRpc.PATH, builder -> builder
                 .testBiDiStreamBlocking(blockingService)
-                .testBiDiStreamBlocking(noOffloadsStrategy(), blockingService));
+                .testBiDiStreamBlocking(offloadNever(), blockingService));
 
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestResponseStreamRpc.PATH, builder -> builder
                 .testResponseStreamBlocking(blockingService)
-                .testResponseStreamBlocking(noOffloadsStrategy(), blockingService));
+                .testResponseStreamBlocking(offloadNever(), blockingService));
 
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestRequestStreamRpc.PATH, builder -> builder
                 .testRequestStreamBlocking(blockingService)
-                .testRequestStreamBlocking(noOffloadsStrategy(), blockingService));
+                .testRequestStreamBlocking(offloadNever(), blockingService));
     }
 
     @Test

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -110,7 +110,7 @@ import static io.servicetalk.concurrent.internal.TestTimeoutConstants.DEFAULT_TI
 import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.encoding.netty.ContentCodings.gzipDefault;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.grpc.api.GrpcStatusCode.CANCELLED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
 import static io.servicetalk.grpc.internal.DeadlineUtils.GRPC_TIMEOUT_HEADER_KEY;
@@ -398,7 +398,7 @@ class ProtocolCompatibilityTest {
                                                        final String compression)
             throws Exception {
         final TestServerContext server = serviceTalkServer(ErrorMode.SIMPLE_IN_RESPONSE, ssl,
-                noOffloadsStrategy(), compression, null);
+                offloadNever(), compression, null);
         final CompatClient client = grpcJavaClient(server.listenAddress(), compression, ssl, null);
         testGrpcError(client, server, false, streaming, compression);
     }
@@ -463,7 +463,7 @@ class ProtocolCompatibilityTest {
         final boolean streaming,
         final String compression) throws Exception {
         final TestServerContext server = serviceTalkServer(ErrorMode.STATUS_IN_RESPONSE, ssl,
-                noOffloadsStrategy(), compression, null);
+                offloadNever(), compression, null);
         final CompatClient client = grpcJavaClient(server.listenAddress(), compression, ssl, null);
         testGrpcError(client, server, true, streaming, compression);
     }
@@ -641,7 +641,7 @@ class ProtocolCompatibilityTest {
         Duration serverTimeout = clientInitiatedTimeout ? null : DEFAULT_DEADLINE;
         BlockingQueue<Throwable> serverErrorQueue = new ArrayBlockingQueue<>(16);
         final TestServerContext server = stServer ?
-                serviceTalkServer(ErrorMode.NONE, false, noOffloadsStrategy(), null, null, serverErrorQueue) :
+                serviceTalkServer(ErrorMode.NONE, false, offloadNever(), null, null, serverErrorQueue) :
                 grpcJavaServer(ErrorMode.NONE, false, null);
         try (ServerContext proxyCtx = buildTimeoutProxy(server.listenAddress(), serverTimeout, false)) {
             final CompatClient client = stClient ?
@@ -671,7 +671,7 @@ class ProtocolCompatibilityTest {
     private static ServerContext buildTimeoutProxy(SocketAddress serverAddress, @Nullable Duration forcedTimeout,
                                                    boolean ssl) throws Exception {
         HttpServerBuilder proxyBuilder = HttpServers.forAddress(localAddress(0))
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .protocols(h2().build());
         if (ssl) {
             proxyBuilder.sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
@@ -689,7 +689,7 @@ class ProtocolCompatibilityTest {
                                  boolean ssl) {
             SingleAddressHttpClientBuilder<InetSocketAddress, InetSocketAddress> builder =
                     HttpClients.forResolvedAddress((InetSocketAddress) serverAddress)
-                            .executionStrategy(noOffloadsStrategy())
+                            .executionStrategy(offloadNever())
                             .protocols(h2().build());
             if (ssl) {
                 builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -84,8 +84,25 @@ public final class HttpExecutionStrategies {
      * </pre>
      *
      * @return {@link HttpExecutionStrategy} that disables all request-response path offloads.
+     * @deprecated Replaced with the more descriptive {@link #offloadNever()}.
      */
+    @Deprecated
     public static HttpExecutionStrategy noOffloadsStrategy() {
+        return NO_OFFLOADS_NO_EXECUTOR;
+    }
+
+    /**
+     * A {@link HttpExecutionStrategy} that disables all offloads on the request-response path.
+     *
+     * <p>The default offloading executor will still be used inside {@link ExecutionContext} and for all places where
+     * it is referenced. To ensure that the default offloading executor is never used configure it with
+     * {@link Executors#immediate()} executor explicitly: <pre>
+     *     HttpExecutionStrategies.customStrategyBuilder().offloadNone().executor(immediate()).build()
+     * </pre>
+     *
+     * @return {@link HttpExecutionStrategy} that disables all request-response path offloads.
+     */
+    public static HttpExecutionStrategy offloadNever() {
         return NO_OFFLOADS_NO_EXECUTOR;
     }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractBlockingStreamingHttpRequesterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractBlockingStreamingHttpRequesterTest.java
@@ -36,7 +36,7 @@ import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -85,7 +85,7 @@ public abstract class AbstractBlockingStreamingHttpRequesterTest {
         StreamingHttpRequester asyncRequester = newAsyncRequester(reqRespFactory, mockExecutionCtx,
                 (strategy, req) -> succeeded(reqRespFactory.ok()));
         BlockingStreamingHttpRequester syncRequester = toBlockingStreamingRequester(asyncRequester);
-        BlockingStreamingHttpResponse syncResponse = syncRequester.request(noOffloadsStrategy(),
+        BlockingStreamingHttpResponse syncResponse = syncRequester.request(offloadNever(),
                 syncRequester.get("/"));
         assertEquals(HTTP_1_1, syncResponse.version());
         assertEquals(OK, syncResponse.status());
@@ -96,7 +96,7 @@ public abstract class AbstractBlockingStreamingHttpRequesterTest {
         StreamingHttpRequester asyncRequester = newAsyncRequester(reqRespFactory, mockExecutionCtx,
                 (strategy, req) -> succeeded(reqRespFactory.ok().payloadBody(from(allocator.fromAscii("hello")))));
         BlockingStreamingHttpRequester syncRequester = toBlockingStreamingRequester(asyncRequester);
-        BlockingStreamingHttpResponse syncResponse = syncRequester.request(noOffloadsStrategy(),
+        BlockingStreamingHttpResponse syncResponse = syncRequester.request(offloadNever(),
                 syncRequester.get("/"));
         assertEquals(HTTP_1_1, syncResponse.version());
         assertEquals(OK, syncResponse.status());
@@ -114,7 +114,7 @@ public abstract class AbstractBlockingStreamingHttpRequesterTest {
                 (strategy, req) -> succeeded(reqRespFactory.ok().payloadBody(
                         from(allocator.fromAscii(expectedPayload)))));
         BlockingStreamingHttpRequester syncRequester = toBlockingStreamingRequester(asyncRequester);
-        BlockingStreamingHttpResponse syncResponse = syncRequester.request(noOffloadsStrategy(),
+        BlockingStreamingHttpResponse syncResponse = syncRequester.request(offloadNever(),
                 syncRequester.get("/"));
         assertEquals(HTTP_1_1, syncResponse.version());
         assertEquals(OK, syncResponse.status());
@@ -140,7 +140,7 @@ public abstract class AbstractBlockingStreamingHttpRequesterTest {
                 (strategy, req) -> succeeded(reqRespFactory.ok().payloadBody(publisher)));
         TestSubscription subscription = new TestSubscription();
         BlockingStreamingHttpRequester syncRequester = toBlockingStreamingRequester(asyncRequester);
-        BlockingStreamingHttpResponse syncResponse = syncRequester.request(noOffloadsStrategy(),
+        BlockingStreamingHttpResponse syncResponse = syncRequester.request(offloadNever(),
                 syncRequester.get("/"));
         assertEquals(HTTP_1_1, syncResponse.version());
         assertEquals(OK, syncResponse.status());

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpClientTest.java
@@ -28,7 +28,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpApiConversions.toBlockingClient;
 import static io.servicetalk.http.api.HttpApiConversions.toBlockingStreamingClient;
 import static io.servicetalk.http.api.HttpApiConversions.toClient;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static java.util.Objects.requireNonNull;
 
 public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHttpRequesterTest {
@@ -105,12 +105,12 @@ public class BlockingStreamingHttpClientTest extends AbstractBlockingStreamingHt
 
         @Override
         public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-            return request(noOffloadsStrategy(), request);
+            return request(offloadNever(), request);
         }
 
         @Override
         public Single<ReservedStreamingHttpConnection> reserveConnection(final HttpRequestMetaData metaData) {
-            return reserveConnection(noOffloadsStrategy(), metaData);
+            return reserveConnection(offloadNever(), metaData);
         }
 
         @Override

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingHttpConnectionTest.java
@@ -28,7 +28,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpApiConversions.toBlockingConnection;
 import static io.servicetalk.http.api.HttpApiConversions.toBlockingStreamingConnection;
 import static io.servicetalk.http.api.HttpApiConversions.toConnection;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -118,7 +118,7 @@ public class BlockingStreamingHttpConnectionTest extends AbstractBlockingStreami
 
         @Override
         public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-            return request(noOffloadsStrategy(), request);
+            return request(offloadNever(), request);
         }
 
         @Override

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyMergeTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyMergeTest.java
@@ -20,7 +20,7 @@ import io.servicetalk.concurrent.api.Executor;
 import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.Builder.MergeStrategy.Merge;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -92,8 +92,8 @@ class DefaultHttpExecutionStrategyMergeTest {
     @Test
     void mergeWithNoOffloads() {
         HttpExecutionStrategy strategy = customStrategyBuilder().offloadSend().executor(executor).build();
-        HttpExecutionStrategy merged = strategy.merge(noOffloadsStrategy());
-        assertThat("Unexpected merge result.", merged, is(sameInstance(noOffloadsStrategy())));
+        HttpExecutionStrategy merged = strategy.merge(offloadNever());
+        assertThat("Unexpected merge result.", merged, is(sameInstance(offloadNever())));
     }
 
     @Test

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
@@ -42,7 +42,7 @@ import static io.servicetalk.concurrent.api.Single.never;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.NoOffloadsHttpExecutionStrategy.NO_OFFLOADS_NO_EXECUTOR;
@@ -215,7 +215,7 @@ class DefaultHttpExecutionStrategyTest {
                         // Use noOffloadsStrategy() for the ctx to indicate that there was no offloading before.
                         // So, the difference function inside #offloadService will return the tested strategy.
                         new ExecutionContextToHttpExecutionContext(contextRule,
-                                noOffloadsStrategy()));
+                                offloadNever()));
         analyzer.instrumentedResponseForServer(svc.handle(ctx, req, ctx.streamingResponseFactory()))
                 .flatMapPublisher(StreamingHttpResponse::payloadBody)
             .toFuture().get();

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategiesTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategiesTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.difference;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -60,7 +60,7 @@ class HttpExecutionStrategiesTest {
     void diffRightNoOffload() {
         Executor fallback = mock(Executor.class);
         HttpExecutionStrategy strat1 = customStrategyBuilder().offloadReceiveData().build();
-        HttpExecutionStrategy strat2 = noOffloadsStrategy();
+        HttpExecutionStrategy strat2 = offloadNever();
         HttpExecutionStrategy result = difference(fallback, strat1, strat2);
         assertThat("Unexpected diff.", result, is(nullValue()));
     }
@@ -68,7 +68,7 @@ class HttpExecutionStrategiesTest {
     @Test
     void diffLeftNoOffload() {
         Executor fallback = mock(Executor.class);
-        HttpExecutionStrategy strat1 = noOffloadsStrategy();
+        HttpExecutionStrategy strat1 = offloadNever();
         HttpExecutionStrategy strat2 = customStrategyBuilder().offloadReceiveData().build();
         HttpExecutionStrategy result = difference(fallback, strat1, strat2);
         assertThat("Unexpected diff.", result, is(sameInstance(strat2)));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilterTest.java
@@ -35,7 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
@@ -63,7 +63,7 @@ class AbsoluteAddressHttpRequesterFilterTest {
     @Test
     void shouldAddAuthorityToOriginFormRequestTarget() throws Exception {
         request.requestTarget("/path?query");
-        filter.request(noOffloadsStrategy(), request).toFuture().get();
+        filter.request(offloadNever(), request).toFuture().get();
         verify(delegate).request(any(), requestCapture.capture());
 
         final StreamingHttpRequest capturedRequest = requestCapture.getValue();
@@ -73,7 +73,7 @@ class AbsoluteAddressHttpRequesterFilterTest {
     @Test
     void shouldNotAddAuthorityToAbsoluteFormRequestTarget() throws Exception {
         request.requestTarget("https://otherhost:443/otherpath?otherQuery");
-        filter.request(noOffloadsStrategy(), request).toFuture().get();
+        filter.request(offloadNever(), request).toFuture().get();
         verify(delegate).request(any(), requestCapture.capture());
 
         final StreamingHttpRequest capturedRequest = requestCapture.getValue();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractEchoServerBasedHttpRequesterTest.java
@@ -39,7 +39,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffFullJitter;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
@@ -65,7 +65,7 @@ abstract class AbstractEchoServerBasedHttpRequesterTest {
     void startServer() throws Exception {
         serverContext = forAddress(localAddress(0))
             .ioExecutor(CTX.ioExecutor())
-            .executionStrategy(noOffloadsStrategy())
+            .executionStrategy(offloadNever())
             .listenStreamingAndAwait(new EchoServiceStreaming());
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -49,7 +49,7 @@ import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.netty.HttpClients.forResolvedAddress;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
@@ -108,7 +108,7 @@ abstract class AbstractHttpServiceAsyncContextTest {
                             forResolvedAddress(serverHostAndPort(ctx))
                                     .protocols(h1().maxPipelinedRequests(numRequests).build());
                     try (StreamingHttpClient client = (!useImmediate ? clientBuilder :
-                            clientBuilder.executionStrategy(noOffloadsStrategy())).buildStreaming()) {
+                            clientBuilder.executionStrategy(offloadNever())).buildStreaming()) {
                         try (StreamingHttpConnection connection = client.reserveConnection(client.get("/"))
                                 .toFuture().get()) {
                             barrier.await();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
@@ -54,7 +54,7 @@ import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.AUTHORIZATION;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -133,7 +133,7 @@ class BasicAuthStrategyInfluencerTest {
         CredentialsVerifier<String> verifier = credentialsVerifier;
         if (noOffloadsInfluence) {
             verifier = new InfluencingVerifier(verifier, strategy -> strategy);
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+            serverBuilder.executionStrategy(offloadNever());
         }
         serverBuilder.appendServiceFilter(new BasicAuthHttpServiceFilter.Builder<>(verifier, "dummy")
                 .buildServer());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -57,7 +57,7 @@ import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.netty.ClientEffectiveStrategyTest.ClientOffloadPoint.RequestPayloadSubscription;
 import static io.servicetalk.http.netty.ClientEffectiveStrategyTest.ClientOffloadPoint.ResponseData;
 import static io.servicetalk.http.netty.ClientEffectiveStrategyTest.ClientOffloadPoint.ResponseMeta;
@@ -451,7 +451,7 @@ class ClientEffectiveStrategyTest {
 
         void initStateHolderUserStrategyNoOffloadsNoExecutor(boolean addFilter, boolean addLoadBalancer,
                                                              boolean addConnectionFilter) {
-            invokingThreadsRecorder = userStrategy(noOffloadsStrategy());
+            invokingThreadsRecorder = userStrategy(offloadNever());
             initState(addFilter, addLoadBalancer, addConnectionFilter);
         }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -50,7 +50,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
@@ -81,7 +81,7 @@ class FlushStrategyOnServerTest {
     private BlockingHttpClient client;
 
     private enum Param {
-        NO_OFFLOAD(noOffloadsStrategy()),
+        NO_OFFLOAD(offloadNever()),
         DEFAULT(defaultStrategy()),
         OFFLOAD_ALL(customStrategyBuilder().offloadAll().build());
         private final HttpExecutionStrategy executionStrategy;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
@@ -52,7 +52,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.immediate;
@@ -75,14 +75,14 @@ class FlushStrategyOverrideTest {
         service = new FlushingService();
         serverCtx = HttpServers.forAddress(localAddress(0))
                 .ioExecutor(ctx.ioExecutor())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .listenStreaming(service)
                 .toFuture().get();
         InetSocketAddress serverAddr = (InetSocketAddress) serverCtx.listenAddress();
         client = forSingleAddress(new NoopSD(serverAddr), serverAddr)
                 .disableHostHeaderFallback()
                 .ioExecutor(ctx.ioExecutor())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .unresolvedAddressToHost(InetSocketAddress::getHostString)
                 .buildStreaming();
         conn = client.reserveConnection(client.get("/")).toFuture().get();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HostHeaderHttpRequesterFilterTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializationProviders.textDeserializer;
@@ -187,7 +187,7 @@ class HostHeaderHttpRequesterFilterTest {
         if (hostHeader != null) {
             request.setHeader(HOST, hostHeader);
         }
-        HttpResponse response = requester.request(noOffloadsStrategy(), request);
+        HttpResponse response = requester.request(offloadNever(), request);
         assertThat(response.status(), equalTo(OK));
         assertThat(response.version(), equalTo(httpVersionConfig.version()));
         // "Host" header is not required for HTTP/1.0. Therefore, we may expect "null" here.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
@@ -74,13 +74,13 @@ class HttpAuthConnectionFactoryClientTest {
     void simulateAuth() throws Exception {
         serverContext = forAddress(localAddress(0))
             .ioExecutor(CTX.ioExecutor())
-            .executionStrategy(noOffloadsStrategy())
+            .executionStrategy(offloadNever())
             .listenStreamingAndAwait((ctx, request, factory) -> succeeded(newTestResponse(factory)));
 
         client = forSingleAddress(serverHostAndPort(serverContext))
             .appendConnectionFactoryFilter(TestHttpAuthConnectionFactory::new)
             .ioExecutor(CTX.ioExecutor())
-            .executionStrategy(noOffloadsStrategy())
+            .executionStrategy(offloadNever())
             .buildStreaming();
 
         StreamingHttpResponse response = client.request(newTestRequest(client, "/foo")).toFuture().get();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
@@ -88,7 +88,7 @@ abstract class HttpClientAsyncContextTest {
                 .appendClientFilter(c -> new TestStreamingHttpClientFilter(c, errorQueue))
                 .appendClientFilter(c -> new TestStreamingHttpClientFilter(c, errorQueue));
         if (useImmediate) {
-            clientBuilder.executionStrategy(HttpExecutionStrategies.noOffloadsStrategy());
+            clientBuilder.executionStrategy(HttpExecutionStrategies.offloadNever());
         }
         return clientBuilder;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mockito.ArgumentMatchers.any;
@@ -78,7 +78,7 @@ class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterTest {
                 .appendConnectionFactoryFilter(factoryFilter(factory1))
                 .appendConnectionFactoryFilter(factoryFilter(factory2))
                 .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .buildStreaming();
         makeRequestValidateResponseAndClose(requester);
 
@@ -116,7 +116,7 @@ class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterTest {
         StreamingHttpClient requester = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
                 .serviceDiscoverer(disco)
                 .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .buildStreaming();
         makeRequestValidateResponseAndClose(requester);
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientOverrideOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientOverrideOffloadingTest.java
@@ -34,7 +34,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -69,9 +69,9 @@ class HttpClientOverrideOffloadingTest {
     }
 
     enum Params {
-        OVERRIDE_NO_OFFLOAD(th -> !isInClientEventLoop(th), noOffloadsStrategy(), null),
+        OVERRIDE_NO_OFFLOAD(th -> !isInClientEventLoop(th), offloadNever(), null),
         DEFAULT_NO_OFFLOAD(HttpClientOverrideOffloadingTest::isInClientEventLoop, null,
-                noOffloadsStrategy()),
+                offloadNever()),
         BOTH_OFFLOADS(HttpClientOverrideOffloadingTest::isInClientEventLoop, null, null);
 
         final Predicate<Thread> isInvalidThread;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionEmptyPayloadTest.java
@@ -35,7 +35,7 @@ import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitelyN
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
@@ -62,7 +62,7 @@ class HttpConnectionEmptyPayloadTest {
             ServerContext serverContext = closeable.merge(HttpServers
                     .forAddress(localAddress(0))
                     .ioExecutor(executionContextRule.ioExecutor())
-                    .executionStrategy(noOffloadsStrategy())
+                    .executionStrategy(offloadNever())
                     .listenStreamingAndAwait(
                             (ctx, req, factory) -> {
                                 StreamingHttpResponse resp = factory.ok().payloadBody(from(

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpStreamingClientOverrideOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpStreamingClientOverrideOffloadingTest.java
@@ -36,7 +36,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -74,9 +74,9 @@ class HttpStreamingClientOverrideOffloadingTest {
 
     enum Params {
 
-        OVERRIDE_NO_OFFLOAD(th -> !isInClientEventLoop(th), noOffloadsStrategy(), null),
+        OVERRIDE_NO_OFFLOAD(th -> !isInClientEventLoop(th), offloadNever(), null),
         DEFAULT_NO_OFFLOAD(HttpStreamingClientOverrideOffloadingTest::isInClientEventLoop, null,
-                noOffloadsStrategy()),
+                offloadNever()),
         BOTH_OFFLOADS(HttpStreamingClientOverrideOffloadingTest::isInClientEventLoop, null, null);
 
         final Predicate<Thread> isInvalidThread;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTestExecutionStrategy.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTestExecutionStrategy.java
@@ -25,7 +25,7 @@ import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static java.lang.Thread.NORM_PRIORITY;
 
 public enum HttpTestExecutionStrategy {
-    NO_OFFLOAD(HttpExecutionStrategies::noOffloadsStrategy),
+    NO_OFFLOAD(HttpExecutionStrategies::offloadNever),
     CACHED(() -> HttpExecutionStrategies.defaultStrategy(newCachedThreadExecutor(
             new DefaultThreadFactory("http-test-executor", true, NORM_PRIORITY))));
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
@@ -43,7 +43,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -69,9 +69,9 @@ class NettyHttpServerConnectionTest {
     private static Stream<Arguments> executionStrategies() {
         return Stream.of(
                 Arguments.of(defaultStrategy(), defaultStrategy()),
-                Arguments.of(noOffloadsStrategy(), defaultStrategy()),
-                Arguments.of(defaultStrategy(), noOffloadsStrategy()),
-                Arguments.of(noOffloadsStrategy(), noOffloadsStrategy()));
+                Arguments.of(offloadNever(), defaultStrategy()),
+                Arguments.of(defaultStrategy(), offloadNever()),
+                Arguments.of(offloadNever(), offloadNever()));
     }
 
     @AfterEach

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerTest.java
@@ -56,7 +56,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.closeAsyncGracefully
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
@@ -166,7 +166,7 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
 
         HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
         if (disableOffloading) {
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+            serverBuilder.executionStrategy(offloadNever());
         }
         try (ServerContext serverCtx = serverBuilder.listenStreamingAndAwait((ctx, request, responseFactory) -> {
                     throw DELIBERATE_EXCEPTION;
@@ -182,7 +182,7 @@ class NettyHttpServerTest extends AbstractNettyHttpServerTest {
     private static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> disableOffloading(
             SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder, boolean disableOffloading) {
         if (disableOffloading) {
-            clientBuilder.executionStrategy(noOffloadsStrategy());
+            clientBuilder.executionStrategy(offloadNever());
         }
         return clientBuilder;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RedirectingClientAndConnectionFilterTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpHeaderNames.LOCATION;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
@@ -61,14 +61,14 @@ final class RedirectingClientAndConnectionFilterTest extends AbstractHttpRequest
         }, newFilterFactory()));
 
         HttpRequest request = client.get("/");
-        HttpResponse response = client.request(noOffloadsStrategy(), request);
+        HttpResponse response = client.request(offloadNever(), request);
         assertThat(response.status(), equalTo(PERMANENT_REDIRECT));
 
-        response = client.request(noOffloadsStrategy(), request.addHeader("X-REDIRECT", "TRUE"));
+        response = client.request(offloadNever(), request.addHeader("X-REDIRECT", "TRUE"));
         assertThat(response.status(), equalTo(OK));
 
         // HTTP/1.0 doesn't support HOST, ensure that we don't get any errors and perform relative redirect
-        response = client.request(noOffloadsStrategy(),
+        response = client.request(offloadNever(),
                 client.get("/")
                         .version(HTTP_1_0)
                         .addHeader("X-REDIRECT", "TRUE"));
@@ -88,14 +88,14 @@ final class RedirectingClientAndConnectionFilterTest extends AbstractHttpRequest
             return succeeded(responseFactory.ok());
         }, newFilterFactory()));
         HttpRequest request = client.get("/");
-        HttpResponse response = client.request(noOffloadsStrategy(), request);
+        HttpResponse response = client.request(offloadNever(), request);
         assertThat(response.status(), equalTo(PERMANENT_REDIRECT));
 
-        response = client.request(noOffloadsStrategy(), request.addHeader("X-REDIRECT", "TRUE"));
+        response = client.request(offloadNever(), request.addHeader("X-REDIRECT", "TRUE"));
         assertThat(response.status(), equalTo(OK));
 
         // HTTP/1.0 doesn't support HOST => we can not infer that the absolute-form location is relative, don't redirect
-        response = client.request(noOffloadsStrategy(),
+        response = client.request(offloadNever(),
                 client.get("/")
                         .version(HTTP_1_0)
                         .addHeader("X-REDIRECT", "TRUE"));
@@ -115,10 +115,10 @@ final class RedirectingClientAndConnectionFilterTest extends AbstractHttpRequest
             return succeeded(responseFactory.ok());
         }, newFilterFactory()));
         HttpRequest request = client.get("/").addHeader(HOST, "servicetalk.io");
-        HttpResponse response = client.request(noOffloadsStrategy(), request);
+        HttpResponse response = client.request(offloadNever(), request);
         assertThat(response.status(), equalTo(PERMANENT_REDIRECT));
 
-        response = client.request(noOffloadsStrategy(), request.addHeader("X-REDIRECT", "TRUE"));
+        response = client.request(offloadNever(), request.addHeader("X-REDIRECT", "TRUE"));
         assertThat(response.status(), equalTo(OK));
     }
 
@@ -135,10 +135,10 @@ final class RedirectingClientAndConnectionFilterTest extends AbstractHttpRequest
             return succeeded(responseFactory.ok());
         }, newFilterFactory()));
         HttpRequest request = client.get("/").addHeader(HOST, "servicetalk.io:80");
-        HttpResponse response = client.request(noOffloadsStrategy(), request);
+        HttpResponse response = client.request(offloadNever(), request);
         assertThat(response.status(), equalTo(PERMANENT_REDIRECT));
 
-        response = client.request(noOffloadsStrategy(), request.addHeader("X-REDIRECT", "TRUE"));
+        response = client.request(offloadNever(), request.addHeader("X-REDIRECT", "TRUE"));
         assertThat(response.status(), equalTo(OK));
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -53,7 +53,7 @@ import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.IO_EXECUTOR_NAME_PREFIX;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.noStrategy;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategy;
@@ -351,7 +351,7 @@ class ServerEffectiveStrategyTest {
 
         void initStateHolderUserStrategyNoOffloadsNoExecutor() {
             verifyStrategyUsed = !addFilter;
-            newRecorder(noOffloadsStrategy());
+            newRecorder(offloadNever());
         }
 
         void initStateHolderCustomUserStrategyNoExecutor() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerGracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerGracefulConnectionClosureHandlingTest.java
@@ -37,7 +37,7 @@ import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.http.netty.HttpServers.forAddress;
@@ -70,7 +70,7 @@ class ServerGracefulConnectionClosureHandlingTest {
         serverContext = forAddress(localAddress(0))
             .ioExecutor(SERVER_CTX.ioExecutor())
             .executionStrategy(defaultStrategy(SERVER_CTX.executor()))
-            .executionStrategy(noOffloadsStrategy())
+            .executionStrategy(offloadNever())
             .appendConnectionAcceptorFilter(original -> new DelegatingConnectionAcceptor(original) {
                 @Override
                 public Completable accept(final ConnectionContext context) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -42,7 +42,7 @@ import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
@@ -73,7 +73,7 @@ class ServerRespondsOnClosingTest {
     ServerRespondsOnClosingTest() throws Exception {
         channel = new EmbeddedDuplexChannel(false);
         DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR,
-                fromNettyEventLoop(channel.eventLoop()), immediate(), noOffloadsStrategy());
+                fromNettyEventLoop(channel.eventLoop()), immediate(), offloadNever());
         final HttpServerConfig httpServerConfig = new HttpServerConfig();
         httpServerConfig.tcpConfig().enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true);
         ReadOnlyHttpServerConfig config = httpServerConfig.asReadOnly();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
@@ -43,7 +43,7 @@ import javax.net.ssl.SSLHandshakeException;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
@@ -91,7 +91,7 @@ class SslAndNonSslConnectionsTest {
         when(STREAMING_HTTP_SERVICE.closeAsync()).thenReturn(completed());
         when(STREAMING_HTTP_SERVICE.closeAsyncGracefully()).thenReturn(completed());
         serverCtx = HttpServers.forAddress(localAddress(0))
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .listenStreamingAndAwait(STREAMING_HTTP_SERVICE);
         final String serverHostHeader = hostHeader(serverHostAndPort(serverCtx));
         requestTarget = "http://" + serverHostHeader + "/";
@@ -109,7 +109,7 @@ class SslAndNonSslConnectionsTest {
         secureServerCtx = HttpServers.forAddress(localAddress(0))
                 .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
                         DefaultTestCerts::loadServerKey).build())
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .listenStreamingAndAwait(SECURE_STREAMING_HTTP_SERVICE);
         final String secureServerHostHeader = hostHeader(serverHostAndPort(secureServerCtx));
         secureRequestTarget = "https://" + secureServerHostHeader + "/";

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static java.lang.Thread.currentThread;
 
@@ -81,7 +81,7 @@ abstract class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceA
     protected ServerContext serverWithEmptyAsyncContextService(HttpServerBuilder serverBuilder,
                                                      boolean useImmediate) throws Exception {
         if (useImmediate) {
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+            serverBuilder.executionStrategy(offloadNever());
         }
         return serverBuilder.listenStreamingAndAwait(newEmptyAsyncContextService());
     }
@@ -109,7 +109,7 @@ abstract class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceA
     protected ServerContext serverWithService(HttpServerBuilder serverBuilder,
                                     boolean useImmediate, boolean asyncService) throws Exception {
         if (useImmediate) {
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+            serverBuilder.executionStrategy(offloadNever());
         }
         return serverBuilder.listenStreamingAndAwait(service(useImmediate, asyncService));
     }

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/JerseyRouteExecutionStrategyUtils.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/JerseyRouteExecutionStrategyUtils.java
@@ -50,7 +50,7 @@ import java.util.concurrent.CompletionStage;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.router.utils.internal.RouteExecutionStrategyUtils.getRouteExecutionStrategyAnnotation;
 import static java.util.Collections.emptyMap;
 import static org.glassfish.jersey.model.Parameter.Source.ENTITY;
@@ -171,7 +171,7 @@ final class JerseyRouteExecutionStrategyUtils {
         }
 
         if (annotation instanceof NoOffloadsRouteExecutionStrategy) {
-            return noOffloadsStrategy();
+            return offloadNever();
         }
 
         // This can never be null because we have pre-validated that all route strategy IDs exist at startup

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractResourceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AbstractResourceTest.java
@@ -42,7 +42,7 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.ext.Provider;
 
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
@@ -134,7 +134,7 @@ public abstract class AbstractResourceTest extends AbstractJerseyStreamingHttpSe
                            final HttpJerseyRouterBuilder jerseyRouterBuilder) {
         super.configureBuilders(serverBuilder, jerseyRouterBuilder);
         if (serverNoOffloads) {
-            serverBuilder.executionStrategy(noOffloadsStrategy());
+            serverBuilder.executionStrategy(offloadNever());
         }
     }
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyTest.java
@@ -42,7 +42,7 @@ import java.util.Set;
 import javax.ws.rs.core.Application;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.router.jersey.AbstractJerseyStreamingHttpServiceTest.RouterApi.BLOCKING_STREAMING;
@@ -104,7 +104,7 @@ final class ExecutionStrategyTest extends AbstractJerseyStreamingHttpServiceTest
         NO_OFFLOADS {
             @Override
             void configureRouterBuilder(final HttpServerBuilder builder, final Executor ignored) {
-                builder.executionStrategy(noOffloadsStrategy());
+                builder.executionStrategy(offloadNever());
             }
         };
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/MixedModeResourceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/MixedModeResourceTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.util.Set;
 import javax.ws.rs.core.Application;
 
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.router.jersey.AbstractResourceTest.assumeSafeToDisableOffloading;
@@ -58,7 +58,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
     void configureBuilders(final HttpServerBuilder serverBuilder,
                            final HttpJerseyRouterBuilder jerseyRouterBuilder) {
         super.configureBuilders(serverBuilder, jerseyRouterBuilder);
-        serverBuilder.executionStrategy(noOffloadsStrategy());
+        serverBuilder.executionStrategy(offloadNever());
     }
 
     @Override
@@ -71,7 +71,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
                 .whenPathEquals(MixedModeResources.PATH + "/cs-string")
                 .thenRouteTo(router)
                 .when(__ -> true)
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .thenRouteTo(router)
                 .buildStreaming());
     }
@@ -86,7 +86,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
                 .whenPathEquals(MixedModeResources.PATH + "/cs-string")
                 .thenRouteTo(router)
                 .when(__ -> true)
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .thenRouteTo(router)
                 .buildStreaming());
     }
@@ -101,7 +101,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
                 .whenPathEquals(MixedModeResources.PATH + "/cs-string")
                 .thenRouteTo(router)
                 .when(__ -> true)
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .thenRouteTo(router)
                 .buildStreaming());
     }
@@ -116,7 +116,7 @@ class MixedModeResourceTest extends AbstractJerseyStreamingHttpServiceTest {
                 .whenPathEquals(MixedModeResources.PATH + "/cs-string")
                 .thenRouteTo(router)
                 .when(__ -> true)
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .thenRouteTo(router)
                 .buildStreaming());
     }

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
@@ -44,7 +44,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpSerializationProviders.textSerializer;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -73,9 +73,9 @@ class HttpServerOverrideOffloadingTest {
         service2 = new OffloadingTesterService(HttpServerOverrideOffloadingTest::isInServerEventLoop);
         server = HttpServers.forAddress(localAddress(0))
                 .ioExecutor(ioExecutor)
-                .executionStrategy(noOffloadsStrategy())
+                .executionStrategy(offloadNever())
                 .listenStreamingAndAwait(new HttpPredicateRouterBuilder()
-                        .whenPathStartsWith("/service1").executionStrategy(noOffloadsStrategy())
+                        .whenPathStartsWith("/service1").executionStrategy(offloadNever())
                         .thenRouteTo(service1)
                         .whenPathStartsWith("/service2").executionStrategy(defaultStrategy(executor))
                         .thenRouteTo(service2).buildStreaming());

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/PredicateRouterOffloadingTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/PredicateRouterOffloadingTest.java
@@ -59,7 +59,7 @@ import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.noOffloadsStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.router.predicate.PredicateRouterOffloadingTest.RouteServiceType.ASYNC_AGGREGATED;
 import static io.servicetalk.http.router.predicate.PredicateRouterOffloadingTest.RouteServiceType.BLOCKING_AGGREGATED;
@@ -129,7 +129,7 @@ class PredicateRouterOffloadingTest {
         assumeSafeToDisableOffloading(routeServiceType);
         final HttpPredicateRouterBuilder routerBuilder = newRouterBuilder();
         routeServiceType.addThreadRecorderService(
-                routerBuilder.when(newPredicate()).executionStrategy(noOffloadsStrategy()),
+                routerBuilder.when(newPredicate()).executionStrategy(offloadNever()),
                 this::recordThread);
         final BlockingHttpClient client = buildServerAndClient(routerBuilder.buildStreaming());
         client.request(client.get("/"));
@@ -143,7 +143,7 @@ class PredicateRouterOffloadingTest {
     void routeOffloadedAndNotPredicate(RouteServiceType routeServiceType) throws Exception {
         this.routeServiceType = routeServiceType;
         final HttpPredicateRouterBuilder routerBuilder = newRouterBuilder();
-        serverBuilder.executionStrategy(noOffloadsStrategy());
+        serverBuilder.executionStrategy(offloadNever());
         routeServiceType.addThreadRecorderService(
                 routerBuilder.when(newPredicate()).executionStrategy(defaultStrategy(executionContextRule.executor())),
                 this::recordThread);
@@ -158,7 +158,7 @@ class PredicateRouterOffloadingTest {
     void routeDefaultAndPredicateNotOffloaded(RouteServiceType routeServiceType) throws Exception {
         this.routeServiceType = routeServiceType;
         final HttpPredicateRouterBuilder routerBuilder = newRouterBuilder();
-        serverBuilder.executionStrategy(noOffloadsStrategy());
+        serverBuilder.executionStrategy(offloadNever());
         routeServiceType.addThreadRecorderService(
                 routerBuilder.when(newPredicate()),
                 this::recordThread);
@@ -174,9 +174,9 @@ class PredicateRouterOffloadingTest {
         this.routeServiceType = routeServiceType;
         assumeSafeToDisableOffloading(routeServiceType);
         final HttpPredicateRouterBuilder routerBuilder = newRouterBuilder();
-        serverBuilder.executionStrategy(noOffloadsStrategy());
+        serverBuilder.executionStrategy(offloadNever());
         routeServiceType.addThreadRecorderService(
-                routerBuilder.when(newPredicate()).executionStrategy(noOffloadsStrategy()),
+                routerBuilder.when(newPredicate()).executionStrategy(offloadNever()),
                 this::recordThread);
         final BlockingHttpClient client = buildServerAndClient(routerBuilder.buildStreaming());
         client.request(client.get("/"));


### PR DESCRIPTION
Motivation:
The name `noOffloadsStrategy` is persistently confusing because, beyond
requiring no offloads, it also enforces that the execution strategy may
not be influenced to perform offloading.
Modifications:
`noOffloadsStrategy` is deprecated and the more descriptive
`offloadNever` is introduced to replace it.
Result:
More obvious offloading behavior.