### PR TITLE
Revert a removed ctor for `ConnectionObserverInitializer`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -47,6 +47,18 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
      * Creates a new instance.
      *
      * @param observer {@link ConnectionObserver} to report network events.
+     * @param secure {@code true} if the observed connection is secure.
+     * @deprecated Use {@link #ConnectionObserverInitializer(ConnectionObserver, boolean, boolean)}
+     */
+    @Deprecated // this ctor is not used by ST and left only for backward compatibility
+    public ConnectionObserverInitializer(final ConnectionObserver observer, final boolean secure) {
+        this(observer, secure, false);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param observer {@link ConnectionObserver} to report network events.
      * @param secure {@code true} if the observed connection is secure
      * @param client {@code true} if this initializer is used on the client-side
      */


### PR DESCRIPTION
Motivation:

#1970 removed a public ctor from `ConnectionObserverInitializer`. We
should revert it back to make the class backward compatible.

Modifications:

- Revert `ConnectionObserverInitializer(ConnectionObserver, boolean)`;

Result:

`ConnectionObserverInitializer` is backward compatible.