### PR TITLE
[Backport] Unified retry / auto-retry filter support

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/AbstractRetryingFilterBuilder.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/AbstractRetryingFilterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,11 @@ import static java.util.Objects.requireNonNull;
  * @param <Builder> the type of builder for retrying filter
  * @param <Filter> the type of retrying filter to build
  * @param <Meta> the type of meta-data for {@link #retryFor(BiPredicate)}
- *
  * @see RetryStrategies
+ * @deprecated Moving forward ServiceTalk will remove this abstraction. Please rely on the protocol specific filter,
+ * like {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter}.
  */
+@Deprecated
 public abstract class AbstractRetryingFilterBuilder<Builder
         extends AbstractRetryingFilterBuilder<Builder, Filter, Meta>, Filter, Meta> {
     private static final Duration FULL_JITTER = ofDays(1024);
@@ -268,7 +270,10 @@ public abstract class AbstractRetryingFilterBuilder<Builder
      * A read-only settings for retryable filters.
      *
      * @param <Meta> the type of meta-data for {@link #retryFor(BiPredicate)}
+     * @deprecated Moving forward ServiceTalk will remove this abstraction. Please rely on the protocol specific
+     * filter, like {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter}
      */
+    @Deprecated
     public static final class ReadOnlyRetryableSettings<Meta> {
 
         private final int maxRetries;

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/AutoRetryStrategyProvider.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/AutoRetryStrategyProvider.java
@@ -36,7 +36,10 @@ public interface AutoRetryStrategyProvider {
 
     /**
      * An {@link AutoRetryStrategyProvider} that disables automatic retries;
+     * @deprecated Alternative available {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter
+     * .disableAutoRetries()}.
      */
+    @Deprecated
     AutoRetryStrategyProvider DISABLE_AUTO_RETRIES = (lbEventStream, sdErrorStream) -> (___, cause) -> failed(cause);
 
     /**

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/AutoRetryStrategyProvider.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/AutoRetryStrategyProvider.java
@@ -27,8 +27,11 @@ import static io.servicetalk.concurrent.api.Completable.failed;
 
 /**
  * A provider for {@link AutoRetryStrategy}.
+ * @deprecated The capabilities of the auto-retry have been introduced under a new universal retrying filter,
+ * available from {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter}.
  */
 @FunctionalInterface
+@Deprecated
 public interface AutoRetryStrategyProvider {
 
     /**

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProvider.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultAutoRetryStrategyProvider.java
@@ -30,7 +30,10 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 
 /**
  * Default implementation for {@link AutoRetryStrategyProvider}.
+ * @deprecated The capabilities of the auto-retry have been introduced under a new universal retrying filter,
+ * available from {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter}.
  */
+@Deprecated
 public final class DefaultAutoRetryStrategyProvider implements AutoRetryStrategyProvider {
     private final int maxRetryCount;
     private final boolean waitForLb;
@@ -57,7 +60,10 @@ public final class DefaultAutoRetryStrategyProvider implements AutoRetryStrategy
 
     /**
      * A builder for {@link DefaultAutoRetryStrategyProvider}.
+     * @deprecated The capabilities of the auto-retry have been introduced under a new universal retrying filter,
+     * available from {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter}.
      */
+    @Deprecated
     public static final class Builder {
         private boolean waitForLb = true;
         private boolean ignoreSdErrors;

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverRequesterFilter.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverRequesterFilter.java
@@ -38,6 +38,7 @@ import io.servicetalk.http.utils.RetryingHttpRequesterFilter;
  * to also get visibility into
  * {@link SingleAddressHttpClientBuilder#autoRetryStrategy(AutoRetryStrategyProvider) automatic retries}.
  */
+//FIXME 0.42 - To be re-phrased once we remove auto-retries.
 public final class GrpcLifecycleObserverRequesterFilter extends HttpLifecycleObserverRequesterFilter {
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -187,7 +187,12 @@ abstract class HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> ex
      *
      * @param autoRetryStrategyProvider {@link AutoRetryStrategyProvider} for the automatic retry strategy.
      * @return {@code this}
+     * @see io.servicetalk.client.api.DefaultAutoRetryStrategyProvider
+     * @deprecated {@link io.servicetalk.client.api.AutoRetryStrategyProvider.AutoRetryStrategy} is going away in
+     * future ServiceTalk releases. Similar behavior is offered through
+     * {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter}.
      */
+    @Deprecated
     public abstract HttpClientBuilder<U, R, SDE> autoRetryStrategy(
             AutoRetryStrategyProvider autoRetryStrategyProvider);
 

--- a/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
@@ -31,4 +31,10 @@
     </Or>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
   </Match>
+
+  <!-- Intentional -->
+  <Match>
+    <Class name="io.servicetalk.http.netty.RetryingHttpRequesterFilter$HttpResponseException"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -20,7 +20,6 @@ import io.servicetalk.buffer.api.CharSequences;
 import io.servicetalk.client.api.AutoRetryStrategyProvider;
 import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.DefaultAutoRetryStrategyProvider.Builder;
 import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
@@ -119,9 +118,21 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     @Nullable
     private StreamingHttpClientFilterFactory clientFilterFactory;
     @Nullable
-    private AutoRetryStrategyProvider autoRetry = new Builder().build();
+    private AutoRetryStrategyProvider autoRetry = new io.servicetalk.client.api.DefaultAutoRetryStrategyProvider
+            .Builder().build();
     private ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> connectionFactoryFilter =
             ConnectionFactoryFilter.identity();
+
+    //FIXME: 0.42 - to be removed when auto-retry is removed.
+    @Deprecated
+    boolean customAutoRetry;
+
+    //FIXME: 0.42 - to be removed when auto-retry is removed.
+    @Deprecated
+    boolean retryingFilterAppended;
+
+    @Nullable
+    private RetryingHttpRequesterFilter retryingHttpRequesterFilter;
 
     DefaultSingleAddressHttpClientBuilder(
             final U address, final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer) {
@@ -160,6 +171,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         addHostHeaderFallbackFilter = from.addHostHeaderFallbackFilter;
         autoRetry = from.autoRetry;
         connectionFactoryFilter = from.connectionFactoryFilter;
+        retryingHttpRequesterFilter = from.retryingHttpRequesterFilter;
+        retryingFilterAppended = from.retryingFilterAppended;
+        customAutoRetry = from.customAutoRetry;
     }
 
     private DefaultSingleAddressHttpClientBuilder<U, R> copy() {
@@ -252,6 +266,14 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         return buildStreaming(copyBuildCtx());
     }
 
+    private static <U, R> void injectRetryingFilterDependencies(final HttpClientBuildContext<U, R> ctx,
+            final LoadBalancer<LoadBalancedStreamingHttpConnection> loadBalancer) {
+        if (ctx.builder.retryingHttpRequesterFilter != null) {
+            ctx.builder.retryingHttpRequesterFilter.inject(ctx.sdStatus);
+            ctx.builder.retryingHttpRequesterFilter.inject(loadBalancer.eventStream());
+        }
+    }
+
     private static <U, R> StreamingHttpClient buildStreaming(final HttpClientBuildContext<U, R> ctx) {
         final ReadOnlyHttpClientConfig roConfig = ctx.httpConfig().asReadOnly();
         if (roConfig.h2Config() != null && roConfig.hasProxy()) {
@@ -325,10 +347,15 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
 
             FilterableStreamingHttpClient lbClient = closeOnException.prepend(
                     new LoadBalancedStreamingHttpClient(ctx.executionContext, lb, reqRespFactory));
-            if (ctx.builder.autoRetry != null) {
+            if (ctx.builder.customAutoRetry) {
                 lbClient = new AutoRetryFilter(lbClient,
                         ctx.builder.autoRetry.newStrategy(lb.eventStream(), ctx.sdStatus));
+            } else if (ctx.builder.autoRetry != null && !ctx.builder.retryingFilterAppended) {
+                ctx.builder.retryingHttpRequesterFilter = new RetryingHttpRequesterFilter.Builder().build();
+                currClientFilterFactory = appendFilter(currClientFilterFactory,
+                        ctx.builder.retryingHttpRequesterFilter);
             }
+            injectRetryingFilterDependencies(ctx, lb);
             return new FilterableClientToClient(currClientFilterFactory != null ?
                     currClientFilterFactory.create(lbClient) : lbClient, executionStrategy,
                     ctx.builder.influencerChainBuilder.buildForClient(executionStrategy));
@@ -524,6 +551,12 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
             final AutoRetryStrategyProvider autoRetryStrategyProvider) {
         autoRetry = autoRetryStrategyProvider == DISABLE_AUTO_RETRIES ? null :
                 requireNonNull(autoRetryStrategyProvider);
+        if (retryingFilterAppended && autoRetryStrategyProvider != DISABLE_AUTO_RETRIES) {
+            throw new IllegalStateException("Retrying HTTP requester filter (or AutoRetry) was already found in " +
+                    "the filter chain, only a single instance of that is allowed.");
+        }
+        customAutoRetry = autoRetryStrategyProvider != DISABLE_AUTO_RETRIES;
+        retryingFilterAppended = autoRetryStrategyProvider != DISABLE_AUTO_RETRIES;
         return this;
     }
 
@@ -538,6 +571,18 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     public DefaultSingleAddressHttpClientBuilder<U, R> appendClientFilter(
             final StreamingHttpClientFilterFactory factory) {
         requireNonNull(factory);
+        // FIXME 0.42 - remove extra check
+        if (factory instanceof RetryingHttpRequesterFilter ||
+                factory instanceof io.servicetalk.http.utils.RetryingHttpRequesterFilter) {
+            if (retryingFilterAppended) {
+                throw new IllegalStateException("Retrying HTTP requester filter (or AutoRetry) was already found in " +
+                        "the filter chain, only a single instance of that is allowed.");
+            }
+            retryingFilterAppended = true;
+            if (factory instanceof RetryingHttpRequesterFilter) {
+                retryingHttpRequesterFilter = (RetryingHttpRequesterFilter) factory;
+            }
+        }
         clientFilterFactory = appendFilter(clientFilterFactory, factory);
         influencerChainBuilder.add(factory);
         return this;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -47,6 +47,7 @@ import io.servicetalk.http.api.ServiceDiscoveryRetryStrategy;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.SingleAddressHttpClientSecurityConfigurator;
 import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
@@ -95,6 +96,10 @@ import static java.util.Objects.requireNonNull;
  * @param <R> the type of address after resolution (resolved address)
  */
 final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHttpClientBuilder<U, R> {
+
+    private static final RetryingHttpRequesterFilter DEFAULT_AUTO_RETRIES =
+            new RetryingHttpRequesterFilter.Builder().build();
+
     static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(10);
     static final Duration SD_RETRY_STRATEGY_JITTER = ofSeconds(5);
     @Nullable
@@ -116,7 +121,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
     @Nullable
     private StreamingHttpConnectionFilterFactory connectionFilterFactory;
     @Nullable
-    private StreamingHttpClientFilterFactory clientFilterFactory;
+    private ContextAwareStreamingHttpClientFilterFactory clientFilterFactory;
     @Nullable
     private AutoRetryStrategyProvider autoRetry = new io.servicetalk.client.api.DefaultAutoRetryStrategyProvider
             .Builder().build();
@@ -266,14 +271,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
         return buildStreaming(copyBuildCtx());
     }
 
-    private static <U, R> void injectRetryingFilterDependencies(final HttpClientBuildContext<U, R> ctx,
-            final LoadBalancer<LoadBalancedStreamingHttpConnection> loadBalancer) {
-        if (ctx.builder.retryingHttpRequesterFilter != null) {
-            ctx.builder.retryingHttpRequesterFilter.inject(ctx.sdStatus);
-            ctx.builder.retryingHttpRequesterFilter.inject(loadBalancer.eventStream());
-        }
-    }
-
     private static <U, R> StreamingHttpClient buildStreaming(final HttpClientBuildContext<U, R> ctx) {
         final ReadOnlyHttpClientConfig roConfig = ctx.httpConfig().asReadOnly();
         if (roConfig.h2Config() != null && roConfig.hasProxy()) {
@@ -333,7 +330,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
                             sdEvents,
                             connectionFactory));
 
-            StreamingHttpClientFilterFactory currClientFilterFactory = ctx.builder.clientFilterFactory;
+            ContextAwareStreamingHttpClientFilterFactory currClientFilterFactory = ctx.builder.clientFilterFactory;
             if (roConfig.hasProxy() && sslContext == null) {
                 // If we're talking to a proxy over http (not https), rewrite the request-target to absolute-form, as
                 // specified by the RFC: https://tools.ietf.org/html/rfc7230#section-5.3.2
@@ -351,13 +348,13 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
                 lbClient = new AutoRetryFilter(lbClient,
                         ctx.builder.autoRetry.newStrategy(lb.eventStream(), ctx.sdStatus));
             } else if (ctx.builder.autoRetry != null && !ctx.builder.retryingFilterAppended) {
-                ctx.builder.retryingHttpRequesterFilter = new RetryingHttpRequesterFilter.Builder().build();
+                ctx.builder.retryingHttpRequesterFilter = DEFAULT_AUTO_RETRIES;
                 currClientFilterFactory = appendFilter(currClientFilterFactory,
                         ctx.builder.retryingHttpRequesterFilter);
             }
-            injectRetryingFilterDependencies(ctx, lb);
             return new FilterableClientToClient(currClientFilterFactory != null ?
-                    currClientFilterFactory.create(lbClient) : lbClient, executionStrategy,
+                    currClientFilterFactory.create(lbClient, lb.eventStream(), ctx.sdStatus) : lbClient,
+                    executionStrategy,
                     ctx.builder.influencerChainBuilder.buildForClient(executionStrategy));
         } catch (final Throwable t) {
             closeOnException.closeAsync().subscribe();
@@ -400,20 +397,42 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
                 ctx.builder.address.toString() : ctx.builder.address + " (via " + ctx.proxyAddress + ")";
     }
 
-    private static StreamingHttpClientFilterFactory appendFilter(
-            @Nullable final StreamingHttpClientFilterFactory currClientFilterFactory,
+    private static ContextAwareStreamingHttpClientFilterFactory appendFilter(
+            @Nullable final ContextAwareStreamingHttpClientFilterFactory currClientFilterFactory,
             final StreamingHttpClientFilterFactory appendClientFilterFactory) {
         return appendFilter0(appendFilter0(currClientFilterFactory, appendClientFilterFactory),
                 NEW_TO_DEPRECATED_FILTER);
     }
 
-    private static StreamingHttpClientFilterFactory appendFilter0(
-            @Nullable final StreamingHttpClientFilterFactory currClientFilterFactory,
+    private static ContextAwareStreamingHttpClientFilterFactory appendFilter0(
+            @Nullable final ContextAwareStreamingHttpClientFilterFactory currClientFilterFactory,
             final StreamingHttpClientFilterFactory appendClientFilterFactory) {
-        if (currClientFilterFactory == null) {
-            return appendClientFilterFactory;
+        if (appendClientFilterFactory instanceof RetryingHttpRequesterFilter) {
+            if (currClientFilterFactory == null) {
+                return (client, lbEventStream, sdStatus) -> {
+                    final RetryingHttpRequesterFilter.ContextAwareRetryingHttpClientFilter filter =
+                            (RetryingHttpRequesterFilter.ContextAwareRetryingHttpClientFilter)
+                                    appendClientFilterFactory.create(client);
+                    filter.inject(lbEventStream, sdStatus);
+                    return filter;
+                };
+            } else {
+                return (client, lbEventStream, sdStatus) -> {
+                    final RetryingHttpRequesterFilter.ContextAwareRetryingHttpClientFilter filter =
+                            (RetryingHttpRequesterFilter.ContextAwareRetryingHttpClientFilter)
+                                    appendClientFilterFactory.create(client);
+                    filter.inject(lbEventStream, sdStatus);
+                    return currClientFilterFactory.create(filter, lbEventStream, sdStatus);
+                };
+            }
         } else {
-            return client -> currClientFilterFactory.create(appendClientFilterFactory.create(client));
+            if (currClientFilterFactory == null) {
+                return (client, lbEventStream, sdError) -> appendClientFilterFactory.create(client);
+            } else {
+                return (client, lbEventStream, sdError) ->
+                        currClientFilterFactory.create(appendClientFilterFactory.create(client),
+                                lbEventStream, sdError);
+            }
         }
     }
 
@@ -906,6 +925,18 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> extends SingleAddressHtt
                 throw new IllegalStateException("HeadersFactory config not found for selected protocol: " + version);
             }
             return factory;
+        }
+    }
+
+    @FunctionalInterface
+    interface ContextAwareStreamingHttpClientFilterFactory extends StreamingHttpClientFilterFactory {
+        StreamingHttpClientFilter create(FilterableStreamingHttpClient client,
+                                         @Nullable Publisher<Object> lbEventStream,
+                                         @Nullable Completable sdStatus);
+
+        @Override
+        default StreamingHttpClientFilter create(FilterableStreamingHttpClient client) {
+            return create(client, null, null);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpLifecycleObserverRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpLifecycleObserverRequesterFilter.java
@@ -33,7 +33,6 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
-import io.servicetalk.http.utils.RetryingHttpRequesterFilter;
 
 /**
  * An HTTP requester filter that tracks events during request/response lifecycle.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancerReadySubscriber.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancerReadySubscriber.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.client.api;
+package io.servicetalk.http.netty;
 
+import io.servicetalk.client.api.LoadBalancerReadyEvent;
 import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
@@ -30,10 +31,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 /**
  * Designed to listen for {@link LoadBalancerReadyEvent}s and provide notification when a {@link LoadBalancerReadyEvent}
  * returns {@code true} from {@link LoadBalancerReadyEvent#isReady()}.
- * @deprecated internal class replaced with {@code io.servicetalk.http.netty.LoadBalancerReadySubscriber}
  */
-//FIXME 0.42 - To be removed
-@Deprecated
 final class LoadBalancerReadySubscriber extends DelayedCancellable implements Subscriber<Object> {
     @Nullable
     private volatile Processor onHostsAvailable = newCompletableProcessor();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -31,7 +31,6 @@ import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
-import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -73,17 +72,13 @@ import static java.util.Objects.requireNonNull;
  * Similarly, max-retries for each flow can be set in the {@link BackOffPolicy}, as well
  * as a total max-retries to be respected by both flows, as set in
  * {@link Builder#maxTotalRetries(int)}.
- * <p>
- * Note that applying this filter on a client it will automatically disable the use of
- * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)}.
  * @see RetryStrategies
  */
 public final class RetryingHttpRequesterFilter
         implements StreamingHttpClientFilterFactory, ExecutionStrategyInfluencer<HttpExecutionStrategy> {
 
-    public static final RetryingHttpRequesterFilter DISABLE_RETRIES =
-            new RetryingHttpRequesterFilter(false, true, 0, null,
-                (__, ___) -> NO_RETRIES);
+    public static final RetryingHttpRequesterFilter DISABLED_RETRIES =
+            new RetryingHttpRequesterFilter(false, true, 0, null, (__, ___) -> NO_RETRIES);
 
     private final boolean waitForLb;
     private final boolean ignoreSdErrors;
@@ -91,13 +86,6 @@ public final class RetryingHttpRequesterFilter
     @Nullable
     private final Function<HttpResponseMetaData, HttpResponseException> responseMapper;
     private final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryFor;
-    @Nullable
-    private Publisher<Object> lbEventStream;
-    @Nullable
-    private LoadBalancerReadySubscriber loadBalancerReadySubscriber;
-
-    @Nullable
-    private Completable sdStatus;
 
     RetryingHttpRequesterFilter(
             final boolean waitForLb, final boolean ignoreSdErrors, final int maxTotalRetries,
@@ -110,61 +98,9 @@ public final class RetryingHttpRequesterFilter
         this.retryFor = retryFor;
     }
 
-    private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
-                                                  final StreamingHttpRequest request,
-                                                  final Executor executor) {
-        Single<StreamingHttpResponse> single = delegate.request(request);
-        if (responseMapper != null) {
-            single = single.map(resp -> {
-                final HttpResponseException exception = responseMapper.apply(resp);
-                if (exception != null) {
-                    throw exception;
-                }
-
-                return resp;
-            });
-        }
-
-        return single.retryWhen(retryStrategy(executor, request));
-    }
-
-    private BiIntFunction<Throwable, Completable> retryStrategy(final Executor executor,
-                                                                final HttpRequestMetaData requestMetaData) {
-        return (count, t) -> {
-            if (count > maxTotalRetries) {
-                return failed(t);
-            }
-
-            if (loadBalancerReadySubscriber != null && t instanceof NoAvailableHostException) {
-                final Completable onHostsAvailable = loadBalancerReadySubscriber.onHostsAvailable();
-                return sdStatus == null ? onHostsAvailable : onHostsAvailable.ambWith(sdStatus);
-            }
-
-            final BackOffPolicy backOffPolicy = retryFor.apply(requestMetaData, t);
-            if (backOffPolicy != NO_RETRIES) {
-                if (t instanceof DelayedRetry) {
-                    final Duration constant = ((DelayedRetry) t).delay();
-                    return backOffPolicy.newStrategy(executor).apply(count, t).concat(executor.timer(constant));
-                }
-
-                return backOffPolicy.newStrategy(executor).apply(count, t);
-            }
-
-            return failed(t);
-        };
-    }
-
-    void inject(final Publisher<Object> lbEventStream) {
-        this.lbEventStream = lbEventStream;
-    }
-
-    void inject(final Completable sdStatus) {
-        this.sdStatus = ignoreSdErrors ? null : sdStatus;
-    }
-
     @Override
     public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
-        return new ContextAwareClientFilter(client);
+        return new ContextAwareRetryingHttpClientFilter(client);
     }
 
     @Override
@@ -173,27 +109,35 @@ public final class RetryingHttpRequesterFilter
         return HttpExecutionStrategies.offloadNone();
     }
 
-    private final class ContextAwareClientFilter extends StreamingHttpClientFilter {
+    final class ContextAwareRetryingHttpClientFilter extends StreamingHttpClientFilter {
+
+        private final Executor executor;
+        @Nullable
+        private Completable sdStatus;
 
         @Nullable
         private AsyncCloseable closeAsync;
 
-        private final Executor executor;
+        @Nullable
+        private LoadBalancerReadySubscriber loadBalancerReadySubscriber;
 
         /**
          * Create a new instance.
          *
          * @param delegate The {@link FilterableStreamingHttpClient} to delegate all calls to.
          */
-        private ContextAwareClientFilter(final FilterableStreamingHttpClient delegate) {
+        private ContextAwareRetryingHttpClientFilter(final FilterableStreamingHttpClient delegate) {
             super(delegate);
             this.executor = delegate.executionContext().executor();
-            init();
         }
 
-        public void init() {
+        void inject(@Nullable final Publisher<Object> lbEventStream,
+                    @Nullable final Completable sdStatus) {
+            assert lbEventStream != null;
+            assert sdStatus != null;
+            this.sdStatus = ignoreSdErrors ? null : sdStatus;
+
             if (waitForLb) {
-                assert lbEventStream != null;
                 loadBalancerReadySubscriber = new LoadBalancerReadySubscriber();
                 closeAsync = toAsyncCloseable(__ -> {
                     loadBalancerReadySubscriber.cancel();
@@ -206,6 +150,33 @@ public final class RetryingHttpRequesterFilter
             }
         }
 
+        // Visible for testing
+        BiIntFunction<Throwable, Completable> retryStrategy(final Executor executor,
+                                                            final HttpRequestMetaData requestMetaData) {
+            return (count, t) -> {
+                if (count > maxTotalRetries) {
+                    return failed(t);
+                }
+
+                if (loadBalancerReadySubscriber != null && t instanceof NoAvailableHostException) {
+                    final Completable onHostsAvailable = loadBalancerReadySubscriber.onHostsAvailable();
+                    return sdStatus == null ? onHostsAvailable : onHostsAvailable.ambWith(sdStatus);
+                }
+
+                final BackOffPolicy backOffPolicy = retryFor.apply(requestMetaData, t);
+                if (backOffPolicy != NO_RETRIES) {
+                    if (t instanceof DelayedRetry) {
+                        final Duration constant = ((DelayedRetry) t).delay();
+                        return backOffPolicy.newStrategy(executor).apply(count, t).concat(executor.timer(constant));
+                    }
+
+                    return backOffPolicy.newStrategy(executor).apply(count, t);
+                }
+
+                return failed(t);
+            };
+        }
+
         @Override
         public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
                 final HttpRequestMetaData metaData) {
@@ -216,7 +187,19 @@ public final class RetryingHttpRequesterFilter
         @Override
         protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                         final StreamingHttpRequest request) {
-            return RetryingHttpRequesterFilter.this.request(delegate(), request, executor);
+            Single<StreamingHttpResponse> single = delegate.request(request);
+            if (responseMapper != null) {
+                single = single.map(resp -> {
+                    final HttpResponseException exception = responseMapper.apply(resp);
+                    if (exception != null) {
+                        throw exception;
+                    }
+
+                    return resp;
+                });
+            }
+
+            return single.retryWhen(retryStrategy(executor, request));
         }
 
         @Override
@@ -234,6 +217,15 @@ public final class RetryingHttpRequesterFilter
             }
             return super.closeAsyncGracefully();
         }
+    }
+
+    /**
+     * Retrying filter that disables any form of retry behaviour. All types of failures will not be re-attempted.
+     * @return a retrying filter that disables any form of retry behaviour. All types of failures will not be
+     * re-attempted.
+     */
+    public static RetryingHttpRequesterFilter disableAutoRetries() {
+        return DISABLED_RETRIES;
     }
 
     /**
@@ -263,7 +255,7 @@ public final class RetryingHttpRequesterFilter
         @Override
         public String toString() {
             return super.toString() +
-                ", metaData=" + metaData.toString(DEFAULT_HEADER_FILTER);
+                    ", metaData=" + metaData.toString(DEFAULT_HEADER_FILTER);
         }
     }
 
@@ -273,6 +265,10 @@ public final class RetryingHttpRequesterFilter
     public static final class BackOffPolicy {
 
         private static final Duration FULL_JITTER = ofDays(1024);
+
+        /**
+         * Special {@link BackOffPolicy} to signal no retries.
+         */
         public static final BackOffPolicy NO_RETRIES = ofNoRetries();
 
         @Nullable
@@ -691,7 +687,6 @@ public final class RetryingHttpRequesterFilter
          * retried.
          * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
          * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
-
          * @param mapper {@link BiFunction} that checks whether a given combination of
          * {@link HttpRequestMetaData meta-data} and {@link Throwable cause} should be retried, producing a
          * {@link BackOffPolicy} in such cases.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -1,0 +1,740 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.LoadBalancer;
+import io.servicetalk.client.api.NoAvailableHostException;
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.concurrent.api.AsyncCloseable;
+import io.servicetalk.concurrent.api.BiIntFunction;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.RetryStrategies;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategies;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
+import io.servicetalk.transport.api.RetryableException;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
+import static io.servicetalk.concurrent.api.AsyncCloseables.toAsyncCloseable;
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Completable.failed;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithConstantBackoffDeltaJitter;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithConstantBackoffFullJitter;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffDeltaJitter;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffFullJitter;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.http.api.HeaderUtils.DEFAULT_HEADER_FILTER;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofInstant;
+import static java.time.Duration.ZERO;
+import static java.time.Duration.ofDays;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A filter to enable retries for HTTP clients.
+ * <p>
+ * Retries are supported for both the request flow and the response flow. Retries, in other words, can be triggered
+ * as part of a service response if needed, through {@link Builder#responseMapper(Function)}.
+ * <p>
+ * Retries can have different criteria and different backoff polices, as defined from the relevant Builder methods (i.e.
+ * {@link Builder#retryOther(BiFunction)}.
+ * Similarly, max-retries for each flow can be set in the {@link BackOffPolicy}, as well
+ * as a total max-retries to be respected by both flows, as set in
+ * {@link Builder#maxTotalRetries(int)}.
+ * <p>
+ * Note that applying this filter on a client it will automatically disable the use of
+ * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)}.
+ * @see RetryStrategies
+ */
+public final class RetryingHttpRequesterFilter
+        implements StreamingHttpClientFilterFactory, ExecutionStrategyInfluencer<HttpExecutionStrategy> {
+
+    private final boolean waitForLb;
+    private final boolean ignoreSdErrors;
+    private final int maxTotalRetries;
+    @Nullable
+    private final Function<HttpResponseMetaData, HttpResponseException> responseMapper;
+    private final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryFor;
+    @Nullable
+    private Publisher<Object> lbEventStream;
+    @Nullable
+    private LoadBalancerReadySubscriber loadBalancerReadySubscriber;
+
+    @Nullable
+    private Completable sdStatus;
+
+    RetryingHttpRequesterFilter(
+            final boolean waitForLb, final boolean ignoreSdErrors, final int maxTotalRetries,
+            @Nullable final Function<HttpResponseMetaData, HttpResponseException> responseMapper,
+            final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryFor) {
+        this.waitForLb = waitForLb;
+        this.ignoreSdErrors = ignoreSdErrors;
+        this.maxTotalRetries = maxTotalRetries;
+        this.responseMapper = responseMapper;
+        this.retryFor = retryFor;
+    }
+
+    private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                  final StreamingHttpRequest request,
+                                                  final Executor executor) {
+        Single<StreamingHttpResponse> single = delegate.request(request);
+        if (responseMapper != null) {
+            single = single.map(resp -> {
+                final HttpResponseException exception = responseMapper.apply(resp);
+                if (exception != null) {
+                    throw exception;
+                }
+
+                return resp;
+            });
+        }
+
+        return single.retryWhen(retryStrategy(executor, request));
+    }
+
+    private BiIntFunction<Throwable, Completable> retryStrategy(final Executor executor,
+                                                                final HttpRequestMetaData requestMetaData) {
+        return (count, t) -> {
+            if (count > maxTotalRetries) {
+                return failed(t);
+            }
+
+            if (loadBalancerReadySubscriber != null && t instanceof NoAvailableHostException) {
+                final Completable onHostsAvailable = loadBalancerReadySubscriber.onHostsAvailable();
+                return sdStatus == null ? onHostsAvailable : onHostsAvailable.ambWith(sdStatus);
+            }
+
+            final BackOffPolicy backOffPolicy = retryFor.apply(requestMetaData, t);
+            if (backOffPolicy != NO_RETRIES) {
+                if (t instanceof DelayedRetry) {
+                    final Duration constant = ((DelayedRetry) t).delay();
+                    return backOffPolicy.newStrategy(executor).apply(count, t).concat(executor.timer(constant));
+                }
+
+                return backOffPolicy.newStrategy(executor).apply(count, t);
+            }
+
+            return failed(t);
+        };
+    }
+
+    void inject(final Publisher<Object> lbEventStream) {
+        this.lbEventStream = lbEventStream;
+    }
+
+    void inject(final Completable sdStatus) {
+        this.sdStatus = ignoreSdErrors ? null : sdStatus;
+    }
+
+    @Override
+    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
+        return new ContextAwareClientFilter(client);
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        // No influence since we do not block.
+        return HttpExecutionStrategies.offloadNone();
+    }
+
+    private final class ContextAwareClientFilter extends StreamingHttpClientFilter {
+
+        @Nullable
+        private AsyncCloseable closeAsync;
+
+        private final Executor executor;
+
+        /**
+         * Create a new instance.
+         *
+         * @param delegate The {@link FilterableStreamingHttpClient} to delegate all calls to.
+         */
+        private ContextAwareClientFilter(final FilterableStreamingHttpClient delegate) {
+            super(delegate);
+            this.executor = delegate.executionContext().executor();
+            init();
+        }
+
+        public void init() {
+            if (waitForLb) {
+                assert lbEventStream != null;
+                loadBalancerReadySubscriber = new LoadBalancerReadySubscriber();
+                closeAsync = toAsyncCloseable(__ -> {
+                    loadBalancerReadySubscriber.cancel();
+                    return completed();
+                });
+                toSource(lbEventStream).subscribe(loadBalancerReadySubscriber);
+            } else {
+                loadBalancerReadySubscriber = null;
+                closeAsync = emptyAsyncCloseable();
+            }
+        }
+
+        @Override
+        public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+                final HttpRequestMetaData metaData) {
+            return delegate().reserveConnection(metaData)
+                    .retryWhen(retryStrategy(executor, metaData));
+        }
+
+        @Override
+        protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                        final StreamingHttpRequest request) {
+            return RetryingHttpRequesterFilter.this.request(delegate(), request, executor);
+        }
+
+        @Override
+        public Completable closeAsync() {
+            if (closeAsync != null) {
+                closeAsync.closeAsync();
+            }
+            return super.closeAsync();
+        }
+
+        @Override
+        public Completable closeAsyncGracefully() {
+            if (closeAsync != null) {
+                closeAsync.closeAsyncGracefully();
+            }
+            return super.closeAsyncGracefully();
+        }
+    }
+
+    /**
+     * This exception indicates response that matched the retrying rules of the {@link RetryingHttpRequesterFilter}
+     * and will-be/was retried.
+     * {@link HttpResponseException}s are user-provided errors, resulting from an {@link HttpRequestMetaData}, through
+     * the {@link Builder#responseMapper(Function)}.
+     */
+    public static final class HttpResponseException extends RuntimeException {
+
+        private static final long serialVersionUID = -7182949760823647710L;
+
+        public final HttpResponseMetaData metaData;
+        public final String message;
+
+        public HttpResponseException(final String message, final HttpResponseMetaData metaData) {
+            super(message);
+            this.metaData = requireNonNull(metaData);
+            this.message = requireNonNull(message);
+        }
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return super.toString() +
+                ", metaData=" + metaData.toString(DEFAULT_HEADER_FILTER) +
+                ", message='" + message + '\'';
+        }
+    }
+
+    /**
+     * Definition and presets of retry backoff policies.
+     */
+    public static final class BackOffPolicy {
+
+        private static final Duration FULL_JITTER = ofDays(1024);
+        public static final BackOffPolicy NO_RETRIES = ofNoRetries();
+
+        @Nullable
+        final Duration initialDelay;
+        final Duration jitter;
+        @Nullable
+        final Duration maxDelay;
+        @Nullable
+        final Executor timerExecutor;
+        final boolean exponential;
+        final int maxRetries;
+
+        BackOffPolicy(@Nullable final Duration initialDelay,
+                      final Duration jitter,
+                      @Nullable final Duration maxDelay,
+                      @Nullable final Executor timerExecutor,
+                      final boolean exponential,
+                      final int maxRetries) {
+            this.initialDelay = initialDelay;
+            this.jitter = jitter;
+            this.maxDelay = maxDelay;
+            this.timerExecutor = timerExecutor;
+            this.exponential = exponential;
+            this.maxRetries = maxRetries > 0 ? maxRetries : (exponential ? 2 : 1);
+        }
+
+        /**
+         * Creates a new {@link BackOffPolicy} that retries failures instantly up-to 3 max retries.
+         * @return a new {@link BackOffPolicy} that retries failures instantly up-to 3 max retries.
+         */
+        public static BackOffPolicy ofInstant() {
+            return new BackOffPolicy(null, ZERO, null, null, false, 3);
+        }
+
+        /**
+         * Special {@link BackOffPolicy} that signals that no retries will be attempted.
+         * @return a special {@link BackOffPolicy} that signals that no retries will be attempted.
+         */
+        private static BackOffPolicy ofNoRetries() {
+            return new BackOffPolicy(null, ZERO, null, null, false, 0);
+        }
+
+        /**
+         * Creates a new retrying {@link BackOffPolicy} which adds a randomized delay between retries
+         * and uses the passed {@link Duration} as a maximum delay possible.
+         * This additionally adds a "Full Jitter" for the backoff as described
+         * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
+         *
+         * @param delay Maximum {@link Duration} of delay between retries
+         * @param maxRetries The maximum retries before it gives up.
+         * @return A new retrying {@link BackOffPolicy} which adds a randomized delay between retries
+         */
+        public static BackOffPolicy ofConstantBackoffFullJitter(final Duration delay, final int maxRetries) {
+            return new BackOffPolicy(delay, FULL_JITTER, null, null, false, maxRetries);
+        }
+
+        /**
+         * Creates a new retrying {@link BackOffPolicy} which adds a randomized delay between retries
+         * and uses the passed {@link Duration} as a maximum delay possible.
+         * This additionally adds a "Full Jitter" for the backoff as described
+         * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
+         *
+         * @param delay Maximum {@link Duration} of delay between retries
+         * @param maxRetries The maximum retries before it gives up.
+         * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+         * It takes precedence over an alternative timer {@link Executor} from
+         * {@link #newStrategy(Executor)} argument
+         * @return A new retrying {@link BackOffPolicy} which adds a randomized delay between retries
+         */
+        public static BackOffPolicy ofConstantBackoffFullJitter(final Duration delay, final int maxRetries,
+                                                                final Executor timerExecutor) {
+            return new BackOffPolicy(delay, FULL_JITTER, null, timerExecutor, false, maxRetries);
+        }
+
+        /**
+         * Creates a new retrying {@link BackOffPolicy} which adds a randomized delay between retries
+         * and uses the passed {@link Duration} as a maximum delay possible.
+         *
+         * @param delay Maximum {@link Duration} of delay between retries
+         * @param jitter The jitter which is used as and offset to {@code initialDelay} on each retry
+         * @param maxRetries The maximum retries before it gives up.
+         * @return A new retrying {@link BackOffPolicy} which adds a randomized delay between retries
+         */
+        public static BackOffPolicy ofConstantBackoffDeltaJitter(final Duration delay, final Duration jitter,
+                                                                 final int maxRetries) {
+            return new BackOffPolicy(delay, jitter, null, null, false, maxRetries);
+        }
+
+        /**
+         * Creates a new retrying {@link BackOffPolicy} which adds a randomized delay between retries
+         * and uses the passed {@link Duration} as a maximum delay possible.
+         *
+         * @param delay Maximum {@link Duration} of delay between retries
+         * @param jitter The jitter which is used as and offset to {@code delay} on each retry
+         * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+         * @param maxRetries The maximum retries before it gives up.
+         * It takes precedence over an alternative timer {@link Executor} from
+         * {@link #newStrategy(Executor)} argument
+         * @return A new retrying {@link BackOffPolicy} which adds a randomized delay between retries
+         */
+        public static BackOffPolicy ofConstantBackoffDeltaJitter(final Duration delay, final Duration jitter,
+                                                                 final Executor timerExecutor,
+                                                                 final int maxRetries) {
+            return new BackOffPolicy(delay, jitter, null, timerExecutor, false, maxRetries);
+        }
+
+        /**
+         * Creates a new retrying {@link BackOffPolicy} which adds a delay between retries.
+         * For first retry, the delay is {@code initialDelay} which is increased exponentially for subsequent
+         * retries.
+         * This additionally adds a "Full Jitter" for the backoff as described
+         * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
+         *
+         * @param initialDelay Delay {@link Duration} for the first retry and increased exponentially
+         * with each retry
+         * @param maxDelay The maximum amount of delay that will be introduced.
+         * @param maxRetries The maximum retries before it gives up.
+         * @return A new retrying {@link BackOffPolicy} which adds an exponentially increasing
+         * delay between retries with jitter
+         */
+        public static BackOffPolicy ofExponentialBackoffFullJitter(final Duration initialDelay,
+                                                                   final Duration maxDelay,
+                                                                   final int maxRetries) {
+            return new BackOffPolicy(initialDelay, FULL_JITTER, maxDelay, null, true, maxRetries);
+        }
+
+        /**
+         * Creates a new retrying {@link BackOffPolicy} which adds a delay between retries.
+         * For first retry, the delay is {@code initialDelay} which is increased exponentially for subsequent
+         * retries.
+         * This additionally adds a "Full Jitter" for the backoff as described
+         * <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">here</a>.
+         *
+         * @param initialDelay Delay {@link Duration} for the first retry and increased exponentially
+         * with each retry
+         * @param maxDelay The maximum amount of delay that will be introduced.
+         * @param maxRetries The maximum retries before it gives up.
+         * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+         * It takes precedence over an alternative timer {@link Executor} from
+         * {@link #newStrategy(Executor)} argument
+         * @return A new retrying {@link BackOffPolicy} which adds an exponentially increasing
+         * delay between retries with jitter
+         */
+        public static BackOffPolicy ofExponentialBackoffFullJitter(
+                final Duration initialDelay, final Duration maxDelay, final int maxRetries,
+                final Executor timerExecutor) {
+            return new BackOffPolicy(initialDelay, FULL_JITTER, maxDelay, timerExecutor, true, maxRetries);
+        }
+
+        /**
+         * Creates a new retrying {@link BackOffPolicy} which adds a delay between retries.
+         * For first retry, the delay is {@code initialDelay} which is increased exponentially for subsequent
+         * retries.
+         *
+         * @param initialDelay Delay {@link Duration} for the first retry and increased exponentially
+         * with each retry
+         * @param jitter The jitter which is used as and offset to {@code initialDelay} on each retry
+         * @param maxDelay The maximum amount of delay that will be introduced.
+         * @param maxRetries The maximum retries before it gives up.
+         * @return A new retrying {@link BackOffPolicy} which adds an exponentially increasing
+         * delay between retries with jitter
+         */
+        public static BackOffPolicy ofExponentialBackoffDeltaJitter(
+                final Duration initialDelay, final Duration jitter, final Duration maxDelay, final int maxRetries) {
+            return new BackOffPolicy(initialDelay, jitter, maxDelay, null, true, maxRetries);
+        }
+
+        /**
+         * Creates a new retrying {@link BackOffPolicy} which adds a delay between retries.
+         * For first retry, the delay is {@code initialDelay} which is increased exponentially for subsequent
+         * retries.
+         *
+         * @param initialDelay Delay {@link Duration} for the first retry and increased exponentially
+         * with each retry
+         * @param jitter The jitter which is used as and offset to {@code initialDelay} on each retry
+         * @param maxDelay The maximum amount of delay that will be introduced.
+         * @param maxRetries The maximum retries before it gives up.
+         * @param timerExecutor {@link Executor} to be used to schedule timers for backoff.
+         * It takes precedence over an alternative timer {@link Executor} from
+         * {@link #newStrategy(Executor)} argument
+         * @return A new retrying {@link BackOffPolicy} which adds an exponentially increasing
+         * delay between retries with jitter
+         */
+        public static BackOffPolicy ofExponentialBackoffDeltaJitter(
+                final Duration initialDelay, final Duration jitter, final Duration maxDelay, final int maxRetries,
+                final Executor timerExecutor) {
+            return new BackOffPolicy(initialDelay, jitter, maxDelay, timerExecutor, true, maxRetries);
+        }
+
+        /**
+         * Builds a new retry strategy {@link BiIntFunction} for retrying with
+         * {@link Publisher#retryWhen(BiIntFunction)}, {@link Single#retryWhen(BiIntFunction)}, and
+         * {@link Completable#retryWhen(BiIntFunction)} or in general with an alternative timer {@link Executor}.
+         *
+         * @param alternativeTimerExecutor {@link Executor} to be used to schedule timers for backoff if no executor
+         * was provided at the build time
+         * @return a new retry strategy {@link BiIntFunction}
+         */
+        public BiIntFunction<Throwable, Completable> newStrategy(final Executor alternativeTimerExecutor) {
+            if (initialDelay == null) {
+                return (count, throwable) -> count <= maxRetries ? completed() : failed(throwable);
+            } else {
+                final Executor effectiveExecutor = timerExecutor == null ?
+                        requireNonNull(alternativeTimerExecutor) : timerExecutor;
+                if (exponential) {
+                    assert maxDelay != null;
+                    return jitter == FULL_JITTER ?
+                            retryWithExponentialBackoffFullJitter(
+                                    maxRetries, t -> true, initialDelay, maxDelay, effectiveExecutor) :
+                            retryWithExponentialBackoffDeltaJitter(
+                                    maxRetries, t -> true, initialDelay, jitter, maxDelay, effectiveExecutor);
+                } else {
+                    return jitter == FULL_JITTER ?
+                            retryWithConstantBackoffFullJitter(
+                                    maxRetries, t -> true, initialDelay, effectiveExecutor) :
+                            retryWithConstantBackoffDeltaJitter(
+                                    maxRetries, t -> true, initialDelay, jitter, effectiveExecutor);
+                }
+            }
+        }
+    }
+
+    /**
+     * An interface that enhances any {@link Exception} to provide a constant {@link Duration delay} to be applied when
+     * retrying through a {@link RetryingHttpRequesterFilter retrying-filter}.
+     * <p>
+     * Constant delay returned from {@link #delay()} will be additive to the backoff policy defined for a certain
+     * retry-able failure.
+     */
+    public interface DelayedRetry {
+
+        /**
+         * A constant delay to apply in milliseconds.
+         * The total delay for the retry logic will be the sum of this value and the result of the
+         * {@link BackOffPolicy back-off policy} in-use. Consider using 'full-jitter'
+         * flavours from the {@link BackOffPolicy} to avoid having another constant delay applied per-retry.
+         *
+         * @return The {@link Duration} to apply as constant delay when retrying.
+         */
+        Duration delay();
+    }
+
+    /**
+     * A builder for {@link RetryingHttpRequesterFilter}, which puts an upper bound on retry attempts.
+     * To configure the maximum number of retry attempts see {@link #maxTotalRetries(int)}.
+     */
+    public static final class Builder {
+        private boolean waitForLb = true;
+        private boolean ignoreSdErrors;
+
+        private int maxRetries = 3;
+
+        @Nullable
+        private Function<HttpResponseMetaData, HttpResponseException> responseMapper;
+
+        private BiFunction<HttpRequestMetaData, RetryableException, BackOffPolicy>
+                retryRetryableExceptions = (requestMetaData, e) -> ofInstant();
+
+        @Nullable
+        private BiFunction<HttpRequestMetaData, IOException, BackOffPolicy>
+                retryIdempotentRequests;
+
+        @Nullable
+        private BiFunction<HttpRequestMetaData, DelayedRetry, BackOffPolicy>
+                retryDelayedRetries;
+
+        @Nullable
+        private BiFunction<HttpRequestMetaData, HttpResponseException, BackOffPolicy>
+                retryResponses;
+
+        @Nullable
+        private BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy>
+                retryOther;
+
+        /**
+         * By default, automatic retries wait for the associated {@link LoadBalancer} to be ready before triggering a
+         * retry for requests. This behavior may add latency to requests till the time the load balancer is ready
+         * instead of failing fast. This method allows controlling that behavior.
+         *
+         * @param waitForLb Whether to wait for the {@link LoadBalancer} to be ready before retrying requests.
+         * @return {@code this}.
+         */
+        public Builder waitForLoadBalancer(final boolean waitForLb) {
+            this.waitForLb = waitForLb;
+            return this;
+        }
+
+        /**
+         * By default, fail a request if the last signal from the associated {@link ServiceDiscoverer} was an error.
+         * This method disables that behavior.
+         *
+         * @param ignoreSdErrors ignore {@link ServiceDiscoverer} errors when evaluating a request failure.
+         * @return {@code this}.
+         */
+        public Builder ignoreServiceDiscovererErrors(final boolean ignoreSdErrors) {
+            this.ignoreSdErrors = ignoreSdErrors;
+            return this;
+        }
+
+        /**
+         * Set the maximum number of allowed retry operations before giving up, applied as total max across all retry
+         * functions (see. {@link #retryDelayedRetries(BiFunction)}, {@link #retryIdempotentRequests(BiFunction)},
+         * {@link #retryRetryableExceptions(BiFunction)}, {@link #retryOther(BiFunction)}).
+         *
+         * @param maxRetries Maximum number of allowed retries before giving up
+         * @return {@code this}
+         */
+        public Builder maxTotalRetries(final int maxRetries) {
+            if (maxRetries <= 0) {
+                throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected: >0)");
+            }
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * Selectively map a {@link HttpResponseMetaData response} to an {@link HttpResponseException} that can match a
+         * retry behaviour through {@link #retryResponses(BiFunction)}.
+         *
+         * @param mapper a {@link Function} that maps a {@link HttpResponseMetaData} to an
+         * {@link HttpResponseException}.
+         * @return {@code this}
+         */
+        public Builder responseMapper(final Function<HttpResponseMetaData, HttpResponseException> mapper) {
+            this.responseMapper = requireNonNull(mapper);
+            return this;
+        }
+
+        /**
+         * The retrying-filter will evaluate for {@link RetryableException}s in the request flow.
+         * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
+         *
+         * @param mapper The mapper to map the {@link HttpRequestMetaData} and the
+         * {@link RetryableException} to a {@link BackOffPolicy}.
+         * @return {@code this}.
+         */
+        public Builder retryRetryableExceptions(
+                final BiFunction<HttpRequestMetaData, RetryableException, BackOffPolicy> mapper) {
+            this.retryRetryableExceptions = requireNonNull(mapper);
+            return this;
+        }
+
+        /**
+         * Retries <a href="https://tools.ietf.org/html/rfc7231#section-4.2.2">idempotent</a> requests when applicable.
+         * <p>
+         * <b>Note:</b> This predicate expects that the retried {@link StreamingHttpRequest requests} have a
+         * {@link StreamingHttpRequest#payloadBody() payload body} that is
+         * <a href="http://reactivex.io/documentation/operators/replay.html">replayable</a>, i.e. multiple subscribes to
+         * the payload {@link Publisher} observe the same data. {@link Publisher}s that do not emit any data or which
+         * are created from in-memory data are typically replayable.
+         * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
+         *
+         * @param mapper The mapper to map the {@link HttpRequestMetaData} and the
+         * {@link IOException} to a {@link BackOffPolicy}.
+         * @return {@code this}.
+         */
+        public Builder retryIdempotentRequests(
+                final BiFunction<HttpRequestMetaData, IOException, BackOffPolicy> mapper) {
+            this.retryIdempotentRequests = requireNonNull(mapper);
+            return this;
+        }
+
+        /**
+         * The retrying-filter will evaluate the {@link DelayedRetry} marker interface
+         * of an exception and use the provided {@link DelayedRetry#delay() delay} as a constant delay on-top ofthe
+         * retry period already defined.
+         * In case a max-delay was set in this builder, the {@link DelayedRetry#delay() constant-delay} overrides
+         * it and takes precedence.
+         * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
+         *
+         * @param mapper The mapper to map the {@link HttpRequestMetaData} and the
+         * {@link DelayedRetry delayed-exception} to a {@link BackOffPolicy}.
+         * @return {@code this}.
+         */
+        public Builder retryDelayedRetries(
+                final BiFunction<HttpRequestMetaData, DelayedRetry, BackOffPolicy> mapper) {
+            this.retryDelayedRetries = requireNonNull(mapper);
+            return this;
+        }
+
+        /**
+         * The retrying-filter will evaluate {@link HttpResponseException} that resulted from the
+         * {@link #responseMapper(Function)}, and support different retry behaviour according to the
+         * {@link HttpRequestMetaData request} and the {@link HttpResponseMetaData response}.
+         * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
+         *
+         * @param mapper The mapper to map the {@link HttpRequestMetaData} and the
+         * {@link DelayedRetry delayed-exception} to a {@link BackOffPolicy}.
+         * @return {@code this}.
+         */
+        public Builder retryResponses(
+                final BiFunction<HttpRequestMetaData, HttpResponseException, BackOffPolicy> mapper) {
+            this.retryResponses = requireNonNull(mapper);
+            return this;
+        }
+
+        /**
+         * Support additional criteria for determining which requests or errors should be
+         * retried.
+         * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
+
+         * @param mapper {@link BiFunction} that checks whether a given combination of
+         * {@link HttpRequestMetaData meta-data} and {@link Throwable cause} should be retried, producing a
+         * {@link BackOffPolicy} in such cases.
+         * @return {@code this}
+         */
+        public Builder retryOther(
+                final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> mapper) {
+            this.retryOther = requireNonNull(mapper);
+            return this;
+        }
+
+        /**
+         * Builds a retrying {@link RetryingHttpRequesterFilter} with this' builders configuration.
+         *
+         * @return A new retrying {@link RetryingHttpRequesterFilter}
+         */
+        public RetryingHttpRequesterFilter build() {
+            final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> allPredicate =
+                    (requestMetaData, throwable) -> {
+                        if (throwable instanceof RetryableException) {
+                            final BackOffPolicy backOffPolicy =
+                                    retryRetryableExceptions.apply(requestMetaData, (RetryableException) throwable);
+                            if (backOffPolicy != NO_RETRIES) {
+                                return backOffPolicy;
+                            }
+                        }
+
+                        if (retryIdempotentRequests != null && throwable instanceof IOException
+                                && requestMetaData.method().properties().isIdempotent()) {
+                            final BackOffPolicy backOffPolicy =
+                                    retryIdempotentRequests.apply(requestMetaData, (IOException) throwable);
+                            if (backOffPolicy != NO_RETRIES) {
+                                return backOffPolicy;
+                            }
+                        }
+
+                        if (retryDelayedRetries != null && throwable instanceof DelayedRetry) {
+                            final BackOffPolicy backOffPolicy =
+                                    retryDelayedRetries.apply(requestMetaData, (DelayedRetry) throwable);
+                            if (backOffPolicy != NO_RETRIES) {
+                                return backOffPolicy;
+                            }
+                        }
+
+                        if (retryResponses != null && throwable instanceof HttpResponseException) {
+                            final BackOffPolicy backOffPolicy =
+                                    retryResponses.apply(requestMetaData, (HttpResponseException) throwable);
+                            if (backOffPolicy != NO_RETRIES) {
+                                return backOffPolicy;
+                            }
+                        }
+
+                        if (retryOther != null) {
+                            return retryOther.apply(requestMetaData, throwable);
+                        }
+
+                        return NO_RETRIES;
+                    };
+            return new RetryingHttpRequesterFilter(waitForLb, ignoreSdErrors, maxRetries, responseMapper, allPredicate);
+        }
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -57,7 +57,7 @@ import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponential
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.http.api.HeaderUtils.DEFAULT_HEADER_FILTER;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
-import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofInstant;
+import static java.lang.Integer.MAX_VALUE;
 import static java.time.Duration.ZERO;
 import static java.time.Duration.ofDays;
 import static java.util.Objects.requireNonNull;
@@ -80,6 +80,10 @@ import static java.util.Objects.requireNonNull;
  */
 public final class RetryingHttpRequesterFilter
         implements StreamingHttpClientFilterFactory, ExecutionStrategyInfluencer<HttpExecutionStrategy> {
+
+    public static final RetryingHttpRequesterFilter DISABLE_RETRIES =
+            new RetryingHttpRequesterFilter(false, true, 0, null,
+                (__, ___) -> NO_RETRIES);
 
     private final boolean waitForLb;
     private final boolean ignoreSdErrors;
@@ -259,8 +263,7 @@ public final class RetryingHttpRequesterFilter
         @Override
         public String toString() {
             return super.toString() +
-                ", metaData=" + metaData.toString(DEFAULT_HEADER_FILTER) +
-                ", message='" + message + '\'';
+                ", metaData=" + metaData.toString(DEFAULT_HEADER_FILTER);
         }
     }
 
@@ -300,8 +303,18 @@ public final class RetryingHttpRequesterFilter
          * Creates a new {@link BackOffPolicy} that retries failures instantly up-to 3 max retries.
          * @return a new {@link BackOffPolicy} that retries failures instantly up-to 3 max retries.
          */
-        public static BackOffPolicy ofInstant() {
+        public static BackOffPolicy ofImmediate() {
             return new BackOffPolicy(null, ZERO, null, null, false, 3);
+        }
+
+        /**
+         * Creates a new {@link BackOffPolicy} that retries failures instantly up-to provided max retries.
+         *
+         * @param maxRetries the number of retry attempts for this {@link BackOffPolicy}.
+         * @return a new {@link BackOffPolicy} that retries failures instantly up-to provided max retries.
+         */
+        public static BackOffPolicy ofImmediate(final int maxRetries) {
+            return new BackOffPolicy(null, ZERO, null, null, false, maxRetries);
         }
 
         /**
@@ -520,13 +533,13 @@ public final class RetryingHttpRequesterFilter
         private boolean waitForLb = true;
         private boolean ignoreSdErrors;
 
-        private int maxRetries = 3;
+        private int maxRetries = MAX_VALUE;
 
         @Nullable
         private Function<HttpResponseMetaData, HttpResponseException> responseMapper;
 
         private BiFunction<HttpRequestMetaData, RetryableException, BackOffPolicy>
-                retryRetryableExceptions = (requestMetaData, e) -> ofInstant();
+                retryRetryableExceptions = (requestMetaData, e) -> BackOffPolicy.ofImmediate();
 
         @Nullable
         private BiFunction<HttpRequestMetaData, IOException, BackOffPolicy>
@@ -572,7 +585,10 @@ public final class RetryingHttpRequesterFilter
         /**
          * Set the maximum number of allowed retry operations before giving up, applied as total max across all retry
          * functions (see. {@link #retryDelayedRetries(BiFunction)}, {@link #retryIdempotentRequests(BiFunction)},
-         * {@link #retryRetryableExceptions(BiFunction)}, {@link #retryOther(BiFunction)}).
+         * {@link #retryRetryableExceptions(BiFunction)}, {@link #retryResponses(BiFunction)},
+         * {@link #retryOther(BiFunction)}).
+         *
+         * If not set, max total retries will be infinite.
          *
          * @param maxRetries Maximum number of allowed retries before giving up
          * @return {@code this}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -27,8 +27,8 @@ import io.servicetalk.concurrent.api.RetryStrategies;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
-import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
@@ -36,7 +36,6 @@ import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
-import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 import io.servicetalk.transport.api.RetryableException;
 
 import java.io.IOException;
@@ -75,7 +74,7 @@ import static java.util.Objects.requireNonNull;
  * @see RetryStrategies
  */
 public final class RetryingHttpRequesterFilter
-        implements StreamingHttpClientFilterFactory, ExecutionStrategyInfluencer<HttpExecutionStrategy> {
+        implements StreamingHttpClientFilterFactory, HttpExecutionStrategyInfluencer {
 
     public static final RetryingHttpRequesterFilter DISABLED_RETRIES =
             new RetryingHttpRequesterFilter(false, true, 0, null, (__, ___) -> NO_RETRIES);
@@ -104,9 +103,9 @@ public final class RetryingHttpRequesterFilter
     }
 
     @Override
-    public HttpExecutionStrategy requiredOffloads() {
-        // No influence since we do not block.
-        return HttpExecutionStrategies.offloadNone();
+    public HttpExecutionStrategy influenceStrategy(final HttpExecutionStrategy strategy) {
+        // No influence not blocking
+        return strategy;
     }
 
     final class ContextAwareRetryingHttpClientFilter extends StreamingHttpClientFilter {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.DefaultAutoRetryStrategyProvider;
+import io.servicetalk.client.api.DelegatingConnectionFactory;
+import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.client.api.LoadBalancer;
+import io.servicetalk.client.api.LoadBalancerFactory;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.AsyncCloseables;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.CompositeCloseable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.utils.RetryingHttpRequesterFilter;
+import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
+import io.servicetalk.transport.api.ExecutionStrategy;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.RetryableException;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.TransportObserver;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Single.defer;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.netty.HttpClients.forResolvedAddress;
+import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
+import static io.servicetalk.http.netty.HttpServers.forAddress;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofInstant;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.Builder;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.HttpResponseException;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.time.Duration.ofSeconds;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class RetryingHttpRequesterFilterTest {
+
+    private static final String RETRYABLE_HEADER = "RETRYABLE";
+
+    private final ServerContext svcCtx;
+    private final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> normalClientBuilder;
+    private final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> failingConnClientBuilder;
+    private final AtomicInteger lbSelectInvoked;
+
+    @Nullable
+    private BlockingHttpClient normalClient;
+
+    @Nullable
+    private BlockingHttpClient failingClient;
+
+    RetryingHttpRequesterFilterTest() throws Exception {
+        svcCtx = forAddress(localAddress(0))
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok()
+                        .addHeader(RETRYABLE_HEADER, "yes"));
+        failingConnClientBuilder = forSingleAddress(serverHostAndPort(svcCtx))
+                .loadBalancerFactory(DefaultHttpLoadBalancerFactory.Builder
+                        .from(new InspectingLoadBalancerFactory<>()).build())
+                .appendConnectionFactoryFilter(ClosingConnectionFactory::new);
+        normalClientBuilder = forSingleAddress(serverHostAndPort(svcCtx))
+                .loadBalancerFactory(DefaultHttpLoadBalancerFactory.Builder
+                        .from(new InspectingLoadBalancerFactory<>()).build());
+        lbSelectInvoked = new AtomicInteger();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        CompositeCloseable closeable = AsyncCloseables.newCompositeCloseable();
+        if (normalClient != null) {
+            closeable.append(normalClient.asClient());
+        }
+        if (failingClient != null) {
+            closeable.append(failingClient.asClient());
+        }
+        closeable.append(svcCtx);
+        closeable.close();
+    }
+
+    @Test
+    void maxTotalRetries() {
+        failingClient = failingConnClientBuilder
+                .appendClientFilter(new Builder().maxTotalRetries(1).build())
+                .buildBlocking();
+        try {
+            failingClient.request(failingClient.get("/"));
+            fail("Request is expected to fail.");
+        } catch (Exception e) {
+            assertThat("Unexpected exception.", e, instanceOf(RetryableException.class));
+            assertThat("Unexpected calls to select.", lbSelectInvoked.get(), is(2));
+        }
+    }
+
+    @Test
+    void requestRetryingPredicate() {
+        failingClient = failingConnClientBuilder
+                .appendClientFilter(new Builder()
+                        .retryRetryableExceptions((requestMetaData, e) -> NO_RETRIES)
+                        .retryOther((requestMetaData, throwable) ->
+                                requestMetaData.requestTarget().equals("/retry") ? ofInstant() : NO_RETRIES).build())
+                .buildBlocking();
+        try {
+            failingClient.request(failingClient.get("/"));
+            fail("Request is expected to fail.");
+        } catch (Exception e) {
+            assertThat("Unexpected exception.", e, instanceOf(RetryableException.class));
+            // Account for LB readiness
+            assertThat("Unexpected calls to select.", (double) lbSelectInvoked.get(), closeTo(1.0, 1.0));
+        }
+
+        try {
+            failingClient.request(failingClient.get("/retry"));
+            fail("Request is expected to fail.");
+        } catch (Exception e) {
+            assertThat("Unexpected exception.", e, instanceOf(RetryableException.class));
+            // 1 Run + 3 Retries + 1 residual count from previous request + account for LB readiness
+            assertThat("Unexpected calls to select.", (double) lbSelectInvoked.get(), closeTo(5.0, 1.0));
+        }
+    }
+
+    @Test
+    void responseRetryingPredicate() {
+        normalClient = normalClientBuilder
+                .appendClientFilter(new Builder()
+                        .responseMapper(metaData -> metaData.headers().contains(RETRYABLE_HEADER) ?
+                                    new HttpResponseException("Retryable header", metaData) : null)
+                        // Disable request retrying
+                        .retryRetryableExceptions((requestMetaData, e) -> NO_RETRIES)
+                        // Retry only responses marked so
+                        .retryResponses((requestMetaData, throwable) -> ofInstant())
+                        .build())
+                .buildBlocking();
+        try {
+            normalClient.request(normalClient.get("/"));
+            fail("Request is expected to fail.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat("Unexpected exception.", e, instanceOf(HttpResponseException.class));
+            assertThat("Unexpected calls to select.", lbSelectInvoked.get(), is(4));
+        }
+    }
+
+    @Test()
+    void singleInstanceOldNew() {
+        Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
+                .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                        .buildWithConstantBackoffFullJitter(ofSeconds(1)))
+                .appendClientFilter(new Builder().build())
+                .build());
+    }
+
+    @Test()
+    void singleInstanceNewOld() {
+        Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
+                .appendClientFilter(new Builder().build())
+                .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                        .buildWithConstantBackoffFullJitter(ofSeconds(1)))
+                .build());
+    }
+
+    @Test()
+    void singleInstanceOldOld() {
+        Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
+                .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                        .buildWithConstantBackoffFullJitter(ofSeconds(1)))
+                .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                        .buildWithConstantBackoffFullJitter(ofSeconds(1)))
+                .build());
+    }
+
+    @Test()
+    void singleInstanceNewNew() {
+        Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
+                .appendClientFilter(new Builder().build())
+                .appendClientFilter(new Builder().build())
+                .build());
+    }
+
+    @Test()
+    void singleInstanceNewForceAutoRetry() {
+        Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
+                .appendClientFilter(new Builder().build())
+                .autoRetryStrategy(new DefaultAutoRetryStrategyProvider.Builder().build())
+                .build());
+    }
+
+    private final class InspectingLoadBalancerFactory<C extends LoadBalancedConnection>
+            implements LoadBalancerFactory<InetSocketAddress, C> {
+
+        private final LoadBalancerFactory<InetSocketAddress, C> rr =
+                new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, C>().build();
+
+        @Override
+        public <T extends C> LoadBalancer<T> newLoadBalancer(
+                final String targetResource,
+                final Publisher<? extends Collection<? extends ServiceDiscovererEvent<InetSocketAddress>>>
+                        eventPublisher,
+                final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
+            return new InspectingLoadBalancer<>(rr.newLoadBalancer(targetResource, eventPublisher, connectionFactory));
+        }
+
+        @Override
+        public ExecutionStrategy requiredOffloads() {
+            return ExecutionStrategy.offloadNone();
+        }
+    }
+
+    private final class InspectingLoadBalancer<C extends LoadBalancedConnection> implements LoadBalancer<C> {
+        private final LoadBalancer<C> delegate;
+
+        private InspectingLoadBalancer(final LoadBalancer<C> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Single<C> selectConnection(final Predicate<C> selector) {
+            return defer(() -> {
+                lbSelectInvoked.incrementAndGet();
+                return delegate.selectConnection(selector);
+            });
+        }
+
+        @Override
+        public Publisher<Object> eventStream() {
+            return delegate.eventStream();
+        }
+
+        @Override
+        public Completable onClose() {
+            return delegate.onClose();
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return delegate.closeAsync();
+        }
+
+        @Override
+        public Completable closeAsyncGracefully() {
+            return delegate.closeAsyncGracefully();
+        }
+    }
+
+    private static final class ClosingConnectionFactory
+            extends DelegatingConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection> {
+        ClosingConnectionFactory(
+                final ConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection> original) {
+            super(original);
+        }
+
+        @Override
+        public Single<FilterableStreamingHttpConnection> newConnection(final InetSocketAddress inetSocketAddress,
+                                                                       @Nullable final TransportObserver observer) {
+            return delegate().newConnection(inetSocketAddress, observer)
+                    .flatMap(c -> c.closeAsync().concat(succeeded(c)));
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -32,7 +32,6 @@ import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.utils.RetryingHttpRequesterFilter;
 import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
-import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.RetryableException;
 import io.servicetalk.transport.api.ServerContext;
@@ -223,16 +222,18 @@ class RetryingHttpRequesterFilterTest {
 
         @Override
         public <T extends C> LoadBalancer<T> newLoadBalancer(
+                final Publisher<? extends ServiceDiscovererEvent<InetSocketAddress>> eventPublisher,
+                final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
+            return new InspectingLoadBalancer<>(rr.newLoadBalancer(eventPublisher, connectionFactory));
+        }
+
+        @Override
+        public <T extends C> LoadBalancer<T> newLoadBalancer(
                 final String targetResource,
                 final Publisher<? extends Collection<? extends ServiceDiscovererEvent<InetSocketAddress>>>
                         eventPublisher,
                 final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
             return new InspectingLoadBalancer<>(rr.newLoadBalancer(targetResource, eventPublisher, connectionFactory));
-        }
-
-        @Override
-        public ExecutionStrategy requiredOffloads() {
-            return ExecutionStrategy.offloadNone();
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -54,7 +54,7 @@ import static io.servicetalk.http.netty.HttpClients.forResolvedAddress;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.http.netty.HttpServers.forAddress;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
-import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofInstant;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofImmediate;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.Builder;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.HttpResponseException;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -128,7 +128,7 @@ class RetryingHttpRequesterFilterTest {
                 .appendClientFilter(new Builder()
                         .retryRetryableExceptions((requestMetaData, e) -> NO_RETRIES)
                         .retryOther((requestMetaData, throwable) ->
-                                requestMetaData.requestTarget().equals("/retry") ? ofInstant() : NO_RETRIES).build())
+                                requestMetaData.requestTarget().equals("/retry") ? ofImmediate() : NO_RETRIES).build())
                 .buildBlocking();
         try {
             failingClient.request(failingClient.get("/"));
@@ -158,7 +158,7 @@ class RetryingHttpRequesterFilterTest {
                         // Disable request retrying
                         .retryRetryableExceptions((requestMetaData, e) -> NO_RETRIES)
                         // Retry only responses marked so
-                        .retryResponses((requestMetaData, throwable) -> ofInstant())
+                        .retryResponses((requestMetaData, throwable) -> ofImmediate())
                         .build())
                 .buildBlocking();
         try {

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RetryingHttpRequesterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,10 @@ import static io.servicetalk.concurrent.api.Completable.failed;
  * A filter to enable retries for HTTP requests.
  *
  * @see RetryStrategies
+ * @deprecated A replacement retrying http filter is available through
+ * {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter}
  */
+@Deprecated
 public final class RetryingHttpRequesterFilter implements StreamingHttpClientFilterFactory,
                                                           StreamingHttpConnectionFilterFactory,
                                                           HttpExecutionStrategyInfluencer {
@@ -107,7 +110,10 @@ public final class RetryingHttpRequesterFilter implements StreamingHttpClientFil
     /**
      * A builder for {@link RetryingHttpRequesterFilter}, which puts an upper bound on retry attempts.
      * To configure the maximum number of retry attempts see {@link #maxRetries(int)}.
+     * @deprecated A replacement retrying http filter builder is available through
+     * {@code io.servicetalk.http.netty.RetryingHttpRequesterFilterBuilder}
      */
+    @Deprecated
     public static final class Builder
             extends AbstractRetryingFilterBuilder<Builder, RetryingHttpRequesterFilter, HttpRequestMetaData> {
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionContext.java
@@ -30,8 +30,8 @@ public interface ExecutionContext {
     BufferAllocator bufferAllocator();
 
     /**
-     * Get the {@link IoExecutor} that is used to handle the IO.
-     * @return The {@link IoExecutor} that is used to handle the.
+     * Get the {@link IoExecutor} that is used to handle the I/O.
+     * @return The {@link IoExecutor} that is used to handle the I/O.
      */
     IoExecutor ioExecutor();
 


### PR DESCRIPTION
Motivation:

Use of `AutoRetry` alongside a `RetryingHttpRequesterFilter` creates issues with the retrying logic exponentially increasing to the product of the two max-retry settings. The conflict arises when both solutions are configured to retry `RetryableException`s which is the case by default.

Modifications:

- `AutoRetry` logic is deprecated, to be removed in the future.
- The logic of the `AutoRetry` is merged with the `RetryingHttpRequesterFilter` which now allows retryable flows. Different exceptions can have different retry, as well as support for retries of responses.

Results:

Unified API for retries.

Note:

This is a cherry-picked combination of 3 PRs to the `main` branch, see  #1905, #2004, #2018.