### PR TITLE
Remove deprecated constructors from HttpHeadersFactories

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
@@ -32,17 +32,6 @@ public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
 
     /**
      * Create an instance of the factory with the default array size hint.
-     * @param validateNames {@code true} to validate header/trailer names.
-     * @param validateCookies {@code true} to validate cookie contents when parsing.
-     * @deprecated Use {@link #DefaultHttpHeadersFactory(boolean, boolean, boolean)}.
-     */
-    @Deprecated
-    public DefaultHttpHeadersFactory(final boolean validateNames, final boolean validateCookies) {
-        this(validateNames, validateCookies, DEFAULT_VALIDATE_VALUES);
-    }
-
-    /**
-     * Create an instance of the factory with the default array size hint.
      *
      * @param validateNames {@code true} to validate header/trailer names.
      * @param validateCookies {@code true} to validate cookie contents when parsing.
@@ -51,20 +40,6 @@ public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
     public DefaultHttpHeadersFactory(final boolean validateNames, final boolean validateCookies,
                                      final boolean validateValues) {
         this(validateNames, validateCookies, validateValues, 16, 4);
-    }
-
-    /**
-     * Create an instance of the factory.
-     * @param validateNames {@code true} to validate header/trailer names.
-     * @param validateCookies {@code true} to validate cookie contents when parsing.
-     * @param headersArraySizeHint A hint as to how large the hash data structure should be for the headers.
-     * @param trailersArraySizeHint A hint as to how large the hash data structure should be for the trailers.
-     * @deprecated Use {@link #DefaultHttpHeadersFactory(boolean, boolean, boolean, int, int)}.
-     */
-    @Deprecated
-    public DefaultHttpHeadersFactory(final boolean validateNames, final boolean validateCookies,
-                                     final int headersArraySizeHint, final int trailersArraySizeHint) {
-        this(validateNames, validateCookies, DEFAULT_VALIDATE_VALUES, headersArraySizeHint, trailersArraySizeHint);
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
@@ -40,17 +40,6 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
 
     /**
      * Create an instance of the factory with the default array size hint.
-     * @param validateNames {@code true} to validate header/trailer names.
-     * @param validateCookies {@code true} to validate cookie contents when parsing.
-     * @deprecated Use {@link #H2HeadersFactory(boolean, boolean, boolean)}.
-     */
-    @Deprecated
-    public H2HeadersFactory(final boolean validateNames, final boolean validateCookies) {
-        this(validateNames, validateCookies, DEFAULT_VALIDATE_VALUES);
-    }
-
-    /**
-     * Create an instance of the factory with the default array size hint.
      *
      * @param validateNames {@code true} to validate header/trailer names.
      * @param validateCookies {@code true} to validate cookie contents when parsing.
@@ -59,20 +48,6 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
     public H2HeadersFactory(final boolean validateNames, final boolean validateCookies,
                             final boolean validateValues) {
         this(validateNames, validateCookies, validateValues, 16, 4);
-    }
-
-    /**
-     * Create an instance of the factory.
-     * @param validateNames {@code true} to validate header/trailer names.
-     * @param validateCookies {@code true} to validate cookie contents when parsing.
-     * @param headersArraySizeHint A hint as to how large the hash data structure should be for the headers.
-     * @param trailersArraySizeHint A hint as to how large the hash data structure should be for the trailers.
-     * @deprecated Use {@link #H2HeadersFactory(boolean, boolean, boolean, int, int)}.
-     */
-    @Deprecated
-    public H2HeadersFactory(final boolean validateNames, final boolean validateCookies,
-                            final int headersArraySizeHint, final int trailersArraySizeHint) {
-        this(validateNames, validateCookies, DEFAULT_VALIDATE_VALUES, headersArraySizeHint, trailersArraySizeHint);
     }
 
     /**

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ToStH1UtilsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ToStH1UtilsTest.java
@@ -42,7 +42,7 @@ class H2ToStH1UtilsTest {
     private static final int ARRAY_SIZE_HINT = 16;
     private static final HttpHeadersFactory H1_FACTORY = new DefaultHttpHeadersFactory(true, true,
             ARRAY_SIZE_HINT, 0);
-    private static final HttpHeadersFactory H2_FACTORY = new H2HeadersFactory(true, true, ARRAY_SIZE_HINT, 0);
+    private static final HttpHeadersFactory H2_FACTORY = new H2HeadersFactory(true, true, false, ARRAY_SIZE_HINT, 0);
 
     private static int bucketIndex(int hashCode) {
         return hashCode & (ARRAY_SIZE_HINT - 1);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ToStH1UtilsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ToStH1UtilsTest.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.hasSize;
 class H2ToStH1UtilsTest {
 
     private static final int ARRAY_SIZE_HINT = 16;
-    private static final HttpHeadersFactory H1_FACTORY = new DefaultHttpHeadersFactory(true, true,
+    private static final HttpHeadersFactory H1_FACTORY = new DefaultHttpHeadersFactory(true, true, false,
             ARRAY_SIZE_HINT, 0);
     private static final HttpHeadersFactory H2_FACTORY = new H2HeadersFactory(true, true, false, ARRAY_SIZE_HINT, 0);
 


### PR DESCRIPTION
Motivation:

Some `DefaultHttpHeadersFactory` and `H2HeadersFactory` constructors
were deprecated in #1757, cherry-picked into 0.41, and can be removed
from the main branch now.

Modifications:

- Remove deprecated constructors from `DefaultHttpHeadersFactory` and
`H2HeadersFactory`;

Result:

Less deprecated API.