### PR TITLE
Use `setClassLevel(true)` on static instances

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
@@ -81,10 +81,12 @@ class GrpcLifecycleObserverTest {
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-            ExecutionContextExtension.cached("server-io", "server-executor");
+            ExecutionContextExtension.cached("server-io", "server-executor")
+                    .setClassLevel(true);
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-            ExecutionContextExtension.cached("client-io", "client-executor");
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
 
     private static final String CONTENT = "content";
     private static final GrpcLifecycleObserver LOGGING = logging("servicetalk-tests-lifecycle-observer-logger", TRACE);

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
@@ -68,10 +68,12 @@ class KeepAliveTest {
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached("server-io", "server-executor");
+        ExecutionContextExtension.cached("server-io", "server-executor")
+                .setClassLevel(true);
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-            ExecutionContextExtension.cached("client-io", "client-executor");
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
 
     @Nullable
     private TesterClient client;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractConditionalHttpFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractConditionalHttpFilterTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractConditionalHttpFilterTest {
     private static final ContextMap.Key<String> CTX_KEY = newKey("test-key", String.class);
 
     @RegisterExtension
-    static final ExecutionContextExtension TEST_CTX = cached();
+    static final ExecutionContextExtension TEST_CTX = cached().setClassLevel(true);
 
     protected static final Predicate<StreamingHttpRequest> TEST_REQ_PREDICATE = req -> {
         AsyncContext.put(CTX_KEY, "in-predicate");

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -58,10 +58,10 @@ import static org.mockito.Mockito.verify;
 class DefaultMultiAddressUrlHttpClientBuilderTest {
 
     @RegisterExtension
-    static final ExecutionContextExtension CTX = immediate();
+    static final ExecutionContextExtension CTX = immediate().setClassLevel(true);
 
     @RegisterExtension
-    static final ExecutionContextExtension INTERNAL_CLIENT_CTX = cached();
+    static final ExecutionContextExtension INTERNAL_CLIENT_CTX = cached().setClassLevel(true);
 
     @Test
     void buildWithDefaults() throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -113,10 +113,12 @@ class GracefulConnectionClosureHandlingTest {
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-            ExecutionContextExtension.cached("server-io", "server-executor");
+            ExecutionContextExtension.cached("server-io", "server-executor")
+                    .setClassLevel(true);
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-            ExecutionContextExtension.cached("client-io", "client-executor");
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
 
     private static final String REQUEST_CONTENT = "request_content";
     private static final String RESPONSE_CONTENT = "response_content";

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
@@ -74,7 +74,8 @@ class H2ConcurrencyControllerTest {
 
     @RegisterExtension
     static final ExecutionContextExtension CTX =
-        ExecutionContextExtension.cached("client-io", "client-executor");
+        ExecutionContextExtension.cached("client-io", "client-executor")
+                .setClassLevel(true);
 
     private EventLoopGroup serverEventLoopGroup;
     private Channel serverAcceptorChannel;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -51,7 +51,7 @@ class HttpAuthConnectionFactoryClientTest {
 
     @RegisterExtension
     static final ExecutionContextExtension CTX =
-        immediate();
+        immediate().setClassLevel(true);
 
     @Nullable
     private StreamingHttpClient client;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -82,10 +82,12 @@ class HttpOffloadingTest {
 
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-        ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX));
+        ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX))
+                .setClassLevel(true);
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX));
+        ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX))
+                .setClassLevel(true);
 
     private StreamingHttpConnection httpConnection;
     private final Queue<Throwable> errors = new ConcurrentLinkedQueue<>();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -111,11 +111,11 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
     static final ExecutionContextExtension SEC =
             new ExecutionContextExtension(() -> allocator,
                     () -> createIoExecutor("server-io"),
-                    Executors::immediate);
+                    Executors::immediate).setClassLevel(true);;
     @RegisterExtension
     static final ExecutionContextExtension CEC = new ExecutionContextExtension(() -> allocator,
             () -> createIoExecutor("client-io"),
-            Executors::newCachedThreadExecutor);
+            Executors::newCachedThreadExecutor).setClassLevel(true);;
 
     @Override
     EmbeddedChannel newEmbeddedChannel() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
@@ -88,12 +88,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class MalformedDataAfterHttpMessageTest {
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached("server-io", "server-executor")
-                .setClassLevel(true);
+        ExecutionContextExtension.cached("server-io", "server-executor");
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-        ExecutionContextExtension.cached("client-io", "client-executor")
-                .setClassLevel(true);
+        ExecutionContextExtension.cached("client-io", "client-executor");
 
     private static final String CONTENT = "hello";
     private static final String RESPONSE_MSG = "HTTP/1.1 200 OK\r\n" +

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
@@ -88,10 +88,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class MalformedDataAfterHttpMessageTest {
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached("server-io", "server-executor");
+        ExecutionContextExtension.cached("server-io", "server-executor")
+                .setClassLevel(true);
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-        ExecutionContextExtension.cached("client-io", "client-executor");
+        ExecutionContextExtension.cached("client-io", "client-executor")
+                .setClassLevel(true);
 
     private static final String CONTENT = "hello";
     private static final String RESPONSE_MSG = "HTTP/1.1 200 OK\r\n" +

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PrematureClosureBeforeResponsePayloadBodyTest.java
@@ -73,7 +73,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class PrematureClosureBeforeResponsePayloadBodyTest {
 
     @RegisterExtension
-    static final ExecutionContextExtension SERVER_CTX = ExecutionContextExtension.immediate();
+    static final ExecutionContextExtension SERVER_CTX = ExecutionContextExtension.immediate().setClassLevel(true);
 
     private ServerSocketChannel server;
     private BlockingHttpClient client;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -67,10 +67,12 @@ class SecurityHandshakeObserverTest {
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached("server-io", "server-executor");
+        ExecutionContextExtension.cached("server-io", "server-executor")
+                .setClassLevel(true);
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-        ExecutionContextExtension.cached("client-io", "client-executor");
+        ExecutionContextExtension.cached("client-io", "client-executor")
+                .setClassLevel(true);
 
     private final TransportObserver clientTransportObserver;
     private final ConnectionObserver clientConnectionObserver;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerGracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerGracefulConnectionClosureHandlingTest.java
@@ -53,7 +53,8 @@ class ServerGracefulConnectionClosureHandlingTest {
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached("server-io", "server-executor");
+        ExecutionContextExtension.cached("server-io", "server-executor")
+                .setClassLevel(true);
 
     private static final HttpStreamingSerializer<String> RAW_STRING_SERIALIZER =
             stringStreamingSerializer(UTF_8, hdr -> { });

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/Tls13Test.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/Tls13Test.java
@@ -56,10 +56,12 @@ class Tls13Test {
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached("server-io", "server-executor");
+        ExecutionContextExtension.cached("server-io", "server-executor")
+                .setClassLevel(true);
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-        ExecutionContextExtension.cached("client-io", "client-executor");
+        ExecutionContextExtension.cached("client-io", "client-executor")
+                .setClassLevel(true);
 
     private static final String TLS1_3 = "TLSv1.3";
     private static final String TLS1_3_REQUIRED_CIPHER = "TLS_AES_128_GCM_SHA256";

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpServerOverrideOffloadingTest.java
@@ -71,7 +71,8 @@ class HttpServerOverrideOffloadingTest {
 
     @RegisterExtension
     private static final ExecutionContextExtension EXECUTION_CONTEXT =
-            ExecutionContextExtension.cached(IO_EXECUTOR_THREAD_NAME_PREFIX, EXECUTOR_THREAD_NAME_PREFIX);
+            ExecutionContextExtension.cached(IO_EXECUTOR_THREAD_NAME_PREFIX, EXECUTOR_THREAD_NAME_PREFIX)
+                    .setClassLevel(true);
     private OffloadingTesterService routeService;
     private ServerContext server;
 

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTcpServerTest.java
@@ -44,10 +44,12 @@ public abstract class AbstractTcpServerTest {
 
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached("server-io", "server-executor");
+        ExecutionContextExtension.cached("server-io", "server-executor")
+                .setClassLevel(true);
     @RegisterExtension
     public static final ExecutionContextExtension CLIENT_CTX =
-            ExecutionContextExtension.cached("client-io", "client-executor");
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
 
     private InfluencerConnectionAcceptor connectionAcceptor =
             InfluencerConnectionAcceptor.withStrategy(ACCEPT_ALL, ConnectExecutionStrategy.offloadNone());

--- a/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextExtension.java
+++ b/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextExtension.java
@@ -47,8 +47,8 @@ public final class ExecutionContextExtension implements AfterEachCallback, Befor
                                                         AfterAllCallback, BeforeAllCallback,
                                                         ExecutionContext<ExecutionStrategy> {
 
-    private static final String IO_THREAD_PREFIX = "exec-ctx-rule-io";
-    private static final String EXEC_THREAD_PREFIX = "exec-ctx-rule-exec";
+    private static final String IO_THREAD_PREFIX = "exec-ctx-ext-io";
+    private static final String EXEC_THREAD_PREFIX = "exec-ctx-ext-exec";
     private final Supplier<Executor> executorSupplier;
     private final Supplier<IoExecutor> ioExecutorSupplier;
     private final Supplier<BufferAllocator> allocatorSupplier;
@@ -116,6 +116,13 @@ public final class ExecutionContextExtension implements AfterEachCallback, Befor
         return fixed(1, nettyIoThreadFactory);
     }
 
+    /**
+     * Set to true if the extension is being shared among all tests in a class.
+     *
+     * @param classLevel true if extension is shared between tests within test class otherwise false to create a new
+     * instance for each test.
+     * @return this
+     */
     public ExecutionContextExtension setClassLevel(final boolean classLevel) {
         this.classLevel = classLevel;
         return this;


### PR DESCRIPTION
Motivation:
The `ExecutionContextExtension` testing extension initializes the
contained execution context once per test unless `setClassLevel(true)`
is called. Some of our tests use a static class-instance of
`ExecutionContextExtension` but fail to call `setClassLevel(true)`
which results in many hundreds of extra invocations of an expensive
operation.
Modifications:
Apply `setClassLevel(true)` to all static instances of
`ExecutionContextExtension`.
Result:
Faster test execution. Saves about 40 seconds for `./gradlew --no-build-cache clean build`
for me.