### PR TITLE
Introduce `HttpServerContext` and `GrpcServerContext`

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -48,6 +48,7 @@ import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.HttpResponseFactory;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -57,12 +58,12 @@ import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceToOffloadedStreamingHttpService;
 import io.servicetalk.oio.api.PayloadWriter;
 import io.servicetalk.transport.api.IoThreadFactory;
-import io.servicetalk.transport.api.ServerContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,6 +95,7 @@ import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A router that can route <a href="https://www.grpc.io">gRPC</a> requests to a user provided
@@ -128,7 +130,7 @@ final class GrpcRouter {
         this.executionStrategies = unmodifiableMap(executionStrategies);
     }
 
-    Single<ServerContext> bind(final ServerBinder binder, final GrpcExecutionContext executionContext) {
+    Single<GrpcServerContext> bind(final ServerBinder binder, final GrpcExecutionContext executionContext) {
         final CompositeCloseable closeable = AsyncCloseables.newCompositeCloseable();
         final Map<String, StreamingHttpService> allRoutes = new HashMap<>();
         populateRoutes(executionContext, allRoutes, routes, closeable, executionStrategies);
@@ -159,7 +161,7 @@ final class GrpcRouter {
             public Completable closeAsyncGracefully() {
                 return closeable.closeAsyncGracefully();
             }
-        });
+        }).map(httpServerContext -> new DefaultGrpcServerContext(httpServerContext, executionContext));
     }
 
     private static void populateRoutes(final GrpcExecutionContext executionContext,
@@ -186,6 +188,62 @@ final class GrpcRouter {
                     path, emptyMap());
             LOGGER.debug("route strategy for path={} : ctx={} route={} → using={}",
                     path, executionContext.executionStrategy(), routeStrategy, missing);
+        }
+    }
+
+    private static final class DefaultGrpcServerContext implements GrpcServerContext {
+
+        private final HttpServerContext delegate;
+        private final GrpcExecutionContext executionContext;
+
+        DefaultGrpcServerContext(final HttpServerContext delegate, final GrpcExecutionContext executionContext) {
+            this.delegate = requireNonNull(delegate);
+            this.executionContext = requireNonNull(executionContext);
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return delegate.closeAsync();
+        }
+
+        @Override
+        public Completable closeAsyncGracefully() {
+            return delegate.closeAsyncGracefully();
+        }
+
+        @Override
+        public Completable onClose() {
+            return delegate.onClose();
+        }
+
+        @Override
+        public SocketAddress listenAddress() {
+            return delegate.listenAddress();
+        }
+
+        @Override
+        public GrpcExecutionContext executionContext() {
+            return executionContext;
+        }
+
+        @Override
+        public void awaitShutdown() {
+            delegate.awaitShutdown();
+        }
+
+        @Override
+        public void close() throws Exception {
+            delegate.close();
+        }
+
+        @Override
+        public void closeGracefully() throws Exception {
+            delegate.closeGracefully();
+        }
+
+        @Override
+        public void acceptConnections(final boolean accept) {
+            delegate.acceptConnections(accept);
         }
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -31,7 +31,6 @@ import io.servicetalk.router.api.NoOffloadsRouteExecutionStrategy;
 import io.servicetalk.router.api.RouteExecutionStrategy;
 import io.servicetalk.router.api.RouteExecutionStrategyFactory;
 import io.servicetalk.transport.api.ExecutionContext;
-import io.servicetalk.transport.api.ServerContext;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -99,7 +98,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
      */
-    final Single<ServerContext> bind(final ServerBinder binder, final GrpcExecutionContext executionContext) {
+    final Single<GrpcServerContext> bind(final ServerBinder binder, final GrpcExecutionContext executionContext) {
         if (!errors.isEmpty()) {
             throw new IllegalStateException("Invalid execution strategy configuration found:\n" + errors);
         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -18,7 +18,6 @@ package io.servicetalk.grpc.api;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpServerBuilder;
-import io.servicetalk.transport.api.ServerContext;
 
 import java.time.Duration;
 
@@ -81,7 +80,7 @@ public interface GrpcServerBuilder {
     GrpcServerBuilder lifecycleObserver(GrpcLifecycleObserver lifecycleObserver);
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link GrpcServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
@@ -89,10 +88,10 @@ public interface GrpcServerBuilder {
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
      */
-    Single<ServerContext> listen(GrpcBindableService<?>... services);
+    Single<GrpcServerContext> listen(GrpcBindableService<?>... services);
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link GrpcServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
@@ -100,29 +99,29 @@ public interface GrpcServerBuilder {
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
      */
-    Single<ServerContext> listen(GrpcServiceFactory<?>... serviceFactories);
+    Single<GrpcServerContext> listen(GrpcServiceFactory<?>... serviceFactories);
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link GrpcServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param serviceFactories {@link GrpcServiceFactory}(s) to create a <a href="https://www.grpc.io">gRPC</a> service.
-     * @return A {@link ServerContext} by blocking the calling thread until the server is successfully started or
+     * @return A {@link GrpcServerContext} by blocking the calling thread until the server is successfully started or
      * throws an {@link Exception} if the server could not be started.
      * @throws Exception if the server could not be started.
      */
-    ServerContext listenAndAwait(GrpcServiceFactory<?>... serviceFactories) throws Exception;
+    GrpcServerContext listenAndAwait(GrpcServiceFactory<?>... serviceFactories) throws Exception;
 
      /**
-      * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+      * Starts this server and returns the {@link GrpcServerContext} after the server has been successfully started.
       * <p>
       * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
       *
       * @param services {@link GrpcBindableService}(s) to create a <a href="https://www.grpc.io">gRPC</a> service.
-      * @return A {@link ServerContext} by blocking the calling thread until the server is successfully started or
+      * @return A {@link GrpcServerContext} by blocking the calling thread until the server is successfully started or
       * throws an {@link Exception} if the server could not be started.
       * @throws Exception if the server could not be started.
       */
-     ServerContext listenAndAwait(GrpcBindableService<?>... services) throws Exception;
+     GrpcServerContext listenAndAwait(GrpcBindableService<?>... services) throws Exception;
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerContext.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import io.servicetalk.transport.api.ServerContext;
+
+/**
+ * Context of a gRPC server.
+ */
+public interface GrpcServerContext extends ServerContext {
+
+    @Override
+    GrpcExecutionContext executionContext();
+}

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFactory.java
@@ -18,10 +18,10 @@ package io.servicetalk.grpc.api;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.BlockingHttpService;
 import io.servicetalk.http.api.BlockingStreamingHttpService;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.transport.api.ExecutionContext;
-import io.servicetalk.transport.api.ServerContext;
 
 /**
  * A factory for binding a <a href="https://www.grpc.io">gRPC</a> service to a server using a {@link ServerBinder}.
@@ -68,7 +68,7 @@ public abstract class GrpcServiceFactory<Service extends GrpcService> {
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
      */
-    public final Single<ServerContext> bind(final ServerBinder binder, final ExecutionContext<?> executionContext) {
+    public final Single<GrpcServerContext> bind(final ServerBinder binder, final ExecutionContext<?> executionContext) {
         return routes.bind(binder, DefaultGrpcExecutionContext.from(executionContext));
     }
 
@@ -87,7 +87,7 @@ public abstract class GrpcServiceFactory<Service extends GrpcService> {
          * @return A {@link Single} that completes when the server is successfully started or terminates with an error
          * if the server could not be started.
          */
-        Single<ServerContext> bind(HttpService service);
+        Single<HttpServerContext> bind(HttpService service);
 
         /**
          * Binds a {@link StreamingHttpService} to the associated server.
@@ -98,7 +98,7 @@ public abstract class GrpcServiceFactory<Service extends GrpcService> {
          * @return A {@link Single} that completes when the server is successfully started or terminates with an error
          * if the server could not be started.
          */
-        Single<ServerContext> bindStreaming(StreamingHttpService service);
+        Single<HttpServerContext> bindStreaming(StreamingHttpService service);
 
         /**
          * Binds a {@link BlockingHttpService} to the associated server.
@@ -109,7 +109,7 @@ public abstract class GrpcServiceFactory<Service extends GrpcService> {
          * @return A {@link Single} that completes when the server is successfully started or terminates with an error
          * if the server could not be started.
          */
-        Single<ServerContext> bindBlocking(BlockingHttpService service);
+        Single<HttpServerContext> bindBlocking(BlockingHttpService service);
 
         /**
          * Binds a {@link BlockingStreamingHttpService} to the associated server.
@@ -120,7 +120,7 @@ public abstract class GrpcServiceFactory<Service extends GrpcService> {
          * @return A {@link Single} that completes when the server is successfully started or terminates with an error
          * if the server could not be started.
          */
-        Single<ServerContext> bindBlockingStreaming(BlockingStreamingHttpService service);
+        Single<HttpServerContext> bindBlockingStreaming(BlockingStreamingHttpService service);
     }
 
     private static final class MergedServiceFactory extends GrpcServiceFactory {

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.api.GrpcBindableService;
 import io.servicetalk.grpc.api.GrpcLifecycleObserver;
 import io.servicetalk.grpc.api.GrpcServerBuilder;
+import io.servicetalk.grpc.api.GrpcServerContext;
 import io.servicetalk.grpc.api.GrpcServiceFactory;
 import io.servicetalk.grpc.api.GrpcServiceFactory.ServerBinder;
 import io.servicetalk.http.api.BlockingHttpService;
@@ -32,6 +33,7 @@ import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpService;
@@ -40,7 +42,6 @@ import io.servicetalk.http.utils.TimeoutHttpServiceFilter;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ConnectionAcceptorFactory;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextBuilder;
@@ -113,7 +114,7 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     }
 
     @Override
-    public Single<ServerContext> listen(GrpcBindableService<?>... services) {
+    public Single<GrpcServerContext> listen(GrpcBindableService<?>... services) {
         GrpcServiceFactory<?>[] factories = Arrays.stream(services)
                 .map(GrpcBindableService::bindService)
                 .toArray(GrpcServiceFactory<?>[]::new);
@@ -121,17 +122,17 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     }
 
     @Override
-    public Single<ServerContext> listen(GrpcServiceFactory<?>... serviceFactories) {
+    public Single<GrpcServerContext> listen(GrpcServiceFactory<?>... serviceFactories) {
         return doListen(GrpcServiceFactory.merge(serviceFactories));
     }
 
     @Override
-    public ServerContext listenAndAwait(GrpcServiceFactory<?>... serviceFactories) throws Exception {
+    public GrpcServerContext listenAndAwait(GrpcServiceFactory<?>... serviceFactories) throws Exception {
         return awaitResult(listen(serviceFactories).toFuture());
     }
 
     @Override
-    public ServerContext listenAndAwait(GrpcBindableService<?>... services) throws Exception {
+    public GrpcServerContext listenAndAwait(GrpcBindableService<?>... services) throws Exception {
         GrpcServiceFactory<?>[] factories = Arrays.stream(services)
                 .map(GrpcBindableService::bindService)
                 .toArray(GrpcServiceFactory<?>[]::new);
@@ -139,15 +140,15 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     }
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link GrpcServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (eg. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param serviceFactory {@link GrpcServiceFactory} to create a <a href="https://www.grpc.io">gRPC</a> service.
-     * @return A {@link ServerContext} by blocking the calling thread until the server is successfully started or
+     * @return A {@link GrpcServerContext} by blocking the calling thread until the server is successfully started or
      * throws an {@link Exception} if the server could not be started.
      */
-    private Single<ServerContext> doListen(final GrpcServiceFactory<?> serviceFactory) {
+    private Single<GrpcServerContext> doListen(final GrpcServiceFactory<?> serviceFactory) {
         interceptorBuilder = preBuild();
         return serviceFactory.bind(this, interceptorBuilder.contextBuilder.build());
     }
@@ -199,22 +200,22 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     }
 
     @Override
-    public Single<ServerContext> bind(final HttpService service) {
+    public Single<HttpServerContext> bind(final HttpService service) {
         return interceptorBuilder.listen(service);
     }
 
     @Override
-    public Single<ServerContext> bindStreaming(final StreamingHttpService service) {
+    public Single<HttpServerContext> bindStreaming(final StreamingHttpService service) {
         return interceptorBuilder.listenStreaming(service);
     }
 
     @Override
-    public Single<ServerContext> bindBlocking(final BlockingHttpService service) {
+    public Single<HttpServerContext> bindBlocking(final BlockingHttpService service) {
         return interceptorBuilder.listenBlocking(service);
     }
 
     @Override
-    public Single<ServerContext> bindBlockingStreaming(final BlockingStreamingHttpService service) {
+    public Single<HttpServerContext> bindBlockingStreaming(final BlockingStreamingHttpService service) {
         return interceptorBuilder.listenBlockingStreaming(service);
     }
 
@@ -353,22 +354,22 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
         }
 
         @Override
-        public Single<ServerContext> listen(final HttpService service) {
+        public Single<HttpServerContext> listen(final HttpService service) {
             return delegate.listen(service);
         }
 
         @Override
-        public Single<ServerContext> listenStreaming(final StreamingHttpService service) {
+        public Single<HttpServerContext> listenStreaming(final StreamingHttpService service) {
             return delegate.listenStreaming(service);
         }
 
         @Override
-        public Single<ServerContext> listenBlocking(final BlockingHttpService service) {
+        public Single<HttpServerContext> listenBlocking(final BlockingHttpService service) {
             return delegate.listenBlocking(service);
         }
 
         @Override
-        public Single<ServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
+        public Single<HttpServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
             return delegate.listenBlockingStreaming(service);
         }
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -25,7 +25,6 @@ import io.servicetalk.transport.api.ConnectionAcceptorFactory;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.TransportObserver;
@@ -311,110 +310,110 @@ public interface HttpServerBuilder {
     HttpServerBuilder executionStrategy(HttpExecutionStrategy strategy);
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
-     * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
-     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
-     * @return A {@link ServerContext} by blocking the calling thread until the server is successfully started or
+     * @param service Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
+     * @return A {@link HttpServerContext} by blocking the calling thread until the server is successfully started or
      * throws an {@link Exception} if the server could not be started.
      * @throws Exception if the server could not be started.
      */
-    default ServerContext listenAndAwait(HttpService service) throws Exception {
+    default HttpServerContext listenAndAwait(HttpService service) throws Exception {
         return blockingInvocation(listen(service));
     }
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
-     * @param handler Service invoked for every request received by this server. The returned {@link ServerContext}
-     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
-     * @return A {@link ServerContext} by blocking the calling thread until the server is successfully started or
+     * @param handler Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
+     * @return A {@link HttpServerContext} by blocking the calling thread until the server is successfully started or
      * throws an {@link Exception} if the server could not be started.
      * @throws Exception if the server could not be started.
      */
-    default ServerContext listenStreamingAndAwait(StreamingHttpService handler) throws Exception {
+    default HttpServerContext listenStreamingAndAwait(StreamingHttpService handler) throws Exception {
         return blockingInvocation(listenStreaming(handler));
     }
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
-     * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
-     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
-     * @return A {@link ServerContext} by blocking the calling thread until the server is successfully started or
+     * @param service Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
+     * @return A {@link HttpServerContext} by blocking the calling thread until the server is successfully started or
      * throws an {@link Exception} if the server could not be started.
      * @throws Exception if the server could not be started.
      */
-    default ServerContext listenBlockingAndAwait(BlockingHttpService service) throws Exception {
+    default HttpServerContext listenBlockingAndAwait(BlockingHttpService service) throws Exception {
         return blockingInvocation(listenBlocking(service));
     }
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
-     * @param handler Service invoked for every request received by this server. The returned {@link ServerContext}
-     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
-     * @return A {@link ServerContext} by blocking the calling thread until the server is successfully started or
+     * @param handler Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
+     * @return A {@link HttpServerContext} by blocking the calling thread until the server is successfully started or
      * throws an {@link Exception} if the server could not be started.
      * @throws Exception if the server could not be started.
      */
-    default ServerContext listenBlockingStreamingAndAwait(BlockingStreamingHttpService handler) throws Exception {
+    default HttpServerContext listenBlockingStreamingAndAwait(BlockingStreamingHttpService handler) throws Exception {
         return blockingInvocation(listenBlockingStreaming(handler));
     }
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
-     * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
-     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
+     * @param service Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
      */
-    Single<ServerContext> listen(HttpService service);
+    Single<HttpServerContext> listen(HttpService service);
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
-     * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
-     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
+     * @param service Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
      */
-    Single<ServerContext> listenStreaming(StreamingHttpService service);
+    Single<HttpServerContext> listenStreaming(StreamingHttpService service);
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
-     * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
-     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
+     * @param service Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
      */
-    Single<ServerContext> listenBlocking(BlockingHttpService service);
+    Single<HttpServerContext> listenBlocking(BlockingHttpService service);
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
-     * @param service Service invoked for every request received by this server. The returned {@link ServerContext}
-     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link ServerContext} is closed.
+     * @param service Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
      */
-    Single<ServerContext> listenBlockingStreaming(BlockingStreamingHttpService service);
+    Single<HttpServerContext> listenBlockingStreaming(BlockingStreamingHttpService service);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerContext.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.transport.api.ServerContext;
+
+/**
+ * Context of an HTTP server.
+ */
+public interface HttpServerContext extends ServerContext {
+
+    @Override
+    HttpExecutionContext executionContext();
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -29,6 +29,7 @@ import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -43,7 +44,6 @@ import io.servicetalk.transport.api.ConnectionAcceptorFactory;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
@@ -263,22 +263,22 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
     }
 
     @Override
-    public Single<ServerContext> listen(final HttpService service) {
+    public Single<HttpServerContext> listen(final HttpService service) {
         return listenForAdapter(toStreamingHttpService(service, computeServiceStrategy(service)));
     }
 
     @Override
-    public Single<ServerContext> listenStreaming(final StreamingHttpService service) {
+    public Single<HttpServerContext> listenStreaming(final StreamingHttpService service) {
         return listenForService(service, strategy);
     }
 
     @Override
-    public Single<ServerContext> listenBlocking(final BlockingHttpService service) {
+    public Single<HttpServerContext> listenBlocking(final BlockingHttpService service) {
         return listenForAdapter(toStreamingHttpService(service, computeServiceStrategy(service)));
     }
 
     @Override
-    public Single<ServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
+    public Single<HttpServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
         return listenForAdapter(toStreamingHttpService(service, computeServiceStrategy(service)));
     }
 
@@ -287,12 +287,12 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
         return executionContextBuilder.build();
     }
 
-    private Single<ServerContext> listenForAdapter(HttpApiConversions.ServiceAdapterHolder adapterHolder) {
+    private Single<HttpServerContext> listenForAdapter(HttpApiConversions.ServiceAdapterHolder adapterHolder) {
         return listenForService(adapterHolder.adaptor(), adapterHolder.serviceInvocationStrategy());
     }
 
     /**
-     * Starts this server and returns the {@link ServerContext} after the server has been successfully started.
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this should result in a socket bind/listen on {@code address}.
      * <p>/p>
@@ -309,7 +309,8 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
      * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
      * the server could not be started.
      */
-    private Single<ServerContext> listenForService(StreamingHttpService rawService, HttpExecutionStrategy strategy) {
+    private Single<HttpServerContext> listenForService(final StreamingHttpService rawService,
+                                                       final HttpExecutionStrategy strategy) {
         InfluencerConnectionAcceptor connectionAcceptor = connectionAcceptorFactory == null ? null :
                 InfluencerConnectionAcceptor.withStrategy(connectionAcceptorFactory.create(ACCEPT_ALL),
                         connectionAcceptorFactory.requiredOffloads());
@@ -343,9 +344,9 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
                         serverContext.listenAddress(), strategy));
     }
 
-    private Single<ServerContext> doBind(final HttpExecutionContext executionContext,
-                                         @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
-                                         final StreamingHttpService service) {
+    private Single<HttpServerContext> doBind(final HttpExecutionContext executionContext,
+                                             @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
+                                             final StreamingHttpService service) {
         ReadOnlyHttpServerConfig roConfig = config.asReadOnly();
         StreamingHttpService filteredService = applyInternalFilters(service, roConfig.lifecycleObserver());
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.netty.AlpnChannelSingle.NoopChannelInitializer;
 import io.servicetalk.http.netty.NettyHttpServer.NettyHttpServerConnection;
@@ -24,7 +25,6 @@ import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
 import io.servicetalk.tcp.netty.internal.TcpServerBinder;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.transport.api.ConnectionObserver;
-import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
@@ -48,13 +48,13 @@ final class DeferredServerChannelBinder {
         // No instances
     }
 
-    static Single<ServerContext> bind(final HttpExecutionContext executionContext,
-                                      final ReadOnlyHttpServerConfig config,
-                                      final SocketAddress listenAddress,
-                                      @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
-                                      final StreamingHttpService service,
-                                      final boolean drainRequestPayloadBody,
-                                      final boolean sniOnly) {
+    static Single<HttpServerContext> bind(final HttpExecutionContext executionContext,
+                                          final ReadOnlyHttpServerConfig config,
+                                          final SocketAddress listenAddress,
+                                          @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
+                                          final StreamingHttpService service,
+                                          final boolean drainRequestPayloadBody,
+                                          final boolean sniOnly) {
         final ReadOnlyTcpServerConfig tcpConfig = config.tcpConfig();
         assert tcpConfig.sslContext() != null;
 
@@ -77,7 +77,7 @@ final class DeferredServerChannelBinder {
                 .map(delegate -> {
                     LOGGER.debug("Started HTTP server with ALPN for address {}", delegate.listenAddress());
                     // The ServerContext returned by TcpServerBinder takes care of closing the connectionAcceptor.
-                    return new NettyHttpServer.NettyHttpServerContext(delegate, service);
+                    return new NettyHttpServer.NettyHttpServerContext(delegate, service, executionContext);
                 });
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableSingle;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.netty.NettyHttpServer.NettyHttpServerConnection;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
@@ -79,12 +80,12 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
         return listenAddress;
     }
 
-    static Single<ServerContext> bind(final HttpExecutionContext executionContext,
-                                      final ReadOnlyHttpServerConfig config,
-                                      final SocketAddress listenAddress,
-                                      @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
-                                      final StreamingHttpService service,
-                                      final boolean drainRequestPayloadBody) {
+    static Single<HttpServerContext> bind(final HttpExecutionContext executionContext,
+                                          final ReadOnlyHttpServerConfig config,
+                                          final SocketAddress listenAddress,
+                                          @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
+                                          final StreamingHttpService service,
+                                          final boolean drainRequestPayloadBody) {
         if (config.h2Config() == null) {
             return failed(newH2ConfigException());
         }
@@ -98,7 +99,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                 .map(delegate -> {
                     LOGGER.debug("Started HTTP/2 server with prior-knowledge for address {}", delegate.listenAddress());
                     // The ServerContext returned by TcpServerBinder takes care of closing the connectionAcceptor.
-                    return new NettyHttpServer.NettyHttpServerContext(delegate, service);
+                    return new NettyHttpServer.NettyHttpServerContext(delegate, service, executionContext);
                 });
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -39,6 +39,7 @@ import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
@@ -47,7 +48,6 @@ import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
 import io.servicetalk.tcp.netty.internal.TcpServerBinder;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.transport.api.ConnectionObserver;
-import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.CloseHandler;
@@ -116,12 +116,12 @@ final class NettyHttpServer {
         // No instances
     }
 
-    static Single<ServerContext> bind(final HttpExecutionContext executionContext,
-                                      final ReadOnlyHttpServerConfig config,
-                                      final SocketAddress address,
-                                      @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
-                                      final StreamingHttpService service,
-                                      final boolean drainRequestPayloadBody) {
+    static Single<HttpServerContext> bind(final HttpExecutionContext executionContext,
+                                          final ReadOnlyHttpServerConfig config,
+                                          final SocketAddress address,
+                                          @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
+                                          final StreamingHttpService service,
+                                          final boolean drainRequestPayloadBody) {
         if (config.h1Config() == null) {
             return failed(newH1ConfigException());
         }
@@ -136,7 +136,7 @@ final class NettyHttpServer {
                 .map(delegate -> {
                     LOGGER.debug("Started HTTP/1.1 server for address {}.", delegate.listenAddress());
                     // The ServerContext returned by TcpServerBinder takes care of closing the connectionAcceptor.
-                    return new NettyHttpServerContext(delegate, service);
+                    return new NettyHttpServerContext(delegate, service, executionContext);
                 });
     }
 
@@ -195,13 +195,16 @@ final class NettyHttpServer {
         });
     }
 
-    static final class NettyHttpServerContext implements ServerContext {
+    static final class NettyHttpServerContext implements HttpServerContext {
         private final ServerContext delegate;
         private final ListenableAsyncCloseable asyncCloseable;
+        private final HttpExecutionContext executionContext;
 
-        NettyHttpServerContext(final ServerContext delegate, final StreamingHttpService service) {
+        NettyHttpServerContext(final ServerContext delegate, final StreamingHttpService service,
+                               final HttpExecutionContext executionContext) {
             this.delegate = delegate;
             asyncCloseable = toListenableAsyncCloseable(newCompositeCloseable().appendAll(service, delegate));
+            this.executionContext = executionContext;
         }
 
         @Override
@@ -215,8 +218,8 @@ final class NettyHttpServer {
         }
 
         @Override
-        public ExecutionContext<?> executionContext() {
-            return delegate.executionContext();
+        public HttpExecutionContext executionContext() {
+            return executionContext;
         }
 
         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -30,6 +30,7 @@ import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
@@ -230,7 +231,7 @@ abstract class AbstractNettyHttpServerTest {
         return HttpClients.forResolvedAddress(serverHostAndPort(serverContext));
     }
 
-    Single<ServerContext> listen(HttpServerBuilder builder) {
+    Single<HttpServerContext> listen(HttpServerBuilder builder) {
         return builder.listenStreaming(service);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -32,11 +32,11 @@ import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.StatelessTrailersTransformer;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
-import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -305,7 +305,7 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
     }
 
     @Override
-    Single<ServerContext> listen(final HttpServerBuilder builder) {
+    Single<HttpServerContext> listen(final HttpServerBuilder builder) {
         return testDefinition.listen(builder);
     }
 
@@ -406,7 +406,7 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
             this.expectation = expectation;
         }
 
-        abstract Single<ServerContext> listen(HttpServerBuilder builder);
+        abstract Single<HttpServerContext> listen(HttpServerBuilder builder);
 
         abstract void runTest(StreamingHttpConnection connection) throws Exception;
     }
@@ -427,7 +427,7 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
         }
 
         @Override
-        Single<ServerContext> listen(final HttpServerBuilder builder) {
+        Single<HttpServerContext> listen(final HttpServerBuilder builder) {
             // service needs to check the request
             return builder.listenStreaming((ctx, request, rf) -> {
                 final HttpHeaders headers = request.headers();
@@ -499,13 +499,13 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
         }
 
         @Override
-        Single<ServerContext> listen(final HttpServerBuilder builder) {
+        Single<HttpServerContext> listen(final HttpServerBuilder builder) {
             // service needs to generate the response
             return builder.listenStreaming((ctx, request, rf) -> {
                 final HttpMetaData metadata = modifier.apply(responseSupplier.get());
                 return succeeded((metadata instanceof StreamingHttpResponse) ?
                         (StreamingHttpResponse) metadata : ((HttpResponse) metadata).toStreamingResponse());
-            });
+            }).map(identity());
         }
 
         @Override
@@ -534,7 +534,7 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
         }
 
         @Override
-        Single<ServerContext> listen(final HttpServerBuilder builder) {
+        Single<HttpServerContext> listen(final HttpServerBuilder builder) {
             // service needs to generate the response
             final HttpMetaData metadata = modifier.apply(responseSupplier.get());
             BlockingStreamingHttpResponse streamingResponse = (metadata instanceof StreamingHttpResponse) ?

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
@@ -22,6 +22,7 @@ import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.ReservedBlockingHttpConnection;
 import io.servicetalk.http.api.ReservedBlockingStreamingHttpConnection;
 import io.servicetalk.http.api.ReservedHttpConnection;
@@ -193,7 +194,7 @@ class ExecutionStrategyInContextTest {
     }
 
     private SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> initClientAndServer(
-        Function<HttpServerBuilder, Single<ServerContext>> serverStarter, boolean customStrategy)
+            Function<HttpServerBuilder, Single<HttpServerContext>> serverStarter, boolean customStrategy)
             throws Exception {
         HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
         if (customStrategy) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -27,6 +27,7 @@ import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.netty.NettyHttpServer.NettyHttpServerContext;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
 import io.servicetalk.tcp.netty.internal.TcpServerBinder;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
@@ -120,7 +121,8 @@ class FlushStrategyOnServerTest {
                                     .andThen((channel1 -> channel1.pipeline().addLast(interceptor))), service,
                             true, connectionObserver),
                     connection -> connection.process(true))
-                    .map(delegate -> new NettyHttpServer.NettyHttpServerContext(delegate, service)).toFuture().get();
+                    .map(delegate -> new NettyHttpServerContext(delegate, service, httpExecutionContext))
+                    .toFuture().get();
         } catch (Exception e) {
             fail(e);
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InvokingThreadsRecorder.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InvokingThreadsRecorder.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.transport.api.HostAndPort;
@@ -68,7 +69,7 @@ final class InvokingThreadsRecorder<T> implements AutoCloseable {
         return new InvokingThreadsRecorder<>(strategy);
     }
 
-    void init(BiFunction<IoExecutor, HttpServerBuilder, Single<ServerContext>> serverStarter,
+    void init(BiFunction<IoExecutor, HttpServerBuilder, Single<HttpServerContext>> serverStarter,
               BiConsumer<IoExecutor, SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress>> clientUpdater) {
         try {
             HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -22,6 +22,7 @@ import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
@@ -31,7 +32,6 @@ import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 import io.servicetalk.oio.api.PayloadWriter;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
-import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -254,7 +254,7 @@ class ServerEffectiveStrategyTest {
             invokingThreadsRecorder.close();
         }
 
-        private void initState(Function<HttpServerBuilder, Single<ServerContext>> serverStarter) {
+        private void initState(Function<HttpServerBuilder, Single<HttpServerContext>> serverStarter) {
             invokingThreadsRecorder.init((ioExecutor, serverBuilder) -> {
                 serverBuilder.ioExecutor(ioExecutor)
                         .appendServiceFilter(new ServiceInvokingThreadRecorder(invokingThreadsRecorder));


### PR DESCRIPTION
Motivation:

Existing server builders always return general `ServerContext` object.
Returning a protocol specific context will give us a way to add more
information about the server later, like: protocols its supports,
default grpc deadline, etc. It also gives a correctly typed
`ExecutionContext`.

Modifications:

- Add `HttpServerContext`, change return parameter of "listen" methods
of `HttpServerBuilder` to `HttpServerContext`;
- Add `GrpcServerContext`, change return parameter of "listen" methods
of `GrpcServerBuilder` to `GrpcServerContext`;
- Adjust tests and related API;

Result:

Returned `ServerContext` is aware of the protocol, which opens a way
to add more protocol-specific information in the context, when necessary.