### PR TITLE
Upgrade Log4J 2.15.0 → 2.16.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ nettyIoUringVersion=0.0.11.Final
 
 jsr305Version=3.0.2
 
-log4jVersion=2.15.0
+log4jVersion=2.16.0
 slf4jVersion=1.7.32
 
 javaxActivationVersion=1.2.2


### PR DESCRIPTION
Motivation:
Log4J upgrade provides additional mitigations for message lookup CVE
Modifications:
Upgrade from 2.15.0 to 2.16.0
Result:
Using safer Log4J version