### PR TITLE
[BACKPORT] Fix infinite retries under particular conditions (#2041)

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContextAwareStreamingHttpClientFilterFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContextAwareStreamingHttpClientFilterFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+
+import javax.annotation.Nullable;
+
+/**
+ * API introduced to help transition 0.41 core to 0.42.
+ * @deprecated DO NOT USE.
+ */
+@FunctionalInterface
+@Deprecated
+public interface ContextAwareStreamingHttpClientFilterFactory
+        extends StreamingHttpClientFilterFactory {
+    StreamingHttpClientFilter create(FilterableStreamingHttpClient client,
+                                     @Nullable Publisher<Object> lbEventStream,
+                                     @Nullable Completable sdStatus);
+
+    @Override
+    default StreamingHttpClientFilter create(FilterableStreamingHttpClient client) {
+        return create(client, null, null);
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.forUnknownHostAndPort;
-import static io.servicetalk.transport.netty.internal.BuilderUtils.toResolvedInetSocketAddress;
 import static java.util.function.Function.identity;
 
 /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -55,8 +55,7 @@ import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponential
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.http.api.HeaderUtils.DEFAULT_HEADER_FILTER;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
-import static java.lang.Integer.MAX_VALUE;
-import static java.time.Duration.ZERO;
+import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static java.time.Duration.ofDays;
 import static java.util.Objects.requireNonNull;
 
@@ -67,7 +66,7 @@ import static java.util.Objects.requireNonNull;
  * as part of a service response if needed, through {@link Builder#responseMapper(Function)}.
  * <p>
  * Retries can have different criteria and different backoff polices, as defined from the relevant Builder methods (i.e.
- * {@link Builder#retryOther(BiFunction)}.
+ * {@link Builder#retryOther(BiFunction)}).
  * Similarly, max-retries for each flow can be set in the {@link BackOffPolicy}, as well
  * as a total max-retries to be respected by both flows, as set in
  * {@link Builder#maxTotalRetries(int)}.
@@ -237,7 +236,22 @@ public final class RetryingHttpRequesterFilter
 
         private static final long serialVersionUID = -7182949760823647710L;
 
+        // FIXME: 0.43 - remove deprecated method
+        /**
+         * {@link HttpResponseMetaData} of the response that caused this exception.
+         *
+         * @deprecated Use {@link #metaData()}.
+         */
+        @Deprecated
         public final HttpResponseMetaData metaData;
+
+        // FIXME: 0.43 - remove deprecated method
+        /**
+         * Exception detail message.
+         *
+         * @deprecated Use {@link #getMessage()}.
+         */
+        @Deprecated
         public final String message;
 
         public HttpResponseException(final String message, final HttpResponseMetaData metaData) {
@@ -249,6 +263,14 @@ public final class RetryingHttpRequesterFilter
         @Override
         public synchronized Throwable fillInStackTrace() {
             return this;
+        }
+
+        /**
+         * {@link HttpResponseMetaData} of the response that caused this exception.
+         * @return The {@link HttpResponseMetaData} of the response that caused this exception.
+         */
+        public HttpResponseMetaData metaData() {
+            return metaData;
         }
 
         @Override
@@ -265,13 +287,18 @@ public final class RetryingHttpRequesterFilter
 
         private static final Duration FULL_JITTER = ofDays(1024);
 
+        // FIXME: 0.43 - change field accessor to default
         /**
          * Special {@link BackOffPolicy} to signal no retries.
+         * @deprecated This will be removed in a future release of ST. Alternative offering here
+         * {@link BackOffPolicy#ofNoRetries()}.
          */
-        public static final BackOffPolicy NO_RETRIES = ofNoRetries();
+        @Deprecated
+        public static final BackOffPolicy NO_RETRIES = new BackOffPolicy(0);
 
         @Nullable
         final Duration initialDelay;
+        @Nullable
         final Duration jitter;
         @Nullable
         final Duration maxDelay;
@@ -280,18 +307,34 @@ public final class RetryingHttpRequesterFilter
         final boolean exponential;
         final int maxRetries;
 
-        BackOffPolicy(@Nullable final Duration initialDelay,
+        BackOffPolicy(final Duration initialDelay,
                       final Duration jitter,
                       @Nullable final Duration maxDelay,
                       @Nullable final Executor timerExecutor,
                       final boolean exponential,
                       final int maxRetries) {
-            this.initialDelay = initialDelay;
-            this.jitter = jitter;
-            this.maxDelay = maxDelay;
+            this.initialDelay = ensurePositive(initialDelay, "Initial delay should be a positive value.");
+            this.jitter = ensurePositive(jitter, "jitter should be a positive value.");
+            this.maxDelay = maxDelay != null ? ensurePositive(maxDelay, "Max delay (if provided), should be a " +
+                    "positive value.") : null;
             this.timerExecutor = timerExecutor;
             this.exponential = exponential;
-            this.maxRetries = maxRetries > 0 ? maxRetries : (exponential ? 2 : 1);
+            if (maxRetries <= 0) {
+                throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected > 0).");
+            }
+            this.maxRetries = maxRetries;
+        }
+
+        BackOffPolicy(final int maxRetries) {
+            this.initialDelay = null;
+            this.jitter = null;
+            this.maxDelay = null;
+            this.timerExecutor = null;
+            this.exponential = false;
+            if (maxRetries < 0) {
+                throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected >= 0).");
+            }
+            this.maxRetries = maxRetries;
         }
 
         /**
@@ -299,7 +342,7 @@ public final class RetryingHttpRequesterFilter
          * @return a new {@link BackOffPolicy} that retries failures instantly up-to 3 max retries.
          */
         public static BackOffPolicy ofImmediate() {
-            return new BackOffPolicy(null, ZERO, null, null, false, 3);
+            return new BackOffPolicy(3);
         }
 
         /**
@@ -309,15 +352,15 @@ public final class RetryingHttpRequesterFilter
          * @return a new {@link BackOffPolicy} that retries failures instantly up-to provided max retries.
          */
         public static BackOffPolicy ofImmediate(final int maxRetries) {
-            return new BackOffPolicy(null, ZERO, null, null, false, maxRetries);
+            return new BackOffPolicy(maxRetries);
         }
 
         /**
          * Special {@link BackOffPolicy} that signals that no retries will be attempted.
          * @return a special {@link BackOffPolicy} that signals that no retries will be attempted.
          */
-        private static BackOffPolicy ofNoRetries() {
-            return new BackOffPolicy(null, ZERO, null, null, false, 0);
+        public static BackOffPolicy ofNoRetries() {
+            return NO_RETRIES;
         }
 
         /**
@@ -480,6 +523,7 @@ public final class RetryingHttpRequesterFilter
             if (initialDelay == null) {
                 return (count, throwable) -> count <= maxRetries ? completed() : failed(throwable);
             } else {
+                assert jitter != null;
                 final Executor effectiveExecutor = timerExecutor == null ?
                         requireNonNull(alternativeTimerExecutor) : timerExecutor;
                 if (exponential) {
@@ -528,7 +572,7 @@ public final class RetryingHttpRequesterFilter
         private boolean waitForLb = true;
         private boolean ignoreSdErrors;
 
-        private int maxRetries = MAX_VALUE;
+        private int maxTotalRetries = 4;
 
         @Nullable
         private Function<HttpResponseMetaData, HttpResponseException> responseMapper;
@@ -583,7 +627,8 @@ public final class RetryingHttpRequesterFilter
          * {@link #retryRetryableExceptions(BiFunction)}, {@link #retryResponses(BiFunction)},
          * {@link #retryOther(BiFunction)}).
          *
-         * If not set, max total retries will be infinite.
+         * Maximum total retries guards the LB/SD readiness flow, making sure LB connection issues will also be
+         * retried with a limit.
          *
          * @param maxRetries Maximum number of allowed retries before giving up
          * @return {@code this}
@@ -592,7 +637,7 @@ public final class RetryingHttpRequesterFilter
             if (maxRetries <= 0) {
                 throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected: >0)");
             }
-            this.maxRetries = maxRetries;
+            this.maxTotalRetries = maxRetries;
             return this;
         }
 
@@ -647,7 +692,7 @@ public final class RetryingHttpRequesterFilter
 
         /**
          * The retrying-filter will evaluate the {@link DelayedRetry} marker interface
-         * of an exception and use the provided {@link DelayedRetry#delay() delay} as a constant delay on-top ofthe
+         * of an exception and use the provided {@link DelayedRetry#delay() delay} as a constant delay on-top of the
          * retry period already defined.
          * In case a max-delay was set in this builder, the {@link DelayedRetry#delay() constant-delay} overrides
          * it and takes precedence.
@@ -754,7 +799,8 @@ public final class RetryingHttpRequesterFilter
 
                         return NO_RETRIES;
                     };
-            return new RetryingHttpRequesterFilter(waitForLb, ignoreSdErrors, maxRetries, responseMapper, allPredicate);
+            return new RetryingHttpRequesterFilter(waitForLb, ignoreSdErrors, maxTotalRetries, responseMapper,
+                    allPredicate);
         }
     }
 }


### PR DESCRIPTION
Motivation:

When the new retrying http filter is applied under some particular conditions, the retry logic yields infinite attempts.

Modifications:

- When the filter is appended conditionally, capture the instance to lazy inject LB/SD state.
- Change the default max-total-retries to guard better LB/SD error flow.
- Additional input validation for durations.

Result:

Safe retry behavior.