### PR TITLE
Fix broken JAX-RS javadoc links

### DIFF
--- a/servicetalk-data-jackson-jersey/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-data-jackson-jersey/docs/modules/ROOT/pages/index.adoc
@@ -11,7 +11,7 @@ CAUTION: This serializer can not currently be used with Server-Sent Events (SSE)
 
 If you have configured a Jackson `ObjectMapper` and want to use it with this module, you need to provide it to the
 JAX-RS runtime as
-a https://eclipse-ee4j.github.io/jaxrs-api/apidocs/2.1.6/javax/ws/rs/ext/ContextResolver.html[`ContextResolver`].
+a https://jakartaee.github.io/rest/apidocs/2.1.6/javax/ws/rs/ext/ContextResolver.html[`ContextResolver`].
 To help with this, `ServiceTalkJacksonSerializerFeature` provides a helper method named `newContextResolver` that
 can build a `ContextResolver<JacksonSerializerFactory>` from an `ObjectMapper` instance.
 
@@ -20,7 +20,7 @@ It is up to the user to properly register this `ContextResolver` with their appl
 == Using a custom JacksonSerializerFactory
 
 Like with `ObjectMapper`, if you want to use a custom `ServiceTalkJacksonSerializerFeature` you need to provide it as
-a https://eclipse-ee4j.github.io/jaxrs-api/apidocs/2.1.6/javax/ws/rs/ext/ContextResolver.html[`ContextResolver`].
+a https://jakartaee.github.io/rest/apidocs/2.1.6/javax/ws/rs/ext/ContextResolver.html[`ContextResolver`].
 `ServiceTalkJacksonSerializerFeature` provides a helper method named `newContextResolver` that
 can build a `ContextResolver<JacksonSerializerFactory>` from an `ServiceTalkJacksonSerializerFeature` instance.
 


### PR DESCRIPTION
Motivation:
The JAX-RS project has moved their site from
`eclipse-ee4j.github.io/jaxrs-api` to `jakartaee.github.io/rest`
without redirection. Our documentation now contains several 404 links
to the former site.
Modifications:
Adjust JAX-RS javadoc links to point to the new site.
Result:
Documentation `validateLocalHtmlLinks` task suceeeds and links work.