### PR TITLE
Allow using pre-existing `AutoRetryStrategyProvider` and `RetryingHttpRequesterFilter`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -170,35 +170,35 @@ class RetryingHttpRequesterFilterTest {
         }
     }
 
-    @Test()
+    @Test
     void singleInstanceOldNew() {
-        Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
+        forResolvedAddress(localAddress(8888))
                 .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
                         .buildWithConstantBackoffFullJitter(ofSeconds(1)))
                 .appendClientFilter(new Builder().build())
-                .build());
+                .build();
     }
 
-    @Test()
+    @Test
     void singleInstanceNewOld() {
-        Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
+        forResolvedAddress(localAddress(8888))
                 .appendClientFilter(new Builder().build())
                 .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
                         .buildWithConstantBackoffFullJitter(ofSeconds(1)))
-                .build());
+                .build();
     }
 
-    @Test()
+    @Test
     void singleInstanceOldOld() {
-        Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
+        forResolvedAddress(localAddress(8888))
                 .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
                         .buildWithConstantBackoffFullJitter(ofSeconds(1)))
                 .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
                         .buildWithConstantBackoffFullJitter(ofSeconds(1)))
-                .build());
+                .build();
     }
 
-    @Test()
+    @Test
     void singleInstanceNewNew() {
         Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
                 .appendClientFilter(new Builder().build())
@@ -206,12 +206,38 @@ class RetryingHttpRequesterFilterTest {
                 .build());
     }
 
-    @Test()
-    void singleInstanceNewForceAutoRetry() {
+    @Test
+    void singleInstanceNewFilterAndAutoRetry() {
         Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
                 .appendClientFilter(new Builder().build())
                 .autoRetryStrategy(new DefaultAutoRetryStrategyProvider.Builder().build())
                 .build());
+    }
+
+    @Test
+    void singleInstanceAutoRetryAndNewFilter() {
+        Assertions.assertThrows(IllegalStateException.class, () -> forResolvedAddress(localAddress(8888))
+                .autoRetryStrategy(new DefaultAutoRetryStrategyProvider.Builder().build())
+                .appendClientFilter(new Builder().build())
+                .build());
+    }
+
+    @Test
+    void singleInstanceAutoRetryAndOldFilter() {
+        forResolvedAddress(localAddress(8888))
+                .autoRetryStrategy(new DefaultAutoRetryStrategyProvider.Builder().build())
+                .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                        .buildWithConstantBackoffFullJitter(ofSeconds(1)))
+                .build();
+    }
+
+    @Test
+    void singleInstanceOldFilterAndAutoRetry() {
+        forResolvedAddress(localAddress(8888))
+                .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                        .buildWithConstantBackoffFullJitter(ofSeconds(1)))
+                .autoRetryStrategy(new DefaultAutoRetryStrategyProvider.Builder().build())
+                .build();
     }
 
     private final class InspectingLoadBalancerFactory<C extends LoadBalancedConnection>


### PR DESCRIPTION
Motivation:

Before 0.41.12 it was possible to use a custom
`AutoRetryStrategyProvider` with
`io.servicetalk.http.utils.RetryingHttpRequesterFilter`. We should
preserve this behavior.
Also, it was possible to use multiple
`io.servicetalk.http.utils.RetryingHttpRequesterFilter`(s). While users
migrate to the new `io.servicetalk.http.netty.RetryingHttpRequesterFilter`,
we should let them use multiple instances of
`io.servicetalk.http.utils.RetryingHttpRequesterFilter`.

Modifications:

- Adjust validation in `DefaultSingleAddressHttpClientBuilder` to
preserve old behavior;

Result:

Users can have multiple
`io.servicetalk.http.utils.RetryingHttpRequesterFilter` instances and
mix them with custom `AutoRetryStrategyProvider`.