### PR TITLE
Fix ClientClosureRaceTest bring back max-retries

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientClosureRaceTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientClosureRaceTest.java
@@ -46,6 +46,7 @@ import static io.servicetalk.concurrent.api.Single.collectUnordered;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofConstantBackoffFullJitter;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofImmediate;
 import static java.lang.Integer.MAX_VALUE;
 import static java.net.InetAddress.getLoopbackAddress;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -176,7 +177,8 @@ class ClientClosureRaceTest {
     private SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilder() {
         final RetryingHttpRequesterFilter.Builder retryBuilder = new RetryingHttpRequesterFilter.Builder();
         return HttpClients.forSingleAddress(HostAndPort.of((InetSocketAddress) serverSocket.getLocalSocketAddress()))
-                .appendClientFilter(retryBuilder
+                .appendClientFilter(retryBuilder.maxTotalRetries(MAX_VALUE)
+                        .retryRetryableExceptions((__, ___) -> ofImmediate(MAX_VALUE))
                         .retryOther((md, t) ->
                                 // This test has the server intentionally hard-close the connection after responding
                                 // to the first request, however some tests use pipelining and may write multiple


### PR DESCRIPTION
Motivation:

During the retrying http rework, the filter changed from having by default infinite max-retries to have 4. Some places that were modified during the refectory with the first assumption, weren't reverted. This can result in rare test failures.

Modifications:

Restore max-retries on the retrying http builder for retryable and other exceptions.

Result:

Restore old behavior.

(cherry picked from commit 5e8d4828a64594cb69409f82d67fad1cfe98d398)