### PR TITLE
`LoadBalancerFactory`: clean up javadoc

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;
 import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.UNAVAILABLE;
 import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.concurrent.api.Publisher.fromIterable;
+import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static java.net.InetSocketAddress.createUnresolved;
 
@@ -80,14 +80,14 @@ public class RoundRobinLoadBalancerSDEventsBenchmark {
     public LoadBalancer<LoadBalancedConnection> mixed() {
         // RR load balancer synchronously subscribes and will consume all events during construction.
         return new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, LoadBalancedConnection>().build()
-                .newLoadBalancer(fromIterable(mixedEvents), ConnFactory.INSTANCE);
+                .newLoadBalancer("benchmark", from(mixedEvents), ConnFactory.INSTANCE);
     }
 
     @Benchmark
     public LoadBalancer<LoadBalancedConnection> available() {
         // RR load balancer synchronously subscribes and will consume all events during construction.
         return new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, LoadBalancedConnection>().build()
-                        .newLoadBalancer(fromIterable(availableEvents), ConnFactory.INSTANCE);
+                        .newLoadBalancer("benchmark", from(availableEvents), ConnFactory.INSTANCE);
     }
 
     private static final class ConnFactory implements ConnectionFactory<InetSocketAddress, LoadBalancedConnection> {

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
@@ -34,6 +34,7 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
 
     /**
      * Create a new {@link LoadBalancer}.
+     *
      * @param eventPublisher A stream of {@link ServiceDiscovererEvent}s which the {@link LoadBalancer} can use to
      * connect to physical hosts. Typically generated from a
      * {@link ServiceDiscoverer#discover(Object) ServiceDiscoverer}.
@@ -55,10 +56,7 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
 
     /**
      * Create a new {@link LoadBalancer}.
-     * <p>
-     * Note this method has a default implementation to not break the {@link FunctionalInterface} contract, however
-     * in a future release the other deprecated {@link #newLoadBalancer(Publisher, ConnectionFactory) method}
-     * will be removed and this method will become the functional interface.
+     *
      * @param targetResource A {@link String} representation of the target resource for which the created instance
      * will perform load balancing. Bear in mind, load balancing is performed over the a collection of hosts provided
      * via the {@code eventPublisher} which may not correspond directly to a single unresolved address, but potentially


### PR DESCRIPTION
Motivation:

Remove javadoc that is not relevant after #1976, don't use deprecated
`newLoadBalancer` method.