### PR TITLE
Prevent retry logic modifications through the builder

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -705,6 +705,16 @@ public final class RetryingHttpRequesterFilter
          * @return A new retrying {@link RetryingHttpRequesterFilter}
          */
         public RetryingHttpRequesterFilter build() {
+            final BiFunction<HttpRequestMetaData, RetryableException, BackOffPolicy> retryRetryableExceptions =
+                    this.retryRetryableExceptions;
+            final BiFunction<HttpRequestMetaData, IOException, BackOffPolicy> retryIdempotentRequests =
+                    this.retryIdempotentRequests;
+            final BiFunction<HttpRequestMetaData, DelayedRetry, BackOffPolicy> retryDelayedRetries =
+                    this.retryDelayedRetries;
+            final BiFunction<HttpRequestMetaData, HttpResponseException, BackOffPolicy> retryResponses =
+                    this.retryResponses;
+            final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryOther = this.retryOther;
+
             final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> allPredicate =
                     (requestMetaData, throwable) -> {
                         if (throwable instanceof RetryableException) {


### PR DESCRIPTION
Motivation:

The final retry predicate depends on class variables of the builder in
`RetryingHttpRequesterFilter`. User can keep a reference to the builder
and modify functions to change the retry behavior in runtime.

Modifications:

- Capture the context of the builder state in `final` variables to
eliminate any runtime behavior change in `RetryingHttpRequesterFilter`;

Result:

`RetryingHttpRequesterFilter` behavior can not be altered through the
builder at runtime.