### PR TITLE
Close can be observed on test executor thread

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -89,7 +89,7 @@ class HttpOffloadingTest {
 
     private StreamingHttpConnection httpConnection;
     private final Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
-    private CountDownLatch terminated = new CountDownLatch(1);
+    private final CountDownLatch terminated = new CountDownLatch(1);
     private ServerContext serverContext;
     private OffloadingVerifyingServiceStreaming service;
     private StreamingHttpClient client;
@@ -98,9 +98,10 @@ class HttpOffloadingTest {
     private Predicate<Thread> wrongPublishThread;
 
     void setup(boolean offloadClose) throws Exception {
+        Thread testThread = Thread.currentThread();
         wrongPublishThread = offloadClose ?
                 IoThreadFactory.IoThread::isIoThread :
-                ((Predicate<Thread>) IoThreadFactory.IoThread::isIoThread).negate();
+                (Thread thread) -> thread != testThread && !IoThreadFactory.IoThread.isIoThread(thread);
         service = new OffloadingVerifyingServiceStreaming();
         serverContext = forAddress(localAddress(0))
             .ioExecutor(SERVER_CTX.ioExecutor())


### PR DESCRIPTION
Motivation:
Occasional test failures have occurred for
`HttpOffloadingTest::serverOnCloseIsOffloaded()`
where the reported thread is the JUnit executor
thread. This is because the server has already
completed close and the Future.get()/subscribe
happens entirely on the Junit thread.
Modifications:
Allow for either ioThread or Junit thread to
execute the onComplete()
Result:
No spurious test failures.