### PR TITLE
Add gRPC Debugging Example

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
@@ -96,6 +96,17 @@ https://grpc.io/docs/what-is-grpc/core-concepts/#deadlines[gRPC deadlines] (aka 
 – Sends hello requests to the server with 1 minute deadline and 3 second deadline and receives a greeting response
 within that time or cancels the request.
 
+[#Debugging]
+== Debugging
+
+Extends the blocking "Hello World" example to demonstrate configuration of debugging features.
+
+* link:{source-root}/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java[DebuggingServer]
+– Waits for hello request from the client and responds with a greeting response.
+* link:{source-root}/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java[DebuggingClient]
+– Sends hello requests to the server and receives a greeting response.
+
+
 [#Observer]
 == Observer
 This example demonstrates the following:

--- a/servicetalk-examples/grpc/debugging/README.adoc
+++ b/servicetalk-examples/grpc/debugging/README.adoc
@@ -1,0 +1,3 @@
+== ServiceTalk gRPC Debugging
+
+"Hello World" example of ServiceTalk gRPC extended to demonstrate configuring of debugging features.

--- a/servicetalk-examples/grpc/debugging/build.gradle
+++ b/servicetalk-examples/grpc/debugging/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-examples/grpc/debugging/build.gradle
+++ b/servicetalk-examples/grpc/debugging/build.gradle
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+  dependencies {
+    classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufGradlePluginVersion"
+  }
+}
+
+apply plugin: "java"
+apply plugin: "com.google.protobuf"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-grpc-netty")
+  implementation project(":servicetalk-grpc-protoc")
+  implementation project(":servicetalk-grpc-protobuf")
+
+  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+      "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
+  plugins {
+    servicetalk_grpc {
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+      //// "path" is used only because we want to use the gradle project local version of the plugin.
+      path = pluginJar.path
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+    }
+  }
+  generateProtoTasks {
+    all().each { task ->
+      //// REMOVE if outside of ServiceTalk gradle project
+      task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+      // you may need to manually add the artifact name as an input
+      task.inputs
+          .file(pluginJar)
+          .withNormalizer(ClasspathNormalizer)
+          .withPropertyName("servicetalkPluginJar")
+          .withPathSensitivity(PathSensitivity.RELATIVE)
+      //// REMOVE if outside of ServiceTalk gradle project
+
+      task.plugins {
+        servicetalk_grpc {
+          // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
+          // code for a single proto goes to a single file (e.g. "java_multiple_files = false" in the .proto).
+          outputSubDir = "java"
+        }
+      }
+    }
+  }
+  generatedFilesBaseDir = "$buildDir/generated/sources/proto"
+}

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
@@ -47,103 +47,54 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>
- * 2022-01-06 12:48:50,653                           main [DEBUG] AsyncContext                   - Enabled.
- * 2022-01-06 12:48:51,241 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888] REGISTERED
- * 2022-01-06 12:48:51,241 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888] CONNECT: localhost/127.0.0.1:8080
- * 2022-01-06 12:48:51,247 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] ACTIVE
- * 2022-01-06 12:48:51,248 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 24B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 50 52 49 20 2a 20 48 54 54 50 2f 32 2e 30 0d 0a |PRI * HTTP/2.0..|
- * |00000010| 0d 0a 53 4d 0d 0a 0d 0a                         |..SM....        |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,255 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
- * 2022-01-06 12:48:51,272 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 27B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 12 04 00 00 00 00 00 00 02 00 00 00 00 00 |................|
- * |00000010| 03 00 00 00 00 00 06 00 00 20 00                |......... .     |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,355 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /helloworld.Greeter/SayHello, user-agent: servicetalk-grpc/, te: trailers, content-type: application/grpc+proto, content-length: 12] padding=0 endStream=false
- * 2022-01-06 12:48:51,360 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 9B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 6c 01 04 00 00 00 03                      |..l......       |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,361 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 108B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 41 0e 6c 6f 63 61 6c 68 6f 73 74 3a 38 30 38 30 |A.localhost:8080|
- * |00000010| 83 86 44 1c 2f 68 65 6c 6c 6f 77 6f 72 6c 64 2e |..D./helloworld.|
- * |00000020| 47 72 65 65 74 65 72 2f 53 61 79 48 65 6c 6c 6f |Greeter/SayHello|
- * |00000030| 7a 11 73 65 72 76 69 63 65 74 61 6c 6b 2d 67 72 |z.servicetalk-gr|
- * |00000040| 70 63 2f 40 02 74 65 08 74 72 61 69 6c 65 72 73 |pc/@.te.trailers|
- * |00000050| 5f 16 61 70 70 6c 69 63 61 74 69 6f 6e 2f 67 72 |_.application/gr|
- * |00000060| 70 63 2b 70 72 6f 74 6f 5c 02 31 32             |pc+proto\.12    |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,374 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=12 bytes=00000000070a05576f726c64
- * 2022-01-06 12:48:51,374 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 9B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 0c 00 01 00 00 00 03                      |.........       |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,374 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 12B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 00 00 07 0a 05 57 6f 72 6c 64             |.......World    |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,375 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
- * 2022-01-06 12:48:51,378 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_REQUEST
- * 2022-01-06 12:48:51,486 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ: 24B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 06 04 00 00 00 00 00 00 06 00 00 20 00 00 |............. ..|
- * |00000010| 00 00 04 01 00 00 00 00                         |........        |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,489 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
- * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=true
- * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 9B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
- * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=true
- * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_COMPLETE
- * 2022-01-06 12:48:51,494 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
- * 2022-01-06 12:48:51,494 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_REQUEST
- * 2022-01-06 12:48:51,552 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ: 108B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 30 01 04 00 00 00 03 88 76 11 73 65 72 76 |..0.......v.serv|
- * |00000010| 69 63 65 74 61 6c 6b 2d 67 72 70 63 2f 5f 16 61 |icetalk-grpc/_.a|
- * |00000020| 70 70 6c 69 63 61 74 69 6f 6e 2f 67 72 70 63 2b |pplication/grpc+|
- * |00000030| 70 72 6f 74 6f 5c 02 31 38 00 00 12 00 00 00 00 |proto\.18.......|
- * |00000040| 00 03 00 00 00 00 0d 0a 0b 48 65 6c 6c 6f 20 57 |.........Hello W|
- * |00000050| 6f 72 6c 64 00 00 0f 01 05 00 00 00 03 40 0b 67 |orld.........@.g|
- * |00000060| 72 70 63 2d 73 74 61 74 75 73 01 30             |rpc-status.0    |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,555 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, server: servicetalk-grpc/, content-type: application/grpc+proto, content-length: 18] padding=0 endStream=false
- * 2022-01-06 12:48:51,563 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND DATA: streamId=3 padding=0 endStream=false length=18 bytes=000000000d0a0b48656c6c6f20576f726c64
- * 2022-01-06 12:48:51,564 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[grpc-status: 0] padding=0 endStream=true
- * 2022-01-06 12:48:51,566 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_COMPLETE
- * 2022-01-06 12:48:51,566 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
- * 2022-01-06 12:48:51,566 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
- * 2022-01-06 12:48:51,567 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_REQUEST
+ * 2022-01-10 10:34:46,942                           main [DEBUG] AsyncContext                   - Enabled.
+ * 2022-01-10 10:34:47,224                           main [DEBUG] GlobalDnsServiceDiscoverer     - Initialized HostAndPortClientInitializer
+ * 2022-01-10 10:34:47,324                           main [DEBUG] DefaultSingleAddressHttpClientBuilder - Client for localhost:8080 created with base strategy DEFAULT_HTTP_EXECUTION_STRATEGY → computed strategy DEFAULT_HTTP_EXECUTION_STRATEGY
+ * 2022-01-10 10:34:47,334 servicetalk-global-io-executor-1-1 [DEBUG] DefaultDnsClient               - DnsClient io.servicetalk.dns.discovery.netty.DefaultDnsClient@1a83d58e, sending events for address: A* lookups for localhost (size 1) [DefaultServiceDiscovererEvent{address=localhost/127.0.0.1, status=available}].
+ * 2022-01-10 10:34:47,334 servicetalk-global-io-executor-1-1 [DEBUG] RoundRobinLoadBalancer         - Load balancer for localhost:8080#1: received new ServiceDiscoverer event DefaultServiceDiscovererEvent{address=localhost/127.0.0.1:8080, status=available}. Inferred status: available.
+ * 2022-01-10 10:34:47,344 servicetalk-global-io-executor-1-1 [DEBUG] RoundRobinLoadBalancer         - Load balancer for localhost:8080#1: now using 1 addresses: [Host{address=localhost/127.0.0.1:8080, state=ACTIVE(failedConnections=0), #connections=0}].
+ * 2022-01-10 10:34:47,526 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52] REGISTERED
+ * 2022-01-10 10:34:47,526 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52] CONNECT: localhost/127.0.0.1:8080
+ * 2022-01-10 10:34:47,530 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] ACTIVE
+ * 2022-01-10 10:34:47,531 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] WRITE: 24B
+ * 2022-01-10 10:34:47,534 servicetalk-global-io-executor-1-2 [DEBUG] Recycler                       - -Dio.netty.recycler.maxCapacityPerThread: 4096
+ * 2022-01-10 10:34:47,534 servicetalk-global-io-executor-1-2 [DEBUG] Recycler                       - -Dio.netty.recycler.ratio: 8
+ * 2022-01-10 10:34:47,534 servicetalk-global-io-executor-1-2 [DEBUG] Recycler                       - -Dio.netty.recycler.chunkSize: 32
+ * 2022-01-10 10:34:47,536 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
+ * 2022-01-10 10:34:47,552 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] WRITE: 27B
+ * 2022-01-10 10:34:47,553 servicetalk-global-io-executor-1-2 [DEBUG] HttpDebugUtils                 - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] HTTP/2.0 pipeline initialized: ServiceTalkWireLogger#0, Http2FrameCodec#0, Http2MultiplexHandler#0, H2ClientParentConnectionContext$DefaultH2ClientParentConnection#0, DefaultChannelPipeline$TailContext#0
+ * 2022-01-10 10:34:47,562 servicetalk-global-io-executor-1-2 [DEBUG] PlatformDependent              - jctools Unbounded/ChunkedArrayQueue: available.
+ * 2022-01-10 10:34:47,587 servicetalk-global-io-executor-1-2 [DEBUG] CloseHandler                   - io.servicetalk.transport.netty.internal.CloseHandler.LogLevel=null
+ * 2022-01-10 10:34:47,639 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] OUTBOUND HEADERS: streamId=3 headers=8 padding=0 endStream=false
+ * 2022-01-10 10:34:47,644 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] WRITE: 9B
+ * 2022-01-10 10:34:47,645 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] WRITE: 108B
+ * 2022-01-10 10:34:47,657 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=12
+ * 2022-01-10 10:34:47,657 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] WRITE: 9B
+ * 2022-01-10 10:34:47,657 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] WRITE: 12B
+ * 2022-01-10 10:34:47,658 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-10 10:34:47,661 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] READ_REQUEST
+ * 2022-01-10 10:34:47,777 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] READ: 24B
+ * 2022-01-10 10:34:47,780 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
+ * 2022-01-10 10:34:47,784 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=true
+ * 2022-01-10 10:34:47,784 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] WRITE: 9B
+ * 2022-01-10 10:34:47,784 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-10 10:34:47,784 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=true
+ * 2022-01-10 10:34:47,784 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] READ_COMPLETE
+ * 2022-01-10 10:34:47,785 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-10 10:34:47,785 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] READ_REQUEST
+ * 2022-01-10 10:34:47,847 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] READ: 108B
+ * 2022-01-10 10:34:47,849 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] INBOUND HEADERS: streamId=3 headers=4 padding=0 endStream=false
+ * 2022-01-10 10:34:47,858 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] INBOUND DATA: streamId=3 padding=0 endStream=false length=18
+ * 2022-01-10 10:34:47,859 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] INBOUND HEADERS: streamId=3 headers=1 padding=0 endStream=true
+ * 2022-01-10 10:34:47,861 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] READ_COMPLETE
+ * 2022-01-10 10:34:47,861 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-10 10:34:47,861 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-10 10:34:47,861 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] READ_REQUEST
  * message: "Hello World"
  *
- * 2022-01-06 12:48:51,623 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] CLOSE
- * 2022-01-06 12:48:51,624 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 ! R:localhost/127.0.0.1:8080] INACTIVE
- * 2022-01-06 12:48:51,624 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 ! R:localhost/127.0.0.1:8080] UNREGISTERED
+ * 2022-01-10 10:34:47,913 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 - R:localhost/127.0.0.1:8080] CLOSE
+ * 2022-01-10 10:34:47,914 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 ! R:localhost/127.0.0.1:8080] INACTIVE
+ * 2022-01-10 10:34:47,914 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1ae4aa52, L:/127.0.0.1:51110 ! R:localhost/127.0.0.1:8080] UNREGISTERED
  * </pre>
  */
 public final class DebuggingClient {
@@ -169,18 +120,24 @@ public final class DebuggingClient {
                          */
                         // .executionStrategy(HHttpExecutionStrategies.offloadNever())
                         /*
-                         * 3. Enables detailed logging of I/O and I/O states.
-                         * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                         * 3. Enables detailed logging of I/O and I/O states, but not payload bodies.
+                         * Be sure to also enable the logger in your logging config file,
+                         * {@code log4j2.xml} for this example.
+                         * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                         * {@code Boolean.TRUE::booleanValue}.
                          */
-                        .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                        .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.FALSE::booleanValue)
 
                         /*
-                         * 4. Enables detailed logging of HTTP2 frames.
-                         * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                         * 4. Enables detailed logging of HTTP2 frames, but not frame contents.
+                         * Be sure to also enable the logger in your logging config file,
+                         * {@code log4j2.xml} for this example.
+                         * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                         * {@code Boolean.TRUE::booleanValue}.
                          */
                         .protocols(HttpProtocolConfigs.h2()
                                 .enableFrameLogging(
-                                        "servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
+                                        "servicetalk-examples-h2-frame-logger", TRACE, Boolean.FALSE::booleanValue)
                                 .build()))
                 .buildBlocking(new ClientFactory())) {
             HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName("World").build());

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.debugging;
+
+import io.servicetalk.grpc.netty.GrpcClients;
+import io.servicetalk.http.netty.HttpProtocolConfigs;
+
+import io.grpc.examples.debugging.Greeter.BlockingGreeterClient;
+import io.grpc.examples.debugging.Greeter.ClientFactory;
+import io.grpc.examples.debugging.HelloReply;
+import io.grpc.examples.debugging.HelloRequest;
+
+import static io.servicetalk.logging.api.LogLevel.TRACE;
+
+public final class DebuggingClient {
+    public static void main(String[] args) throws Exception {
+        try (BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)
+                .initializeHttp(builder -> builder.enableWireLogging(
+                                "servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                        .protocols(HttpProtocolConfigs.h2()
+                                .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
+                                .build()))
+                .buildBlocking(new ClientFactory())) {
+            HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName("World").build());
+            System.out.println(reply);
+        }
+    }
+}

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
@@ -15,23 +15,172 @@
  */
 package io.servicetalk.examples.grpc.debugging;
 
+import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.grpc.netty.GrpcClients;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.netty.H2ProtocolConfigBuilder;
 import io.servicetalk.http.netty.HttpProtocolConfigs;
+import io.servicetalk.logging.api.LogLevel;
 
 import io.grpc.examples.debugging.Greeter.BlockingGreeterClient;
 import io.grpc.examples.debugging.Greeter.ClientFactory;
 import io.grpc.examples.debugging.HelloReply;
 import io.grpc.examples.debugging.HelloRequest;
 
+import java.util.function.BooleanSupplier;
+
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 
+/**
+ * The blocking "Hello World" example with debugging features enabled. Five debugging features are demonstrated:
+ * <ol>
+ *     <li>Disabling {@link AsyncContext}</li>
+ *     <li>Disabling {@link HttpExecutionStrategy offloading}</li>
+ *     <li>Enabling {@link SingleAddressHttpClientBuilder#enableWireLogging(String, LogLevel, BooleanSupplier) HTTP wire logging}</li>
+ *     <li>Enabling {@link H2ProtocolConfigBuilder#enableFrameLogging(String, LogLevel, BooleanSupplier) HTTP/2 frame logging}</li>
+ *     <li>Enabling additional logger verbosity in the {@code log4j2.xml} configuration file</li>
+ * </ol>
+ * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
+ * example {@code log4j2.xml} is used by both the client and server and configures the
+ * ({@code servicetalk-examples-wire-logger} logger at {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level.
+ *
+ * <p>When configured correctly the output should be similar to the following:
+ * <pre>
+ * 2022-01-06 12:48:50,653                           main [DEBUG] AsyncContext                   - Enabled.
+ * 2022-01-06 12:48:51,241 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888] REGISTERED
+ * 2022-01-06 12:48:51,241 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888] CONNECT: localhost/127.0.0.1:8080
+ * 2022-01-06 12:48:51,247 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] ACTIVE
+ * 2022-01-06 12:48:51,248 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 24B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 50 52 49 20 2a 20 48 54 54 50 2f 32 2e 30 0d 0a |PRI * HTTP/2.0..|
+ * |00000010| 0d 0a 53 4d 0d 0a 0d 0a                         |..SM....        |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,255 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
+ * 2022-01-06 12:48:51,272 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 27B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 12 04 00 00 00 00 00 00 02 00 00 00 00 00 |................|
+ * |00000010| 03 00 00 00 00 00 06 00 00 20 00                |......... .     |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,355 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /helloworld.Greeter/SayHello, user-agent: servicetalk-grpc/, te: trailers, content-type: application/grpc+proto, content-length: 12] padding=0 endStream=false
+ * 2022-01-06 12:48:51,360 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 9B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 6c 01 04 00 00 00 03                      |..l......       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,361 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 108B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 41 0e 6c 6f 63 61 6c 68 6f 73 74 3a 38 30 38 30 |A.localhost:8080|
+ * |00000010| 83 86 44 1c 2f 68 65 6c 6c 6f 77 6f 72 6c 64 2e |..D./helloworld.|
+ * |00000020| 47 72 65 65 74 65 72 2f 53 61 79 48 65 6c 6c 6f |Greeter/SayHello|
+ * |00000030| 7a 11 73 65 72 76 69 63 65 74 61 6c 6b 2d 67 72 |z.servicetalk-gr|
+ * |00000040| 70 63 2f 40 02 74 65 08 74 72 61 69 6c 65 72 73 |pc/@.te.trailers|
+ * |00000050| 5f 16 61 70 70 6c 69 63 61 74 69 6f 6e 2f 67 72 |_.application/gr|
+ * |00000060| 70 63 2b 70 72 6f 74 6f 5c 02 31 32             |pc+proto\.12    |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,374 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=12 bytes=00000000070a05576f726c64
+ * 2022-01-06 12:48:51,374 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 9B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 0c 00 01 00 00 00 03                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,374 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 12B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 00 00 07 0a 05 57 6f 72 6c 64             |.......World    |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,375 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-06 12:48:51,378 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_REQUEST
+ * 2022-01-06 12:48:51,486 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ: 24B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 06 04 00 00 00 00 00 00 06 00 00 20 00 00 |............. ..|
+ * |00000010| 00 00 04 01 00 00 00 00                         |........        |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,489 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
+ * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] OUTBOUND SETTINGS: ack=true
+ * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] WRITE: 9B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND SETTINGS: ack=true
+ * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_COMPLETE
+ * 2022-01-06 12:48:51,494 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-06 12:48:51,494 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_REQUEST
+ * 2022-01-06 12:48:51,552 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ: 108B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 30 01 04 00 00 00 03 88 76 11 73 65 72 76 |..0.......v.serv|
+ * |00000010| 69 63 65 74 61 6c 6b 2d 67 72 70 63 2f 5f 16 61 |icetalk-grpc/_.a|
+ * |00000020| 70 70 6c 69 63 61 74 69 6f 6e 2f 67 72 70 63 2b |pplication/grpc+|
+ * |00000030| 70 72 6f 74 6f 5c 02 31 38 00 00 12 00 00 00 00 |proto\.18.......|
+ * |00000040| 00 03 00 00 00 00 0d 0a 0b 48 65 6c 6c 6f 20 57 |.........Hello W|
+ * |00000050| 6f 72 6c 64 00 00 0f 01 05 00 00 00 03 40 0b 67 |orld.........@.g|
+ * |00000060| 72 70 63 2d 73 74 61 74 75 73 01 30             |rpc-status.0    |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,555 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, server: servicetalk-grpc/, content-type: application/grpc+proto, content-length: 18] padding=0 endStream=false
+ * 2022-01-06 12:48:51,563 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND DATA: streamId=3 padding=0 endStream=false length=18 bytes=000000000d0a0b48656c6c6f20576f726c64
+ * 2022-01-06 12:48:51,564 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[grpc-status: 0] padding=0 endStream=true
+ * 2022-01-06 12:48:51,566 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_COMPLETE
+ * 2022-01-06 12:48:51,566 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-06 12:48:51,566 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] FLUSH
+ * 2022-01-06 12:48:51,567 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] READ_REQUEST
+ * message: "Hello World"
+ *
+ * 2022-01-06 12:48:51,623 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 - R:localhost/127.0.0.1:8080] CLOSE
+ * 2022-01-06 12:48:51,624 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 ! R:localhost/127.0.0.1:8080] INACTIVE
+ * 2022-01-06 12:48:51,624 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x35810888, L:/127.0.0.1:55604 ! R:localhost/127.0.0.1:8080] UNREGISTERED
+ * </pre>
+ */
 public final class DebuggingClient {
+
+    static {
+        /*
+         * 1. (optional) Disables the AsyncContext associated with individual request/responses to reduce stack-trace
+         * depth and simplify execution tracing. This will disable/break some features such as request tracing,
+         * authentication, propagated timeouts, etc. that rely upon the AsyncContext so should only be disabled when
+         * necessary for debugging:
+         */
+        // AsyncContext.disable();
+    }
+
     public static void main(String[] args) throws Exception {
         try (BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)
-                .initializeHttp(builder -> builder.enableWireLogging(
-                                "servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                .initializeHttp(builder -> builder
+                        /*
+                         * 2. Disables most asynchronous offloading to simplify execution tracing. Changing this may
+                         * significantly change application behavior and introduce unexpected blocking. It is most
+                         * useful for being able to directly trace through situations that would normally involve a
+                         * thread handoff.
+                         */
+                        // .executionStrategy(HHttpExecutionStrategies.offloadNever())
+                        /*
+                         * 3. Enables detailed logging of I/O and I/O states.
+                         * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                         */
+                        .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+
+                        /*
+                         * 4. Enables detailed logging of HTTP2 frames.
+                         * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                         */
                         .protocols(HttpProtocolConfigs.h2()
-                                .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
+                                .enableFrameLogging(
+                                        "servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
                                 .build()))
                 .buildBlocking(new ClientFactory())) {
             HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName("World").build());

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
@@ -41,112 +41,58 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>
- * 2022-01-06 12:48:31,903                           main [DEBUG] AsyncContext                   - Enabled.
- * 2022-01-06 12:48:51,363 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
- * 2022-01-06 12:48:51,382 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 15B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 06 04 00 00 00 00 00 00 06 00 00 20 00    |............. . |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,384 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] REGISTERED
- * 2022-01-06 12:48:51,384 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] ACTIVE
- * 2022-01-06 12:48:51,384 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
- * 2022-01-06 12:48:51,385 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ: 189B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 50 52 49 20 2a 20 48 54 54 50 2f 32 2e 30 0d 0a |PRI * HTTP/2.0..|
- * |00000010| 0d 0a 53 4d 0d 0a 0d 0a 00 00 12 04 00 00 00 00 |..SM............|
- * |00000020| 00 00 02 00 00 00 00 00 03 00 00 00 00 00 06 00 |................|
- * |00000030| 00 20 00 00 00 6c 01 04 00 00 00 03 41 0e 6c 6f |. ...l......A.lo|
- * |00000040| 63 61 6c 68 6f 73 74 3a 38 30 38 30 83 86 44 1c |calhost:8080..D.|
- * |00000050| 2f 68 65 6c 6c 6f 77 6f 72 6c 64 2e 47 72 65 65 |/helloworld.Gree|
- * |00000060| 74 65 72 2f 53 61 79 48 65 6c 6c 6f 7a 11 73 65 |ter/SayHelloz.se|
- * |00000070| 72 76 69 63 65 74 61 6c 6b 2d 67 72 70 63 2f 40 |rvicetalk-grpc/@|
- * |00000080| 02 74 65 08 74 72 61 69 6c 65 72 73 5f 16 61 70 |.te.trailers_.ap|
- * |00000090| 70 6c 69 63 61 74 69 6f 6e 2f 67 72 70 63 2b 70 |plication/grpc+p|
- * |000000a0| 72 6f 74 6f 5c 02 31 32 00 00 0c 00 01 00 00 00 |roto\.12........|
- * |000000b0| 03 00 00 00 00 07 0a 05 57 6f 72 6c 64          |........World   |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,388 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] INBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
- * 2022-01-06 12:48:51,389 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND SETTINGS: ack=true
- * 2022-01-06 12:48:51,389 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 9B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,398 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /helloworld.Greeter/SayHello, user-agent: servicetalk-grpc/, te: trailers, content-type: application/grpc+proto, content-length: 12] padding=0 endStream=false
- * 2022-01-06 12:48:51,477 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] INBOUND DATA: streamId=3 padding=0 endStream=true length=12 bytes=00000000070a05576f726c64
- * 2022-01-06 12:48:51,483 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_COMPLETE
- * 2022-01-06 12:48:51,483 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
- * 2022-01-06 12:48:51,484 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
- * 2022-01-06 12:48:51,484 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
- * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ: 9B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] INBOUND SETTINGS: ack=true
- * 2022-01-06 12:48:51,495 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_COMPLETE
- * 2022-01-06 12:48:51,495 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
- * 2022-01-06 12:48:51,495 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
- * 2022-01-06 12:48:51,540 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, server: servicetalk-grpc/, content-type: application/grpc+proto, content-length: 18] padding=0 endStream=false
- * 2022-01-06 12:48:51,541 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 9B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 30 01 04 00 00 00 03                      |..0......       |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,541 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 48B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 88 76 11 73 65 72 76 69 63 65 74 61 6c 6b 2d 67 |.v.servicetalk-g|
- * |00000010| 72 70 63 2f 5f 16 61 70 70 6c 69 63 61 74 69 6f |rpc/_.applicatio|
- * |00000020| 6e 2f 67 72 70 63 2b 70 72 6f 74 6f 5c 02 31 38 |n/grpc+proto\.18|
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,549 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND DATA: streamId=3 padding=0 endStream=false length=18 bytes=000000000d0a0b48656c6c6f20576f726c64
- * 2022-01-06 12:48:51,549 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 9B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 12 00 00 00 00 00 03                      |.........       |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,549 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 18B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 00 00 0d 0a 0b 48 65 6c 6c 6f 20 57 6f 72 |.......Hello Wor|
- * |00000010| 6c 64                                           |ld              |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,550 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[grpc-status: 0] padding=0 endStream=true
- * 2022-01-06 12:48:51,550 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 9B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 00 00 0f 01 05 00 00 00 03                      |.........       |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,550 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 15B
- * +-------------------------------------------------+
- * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
- * +--------+-------------------------------------------------+----------------+
- * |00000000| 40 0b 67 72 70 63 2d 73 74 61 74 75 73 01 30    |@.grpc-status.0 |
- * +--------+-------------------------------------------------+----------------+
- * 2022-01-06 12:48:51,552 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
- * 2022-01-06 12:48:51,623 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_COMPLETE
- * 2022-01-06 12:48:51,623 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
- * 2022-01-06 12:48:51,623 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
- * 2022-01-06 12:48:51,626 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] USER_EVENT: io.netty.channel.socket.ChannelInputShutdownEvent@414f7489
- * 2022-01-06 12:48:51,628 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_COMPLETE
- * 2022-01-06 12:48:51,629 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
- * 2022-01-06 12:48:51,629 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
- * 2022-01-06 12:48:51,629 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] USER_EVENT: io.netty.channel.socket.ChannelInputShutdownReadComplete@1a6252d6
- * 2022-01-06 12:48:51,629 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] CLOSE
- * 2022-01-06 12:48:51,631 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 ! R:/127.0.0.1:55604] INACTIVE
- * 2022-01-06 12:48:51,631 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 ! R:/127.0.0.1:55604] UNREGISTERED
+ * 2022-01-10 10:34:34,345                           main [DEBUG] AsyncContext                   - Enabled.
+ * 2022-01-10 10:34:34,646                           main [DEBUG] GlobalExecutionContext         - Initialized GlobalExecutionContext
+ * 2022-01-10 10:34:34,658                           main [DEBUG] GrpcRouter                     - route strategy for path=/helloworld.Greeter/SayHello : ctx=DEFAULT_HTTP_EXECUTION_STRATEGY route=null → using=OFFLOAD_NEVER_STRATEGY
+ * 2022-01-10 10:34:34,803 servicetalk-global-io-executor-1-1 [DEBUG] H2ServerParentConnectionContext - Started HTTP/2 server with prior-knowledge for address /[0:0:0:0:0:0:0:0%0]:8080
+ * 2022-01-10 10:34:34,804 servicetalk-global-io-executor-1-1 [DEBUG] DefaultHttpServerBuilder       - Server for address /[0:0:0:0:0:0:0:0%0]:8080 uses strategy DEFAULT_HTTP_EXECUTION_STRATEGY
+ * 2022-01-10 10:34:47,649 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] OUTBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
+ * 2022-01-10 10:34:47,654 servicetalk-global-io-executor-1-2 [DEBUG] Recycler                       - -Dio.netty.recycler.maxCapacityPerThread: 4096
+ * 2022-01-10 10:34:47,654 servicetalk-global-io-executor-1-2 [DEBUG] Recycler                       - -Dio.netty.recycler.ratio: 8
+ * 2022-01-10 10:34:47,654 servicetalk-global-io-executor-1-2 [DEBUG] Recycler                       - -Dio.netty.recycler.chunkSize: 32
+ * 2022-01-10 10:34:47,669 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] WRITE: 15B
+ * 2022-01-10 10:34:47,671 servicetalk-global-io-executor-1-2 [DEBUG] HttpDebugUtils                 - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] HTTP/2.0 pipeline initialized: TcpServerBinder$2#0, ServiceTalkWireLogger#0, Http2FrameCodec#0, Http2MultiplexHandler#0, H2ServerParentConnectionContext$DefaultH2ServerParentConnection#0, DefaultChannelPipeline$TailContext#0
+ * 2022-01-10 10:34:47,671 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] REGISTERED
+ * 2022-01-10 10:34:47,672 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] ACTIVE
+ * 2022-01-10 10:34:47,672 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ_REQUEST
+ * 2022-01-10 10:34:47,672 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ: 189B
+ * 2022-01-10 10:34:47,675 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] INBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
+ * 2022-01-10 10:34:47,676 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] OUTBOUND SETTINGS: ack=true
+ * 2022-01-10 10:34:47,676 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] WRITE: 9B
+ * 2022-01-10 10:34:47,685 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] INBOUND HEADERS: streamId=3 headers=8 padding=0 endStream=false
+ * 2022-01-10 10:34:47,693 servicetalk-global-io-executor-1-2 [DEBUG] CloseHandler                   - io.servicetalk.transport.netty.internal.CloseHandler.LogLevel=null
+ * 2022-01-10 10:34:47,768 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] INBOUND DATA: streamId=3 padding=0 endStream=true length=12
+ * 2022-01-10 10:34:47,774 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ_COMPLETE
+ * 2022-01-10 10:34:47,774 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] FLUSH
+ * 2022-01-10 10:34:47,775 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] FLUSH
+ * 2022-01-10 10:34:47,775 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ_REQUEST
+ * 2022-01-10 10:34:47,779 servicetalk-global-executor-1-2 [DEBUG] PlatformDependent              - jctools Unbounded/ChunkedArrayQueue: available.
+ * 2022-01-10 10:34:47,784 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ: 9B
+ * 2022-01-10 10:34:47,784 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] INBOUND SETTINGS: ack=true
+ * 2022-01-10 10:34:47,786 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ_COMPLETE
+ * 2022-01-10 10:34:47,786 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] FLUSH
+ * 2022-01-10 10:34:47,786 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ_REQUEST
+ * 2022-01-10 10:34:47,835 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] OUTBOUND HEADERS: streamId=3 headers=4 padding=0 endStream=false
+ * 2022-01-10 10:34:47,837 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] WRITE: 9B
+ * 2022-01-10 10:34:47,837 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] WRITE: 48B
+ * 2022-01-10 10:34:47,845 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] OUTBOUND DATA: streamId=3 padding=0 endStream=false length=18
+ * 2022-01-10 10:34:47,845 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] WRITE: 9B
+ * 2022-01-10 10:34:47,845 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] WRITE: 18B
+ * 2022-01-10 10:34:47,845 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] OUTBOUND HEADERS: streamId=3 headers=1 padding=0 endStream=true
+ * 2022-01-10 10:34:47,846 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] WRITE: 9B
+ * 2022-01-10 10:34:47,846 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] WRITE: 15B
+ * 2022-01-10 10:34:47,847 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] FLUSH
+ * 2022-01-10 10:34:47,913 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ_COMPLETE
+ * 2022-01-10 10:34:47,913 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] FLUSH
+ * 2022-01-10 10:34:47,913 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ_REQUEST
+ * 2022-01-10 10:34:47,916 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] USER_EVENT: class io.netty.channel.socket.ChannelInputShutdownEvent
+ * 2022-01-10 10:34:47,919 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ_COMPLETE
+ * 2022-01-10 10:34:47,919 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] FLUSH
+ * 2022-01-10 10:34:47,919 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] READ_REQUEST
+ * 2022-01-10 10:34:47,919 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] USER_EVENT: class io.netty.channel.socket.ChannelInputShutdownReadComplete
+ * 2022-01-10 10:34:47,919 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 - R:/127.0.0.1:51110] CLOSE
+ * 2022-01-10 10:34:47,920 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 ! R:/127.0.0.1:51110] INACTIVE
+ * 2022-01-10 10:34:47,920 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x9e2eae25, L:/127.0.0.1:8080 ! R:/127.0.0.1:51110] UNREGISTERED
  * </pre>
  */
 public final class DebuggingServer {
@@ -173,18 +119,24 @@ public final class DebuggingServer {
                              */
                             //.executionStrategy(HttpExecutionStrategies.offloadNever())
                             /*
-                             * 3. Enables detailed logging of I/O and I/O states.
-                             * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                             * 3. Enables detailed logging of I/O and I/O states, but not payload bodies.
+                             * Be sure to also enable the logger in your logging config file,
+                             * {@code log4j2.xml} for this example.
+                             * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                             * {@code Boolean.TRUE::booleanValue}.
                              */
-                            .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                            .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.FALSE::booleanValue)
 
                             /*
-                             * 4. Enables detailed logging of HTTP2 frames.
-                             * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                             * 4. Enables detailed logging of HTTP2 frames, but not frame contents.
+                             * Be sure to also enable the logger in your logging config file,
+                             * {@code log4j2.xml} for this example.
+                             * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                             * {@code Boolean.TRUE::booleanValue}.
                              */
                             .protocols(HttpProtocolConfigs.h2()
                                     .enableFrameLogging(
-                                            "servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
+                                            "servicetalk-examples-h2-frame-logger", TRACE, Boolean.FALSE::booleanValue)
                                     .build());
                 })
                 .listenAndAwait((BlockingGreeterService) (ctx, request) ->

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
@@ -17,17 +17,171 @@ package io.servicetalk.examples.grpc.debugging;
 
 import io.servicetalk.grpc.netty.GrpcServers;
 import io.servicetalk.http.netty.HttpProtocolConfigs;
+import io.servicetalk.logging.api.LogLevel;
 
 import io.grpc.examples.debugging.Greeter.BlockingGreeterService;
 import io.grpc.examples.debugging.HelloReply;
 
+import java.util.function.BooleanSupplier;
+
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 
+/**
+ * The blocking "Hello World" example with debugging features enabled. Five debugging features are demonstrated:
+ * <ol>
+ *     <li>Disabling {@link io.servicetalk.concurrent.api.AsyncContext}</li>
+ *     <li>Disabling {@link io.servicetalk.http.api.HttpExecutionStrategy offloading}</li>
+ *     <li>Enabling {@link io.servicetalk.http.api.SingleAddressHttpClientBuilder#enableWireLogging(String, LogLevel, BooleanSupplier) HTTP wire logging}</li>
+ *     <li>Enabling {@link io.servicetalk.http.netty.H2ProtocolConfigBuilder#enableFrameLogging(String, LogLevel, BooleanSupplier) HTTP/2 frame logging}</li>
+ *     <li>Enabling additional logger verbosity in the {@code log4j2.xml} configuration file</li>
+ * </ol>
+ * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
+ * example {@code log4j2.xml} is used by both the client and server and configures the
+ * ({@code servicetalk-examples-wire-logger} logger at {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level.
+ *
+ * <p>When configured correctly the output should be similar to the following:
+ * <pre>
+ * 2022-01-06 12:48:31,903                           main [DEBUG] AsyncContext                   - Enabled.
+ * 2022-01-06 12:48:51,363 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND SETTINGS: ack=false settings={MAX_HEADER_LIST_SIZE=8192}
+ * 2022-01-06 12:48:51,382 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 15B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 06 04 00 00 00 00 00 00 06 00 00 20 00    |............. . |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,384 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] REGISTERED
+ * 2022-01-06 12:48:51,384 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] ACTIVE
+ * 2022-01-06 12:48:51,384 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
+ * 2022-01-06 12:48:51,385 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ: 189B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 50 52 49 20 2a 20 48 54 54 50 2f 32 2e 30 0d 0a |PRI * HTTP/2.0..|
+ * |00000010| 0d 0a 53 4d 0d 0a 0d 0a 00 00 12 04 00 00 00 00 |..SM............|
+ * |00000020| 00 00 02 00 00 00 00 00 03 00 00 00 00 00 06 00 |................|
+ * |00000030| 00 20 00 00 00 6c 01 04 00 00 00 03 41 0e 6c 6f |. ...l......A.lo|
+ * |00000040| 63 61 6c 68 6f 73 74 3a 38 30 38 30 83 86 44 1c |calhost:8080..D.|
+ * |00000050| 2f 68 65 6c 6c 6f 77 6f 72 6c 64 2e 47 72 65 65 |/helloworld.Gree|
+ * |00000060| 74 65 72 2f 53 61 79 48 65 6c 6c 6f 7a 11 73 65 |ter/SayHelloz.se|
+ * |00000070| 72 76 69 63 65 74 61 6c 6b 2d 67 72 70 63 2f 40 |rvicetalk-grpc/@|
+ * |00000080| 02 74 65 08 74 72 61 69 6c 65 72 73 5f 16 61 70 |.te.trailers_.ap|
+ * |00000090| 70 6c 69 63 61 74 69 6f 6e 2f 67 72 70 63 2b 70 |plication/grpc+p|
+ * |000000a0| 72 6f 74 6f 5c 02 31 32 00 00 0c 00 01 00 00 00 |roto\.12........|
+ * |000000b0| 03 00 00 00 00 07 0a 05 57 6f 72 6c 64          |........World   |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,388 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] INBOUND SETTINGS: ack=false settings={ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=0, MAX_HEADER_LIST_SIZE=8192}
+ * 2022-01-06 12:48:51,389 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND SETTINGS: ack=true
+ * 2022-01-06 12:48:51,389 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 9B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,398 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:authority: localhost:8080, :method: POST, :scheme: http, :path: /helloworld.Greeter/SayHello, user-agent: servicetalk-grpc/, te: trailers, content-type: application/grpc+proto, content-length: 12] padding=0 endStream=false
+ * 2022-01-06 12:48:51,477 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] INBOUND DATA: streamId=3 padding=0 endStream=true length=12 bytes=00000000070a05576f726c64
+ * 2022-01-06 12:48:51,483 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_COMPLETE
+ * 2022-01-06 12:48:51,483 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
+ * 2022-01-06 12:48:51,484 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
+ * 2022-01-06 12:48:51,484 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
+ * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ: 9B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 00 04 01 00 00 00 00                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,493 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] INBOUND SETTINGS: ack=true
+ * 2022-01-06 12:48:51,495 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_COMPLETE
+ * 2022-01-06 12:48:51,495 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
+ * 2022-01-06 12:48:51,495 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
+ * 2022-01-06 12:48:51,540 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, server: servicetalk-grpc/, content-type: application/grpc+proto, content-length: 18] padding=0 endStream=false
+ * 2022-01-06 12:48:51,541 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 9B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 30 01 04 00 00 00 03                      |..0......       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,541 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 48B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 88 76 11 73 65 72 76 69 63 65 74 61 6c 6b 2d 67 |.v.servicetalk-g|
+ * |00000010| 72 70 63 2f 5f 16 61 70 70 6c 69 63 61 74 69 6f |rpc/_.applicatio|
+ * |00000020| 6e 2f 67 72 70 63 2b 70 72 6f 74 6f 5c 02 31 38 |n/grpc+proto\.18|
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,549 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND DATA: streamId=3 padding=0 endStream=false length=18 bytes=000000000d0a0b48656c6c6f20576f726c64
+ * 2022-01-06 12:48:51,549 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 9B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 12 00 00 00 00 00 03                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,549 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 18B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 00 00 0d 0a 0b 48 65 6c 6c 6f 20 57 6f 72 |.......Hello Wor|
+ * |00000010| 6c 64                                           |ld              |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,550 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-h2-frame-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] OUTBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[grpc-status: 0] padding=0 endStream=true
+ * 2022-01-06 12:48:51,550 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 9B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 00 00 0f 01 05 00 00 00 03                      |.........       |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,550 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] WRITE: 15B
+ * +-------------------------------------------------+
+ * |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ * +--------+-------------------------------------------------+----------------+
+ * |00000000| 40 0b 67 72 70 63 2d 73 74 61 74 75 73 01 30    |@.grpc-status.0 |
+ * +--------+-------------------------------------------------+----------------+
+ * 2022-01-06 12:48:51,552 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
+ * 2022-01-06 12:48:51,623 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_COMPLETE
+ * 2022-01-06 12:48:51,623 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
+ * 2022-01-06 12:48:51,623 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
+ * 2022-01-06 12:48:51,626 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] USER_EVENT: io.netty.channel.socket.ChannelInputShutdownEvent@414f7489
+ * 2022-01-06 12:48:51,628 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_COMPLETE
+ * 2022-01-06 12:48:51,629 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] FLUSH
+ * 2022-01-06 12:48:51,629 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] READ_REQUEST
+ * 2022-01-06 12:48:51,629 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] USER_EVENT: io.netty.channel.socket.ChannelInputShutdownReadComplete@1a6252d6
+ * 2022-01-06 12:48:51,629 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 - R:/127.0.0.1:55604] CLOSE
+ * 2022-01-06 12:48:51,631 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 ! R:/127.0.0.1:55604] INACTIVE
+ * 2022-01-06 12:48:51,631 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0x1647dcf1, L:/127.0.0.1:8080 ! R:/127.0.0.1:55604] UNREGISTERED
+ * </pre>
+ */
 public final class DebuggingServer {
+
+    static {
+        /*
+         * 1. (optional) Disables the AsyncContext associated with individual request/responses to reduce stack-trace
+         * depth and simplify execution tracing. This will disable/break some features such as request tracing,
+         * authentication, propagated timeouts, etc. that rely upon the AsyncContext so should only be disabled when
+         * necessary for debugging:
+         */
+        // AsyncContext.disable();
+    }
+
     public static void main(String[] args) throws Exception {
         GrpcServers.forPort(8080)
                 .initializeHttp(builder -> {
-                    builder.enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                    builder
+                            /*
+                             * 2. Disables most asynchronous offloading to simplify execution tracing. Changing this may
+                             * significantly change application behavior and introduce unexpected blocking. It is most
+                             * useful for being able to directly trace through situations that would normally involve a
+                             * thread handoff.
+                             */
+                            //.executionStrategy(HttpExecutionStrategies.offloadNever())
+                            /*
+                             * 3. Enables detailed logging of I/O and I/O states.
+                             * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                             */
+                            .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+
+                            /*
+                             * 4. Enables detailed logging of HTTP2 frames.
+                             * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                             */
                             .protocols(HttpProtocolConfigs.h2()
                                     .enableFrameLogging(
                                             "servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.debugging;
+
+import io.servicetalk.grpc.netty.GrpcServers;
+import io.servicetalk.http.netty.HttpProtocolConfigs;
+
+import io.grpc.examples.debugging.Greeter.BlockingGreeterService;
+import io.grpc.examples.debugging.HelloReply;
+
+import static io.servicetalk.logging.api.LogLevel.TRACE;
+
+public final class DebuggingServer {
+    public static void main(String[] args) throws Exception {
+        GrpcServers.forPort(8080)
+                .initializeHttp(builder -> {
+                    builder.enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                            .protocols(HttpProtocolConfigs.h2()
+                                    .enableFrameLogging(
+                                            "servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
+                                    .build());
+                })
+                .listenAndAwait((BlockingGreeterService) (ctx, request) ->
+                        HelloReply.newBuilder().setMessage("Hello " + request.getName()).build())
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/package-info.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.grpc.debugging;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/package-info.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/package-info.java
@@ -17,3 +17,7 @@
 package io.servicetalk.examples.grpc.debugging;
 
 import io.servicetalk.annotations.ElementsAreNonnullByDefault;
+
+/**
+ * Blocking "Hello World" example of ServiceTalk gRPC extended to demonstrate configuring of debugging features.
+ */

--- a/servicetalk-examples/grpc/debugging/src/main/proto/helloworld.proto
+++ b/servicetalk-examples/grpc/debugging/src/main/proto/helloworld.proto
@@ -1,0 +1,37 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.debugging";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/servicetalk-examples/grpc/debugging/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/grpc/debugging/src/main/resources/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+  ~ Copyright © 2022 Apple Inc. and the ServiceTalk project authors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -21,18 +21,33 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!-- Prints server start and shutdown -->
-    <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
-
     <!-- Enables wire logging and h2-frame logging messages -->
     <Logger name="servicetalk-examples-wire-logger" level="TRACE"/>
     <Logger name="servicetalk-examples-h2-frame-logger" level="TRACE"/>
 
+    <!-- Additional useful loggers of interest - include relevant loggers in your log4j2.xml file -->
+
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
+
     <!-- Prints default subscriber errors-->
     <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
 
-    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
-    <Root level="${sys:servicetalk.logger.level:-INFO}">
+    <!-- Gives visibility into internal state of the LoadBalancer -->
+    <Logger name="io.servicetalk.loadbalancer" level="DEBUG"/>
+
+    <!--  Prints results of each DNS resolution -->
+    <Logger name="io.servicetalk.dns.discovery.netty" level="DEBUG"/>
+    <Logger name="io.netty.resolver.dns" level="DEBUG"/>
+
+    <!-- Gives visibility into HTTP processing -->
+    <Logger name="io.servicetalk.http" level="DEBUG"/>
+
+    <!-- Gives visibility for transport events. -->
+    <Logger name="io.servicetalk.transport" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=INFO` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-DEBUG}">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>

--- a/servicetalk-examples/grpc/debugging/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/grpc/debugging/src/main/resources/log4j2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
+
+    <!-- Enables wire logging and h2-frame logging messages -->
+    <Logger name="servicetalk-examples-wire-logger" level="TRACE"/>
+    <Logger name="servicetalk-examples-h2-frame-logger" level="TRACE"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/servicetalk-examples/grpc/helloworld/pom.xml
+++ b/servicetalk-examples/grpc/helloworld/pom.xml
@@ -13,8 +13,8 @@
     <servicetalk.version>0.42.0</servicetalk.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <protoc.version>3.12.3</protoc.version>
-    <os-mave-plugin.version>1.6.0</os-mave-plugin.version>
-    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+    <os-maven-plugin.version>1.6.0</os-maven-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
   </properties>
 
   <build>
@@ -22,7 +22,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>${os-mave-plugin.version}</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
 

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -30,12 +30,13 @@ import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
- * The async "Hello World" example with debugging features enabled. Four debugging features are demonstrated:
+ * The async "Hello World" example with debugging features enabled. Five debugging features are demonstrated:
  * <ol>
  *     <li>Disabling {@link AsyncContext}</li>
  *     <li>Disabling {@link HttpExecutionStrategy offloading}</li>
  *     <li>Enabling {@link SingleAddressHttpClientBuilder#enableWireLogging(String, LogLevel, BooleanSupplier) HTTP wire logging}</li>
  *     <li>Enabling {@link H2ProtocolConfigBuilder#enableFrameLogging(String, LogLevel, BooleanSupplier) HTTP/2 frame logging}</li>
+ *     <li>Enabling additional logger verbosity in the {@code log4j2.xml} configuration file</li>
  * </ol>
  * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
  * example {@code log4j2.xml} is used by both the client and server and configures the
@@ -147,7 +148,7 @@ public final class DebuggingExampleClient {
                  * significantly change application behavior and introduce unexpected blocking. It is most useful for
                  * being able to directly trace through situations that would normally involve a thread handoff.
                  */
-                // .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
+                // .executionStrategy(HttpExecutionStrategies.offloadNever())
 
                 /*
                  * 3. Enables detailed logging of I/O and I/O states.

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -30,12 +30,13 @@ import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
- * Extends the async "Hello World" sample with debugging features. Four debugging features are demonstrated:
+ * Extends the async "Hello World" sample with debugging features. Five debugging features are demonstrated:
  * <ol>
  *     <li>Disabling {@link AsyncContext}</li>
  *     <li>Disabling {@link HttpExecutionStrategy offloading}</li>
  *     <li>Enabling {@link HttpServerBuilder#enableWireLogging(String, LogLevel, BooleanSupplier) HTTP wire logging}</li>
  *     <li>Enabling {@link H2ProtocolConfigBuilder#enableFrameLogging(String, LogLevel, BooleanSupplier) HTTP/2 frame logging}</li>
+ *     <li>Enabling additional logger verbosity in the {@code log4j2.xml} configuration file</li>
  * </ol>
  * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
  * example {@code log4j2.xml} is used by both the client and server and configures the
@@ -142,7 +143,7 @@ public final class DebuggingExampleServer {
                  * significantly change application behavior and introduce unexpected blocking. It is most useful for
                  * being able to directly trace through situations that would normally involve a thread handoff.
                  */
-                // .executionStrategy(HttpExecutionStrategies.noOffloadsStrategy())
+                // .executionStrategy(HttpExecutionStrategies.offloadNever())
 
                 /*
                  * 3. Enables detailed logging of I/O and I/O states.

--- a/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
@@ -25,6 +25,27 @@
     <Logger name="servicetalk-examples-wire-logger" level="TRACE"/>
     <Logger name="servicetalk-examples-h2-frame-logger" level="TRACE"/>
 
+    <!-- Additional useful loggers of interest - include relevant loggers in your log4j2.xml file -->
+
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Gives visibility into internal state of the LoadBalancer -->
+    <Logger name="io.servicetalk.loadbalancer" level="DEBUG"/>
+
+    <!--  Prints results of each DNS resolution -->
+    <Logger name="io.servicetalk.dns.discovery.netty" level="DEBUG"/>
+    <Logger name="io.netty.resolver.dns" level="DEBUG"/>
+
+    <!-- Gives visibility into HTTP processing -->
+    <Logger name="io.servicetalk.http" level="DEBUG"/>
+
+    <!-- Gives visibility for transport events. -->
+    <Logger name="io.servicetalk.transport" level="DEBUG"/>
+
     <!-- Use `-Dservicetalk.logger.level=INFO` to change the root logger level via command line  -->
     <Root level="${sys:servicetalk.logger.level:-DEBUG}">
       <AppenderRef ref="Console"/>

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:grpc:compression",
         "servicetalk-examples:grpc:errors",
         "servicetalk-examples:grpc:deadline",
+        "servicetalk-examples:grpc:debugging",
         "servicetalk-examples:grpc:execution-strategy",
         "servicetalk-examples:grpc:observer",
         "servicetalk-examples:http:helloworld",
@@ -105,8 +106,9 @@ project(":servicetalk-examples:grpc:helloworld").name = "servicetalk-examples-gr
 project(":servicetalk-examples:grpc:routeguide").name = "servicetalk-examples-grpc-routeguide"
 project(":servicetalk-examples:grpc:protoc-options").name = "servicetalk-examples-grpc-protoc-options"
 project(":servicetalk-examples:grpc:compression").name = "servicetalk-examples-grpc-compression"
-project(":servicetalk-examples:grpc:errors").name = "servicetalk-examples-grpc-errors"
 project(":servicetalk-examples:grpc:deadline").name = "servicetalk-examples-grpc-deadline"
+project(":servicetalk-examples:grpc:debugging").name = "servicetalk-examples-grpc-debugging"
+project(":servicetalk-examples:grpc:errors").name = "servicetalk-examples-grpc-errors"
 project(":servicetalk-examples:grpc:execution-strategy").name = "servicetalk-examples-grpc-execution-strategy"
 project(":servicetalk-examples:grpc:observer").name = "servicetalk-examples-grpc-observer"
 project(":servicetalk-examples:http:http2").name = "servicetalk-examples-http-http2"


### PR DESCRIPTION
Motivation:
Enabling wire logging for gRPC is sufficiently different from the HTTP
example that a separate example would be useful.
Modifications:
Adds example for enabling wire logging for gRPC client and server. Also
demonstrates HTTP initializer.
Result:
Additional example available to reference for support requests.