### PR TITLE
Give more context on CHANNEL_CLOSED_INBOUND when no native transport

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
@@ -18,6 +18,9 @@ package io.servicetalk.transport.netty.internal;
 import io.servicetalk.concurrent.internal.ThrowableUtils;
 
 import java.nio.channels.ClosedChannelException;
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * {@link ClosedChannelException} that will not not fill in the stacktrace but use a cheaper way of producing
@@ -26,7 +29,22 @@ import java.nio.channels.ClosedChannelException;
 public final class StacklessClosedChannelException extends ClosedChannelException {
     private static final long serialVersionUID = -5021225720136487769L;
 
-    private StacklessClosedChannelException() { }
+    @Nullable
+    private final String message;
+
+    private StacklessClosedChannelException() {
+        message = null;
+    }
+
+    StacklessClosedChannelException(final String message, final Throwable cause) {
+        this.message = requireNonNull(message);
+        initCause(cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return message == null ? super.getMessage() : message;
+    }
 
     @Override
     public Throwable fillInStackTrace() {


### PR DESCRIPTION
Motivation:

When native transport is not used, users can see increased number of
`CHANNEL_CLOSED_INBOUND` exceptions because Java NIO does not notify
us about a closed connection until we make an attempt to write data.

Modifications:

- Provide more context for users when `CHANNEL_CLOSED_INBOUND` happens
with no native transport available;

Result:

Users can get an idea where to look for the root cause for this
use-case.