### PR TITLE
Default `requiredOffloads` use `influenceStrategy`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
@@ -18,6 +18,8 @@ package io.servicetalk.http.api;
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
 import static io.servicetalk.http.api.DefaultStreamingStrategyInfluencer.DEFAULT_STREAMING_STRATEGY_INFLUENCER;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 
 /**
  * An entity that wishes to influence {@link HttpExecutionStrategy} for an HTTP client or server.
@@ -34,7 +36,14 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
      */
     @Deprecated
     default HttpExecutionStrategy influenceStrategy(HttpExecutionStrategy strategy) {
-        return requiredOffloads().merge(strategy);
+        boolean defaultRequiredOffloads;
+        try {
+            // avoid infinite recursion of default requiredOffloads calling this default
+            defaultRequiredOffloads = this.getClass().getMethod("requiredOffloads").isDefault();
+        } catch (NoSuchMethodException impossible) {
+            defaultRequiredOffloads = true;
+        }
+        return defaultRequiredOffloads ? offloadAll() : requiredOffloads().merge(strategy);
     }
 
     /**
@@ -47,7 +56,8 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
     @Override
     default HttpExecutionStrategy requiredOffloads() {
         // safe default--implementations are expected to override
-        return HttpExecutionStrategies.offloadAll();
+        HttpExecutionStrategy result = influenceStrategy(defaultStrategy());
+        return defaultStrategy() == result ? offloadAll() : result;
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
@@ -17,6 +17,8 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
+import java.lang.reflect.Method;
+
 import static io.servicetalk.http.api.DefaultStreamingStrategyInfluencer.DEFAULT_STREAMING_STRATEGY_INFLUENCER;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
@@ -40,7 +42,9 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
         boolean defaultRequiredOffloads;
         try {
             // avoid infinite recursion of default requiredOffloads calling this default
-            defaultRequiredOffloads = this.getClass().getMethod("requiredOffloads").isDefault();
+            Method requiredOffloads = this.getClass().getMethod("requiredOffloads");
+            defaultRequiredOffloads = requiredOffloads.getDeclaringClass() == HttpExecutionStrategyInfluencer.class &&
+                    requiredOffloads.isDefault();
         } catch (NoSuchMethodException impossible) {
             defaultRequiredOffloads = true;
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
@@ -20,6 +20,7 @@ import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 import static io.servicetalk.http.api.DefaultStreamingStrategyInfluencer.DEFAULT_STREAMING_STRATEGY_INFLUENCER;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 
 /**
  * An entity that wishes to influence {@link HttpExecutionStrategy} for an HTTP client or server.
@@ -57,7 +58,7 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
     default HttpExecutionStrategy requiredOffloads() {
         // safe default--implementations are expected to override
         HttpExecutionStrategy result = influenceStrategy(defaultStrategy());
-        return defaultStrategy() == result ? offloadAll() : result;
+        return defaultStrategy() == result ? offloadNone() : result;
     }
 
     /**

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategyTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import org.junit.jupiter.api.Test;
+
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+
+class HttpExecutionStrategyTest {
+
+    private static final HttpExecutionStrategy MAGIC_REQUIRED_STRATEGY = new HttpExecutionStrategy() {
+
+        @Override
+        public boolean isCloseOffloaded() {
+            return false;
+        }
+
+        @Override
+        public boolean isMetadataReceiveOffloaded() {
+            return false;
+        }
+
+        @Override
+        public boolean isDataReceiveOffloaded() {
+            return false;
+        }
+
+        @Override
+        public boolean isSendOffloaded() {
+            return false;
+        }
+
+        @Override
+        public boolean isEventOffloaded() {
+            return false;
+        }
+
+        @Override
+        public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
+            return this;
+        }
+    };
+
+    private static final HttpExecutionStrategy MAGIC_INFLUENCE_STRATEGY = new HttpExecutionStrategy() {
+
+        @Override
+        public boolean isCloseOffloaded() {
+            return false;
+        }
+
+        @Override
+        public boolean isMetadataReceiveOffloaded() {
+            return false;
+        }
+
+        @Override
+        public boolean isDataReceiveOffloaded() {
+            return false;
+        }
+
+        @Override
+        public boolean isSendOffloaded() {
+            return false;
+        }
+
+        @Override
+        public boolean isEventOffloaded() {
+            return false;
+        }
+
+        @Override
+        public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
+            return this;
+        }
+    };
+
+    @Test
+    void bothDefaults() {
+        class BothDefaults implements HttpExecutionStrategyInfluencer {
+        }
+
+        BothDefaults bothDefaults = new BothDefaults();
+        assertThat(bothDefaults.requiredOffloads(), sameInstance(offloadAll()));
+        assertThat(bothDefaults.influenceStrategy(defaultStrategy()), sameInstance(offloadAll()));
+    }
+
+    @Test
+    void onlyRequiredOffloadsImplemented() {
+        class RequiredOnly implements HttpExecutionStrategyInfluencer {
+            @Override
+            public HttpExecutionStrategy requiredOffloads() {
+                return MAGIC_REQUIRED_STRATEGY;
+            }
+        }
+
+        RequiredOnly requiredOnly = new RequiredOnly();
+        assertThat(requiredOnly.requiredOffloads(), sameInstance(MAGIC_REQUIRED_STRATEGY));
+        assertThat(requiredOnly.influenceStrategy(defaultStrategy()), sameInstance(MAGIC_REQUIRED_STRATEGY));
+    }
+
+    @Test
+    void onlyInfluenceStrategyImplemented() {
+        class InfluenceOnly implements HttpExecutionStrategyInfluencer {
+            @Override
+            public HttpExecutionStrategy influenceStrategy(HttpExecutionStrategy strategy) {
+                return MAGIC_INFLUENCE_STRATEGY;
+            }
+        }
+
+        InfluenceOnly influenceOnly = new InfluenceOnly();
+        assertThat(influenceOnly.requiredOffloads(), sameInstance(MAGIC_INFLUENCE_STRATEGY));
+        assertThat(influenceOnly.influenceStrategy(defaultStrategy()), sameInstance(MAGIC_INFLUENCE_STRATEGY));
+    }
+
+    @Test
+    void bothRequiredOffloadsAndInfluenceStrategyImplemented() {
+        class BothImplemented implements HttpExecutionStrategyInfluencer {
+            @Override
+            public HttpExecutionStrategy requiredOffloads() {
+                return MAGIC_REQUIRED_STRATEGY;
+            }
+
+            @Override
+            public HttpExecutionStrategy influenceStrategy(HttpExecutionStrategy strategy) {
+                return MAGIC_INFLUENCE_STRATEGY;
+            }
+        }
+
+        BothImplemented bothImplemented = new BothImplemented();
+        assertThat(bothImplemented.requiredOffloads(), sameInstance(MAGIC_REQUIRED_STRATEGY));
+        assertThat(bothImplemented.influenceStrategy(defaultStrategy()), sameInstance(MAGIC_INFLUENCE_STRATEGY));
+    }
+}

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategyTest.java
@@ -116,6 +116,22 @@ class HttpExecutionStrategyTest {
         assertThat(requiredOnly.influenceStrategy(defaultStrategy()), sameInstance(MAGIC_REQUIRED_STRATEGY));
     }
 
+    private interface MyOwnDefaultRequiredOffloads extends HttpExecutionStrategyInfluencer {
+        @Override
+        default HttpExecutionStrategy requiredOffloads() {
+            return MAGIC_REQUIRED_STRATEGY;
+        }
+    }
+
+    @Test
+    void requiredOffloadsSubInterfaceDefault() {
+        class RequiredDefault implements MyOwnDefaultRequiredOffloads { }
+
+        RequiredDefault requiredOnly = new RequiredDefault();
+        assertThat(requiredOnly.requiredOffloads(), sameInstance(MAGIC_REQUIRED_STRATEGY));
+        assertThat(requiredOnly.influenceStrategy(defaultStrategy()), sameInstance(MAGIC_REQUIRED_STRATEGY));
+    }
+
     @Test
     void onlyInfluenceStrategyImplemented() {
         class InfluenceOnly implements HttpExecutionStrategyInfluencer {


### PR DESCRIPTION
Motivation:
The current default implementation of `requiredOffloads` does not
consider the case where `influenceStrategy` is implemented.
Modifications:
Call `influenceStrategy` within default `requiredOffloads` to determine
needed offloads. Default `influenceStrategy` may not call default
`requiredOffloads` to avoid infinite recursion.
Result:
Legacy influencers which do not yet implement `requiredOffloads` will
still be able to influence execution strategy.