### PR TITLE
Enable CI for 0.42 branch

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -1,7 +1,7 @@
 name: PR Builder
 on:
   pull_request:
-    branches: [ main, '0.41' ]
+    branches: [ main, '0.41', '0.42' ]
 jobs:
   build:
     name: Build JDK ${{ matrix.java }} ${{ matrix.os }}

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -1,7 +1,7 @@
 name: PR Quality
 on:
   pull_request:
-    branches: [ main, '0.41' ]
+    branches: [ main, '0.41', '0.42' ]
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -1,7 +1,7 @@
 name: Snapshot Publisher
 on:
   push:
-    branches: [ main, '0.41' ]
+    branches: [ main, '0.41', '0.42' ]
     tags-ignore:
       - "[0-9]+.[0-9]+.[0-9]+"
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,7 @@
 name: CodeQL
 on:
   push:
-    branches: [ main, '0.41' ]
+    branches: [ main, '0.41', '0.42' ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main, '0.41' ]


### PR DESCRIPTION
`0.42` branch will be used for a while until we have API changes that
justify going 0.43.

Modifications:
- Add `0.42` to the list of branches for all CI configurations;

Result:

CI will publish snapshots for `0.42` branch and validate all PRs.