### PR TITLE
`TransportObserver#onNewConnection` give visibility into addresses

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -110,16 +110,19 @@ class FlushStrategyOnServerTest {
                 globalExecutionContext().ioExecutor(), EXECUTOR_RULE.executor(), param.executionStrategy);
 
         final ReadOnlyHttpServerConfig config = new HttpServerConfig().asReadOnly();
-        final ConnectionObserver connectionObserver = config.tcpConfig().transportObserver().onNewConnection();
         final ReadOnlyTcpServerConfig tcpReadOnly = new TcpServerConfig().asReadOnly();
 
         try {
             serverContext = TcpServerBinder.bind(localAddress(0), tcpReadOnly, true,
                     httpExecutionContext, null,
-                    (channel, observer) -> initChannel(channel, httpExecutionContext, config,
-                            new TcpServerChannelInitializer(tcpReadOnly, connectionObserver)
-                                    .andThen((channel1 -> channel1.pipeline().addLast(interceptor))), service,
-                            true, connectionObserver),
+                    (channel, observer) -> {
+                        final ConnectionObserver connectionObserver = config.tcpConfig().transportObserver()
+                                .onNewConnection(channel.localAddress(), channel.remoteAddress());
+                        return initChannel(channel, httpExecutionContext, config,
+                                new TcpServerChannelInitializer(tcpReadOnly, connectionObserver)
+                                        .andThen(channel1 -> channel1.pipeline().addLast(interceptor)), service,
+                                true, connectionObserver);
+                    },
                     connection -> connection.process(true))
                     .map(delegate -> new NettyHttpServerContext(delegate, service, httpExecutionContext))
                     .toFuture().get();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
@@ -169,6 +170,11 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
 
         @Override
         public ConnectionObserver onNewConnection() {
+            throw new UnsupportedOperationException("This deprecated method is not expected to be invoked");
+        }
+
+        @Override
+        public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
             // Use String.valueOf(...) here and in all other callbacks to prevent passing `null` value to the
             // ConcurrentHashMap which does not allow `null` values:
             storageMap.put("onNewConnection", valueOf(AsyncContext.get(key)));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -129,7 +129,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         clientStreamObserver = mock(StreamObserver.class, "clientStreamObserver");
         clientReadObserver = mock(ReadObserver.class, "clientReadObserver");
         clientWriteObserver = mock(WriteObserver.class, "clientWriteObserver");
-        when(clientTransportObserver.onNewConnection()).thenReturn(clientConnectionObserver);
+        when(clientTransportObserver.onNewConnection(any(), any())).thenReturn(clientConnectionObserver);
         lenient().when(clientConnectionObserver.connectionEstablished(any(ConnectionInfo.class)))
                 .thenReturn(clientDataObserver);
         lenient().when(clientConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
@@ -146,7 +146,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         serverStreamObserver = mock(StreamObserver.class, "serverStreamObserver");
         serverReadObserver = mock(ReadObserver.class, "serverReadObserver");
         serverWriteObserver = mock(WriteObserver.class, "serverWriteObserver");
-        when(serverTransportObserver.onNewConnection()).thenReturn(serverConnectionObserver);
+        when(serverTransportObserver.onNewConnection(any(), any())).thenReturn(serverConnectionObserver);
         lenient().when(serverConnectionObserver.connectionEstablished(any(ConnectionInfo.class)))
                 .thenReturn(serverDataObserver);
         lenient().when(serverConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
@@ -167,8 +167,8 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         processRequest.countDown();
         StreamingHttpConnection connection = streamingHttpConnection();
 
-        verify(clientTransportObserver).onNewConnection();
-        verify(serverTransportObserver, await()).onNewConnection();
+        verify(clientTransportObserver).onNewConnection(any(), any());
+        verify(serverTransportObserver, await()).onNewConnection(any(), any());
         verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
         if (protocol == HTTP_1) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -89,7 +89,7 @@ class SecurityHandshakeObserverTest {
         StreamObserver clientStreamObserver = mock(StreamObserver.class, "clientStreamObserver");
         ReadObserver clientReadObserver = mock(ReadObserver.class, "clientReadObserver");
         WriteObserver clientWriteObserver = mock(WriteObserver.class, "clientWriteObserver");
-        when(clientTransportObserver.onNewConnection()).thenReturn(clientConnectionObserver);
+        when(clientTransportObserver.onNewConnection(any(), any())).thenReturn(clientConnectionObserver);
         when(clientConnectionObserver.onSecurityHandshake()).thenReturn(clientSecurityHandshakeObserver);
         when(clientConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(clientDataObserver);
         when(clientConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
@@ -107,7 +107,7 @@ class SecurityHandshakeObserverTest {
         StreamObserver serverStreamObserver = mock(StreamObserver.class, "serverStreamObserver");
         ReadObserver serverReadObserver = mock(ReadObserver.class, "serverReadObserver");
         WriteObserver serverWriteObserver = mock(WriteObserver.class, "serverWriteObserver");
-        when(serverTransportObserver.onNewConnection()).thenReturn(serverConnectionObserver);
+        when(serverTransportObserver.onNewConnection(any(), any())).thenReturn(serverConnectionObserver);
         when(serverConnectionObserver.onSecurityHandshake()).thenReturn(serverSecurityHandshakeObserver);
         when(serverConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(serverDataObserver);
         when(serverConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -93,7 +93,7 @@ class StreamObserverTest {
         clientDataObserver = mock(DataObserver.class, "clientDataObserver");
         clientReadObserver = mock(ReadObserver.class, "clientReadObserver");
         clientWriteObserver = mock(WriteObserver.class, "clientWriteObserver");
-        when(clientTransportObserver.onNewConnection()).thenReturn(clientConnectionObserver);
+        when(clientTransportObserver.onNewConnection(any(), any())).thenReturn(clientConnectionObserver);
         when(clientConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
                 .thenReturn(clientMultiplexedObserver);
         when(clientMultiplexedObserver.onNewStream()).thenReturn(clientStreamObserver);
@@ -153,7 +153,7 @@ class StreamObserverTest {
             });
             return conn;
         }).toFuture().get()) {
-            verify(clientTransportObserver).onNewConnection();
+            verify(clientTransportObserver).onNewConnection(any(), any());
             verify(clientConnectionObserver).multiplexedConnectionEstablished(any(ConnectionInfo.class));
 
             connection.request(connection.get("/first")).subscribe(__ -> { /* no response expected */ });

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
@@ -96,7 +96,8 @@ public final class TcpConnector {
         return new SubscribableSingle<C>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super C> subscriber) {
-                ConnectHandler<C> connectHandler = new ConnectHandler<>(subscriber, connectionFactory, observer);
+                ConnectHandler<C> connectHandler = new ConnectHandler<>(subscriber, connectionFactory,
+                        observer.onNewConnection(localAddress, resolvedRemoteAddress));
                 try {
                     Future<?> connectFuture = connect0(localAddress, resolvedRemoteAddress, config, autoRead,
                             executionContext, connectHandler);
@@ -229,7 +230,7 @@ public final class TcpConnector {
 
         ConnectHandler(final Subscriber<? super C> target,
                        final BiFunction<Channel, ConnectionObserver, Single<? extends C>> connectionFactory,
-                       final TransportObserver observer) {
+                       final ConnectionObserver connectionObserver) {
             this.target = target;
             this.connectionFactory = connectionFactory;
             target.onSubscribe(() -> {
@@ -239,7 +240,7 @@ public final class TcpConnector {
                     flatMapCancellable.cancel();
                 }
             });
-            connectionObserver = observer.onNewConnection();
+            this.connectionObserver = connectionObserver;
         }
 
         @Override

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
@@ -127,7 +127,7 @@ public final class TcpServerBinder {
             @Override
             protected void initChannel(Channel channel) {
                 Single<CC> connectionSingle = connectionFunction.apply(channel,
-                        config.transportObserver().onNewConnection());
+                        config.transportObserver().onNewConnection(channel.localAddress(), channel.remoteAddress()));
                 if (connectionAcceptor != null) {
                     connectionSingle = connectionSingle.flatMap(conn ->
                             // Defer is required to isolate context for ConnectionAcceptor#accept and the rest

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -66,7 +66,7 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         clientDataObserver = mock(DataObserver.class, "clientDataObserver");
         clientReadObserver = mock(ReadObserver.class, "clientReadObserver");
         clientWriteObserver = mock(WriteObserver.class, "clientWriteObserver");
-        when(clientTransportObserver.onNewConnection()).thenReturn(clientConnectionObserver);
+        when(clientTransportObserver.onNewConnection(any(), any())).thenReturn(clientConnectionObserver);
         when(clientConnectionObserver.onSecurityHandshake()).thenReturn(clientSecurityHandshakeObserver);
         when(clientConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(clientDataObserver);
         when(clientDataObserver.onNewRead()).thenReturn(clientReadObserver);
@@ -78,7 +78,7 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         serverDataObserver = mock(DataObserver.class, "serverDataObserver");
         serverReadObserver = mock(ReadObserver.class, "serverReadObserver");
         serverWriteObserver = mock(WriteObserver.class, "serverWriteObserver");
-        when(serverTransportObserver.onNewConnection()).thenReturn(serverConnectionObserver);
+        when(serverTransportObserver.onNewConnection(any(), any())).thenReturn(serverConnectionObserver);
         when(serverConnectionObserver.onSecurityHandshake()).thenReturn(serverSecurityHandshakeObserver);
         when(serverConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(serverDataObserver);
         when(serverDataObserver.onNewRead()).thenReturn(serverReadObserver);

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
@@ -163,8 +163,8 @@ final class SecureTcpTransportObserverErrorsTest extends AbstractTransportObserv
             connection.set(c);
             clientConnected.countDown();
         });
-        verify(clientTransportObserver, await()).onNewConnection();
-        verify(serverTransportObserver, await()).onNewConnection();
+        verify(clientTransportObserver, await()).onNewConnection(any(), any());
+        verify(serverTransportObserver, await()).onNewConnection(any(), any());
         switch (errorReason) {
             case SECURE_CLIENT_TO_PLAIN_SERVER:
                 verify(clientConnectionObserver, await()).onSecurityHandshake();

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
@@ -73,8 +73,8 @@ class SecureTcpTransportObserverTest extends AbstractTransportObserverTest {
     void testConnectionObserverEvents(SslProvider clientProvider, SslProvider serverProvider) throws Exception {
         setUp(clientProvider, serverProvider);
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
-        verify(clientTransportObserver).onNewConnection();
-        verify(serverTransportObserver, await()).onNewConnection();
+        verify(clientTransportObserver).onNewConnection(any(), any());
+        verify(serverTransportObserver, await()).onNewConnection(any(), any());
 
         verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
@@ -116,8 +116,8 @@ final class TcpTransportObserverErrorsTest extends AbstractTransportObserverTest
         setUp(errorSource);
 
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
-        verify(clientTransportObserver).onNewConnection();
-        verify(serverTransportObserver, await()).onNewConnection();
+        verify(clientTransportObserver).onNewConnection(any(), any());
+        verify(serverTransportObserver, await()).onNewConnection(any(), any());
         verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
         verify(serverConnectionObserver, await()).onTransportHandshakeComplete();

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
@@ -46,8 +46,8 @@ class TcpTransportObserverTest extends AbstractTransportObserverTest {
     @Test
     void testConnectionObserverEvents() throws Exception {
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
-        verify(clientTransportObserver).onNewConnection();
-        verify(serverTransportObserver, await()).onNewConnection();
+        verify(clientTransportObserver).onNewConnection(any(), any());
+        verify(serverTransportObserver, await()).onNewConnection(any(), any());
         verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
         verify(serverConnectionObserver, await()).onTransportHandshakeComplete();

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -22,6 +22,7 @@ import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import static io.servicetalk.transport.api.TransportObservers.asSafeObserver;
@@ -39,6 +40,12 @@ final class BiTransportObserver implements TransportObserver {
     @Override
     public ConnectionObserver onNewConnection() {
         return new BiConnectionObserver(first.onNewConnection(), second.onNewConnection());
+    }
+
+    @Override
+    public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
+        return new BiConnectionObserver(first.onNewConnection(localAddress, remoteAddress),
+                second.onNewConnection(localAddress, remoteAddress));
     }
 
     private static final class BiConnectionObserver implements ConnectionObserver {

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import static java.util.Objects.requireNonNull;
@@ -54,6 +55,12 @@ final class CatchAllTransportObserver implements TransportObserver {
     @Override
     public ConnectionObserver onNewConnection() {
         return safeReport(observer::onNewConnection, observer, "new connection",
+                CatchAllConnectionObserver::new, NoopConnectionObserver.INSTANCE);
+    }
+
+    @Override
+    public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
+        return safeReport(() -> observer.onNewConnection(localAddress, remoteAddress), observer, "new connection",
                 CatchAllConnectionObserver::new, NoopConnectionObserver.INSTANCE);
     }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -22,6 +22,7 @@ import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 final class NoopTransportObserver implements TransportObserver {
@@ -34,6 +35,11 @@ final class NoopTransportObserver implements TransportObserver {
 
     @Override
     public ConnectionObserver onNewConnection() {
+        return NoopConnectionObserver.INSTANCE;
+    }
+
+    @Override
+    public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
         return NoopConnectionObserver.INSTANCE;
     }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObserver.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.transport.api;
 
+import javax.annotation.Nullable;
+
 /**
  * An observer interface that provides visibility into transport events.
  */
@@ -24,6 +26,19 @@ public interface TransportObserver {
      * Callback when transport starts initializing a new network connection.
      *
      * @return a new {@link ConnectionObserver} that provides visibility into events associated with a new connection
+     * @deprecated Use {@link #onNewConnection(Object, Object)}
      */
+    @Deprecated // FIXME: 0.42 - remove deprecated method
     ConnectionObserver onNewConnection();
+
+    /**
+     * Callback when transport starts initializing a new network connection.
+     *
+     * @param localAddress a local address of a new connection, if known
+     * @param remoteAddress a remote address of a new connection
+     * @return a new {@link ConnectionObserver} that provides visibility into events associated with a new connection
+     */
+    default ConnectionObserver onNewConnection(@Nullable Object localAddress, Object remoteAddress) {
+        return onNewConnection();   // FIXME: 0.42 - remove default impl
+    }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -25,6 +25,7 @@ import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 import io.servicetalk.transport.api.TransportObserver;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 /**
@@ -40,6 +41,11 @@ public final class NoopTransportObserver implements TransportObserver {
 
     @Override
     public ConnectionObserver onNewConnection() {
+        return NoopConnectionObserver.INSTANCE;
+    }
+
+    @Override
+    public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
         return NoopConnectionObserver.INSTANCE;
     }
 


### PR DESCRIPTION
Motivation:

Existing `TransportObserver#onNewConnection()` callback does not
provide visibility into an address. In case a connect attempt fails,
users don't know which remote was involved.

Modifications:

- Add a new callback `onNewConnection(Object, Object)` that gives
visibility to local/remote address;
- Deprecate `TransportObserver#onNewConnection()`;
- Update tests and implementation classes;

Result:

`TransportObserver` users have visibility into local/remote address
for each `onNewConnection` attempt.