### PR TITLE
`IoExecutor` implements `concurrent.Executor`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executor.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
  * A general abstraction to execute immediate and delayed tasks.
  *
  * <h2>Long running tasks</h2>
- * {@link Executor} implementations are expected to run long running (blocking) tasks which may depend on other tasks
+ * {@link Executor} implementations are expected to run long-running (blocking) tasks which may depend on other tasks
  * submitted to the same {@link Executor} instance.
  * In order to avoid deadlocks, it is generally a good idea to not allow task queuing in the {@link Executor}.
  */

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -138,9 +138,9 @@ final class DefaultDnsClient implements DnsClient {
         this.nettyIoExecutor = toEventLoopAwareNettyIoExecutor(ioExecutor).next();
         // We must use nettyIoExecutor for the repeater for thread safety!
         srvHostNameRepeater = repeatWithConstantBackoffDeltaJitter(
-                srvHostNameRepeatInitialDelay, srvHostNameRepeatJitter, nettyIoExecutor.asExecutor());
+                srvHostNameRepeatInitialDelay, srvHostNameRepeatJitter, nettyIoExecutor);
         this.ttlCache = new MinTtlCache(new DefaultDnsCache(minTTL, Integer.MAX_VALUE, minTTL), minTTL,
-                nettyIoExecutor.asExecutor());
+                nettyIoExecutor);
         this.observer = observer;
         this.missingRecordStatus = missingRecordStatus;
         asyncCloseable = toAsyncCloseable(graceful -> {
@@ -148,7 +148,7 @@ final class DefaultDnsClient implements DnsClient {
                 closeAsync0();
                 return completed();
             }
-            return nettyIoExecutor.asExecutor().submit(this::closeAsync0);
+            return nettyIoExecutor.submit(this::closeAsync0);
         });
         final EventLoop eventLoop = this.nettyIoExecutor.eventLoopGroup().next();
         @SuppressWarnings("unchecked")
@@ -462,7 +462,7 @@ final class DefaultDnsClient implements DnsClient {
             if (nettyIoExecutor.isCurrentThreadEventLoop()) {
                 handleSubscribe0(subscriber);
             } else {
-                nettyIoExecutor.asExecutor().execute(() -> handleSubscribe0(subscriber));
+                nettyIoExecutor.execute(() -> handleSubscribe0(subscriber));
             }
         }
 
@@ -537,7 +537,7 @@ final class DefaultDnsClient implements DnsClient {
                 if (nettyIoExecutor.isCurrentThreadEventLoop()) {
                     request0(n);
                 } else {
-                    nettyIoExecutor.asExecutor().execute(() -> request0(n));
+                    nettyIoExecutor.execute(() -> request0(n));
                 }
             }
 
@@ -546,7 +546,7 @@ final class DefaultDnsClient implements DnsClient {
                 if (nettyIoExecutor.isCurrentThreadEventLoop()) {
                     cancel0();
                 } else {
-                    nettyIoExecutor.asExecutor().execute(this::cancel0);
+                    nettyIoExecutor.execute(this::cancel0);
                 }
             }
 
@@ -564,7 +564,7 @@ final class DefaultDnsClient implements DnsClient {
                         doQuery0();
                     } else {
                         final long durationNs =
-                                nettyIoExecutor.asExecutor().currentTime(NANOSECONDS) - resolveDoneNoScheduleTime;
+                                nettyIoExecutor.currentTime(NANOSECONDS) - resolveDoneNoScheduleTime;
                         if (durationNs > ttlNanos) {
                             doQuery0();
                         } else {
@@ -634,8 +634,7 @@ final class DefaultDnsClient implements DnsClient {
 
                 // This value is coming from DNS TTL for which the unit is seconds and the minimum value we accept
                 // in the builder is 1 second.
-                cancellableForQuery = nettyIoExecutor.asExecutor().schedule(
-                        this::doQuery0, nanos, NANOSECONDS);
+                cancellableForQuery = nettyIoExecutor.schedule(this::doQuery0, nanos, NANOSECONDS);
             }
 
             private void handleResolveDone0(final Future<DnsAnswer<T>> addressFuture,
@@ -663,7 +662,7 @@ final class DefaultDnsClient implements DnsClient {
                         if (--pendingRequests > 0) {
                             scheduleQuery0(ttlNanos);
                         } else {
-                            resolveDoneNoScheduleTime = nettyIoExecutor.asExecutor().currentTime(NANOSECONDS);
+                            resolveDoneNoScheduleTime = nettyIoExecutor.currentTime(NANOSECONDS);
                             cancellableForQuery = null;
                         }
                         try {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpExecutionStrategyTest.java
@@ -162,7 +162,7 @@ class DefaultHttpExecutionStrategyTest {
         };
         if (params.offloadSend || params.offloadReceiveMeta || params.offloadReceiveData) {
             NettyIoExecutor ioExecutor = (NettyIoExecutor) contextRule.ioExecutor();
-            ioExecutor.asExecutor().submit(runHandle).toFuture().get();
+            ioExecutor.submit(runHandle).toFuture().get();
         } else {
             runHandle.call();
         }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
@@ -15,15 +15,15 @@
  */
 package io.servicetalk.transport.api;
 
+import io.servicetalk.concurrent.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
-import java.util.concurrent.Executor;
 import java.util.function.BooleanSupplier;
 
 /**
  * {@link Executor} that handles IO.
  */
-public interface IoExecutor extends ListenableAsyncCloseable {
+public interface IoExecutor extends Executor, ListenableAsyncCloseable {
 
     /**
      * Determine if <a href="https://en.wikipedia.org/wiki/Unix_domain_socket">Unix Domain Sockets</a> are supported.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
@@ -15,15 +15,17 @@
  */
 package io.servicetalk.transport.api;
 
+import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
 /**
  * {@link Executor} that handles IO.
  */
-public interface IoExecutor extends Executor, ListenableAsyncCloseable {
+public interface IoExecutor extends Executor {
 
     /**
      * Determine if <a href="https://en.wikipedia.org/wiki/Unix_domain_socket">Unix Domain Sockets</a> are supported.
@@ -59,5 +61,17 @@ public interface IoExecutor extends Executor, ListenableAsyncCloseable {
         return isIoThreadSupported() ?
                 IoThreadFactory.IoThread::currentThreadIsIoThread : // offload if on IO thread
                 Boolean.TRUE::booleanValue; // unconditional
+    }
+
+    // FIXME: 0.43 - remove default method
+    @Override
+    default Cancellable execute(Runnable task) throws RejectedExecutionException {
+        throw new UnsupportedOperationException("No existing IoExecutor implementations require this default");
+    }
+
+    // FIXME: 0.43 - remove default method
+    @Override
+    default Cancellable schedule(Runnable task, long delay, TimeUnit unit) throws RejectedExecutionException {
+        throw new UnsupportedOperationException("No existing IoExecutor implementations require this default");
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.transport.api;
 
-import io.servicetalk.concurrent.Executor;
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
 import java.util.function.BooleanSupplier;

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/AbstractNettyIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/AbstractNettyIoExecutor.java
@@ -96,6 +96,7 @@ abstract class AbstractNettyIoExecutor<T extends EventLoopGroup> implements Nett
     }
 
     @Override
+    @Deprecated
     public Executor asExecutor() {
         return this;
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.transport.netty.internal;
 
+import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Executors;
@@ -26,6 +27,9 @@ import io.servicetalk.transport.api.IoExecutor;
 import io.netty.channel.EventLoopGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.transport.api.ExecutionStrategy.offloadAll;
@@ -132,6 +136,17 @@ public final class GlobalExecutionContext {
         @Override
         public Executor asExecutor() {
             return delegate.asExecutor();
+        }
+
+        @Override
+        public Cancellable execute(final Runnable task) throws RejectedExecutionException {
+            return delegate.execute(task);
+        }
+
+        @Override
+        public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit)
+                throws RejectedExecutionException {
+            return delegate.schedule(task, delay, unit);
         }
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
@@ -134,6 +134,7 @@ public final class GlobalExecutionContext {
         }
 
         @Override
+        @Deprecated
         public Executor asExecutor() {
             return delegate.asExecutor();
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
@@ -33,6 +33,7 @@ public interface NettyIoExecutor extends IoExecutor {
      * @return an {@link Executor} which will use an {@link IoExecutor} thread for execution.
      * @deprecated IoExecutor now implements {@link Executor} so this method is redundant.
      */
+    // FIXME 0.43 - remove deprecated method
     @Deprecated
     Executor asExecutor();
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
@@ -24,7 +24,7 @@ import io.servicetalk.transport.api.IoExecutor;
  * Implementations of this interface assumes that they would not be used to run blocking code.
  * If this assumption is violated, it will impact eventloop responsiveness and hence should be avoided.
  */
-public interface NettyIoExecutor extends IoExecutor {
+public interface NettyIoExecutor extends IoExecutor, Executor {
     /**
      * Get an {@link Executor} which will use an {@link IoExecutor} thread for execution.
      * <p><strong>Caution</strong></p>

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutor.java
@@ -24,13 +24,15 @@ import io.servicetalk.transport.api.IoExecutor;
  * Implementations of this interface assumes that they would not be used to run blocking code.
  * If this assumption is violated, it will impact eventloop responsiveness and hence should be avoided.
  */
-public interface NettyIoExecutor extends IoExecutor, Executor {
+public interface NettyIoExecutor extends IoExecutor {
     /**
      * Get an {@link Executor} which will use an {@link IoExecutor} thread for execution.
      * <p><strong>Caution</strong></p>
      * Implementation of this method assumes there would be no blocking code inside the submitted {@link Runnable}s.
      * If this assumption is violated, it will impact EventLoop responsiveness and hence should be avoided.
      * @return an {@link Executor} which will use an {@link IoExecutor} thread for execution.
+     * @deprecated IoExecutor now implements {@link Executor} so this method is redundant.
      */
+    @Deprecated
     Executor asExecutor();
 }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/GlobalExecutionContextTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/GlobalExecutionContextTest.java
@@ -35,7 +35,7 @@ class GlobalExecutionContextTest {
         gec.executor().schedule(scheduleLatch::countDown, 5, MILLISECONDS);
         NettyIoExecutor ioExecutor = toNettyIoExecutor(gec.ioExecutor());
         assertThat("global ioExecutor does not support IoThread", ioExecutor.isIoThreadSupported());
-        ioExecutor.asExecutor().schedule(scheduleLatch::countDown, 5, MILLISECONDS);
+        ioExecutor.schedule(scheduleLatch::countDown, 5, MILLISECONDS);
         scheduleLatch.await();
     }
 }


### PR DESCRIPTION
Motivation:
Implementing `Executor` allows `IoExecutor` to used in existing
interfaces. Usage of `IoExecutor`s for `Executor` will still be very
limited for specialized cases.
Modifications:
`IoExecutor` extends `io.servicetalk.concurrent.Executor`. No user
implementations of `IoExecutor` likely exist and `NettyIoExecutor`
already implements the interface.
Result:
`IoExecutor` instances can now be passed in interfaces which currently
only accept `io.servicetalk.concurrent.Executor`.