### PR TITLE
Upgrade build Checkstyle 9.0 → 9.2

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.JavaVersion
 import static org.gradle.api.JavaVersion.VERSION_1_8
 
 final class Versions {
-  static final String CHECKSTYLE_VERSION = "9.0"
+  static final String CHECKSTYLE_VERSION = "9.2"
   static final String PMD_VERSION = "6.38.0"
   static final String SPOTBUGS_VERSION = "4.4.1"
   static final String PITEST_VERSION = "1.7.3"


### PR DESCRIPTION
Motivation:
A newer release of Checkstyle, 9.2, is available
Modifications:
Upgrade version of Checkstyle used to 9.2
Result:
Newer version of Checkstyle used for builds