### PR TITLE
MultiAddressUrlHttpClient should redirect POST/PUT/PATCH/DELETE by default

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -33,6 +33,12 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static io.servicetalk.http.api.HttpRequestMethod.DELETE;
+import static io.servicetalk.http.api.HttpRequestMethod.GET;
+import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
+import static io.servicetalk.http.api.HttpRequestMethod.PATCH;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
+import static io.servicetalk.http.api.HttpRequestMethod.PUT;
 import static io.servicetalk.http.api.StrategyInfluencerAwareConversions.toMultiAddressConditionalFilterFactory;
 import static java.util.Objects.requireNonNull;
 
@@ -355,7 +361,7 @@ public abstract class MultiAddressHttpClientBuilder<U, R>
     @Deprecated
     public MultiAddressHttpClientBuilder<U, R> maxRedirects(int maxRedirects) {
         return followRedirects(new RedirectConfigBuilder().maxRedirects(maxRedirects)
-                .allowNonRelativeRedirects(true).build());
+                .allowNonRelativeRedirects(true).allowedMethods(GET, HEAD, POST, PUT, DELETE, PATCH).build());
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -75,6 +75,12 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
+import static io.servicetalk.http.api.HttpRequestMethod.DELETE;
+import static io.servicetalk.http.api.HttpRequestMethod.GET;
+import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
+import static io.servicetalk.http.api.HttpRequestMethod.PATCH;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
+import static io.servicetalk.http.api.HttpRequestMethod.PUT;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.defaultReqRespFactory;
 import static io.servicetalk.http.netty.NewToDeprecatedFilter.NEW_TO_DEPRECATED_FILTER;
 import static java.util.Objects.requireNonNull;
@@ -93,7 +99,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
 
     private static final String HTTPS_SCHEME = HTTPS.toString();
     private static final RedirectConfig DEFAULT_REDIRECT_CONFIG = new RedirectConfigBuilder()
-            .allowNonRelativeRedirects(true).build();
+            .allowNonRelativeRedirects(true).allowedMethods(GET, HEAD, POST, PUT, DELETE, PATCH).build();
 
     private final DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builderTemplate;
 


### PR DESCRIPTION
Motivation:

Users of 0.41.x branch expect to see backward compatible behavior when
they upgrade to the latest bug fix release.
Starting from 0.41.7 (see #1792), default redirect behavior of
`MultiAddressHttpClient` has changed, the following request types are
not redirected by default anymore: POST, PUT, PATCH, DELETE.
Users of deprecated `MultiAddressHttpClientBuilder#maxRedirects(int)`
method also see this behavior change.
Expectation: all the following request methods should follow redirects
as it worked in 0.41.6 and before: GET, HEAD, POST, PUT, DELETE, PATCH.

Modifications:

- List of methods that were redirected in 0.41.6 and before for
`MultiAddressHttpClientBuilder#maxRedirects(int)` and
`DefaultMultiAddressUrlHttpClientBuilder#DEFAULT_REDIRECT_CONFIG`;
- Test that `MultiAddressUrlHttpClient` can redirect GET and POST
requests;

Result:

Default behavior of `MultiAddressUrlHttpClient` is backward compatible
with 0.41.6 and earlier releases.