### PR TITLE
Fix filters for MultiAddressUrlHttpClientBuilder

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerAwareConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerAwareConversions.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.http.api.NewToDeprecatedFilter.NEW_TO_DEPRECATED_FILTER;
 import static java.util.Objects.requireNonNull;
 
 final class StrategyInfluencerAwareConversions {
@@ -67,7 +68,8 @@ final class StrategyInfluencerAwareConversions {
                 }
             };
         }
-        return (address, client) -> new StreamingHttpClientFilter(original.create(client));
+        return (address, client) -> new StreamingHttpClientFilter(
+                NEW_TO_DEPRECATED_FILTER.create(original.create(client)));
     }
 
     static StreamingHttpServiceFilterFactory toConditionalServiceFilterFactory(


### PR DESCRIPTION
Motivation:

Recently the API of filters changed to align better with the way
`ExecutionStrategy` should be set. A temporary additional filter
bridging calls via new API to old API was created to assure compatibility.
Unfortunately, the `MultiAddressUrlHttpClientBuilder` was not updated
and legacy filters may not be exercised.

Modifications:

- Properly appending the `NewToDeprecatedFilter` to filters added via
  `MultiAddressUrlHttpClientBuilder`,
- Legacy `StrategyInfluencerAwareConversions#toMultiAddressClientFactory`
  was also updated to include the bridge,
- `MixedFiltersTest` include a case validating the
  `MultiAddressUrlHttpClientBuilder` behavior.

Result:

Deprecated methods on filters are properly executed when using
`MultiAddressUrlHttpClientBuilder`.