### PR TITLE
`Read/WriteObserver`: give users visibility into items

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
@@ -287,7 +288,7 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
-            public void itemRead(final Object item) {
+            public void itemRead(@Nullable final Object item) {
                 storageMap.put("itemRead", valueOf(AsyncContext.get(key)));
             }
 
@@ -320,7 +321,7 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
-            public void itemReceived(final Object item) {
+            public void itemReceived(@Nullable final Object item) {
                 storageMap.put("itemReceived", valueOf(AsyncContext.get(key)));
             }
 
@@ -337,7 +338,7 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
-            public void itemWritten(final Object item) {
+            public void itemWritten(@Nullable final Object item) {
             }
 
             @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -337,7 +337,7 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
-            public void itemWritten(final Object item, final long size) {
+            public void itemWritten(final Object item) {
             }
 
             @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -287,6 +287,11 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
+            public void itemRead(final Object item) {
+                storageMap.put("itemRead", valueOf(AsyncContext.get(key)));
+            }
+
+            @Override
             public void readFailed(final Throwable cause) {
                 storageMap.put("readFailed", valueOf(AsyncContext.get(key)));
             }
@@ -315,6 +320,11 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
+            public void itemReceived(final Object item) {
+                storageMap.put("itemReceived", valueOf(AsyncContext.get(key)));
+            }
+
+            @Override
             public void onFlushRequest() {
                 storageMap.put("onFlushRequest", valueOf(AsyncContext.get(key)));
             }
@@ -324,6 +334,14 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             // class local variable.
             @Override
             public void itemWritten() {
+            }
+
+            @Override
+            public void itemWritten(final Object item, final long size) {
+            }
+
+            @Override
+            public void itemFlushed() {
             }
 
             @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -222,26 +222,28 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         verifyNewReadAndNewWrite(2);
 
         verify(clientWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
-        verify(clientWriteObserver, atLeastOnce()).itemReceived();
+        verify(clientWriteObserver, atLeastOnce()).itemReceived(any());
         verify(clientWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(clientWriteObserver, atLeastOnce()).itemWritten();
+        verify(clientWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(clientWriteObserver, atLeastOnce()).itemFlushed();
         verify(clientWriteObserver).writeComplete();
 
         verify(serverReadObserver, await()).readComplete();
         verify(serverReadObserver, atLeastOnce()).requestedToRead(anyLong());
-        verify(serverReadObserver, atLeastOnce()).itemRead();
+        verify(serverReadObserver, atLeastOnce()).itemRead(any());
 
         if (protocol == HTTP_2) {
             // HTTP/1.x has a single write publisher across all requests that does not complete after each response
             verify(serverWriteObserver, await()).writeComplete();
         }
         verify(serverWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
-        verify(serverWriteObserver, atLeastOnce()).itemReceived();
+        verify(serverWriteObserver, atLeastOnce()).itemReceived(any());
         verify(serverWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(serverWriteObserver, atLeastOnce()).itemWritten();
+        verify(serverWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(serverWriteObserver, atLeastOnce()).itemFlushed();
 
         verify(clientReadObserver, atLeastOnce()).requestedToRead(anyLong());
-        verify(clientReadObserver, atLeastOnce()).itemRead();
+        verify(clientReadObserver, atLeastOnce()).itemRead(any());
         verify(clientReadObserver).readComplete();
 
         if (protocol == HTTP_2) {
@@ -285,13 +287,14 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         verifyNewReadAndNewWrite(1);
 
         verify(clientWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
-        verify(clientWriteObserver, atLeastOnce()).itemReceived();
+        verify(clientWriteObserver, atLeastOnce()).itemReceived(any());
         verify(clientWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(clientWriteObserver, atLeastOnce()).itemWritten();
+        verify(clientWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(clientWriteObserver, atLeastOnce()).itemFlushed();
         verify(clientWriteObserver).writeComplete();
 
         verify(serverReadObserver, atLeastOnce()).requestedToRead(anyLong());
-        verify(serverReadObserver, atLeastOnce()).itemRead();
+        verify(serverReadObserver, atLeastOnce()).itemRead(any());
         if (serverReadCompletes) {
             verify(serverReadObserver).readComplete();
         } else {
@@ -300,13 +303,14 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         }
 
         verify(serverWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
-        verify(serverWriteObserver, atLeastOnce()).itemReceived();
+        verify(serverWriteObserver, atLeastOnce()).itemReceived(any());
         verify(serverWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(serverWriteObserver, atLeastOnce()).itemWritten();
+        verify(serverWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(serverWriteObserver, atLeastOnce()).itemFlushed();
         verify(serverWriteObserver, atLeastOnce()).writeFailed(DELIBERATE_EXCEPTION);
 
         verify(clientReadObserver, atLeastOnce()).requestedToRead(anyLong());
-        verify(clientReadObserver, atLeastOnce()).itemRead();
+        verify(clientReadObserver, atLeastOnce()).itemRead(any());
         verify(clientReadObserver).readFailed(any(causeType));
 
         if (protocol == HTTP_1) {
@@ -364,9 +368,10 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         // After all "closed" events have been received, verify all other events in between. Otherwise, there is a risk
         // of race between verification and events.
         verify(clientWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
-        verify(clientWriteObserver, atLeastOnce()).itemReceived();
+        verify(clientWriteObserver, atLeastOnce()).itemReceived(any());
         verify(clientWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(clientWriteObserver, atLeastOnce()).itemWritten();
+        verify(clientWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(clientWriteObserver, atLeastOnce()).itemFlushed();
         verify(clientWriteObserver).writeFailed(DELIBERATE_EXCEPTION);
 
         if (protocol == HTTP_1) {
@@ -375,7 +380,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
             verify(serverReadObserver, await()).readFailed(any(H2StreamResetException.class));
         }
         verify(serverReadObserver, atLeastOnce()).requestedToRead(anyLong());
-        verify(serverReadObserver, atLeastOnce()).itemRead();
+        verify(serverReadObserver, atLeastOnce()).itemRead(any());
         verify(serverReadObserver, atMostOnce()).readCancelled();
 
         verify(serverWriteObserver, atLeastOnce()).requestedToWrite(anyLong());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -224,7 +224,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         verify(clientWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
         verify(clientWriteObserver, atLeastOnce()).itemReceived(any());
         verify(clientWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(clientWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(clientWriteObserver, atLeastOnce()).itemWritten(any());
         verify(clientWriteObserver, atLeastOnce()).itemFlushed();
         verify(clientWriteObserver).writeComplete();
 
@@ -239,7 +239,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         verify(serverWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
         verify(serverWriteObserver, atLeastOnce()).itemReceived(any());
         verify(serverWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(serverWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(serverWriteObserver, atLeastOnce()).itemWritten(any());
         verify(serverWriteObserver, atLeastOnce()).itemFlushed();
 
         verify(clientReadObserver, atLeastOnce()).requestedToRead(anyLong());
@@ -289,7 +289,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         verify(clientWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
         verify(clientWriteObserver, atLeastOnce()).itemReceived(any());
         verify(clientWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(clientWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(clientWriteObserver, atLeastOnce()).itemWritten(any());
         verify(clientWriteObserver, atLeastOnce()).itemFlushed();
         verify(clientWriteObserver).writeComplete();
 
@@ -305,7 +305,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         verify(serverWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
         verify(serverWriteObserver, atLeastOnce()).itemReceived(any());
         verify(serverWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(serverWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(serverWriteObserver, atLeastOnce()).itemWritten(any());
         verify(serverWriteObserver, atLeastOnce()).itemFlushed();
         verify(serverWriteObserver, atLeastOnce()).writeFailed(DELIBERATE_EXCEPTION);
 
@@ -370,7 +370,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         verify(clientWriteObserver, atLeastOnce()).requestedToWrite(anyLong());
         verify(clientWriteObserver, atLeastOnce()).itemReceived(any());
         verify(clientWriteObserver, atLeastOnce()).onFlushRequest();
-        verify(clientWriteObserver, atLeastOnce()).itemWritten(any(), anyLong());
+        verify(clientWriteObserver, atLeastOnce()).itemWritten(any());
         verify(clientWriteObserver, atLeastOnce()).itemFlushed();
         verify(clientWriteObserver).writeFailed(DELIBERATE_EXCEPTION);
 

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -130,7 +130,7 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         verify(writeObserver, atLeastOnce()).requestedToWrite(anyLong());
         verify(writeObserver).itemReceived(any());
         verify(writeObserver).onFlushRequest();
-        verify(writeObserver).itemWritten(any(), anyLong());
+        verify(writeObserver).itemWritten(any());
         verify(writeObserver).itemFlushed();
         if (completeExpected) {
             verify(writeObserver).writeComplete();

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -128,9 +128,10 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
                                     boolean completeExpected) {
         verify(dataObserver).onNewWrite();
         verify(writeObserver, atLeastOnce()).requestedToWrite(anyLong());
-        verify(writeObserver).itemReceived();
+        verify(writeObserver).itemReceived(any());
         verify(writeObserver).onFlushRequest();
-        verify(writeObserver).itemWritten();
+        verify(writeObserver).itemWritten(any(), anyLong());
+        verify(writeObserver).itemFlushed();
         if (completeExpected) {
             verify(writeObserver).writeComplete();
         }
@@ -139,7 +140,7 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
     static void verifyReadObserver(DataObserver dataObserver, ReadObserver readObserver) {
         verify(dataObserver).onNewRead();
         verify(readObserver).requestedToRead(anyLong());
-        verify(readObserver, atLeastOnce()).itemRead();
+        verify(readObserver, atLeastOnce()).itemRead(any());
     }
 
     static VerificationWithTimeout await() {

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -287,9 +287,9 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemWritten(final Object item, final long size) {
-            first.itemWritten(item, size);
-            second.itemWritten(item, size);
+        public void itemWritten(final Object item) {
+            first.itemWritten(item);
+            second.itemWritten(item);
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -222,6 +222,12 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void itemRead(final Object item) {
+            first.itemRead(item);
+            second.itemRead(item);
+        }
+
+        @Override
         public void readFailed(final Throwable cause) {
             first.readFailed(cause);
             second.readFailed(cause);
@@ -263,6 +269,12 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void itemReceived(final Object item) {
+            first.itemReceived(item);
+            second.itemReceived(item);
+        }
+
+        @Override
         public void onFlushRequest() {
             first.onFlushRequest();
             second.onFlushRequest();
@@ -272,6 +284,18 @@ final class BiTransportObserver implements TransportObserver {
         public void itemWritten() {
             first.itemWritten();
             second.itemWritten();
+        }
+
+        @Override
+        public void itemWritten(final Object item, final long size) {
+            first.itemWritten(item, size);
+            second.itemWritten(item, size);
+        }
+
+        @Override
+        public void itemFlushed() {
+            first.itemFlushed();
+            second.itemFlushed();
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -22,6 +22,7 @@ import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import static io.servicetalk.transport.api.TransportObservers.asSafeObserver;
@@ -222,7 +223,7 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemRead(final Object item) {
+        public void itemRead(@Nullable final Object item) {
             first.itemRead(item);
             second.itemRead(item);
         }
@@ -269,7 +270,7 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemReceived(final Object item) {
+        public void itemReceived(@Nullable final Object item) {
             first.itemReceived(item);
             second.itemReceived(item);
         }
@@ -287,7 +288,7 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemWritten(final Object item) {
+        public void itemWritten(@Nullable final Object item) {
             first.itemWritten(item);
             second.itemWritten(item);
         }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import static java.util.Objects.requireNonNull;
@@ -219,7 +220,7 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemRead(final Object item) {
+        public void itemRead(@Nullable final Object item) {
             safeReport(() -> observer.itemRead(item), observer, "item read");
         }
 
@@ -258,7 +259,7 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemReceived(final Object item) {
+        public void itemReceived(@Nullable final Object item) {
             safeReport(() -> observer.itemReceived(item), observer, "item received");
         }
 
@@ -273,7 +274,7 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemWritten(final Object item) {
+        public void itemWritten(@Nullable final Object item) {
             safeReport(() -> observer.itemWritten(item), observer, "item written");
         }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -273,8 +273,8 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemWritten(final Object item, final long size) {
-            safeReport(() -> observer.itemWritten(item, size), observer, "item written");
+        public void itemWritten(final Object item) {
+            safeReport(() -> observer.itemWritten(item), observer, "item written");
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -219,6 +219,11 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void itemRead(final Object item) {
+            safeReport(() -> observer.itemRead(item), observer, "item read");
+        }
+
+        @Override
         public void readFailed(final Throwable cause) {
             safeReport(() -> observer.readFailed(cause), observer, "read failed", cause);
         }
@@ -253,6 +258,11 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void itemReceived(final Object item) {
+            safeReport(() -> observer.itemReceived(item), observer, "item received");
+        }
+
+        @Override
         public void onFlushRequest() {
             safeReport(observer::onFlushRequest, observer, "flush request");
         }
@@ -260,6 +270,16 @@ final class CatchAllTransportObserver implements TransportObserver {
         @Override
         public void itemWritten() {
             safeReport(observer::itemWritten, observer, "item written");
+        }
+
+        @Override
+        public void itemWritten(final Object item, final long size) {
+            safeReport(() -> observer.itemWritten(item, size), observer, "item written");
+        }
+
+        @Override
+        public void itemFlushed() {
+            safeReport(observer::itemFlushed, observer, "item flushed");
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -293,7 +293,7 @@ public interface ConnectionObserver {
          * <p>
          * Content of the written items should be inspected at the higher level API when these items are produced.
          *
-         * @deprecated Use {@link #itemWritten(Object, long)}
+         * @deprecated Use {@link #itemWritten(Object)}
          */
         @Deprecated
         void itemWritten();
@@ -302,9 +302,8 @@ public interface ConnectionObserver {
          * Callback when an item is serialized and written to the socket.
          *
          * @param item written item
-         * @param size resulting size of the serialized item
          */
-        default void itemWritten(Object item, long size) {
+        default void itemWritten(Object item) {
             itemWritten();  // FIXME: 0.42 - remove default impl
         }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.transport.api;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 /**
@@ -226,7 +227,7 @@ public interface ConnectionObserver {
          *
          * @param item an item that was read
          */
-        default void itemRead(Object item) {
+        default void itemRead(@Nullable Object item) {
             itemRead(); // FIXME: 0.42 - remove default impl
         }
 
@@ -279,7 +280,7 @@ public interface ConnectionObserver {
          *
          * @param item received item
          */
-        default void itemReceived(Object item) {
+        default void itemReceived(@Nullable Object item) {
             itemReceived(); // FIXME: 0.42 - remove default impl
         }
 
@@ -303,7 +304,7 @@ public interface ConnectionObserver {
          *
          * @param item written item
          */
-        default void itemWritten(Object item) {
+        default void itemWritten(@Nullable Object item) {
             itemWritten();  // FIXME: 0.42 - remove default impl
         }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -215,8 +215,20 @@ public interface ConnectionObserver {
          * Invokes when a new item is read.
          * <p>
          * Content of the read items should be inspected at the higher level API when these items are consumed.
+         *
+         * @deprecated Use {@link #itemRead(Object)}
          */
+        @Deprecated
         void itemRead();
+
+        /**
+         * Invokes when a new item is read.
+         *
+         * @param item an item that was read
+         */
+        default void itemRead(Object item) {
+            itemRead(); // FIXME: 0.42 - remove default impl
+        }
 
         /**
          * Callback when the read operation fails with an {@link Throwable error}.
@@ -256,8 +268,20 @@ public interface ConnectionObserver {
          * Callback when an item is received and ready to be written.
          * <p>
          * Content of the received items should be inspected at the higher level API when these items are produced.
+         *
+         * @deprecated Use {{@link #itemReceived(Object)}}
          */
+        @Deprecated
         void itemReceived();
+
+        /**
+         * Callback when an item is received and ready to be written.
+         *
+         * @param item received item
+         */
+        default void itemReceived(Object item) {
+            itemReceived(); // FIXME: 0.42 - remove default impl
+        }
 
         /**
          * Callback when flush operation is requested.
@@ -268,8 +292,28 @@ public interface ConnectionObserver {
          * Callback when an item is written to the transport.
          * <p>
          * Content of the written items should be inspected at the higher level API when these items are produced.
+         *
+         * @deprecated Use {@link #itemWritten(Object, long)}
          */
+        @Deprecated
         void itemWritten();
+
+        /**
+         * Callback when an item is serialized and written to the socket.
+         *
+         * @param item written item
+         * @param size resulting size of the serialized item
+         */
+        default void itemWritten(Object item, long size) {
+            itemWritten();  // FIXME: 0.42 - remove default impl
+        }
+
+        /**
+         * Callback when an item is flushed to the network. Items are flushed in order they have been written.
+         */
+        default void itemFlushed() {
+            // FIXME: 0.42 - remove default impl
+        }
 
         /**
          * Callback when the write operation fails with an {@link Throwable error}.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -223,7 +223,7 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemWritten(final Object item, final long size) {
+        public void itemWritten(final Object item) {
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -22,6 +22,7 @@ import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 final class NoopTransportObserver implements TransportObserver {
@@ -178,7 +179,7 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemRead(final Object item) {
+        public void itemRead(@Nullable final Object item) {
         }
 
         @Override
@@ -211,7 +212,7 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemReceived(final Object item) {
+        public void itemReceived(@Nullable final Object item) {
         }
 
         @Override
@@ -223,7 +224,7 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemWritten(final Object item) {
+        public void itemWritten(@Nullable final Object item) {
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -178,6 +178,10 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void itemRead(final Object item) {
+        }
+
+        @Override
         public void readFailed(final Throwable cause) {
         }
 
@@ -207,11 +211,23 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void itemReceived(final Object item) {
+        }
+
+        @Override
         public void onFlushRequest() {
         }
 
         @Override
         public void itemWritten() {
+        }
+
+        @Override
+        public void itemWritten(final Object item, final long size) {
+        }
+
+        @Override
+        public void itemFlushed() {
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -338,7 +338,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
                 @Override
                 public void onNext(@Nullable final Read read) {
-                    observer.itemRead();
+                    observer.itemRead(read);
                     target.onNext(read);
                 }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/Flush.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/Flush.java
@@ -112,7 +112,7 @@ final class Flush {
             if (!eventLoop.inEventLoop() && !enqueueFlush) {
                 enqueueFlush = true;
             }
-            observer.itemReceived();
+            observer.itemReceived(t);
             subscriber.onNext(t);
             writeEventsListener.itemWritten(t);
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -250,7 +250,7 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemWritten(final Object item, final long size) {
+        public void itemWritten(final Object item) {
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -202,6 +202,10 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void itemRead(final Object item) {
+        }
+
+        @Override
         public void readFailed(final Throwable cause) {
         }
 
@@ -234,11 +238,23 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void itemReceived(final Object item) {
+        }
+
+        @Override
         public void onFlushRequest() {
         }
 
         @Override
         public void itemWritten() {
+        }
+
+        @Override
+        public void itemWritten(final Object item, final long size) {
+        }
+
+        @Override
+        public void itemFlushed() {
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -25,6 +25,7 @@ import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 import io.servicetalk.transport.api.TransportObserver;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 /**
@@ -202,7 +203,7 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemRead(final Object item) {
+        public void itemRead(@Nullable final Object item) {
         }
 
         @Override
@@ -238,7 +239,7 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemReceived(final Object item) {
+        public void itemReceived(@Nullable final Object item) {
         }
 
         @Override
@@ -250,7 +251,7 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void itemWritten(final Object item) {
+        public void itemWritten(@Nullable final Object item) {
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -167,7 +167,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             long capacityBefore = channel.bytesBeforeUnwritable();
             promise.writeNext(msg);
             long capacityAfter = channel.bytesBeforeUnwritable();
-            observer.itemWritten(msg, capacityBefore - capacityAfter);
+            observer.itemWritten(msg);
             demandEstimator.onItemWrite(msg, capacityBefore, capacityAfter);
             requestMoreIfRequired(subscription, capacityAfter);
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -106,6 +106,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
      */
     private boolean enqueueWrites;
     private final CloseHandler closeHandler;
+    private final WriteObserver observer;
     private final boolean isClient;
 
     WriteStreamSubscriber(Channel channel, WriteDemandEstimator demandEstimator, Subscriber subscriber,
@@ -115,8 +116,9 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
         this.subscriber = subscriber;
         this.channel = channel;
         this.demandEstimator = demandEstimator;
-        promise = new AllWritesPromise(channel, observer, enrichProtocolError);
+        promise = new AllWritesPromise(channel, enrichProtocolError);
         this.closeHandler = closeHandler;
+        this.observer = observer;
         this.isClient = isClient;
     }
 
@@ -165,6 +167,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             long capacityBefore = channel.bytesBeforeUnwritable();
             promise.writeNext(msg);
             long capacityAfter = channel.bytesBeforeUnwritable();
+            observer.itemWritten(msg, capacityBefore - capacityAfter);
             demandEstimator.onItemWrite(msg, capacityBefore, capacityAfter);
             requestMoreIfRequired(subscription, capacityAfter);
         }
@@ -304,13 +307,10 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
          * streaming payload body may have more listeners. However, the MIN_INITIAL_CAPACITY of ArrayDeque is 8.
          */
         private final Deque<GenericFutureListener<?>> listenersOnWriteBoundaries = new ArrayDeque<>(8);
-        private final WriteObserver observer;
         private final UnaryOperator<Throwable> enrichProtocolError;
 
-        AllWritesPromise(final Channel channel, final WriteObserver observer,
-                         final UnaryOperator<Throwable> enrichProtocolError) {
+        AllWritesPromise(final Channel channel, final UnaryOperator<Throwable> enrichProtocolError) {
             super(channel);
-            this.observer = observer;
             this.enrichProtocolError = enrichProtocolError;
         }
 
@@ -456,7 +456,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             if (isAllSet(state, SUBSCRIBER_TERMINATED)) {
                 return nettySharedPromiseTryStatus();
             }
-            observer.itemWritten();
+            observer.itemFlushed();
             if (--activeWrites == 0 && isAllSet(state, SOURCE_TERMINATED)) {
                 state = set(state, SUBSCRIBER_TERMINATED);
                 try {


### PR DESCRIPTION
Motivation:

Existing `ReadObserver` and `WriteObserver` API sends signals without
letting users know what exactly was read or written.

Modifications:

- Add `ReadObserver#itemRead(Object)`, deprecate `ReadObserver#itemRead()`;
- Add `WriteObserver#itemReceived(Object)`, deprecate `WriteObserver#itemReceived()`;
- Add `WriteObserver#itemWritten(Object)`, deprecate `WriteObserver#itemWritten()`;
- Add `WriteObserver#itemFlushed(Object)`;
- Update tests and implementations;

Result:

Users can see what items have been read or written at L4 level.