### PR TITLE
Upgrade build PMD 6.38.0 → 6.41.0

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
@@ -21,7 +21,7 @@ import static org.gradle.api.JavaVersion.VERSION_1_8
 
 final class Versions {
   static final String CHECKSTYLE_VERSION = "9.0"
-  static final String PMD_VERSION = "6.38.0"
+  static final String PMD_VERSION = "6.41.0"
   static final String SPOTBUGS_VERSION = "4.4.1"
   static final String PITEST_VERSION = "1.7.3"
   static final String PITEST_JUNIT5_PLUGIN_VERSION = "0.15"


### PR DESCRIPTION
Motivation:
A newer release of PMD, 6.41.0, is available
Modifications:
Upgrade version of PMD, used to 6.41.0
Result:
Newer version of PMD used for builds