### PR TITLE
Fix sharing issue with Retrying requests filter factory

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/AutoRetryStrategyProvider.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/AutoRetryStrategyProvider.java
@@ -36,7 +36,10 @@ public interface AutoRetryStrategyProvider {
 
     /**
      * An {@link AutoRetryStrategyProvider} that disables automatic retries;
+     * @deprecated Alternative available {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter
+     * .disableAutoRetries()}.
      */
+    @Deprecated
     AutoRetryStrategyProvider DISABLE_AUTO_RETRIES = (lbEventStream, sdErrorStream) -> (___, cause) -> failed(cause);
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -43,6 +43,7 @@ import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -100,6 +101,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSingleAddressHttpClientBuilder.class);
 
+    private static final RetryingHttpRequesterFilter DEFAULT_AUTO_RETRIES =
+            new RetryingHttpRequesterFilter.Builder().build();
+
     static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(10);
     static final Duration SD_RETRY_STRATEGY_JITTER = ofSeconds(5);
     @Nullable
@@ -119,7 +123,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     @Nullable
     private StreamingHttpConnectionFilterFactory connectionFilterFactory;
     @Nullable
-    private StreamingHttpClientFilterFactory clientFilterFactory;
+    private ContextAwareStreamingHttpClientFilterFactory clientFilterFactory;
     @Nullable
     private AutoRetryStrategyProvider autoRetry = new io.servicetalk.client.api.DefaultAutoRetryStrategyProvider
             .Builder().build();
@@ -259,14 +263,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         return buildStreaming(copyBuildCtx());
     }
 
-    private static <U, R> void injectRetryingFilterDependencies(final HttpClientBuildContext<U, R> ctx,
-            final LoadBalancer<LoadBalancedStreamingHttpConnection> loadBalancer) {
-        if (ctx.builder.retryingHttpRequesterFilter != null) {
-            ctx.builder.retryingHttpRequesterFilter.inject(ctx.sdStatus);
-            ctx.builder.retryingHttpRequesterFilter.inject(loadBalancer.eventStream());
-        }
-    }
-
     private static <U, R> StreamingHttpClient buildStreaming(final HttpClientBuildContext<U, R> ctx) {
         final ReadOnlyHttpClientConfig roConfig = ctx.httpConfig().asReadOnly();
         final HttpExecutionContext executionContext = ctx.builder.executionContextBuilder.build();
@@ -332,7 +328,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                             sdEvents,
                             connectionFactory));
 
-            StreamingHttpClientFilterFactory currClientFilterFactory = ctx.builder.clientFilterFactory;
+            ContextAwareStreamingHttpClientFilterFactory currClientFilterFactory = ctx.builder.clientFilterFactory;
             if (roConfig.hasProxy() && sslContext == null) {
                 // If we're talking to a proxy over http (not https), rewrite the request-target to absolute-form, as
                 // specified by the RFC: https://tools.ietf.org/html/rfc7230#section-5.3.2
@@ -350,16 +346,16 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 lbClient = new AutoRetryFilter(lbClient,
                         ctx.builder.autoRetry.newStrategy(lb.eventStream(), ctx.sdStatus));
             } else if (ctx.builder.autoRetry != null && !ctx.builder.retryingFilterAppended) {
-                ctx.builder.retryingHttpRequesterFilter = new RetryingHttpRequesterFilter.Builder().build();
+                ctx.builder.retryingHttpRequesterFilter = DEFAULT_AUTO_RETRIES;
                 currClientFilterFactory = appendFilter(currClientFilterFactory,
                         ctx.builder.retryingHttpRequesterFilter);
             }
             HttpExecutionStrategy computedStrategy = ctx.builder.strategyComputation.buildForClient(executionStrategy);
             LOGGER.debug("Client for {} created with base strategy {} → computed strategy {}",
                     targetAddress(ctx), executionStrategy, computedStrategy);
-            injectRetryingFilterDependencies(ctx, lb);
             return new FilterableClientToClient(currClientFilterFactory != null ?
-                    currClientFilterFactory.create(lbClient) : lbClient, computedStrategy);
+                    currClientFilterFactory.create(lbClient, lb.eventStream(), ctx.sdStatus) :
+                        lbClient, computedStrategy);
         } catch (final Throwable t) {
             closeOnException.closeAsync().subscribe();
             throw t;
@@ -401,13 +397,35 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 ctx.builder.address.toString() : ctx.builder.address + " (via " + ctx.proxyAddress + ")";
     }
 
-    private static StreamingHttpClientFilterFactory appendFilter(
-            @Nullable final StreamingHttpClientFilterFactory currClientFilterFactory,
+    private static ContextAwareStreamingHttpClientFilterFactory appendFilter(
+            @Nullable final ContextAwareStreamingHttpClientFilterFactory currClientFilterFactory,
             final StreamingHttpClientFilterFactory appendClientFilterFactory) {
-        if (currClientFilterFactory == null) {
-            return appendClientFilterFactory;
+        if (appendClientFilterFactory instanceof RetryingHttpRequesterFilter) {
+            if (currClientFilterFactory == null) {
+                return (client, lbEventStream, sdStatus) -> {
+                    final RetryingHttpRequesterFilter.ContextAwareRetryingHttpClientFilter filter =
+                            (RetryingHttpRequesterFilter.ContextAwareRetryingHttpClientFilter)
+                                    appendClientFilterFactory.create(client);
+                    filter.inject(lbEventStream, sdStatus);
+                    return filter;
+                };
+            } else {
+                return (client, lbEventStream, sdStatus) -> {
+                    final RetryingHttpRequesterFilter.ContextAwareRetryingHttpClientFilter filter =
+                            (RetryingHttpRequesterFilter.ContextAwareRetryingHttpClientFilter)
+                                    appendClientFilterFactory.create(client);
+                    filter.inject(lbEventStream, sdStatus);
+                    return currClientFilterFactory.create(filter, lbEventStream, sdStatus);
+                };
+            }
         } else {
-            return client -> currClientFilterFactory.create(appendClientFilterFactory.create(client));
+            if (currClientFilterFactory == null) {
+                return (client, lbEventStream, sdError) -> appendClientFilterFactory.create(client);
+            } else {
+                return (client, lbEventStream, sdError) ->
+                        currClientFilterFactory.create(appendClientFilterFactory.create(client),
+                                lbEventStream, sdError);
+            }
         }
     }
 
@@ -867,6 +885,18 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 throw new IllegalStateException("HeadersFactory config not found for selected protocol: " + version);
             }
             return factory;
+        }
+    }
+
+    @FunctionalInterface
+    interface ContextAwareStreamingHttpClientFilterFactory extends StreamingHttpClientFilterFactory {
+        StreamingHttpClientFilter create(FilterableStreamingHttpClient client,
+                                         @Nullable Publisher<Object> lbEventStream,
+                                         @Nullable SdStatusCompletable sdStatus);
+
+        @Override
+        default StreamingHttpClientFilter create(FilterableStreamingHttpClient client) {
+            return create(client, null, null);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -892,7 +892,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     interface ContextAwareStreamingHttpClientFilterFactory extends StreamingHttpClientFilterFactory {
         StreamingHttpClientFilter create(FilterableStreamingHttpClient client,
                                          @Nullable Publisher<Object> lbEventStream,
-                                         @Nullable SdStatusCompletable sdStatus);
+                                         @Nullable Completable sdStatus);
 
         @Override
         default StreamingHttpClientFilter create(FilterableStreamingHttpClient client) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -31,7 +31,6 @@ import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
-import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -73,17 +72,13 @@ import static java.util.Objects.requireNonNull;
  * Similarly, max-retries for each flow can be set in the {@link BackOffPolicy}, as well
  * as a total max-retries to be respected by both flows, as set in
  * {@link Builder#maxTotalRetries(int)}.
- * <p>
- * Note that applying this filter on a client it will automatically disable the use of
- * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)}.
  * @see RetryStrategies
  */
 public final class RetryingHttpRequesterFilter
         implements StreamingHttpClientFilterFactory, ExecutionStrategyInfluencer<HttpExecutionStrategy> {
 
-    public static final RetryingHttpRequesterFilter DISABLE_RETRIES =
-            new RetryingHttpRequesterFilter(false, true, 0, null,
-                (__, ___) -> NO_RETRIES);
+    public static final RetryingHttpRequesterFilter DISABLED_RETRIES =
+            new RetryingHttpRequesterFilter(false, true, 0, null, (__, ___) -> NO_RETRIES);
 
     private final boolean waitForLb;
     private final boolean ignoreSdErrors;
@@ -91,13 +86,6 @@ public final class RetryingHttpRequesterFilter
     @Nullable
     private final Function<HttpResponseMetaData, HttpResponseException> responseMapper;
     private final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryFor;
-    @Nullable
-    private Publisher<Object> lbEventStream;
-    @Nullable
-    private LoadBalancerReadySubscriber loadBalancerReadySubscriber;
-
-    @Nullable
-    private Completable sdStatus;
 
     RetryingHttpRequesterFilter(
             final boolean waitForLb, final boolean ignoreSdErrors, final int maxTotalRetries,
@@ -110,61 +98,9 @@ public final class RetryingHttpRequesterFilter
         this.retryFor = retryFor;
     }
 
-    private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
-                                                  final StreamingHttpRequest request,
-                                                  final Executor executor) {
-        Single<StreamingHttpResponse> single = delegate.request(request);
-        if (responseMapper != null) {
-            single = single.map(resp -> {
-                final HttpResponseException exception = responseMapper.apply(resp);
-                if (exception != null) {
-                    throw exception;
-                }
-
-                return resp;
-            });
-        }
-
-        return single.retryWhen(retryStrategy(executor, request));
-    }
-
-    private BiIntFunction<Throwable, Completable> retryStrategy(final Executor executor,
-                                                                final HttpRequestMetaData requestMetaData) {
-        return (count, t) -> {
-            if (count > maxTotalRetries) {
-                return failed(t);
-            }
-
-            if (loadBalancerReadySubscriber != null && t instanceof NoAvailableHostException) {
-                final Completable onHostsAvailable = loadBalancerReadySubscriber.onHostsAvailable();
-                return sdStatus == null ? onHostsAvailable : onHostsAvailable.ambWith(sdStatus);
-            }
-
-            final BackOffPolicy backOffPolicy = retryFor.apply(requestMetaData, t);
-            if (backOffPolicy != NO_RETRIES) {
-                if (t instanceof DelayedRetry) {
-                    final Duration constant = ((DelayedRetry) t).delay();
-                    return backOffPolicy.newStrategy(executor).apply(count, t).concat(executor.timer(constant));
-                }
-
-                return backOffPolicy.newStrategy(executor).apply(count, t);
-            }
-
-            return failed(t);
-        };
-    }
-
-    void inject(final Publisher<Object> lbEventStream) {
-        this.lbEventStream = lbEventStream;
-    }
-
-    void inject(final Completable sdStatus) {
-        this.sdStatus = ignoreSdErrors ? null : sdStatus;
-    }
-
     @Override
     public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
-        return new ContextAwareClientFilter(client);
+        return new ContextAwareRetryingHttpClientFilter(client);
     }
 
     @Override
@@ -173,27 +109,35 @@ public final class RetryingHttpRequesterFilter
         return HttpExecutionStrategies.offloadNone();
     }
 
-    private final class ContextAwareClientFilter extends StreamingHttpClientFilter {
+    final class ContextAwareRetryingHttpClientFilter extends StreamingHttpClientFilter {
+
+        private final Executor executor;
+        @Nullable
+        private Completable sdStatus;
 
         @Nullable
         private AsyncCloseable closeAsync;
 
-        private final Executor executor;
+        @Nullable
+        private LoadBalancerReadySubscriber loadBalancerReadySubscriber;
 
         /**
          * Create a new instance.
          *
          * @param delegate The {@link FilterableStreamingHttpClient} to delegate all calls to.
          */
-        private ContextAwareClientFilter(final FilterableStreamingHttpClient delegate) {
+        private ContextAwareRetryingHttpClientFilter(final FilterableStreamingHttpClient delegate) {
             super(delegate);
             this.executor = delegate.executionContext().executor();
-            init();
         }
 
-        public void init() {
+        void inject(@Nullable final Publisher<Object> lbEventStream,
+                    @Nullable final Completable sdStatus) {
+            assert lbEventStream != null;
+            assert sdStatus != null;
+            this.sdStatus = ignoreSdErrors ? null : sdStatus;
+
             if (waitForLb) {
-                assert lbEventStream != null;
                 loadBalancerReadySubscriber = new LoadBalancerReadySubscriber();
                 closeAsync = toAsyncCloseable(__ -> {
                     loadBalancerReadySubscriber.cancel();
@@ -206,6 +150,33 @@ public final class RetryingHttpRequesterFilter
             }
         }
 
+        // Visible for testing
+        BiIntFunction<Throwable, Completable> retryStrategy(final Executor executor,
+                                                            final HttpRequestMetaData requestMetaData) {
+            return (count, t) -> {
+                if (count > maxTotalRetries) {
+                    return failed(t);
+                }
+
+                if (loadBalancerReadySubscriber != null && t instanceof NoAvailableHostException) {
+                    final Completable onHostsAvailable = loadBalancerReadySubscriber.onHostsAvailable();
+                    return sdStatus == null ? onHostsAvailable : onHostsAvailable.ambWith(sdStatus);
+                }
+
+                final BackOffPolicy backOffPolicy = retryFor.apply(requestMetaData, t);
+                if (backOffPolicy != NO_RETRIES) {
+                    if (t instanceof DelayedRetry) {
+                        final Duration constant = ((DelayedRetry) t).delay();
+                        return backOffPolicy.newStrategy(executor).apply(count, t).concat(executor.timer(constant));
+                    }
+
+                    return backOffPolicy.newStrategy(executor).apply(count, t);
+                }
+
+                return failed(t);
+            };
+        }
+
         @Override
         public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
                 final HttpRequestMetaData metaData) {
@@ -216,7 +187,19 @@ public final class RetryingHttpRequesterFilter
         @Override
         protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                         final StreamingHttpRequest request) {
-            return RetryingHttpRequesterFilter.this.request(delegate(), request, executor);
+            Single<StreamingHttpResponse> single = delegate.request(request);
+            if (responseMapper != null) {
+                single = single.map(resp -> {
+                    final HttpResponseException exception = responseMapper.apply(resp);
+                    if (exception != null) {
+                        throw exception;
+                    }
+
+                    return resp;
+                });
+            }
+
+            return single.retryWhen(retryStrategy(executor, request));
         }
 
         @Override
@@ -234,6 +217,15 @@ public final class RetryingHttpRequesterFilter
             }
             return super.closeAsyncGracefully();
         }
+    }
+
+    /**
+     * Retrying filter that disables any form of retry behaviour. All types of failures will not be re-attempted.
+     * @return a retrying filter that disables any form of retry behaviour. All types of failures will not be
+     * re-attempted.
+     */
+    public static RetryingHttpRequesterFilter disableAutoRetries() {
+        return DISABLED_RETRIES;
     }
 
     /**
@@ -263,7 +255,7 @@ public final class RetryingHttpRequesterFilter
         @Override
         public String toString() {
             return super.toString() +
-                ", metaData=" + metaData.toString(DEFAULT_HEADER_FILTER);
+                    ", metaData=" + metaData.toString(DEFAULT_HEADER_FILTER);
         }
     }
 
@@ -273,6 +265,10 @@ public final class RetryingHttpRequesterFilter
     public static final class BackOffPolicy {
 
         private static final Duration FULL_JITTER = ofDays(1024);
+
+        /**
+         * Special {@link BackOffPolicy} to signal no retries.
+         */
         public static final BackOffPolicy NO_RETRIES = ofNoRetries();
 
         @Nullable
@@ -691,7 +687,6 @@ public final class RetryingHttpRequesterFilter
          * retried.
          * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
          * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
-
          * @param mapper {@link BiFunction} that checks whether a given combination of
          * {@link HttpRequestMetaData meta-data} and {@link Throwable cause} should be retried, producing a
          * {@link BackOffPolicy} in such cases.


### PR DESCRIPTION
Motivation:

New retrying http request filter has bug when the factory is shared across client builders.

Modifications:

Internalized the state to the filter, where the lazy injection now happens rather than the factory as it was before.

Result:

Safer implementation