### PR TITLE
Schedule/execute no offload timeouts on IoExecutor

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
@@ -20,6 +20,9 @@ import org.slf4j.LoggerFactory;
 
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 
+/**
+ * Implements {@link Executor} for {@link Executors#global()}.
+ */
 final class GlobalExecutor extends DelegatingExecutor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExecutor.class);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ImmediateExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ImmediateExecutor.java
@@ -23,6 +23,9 @@ import java.util.concurrent.TimeUnit;
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.Executors.from;
 
+/**
+ * Implements {@link Executor} for {@link Executors#immediate()}.
+ */
 final class ImmediateExecutor extends AbstractExecutor {
 
     private static final Executor IMMEDIATE = from(Runnable::run);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutSingle.java
@@ -62,7 +62,7 @@ final class TimeoutSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
                 contextMap, contextProvider);
     }
 
-    private static final class TimeoutSubscriber<X> implements Subscriber<X>, Cancellable, Runnable {
+    private static final class TimeoutSubscriber<X> implements Subscriber<X>, Cancellable {
         /**
          * Create a local instance because the instance is used as part of the local state machine.
          */
@@ -104,7 +104,7 @@ final class TimeoutSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
                 // it enabled for the Subscriber, however the user explicitly specifies the Executor with this operator
                 // so they can wrap the Executor in this case.
                 localTimerCancellable = requireNonNull(
-                        parent.timeoutExecutor.schedule(s, parent.durationNs, NANOSECONDS));
+                        parent.timeoutExecutor.schedule(s::timerFires, parent.durationNs, NANOSECONDS));
             } catch (Throwable cause) {
                 localTimerCancellable = IGNORE_CANCEL;
                 // We must set this to ignore so there are no further interactions with Subscriber in the future.
@@ -167,8 +167,7 @@ final class TimeoutSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
             }
         }
 
-        @Override
-        public void run() {
+        private void timerFires() {
             Cancellable oldCancellable = cancellableUpdater.getAndSet(this, LOCAL_IGNORE_CANCEL);
             if (oldCancellable != LOCAL_IGNORE_CANCEL) {
                 // The timeout may be running on a different Executor than the original async source. If that is the

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/TimeoutPublisherTest.java
@@ -83,7 +83,7 @@ class TimeoutPublisherTest {
     }
 
     @RegisterExtension
-    final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
+    static final ExecutorExtension<TestExecutor> executorExtension = ExecutorExtension.withTestExecutor();
 
     private final TestPublisher<Integer> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();

--- a/servicetalk-http-utils/build.gradle
+++ b/servicetalk-http-utils/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-http-api"))
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-concurrent-api-test")
+  testImplementation project(":servicetalk-transport-netty")
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
@@ -15,9 +15,8 @@
  */
 package io.servicetalk.http.utils;
 
+import io.servicetalk.concurrent.Executor;
 import io.servicetalk.concurrent.TimeSource;
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.Executors;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -51,8 +50,7 @@ abstract class AbstractTimeoutHttpFilter implements HttpExecutionStrategyInfluen
     private final boolean fullRequestResponse;
 
     /**
-     * Executor that will be used for timeout actions. This is optional and the connection or request context executor
-     * or global executor will be used if not specified.
+     * Optional executor that will be used for scheduling and execution of timeout actions. If unspecified, the
      */
     @Nullable
     private final Executor timeoutExecutor;
@@ -106,11 +104,9 @@ abstract class AbstractTimeoutHttpFilter implements HttpExecutionStrategyInfluen
      */
     final Single<StreamingHttpResponse> withTimeout(final StreamingHttpRequest request,
             final Function<StreamingHttpRequest, Single<StreamingHttpResponse>> responseFunction,
-            @Nullable final Executor contextExecutor) {
+            final Executor contextExecutor) {
 
-        // timeoutExecutor → context executor → global default executor
-        final Executor effectiveExecutor = null != contextExecutor ? contextExecutor : Executors.global();
-        final Executor useForTimeout = null != this.timeoutExecutor ? this.timeoutExecutor : effectiveExecutor;
+        final Executor useForTimeout = null != this.timeoutExecutor ? this.timeoutExecutor : contextExecutor;
 
         return Single.defer(() -> {
             final Duration timeout = timeoutForRequest.apply(request, useForTimeout);

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
@@ -15,11 +15,12 @@
  */
 package io.servicetalk.http.utils;
 
+import io.servicetalk.concurrent.Executor;
 import io.servicetalk.concurrent.TimeSource;
-import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
@@ -37,6 +38,11 @@ import java.util.function.BiFunction;
  *
  * <p>The timeout applies either the response metadata (headers) completion or the complete reception of the response
  * payload body and optional trailers.
+ *
+ * <p>If no executor is specified at construction an executor from {@link HttpExecutionContext} associated with the
+ * client or connection will be used. If the {@link HttpExecutionContext#executionStrategy()} specifies an
+ * {@link io.servicetalk.http.api.HttpExecutionStrategy} with offloads then {@link HttpExecutionContext#executor()} will
+ * be used and if no offloads are specified then {@link HttpExecutionContext#ioExecutor()} will be used.
  *
  * <p>The order with which this filter is applied may be highly significant. For example, appending it before a retry
  * filter would have different results than applying it after the retry filter; timeout would apply for all retries vs
@@ -154,8 +160,10 @@ public final class TimeoutHttpRequesterFilter extends AbstractTimeoutHttpFilter
             @Override
             protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                             final StreamingHttpRequest request) {
+                HttpExecutionContext executionContext = client.executionContext();
                 return TimeoutHttpRequesterFilter.this.withTimeout(request, delegate::request,
-                        client.executionContext().executor());
+                        executionContext.executionStrategy().hasOffloads() ?
+                                executionContext.executor() : executionContext.ioExecutor());
             }
         };
     }
@@ -165,8 +173,10 @@ public final class TimeoutHttpRequesterFilter extends AbstractTimeoutHttpFilter
         return new StreamingHttpConnectionFilter(connection) {
             @Override
             public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                HttpExecutionContext executionContext = connection.executionContext();
                 return TimeoutHttpRequesterFilter.this.withTimeout(request, r -> delegate().request(r),
-                        connection.executionContext().executor());
+                        executionContext.executionStrategy().hasOffloads() ?
+                                executionContext.executor() : executionContext.ioExecutor());
             }
         };
     }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
@@ -41,8 +42,8 @@ import java.util.function.BiFunction;
  *
  * <p>If no executor is specified at construction an executor from {@link HttpExecutionContext} associated with the
  * client or connection will be used. If the {@link HttpExecutionContext#executionStrategy()} specifies an
- * {@link io.servicetalk.http.api.HttpExecutionStrategy} with offloads then {@link HttpExecutionContext#executor()} will
- * be used and if no offloads are specified then {@link HttpExecutionContext#ioExecutor()} will be used.
+ * {@link HttpExecutionStrategy} with offloads then {@link HttpExecutionContext#executor()} will be used and if no
+ * offloads are specified then {@link HttpExecutionContext#ioExecutor()} will be used.
  *
  * <p>The order with which this filter is applied may be highly significant. For example, appending it before a retry
  * filter would have different results than applying it after the retry filter; timeout would apply for all retries vs

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.Executor;
 import io.servicetalk.concurrent.TimeSource;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -38,9 +39,9 @@ import java.util.function.BiFunction;
  * payload body and optional trailers.
  *
  * <p>If no executor is specified at construction an executor from {@link HttpExecutionContext} associated with the
- * service will be used. If the {@link HttpExecutionContext#executionStrategy()} specifies an
- * {@link io.servicetalk.http.api.HttpExecutionStrategy} with offloads then {@link HttpExecutionContext#executor()} will
- * be used and if no offloads are specified then {@link HttpExecutionContext#ioExecutor()} will be used.
+ * client or connection will be used. If the {@link HttpExecutionContext#executionStrategy()} specifies an
+ * {@link HttpExecutionStrategy} with offloads then {@link HttpExecutionContext#executor()} will be used and if no
+ * offloads are specified then {@link HttpExecutionContext#ioExecutor()} will be used.
  *
  * <p>The order with which this filter is applied may be highly significant. For example, appending it before a retry
  * filter would have different results than applying it after the retry filter; timeout would apply for all retries vs

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
@@ -27,6 +27,7 @@ import io.servicetalk.concurrent.api.TestSingle;
 import io.servicetalk.concurrent.api.test.StepVerifiers;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.EmptyHttpHeaders;
+import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.StreamingHttpResponse;
@@ -138,7 +139,9 @@ abstract class AbstractTimeoutHttpFilterTest {
     }
 
     static Iterable<HttpExecutionStrategy> executionStrategies() {
-        return Arrays.asList(offloadNever(), offloadNone(), defaultStrategy(), offloadAll());
+        return Arrays.asList(offloadNever(), offloadNone(),
+                HttpExecutionStrategies.customStrategyBuilder().offloadEvent().build(),
+                defaultStrategy(), offloadAll());
     }
 
     @ParameterizedTest

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
@@ -17,6 +17,9 @@ package io.servicetalk.http.utils;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.TimeSource;
+import io.servicetalk.concurrent.api.DefaultThreadFactory;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Executors;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestPublisher;
@@ -24,14 +27,20 @@ import io.servicetalk.concurrent.api.TestSingle;
 import io.servicetalk.concurrent.api.test.StepVerifiers;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.EmptyHttpHeaders;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.IoThreadFactory;
+import io.servicetalk.transport.netty.NettyIoExecutors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -41,6 +50,10 @@ import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.TimeoutTracingInfoExtension.DEFAULT_TIMEOUT_SECONDS;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
@@ -56,14 +69,21 @@ import static org.mockito.Mockito.mock;
 
 abstract class AbstractTimeoutHttpFilterTest {
 
+    private static final String EXECUTOR_NAME_PREFIX = "Timeout-Executor";
+    protected static final Executor EXECUTOR = Executors.newCachedThreadExecutor(
+            new DefaultThreadFactory(EXECUTOR_NAME_PREFIX));
+    protected static final IoExecutor IO_EXECUTOR = NettyIoExecutors.createIoExecutor("Timeout-IoExecutor");
+
     abstract void newFilter(Duration duration);
 
     abstract Single<StreamingHttpResponse> applyFilter(Duration duration, boolean fullRequestResponse,
+                                                       HttpExecutionStrategy strategy,
                                                        Single<StreamingHttpResponse> responseSingle);
 
     abstract Single<StreamingHttpResponse> applyFilter(
             BiFunction<HttpRequestMetaData, TimeSource, Duration> timeoutForRequest,
             boolean fullRequestResponse,
+            HttpExecutionStrategy strategy,
             Single<StreamingHttpResponse> responseSingle);
 
     @Test
@@ -78,7 +98,7 @@ abstract class AbstractTimeoutHttpFilterTest {
     @ValueSource(booleans = {false, true})
     void responseTimeout(boolean fullRequestResponse) {
         TestSingle<StreamingHttpResponse> responseSingle = new TestSingle<>();
-        StepVerifiers.create(applyFilter(ofNanos(1L), fullRequestResponse, responseSingle))
+        StepVerifiers.create(applyFilter(ofNanos(1L), fullRequestResponse, defaultStrategy(), responseSingle))
                 .expectError(TimeoutException.class)
                 .verify();
         assertThat("No subscribe for response single", responseSingle.isSubscribed(), is(true));
@@ -98,7 +118,7 @@ abstract class AbstractTimeoutHttpFilterTest {
 
     private void responseWithNonPositiveTimeout(Duration timeout, boolean fullRequestResponse) {
         TestSingle<StreamingHttpResponse> responseSingle = new TestSingle<>();
-        StepVerifiers.create(applyFilter((req, ts) -> timeout, fullRequestResponse, responseSingle))
+        StepVerifiers.create(applyFilter((req, ts) -> timeout, fullRequestResponse, defaultStrategy(), responseSingle))
                 .expectError(TimeoutException.class)
                 .verify();
         assertThat("No subscribe for payload body", responseSingle.isSubscribed(), is(true));
@@ -108,7 +128,8 @@ abstract class AbstractTimeoutHttpFilterTest {
     @ValueSource(booleans = {false, true})
     void responseCompletesBeforeTimeout(boolean fullRequestResponse) {
         TestSingle<StreamingHttpResponse> responseSingle = new TestSingle<>();
-        StepVerifiers.create(applyFilter(ofSeconds(DEFAULT_TIMEOUT_SECONDS / 2), fullRequestResponse, responseSingle))
+        StepVerifiers.create(applyFilter(ofSeconds(DEFAULT_TIMEOUT_SECONDS / 2),
+                        fullRequestResponse, defaultStrategy(), responseSingle))
                 .then(() -> immediate().schedule(() -> responseSingle.onSuccess(mock(StreamingHttpResponse.class)),
                         ofMillis(50L)))
                 .expectSuccess()
@@ -116,15 +137,21 @@ abstract class AbstractTimeoutHttpFilterTest {
         assertThat("No subscribe for response single", responseSingle.isSubscribed(), is(true));
     }
 
-    @Test
-    void payloadBodyTimeout() {
+    static Iterable<HttpExecutionStrategy> executionStrategies() {
+        return Arrays.asList(offloadNever(), offloadNone(), defaultStrategy(), offloadAll());
+    }
+
+    @ParameterizedTest
+    @MethodSource("executionStrategies")
+    void payloadBodyTimeout(HttpExecutionStrategy strategy) {
         TestPublisher<Buffer> payloadBody = new TestPublisher<>();
         AtomicBoolean responseSucceeded = new AtomicBoolean();
-        StepVerifiers.create(applyFilter(ofMillis(100L), true, responseWith(payloadBody))
-                .whenOnSuccess(__ -> responseSucceeded.set(true))
-                .flatMapPublisher(StreamingHttpResponse::payloadBody))
+        StepVerifiers.create(applyFilter(ofMillis(100L), true, strategy, responseWith(payloadBody))
+                    .whenOnSuccess(__ -> responseSucceeded.set(true))
+                    .flatMapPublisher(StreamingHttpResponse::payloadBody))
                 .thenRequest(MAX_VALUE)
-                .expectError(TimeoutException.class)
+                .expectErrorMatches(t -> TimeoutException.class.isInstance(t) &&
+                        (Thread.currentThread() instanceof IoThreadFactory.IoThread ^ strategy.hasOffloads()))
                 .verify();
         assertThat("Response did not succeeded", responseSucceeded.get(), is(true));
         assertThat("No subscribe for payload body", payloadBody.isSubscribed(), is(true));
@@ -135,9 +162,9 @@ abstract class AbstractTimeoutHttpFilterTest {
         Duration timeout = ofMillis(100L);
         TestPublisher<Buffer> payloadBody = new TestPublisher<>();
         AtomicBoolean responseSucceeded = new AtomicBoolean();
-        StepVerifiers.create(applyFilter(timeout, false, responseWith(payloadBody))
-                .whenOnSuccess(__ -> responseSucceeded.set(true))
-                .flatMapPublisher(StreamingHttpResponse::payloadBody))
+        StepVerifiers.create(applyFilter(timeout, false, defaultStrategy(), responseWith(payloadBody))
+                    .whenOnSuccess(__ -> responseSucceeded.set(true))
+                    .flatMapPublisher(StreamingHttpResponse::payloadBody))
                 .expectSubscriptionConsumed(subscription ->
                         immediate().schedule(subscription::cancel, timeout.plusMillis(10L)))
                 .thenRequest(MAX_VALUE)
@@ -155,7 +182,8 @@ abstract class AbstractTimeoutHttpFilterTest {
         Duration timeout = ofMillis(100L);
         TestPublisher<Buffer> payloadBody = new TestPublisher<>();
         AtomicReference<StreamingHttpResponse> response = new AtomicReference<>();
-        StepVerifiers.create(applyFilter(timeout, true, responseWith(payloadBody)))
+        StepVerifiers.create(applyFilter(timeout, true,
+                        defaultStrategy(), responseWith(payloadBody)))
                 .expectSuccessConsumed(response::set)
                 .verify();
 
@@ -170,7 +198,8 @@ abstract class AbstractTimeoutHttpFilterTest {
     void payloadBodyCompletesBeforeTimeout() {
         TestPublisher<Buffer> payloadBody = new TestPublisher<>();
         AtomicReference<StreamingHttpResponse> response = new AtomicReference<>();
-        StepVerifiers.create(applyFilter(ofSeconds(DEFAULT_TIMEOUT_SECONDS / 2), true, responseWith(payloadBody)))
+        StepVerifiers.create(applyFilter(ofSeconds(DEFAULT_TIMEOUT_SECONDS / 2),
+                        true, defaultStrategy(), responseWith(payloadBody)))
                 .expectSuccessConsumed(response::set)
                 .verify();
 


### PR DESCRIPTION
Motivation:
Currently the timeout filter executes timeout events on the execution
context executor even if the execution strategy requires no offloading.
The IoExecutor should instead be use for these situations to reduce
offloads.
Modifications:
Request `ExecutionContext.ioExecutor()` as the `contextExecutor` if no
offloads are configured.
Result:
Less offloading for some timeout events.
