### PR TITLE
Add more logging for `GrpcRouter` and other transport classes

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -361,9 +361,15 @@ final class GrpcRouter {
                                                     .payloadBody(serializer.serialize(rawResp,
                                                             ctx.executionContext().bufferAllocator()));
                                         })
-                                        .onErrorReturn(cause -> newErrorResponse(responseFactory,
-                                            responseContentType, cause, ctx.executionContext().bufferAllocator()));
+                                        .onErrorReturn(cause -> {
+                                            LOGGER.debug("Unexpected exception from aggregated response for path : {}",
+                                                    methodDescriptor.httpPath(), cause);
+                                            return newErrorResponse(responseFactory,
+                                                    responseContentType, cause, ctx.executionContext().bufferAllocator());
+                                        });
                             } catch (Throwable t) {
+                                LOGGER.debug("Unexpected exception from aggregated endpoint for path: {}",
+                                        methodDescriptor.httpPath(), t);
                                 return succeeded(newErrorResponse(responseFactory, responseContentType, t,
                                         ctx.executionContext().bufferAllocator()));
                             }
@@ -427,6 +433,8 @@ final class GrpcRouter {
                                             serializer.messageEncoding(), acceptedEncoding, response, serializer,
                                             ctx.executionContext().bufferAllocator()));
                                 } catch (Throwable t) {
+                                    LOGGER.debug("Unexpected exception from streaming endpoint for path: {}",
+                                            methodDescriptor.httpPath(), t);
                                     return succeeded(newErrorResponse(responseFactory, responseContentType, t,
                                             ctx.executionContext().bufferAllocator()));
                                 }
@@ -568,6 +576,8 @@ final class GrpcRouter {
                                         .payloadBody(serializer.serialize(rawResp,
                                                 ctx.executionContext().bufferAllocator()));
                             } catch (Throwable t) {
+                                LOGGER.debug("Unexpected exception from blocking aggregated endpoint for path: {}",
+                                        methodDescriptor.httpPath(), t);
                                 return newErrorResponse(responseFactory, responseContentType, t,
                                         ctx.executionContext().bufferAllocator());
                             }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -364,8 +364,8 @@ final class GrpcRouter {
                                         .onErrorReturn(cause -> {
                                             LOGGER.debug("Unexpected exception from aggregated response for path : {}",
                                                     methodDescriptor.httpPath(), cause);
-                                            return newErrorResponse(responseFactory,
-                                                    responseContentType, cause, ctx.executionContext().bufferAllocator());
+                                            return newErrorResponse(responseFactory, responseContentType, cause,
+                                                    ctx.executionContext().bufferAllocator());
                                         });
                             } catch (Throwable t) {
                                 LOGGER.debug("Unexpected exception from aggregated endpoint for path: {}",

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -46,6 +46,8 @@ import io.servicetalk.serializer.api.SerializerDeserializer;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -724,6 +726,8 @@ final class GrpcUtils {
     }
 
     static final class GrpcStatusUpdater extends StatelessTrailersTransformer<Buffer> {
+        private static final Logger LOGGER = LoggerFactory.getLogger(GrpcStatusUpdater.class);
+
         private final BufferAllocator allocator;
         private final GrpcStatus successStatus;
 
@@ -742,6 +746,7 @@ final class GrpcUtils {
         protected HttpHeaders payloadFailed(final Throwable cause, final HttpHeaders trailers) {
             setStatus(trailers, cause, allocator);
             // Swallow exception as we are converting it to the trailers.
+            LOGGER.debug("Converted an exception into grpc-status: {}", trailers.get(GRPC_STATUS), cause);
             return trailers;
         }
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -303,6 +303,7 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
             // Subscription shares common state hence a requestN after termination/cancellation must be ignored
             return;
         }
+        LOGGER.debug("{} Cancelling subscription", channel);
         resetSubscription();
 
         // If a cancel occurs with a valid subscription we need to clear any pending data and set a fatalError so that

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -506,7 +506,9 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
 
         private void terminateSubscriber(@Nullable Throwable cause) {
             if (cause == null) {
-                LOGGER.debug("{} Terminate subscriber, state: {}", channel, Integer.toString(state, 2));
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("{} Terminate subscriber, state: {}", channel, Integer.toString(state, 2));
+                }
                 try {
                     observer.writeComplete();
                     subscriber.onComplete();
@@ -520,8 +522,10 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
                 Throwable enrichedCause = enrichProtocolError.apply(cause);
                 assignConnectionError(channel, enrichedCause);
                 enrichedCause = !written ? new AbortedFirstWriteException(enrichedCause) : enrichedCause;
-                LOGGER.debug("{} Terminate subscriber with an error, state: {}", channel, Integer.toString(state, 2),
-                        cause);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("{} Terminate subscriber with an error, state: {}",
+                            channel, Integer.toString(state, 2), cause);
+                }
                 try {
                     observer.writeFailed(enrichedCause);
                     subscriber.onError(enrichedCause);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -506,6 +506,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
 
         private void terminateSubscriber(@Nullable Throwable cause) {
             if (cause == null) {
+                LOGGER.debug("{} Terminate subscriber, state: {}", channel, Integer.toString(state, 2));
                 try {
                     observer.writeComplete();
                     subscriber.onComplete();
@@ -519,6 +520,8 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
                 Throwable enrichedCause = enrichProtocolError.apply(cause);
                 assignConnectionError(channel, enrichedCause);
                 enrichedCause = !written ? new AbortedFirstWriteException(enrichedCause) : enrichedCause;
+                LOGGER.debug("{} Terminate subscriber with an error, state: {}", channel, Integer.toString(state, 2),
+                        cause);
                 try {
                     observer.writeFailed(enrichedCause);
                     subscriber.onError(enrichedCause);


### PR DESCRIPTION
Motivation:

Better visibility of the request-response processing.

Modifications:

- Add debug level logging when route fails with an error in `GrpcRouter`;
- Add debug level logging when `GrpcStatusUpdater` converts an exception
into a `grpc-status` code;
- Add more debug logging in `NettyChannelPublisher` and
`WriteStreamSubscriber`;

Result:

Easier debugging.