### PR TITLE
Add Publisher#cast, Single#cast, and Publisher#ofType

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -131,7 +131,8 @@ public abstract class Publisher<T> {
      * }</pre>
      * @param clazz The type to cast to.
      * @param <R> The resulting type of the cast operation.
-     * @return The cast of this {@link Publisher} to type {@link R}.
+     * @return The cast of this {@link Publisher} to type {@link R}. Terminate with a {@link ClassCastException} if
+     * signals cannot be cast to type {@link R}.
      * @see <a href="https://reactivex.io/documentation/operators/map.html">ReactiveX cast operator.</a>
      */
     public final <R> Publisher<R> cast(Class<R> clazz) {
@@ -161,7 +162,7 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Filters items so that only items of type {@link R} are emitted by the return value.
+     * Filters items so that only non-{@code null} items of type {@link R} are emitted by the return value.
      * <p>
      * This method provides a data transformation in sequential programming similar to:
      * <pre>{@code

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -131,7 +131,7 @@ public abstract class Publisher<T> {
      * }</pre>
      * @param clazz The type to cast to.
      * @param <R> The resulting type of the cast operation.
-     * @return The cast of this {@link Publisher} to type {@link R}. Terminate with a {@link ClassCastException} if
+     * @return The cast of this {@link Publisher} to type {@link R}. Terminates with a {@link ClassCastException} if
      * signals cannot be cast to type {@link R}.
      * @see <a href="https://reactivex.io/documentation/operators/map.html">ReactiveX cast operator.</a>
      */

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -119,6 +119,26 @@ public abstract class Publisher<T> {
     }
 
     /**
+     * Cast this {@link Publisher} from type {@link T} to type {@link R}.
+     * <p>
+     * This method provides a data transformation in sequential programming similar to:
+     * <pre>{@code
+     *     List<R> results = ...;
+     *     for (T t : resultOfThisPublisher()) {
+     *         results.add(clazz.cast(t));
+     *     }
+     *     return results;
+     * }</pre>
+     * @param clazz The type to cast to.
+     * @param <R> The resulting type of the cast operation.
+     * @return The cast of this {@link Publisher} to type {@link R}.
+     * @see <a href="https://reactivex.io/documentation/operators/map.html">ReactiveX cast operator.</a>
+     */
+    public final <R> Publisher<R> cast(Class<R> clazz) {
+        return map(clazz::cast);
+    }
+
+    /**
      * Filters items emitted by this {@link Publisher}.
      * <p>
      * This method provides a data transformation in sequential programming similar to:
@@ -134,11 +154,32 @@ public abstract class Publisher<T> {
      *
      * @param predicate for the filter.
      * @return A {@link Publisher} that only emits the items that pass the {@code predicate}.
-     *
      * @see <a href="http://reactivex.io/documentation/operators/filter.html">ReactiveX filter operator.</a>
      */
     public final Publisher<T> filter(Predicate<? super T> predicate) {
         return filter(() -> predicate);
+    }
+
+    /**
+     * Filters items so that only items of type {@link R} are emitted by the return value.
+     * <p>
+     * This method provides a data transformation in sequential programming similar to:
+     * <pre>{@code
+     *     List<R> results = ...;
+     *     for (T t : resultOfThisPublisher()) {
+     *         if (clazz.isInstance(t)) {
+     *             results.add((R) t);
+     *         }
+     *     }
+     *     return results;
+     * }</pre>
+     * @param clazz The type to filter and cast to.
+     * @param <R> The resulting type of the cast operation.
+     * @return a {@link Publisher} that only emits
+     * @see <a href="https://reactivex.io/documentation/operators/filter.html">ReactiveX ofType operator.</a>
+     */
+    public final <R> Publisher<R> ofType(Class<R> clazz) {
+        return filter(clazz::isInstance).cast(clazz);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -110,7 +110,8 @@ public abstract class Single<T> {
      * }</pre>
      * @param clazz The type to cast to.
      * @param <R> The resulting type of the cast operation.
-     * @return The cast of this {@link Single} to type {@link R}.
+     * @return The cast of this {@link Single} to type {@link R}. Terminates with a {@link ClassCastException} if
+     * signals cannot be cast to type {@link R}.
      * @see <a href="https://reactivex.io/documentation/operators/map.html">ReactiveX cast operator.</a>
      */
     public final <R> Single<R> cast(Class<R> clazz) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -101,6 +101,23 @@ public abstract class Single<T> {
     }
 
     /**
+     * Cast this {@link Single} from type {@link T} to type {@link R}.
+     * <p>
+     * This method provides a data transformation in sequential programming similar to:
+     * <pre>{@code
+     *     T tResult = resultOfThisSingle();
+     *     R rResult = clazz.cast(tResult);
+     * }</pre>
+     * @param clazz The type to cast to.
+     * @param <R> The resulting type of the cast operation.
+     * @return The cast of this {@link Single} to type {@link R}.
+     * @see <a href="https://reactivex.io/documentation/operators/map.html">ReactiveX cast operator.</a>
+     */
+    public final <R> Single<R> cast(Class<R> clazz) {
+        return map(clazz::cast);
+    }
+
+    /**
      * Transform errors emitted on this {@link Single} into {@link Subscriber#onSuccess(Object)} signal
      * (e.g. swallows the error).
      * <p>

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherCastTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherCastTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
+import org.junit.jupiter.api.Test;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+class PublisherCastTest {
+    private final TestPublisher<Object> source = new TestPublisher<>();
+    private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+
+    @Test
+    void correctTypeSucceeds() {
+        toSource(source.cast(Integer.class)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(2);
+        source.onNext(1, 2);
+        assertThat(subscriber.takeOnNext(2), contains(1, 2));
+        source.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    void mixedTypeFails() {
+        toSource(source.cast(Integer.class)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(2);
+        source.onNext(1, "error");
+        assertThat(subscriber.takeOnNext(), is(1));
+        assertThat(subscriber.awaitOnError(), instanceOf(ClassCastException.class));
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherOfTypeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherOfTypeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
+import org.junit.jupiter.api.Test;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+class PublisherOfTypeTest {
+    private final TestPublisher<Object> source = new TestPublisher<>();
+    private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+
+    @Test
+    void allSignals() {
+        toSource(source.ofType(Integer.class)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(2);
+        source.onNext(1, 2);
+        assertThat(subscriber.takeOnNext(2), contains(1, 2));
+        source.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    void someSignals() {
+        toSource(source.ofType(Integer.class)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(2);
+        source.onNext(1, "NotInteger");
+        assertThat(subscriber.takeOnNext(), is(1));
+        source.onComplete();
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    void noSignals() {
+        toSource(source.ofType(Integer.class)).subscribe(subscriber);
+        subscriber.awaitSubscription().request(2);
+        source.onNext("NotInteger1", "NotInteger2");
+        source.onComplete();
+        subscriber.awaitOnComplete();
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherOfTypeTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherOfTypeTest.java
@@ -18,6 +18,10 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,11 +42,12 @@ class PublisherOfTypeTest {
         subscriber.awaitOnComplete();
     }
 
-    @Test
-    void someSignals() {
+    @ParameterizedTest
+    @MethodSource("someSignalsParams")
+    void someSignals(String param) {
         toSource(source.ofType(Integer.class)).subscribe(subscriber);
         subscriber.awaitSubscription().request(2);
-        source.onNext(1, "NotInteger");
+        source.onNext(1, param);
         assertThat(subscriber.takeOnNext(), is(1));
         source.onComplete();
         subscriber.awaitOnComplete();
@@ -55,5 +60,9 @@ class PublisherOfTypeTest {
         source.onNext("NotInteger1", "NotInteger2");
         source.onComplete();
         subscriber.awaitOnComplete();
+    }
+
+    private static Stream<String> someSignalsParams() {
+        return Stream.of("NotInteger", null);
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleCastTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleCastTest.java
@@ -18,6 +18,10 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,12 +32,13 @@ class SingleCastTest {
     private final TestSingle<Object> source = new TestSingle<>();
     private final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
 
-    @Test
-    void correctTypeSucceeds() {
+    @ParameterizedTest
+    @MethodSource("correctTypeParams")
+    void correctTypeSucceeds(Integer v) {
         toSource(source.cast(Integer.class)).subscribe(subscriber);
         subscriber.awaitSubscription();
-        source.onSuccess(1);
-        assertThat(subscriber.awaitOnSuccess(), is(1));
+        source.onSuccess(v);
+        assertThat(subscriber.awaitOnSuccess(), is(v));
     }
 
     @Test
@@ -42,5 +47,9 @@ class SingleCastTest {
         subscriber.awaitSubscription();
         source.onSuccess("error");
         assertThat(subscriber.awaitOnError(), instanceOf(ClassCastException.class));
+    }
+
+    private static Stream<Integer> correctTypeParams() {
+        return Stream.of(1, null);
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleCastTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleCastTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
+
+import org.junit.jupiter.api.Test;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+class SingleCastTest {
+    private final TestSingle<Object> source = new TestSingle<>();
+    private final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
+
+    @Test
+    void correctTypeSucceeds() {
+        toSource(source.cast(Integer.class)).subscribe(subscriber);
+        subscriber.awaitSubscription();
+        source.onSuccess(1);
+        assertThat(subscriber.awaitOnSuccess(), is(1));
+    }
+
+    @Test
+    void mixedTypeFails() {
+        toSource(source.cast(Integer.class)).subscribe(subscriber);
+        subscriber.awaitSubscription();
+        source.onSuccess("error");
+        assertThat(subscriber.awaitOnError(), instanceOf(ClassCastException.class));
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherCastTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherCastTckTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+@Test
+public class PublisherCastTckTest extends AbstractPublisherOperatorTckTest<Object> {
+    @Override
+    protected Publisher<Object> composePublisher(Publisher<Integer> publisher, int elements) {
+        return publisher.cast(Object.class);
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherOfTypeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherOfTypeTckTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+@Test
+public class PublisherOfTypeTckTest extends AbstractPublisherOperatorTckTest<Object> {
+    @Override
+    protected Publisher<Object> composePublisher(Publisher<Integer> publisher, int elements) {
+        return publisher.ofType(Object.class);
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleCastTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleCastTckTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Single;
+
+import org.testng.annotations.Test;
+
+@Test
+public class SingleCastTckTest extends AbstractSingleOperatorTckTest<Object> {
+    @Override
+    protected Single<Object> composeSingle(Single<Integer> single) {
+        return single.cast(Object.class);
+    }
+}


### PR DESCRIPTION
Motivation:
Filtering and casting based upon types maybe a common
use case but it currently requires knowledge of Class
methods and potentially multiple operators.

Modifications:
- Add Publisher#cast, Single#cast, and Publisher#ofType
  operators and associated tests.

Result:
Operators exist which make casting and filtering between
types easier.