### PR TITLE
Implement `setClassLevel()` for `ExecutorExtension`

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/AbstractCompletableOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/AbstractCompletableOffloadingTest.java
@@ -144,7 +144,7 @@ public abstract class AbstractCompletableOffloadingTest extends AbstractOffloadi
                 testSubscriber.onError(all);
             }
         };
-        app.executor().execute(appCode);
+        APP_EXECUTOR_EXT.executor().execute(appCode);
 
         // Ensure we reached the correct terminal condition
         switch (terminal) {

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/AbstractOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/AbstractOffloadingTest.java
@@ -80,9 +80,9 @@ public abstract class AbstractOffloadingTest {
     protected static final Matcher<String> OFFLOAD_EXECUTOR = startsWith("TestExecutor");
 
     @RegisterExtension
-    public final ExecutorExtension<Executor> app = APP_ISOLATION ?
+    public static final ExecutorExtension<Executor> APP_EXECUTOR_EXT = APP_ISOLATION ?
             withCachedExecutor(APP_EXECUTOR_PREFIX) :
-            ExecutorExtension.withExecutor(() -> immediate());
+            ExecutorExtension.withExecutor(() -> immediate()).setClassLevel(true);
     @RegisterExtension
     public final ExecutorExtension<TestExecutor> testExecutor = ExecutorExtension.withTestExecutor();
 

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublisherOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/AbstractPublisherOffloadingTest.java
@@ -181,7 +181,7 @@ public abstract class AbstractPublisherOffloadingTest extends AbstractOffloading
                 testSubscriber.onError(all);
             }
         };
-        app.executor().execute(appCode);
+        APP_EXECUTOR_EXT.executor().execute(appCode);
 
         // Ensure we reached the correct terminal condition
         switch (terminal) {

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/AbstractSingleOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/AbstractSingleOffloadingTest.java
@@ -147,7 +147,7 @@ public abstract class AbstractSingleOffloadingTest extends AbstractOffloadingTes
                 testSubscriber.onError(all);
             }
         };
-        app.executor().execute(appCode);
+        APP_EXECUTOR_EXT.executor().execute(appCode);
 
         // Ensure we reached the correct terminal condition
         switch (terminal) {

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/CompletableStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/CompletableStepVerifierTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CompletableStepVerifierTest {
     private static final ContextMap.Key<Integer> ASYNC_KEY = newKey("ASYNC_KEY", Integer.class);
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     @Test
     void expectCancellable() {

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
@@ -65,7 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PublisherStepVerifierTest {
     private static final ContextMap.Key<Integer> ASYNC_KEY = newKey("ASYNC_KEY", Integer.class);
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     @Test
     void expectSubscription() {

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/SingleStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/SingleStepVerifierTest.java
@@ -54,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SingleStepVerifierTest {
     private static final ContextMap.Key<Integer> ASYNC_KEY = newKey("ASYNC_KEY", Integer.class);
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     @Test
     void expectCancellable() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verify;
 
 public abstract class AbstractCompositeCancellableTest<T extends Cancellable> {
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     protected abstract T newCompositeCancellable();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
@@ -77,10 +77,10 @@ import static org.mockito.Mockito.when;
 class BufferStrategiesTest {
 
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_EXTENSION = withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_EXTENSION = withCachedExecutor().setClassLevel(true);
 
     @RegisterExtension
-    static final ExecutorExtension<TestExecutor> TEST_EXECUTOR_EXTENSION = withTestExecutor();
+    final ExecutorExtension<TestExecutor> testExecutorExtension = withTestExecutor();
 
     @Test
     @Disabled("https://github.com/apple/servicetalk/issues/1259")
@@ -194,7 +194,7 @@ class BufferStrategiesTest {
 
     @Test
     void forTimeNoItems() {
-        TestExecutor executor = TEST_EXECUTOR_EXTENSION.executor();
+        TestExecutor executor = testExecutorExtension.executor();
         BlockingQueue<Iterable<Integer>> queue = new LinkedBlockingDeque<>();
         Cancellable cancellable = Publisher.<Integer>never()
                 .buffer(forCountOrTime(Integer.MAX_VALUE, ofMillis(1), executor))
@@ -214,7 +214,7 @@ class BufferStrategiesTest {
     @Test
     void forTimeWithItems() {
         TestPublisher<Integer> publisher = new TestPublisher<>();
-        TestExecutor executor = TEST_EXECUTOR_EXTENSION.executor();
+        TestExecutor executor = testExecutorExtension.executor();
         BlockingQueue<Iterable<Integer>> queue = new LinkedBlockingDeque<>();
         publisher.buffer(forCountOrTime(Integer.MAX_VALUE, ofMillis(1), executor))
                 .forEach(queue::add);
@@ -235,7 +235,7 @@ class BufferStrategiesTest {
     @Test
     void forCount1OrTimeWithItems() {
         TestPublisher<Integer> publisher = new TestPublisher<>();
-        TestExecutor executor = TEST_EXECUTOR_EXTENSION.executor();
+        TestExecutor executor = testExecutorExtension.executor();
         BlockingQueue<Iterable<Integer>> queue = new LinkedBlockingDeque<>();
         publisher.buffer(forCountOrTime(1, ofMillis(1), executor))
                 .forEach(queue::add);
@@ -259,7 +259,7 @@ class BufferStrategiesTest {
     @Test
     void forCountOrTimeWithItems() {
         TestPublisher<Integer> publisher = new TestPublisher<>();
-        TestExecutor executor = TEST_EXECUTOR_EXTENSION.executor();
+        TestExecutor executor = testExecutorExtension.executor();
         BlockingQueue<Iterable<Integer>> queue = new LinkedBlockingDeque<>();
         publisher.buffer(forCountOrTime(3, ofMillis(1), executor))
                 .forEach(queue::add);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.verify;
 
 class ClosableConcurrentStackTest {
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     @Test
     void singleThreadPushClose() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.verify;
 
 class CompletableProcessorTest {
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
     private final TestCompletableSubscriber rule = new TestCompletableSubscriber();
     private final TestCompletableSubscriber rule2 = new TestCompletableSubscriber();
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.mock;
 
 class PublisherConcatMapIterableTest {
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     private final TestPublisher<List<String>> publisher = new TestPublisher<>();
     private final TestPublisher<BlockingIterable<String>> cancellablePublisher = new TestPublisher<>();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.verify;
 
 class SingleProcessorTest {
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
     @Test
     void testSuccessBeforeListen() {
         testSuccessBeforeListen("foo");

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
@@ -75,7 +75,7 @@ class ExecutionStrategyTest {
 
     @RegisterExtension
     static final ExecutorExtension<Executor> CONTEXT_EXEC =
-            ExecutorExtension.withCachedExecutor(CONTEXT_EXEC_NAME_PREFIX);
+            ExecutorExtension.withCachedExecutor(CONTEXT_EXEC_NAME_PREFIX).setClassLevel(true);
 
     private static final TestRequest REQUEST = TestRequest.newBuilder().setName("name").build();
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -71,7 +71,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class FlushStrategyOnServerTest {
 
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
     private static final String USE_AGGREGATED_RESP = "aggregated-resp";
     private static final String USE_EMPTY_RESP_BODY = "empty-resp-body";
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyConfigurationFailuresTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyConfigurationFailuresTest.java
@@ -40,7 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ExecutionStrategyConfigurationFailuresTest {
 
     @RegisterExtension
-    static final ExecutorExtension<Executor> TEST_EXEC = ExecutorExtension.withCachedExecutor("test");
+    static final ExecutorExtension<Executor> TEST_EXEC =
+            ExecutorExtension.withCachedExecutor("test").setClassLevel(true);
 
     @Test
     void invalidStrategies() {

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyTest.java
@@ -73,10 +73,12 @@ final class ExecutionStrategyTest extends AbstractJerseyStreamingHttpServiceTest
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @RegisterExtension
-    static final ExecutorExtension<Executor> ROUTER_EXEC = ExecutorExtension.withCachedExecutor("router");
+    static final ExecutorExtension<Executor> ROUTER_EXEC =
+            ExecutorExtension.withCachedExecutor("router").setClassLevel(true);
 
     @RegisterExtension
-    static final ExecutorExtension<Executor> ROUTE_EXEC = ExecutorExtension.withCachedExecutor("route");
+    static final ExecutorExtension<Executor> ROUTE_EXEC =
+            ExecutorExtension.withCachedExecutor("route").setClassLevel(true);
 
     public static class TestApplication extends Application {
         @Override

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilterTest.java
@@ -113,7 +113,7 @@ import static org.mockito.Mockito.when;
 class RedirectingHttpRequesterFilterTest {
 
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXECUTOR = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     private static final String CUSTOM_HEADER = "custom-header";
     private static final String CUSTOM_TRAILER = "custom-trailer";

--- a/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextExtension.java
+++ b/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/ExecutionContextExtension.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,9 +40,12 @@ import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor;
 
 /**
- * Test helper that creates and disposes an {@link ExecutionContext} for your test case or suite.
+ * An {@link Extension} that creates and disposes an {@link ExecutionContext} for your test case or suite.
  * <p>
- * Can be used with a @{@link RegisterExtension} field.
+ * Can be used with a {@link RegisterExtension} field. If used with a class static field then use
+ * {@link #setClassLevel(boolean) setClassLevel(true)} to create contained {@link ExecutionContext} instance only once
+ * for all tests in class.
+ *
  */
 public final class ExecutionContextExtension implements AfterEachCallback, BeforeEachCallback,
                                                         AfterAllCallback, BeforeAllCallback,


### PR DESCRIPTION
Motivation:
The `ExecutorExtension` is often used as a class static with the
assumption that the instance will only be created once per test class
and reused (shared) for all tests. This was not the case and the
contained Executor instance was being created for each test case.
Modifications:
Provide `setClassLevel()` method similar to `ExecutionContextExtension`
and call it with `true` for shared instances.
Result:
Reduced test overhead.