### PR TITLE
Upgrade Log4J 2.16.0 to 2.17.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ nettyIoUringVersion=0.0.11.Final
 
 jsr305Version=3.0.2
 
-log4jVersion=2.16.0
+log4jVersion=2.17.0
 slf4jVersion=1.7.32
 
 javaxActivationVersion=1.2.2


### PR DESCRIPTION
Motivation:

Log4J upgrade to address a security risk CVE-2021-45105

Modifications:

Upgrade from 2.16.0 to 2.17.0

Result:

Using a safer Log4J version