### PR TITLE
HTTP `Expect: 100-continue`

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
@@ -86,7 +86,7 @@ public class HttpResponseDecoderBenchmark {
         responseBuffer.writeShort(CRLF_SHORT);
         responseByteBuf = toByteBuf(responseBuffer.slice());
 
-        channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(), new ArrayDeque<>(),
+        channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(), new PollLikePeakArrayDeque<>(),
                 getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
                 false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }
@@ -103,5 +103,14 @@ public class HttpResponseDecoderBenchmark {
         }
 
         return response.headers().size() + trailers.size();
+    }
+
+    private static final class PollLikePeakArrayDeque<T> extends ArrayDeque<T> {
+        private static final long serialVersionUID = -8160337336374186819L;
+
+        @Override
+        public T poll() {
+            return peek();  // Prevent taking an element out of the queue to allow reuse for multiple tests
+        }
     }
 }

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
@@ -86,7 +86,7 @@ public class HttpResponseDecoderBenchmark {
         responseBuffer.writeShort(CRLF_SHORT);
         responseByteBuf = toByteBuf(responseBuffer.slice());
 
-        channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(), new ArrayDeque<>(0),
+        channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(), new ArrayDeque<>(),
                 getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
                 false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
@@ -45,6 +45,7 @@ import static io.servicetalk.buffer.netty.BufferUtils.toByteBuf;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.HttpObjectEncoder.CRLF_SHORT;
 import static io.servicetalk.http.netty.HttpUtils.status;
+import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /*
@@ -86,7 +87,8 @@ public class HttpResponseDecoderBenchmark {
         responseByteBuf = toByteBuf(responseBuffer.slice());
 
         channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(),
-                getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192));
+                getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
+                false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }
 
     @Benchmark

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
@@ -86,7 +86,7 @@ public class HttpResponseDecoderBenchmark {
         responseBuffer.writeShort(CRLF_SHORT);
         responseByteBuf = toByteBuf(responseBuffer.slice());
 
-        channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(),
+        channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(), new ArrayDeque<>(0),
                 getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
                 false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseEncoderFullResponseBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseEncoderFullResponseBenchmark.java
@@ -43,6 +43,8 @@ import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.netty.HttpResponseEncoder.NOOP_ON_RESPONSE;
+import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 
 /*
  * This benchmark measures encoding of full HTTP request with headers and payload body. Everything is allocated using
@@ -71,7 +73,8 @@ public class HttpResponseEncoderFullResponseBenchmark {
                 .addHeader(CONTENT_TYPE, TEXT_PLAIN)
                 .addHeader(newAsciiString("X-Custom-Header-Name"), newAsciiString("X-Custom-Header-Value"));
 
-        channel = new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256));
+        channel = new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NOOP_ON_RESPONSE));
     }
 
     @Benchmark

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseEncoderInitialLineBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseEncoderInitialLineBenchmark.java
@@ -39,7 +39,9 @@ import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
+import static io.servicetalk.http.netty.HttpResponseEncoder.NOOP_ON_RESPONSE;
 import static io.servicetalk.http.netty.HttpUtils.status;
+import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 
 /*
  * This benchmark compares encoding of HTTP requests with different status codes (with short and long reason phrase,
@@ -71,7 +73,8 @@ public class HttpResponseEncoderInitialLineBenchmark {
         metaData = newResponseMetaData(HTTP_1_1, status(statusCode), INSTANCE.newHeaders())
                 .addHeader(CONTENT_LENGTH, ZERO);
 
-        channel = new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256));
+        channel = new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NOOP_ON_RESPONSE));
     }
 
     @Benchmark

--- a/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
@@ -270,7 +270,7 @@ tracing headers in the final response.
 TIP: The interim response is not propagated as a response
 returned by the client because the client has to wait for a final status code returned by the server. There are a couple
 of other ways how to get visibility into interim response: using wire-logging for HTTP/1.x or frame-logging for HTTP/2
-(see link:{source-root}servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java[DebuggingClient]
+(see link:{source-root}/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java[DebuggingClient]
 as an example) or by monitoring when
-link:{source-root}servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java[WriteObserver]
+link:{source-root}/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java[WriteObserver]
 signals that more items are requested to write.

--- a/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
@@ -250,3 +250,27 @@ deserialization format and also adding a `content-type` header identifying the r
 
 For more information about how to use serializers and deserializers see
 xref:{page-version}@servicetalk-examples::http/index.adoc#Serialization[these] examples.
+
+== Expect: 100-continue
+
+HTTP protocol defines link:https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1[Expect] header with
+`100-continue` expectation. This feature allows users to defer sending a request payload body until after the server
+responds with link:https://datatracker.ietf.org/doc/html/rfc7231#section-6.2.1[100 Continue] status code signaling that
+it's ready to receive and process the payload body.
+
+NOTE: This feature is expected to be used with streaming API (see
+xref:{page-version}@servicetalk::programming-paradigms.adoc[Programming paradigms]) because only streaming API can
+give granular control of how and when a request payload body is produced and consumed.
+
+Server-side users should subscribe to the request payload body when they are ready to consume it. It will generate
+`100 Continue` interim response. After the request is consumed, service should produce a final response with a correct
+status code. If service decides to reject a request, an appropriate `4xx` status code should be returned. Put meaningful
+tracing headers in the final response.
+
+TIP: The interim response is not propagated as a response
+returned by the client because the client has to wait for a final status code returned by the server. There are a couple
+of other ways how to get visibility into interim response: using wire-logging for HTTP/1.x or frame-logging for HTTP/2
+(see link:{source-root}servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java[DebuggingClient]
+as an example) or by monitoring when
+link:{source-root}servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java[WriteObserver]
+signals that more items are requested to write.

--- a/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
@@ -258,14 +258,22 @@ HTTP protocol defines link:https://datatracker.ietf.org/doc/html/rfc7231#section
 responds with link:https://datatracker.ietf.org/doc/html/rfc7231#section-6.2.1[100 Continue] status code signaling that
 it's ready to receive and process the payload body.
 
-NOTE: This feature is expected to be used with streaming API (see
-xref:{page-version}@servicetalk::programming-paradigms.adoc[Programming paradigms]) because only streaming API can
-give granular control of how and when a request payload body is produced and consumed.
+NOTE: xref:{page-version}@servicetalk-http-api::programming-paradigms.adoc#client-blocking-and-aggregated[Aggregated]
+client will automatically de-optimize its flush strategy to flush on each element of the request to force flushing of
+the request meta-data and deffer flushing payload body until after a `100 Continue` response is received.
 
 Server-side users should subscribe to the request payload body when they are ready to consume it. It will generate
-`100 Continue` interim response. After the request is consumed, service should produce a final response with a correct
-status code. If service decides to reject a request, an appropriate `4xx` status code should be returned. Put meaningful
-tracing headers in the final response.
+link:https://datatracker.ietf.org/doc/html/rfc7231#section-6.2.1[100 Continue] interim response. After the request is
+consumed, service should produce a final response with an appropriate status code. If service decides to reject a
+request before consuming a request payload body, an appropriate `4xx` status code, like
+link:https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.14[417 Expectation Failed], should be returned. Put
+meaningful tracing headers in the final response.
+
+NOTE: xref:{page-version}@servicetalk-http-api::programming-paradigms.adoc#svc-blocking-and-aggregated[Aggregated]
+service will automatically subscribe to the request payload body before invoking the `handle` method, that will send
+`100 Continue` response back to the client. For manual control consider migrating to
+xref:{page-version}@servicetalk-http-api::programming-paradigms.adoc#svc-blocking-and-streaming[streaming] API or
+implement a filter to accept or reject requests before processing their payload body.
 
 TIP: The interim response is not propagated as a response
 returned by the client because the client has to wait for a final status code returned by the server. There are a couple

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpProtocolVersion.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpProtocolVersion.java
@@ -20,11 +20,12 @@ import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.PREFER_HEAP_RO_ALLOCATOR;
 import static io.servicetalk.http.api.BufferUtils.writeReadOnlyBuffer;
+import static java.lang.Integer.compare;
 
 /**
  * HTTP <a href="https://tools.ietf.org/html/rfc7230.html#section-2.6">protocol versioning</a>.
  */
-public final class HttpProtocolVersion implements Protocol {
+public final class HttpProtocolVersion implements Protocol, Comparable<HttpProtocolVersion> {
     /**
      * HTTP/1.1 version described in <a href="https://tools.ietf.org/html/rfc7230">RFC 7230</a>.
      */
@@ -155,5 +156,11 @@ public final class HttpProtocolVersion implements Protocol {
      */
     static boolean h1TrailersSupported(HttpProtocolVersion version) {
         return version.major() == 1 && version.minor() > 0;
+    }
+
+    @Override
+    public int compareTo(final HttpProtocolVersion that) {
+        final int compareMajor = compare(this.major(), that.major());
+        return compareMajor == 0 ? compare(this.minor(), that.minor()) : compareMajor;
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpProtocolVersionTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpProtocolVersionTest.java
@@ -23,7 +23,12 @@ import org.junit.jupiter.api.Test;
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -85,5 +90,20 @@ class HttpProtocolVersionTest {
     @Test
     void testIllegalMinorVersionGT9() {
         assertThrows(IllegalArgumentException.class, () -> HttpProtocolVersion.of(1, 10));
+    }
+
+    @Test
+    void testCompareTo() {
+        assertThat(HTTP_1_0.compareTo(HTTP_1_1), lessThan(0));
+        assertThat(HTTP_1_0.compareTo(HTTP_2_0), lessThan(0));
+        assertThat(HTTP_1_1.compareTo(HTTP_2_0), lessThan(0));
+
+        assertThat(HTTP_1_0.compareTo(HTTP_1_0), is(0));
+        assertThat(HTTP_1_1.compareTo(HTTP_1_1), is(0));
+        assertThat(HTTP_2_0.compareTo(HTTP_2_0), is(0));
+
+        assertThat(HTTP_2_0.compareTo(HTTP_1_1), greaterThan(0));
+        assertThat(HTTP_2_0.compareTo(HTTP_1_0), greaterThan(0));
+        assertThat(HTTP_1_1.compareTo(HTTP_1_0), greaterThan(0));
     }
 }

--- a/servicetalk-http-netty/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/test-exclusions.xml
@@ -59,4 +59,9 @@
     <Method name="noMaxActiveStreamsViolatedError" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
   </Match>
+  <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/756 -->
+  <Match>
+    <Class name="io.servicetalk.http.netty.ExpectContinueTest"/>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
@@ -67,8 +67,8 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
     }
 
     final void writeMetaData(ChannelHandlerContext ctx, HttpMetaData metaData, Http2Headers h2Headers,
-                             ChannelPromise promise) {
-        final boolean endStream = emptyMessageBody(metaData);
+                             boolean maybeEndStream, ChannelPromise promise) {
+        final boolean endStream = maybeEndStream && emptyMessageBody(metaData);
         if (endStream) {
             closeHandler.protocolPayloadEndOutbound(ctx, promise);
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -160,10 +160,10 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     @Nullable
     static FlushStrategy determineFlushStrategyForApi(final HttpMetaData request) {
         // For non-aggregated, don't change the flush strategy, keep the default.
-        return isAggregated(request) ? flushOnEnd() : null;
+        return isSafeToAggregateOrEmpty(request) ? flushOnEnd() : null;
     }
 
-    static boolean isAggregated(final HttpMetaData request) {
+    static boolean isSafeToAggregateOrEmpty(final HttpMetaData request) {
         return isPayloadEmpty(request) || isSafeToAggregate(request);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -50,6 +50,7 @@ import static io.servicetalk.http.api.HttpApiConversions.isPayloadEmpty;
 import static io.servicetalk.http.api.HttpApiConversions.isSafeToAggregate;
 import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
 import static io.servicetalk.http.api.StreamingHttpResponses.newTransportResponse;
+import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HeaderUtils.addRequestTransferEncodingIfNecessary;
 import static io.servicetalk.http.netty.HeaderUtils.canAddRequestContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.emptyMessageBody;
@@ -158,9 +159,10 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     }
 
     @Nullable
-    static FlushStrategy determineFlushStrategyForApi(final HttpMetaData request) {
-        // For non-aggregated, don't change the flush strategy, keep the default.
-        return isSafeToAggregateOrEmpty(request) ? flushOnEnd() : null;
+    private static FlushStrategy determineFlushStrategyForApi(final HttpRequestMetaData request) {
+        // For non-aggregated requests or when "Expect: 100-continue" is detected, don't change the flush strategy,
+        // keep the default.
+        return isSafeToAggregateOrEmpty(request) && !REQ_EXPECT_CONTINUE.test(request) ? flushOnEnd() : null;
     }
 
     static boolean isSafeToAggregateOrEmpty(final HttpMetaData request) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -160,7 +160,11 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     @Nullable
     static FlushStrategy determineFlushStrategyForApi(final HttpMetaData request) {
         // For non-aggregated, don't change the flush strategy, keep the default.
-        return isPayloadEmpty(request) || isSafeToAggregate(request) ? flushOnEnd() : null;
+        return isAggregated(request) ? flushOnEnd() : null;
+    }
+
+    static boolean isAggregated(final HttpMetaData request) {
+        return isPayloadEmpty(request) || isSafeToAggregate(request);
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ExpectationFailedException.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ExpectationFailedException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.netty.RetryingHttpRequesterFilter.HttpResponseException;
+
+/**
+ * An exception that represents <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.14">
+ *     417 Expectation Failed</a> response status code.
+ * <p>
+ * A response will be automatically converted into this exception type when
+ * {@link RetryingHttpRequesterFilter.Builder#retryExpectationFailed(boolean)} is set to {@code true}.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1">Expect</a>
+ */
+public final class ExpectationFailedException extends HttpResponseException {
+    private static final long serialVersionUID = -5608030718662972886L;
+
+    ExpectationFailedException(final String message, final HttpResponseMetaData response) {
+        super(message, response);
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -83,7 +83,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFro
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
-import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
+import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
@@ -357,7 +357,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                     parentContext.sslSession(),
                                     parentContext.nettyChannel().config(),
                                     streamObserver,
-                                    true, EXPECT_CONTINUE,
+                                    true, REQ_EXPECT_CONTINUE,
                                     NettyHttp2ExceptionUtils::wrapIfNecessary);
 
                     // In h2 a stream is 1 to 1 with a request/response life cycle. This means there is no concept of

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -83,7 +83,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFro
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
-import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
+import static io.servicetalk.http.netty.HeaderUtils.OBJ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
@@ -357,7 +357,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                     parentContext.sslSession(),
                                     parentContext.nettyChannel().config(),
                                     streamObserver,
-                                    true, REQ_EXPECT_CONTINUE,
+                                    true, OBJ_EXPECT_CONTINUE,
                                     NettyHttp2ExceptionUtils::wrapIfNecessary);
 
                     // In h2 a stream is 1 to 1 with a request/response life cycle. This means there is no concept of

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -83,6 +83,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFro
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
@@ -356,7 +357,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                     parentContext.sslSession(),
                                     parentContext.nettyChannel().config(),
                                     streamObserver,
-                                    true,
+                                    true, EXPECT_CONTINUE,
                                     NettyHttp2ExceptionUtils::wrapIfNecessary);
 
                     // In h2 a stream is 1 to 1 with a request/response life cycle. This means there is no concept of

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -174,7 +174,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                                 connection.sslSession(),
                                                 channel.config(),
                                                 streamObserver,
-                                                false,
+                                                false, __ -> false,
                                                 NettyHttp2ExceptionUtils::wrapIfNecessary);
 
                                 // ServiceTalk HTTP service handler

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -24,6 +24,8 @@ import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.netty.internal.CloseHandler;
+import io.servicetalk.transport.netty.internal.DefaultNettyConnection.CancelWriteUserEvent;
+import io.servicetalk.transport.netty.internal.DefaultNettyConnection.ContinueUserEvent;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -45,8 +47,10 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
+import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h2HeadersSanitizeForH1;
+import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HeaderUtils.responseMayHaveContent;
 import static io.servicetalk.http.netty.HeaderUtils.serverMaySendPayloadBodyFor;
 
@@ -55,6 +59,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
     private final HttpScheme scheme;
     @Nullable
     private HttpRequestMethod method;
+    private boolean waitForContinuation;
 
     H2ToStH1ClientDuplexHandler(boolean sslEnabled, BufferAllocator allocator, HttpHeadersFactory headersFactory,
                                 CloseHandler closeHandler, StreamObserver observer) {
@@ -68,6 +73,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
             closeHandler.protocolPayloadBeginOutbound(ctx);
             HttpRequestMetaData metaData = (HttpRequestMetaData) msg;
             HttpHeaders h1Headers = metaData.headers();
+            waitForContinuation = EXPECT_CONTINUE.test(msg);
             CharSequence host = h1Headers.getAndRemove(HOST);
             Http2Headers h2Headers = h1HeadersToH2Headers(h1Headers);
             if (host == null) {
@@ -87,7 +93,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 h2Headers.path(metaData.requestTarget());
             }
             try {
-                writeMetaData(ctx, metaData, h2Headers, promise);
+                writeMetaData(ctx, metaData, h2Headers, true, promise);
             } finally {
                 final Http2StreamChannel streamChannel = (Http2StreamChannel) ctx.channel();
                 final int streamId = streamChannel.stream().id();
@@ -111,12 +117,22 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
             Http2Headers h2Headers = headersFrame.headers();
             final HttpResponseStatus httpStatus;
             if (!readHeaders) {
-                closeHandler.protocolPayloadBeginInbound(ctx);
                 CharSequence status = h2Headers.getAndRemove(STATUS.value());
                 if (status == null) {
                     throw new IllegalArgumentException("a response must have " + STATUS + " header");
                 }
                 httpStatus = HttpResponseStatus.of(status);
+                if (waitForContinuation) {
+                    if (httpStatus.code() == HttpResponseStatus.CONTINUE.code() ||
+                            httpStatus.statusClass() == SUCCESSFUL_2XX) {
+                        // Write of payload body can continue for either 100 or 2XX response code:
+                        ctx.fireUserEventTriggered(ContinueUserEvent.INSTANCE);
+                    } else if (httpStatus.statusClass() != INFORMATIONAL_1XX) {
+                        // All other non-informational responses should cancel ongoing write operation when write waits
+                        // for continuation.
+                        ctx.fireUserEventTriggered(CancelWriteUserEvent.INSTANCE);
+                    }
+                }
                 if (httpStatus.statusClass() == INFORMATIONAL_1XX) {
                     // We don't expose 1xx "interim responses" [2] to the user, and discard them to make way for the
                     // "real" response.
@@ -135,6 +151,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                     return;
                 }
                 readHeaders = true;
+                closeHandler.protocolPayloadBeginInbound(ctx);
             } else {
                 httpStatus = null;
             }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -73,7 +73,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
             closeHandler.protocolPayloadBeginOutbound(ctx);
             HttpRequestMetaData metaData = (HttpRequestMetaData) msg;
             HttpHeaders h1Headers = metaData.headers();
-            waitForContinuation = REQ_EXPECT_CONTINUE.test(msg);
+            waitForContinuation = REQ_EXPECT_CONTINUE.test(metaData);
             CharSequence host = h1Headers.getAndRemove(HOST);
             Http2Headers h2Headers = h1HeadersToH2Headers(h1Headers);
             if (host == null) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -50,7 +50,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATION
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h2HeadersSanitizeForH1;
-import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
+import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HeaderUtils.responseMayHaveContent;
 import static io.servicetalk.http.netty.HeaderUtils.serverMaySendPayloadBodyFor;
 
@@ -73,7 +73,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
             closeHandler.protocolPayloadBeginOutbound(ctx);
             HttpRequestMetaData metaData = (HttpRequestMetaData) msg;
             HttpHeaders h1Headers = metaData.headers();
-            waitForContinuation = EXPECT_CONTINUE.test(msg);
+            waitForContinuation = REQ_EXPECT_CONTINUE.test(msg);
             CharSequence host = h1Headers.getAndRemove(HOST);
             Http2Headers h2Headers = h1HeadersToH2Headers(h1Headers);
             if (host == null) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -51,6 +51,7 @@ import static io.servicetalk.http.netty.HeaderUtils.shouldAddZeroContentLength;
 
 final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
     private boolean readHeaders;
+    private boolean responseSent;
 
     H2ToStH1ServerDuplexHandler(BufferAllocator allocator, HttpHeadersFactory headersFactory,
                                 CloseHandler closeHandler, StreamObserver observer) {
@@ -60,16 +61,20 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof HttpResponseMetaData) {
-            final boolean maybeEndStream = ((HttpResponseMetaData) msg).status().statusClass() != INFORMATIONAL_1XX;
-            if (maybeEndStream) {
-                // We don't expose 1xx "interim responses" [2] to the user, and discard them to make way for the
-                // "real" response.
+            final boolean realResponse = ((HttpResponseMetaData) msg).status().statusClass() != INFORMATIONAL_1XX;
+            if (realResponse) {
+                // Notify the CloseHandler only about "real" responses. We don't expose 1xx "interim responses" to the
+                // user, and handle them internally.
+                responseSent = true;
                 closeHandler.protocolPayloadBeginOutbound(ctx);
+            } else if (responseSent) {
+                // Discard an "interim response" if it arrives after a "real response" is already sent.
+                return;
             }
             HttpResponseMetaData metaData = (HttpResponseMetaData) msg;
             Http2Headers h2Headers = h1HeadersToH2Headers(metaData.headers());
             h2Headers.status(metaData.status().codeAsCharSequence());
-            writeMetaData(ctx, metaData, h2Headers, maybeEndStream, promise);
+            writeMetaData(ctx, metaData, h2Headers, realResponse, promise);
         } else if (msg instanceof Buffer) {
             writeBuffer(ctx, (Buffer) msg, promise);
         } else if (msg instanceof HttpHeaders) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -43,6 +43,7 @@ import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.PATH;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpRequestMetaDataFactory.newRequestMetaData;
 import static io.servicetalk.http.api.HttpRequestMethod.Properties.NONE;
+import static io.servicetalk.http.api.HttpResponseStatus.CONTINUE;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h2HeadersSanitizeForH1;
 import static io.servicetalk.http.netty.HeaderUtils.clientMaySendPayloadBodyFor;
@@ -59,11 +60,14 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof HttpResponseMetaData) {
-            closeHandler.protocolPayloadBeginOutbound(ctx);
+            final boolean maybeEndStream = ((HttpResponseMetaData) msg).status().code() != CONTINUE.code();
+            if (maybeEndStream) {
+                closeHandler.protocolPayloadBeginOutbound(ctx);
+            }
             HttpResponseMetaData metaData = (HttpResponseMetaData) msg;
             Http2Headers h2Headers = h1HeadersToH2Headers(metaData.headers());
             h2Headers.status(metaData.status().codeAsCharSequence());
-            writeMetaData(ctx, metaData, h2Headers, promise);
+            writeMetaData(ctx, metaData, h2Headers, maybeEndStream, promise);
         } else if (msg instanceof Buffer) {
             writeBuffer(ctx, (Buffer) msg, promise);
         } else if (msg instanceof HttpHeaders) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -64,7 +64,7 @@ import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.isSafeTo
 
 final class HeaderUtils {
 
-    // Predicates that validate when `expect: 100-continue` feature have to be handled
+    // Predicates that validate when `expect: 100-continue` feature has to be handled.
     static final Predicate<HttpRequestMetaData> REQ_EXPECT_CONTINUE = reqMetaData -> {
         // Versions prior HTTP/1.1 do not support Expect-Continue
         return !isSafeToAggregateOrEmpty(reqMetaData) && reqMetaData.version().compareTo(HTTP_1_1) >= 0 &&

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -60,14 +60,13 @@ import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
-import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.isSafeToAggregateOrEmpty;
 
 final class HeaderUtils {
 
     // Predicates that validate when `expect: 100-continue` feature has to be handled.
     static final Predicate<HttpRequestMetaData> REQ_EXPECT_CONTINUE = reqMetaData -> {
         // Versions prior HTTP/1.1 do not support Expect-Continue
-        return !isSafeToAggregateOrEmpty(reqMetaData) && reqMetaData.version().compareTo(HTTP_1_1) >= 0 &&
+        return reqMetaData.version().compareTo(HTTP_1_1) >= 0 &&
                 reqMetaData.headers().containsIgnoreCase(EXPECT, CONTINUE);
     };
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -60,18 +60,18 @@ import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
-import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.isAggregated;
+import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.isSafeToAggregateOrEmpty;
 
 final class HeaderUtils {
 
     // A Predicate that validates when `expect: 100-continue` feature have to be handled
-    static final Predicate<Object> EXPECT_CONTINUE = msg -> {
+    static final Predicate<Object> REQ_EXPECT_CONTINUE = msg -> {
         if (!(msg instanceof HttpRequestMetaData)) {
             return false;
         }
         final HttpRequestMetaData metaData = (HttpRequestMetaData) msg;
         // Versions prior HTTP/1.1 do not support Expect-Continue
-        return !isAggregated(metaData) && metaData.version().compareTo(HTTP_1_1) >= 0 &&
+        return !isSafeToAggregateOrEmpty(metaData) && metaData.version().compareTo(HTTP_1_1) >= 0 &&
                 metaData.headers().containsIgnoreCase(EXPECT, CONTINUE);
     };
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
@@ -44,12 +44,13 @@ final class HttpClientChannelInitializer implements ChannelInitializer {
         // user-code. Therefore, ByteBufs must be copied to unpooled memory before HttpObjectDecoder.
         this.delegate = new CopyByteBufHandlerChannelInitializer(alloc).andThen(channel -> {
             final Queue<HttpRequestMethod> methodQueue = new ArrayDeque<>(min(8, config.maxPipelinedRequests()));
+            final ArrayDeque<Object> signalsQueue = new ArrayDeque<>(0);
             final ChannelPipeline pipeline = channel.pipeline();
-            pipeline.addLast(new HttpResponseDecoder(methodQueue, alloc, config.headersFactory(),
+            pipeline.addLast(new HttpResponseDecoder(methodQueue, signalsQueue, alloc, config.headersFactory(),
                     config.maxStartLineLength(), config.maxHeaderFieldLength(),
                     config.specExceptions().allowPrematureClosureBeforePayloadBody(),
                     config.specExceptions().allowLFWithoutCR(), closeHandler));
-            pipeline.addLast(new HttpRequestEncoder(methodQueue,
+            pipeline.addLast(new HttpRequestEncoder(methodQueue, signalsQueue,
                     config.headersEncodedSizeEstimate(), config.trailersEncodedSizeEstimate(), closeHandler));
         });
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -40,7 +40,6 @@ import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.transport.netty.internal.ByteToMessageDecoder;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.CloseHandler.DiscardFurtherInboundEvent;
-import io.servicetalk.transport.netty.internal.DefaultNettyConnection.ContinueUserEvent;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.buffer.ByteBuf;
@@ -306,7 +305,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                     case SKIP_CONTROL_CHARS:
                         // fast-path
                         // No content is expected.
-                        if (isInterim(message)) {
+                        if (!isInterim(message)) {
                             // We don't expose 1xx "interim responses" [2] to the user, and discard them to make way for
                             // the "real" response.
                             //
@@ -317,8 +316,6 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                             //    the status-line (the empty line signaling the end of the header
                             //    section). [1]
                             // [1] https://tools.ietf.org/html/rfc7231#section-6.2
-                            ctx.fireUserEventTriggered(ContinueUserEvent.INSTANCE);
-                        } else {
                             ctx.fireChannelRead(message);
                             closeHandler.protocolPayloadEndInbound(ctx);
                         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -40,6 +40,7 @@ import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.transport.netty.internal.ByteToMessageDecoder;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.CloseHandler.DiscardFurtherInboundEvent;
+import io.servicetalk.transport.netty.internal.DefaultNettyConnection.ContinueUserEvent;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.buffer.ByteBuf;
@@ -284,7 +285,10 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
                 message = createMessage(buffer, aStart, aEnd - aStart, bStart, bEnd - bStart, cStart, cLength);
                 currentState = State.READ_HEADER;
-                closeHandler.protocolPayloadBeginInbound(ctx);
+                if (!isInterim(message)) {
+                    // Don't notify CloseHandler if it's interim 100 (Continue) response
+                    closeHandler.protocolPayloadBeginInbound(ctx);
+                }
                 // fall-through
             }
             case READ_HEADER: {
@@ -296,13 +300,28 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 if (shouldClose(message)) {
                     closeHandler.protocolClosingInbound(ctx);
                 }
+                onMetaDataRead(ctx, message);
                 currentState = nextState;
                 switch (nextState) {
                     case SKIP_CONTROL_CHARS:
                         // fast-path
                         // No content is expected.
-                        ctx.fireChannelRead(message);
-                        closeHandler.protocolPayloadEndInbound(ctx);
+                        if (isInterim(message)) {
+                            // We don't expose 1xx "interim responses" [2] to the user, and discard them to make way for
+                            // the "real" response.
+                            //
+                            // A client MUST be able to parse one or more 1xx responses received
+                            //    prior to a final response, even if the client does not expect one.  A
+                            //    user agent MAY ignore unexpected 1xx responses. [2]
+                            // 1xx responses are terminated by the first empty line after
+                            //    the status-line (the empty line signaling the end of the header
+                            //    section). [1]
+                            // [1] https://tools.ietf.org/html/rfc7231#section-6.2
+                            ctx.fireUserEventTriggered(ContinueUserEvent.INSTANCE);
+                        } else {
+                            ctx.fireChannelRead(message);
+                            closeHandler.protocolPayloadEndInbound(ctx);
+                        }
                         resetNow();
                         return;
                     case READ_CHUNK_SIZE:
@@ -343,6 +362,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 // Keep reading data as a chunk until the end of connection is reached.
                 int toRead = buffer.readableBytes();
                 if (toRead > 0) {
+                    onDataSeen();
                     ByteBuf content = buffer.readRetainedSlice(toRead);
                     cumulationIndex = buffer.readerIndex();
                     ctx.fireChannelRead(newBufferFrom(content));
@@ -361,6 +381,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 if (toRead == 0) {
                     return;
                 }
+                onDataSeen();
 
                 if (toRead > chunkSize) {
                     toRead = (int) chunkSize;
@@ -388,6 +409,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 if (longLFIndex < 0) {
                     return;
                 }
+                onDataSeen();
                 final int lfIndex = crlfIndex(longLFIndex);
                 long chunkSize = getChunkSize(buffer, lfIndex);
                 consumeCRLF(buffer, lfIndex);
@@ -405,6 +427,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 if (toRead == 0) {
                     return;
                 }
+                onDataSeen();
                 Buffer chunk = newBufferFrom(buffer.readRetainedSlice(toRead));
                 chunkSize -= toRead;
                 cumulationIndex = buffer.readerIndex();
@@ -539,6 +562,14 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
     protected abstract boolean isContentAlwaysEmpty(T msg);
 
+    protected abstract boolean isInterim(T msg);
+
+    protected abstract void onMetaDataRead(ChannelHandlerContext ctx, T msg);
+
+    protected abstract void onDataSeen();
+
+    protected abstract void onStateReset();
+
     /**
      * Returns true if the server switched to a different protocol than HTTP/1.0 or HTTP/1.1, e.g. HTTP/2 or Websocket.
      * Returns false if the upgrade happened in a different layer, e.g. upgrade from HTTP/1.1 to HTTP/1.1 over TLS.
@@ -553,7 +584,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                         !AsciiString.contains(newProtocol, HTTP_1_1.toString());
     }
 
-    private void resetNow() {
+    protected final void resetNow() {
         T message = this.message;
         this.message = null;
         this.trailer = null;
@@ -570,6 +601,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
         currentState = State.SKIP_CONTROL_CHARS;
         skippedControls = 0;
+        onStateReset();
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -568,8 +568,6 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
     protected abstract void onDataSeen();
 
-    protected abstract void onStateReset();
-
     /**
      * Returns true if the server switched to a different protocol than HTTP/1.0 or HTTP/1.1, e.g. HTTP/2 or Websocket.
      * Returns false if the upgrade happened in a different layer, e.g. upgrade from HTTP/1.1 to HTTP/1.1 over TLS.
@@ -584,7 +582,12 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                         !AsciiString.contains(newProtocol, HTTP_1_1.toString());
     }
 
-    protected final void resetNow() {
+    /**
+     * Resets the state of the decoder to prepare it for parsing a new incoming message.
+     * <p>
+     * Subclasses that override this method have to invoke this implementation using {@code super} keyword.
+     */
+    protected void resetNow() {
         T message = this.message;
         this.message = null;
         this.trailer = null;
@@ -601,7 +604,6 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
         currentState = State.SKIP_CONTROL_CHARS;
         skippedControls = 0;
-        onStateReset();
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
@@ -141,6 +141,8 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelDuplexHa
             } else if (state == -1) {
                 unknownContentLengthNewRequest(ctx);
             }
+
+            onMetaData(ctx, metaData);
             if (realResponse) {
                 // Notify the CloseHandler only about "real" messages. We don't expose "interim messages", like 1xx
                 // responses to the user, and handle them internally.
@@ -160,7 +162,6 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelDuplexHa
 
                 // Encode the message.
                 encodeInitialLine(ctx, stBuf, metaData);
-                onMetaData(ctx, metaData);
                 if (isContentAlwaysEmpty(metaData)) {
                     state = CONTENT_LEN_EMPTY;
                     if (realResponse) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
@@ -151,7 +151,7 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelDuplexHa
 
                 // Encode the message.
                 encodeInitialLine(ctx, stBuf, metaData);
-                onMetaData(metaData);
+                onMetaData(ctx, metaData);
                 if (isContentAlwaysEmpty(metaData)) {
                     state = CONTENT_LEN_EMPTY;
                     if (!isContinue(metaData)) {
@@ -290,9 +290,11 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelDuplexHa
 
     /**
      * Callback when a meta-data object have been encoded.
-     * @param metaData
+     *
+     * @param ctx the {@link ChannelHandlerContext} for which the write operation is made.
+     * @param metaData the meta-data message.
      */
-    protected void onMetaData(final T metaData) {
+    protected void onMetaData(final ChannelHandlerContext ctx, final T metaData) {
         // noop
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectEncoder.java
@@ -69,7 +69,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
-import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
+import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpKeepAlive.shouldClose;
 import static java.lang.Long.toHexString;
 import static java.lang.Math.max;
@@ -166,14 +166,14 @@ abstract class HttpObjectEncoder<T extends HttpMetaData> extends ChannelDuplexHa
                     }
                 } else if (isTransferEncodingChunked(metaData.headers())) {
                     state = CONTENT_LEN_CHUNKED;
-                    expectContinue = EXPECT_CONTINUE.test(metaData);
+                    expectContinue = REQ_EXPECT_CONTINUE.test(metaData);
                 } else {
                     state = getContentLength(metaData);
                     assert state > CONTENT_LEN_LARGEST_VALUE;
                     if (state == 0) {
                         contentLenConsumed(ctx, promise);
                     } else {
-                        expectContinue = EXPECT_CONTINUE.test(metaData);
+                        expectContinue = REQ_EXPECT_CONTINUE.test(metaData);
                     }
                 }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
@@ -18,6 +18,8 @@ package io.servicetalk.http.netty;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.netty.HttpResponseEncoder.OnResponse;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
@@ -31,10 +33,14 @@ import java.util.Queue;
 
 import static io.servicetalk.http.api.HttpRequestMetaDataFactory.newRequestMetaData;
 import static io.servicetalk.http.api.HttpRequestMethod.Properties.NONE;
+import static io.servicetalk.http.api.HttpResponseStatus.CONTINUE;
+import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
+import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
+import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
 
-final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
+final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> implements OnResponse {
     private static final ByteProcessor FIND_WS_AFTER_METHOD_NAME = value -> {
         if (isWS(value)) {
             return false;
@@ -48,6 +54,9 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
     };
 
     private final Queue<HttpRequestMethod> methodQueue;
+    private final CloseHandler closeHandler;
+    private boolean expectContinue;
+    private boolean seenPayloadBody;
 
     HttpRequestDecoder(final Queue<HttpRequestMethod> methodQueue, final ByteBufAllocator alloc,
                        final HttpHeadersFactory headersFactory, final int maxStartLineLength,
@@ -56,6 +65,7 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
         super(alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength, allowPrematureClosureBeforePayloadBody,
                 allowLFWithoutCR, closeHandler);
         this.methodQueue = requireNonNull(methodQueue);
+        this.closeHandler = closeHandler;
     }
 
     @Override
@@ -123,5 +133,43 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
         // iterate a decoded list it makes some assumptions about the base class ordering of events.
         methodQueue.add(msg.method());
         return false;
+    }
+
+    @Override
+    protected boolean isInterim(final HttpRequestMetaData msg) {
+        return false;   // Only response decoder may encounter interim messages
+    }
+
+    @Override
+    protected void onMetaDataRead(final ChannelHandlerContext ctx, final HttpRequestMetaData msg) {
+        expectContinue = EXPECT_CONTINUE.test(msg);
+    }
+
+    @Override
+    protected void onDataSeen() {
+        seenPayloadBody = true;
+    }
+
+    @Override
+    protected void onStateReset() {
+        expectContinue = false;
+        seenPayloadBody = false;
+    }
+
+    @Override
+    public void onResponse(final ChannelHandlerContext ctx, final HttpResponseStatus status) {
+        if (expectContinue && !seenPayloadBody) {
+            if (status == CONTINUE) {
+                // If server responds with 100 (Continue), no need to trigger resetNow() anymore because server expects
+                // to receive a payload body.
+                onStateReset();
+            } else if (status.statusClass() != SUCCESSFUL_2XX && status.statusClass() != INFORMATIONAL_1XX) {
+                // If a request expects continuation, but server responds with an error or redirect before it sees a
+                // request payload body, notify CloseHandler and reset the state to prepare for receiving a new request
+                // on the same connection.
+                closeHandler.protocolPayloadEndInbound(ctx);
+                resetNow();
+            }
+        }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
@@ -36,7 +36,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.Properties.NONE;
 import static io.servicetalk.http.api.HttpResponseStatus.CONTINUE;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
-import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
+import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
 
@@ -142,7 +142,7 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> im
 
     @Override
     protected void onMetaDataRead(final ChannelHandlerContext ctx, final HttpRequestMetaData msg) {
-        expectContinue = EXPECT_CONTINUE.test(msg);
+        expectContinue = REQ_EXPECT_CONTINUE.test(msg);
     }
 
     @Override
@@ -151,7 +151,12 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> im
     }
 
     @Override
-    protected void onStateReset() {
+    protected void resetNow() {
+        super.resetNow();
+        onStateReset();
+    }
+
+    private void onStateReset() {
         expectContinue = false;
         seenPayloadBody = false;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
@@ -160,12 +160,10 @@ final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
     @Override
     protected void onMetaData(final ChannelHandlerContext ctx, final HttpRequestMetaData metaData) {
         expectContinue = REQ_EXPECT_CONTINUE.test(metaData);
-        if (expectContinue) {
-            if (!signalsQueue.offer(EXPECT_CONTINUE_SIGNAL)) {
-                LOGGER.error(
+        if (expectContinue && !signalsQueue.offer(EXPECT_CONTINUE_SIGNAL)) {
+            LOGGER.error(
                     "{} Can not signal to the decoder that outgoing request {} contains `Expect: 100-continue` header.",
                     ctx.channel(), metaData);
-            }
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
@@ -35,6 +35,8 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 
+import io.netty.channel.ChannelHandlerContext;
+
 import java.util.Queue;
 
 import static io.netty.handler.codec.http.HttpConstants.SP;
@@ -101,7 +103,7 @@ final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
     }
 
     @Override
-    protected void encodeInitialLine(Buffer stBuffer, HttpRequestMetaData message) {
+    protected void encodeInitialLine(ChannelHandlerContext ctx, Buffer stBuffer, HttpRequestMetaData message) {
         message.method().writeTo(stBuffer);
 
         String uri = message.requestTarget();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
@@ -54,7 +54,7 @@ import static java.util.Objects.requireNonNull;
 final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> {
 
     enum Signal {
-        REQUEST_SIGNAL, REQUEST_WITH_EXPECT_CONTINUE_SIGNAL;
+        REQUEST_SIGNAL, REQUEST_WITH_EXPECT_CONTINUE_SIGNAL
     }
 
     private static final byte[] FIRST_BYTES = "HTTP/".getBytes(US_ASCII);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
@@ -44,7 +44,6 @@ import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.SWITCHING_PROTOCOLS;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
-import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
@@ -63,12 +62,6 @@ final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> 
     };
 
     private final Queue<HttpRequestMethod> methodQueue;
-
-    HttpResponseDecoder(final Queue<HttpRequestMethod> methodQueue, final ByteBufAllocator alloc,
-                        final HttpHeadersFactory headersFactory, int maxStartLineLength, int maxHeaderFieldLength) {
-        this(methodQueue, alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength,
-                false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER);
-    }
 
     HttpResponseDecoder(final Queue<HttpRequestMethod> methodQueue, final ByteBufAllocator alloc,
                         final HttpHeadersFactory headersFactory, final int maxStartLineLength, int maxHeaderFieldLength,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
@@ -181,11 +181,6 @@ final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> 
         // noop
     }
 
-    @Override
-    protected void onStateReset() {
-        // noop
-    }
-
     private static int nettyBufferToStatusCode(final ByteBuf buffer, final int start, final int length) {
         ensureStatusCodeLength(length);
         final int medium = buffer.getUnsignedMedium(start);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseEncoder.java
@@ -47,7 +47,6 @@ import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_VERSION;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
 import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
-import static io.servicetalk.http.api.HttpResponseStatus.CONTINUE;
 import static io.servicetalk.http.api.HttpResponseStatus.NOT_MODIFIED;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.SWITCHING_PROTOCOLS;
@@ -161,8 +160,8 @@ final class HttpResponseEncoder extends HttpObjectEncoder<HttpResponseMetaData> 
     }
 
     @Override
-    protected boolean isContinue(final HttpResponseMetaData msg) {
-        return msg.status().code() == CONTINUE.code();
+    protected boolean isInterim(final HttpResponseMetaData msg) {
+        return msg.status().statusClass() == INFORMATIONAL_1XX;
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -93,7 +93,7 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.StreamingHttpRequests.newTransportRequest;
 import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.determineFlushStrategyForApi;
-import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
+import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HeaderUtils.addResponseTransferEncodingIfNecessary;
 import static io.servicetalk.http.netty.HeaderUtils.canAddResponseContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.emptyMessageBody;
@@ -341,7 +341,7 @@ final class NettyHttpServer {
                 // closure.
                 final SingleSubscriberProcessor requestCompletion = new SingleSubscriberProcessor();
                 final AtomicBoolean payloadSubscribed = drainRequestPayloadBody ? new AtomicBoolean() : null;
-                final MutableBoolean continueSent = EXPECT_CONTINUE.test(rawRequest) ? new MutableBoolean() : null;
+                final MutableBoolean continueSent = REQ_EXPECT_CONTINUE.test(rawRequest) ? new MutableBoolean() : null;
                 final StreamingHttpRequest request = rawRequest.transformMessageBody(
                         // Cancellation is assumed to close the connection, or be ignored if this Subscriber has already
                         // terminated. That means we don't need to trigger the processor as completed because we don't

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -36,7 +36,7 @@ import javax.net.ssl.SNIHostName;
 
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
-import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
+import static io.servicetalk.http.netty.HeaderUtils.OBJ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static java.util.Objects.requireNonNull;
@@ -70,7 +70,7 @@ final class StreamingConnectionFactory {
                 tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(),
                 initializer.andThen(new HttpClientChannelInitializer(
                         getByteBufAllocator(executionContext.bufferAllocator()), h1Config, closeHandler)),
-                executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true, REQ_EXPECT_CONTINUE),
+                executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true, OBJ_EXPECT_CONTINUE),
                 HTTP_1_1, channel);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -36,7 +36,7 @@ import javax.net.ssl.SNIHostName;
 
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
-import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
+import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static java.util.Objects.requireNonNull;
@@ -70,7 +70,7 @@ final class StreamingConnectionFactory {
                 tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(),
                 initializer.andThen(new HttpClientChannelInitializer(
                         getByteBufAllocator(executionContext.bufferAllocator()), h1Config, closeHandler)),
-                executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true, EXPECT_CONTINUE),
+                executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true, REQ_EXPECT_CONTINUE),
                 HTTP_1_1, channel);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -36,6 +36,7 @@ import javax.net.ssl.SNIHostName;
 
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.netty.HeaderUtils.EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static java.util.Objects.requireNonNull;
@@ -69,7 +70,8 @@ final class StreamingConnectionFactory {
                 tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(),
                 initializer.andThen(new HttpClientChannelInitializer(
                         getByteBufAllocator(executionContext.bufferAllocator()), h1Config, closeHandler)),
-                executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true), HTTP_1_1, channel);
+                executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true, EXPECT_CONTINUE),
+                HTTP_1_1, channel);
     }
 
     static ReadOnlyTcpClientConfig withSslConfigPeerHost(Object resolvedRemoteAddress,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
@@ -1,0 +1,621 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.BlockingIterator;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.http.api.BlockingStreamingHttpService;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpConnection;
+import io.servicetalk.http.api.HttpPayloadWriter;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpRequestFactory;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.http.api.RedirectConfigBuilder;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestFactory;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
+import static io.servicetalk.http.api.HttpHeaderNames.EXPECT;
+import static io.servicetalk.http.api.HttpHeaderNames.LOCATION;
+import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
+import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
+import static io.servicetalk.http.api.HttpHeaderValues.CONTINUE;
+import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
+import static io.servicetalk.http.api.HttpResponseStatus.ACCEPTED;
+import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
+import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
+import static io.servicetalk.logging.api.LogLevel.TRACE;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.lang.String.valueOf;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class ExpectContinueTest {
+
+    @RegisterExtension
+    static final ExecutionContextExtension SERVER_CTX =
+            ExecutionContextExtension.cached("server-io", "server-executor");
+    @RegisterExtension
+    static final ExecutionContextExtension CLIENT_CTX =
+            ExecutionContextExtension.cached("client-io", "client-executor");
+
+    private static final String PAYLOAD = "hello";
+    private static final String FAIL = "fail";
+
+    private final CountDownLatch requestReceived = new CountDownLatch(1);
+    private final CountDownLatch sendContinue = new CountDownLatch(1);
+    private final CountDownLatch returnResponse = new CountDownLatch(1);
+    private final BlockingQueue<StreamingHttpResponse> responses = new LinkedBlockingDeque<>();
+
+    private static Stream<Arguments> arguments() {
+        return Stream.of(Arguments.of(HTTP_1, false),
+                Arguments.of(HTTP_1, true),
+                Arguments.of(HttpProtocol.HTTP_2, false),
+                Arguments.of(HttpProtocol.HTTP_2, true));
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinue(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, allocator);
+
+            returnResponse.countDown();
+            assertResponse(OK, PAYLOAD + PAYLOAD);
+
+            sendFollowUpRequest(connection, withCL, allocator, OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinueAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get().asConnection()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            Future<HttpResponse> responseFuture = connection.request(
+                    newRequest(connection, withCL, false, PAYLOAD + PAYLOAD, allocator)).toFuture();
+            requestReceived.await();
+            sendContinue.countDown();
+            returnResponse.countDown();
+            HttpResponse response = responseFuture.get();
+            assertThat(response.status(), is(OK));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(PAYLOAD + PAYLOAD));
+
+            sendFollowUpRequest(connection.asStreamingConnection(), withCL,
+                    allocator, OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinueThenFailure(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            requestReceived.countDown();
+            sendContinue.await();
+            StringBuilder sb = new StringBuilder();
+            request.payloadBody().forEach(chunk -> sb.append(chunk.toString(US_ASCII)));
+            returnResponse.await();
+            try (HttpPayloadWriter<Buffer> writer = response.status(UNPROCESSABLE_ENTITY).sendMetaData()) {
+                writer.write(ctx.executionContext().bufferAllocator().fromAscii(sb));
+            }
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, allocator);
+
+            returnResponse.countDown();
+            assertResponse(UNPROCESSABLE_ENTITY, PAYLOAD + PAYLOAD);
+
+            sendFollowUpRequest(connection, withCL, allocator, UNPROCESSABLE_ENTITY);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinueThenFailureThenRequestPayload(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            requestReceived.countDown();
+            sendContinue.await();
+            BlockingIterator<Buffer> iterator = request.payloadBody().iterator();
+            returnResponse.await();
+            try (HttpPayloadWriter<Buffer> writer = response.status(UNPROCESSABLE_ENTITY).sendMetaData()) {
+                while (iterator.hasNext()) {
+                    Buffer next = iterator.next();
+                    if (next != null) {
+                        writer.write(next);
+                    }
+                }
+            }
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            payload.awaitSubscribed();
+
+            returnResponse.countDown();
+            StreamingHttpResponse response = responses.take();
+            assertThat(response.status(), is(UNPROCESSABLE_ENTITY));
+
+            payload.onNext(allocator.fromAscii(PAYLOAD));
+            payload.onNext(allocator.fromAscii(PAYLOAD));
+            payload.onComplete();
+            assertThat(response.toResponse().toFuture().get().payloadBody().toString(US_ASCII),
+                    equalTo(PAYLOAD + PAYLOAD));
+
+            sendFollowUpRequest(connection, withCL, allocator, UNPROCESSABLE_ENTITY);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinueConnectionClose(HttpProtocol protocol, boolean withCL) throws Exception {
+        assumeTrue(protocol == HTTP_1);
+        try (HttpServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload).setHeader(CONNECTION, CLOSE))
+                    .subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, connection.executionContext().bufferAllocator());
+
+            returnResponse.countDown();
+            assertResponse(OK, PAYLOAD + PAYLOAD);
+
+            connection.onClose().toFuture().get();
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverRespondsWithSuccess(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+                requestReceived.countDown();
+                returnResponse.await();
+                response.status(ACCEPTED);
+                try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                    for (Buffer chunk : request.payloadBody()) {
+                        writer.write(chunk);
+                    }
+                }
+            });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            returnResponse.countDown();
+
+            StreamingHttpResponse response = responses.take();
+            assertThat(response.status(), is(ACCEPTED));
+            sendRequestPayload(payload, allocator);
+            assertThat(response.toResponse().toFuture().get().payloadBody().toString(US_ASCII),
+                    equalTo(PAYLOAD + PAYLOAD));
+
+            sendFollowUpRequest(connection, withCL, allocator, ACCEPTED);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverRespondsWithSuccessAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            requestReceived.countDown();
+            returnResponse.await();
+            response.status(ACCEPTED);
+            try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                for (Buffer chunk : request.payloadBody()) {
+                    writer.write(chunk);
+                }
+            }
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get().asConnection()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            returnResponse.countDown();
+            HttpResponse response = connection.request(newRequest(connection, withCL, false, PAYLOAD + PAYLOAD,
+                    allocator)).toFuture().get();
+            assertThat(response.status(), is(ACCEPTED));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(PAYLOAD + PAYLOAD));
+
+            sendFollowUpRequest(connection.asStreamingConnection(), withCL, allocator, ACCEPTED);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverRespondsWithRedirect(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            if ("/redirect".equals(request.requestTarget())) {
+                response.status(PERMANENT_REDIRECT);
+                response.setHeader(LOCATION, "/");
+                response.sendMetaData().close();
+                return;
+            }
+            requestReceived.countDown();
+            sendContinue.await();
+            StringBuilder sb = new StringBuilder();
+            request.payloadBody().forEach(chunk -> sb.append(chunk.toString(US_ASCII)));
+            returnResponse.await();
+            try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                writer.write(ctx.executionContext().bufferAllocator().fromAscii(sb));
+            }
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol, new RedirectingHttpRequesterFilter(
+                     new RedirectConfigBuilder()
+                             .allowedMethods(POST)
+                             .headersToRedirect(CONTENT_LENGTH, TRANSFER_ENCODING, EXPECT)
+                             .redirectPayloadBody(true)
+                             .build()));
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload).requestTarget("/redirect"))
+                    .subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, allocator);
+
+            returnResponse.countDown();
+            assertResponse(OK, PAYLOAD + PAYLOAD);
+
+            sendFollowUpRequest(connection, withCL, allocator, OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectationFailed(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, true, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            returnResponse.countDown();
+            assertResponse(EXPECTATION_FAILED, "");
+            assertThat("Unexpected subscribe to payload body on expectation failed",
+                    payload.isSubscribed(), is(false));
+
+            sendContinue.countDown();
+            sendFollowUpRequest(connection, withCL, connection.executionContext().bufferAllocator(), OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectationFailedAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get().asConnection()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            Future<HttpResponse> responseFuture = connection.request(
+                    newRequest(connection, withCL, true, PAYLOAD + PAYLOAD, allocator)).toFuture();
+            requestReceived.await();
+            sendContinue.countDown();
+            returnResponse.countDown();
+            HttpResponse response = responseFuture.get();
+            assertThat(response.status(), is(EXPECTATION_FAILED));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(""));
+
+            sendFollowUpRequest(connection.asStreamingConnection(), withCL, allocator, OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectationFailedConnectionClose(HttpProtocol protocol, boolean withCL) throws Exception {
+        assumeTrue(protocol == HTTP_1);
+        try (HttpServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, true, payload).setHeader(CONNECTION, CLOSE))
+                    .subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            returnResponse.countDown();
+            assertResponse(EXPECTATION_FAILED, "");
+            assertThat("Unexpected subscribe to payload body on expectation failed",
+                    payload.isSubscribed(), is(false));
+
+            connection.onClose().toFuture().get();
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverError(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+                requestReceived.countDown();
+                returnResponse.await();
+                if (request.headers().contains(EXPECT, CONTINUE)) {
+                    response.status(INTERNAL_SERVER_ERROR);
+                }
+                response.sendMetaData().close();
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, true, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            returnResponse.countDown();
+            assertResponse(INTERNAL_SERVER_ERROR, "");
+
+            // send a follow-up request on the same connection:
+            connection.request(connection.get("/")).subscribe(responses::add);
+            assertResponse(OK, "");
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverErrorAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            requestReceived.countDown();
+            returnResponse.await();
+            if (request.headers().contains(EXPECT, CONTINUE)) {
+                response.status(INTERNAL_SERVER_ERROR);
+            }
+            response.sendMetaData().close();
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get().asConnection()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            Future<HttpResponse> responseFuture = connection.request(
+                    newRequest(connection, withCL, false, PAYLOAD + PAYLOAD, allocator)).toFuture();
+            requestReceived.await();
+            returnResponse.countDown();
+            HttpResponse response = responseFuture.get();
+            assertThat(response.status(), is(INTERNAL_SERVER_ERROR));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(""));
+
+            // send a follow-up request on the same connection:
+            response = connection.request(connection.get("/")).toFuture().get();
+            assertThat(response.status(), is(OK));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(""));
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void retryExpectationFailed(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol,
+                     new RetryingHttpRequesterFilter.Builder().retryExpectationFailed(true).build())) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            client.request(newRequest(client, withCL, true, payload)).subscribe(responses::add);
+            requestReceived.await();
+            returnResponse.countDown();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, client.executionContext().bufferAllocator());
+            assertResponse(OK, PAYLOAD + PAYLOAD);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void retryExpectationFailedAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (HttpServerContext serverContext = startServer(protocol);
+             HttpClient client = createClient(serverContext, protocol,
+                     new RetryingHttpRequesterFilter.Builder().retryExpectationFailed(true).build()).asClient()) {
+
+            Future<HttpResponse> responseFuture = client.request(newRequest(client, withCL, true, PAYLOAD + PAYLOAD,
+                    client.executionContext().bufferAllocator())).toFuture();
+            requestReceived.await();
+            sendContinue.countDown();
+            returnResponse.countDown();
+            HttpResponse response = responseFuture.get();
+            assertThat(response.status(), is(OK));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(PAYLOAD + PAYLOAD));
+        }
+    }
+
+    private HttpServerContext startServer(HttpProtocol protocol) throws Exception {
+        return startServer(protocol, (ctx, request, response) -> {
+                    requestReceived.countDown();
+                    if (request.headers().containsIgnoreCase(EXPECT, CONTINUE) &&
+                            request.headers().contains(FAIL, "true")) {
+                        returnResponse.await();
+                        response.status(EXPECTATION_FAILED).setHeader(CONTENT_LENGTH, ZERO);
+                        response.sendMetaData().close();
+                        return;
+                    }
+                    sendContinue.await();
+                    StringBuilder sb = new StringBuilder();
+                    request.payloadBody().forEach(chunk -> sb.append(chunk.toString(US_ASCII)));
+                    returnResponse.await();
+                    try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                        writer.write(ctx.executionContext().bufferAllocator().fromAscii(sb));
+                    }
+                });
+    }
+
+    private static HttpServerContext startServer(HttpProtocol protocol,
+                                                 BlockingStreamingHttpService service) throws Exception {
+        return HttpServers.forAddress(localAddress(0))
+                .ioExecutor(SERVER_CTX.ioExecutor())
+                .executor(SERVER_CTX.executor())
+                .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true)
+                .protocols(protocol.config)
+                .listenBlockingStreamingAndAwait(service);
+    }
+
+    private static StreamingHttpClient createClient(HttpServerContext serverContext, HttpProtocol protocol) {
+        return createClient(serverContext, protocol, null);
+    }
+
+    private static StreamingHttpClient createClient(HttpServerContext serverContext,
+                                                    HttpProtocol protocol,
+                                                    @Nullable StreamingHttpClientFilterFactory filterFactory) {
+        final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                        .ioExecutor(CLIENT_CTX.ioExecutor())
+                        .executor(CLIENT_CTX.executor())
+                        .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true)
+                        .protocols(protocol.config);
+        if (filterFactory != null) {
+            builder.appendClientFilter(filterFactory);
+        }
+        return builder.buildStreaming();
+    }
+
+    private static StreamingHttpRequest newRequest(StreamingHttpRequestFactory factory,
+                                                   boolean withCL, boolean fail,
+                                                   Publisher<Buffer> payload) {
+        return factory.post("/")
+                .setHeader(EXPECT, CONTINUE)
+                .setHeader(withCL ? CONTENT_LENGTH : TRANSFER_ENCODING,
+                        withCL ? valueOf(PAYLOAD.length() * 2) : CHUNKED)
+                .setHeader(FAIL, valueOf(fail))
+                .payloadBody(payload);
+    }
+
+    private static HttpRequest newRequest(HttpRequestFactory factory,
+                                          boolean withCL, boolean fail,
+                                          String payload,
+                                          BufferAllocator allocator) {
+        return factory.post("/")
+                .setHeader(EXPECT, CONTINUE)
+                .setHeader(withCL ? CONTENT_LENGTH : TRANSFER_ENCODING,
+                        withCL ? valueOf(PAYLOAD.length() * 2) : CHUNKED)
+                .setHeader(FAIL, valueOf(fail))
+                .payloadBody(allocator.fromAscii(payload));
+    }
+
+    private static void sendRequestPayload(TestPublisher<Buffer> payload, BufferAllocator alloc) {
+        payload.awaitSubscribed();
+        payload.onNext(alloc.fromAscii(PAYLOAD));
+        payload.onNext(alloc.fromAscii(PAYLOAD));
+        payload.onComplete();
+    }
+
+    private void sendFollowUpRequest(StreamingHttpRequester requester, boolean withCL,
+                                     BufferAllocator alloc, HttpResponseStatus expectedStatus) throws Exception {
+        TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+        requester.request(newRequest(requester, withCL, false, payload)).subscribe(responses::add);
+        sendRequestPayload(payload, alloc);
+        assertResponse(expectedStatus, PAYLOAD + PAYLOAD);
+    }
+
+    private void assertResponse(HttpResponseStatus expectedStatus, String expectedPayload) throws Exception {
+        StreamingHttpResponse response = responses.take();
+        assertThat(response.status(), is(expectedStatus));
+        assertThat(response.toResponse().toFuture().get().payloadBody().toString(US_ASCII), equalTo(expectedPayload));
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -83,6 +83,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.defaultFlushStrategy;
 import static java.lang.Integer.toHexString;
@@ -119,7 +120,8 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
 
     @Override
     EmbeddedChannel newEmbeddedChannel() {
-        return new EmbeddedChannel(new HttpRequestEncoder(new ArrayDeque<>(), 256, 256));
+        return new EmbeddedChannel(new HttpRequestEncoder(new ArrayDeque<>(), 256, 256,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -425,7 +425,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                                             channel2 -> {
                                                 serverChannelRef.compareAndSet(null, channel2);
                                                 serverChannelLatch.countDown();
-                                            }), defaultStrategy(), mock(Protocol.class), observer, false),
+                                            }), defaultStrategy(), mock(Protocol.class), observer, false, __ -> false),
                             connection -> { }).toFuture().get());
             ReadOnlyHttpClientConfig cConfig = new HttpClientConfig().asReadOnly();
             assert cConfig.h1Config() != null;
@@ -455,7 +455,8 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                                                                     serverCloseTrigger.onComplete();
                                                                 }
                                                             }
-                                                        })), defaultStrategy(), HTTP_1_1, connectionObserver, true);
+                                                        })), defaultStrategy(), HTTP_1_1, connectionObserver, true,
+                                        __ -> false);
                             },
                             NoopTransportObserver.INSTANCE).toFuture().get());
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -120,7 +120,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
 
     @Override
     EmbeddedChannel newEmbeddedChannel() {
-        return new EmbeddedChannel(new HttpRequestEncoder(new ArrayDeque<>(), 256, 256,
+        return new EmbeddedChannel(new HttpRequestEncoder(new ArrayDeque<>(), new ArrayDeque<>(), 256, 256,
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -76,7 +76,7 @@ class HttpResponseDecoderTest extends HttpObjectDecoderTest {
     private final EmbeddedChannel channelSpecException = newChannel(true);
 
     private EmbeddedChannel newChannel(boolean allowLFWithoutCR) {
-        return new EmbeddedChannel(new HttpResponseDecoder(methodQueue,
+        return new EmbeddedChannel(new HttpResponseDecoder(methodQueue, new ArrayDeque<>(),
                 getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
                 false, allowLFWithoutCR, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
@@ -43,6 +43,8 @@ import static io.servicetalk.http.api.HttpHeaderValues.KEEP_ALIVE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.HttpResponseEncoder.NOOP_ON_RESPONSE;
+import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static java.lang.Integer.toHexString;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -56,7 +58,8 @@ class HttpResponseEncoderTest extends HttpEncoderTest<HttpResponseMetaData> {
 
     @Override
     EmbeddedChannel newEmbeddedChannel() {
-        return new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256));
+        return new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NOOP_ON_RESPONSE));
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
@@ -111,7 +111,7 @@ class NettyPipelinedConnectionTest {
                             closeHandler.protocolPayloadEndInbound(ctx);
                         }
                     });
-                }, defaultStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true)
+                }, defaultStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
                         .toFuture().get();
         requester = new NettyPipelinedConnection<>(connection);
     }

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
@@ -122,7 +122,8 @@ final class TcpConnectorTest extends AbstractTcpServerTest {
                                 ctx.fireChannelRead(msg);
                                 closeHandler.protocolPayloadEndInbound(ctx);
                             }
-                        }), CLIENT_CTX.executionStrategy(), mock(Protocol.class), connectionObserver, true),
+                        }), CLIENT_CTX.executionStrategy(), mock(Protocol.class), connectionObserver, true,
+                        __ -> false),
                 NoopTransportObserver.INSTANCE).toFuture().get();
         connection.closeAsync().toFuture().get();
 

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -97,7 +97,7 @@ final class TcpClient {
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
                         new TcpClientChannelInitializer(config, connectionObserver).andThen(
                                 channel2 -> channel2.pipeline().addLast(BufferHandler.INSTANCE)),
-                        executionContext.executionStrategy(), TCP, connectionObserver, true),
+                        executionContext.executionStrategy(), TCP, connectionObserver, true, __ -> false),
                 observer);
     }
 

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -88,7 +88,7 @@ public class TcpServer {
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
                         new TcpServerChannelInitializer(config, connectionObserver)
                                 .andThen(getChannelInitializer(service, executionContext)), executionStrategy, TCP,
-                        connectionObserver, false),
+                        connectionObserver, false, __ -> false),
                 serverConnection -> service.apply(serverConnection)
                         .beforeOnError(throwable -> LOGGER.error("Error handling a connection.", throwable))
                         .beforeFinally(() -> serverConnection.closeAsync().subscribe())

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelOutboundListener.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelOutboundListener.java
@@ -28,11 +28,23 @@ interface ChannelOutboundListener {
     void channelWritable();
 
     /**
+     * Signals that further write operations can be continued.
+     */
+    void continueWriting();
+
+    /**
      * Notification that the channel's outbound side has been closed and will no longer accept writes.
      * <p>
      * Always called from the event loop thread.
      */
     void channelOutboundClosed();
+
+    /**
+     * Request to terminate the source of data.
+     * <p>
+     * Could happen if protocol supports termination/cancellation of the data it supposes to send.
+     */
+    void terminateSource();
 
     /**
      * Notification that the channel has been closed.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelOutboundListener.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelOutboundListener.java
@@ -40,9 +40,10 @@ interface ChannelOutboundListener {
     void channelOutboundClosed();
 
     /**
-     * Request to terminate the source of data.
+     * Request to terminate the source of data, without affecting a state of the channel.
      * <p>
-     * Could happen if protocol supports termination/cancellation of the data it supposes to send.
+     * Could happen if protocol supports termination/cancellation of the data it supposes to send, and the channel can
+     * be reused for next requests.
      */
     void terminateSource();
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -111,10 +111,11 @@ public abstract class CloseHandler {
     /**
      * Signal end of outbound payload, including the {@link ChannelPromise} associated with the last write. Must be
      * called from the {@link EventLoop} for the {@link Channel}.
-     * @param promise The {@link ChannelPromise} associated with the last write operation.
+     * @param promise The {@link ChannelPromise} associated with the last write operation or {@code null} if payload
+     * ends without a write operation (aborted/cancelled).
      * @param ctx {@link ChannelHandlerContext}
      */
-    public abstract void protocolPayloadEndOutbound(ChannelHandlerContext ctx, ChannelPromise promise);
+    public abstract void protocolPayloadEndOutbound(ChannelHandlerContext ctx, @Nullable ChannelPromise promise);
 
     /**
      * Signal inbound close command observed, to be emitted from the {@link EventLoop} for the {@link Channel}.
@@ -316,7 +317,8 @@ public abstract class CloseHandler {
         }
 
         @Override
-        public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, final ChannelPromise promise) {
+        public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx,
+                                               @Nullable final ChannelPromise promise) {
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/LoggingCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/LoggingCloseHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.logging.slf4j.internal.Slf4jFixedLevelLoggers.newLogger;
 
@@ -54,7 +55,7 @@ final class LoggingCloseHandler extends CloseHandler {
     }
 
     @Override
-    public void protocolPayloadEndOutbound(ChannelHandlerContext ctx, final ChannelPromise promise) {
+    public void protocolPayloadEndOutbound(ChannelHandlerContext ctx, @Nullable final ChannelPromise promise) {
         logger.log("{} protocolPayloadEndOutbound {}", ctx.channel(), delegate);
         delegate.protocolPayloadEndOutbound(ctx, promise);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
@@ -79,12 +79,18 @@ final class NonPipelinedCloseHandler extends CloseHandler {
     }
 
     @Override
-    public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, final ChannelPromise promise) {
-        ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
-        promise.addListener(f -> {
-            state = unset(state, WRITE);
-            outboundEventCheckClose(ctx.channel(), closeEvent);
-        });
+    public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, @Nullable final ChannelPromise promise) {
+        if (promise == null) {
+            protocolPayloadEndOutbound0(ctx);
+        } else {
+            ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
+            promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
+        }
+    }
+
+    private void protocolPayloadEndOutbound0(final ChannelHandlerContext ctx) {
+        state = unset(state, WRITE);
+        outboundEventCheckClose(ctx.channel(), closeEvent);
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
@@ -82,10 +82,10 @@ final class NonPipelinedCloseHandler extends CloseHandler {
     public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, @Nullable final ChannelPromise promise) {
         if (promise == null) {
             protocolPayloadEndOutbound0(ctx);
-        } else {
-            ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
-            promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
+            return;
         }
+        ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
+        promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
     }
 
     private void protocolPayloadEndOutbound0(final ChannelHandlerContext ctx) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -152,12 +152,12 @@ final class RequestResponseCloseHandler extends CloseHandler {
     public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, @Nullable final ChannelPromise promise) {
         if (promise == null) {
             protocolPayloadEndOutbound0(ctx);
-        } else {
-            if (isClient || closeEvent != null && pending == 0) {
-                ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
-            }
-            promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
+            return;
         }
+        if (isClient || (closeEvent != null && pending == 0)) {
+            ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
+        }
+        promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
     }
 
     private void protocolPayloadEndOutbound0(final ChannelHandlerContext ctx) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -150,12 +150,12 @@ final class RequestResponseCloseHandler extends CloseHandler {
 
     @Override
     public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, @Nullable final ChannelPromise promise) {
-        if (promise != null && (isClient || (closeEvent != null && pending == 0))) {
-            ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
-        }
         if (promise == null) {
             protocolPayloadEndOutbound0(ctx);
         } else {
+            if (isClient || closeEvent != null && pending == 0) {
+                ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
+            }
             promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
         }
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -149,17 +149,23 @@ final class RequestResponseCloseHandler extends CloseHandler {
     }
 
     @Override
-    public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, final ChannelPromise promise) {
-        if (isClient || (closeEvent != null && pending == 0)) {
+    public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, @Nullable final ChannelPromise promise) {
+        if (promise != null && (isClient || (closeEvent != null && pending == 0))) {
             ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
         }
-        promise.addListener(f -> {
-            state = unset(state, WRITE);
-            final CloseEvent evt = this.closeEvent;
-            if (evt != null) {
-                closeChannelHalfOrFullyOnPayloadEnd(ctx.channel(), evt, false);
-            }
-        });
+        if (promise == null) {
+            protocolPayloadEndOutbound0(ctx);
+        } else {
+            promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
+        }
+    }
+
+    private void protocolPayloadEndOutbound0(final ChannelHandlerContext ctx) {
+        state = unset(state, WRITE);
+        final CloseEvent evt = this.closeEvent;
+        if (evt != null) {
+            closeChannelHalfOrFullyOnPayloadEnd(ctx.channel(), evt, false);
+        }
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -174,7 +174,10 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             long capacityAfter = channel.bytesBeforeUnwritable();
             observer.itemWritten(msg);
             demandEstimator.onItemWrite(msg, capacityBefore, capacityAfter);
-            // Request more items only if there is no need to wait for continuation:
+            // Client-side always starts a request with request(1) to probe a Channel with meta-data before continuing
+            // to write the payload body, see https://github.com/apple/servicetalk/pull/1644.
+            // Requests that await feedback from the remote peer should not request more until they receive
+            // continueWriting() signal.
             if (!isClient || !(shouldWaitFlag = shouldWait.test(msg))) {
                 requestMoreIfRequired(subscription, capacityAfter);
             }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -215,8 +215,10 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
     @Override
     public void continueWriting() {
         assert eventLoop.inEventLoop();
-        shouldWaitFlag = false; // Reset the flag to avoid promise.sourceTerminated(null)
-        requestMoreIfRequired(subscription, -1L);
+        if (shouldWaitFlag) {
+            shouldWaitFlag = false; // Reset the flag to avoid promise.sourceTerminated(null)
+            requestMoreIfRequired(subscription, -1L);
+        }
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
@@ -108,10 +109,13 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
     private final CloseHandler closeHandler;
     private final WriteObserver observer;
     private final boolean isClient;
+    private final Predicate<Object> shouldWait;
+    private boolean shouldWaitFlag;
 
     WriteStreamSubscriber(Channel channel, WriteDemandEstimator demandEstimator, Subscriber subscriber,
                           CloseHandler closeHandler, WriteObserver observer,
-                          UnaryOperator<Throwable> enrichProtocolError, boolean isClient) {
+                          UnaryOperator<Throwable> enrichProtocolError, boolean isClient,
+                          Predicate<Object> shouldWait) {
         this.eventLoop = requireNonNull(channel.eventLoop());
         this.subscriber = subscriber;
         this.channel = channel;
@@ -120,6 +124,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
         this.closeHandler = closeHandler;
         this.observer = observer;
         this.isClient = isClient;
+        this.shouldWait = requireNonNull(shouldWait);
     }
 
     @Override
@@ -169,7 +174,10 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             long capacityAfter = channel.bytesBeforeUnwritable();
             observer.itemWritten(msg);
             demandEstimator.onItemWrite(msg, capacityBefore, capacityAfter);
-            requestMoreIfRequired(subscription, capacityAfter);
+            // Request more items only if there is no need to wait for continuation:
+            if (!isClient || !(shouldWaitFlag = shouldWait.test(msg))) {
+                requestMoreIfRequired(subscription, capacityAfter);
+            }
         }
     }
 
@@ -195,6 +203,19 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
     @Override
     public void channelWritable() {
         assert eventLoop.inEventLoop();
+        final Subscription subscription = this.subscription;
+        if (isClient && subscription != null && !promise.written) {
+            // If nothing was written, make initial requestN
+            initialRequestN(subscription);
+        } else {
+            requestMoreIfRequired(subscription, -1L);
+        }
+    }
+
+    @Override
+    public void continueWriting() {
+        assert eventLoop.inEventLoop();
+        shouldWaitFlag = false; // Reset the flag to avoid promise.sourceTerminated(null)
         requestMoreIfRequired(subscription, -1L);
     }
 
@@ -211,6 +232,16 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             sub.request(Long.MAX_VALUE);
         }
         promise.sourceTerminated(null);
+    }
+
+    @Override
+    public void terminateSource() {
+        assert eventLoop.inEventLoop();
+        // Terminate the source only if it awaits continuation.
+        if (shouldWaitFlag) {
+            assert promise.activeWrites == 0;   // We never start sending payload body until we receive 100 (Continue)
+            promise.sourceTerminated(null);
+        }
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -76,7 +76,8 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
                         }
                         ctx.write(msg, promise);
                     }
-                })), ExecutionStrategy.offloadNone(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, isClient)
+                })), ExecutionStrategy.offloadNone(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, isClient,
+                        __ -> false)
                 .toFuture().get();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -114,7 +114,8 @@ class DefaultNettyConnectionTest {
         CloseHandler closeHandler = closeHandlerFactory.apply(channel);
         conn = DefaultNettyConnection.<Buffer, Buffer>initChannel(channel, allocator, executor,
                 null, closeHandler, defaultFlushStrategy(), null, trailerProtocolEndEventEmitter(closeHandler),
-                offloadAll(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get();
+                offloadAll(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
+                .toFuture().get();
         publisher = new TestPublisher<>();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
@@ -51,7 +51,7 @@ class NettyChannelPublisherRefCountTest {
         publisher = DefaultNettyConnection.initChannel(channel,
                         DEFAULT_ALLOCATOR, immediate(), null, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER,
                         defaultFlushStrategy(), null, channel2 -> { }, offloadAll(), mock(Protocol.class),
-                        NoopConnectionObserver.INSTANCE, true).toFuture().get()
+                        NoopConnectionObserver.INSTANCE, true, __ -> false).toFuture().get()
                 .read();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
@@ -107,7 +107,8 @@ class NettyChannelPublisherTest {
                         closeHandler.protocolPayloadEndInbound(ctx);
                     }
                 }
-            }), offloadAll(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get();
+            }), offloadAll(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
+                        .toFuture().get();
         publisher = connection.read();
         channel.config().setAutoRead(false);
     }
@@ -155,7 +156,8 @@ class NettyChannelPublisherTest {
                             super.read(ctx);
                         }
                     });
-                }, offloadAll(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get();
+                }, offloadAll(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
+                .toFuture().get();
         publisher = connection.read();
         channel.config().setAutoRead(false);
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
@@ -69,7 +69,7 @@ class WriteStreamSubscriberFutureListenersTest {
         WriteDemandEstimator estimator = WriteDemandEstimators.newDefaultEstimator();
         TestCompletableSubscriber completableSubscriber = new TestCompletableSubscriber();
         subscriber = new WriteStreamSubscriber(channel, estimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         TestSubscription subscription = new TestSubscription();
         subscriber.onSubscribe(subscription);
         assertThat("No items requested.", subscription.requested(), greaterThan(0L));
@@ -173,7 +173,7 @@ class WriteStreamSubscriberFutureListenersTest {
         WriteDemandEstimator estimator = WriteDemandEstimators.newDefaultEstimator();
         TestCompletableSubscriber completableSubscriber = new TestCompletableSubscriber();
         WriteStreamSubscriber subscriber = new WriteStreamSubscriber(mockChannel, estimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         subscriber.onNext(1);
         verifyListenerInvokedWithSuccess(listeners.take());
         subscriber.onNext(2);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
@@ -46,7 +46,7 @@ class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventloopTest
         CompletableSource.Subscriber completableSubscriber = mock(CompletableSource.Subscriber.class);
         WriteDemandEstimator demandEstimator = mock(WriteDemandEstimator.class);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
     }
 
     @Test
@@ -104,7 +104,7 @@ class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventloopTest
         };
         WriteDemandEstimator demandEstimator = mock(WriteDemandEstimator.class);
         this.subscriber = new WriteStreamSubscriber(channel, demandEstimator, subscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
 
         this.subscriber.onNext(1);
         this.subscriber.onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
@@ -56,7 +56,7 @@ class WriteStreamSubscriberTest extends AbstractWriteTest {
         super.setUp();
         closeHandler = mock(CloseHandler.class);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber, closeHandler,
-                NoopWriteObserver.INSTANCE, identity(), false);
+                NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         subscription = mock(Subscription.class);
         when(demandEstimator.estimateRequestN(anyLong())).thenReturn(1L);
         subscriber.onSubscribe(subscription);
@@ -114,7 +114,7 @@ class WriteStreamSubscriberTest extends AbstractWriteTest {
     @Test
     void testCancelBeforeOnSubscribe() {
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         subscription = mock(Subscription.class);
         subscriber.cancel();
         subscriber.onSubscribe(subscription);
@@ -133,7 +133,7 @@ class WriteStreamSubscriberTest extends AbstractWriteTest {
     void testRequestMoreBeforeOnSubscribe() {
         reset(completableSubscriber);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         subscriber.channelWritable();
         subscription = mock(Subscription.class);
         subscriber.onSubscribe(subscription);
@@ -177,7 +177,7 @@ class WriteStreamSubscriberTest extends AbstractWriteTest {
         reset(completableSubscriber, demandEstimator);
         when(demandEstimator.estimateRequestN(anyLong())).thenReturn(10L);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), true);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), true, __ -> false);
         subscription = mock(Subscription.class);
         subscriber.onSubscribe(subscription);
         verify(subscription).request(1L);


### PR DESCRIPTION
Motivation:

Add support for `Expect: 100-continue` header to allow users deffer
sending request payload body until server signals that it's ready to
receive it.

Modification:

- Enhance `HttpObjectEncoder`, `HttpObjectDecoder`,
`AbstractH2DuplexHandler`, their subclasses, and `NettyHttpServer` to
support new feature;
- `DefaultNettyConnection`: add `ContinueUserEvent` and
`CancelWriteUserEvent`;
- `WriteStreamSubscriber`: add `continueWriting()` and
`terminateSource()` to support continuation;
- Fix `WriteStreamSubscriber#channelWritable()` to make
`initialRequestN` if subscription was assigned while a channel was not
writable;
- `RequestResponseCloseHandler` and `NonPipelinedCloseHandler`: fire
`OutboundDataEndEvent` only when it ends outbound data but not when
`CancelWriteUserEvent`;
- `HttpProtocolVersion`: implement `Comparable` interface to allow
easier version number comparison;
- `RetryingHttpRequesterFilter`: add `retryExpectationFailed(boolean)`
feature and public `ExpectationFailedException`;
- Test new behavior;
- Add docs section about `Expect: 100-continue` for http-api module;

Result:

HTTP supports `Expect: 100-continue` feature on client and server sides.