### PR TITLE
Backport all changes for `AwaitUtils`

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -82,7 +83,7 @@ public final class TestCompletable extends Completable implements CompletableSou
      * {@link Thread#isInterrupted()} will be set upon return.
      */
     public void awaitSubscribed() {
-        AwaitUtils.awaitUninterruptibly(subscriberLatch);
+        AwaitUtils.await(subscriberLatch);
     }
 
     @Override
@@ -163,7 +164,7 @@ public final class TestCompletable extends Completable implements CompletableSou
     }
 
     /**
-     * Allows for creating {@link TestCompletable}s with non-default settings. For defaults, see <b>Defaults</b> section
+     * Allows creation of {@link TestCompletable}s with non-default settings. For defaults, see <b>Defaults</b> section
      * of class javadoc.
      */
     public static class Builder {
@@ -347,7 +348,10 @@ public final class TestCompletable extends Completable implements CompletableSou
         private Subscriber waitForSubscriber() {
             try {
                 return realSubscriberSingle.toFuture().get();
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return throwException(e);
+            } catch (ExecutionException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
@@ -29,7 +29,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.test.internal.AwaitUtils.awaitUninterruptibly;
+import static io.servicetalk.concurrent.test.internal.AwaitUtils.await;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -83,7 +84,7 @@ public final class TestSingle<T> extends Single<T> implements SingleSource<T> {
      * will be set upon return.
      */
     public void awaitSubscribed() {
-        awaitUninterruptibly(subscriberLatch);
+        await(subscriberLatch);
     }
 
     @Override
@@ -352,8 +353,11 @@ public final class TestSingle<T> extends Single<T> implements SingleSource<T> {
         private Subscriber<? super T> waitForSubscriber() {
             try {
                 return realSubscriberSingle.toFuture().get();
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return throwException(e);
+            } catch (ExecutionException e) {
+                return throwException(e);
             }
         }
     }

--- a/servicetalk-concurrent-test-internal/build.gradle
+++ b/servicetalk-concurrent-test-internal/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))


### PR DESCRIPTION
Motivation:

This is a combination of #1687, #1834, #1851, #1856, #1927 PRs in order
to make backport of #1661 compatible with the `main` branch.