### PR TITLE
Improve BlockingIterable javadoc

### DIFF
--- a/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/BlockingIterable.java
+++ b/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/BlockingIterable.java
@@ -46,8 +46,13 @@ public interface BlockingIterable<T> extends CloseableIterable<T> {
      * <p>
      * By default the {@code timeoutSupplier} will be used for each interaction with
      * {@link BlockingIterator#hasNext(long, TimeUnit)} and {@link BlockingIterator#next(long, TimeUnit)}. However
-     * implementations of {@link BlockingIterable} may decide to only apply the timeout when they are not be sure if
+     * implementations of {@link BlockingIterable} may decide to only apply the timeout when they are not sure if
      * an interaction with the {@link BlockingIterator} will block or not.
+     * <p>
+     * Note: This method can sneaky-throw an {@link InterruptedException} when a blocking operation internally does so.
+     * The reason it's not declared is that the {@link java.util.Iterator} and {@link AutoCloseable} interfaces do not
+     * declare checked exceptions and {@link BlockingIterator} extends them to allow use in try-with-resources
+     * and enhanced for loop.
      * @param action The action to be performed for each element.
      * @param timeoutSupplier A {@link LongSupplier} that provides the timeout duration for the next call to
      * {@link BlockingIterator#hasNext(long, TimeUnit)} and {@link BlockingIterator#next(long, TimeUnit)}. These
@@ -77,6 +82,11 @@ public interface BlockingIterable<T> extends CloseableIterable<T> {
      * {@link BlockingIterator#hasNext(long, TimeUnit)} and {@link BlockingIterator#next(long, TimeUnit)}. However
      * implementations of {@link BlockingIterable} may decide to only apply the timeout when they are not be sure if
      * an interaction with the {@link BlockingIterator} will block or not.
+     * <p>
+     * Note: This method can sneaky-throw an {@link InterruptedException} when a blocking operation internally does so.
+     * The reason it's not declared is that the {@link java.util.Iterator} and {@link AutoCloseable} interfaces do not
+     * declare checked exceptions and {@link BlockingIterator} extends them to allow use in try-with-resources
+     * and enhanced for loop.
      * @param action The action to be performed for each element.
      * @param timeout An approximate total duration for the overall completion of this method. This value is used to
      * approximate because the actual duration maybe longer if data is available without blocking.

--- a/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/BlockingIterator.java
+++ b/servicetalk-concurrent/src/main/java/io/servicetalk/concurrent/BlockingIterator.java
@@ -38,6 +38,11 @@ public interface BlockingIterator<T> extends CloseableIterator<T> {
      * The equivalent of {@link #hasNext()} but only waits for {@code timeout} duration amount of time.
      * <p>
      * Note that {@link #close()} is not required to interrupt this call.
+     * <p>
+     * Also note, this method can sneaky-throw an {@link InterruptedException} when a blocking operation internally
+     * does so. The reason it's not declared is that the {@link java.util.Iterator} and {@link AutoCloseable}
+     * interfaces do not declare checked exceptions and {@link BlockingIterator} extends them to allow use in
+     * try-with-resources and enhanced for loop.
      * @param timeout The duration of time to wait. If this value is non-positive that means the timeout expiration is
      * immediate or in the past. In this case, if this implementation cannot determine if there is more data immediately
      * (e.g. without external dependencies) then a {@link TimeoutException} should be thrown, otherwise the method can
@@ -54,6 +59,11 @@ public interface BlockingIterator<T> extends CloseableIterator<T> {
      * The equivalent of {@link #next()} but only waits for {@code timeout} duration of time.
      * <p>
      * Note that {@link #close()} is not required to interrupt this call.
+     * <p>
+     * Also note, this method can sneaky-throw an {@link InterruptedException} when a blocking operation internally
+     * does so. The reason it's not declared is that the {@link java.util.Iterator} and {@link AutoCloseable}
+     * interfaces do not declare checked exceptions and {@link BlockingIterator} extends them to allow use in
+     * try-with-resources and enhanced for loop.
      * @param timeout The duration of time to wait. If this value is non-positive that means the timeout expiration is
      * immediate or in the past. In this case, if this implementation cannot determine if there is more data immediately
      * (e.g. without external dependencies) then a {@link TimeoutException} should be thrown, otherwise the method can
@@ -67,6 +77,14 @@ public interface BlockingIterator<T> extends CloseableIterator<T> {
     @Nullable
     T next(long timeout, TimeUnit unit) throws TimeoutException;
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note, this method can sneaky-throw an {@link InterruptedException} when a blocking operation internally
+     * does so. The reason it's not declared is that the {@link java.util.Iterator} and {@link AutoCloseable}
+     * interfaces do not declare checked exceptions and {@link BlockingIterator} extends them to allow use in
+     * try-with-resources and enhanced for loop.
+     */
     @Nullable
     @Override
     T next();


### PR DESCRIPTION
Motivation:

`BlockingIterable` and `BlockingIterator` methods can throw
`InterruptedException` using the sneaky-throw mechanism. The reason for
it is that implementations rely on `BlockingQueue` which may be
interrupted. However, as `BlockingIterator` extends `Iterator` from the
JDK, its' method signatures don't list any checked exception. Therefore
it would be inconsistent to have some methods declare checked
exceptions, while the overridden ones not.

Modification:

Add javadoc notes to all methods that can throw `InterruptedException`
to `BlockingIterable` and `BlockingIterator`.

Result:

The runtime behavior is better described via javadoc.