### PR TITLE
Fix infinite retries under particular conditions

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -400,6 +400,15 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                     return currClientFilterFactory.create(filter, lbEventStream, sdStatus);
                 };
             }
+        } else if (appendClientFilterFactory instanceof ContextAwareStreamingHttpClientFilterFactory) {
+            if (currClientFilterFactory == null) {
+                return ((ContextAwareStreamingHttpClientFilterFactory) appendClientFilterFactory);
+            } else {
+                return (client, lbEventStream, sdError) ->
+                        currClientFilterFactory.create(
+                                ((ContextAwareStreamingHttpClientFilterFactory) appendClientFilterFactory)
+                                        .create(client, lbEventStream, sdError), lbEventStream, sdError);
+            }
         } else {
             if (currClientFilterFactory == null) {
                 return (client, lbEventStream, sdError) -> appendClientFilterFactory.create(client);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -542,13 +542,17 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     public SingleAddressHttpClientBuilder<U, R> appendClientFilter(final Predicate<StreamingHttpRequest> predicate,
                                                                    final StreamingHttpClientFilterFactory factory) {
         if (factory instanceof RetryingHttpRequesterFilter) {
-            if (retryingHttpRequesterFilter != null) {
-                throw new IllegalStateException("Retrying HTTP requester filter was already found in " +
-                        "the filter chain, only a single instance of that is allowed.");
-            }
+            ensureSingleRetryFilter();
             retryingHttpRequesterFilter = (RetryingHttpRequesterFilter) factory;
         }
         return appendClientFilter(toConditionalClientFilterFactory(predicate, factory));
+    }
+
+    private void ensureSingleRetryFilter() {
+        if (retryingHttpRequesterFilter != null) {
+            throw new IllegalStateException("Retrying HTTP requester filter was already found in " +
+                    "the filter chain, only a single instance of that is allowed.");
+        }
     }
 
     @Override
@@ -563,10 +567,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
             final StreamingHttpClientFilterFactory factory) {
         requireNonNull(factory);
         if (factory instanceof RetryingHttpRequesterFilter) {
-            if (retryingHttpRequesterFilter != null) {
-                throw new IllegalStateException("Retrying HTTP requester filter was already found in " +
-                        "the filter chain, only a single instance of that is allowed.");
-            }
+            ensureSingleRetryFilter();
             retryingHttpRequesterFilter = (RetryingHttpRequesterFilter) factory;
         }
         clientFilterFactory = appendFilter(clientFilterFactory, factory);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -532,6 +532,13 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     @Override
     public SingleAddressHttpClientBuilder<U, R> appendClientFilter(final Predicate<StreamingHttpRequest> predicate,
                                                                    final StreamingHttpClientFilterFactory factory) {
+        if (factory instanceof RetryingHttpRequesterFilter) {
+            if (retryingHttpRequesterFilter != null) {
+                throw new IllegalStateException("Retrying HTTP requester filter was already found in " +
+                        "the filter chain, only a single instance of that is allowed.");
+            }
+            retryingHttpRequesterFilter = (RetryingHttpRequesterFilter) factory;
+        }
         return appendClientFilter(toConditionalClientFilterFactory(predicate, factory));
     }
 
@@ -547,6 +554,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
             final StreamingHttpClientFilterFactory factory) {
         requireNonNull(factory);
         if (factory instanceof RetryingHttpRequesterFilter) {
+            if (retryingHttpRequesterFilter != null) {
+                throw new IllegalStateException("Retrying HTTP requester filter was already found in " +
+                        "the filter chain, only a single instance of that is allowed.");
+            }
             retryingHttpRequesterFilter = (RetryingHttpRequesterFilter) factory;
         }
         clientFilterFactory = appendFilter(clientFilterFactory, factory);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -238,7 +238,22 @@ public final class RetryingHttpRequesterFilter
 
         private static final long serialVersionUID = -7182949760823647710L;
 
+        // FIXME: 0.43 - remove deprecated method
+        /**
+         * {@link HttpResponseMetaData} of the response that caused this exception.
+         *
+         * @deprecated Use {@link #metaData()}.
+         */
+        @Deprecated
         public final HttpResponseMetaData metaData;
+
+        // FIXME: 0.43 - remove deprecated method
+        /**
+         * Exception detail message.
+         *
+         * @deprecated Use {@link #getMessage()}.
+         */
+        @Deprecated
         public final String message;
 
         public HttpResponseException(final String message, final HttpResponseMetaData metaData) {
@@ -250,6 +265,14 @@ public final class RetryingHttpRequesterFilter
         @Override
         public synchronized Throwable fillInStackTrace() {
             return this;
+        }
+
+        /**
+         * {@link HttpResponseMetaData} of the response that caused this exception.
+         * @return The {@link HttpResponseMetaData} of the response that caused this exception.
+         */
+        public HttpResponseMetaData metaData() {
+            return metaData;
         }
 
         @Override
@@ -266,7 +289,14 @@ public final class RetryingHttpRequesterFilter
 
         private static final Duration FULL_JITTER = ofDays(1024);
 
-        static final BackOffPolicy NO_RETRIES = new BackOffPolicy(0);
+        // FIXME: 0.43 - change field accessor to default
+        /**
+         * Special {@link BackOffPolicy} to signal no retries.
+         * @deprecated This will be removed in a future release of ST. Alternative offering here
+         * {@link BackOffPolicy#ofNoRetries()}.
+         */
+        @Deprecated
+        public static final BackOffPolicy NO_RETRIES = new BackOffPolicy(0);
 
         @Nullable
         final Duration initialDelay;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -56,8 +56,7 @@ import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponential
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.http.api.HeaderUtils.DEFAULT_HEADER_FILTER;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
-import static java.lang.Integer.MAX_VALUE;
-import static java.time.Duration.ZERO;
+import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static java.time.Duration.ofDays;
 import static java.util.Objects.requireNonNull;
 
@@ -68,7 +67,7 @@ import static java.util.Objects.requireNonNull;
  * as part of a service response if needed, through {@link Builder#responseMapper(Function)}.
  * <p>
  * Retries can have different criteria and different backoff polices, as defined from the relevant Builder methods (i.e.
- * {@link Builder#retryOther(BiFunction)}.
+ * {@link Builder#retryOther(BiFunction)}).
  * Similarly, max-retries for each flow can be set in the {@link BackOffPolicy}, as well
  * as a total max-retries to be respected by both flows, as set in
  * {@link Builder#maxTotalRetries(int)}.
@@ -267,13 +266,11 @@ public final class RetryingHttpRequesterFilter
 
         private static final Duration FULL_JITTER = ofDays(1024);
 
-        /**
-         * Special {@link BackOffPolicy} to signal no retries.
-         */
-        public static final BackOffPolicy NO_RETRIES = ofNoRetries();
+        static final BackOffPolicy NO_RETRIES = new BackOffPolicy(0);
 
         @Nullable
         final Duration initialDelay;
+        @Nullable
         final Duration jitter;
         @Nullable
         final Duration maxDelay;
@@ -282,18 +279,34 @@ public final class RetryingHttpRequesterFilter
         final boolean exponential;
         final int maxRetries;
 
-        BackOffPolicy(@Nullable final Duration initialDelay,
+        BackOffPolicy(final Duration initialDelay,
                       final Duration jitter,
                       @Nullable final Duration maxDelay,
                       @Nullable final Executor timerExecutor,
                       final boolean exponential,
                       final int maxRetries) {
-            this.initialDelay = initialDelay;
-            this.jitter = jitter;
-            this.maxDelay = maxDelay;
+            this.initialDelay = ensurePositive(initialDelay, "Initial delay should be a positive value.");
+            this.jitter = ensurePositive(jitter, "jitter should be a positive value.");
+            this.maxDelay = maxDelay != null ? ensurePositive(maxDelay, "Max delay (if provided), should be a " +
+                    "positive value.") : null;
             this.timerExecutor = timerExecutor;
             this.exponential = exponential;
-            this.maxRetries = maxRetries > 0 ? maxRetries : (exponential ? 2 : 1);
+            if (maxRetries <= 0) {
+                throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected > 0).");
+            }
+            this.maxRetries = maxRetries;
+        }
+
+        BackOffPolicy(final int maxRetries) {
+            this.initialDelay = null;
+            this.jitter = null;
+            this.maxDelay = null;
+            this.timerExecutor = null;
+            this.exponential = false;
+            if (maxRetries < 0) {
+                throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected >= 0).");
+            }
+            this.maxRetries = maxRetries;
         }
 
         /**
@@ -301,7 +314,7 @@ public final class RetryingHttpRequesterFilter
          * @return a new {@link BackOffPolicy} that retries failures instantly up-to 3 max retries.
          */
         public static BackOffPolicy ofImmediate() {
-            return new BackOffPolicy(null, ZERO, null, null, false, 3);
+            return new BackOffPolicy(3);
         }
 
         /**
@@ -311,15 +324,15 @@ public final class RetryingHttpRequesterFilter
          * @return a new {@link BackOffPolicy} that retries failures instantly up-to provided max retries.
          */
         public static BackOffPolicy ofImmediate(final int maxRetries) {
-            return new BackOffPolicy(null, ZERO, null, null, false, maxRetries);
+            return new BackOffPolicy(maxRetries);
         }
 
         /**
          * Special {@link BackOffPolicy} that signals that no retries will be attempted.
          * @return a special {@link BackOffPolicy} that signals that no retries will be attempted.
          */
-        private static BackOffPolicy ofNoRetries() {
-            return new BackOffPolicy(null, ZERO, null, null, false, 0);
+        public static BackOffPolicy ofNoRetries() {
+            return NO_RETRIES;
         }
 
         /**
@@ -482,6 +495,7 @@ public final class RetryingHttpRequesterFilter
             if (initialDelay == null) {
                 return (count, throwable) -> count <= maxRetries ? completed() : failed(throwable);
             } else {
+                assert jitter != null;
                 final Executor effectiveExecutor = timerExecutor == null ?
                         requireNonNull(alternativeTimerExecutor) : timerExecutor;
                 if (exponential) {
@@ -530,7 +544,7 @@ public final class RetryingHttpRequesterFilter
         private boolean waitForLb = true;
         private boolean ignoreSdErrors;
 
-        private int maxRetries = MAX_VALUE;
+        private int maxTotalRetries = 4;
 
         @Nullable
         private Function<HttpResponseMetaData, HttpResponseException> responseMapper;
@@ -585,7 +599,8 @@ public final class RetryingHttpRequesterFilter
          * {@link #retryRetryableExceptions(BiFunction)}, {@link #retryResponses(BiFunction)},
          * {@link #retryOther(BiFunction)}).
          *
-         * If not set, max total retries will be infinite.
+         * Maximum total retries guards the LB/SD readiness flow, making sure LB connection issues will also be
+         * retried with a limit.
          *
          * @param maxRetries Maximum number of allowed retries before giving up
          * @return {@code this}
@@ -594,7 +609,7 @@ public final class RetryingHttpRequesterFilter
             if (maxRetries <= 0) {
                 throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected: >0)");
             }
-            this.maxRetries = maxRetries;
+            this.maxTotalRetries = maxRetries;
             return this;
         }
 
@@ -649,7 +664,7 @@ public final class RetryingHttpRequesterFilter
 
         /**
          * The retrying-filter will evaluate the {@link DelayedRetry} marker interface
-         * of an exception and use the provided {@link DelayedRetry#delay() delay} as a constant delay on-top ofthe
+         * of an exception and use the provided {@link DelayedRetry#delay() delay} as a constant delay on-top of the
          * retry period already defined.
          * In case a max-delay was set in this builder, the {@link DelayedRetry#delay() constant-delay} overrides
          * it and takes precedence.
@@ -746,7 +761,8 @@ public final class RetryingHttpRequesterFilter
 
                         return NO_RETRIES;
                     };
-            return new RetryingHttpRequesterFilter(waitForLb, ignoreSdErrors, maxRetries, responseMapper, allPredicate);
+            return new RetryingHttpRequesterFilter(waitForLb, ignoreSdErrors, maxTotalRetries, responseMapper,
+                    allPredicate);
         }
     }
 }


### PR DESCRIPTION
Motivation:

When the new retrying http filter is applied under some particular conditions, the retry logic yields infinite attempts.

Modifications:

- When the filter is appended conditionally, capture the instance to lazy inject LB/SD state.
- Change the default max-total-retries to guard better LB/SD error flow.
- Additional input validation for durations.

Result:

Safe retry behaviour.