### PR TITLE
`RetryingHttpRequesterFilter`: change max retries to 5

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -56,7 +56,6 @@ import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponential
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.http.api.HeaderUtils.DEFAULT_HEADER_FILTER;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
-import static java.lang.Integer.MAX_VALUE;
 import static java.time.Duration.ZERO;
 import static java.time.Duration.ofDays;
 import static java.util.Objects.requireNonNull;
@@ -530,7 +529,7 @@ public final class RetryingHttpRequesterFilter
         private boolean waitForLb = true;
         private boolean ignoreSdErrors;
 
-        private int maxRetries = MAX_VALUE;
+        private int maxRetries = 5;
 
         @Nullable
         private Function<HttpResponseMetaData, HttpResponseException> responseMapper;


### PR DESCRIPTION
Motivation:

Current default is to retry indefinitely. This may lead to an issues,
like retry storm, timeout exceptions, or inability for users to know
that request keeps failing.

Modifications:

- Change default value for `maxRetries` from `MAX_VALUE` to `5`;

Result:

Default version of `RetryingHttpRequesterFilter` propagates an error to
the user after 5 failed attempts.