### PR TITLE
[Backport] HTTP `Expect: 100-continue` (#2037)

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseEncoderFullResponseBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseEncoderFullResponseBenchmark.java
@@ -43,6 +43,8 @@ import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.netty.HttpResponseEncoder.NOOP_ON_RESPONSE;
+import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 
 /*
  * This benchmark measures encoding of full HTTP request with headers and payload body. Everything is allocated using
@@ -71,7 +73,8 @@ public class HttpResponseEncoderFullResponseBenchmark {
                 .addHeader(CONTENT_TYPE, TEXT_PLAIN)
                 .addHeader(newAsciiString("X-Custom-Header-Name"), newAsciiString("X-Custom-Header-Value"));
 
-        channel = new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256));
+        channel = new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NOOP_ON_RESPONSE));
     }
 
     @Benchmark

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseEncoderInitialLineBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseEncoderInitialLineBenchmark.java
@@ -39,7 +39,9 @@ import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
+import static io.servicetalk.http.netty.HttpResponseEncoder.NOOP_ON_RESPONSE;
 import static io.servicetalk.http.netty.HttpUtils.status;
+import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 
 /*
  * This benchmark compares encoding of HTTP requests with different status codes (with short and long reason phrase,
@@ -71,7 +73,8 @@ public class HttpResponseEncoderInitialLineBenchmark {
         metaData = newResponseMetaData(HTTP_1_1, status(statusCode), INSTANCE.newHeaders())
                 .addHeader(CONTENT_LENGTH, ZERO);
 
-        channel = new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256));
+        channel = new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NOOP_ON_RESPONSE));
     }
 
     @Benchmark

--- a/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
@@ -250,3 +250,34 @@ deserialization format and also adding a `content-type` header identifying the r
 
 For more information about how to use serializers and deserializers see
 xref:{page-version}@servicetalk-examples::http/index.adoc#Serialization[these] examples.
+
+== Expect: 100-continue
+
+HTTP protocol defines link:https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1[Expect] header with
+`100-continue` expectation. This feature allows users to defer sending a request payload body until after the server
+responds with link:https://datatracker.ietf.org/doc/html/rfc7231#section-6.2.1[100 Continue] status code signaling that
+it's ready to receive and process the payload body.
+
+NOTE: xref:{page-version}@servicetalk-http-api::programming-paradigms.adoc#client-blocking-and-aggregated[Aggregated]
+client will automatically de-optimize its flush strategy to flush on each element of the request to force flushing of
+the request meta-data and deffer flushing payload body until after a `100 Continue` response is received.
+
+Server-side users should subscribe to the request payload body when they are ready to consume it. It will generate
+link:https://datatracker.ietf.org/doc/html/rfc7231#section-6.2.1[100 Continue] interim response. After the request is
+consumed, service should produce a final response with an appropriate status code. If service decides to reject a
+request before consuming a request payload body, an appropriate `4xx` status code, like
+link:https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.14[417 Expectation Failed], should be returned. Put
+meaningful tracing headers in the final response.
+
+NOTE: xref:{page-version}@servicetalk-http-api::programming-paradigms.adoc#svc-blocking-and-aggregated[Aggregated]
+service will automatically subscribe to the request payload body before invoking the `handle` method, that will send
+`100 Continue` response back to the client. For manual control consider migrating to
+xref:{page-version}@servicetalk-http-api::programming-paradigms.adoc#svc-blocking-and-streaming[streaming] API or
+implement a filter to accept or reject requests before processing their payload body.
+
+TIP: The interim response is not propagated as a response
+returned by the client because the client has to wait for a final status code returned by the server. There are a couple
+of other ways how to get visibility into interim response: using wire-logging for HTTP/1.x or frame-logging for HTTP/2
+or by monitoring when
+link:{source-root}/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java[WriteObserver]
+signals that more items are requested to write.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpProtocolVersion.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpProtocolVersion.java
@@ -20,11 +20,12 @@ import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.PREFER_HEAP_RO_ALLOCATOR;
 import static io.servicetalk.http.api.BufferUtils.writeReadOnlyBuffer;
+import static java.lang.Integer.compare;
 
 /**
  * HTTP <a href="https://tools.ietf.org/html/rfc7230.html#section-2.6">protocol versioning</a>.
  */
-public final class HttpProtocolVersion implements Protocol {
+public final class HttpProtocolVersion implements Protocol, Comparable<HttpProtocolVersion> {
     /**
      * HTTP/1.1 version described in <a href="https://tools.ietf.org/html/rfc7230">RFC 7230</a>.
      */
@@ -155,5 +156,11 @@ public final class HttpProtocolVersion implements Protocol {
      */
     static boolean h1TrailersSupported(HttpProtocolVersion version) {
         return version.major() == 1 && version.minor() > 0;
+    }
+
+    @Override
+    public int compareTo(final HttpProtocolVersion that) {
+        final int compareMajor = compare(this.major(), that.major());
+        return compareMajor == 0 ? compare(this.minor(), that.minor()) : compareMajor;
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpProtocolVersionTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpProtocolVersionTest.java
@@ -23,7 +23,12 @@ import org.junit.jupiter.api.Test;
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -85,5 +90,20 @@ class HttpProtocolVersionTest {
     @Test
     void testIllegalMinorVersionGT9() {
         assertThrows(IllegalArgumentException.class, () -> HttpProtocolVersion.of(1, 10));
+    }
+
+    @Test
+    void testCompareTo() {
+        assertThat(HTTP_1_0.compareTo(HTTP_1_1), lessThan(0));
+        assertThat(HTTP_1_0.compareTo(HTTP_2_0), lessThan(0));
+        assertThat(HTTP_1_1.compareTo(HTTP_2_0), lessThan(0));
+
+        assertThat(HTTP_1_0.compareTo(HTTP_1_0), is(0));
+        assertThat(HTTP_1_1.compareTo(HTTP_1_1), is(0));
+        assertThat(HTTP_2_0.compareTo(HTTP_2_0), is(0));
+
+        assertThat(HTTP_2_0.compareTo(HTTP_1_1), greaterThan(0));
+        assertThat(HTTP_2_0.compareTo(HTTP_1_0), greaterThan(0));
+        assertThat(HTTP_1_1.compareTo(HTTP_1_0), greaterThan(0));
     }
 }

--- a/servicetalk-http-netty/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/test-exclusions.xml
@@ -55,4 +55,9 @@
     </Or>
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
   </Match>
+  <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/756 -->
+  <Match>
+    <Class name="io.servicetalk.http.netty.ExpectContinueTest"/>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractH2DuplexHandler.java
@@ -68,12 +68,18 @@ abstract class AbstractH2DuplexHandler extends ChannelDuplexHandler {
     }
 
     final void writeMetaData(ChannelHandlerContext ctx, HttpMetaData metaData, Http2Headers h2Headers,
-                             ChannelPromise promise) {
-        final boolean endStream = emptyMessageBody(metaData);
+                             boolean realMessage, ChannelPromise promise) {
+        final boolean endStream = realMessage && emptyMessageBody(metaData);
         if (endStream) {
             closeHandler.protocolPayloadEndOutbound(ctx, promise);
         }
-        ctx.write(new DefaultHttp2HeadersFrame(h2Headers, endStream), promise);
+        final DefaultHttp2HeadersFrame frame = new DefaultHttp2HeadersFrame(h2Headers, endStream);
+        if (realMessage) {
+            ctx.write(frame, promise);
+        } else {
+            // All "interim messages" have to be flushed right away.
+            ctx.writeAndFlush(frame, promise);
+        }
     }
 
     static void writeBuffer(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ExpectationFailedException.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ExpectationFailedException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.netty.RetryingHttpRequesterFilter.HttpResponseException;
+
+/**
+ * An exception that represents <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.14">
+ *     417 Expectation Failed</a> response status code.
+ * <p>
+ * A response will be automatically converted into this exception type when
+ * {@link RetryingHttpRequesterFilter.Builder#retryExpectationFailed(boolean)} is set to {@code true}.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1">Expect</a>
+ */
+public final class ExpectationFailedException extends HttpResponseException {
+    private static final long serialVersionUID = -5608030718662972886L;
+
+    ExpectationFailedException(final String message, final HttpResponseMetaData response) {
+        super(message, response);
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -85,6 +85,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.handleException
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
+import static io.servicetalk.http.netty.HeaderUtils.OBJ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
@@ -360,7 +361,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                     parentContext.sslSession(),
                                     parentContext.nettyChannel().config(),
                                     streamObserver,
-                                    true,
+                                    true, OBJ_EXPECT_CONTINUE,
                                     NettyHttp2ExceptionUtils::wrapIfNecessary);
 
                     // In h2 a stream is 1 to 1 with a request/response life cycle. This means there is no concept of

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -178,7 +178,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                                 connection.sslSession(),
                                                 channel.config(),
                                                 streamObserver,
-                                                false,
+                                                false, __ -> false,
                                                 NettyHttp2ExceptionUtils::wrapIfNecessary);
 
                                 // ServiceTalk HTTP service handler

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.netty.HttpResponseDecoder.Signal;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer;
@@ -43,13 +44,15 @@ final class HttpClientChannelInitializer implements ChannelInitializer {
         // H1 slices passed memory chunks into headers and payload body without copying and will emit them to the
         // user-code. Therefore, ByteBufs must be copied to unpooled memory before HttpObjectDecoder.
         this.delegate = new CopyByteBufHandlerChannelInitializer(alloc).andThen(channel -> {
-            final Queue<HttpRequestMethod> methodQueue = new ArrayDeque<>(min(8, config.maxPipelinedRequests()));
+            final int minPipelinedRequests = min(8, config.maxPipelinedRequests());
+            final Queue<HttpRequestMethod> methodQueue = new ArrayDeque<>(minPipelinedRequests);
+            final ArrayDeque<Signal> signalsQueue = new ArrayDeque<>(minPipelinedRequests);
             final ChannelPipeline pipeline = channel.pipeline();
-            pipeline.addLast(new HttpResponseDecoder(methodQueue, alloc, config.headersFactory(),
+            pipeline.addLast(new HttpResponseDecoder(methodQueue, signalsQueue, alloc, config.headersFactory(),
                     config.maxStartLineLength(), config.maxHeaderFieldLength(),
                     config.specExceptions().allowPrematureClosureBeforePayloadBody(),
                     config.specExceptions().allowLFWithoutCR(), closeHandler));
-            pipeline.addLast(new HttpRequestEncoder(methodQueue,
+            pipeline.addLast(new HttpRequestEncoder(methodQueue, signalsQueue,
                     config.headersEncodedSizeEstimate(), config.trailersEncodedSizeEstimate(), closeHandler));
         });
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
@@ -15,9 +15,12 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.http.api.EmptyHttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.netty.HttpResponseEncoder.OnResponse;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
@@ -31,11 +34,14 @@ import java.util.Queue;
 
 import static io.servicetalk.http.api.HttpRequestMetaDataFactory.newRequestMetaData;
 import static io.servicetalk.http.api.HttpRequestMethod.Properties.NONE;
-import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
+import static io.servicetalk.http.api.HttpResponseStatus.CONTINUE;
+import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
+import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
+import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
 
-final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
+final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> implements OnResponse {
     private static final ByteProcessor FIND_WS_AFTER_METHOD_NAME = value -> {
         if (isWS(value)) {
             return false;
@@ -49,13 +55,9 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
     };
 
     private final Queue<HttpRequestMethod> methodQueue;
-
-    HttpRequestDecoder(final Queue<HttpRequestMethod> methodQueue, final ByteBufAllocator alloc,
-                       final HttpHeadersFactory headersFactory, final int maxStartLineLength,
-                       final int maxHeaderFieldLength) {
-        this(methodQueue, alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength,
-                false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER);
-    }
+    private final CloseHandler closeHandler;
+    private boolean expectContinue;
+    private boolean seenPayloadBody;
 
     HttpRequestDecoder(final Queue<HttpRequestMethod> methodQueue, final ByteBufAllocator alloc,
                        final HttpHeadersFactory headersFactory, final int maxStartLineLength,
@@ -64,6 +66,7 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
         super(alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength, allowPrematureClosureBeforePayloadBody,
                 allowLFWithoutCR, closeHandler);
         this.methodQueue = requireNonNull(methodQueue);
+        this.closeHandler = closeHandler;
     }
 
     @Override
@@ -131,5 +134,49 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> {
         // iterate a decoded list it makes some assumptions about the base class ordering of events.
         methodQueue.add(msg.method());
         return false;
+    }
+
+    @Override
+    protected boolean isInterim(final HttpRequestMetaData msg) {
+        return false;   // Only response decoder may encounter interim messages
+    }
+
+    @Override
+    protected void onMetaDataRead(final ChannelHandlerContext ctx, final HttpRequestMetaData msg) {
+        expectContinue = REQ_EXPECT_CONTINUE.test(msg);
+    }
+
+    @Override
+    protected void onDataSeen() {
+        seenPayloadBody = true;
+    }
+
+    @Override
+    protected void resetNow() {
+        super.resetNow();
+        onStateReset();
+    }
+
+    private void onStateReset() {
+        expectContinue = false;
+        seenPayloadBody = false;
+    }
+
+    @Override
+    public void onResponse(final ChannelHandlerContext ctx, final HttpResponseStatus status) {
+        if (expectContinue && !seenPayloadBody) {
+            if (status == CONTINUE) {
+                // If server responds with 100 (Continue), no need to trigger resetNow() anymore because server expects
+                // to receive a payload body.
+                onStateReset();
+            } else if (status.statusClass() != SUCCESSFUL_2XX && status.statusClass() != INFORMATIONAL_1XX) {
+                // If a request expects continuation, but server responds with an error or redirect before it sees a
+                // request payload body, notify CloseHandler and reset the state to prepare for receiving a new request
+                // on the same connection.
+                ctx.fireChannelRead(EmptyHttpHeaders.INSTANCE);
+                closeHandler.protocolPayloadEndInbound(ctx);
+                resetNow();
+            }
+        }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
@@ -31,15 +31,23 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.internal.QueueFullException;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.netty.HttpResponseDecoder.Signal;
 import io.servicetalk.transport.netty.internal.CloseHandler;
+import io.servicetalk.transport.netty.internal.DefaultNettyConnection.CancelWriteUserEvent;
+import io.servicetalk.transport.netty.internal.DefaultNettyConnection.ContinueUserEvent;
+
+import io.netty.channel.ChannelHandlerContext;
 
 import java.util.Queue;
 
 import static io.netty.handler.codec.http.HttpConstants.SP;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
-import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
+import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
+import static io.servicetalk.http.netty.HttpResponseDecoder.Signal.REQUEST_SIGNAL;
+import static io.servicetalk.http.netty.HttpResponseDecoder.Signal.REQUEST_WITH_EXPECT_CONTINUE_SIGNAL;
 import static java.util.Objects.requireNonNull;
 
 final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
@@ -49,35 +57,29 @@ final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
     private static final int SPACE_SLASH_AND_SPACE_MEDIUM = (SP << 16) | SLASH_AND_SPACE_SHORT;
 
     private final Queue<HttpRequestMethod> methodQueue;
+    private final Queue<Signal> signalsQueue;
 
     /**
-     * Create a new instance.
-     * @param methodQueue A queue used to enforce HTTP protocol semantics related to request/response lengths.
-     * @param headersEncodedSizeAccumulator Used to calculate an exponential moving average of the encoded size of the
-     * initial line and the headers for a guess for future buffer allocations.
-     * @param trailersEncodedSizeAccumulator  Used to calculate an exponential moving average of the encoded size of
-     * the trailers for a guess for future buffer allocations.
+     * Used to remember when an outgoing request has "Expect: 100-continue" header.
      */
-    HttpRequestEncoder(Queue<HttpRequestMethod> methodQueue,
-                       int headersEncodedSizeAccumulator, int trailersEncodedSizeAccumulator) {
-        this(methodQueue, headersEncodedSizeAccumulator, trailersEncodedSizeAccumulator,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER);
-    }
+    private boolean expectContinue;
 
     /**
      * Create a new instance.
      * @param methodQueue A queue used to enforce HTTP protocol semantics related to request/response lengths.
+     * @param signalsQueue A queue used to communicate extra signals between encoder and decoder.
      * @param headersEncodedSizeAccumulator Used to calculate an exponential moving average of the encoded size of the
      * initial line and the headers for a guess for future buffer allocations.
      * @param trailersEncodedSizeAccumulator  Used to calculate an exponential moving average of the encoded size of
      * the trailers for a guess for future buffer allocations.
      * @param closeHandler observes protocol state events
      */
-    HttpRequestEncoder(Queue<HttpRequestMethod> methodQueue,
-                       int headersEncodedSizeAccumulator, int trailersEncodedSizeAccumulator,
+    HttpRequestEncoder(final Queue<HttpRequestMethod> methodQueue, final Queue<Signal> signalsQueue,
+                       final int headersEncodedSizeAccumulator, final int trailersEncodedSizeAccumulator,
                        final CloseHandler closeHandler) {
         super(headersEncodedSizeAccumulator, trailersEncodedSizeAccumulator, closeHandler);
         this.methodQueue = requireNonNull(methodQueue);
+        this.signalsQueue = requireNonNull(signalsQueue);
     }
 
     @Override
@@ -100,7 +102,7 @@ final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
     }
 
     @Override
-    protected void encodeInitialLine(Buffer stBuffer, HttpRequestMetaData message) {
+    protected void encodeInitialLine(ChannelHandlerContext ctx, Buffer stBuffer, HttpRequestMetaData message) {
         message.method().writeTo(stBuffer);
 
         String uri = message.requestTarget();
@@ -144,5 +146,30 @@ final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
         // if this happens just force http/1.1 to avoid generating an invalid request.
         (message.version().major() == 1 ? message.version() : HTTP_1_1).writeTo(stBuffer);
         stBuffer.writeShort(CRLF_SHORT);
+    }
+
+    @Override
+    protected void onMetaData(final ChannelHandlerContext ctx, final HttpRequestMetaData metaData) {
+        expectContinue = REQ_EXPECT_CONTINUE.test(metaData);
+        // Offer signals for all request types. Otherwise, decoder may receive a wrong signal if client sends multiple
+        // pipelined requests.
+        if (!signalsQueue.offer(expectContinue ? REQUEST_WITH_EXPECT_CONTINUE_SIGNAL : REQUEST_SIGNAL)) {
+            throw new QueueFullException("Can not enqueue a request type for the decoder");
+        }
+    }
+
+    @Override
+    public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+        if (expectContinue) {
+            if (evt == ContinueUserEvent.INSTANCE) {
+                // Reset the flag after receiving 100 (Continue).
+                expectContinue = false;
+            } else if (evt == CancelWriteUserEvent.INSTANCE) {
+                // Mark as content consumed and reset the flag to prepare for the next request on the same connection.
+                resetState(ctx, null);
+                expectContinue = false;
+            }
+        }
+        ctx.fireUserEventTriggered(evt);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseEncoder.java
@@ -37,6 +37,8 @@ import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 
+import io.netty.channel.ChannelHandlerContext;
+
 import java.util.Queue;
 
 import static io.netty.handler.codec.http.HttpConstants.SP;
@@ -49,11 +51,13 @@ import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.SWITCHING_PROTOCOLS;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
-import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static java.util.Objects.requireNonNull;
 
 final class HttpResponseEncoder extends HttpObjectEncoder<HttpResponseMetaData> {
+    static final OnResponse NOOP_ON_RESPONSE = (ctx, status) -> { /* noop */ };
+
     private final Queue<HttpRequestMethod> methodQueue;
+    private final OnResponse onResponse;
 
     /**
      * Create a new instance.
@@ -62,26 +66,15 @@ final class HttpResponseEncoder extends HttpObjectEncoder<HttpResponseMetaData> 
      * initial line and the headers for a guess for future buffer allocations.
      * @param trailersEncodedSizeAccumulator  Used to calculate an exponential moving average of the encoded size of
      * the trailers for a guess for future buffer allocations.
-     * @param closeHandler the {@link CloseHandler}
+     * @param closeHandler the {@link CloseHandler}.
+     * @param onResponse listener for encoded responses.
      */
     HttpResponseEncoder(Queue<HttpRequestMethod> methodQueue, int headersEncodedSizeAccumulator,
-                        int trailersEncodedSizeAccumulator, final CloseHandler closeHandler) {
+                        int trailersEncodedSizeAccumulator, final CloseHandler closeHandler,
+                        final OnResponse onResponse) {
         super(headersEncodedSizeAccumulator, trailersEncodedSizeAccumulator, closeHandler);
         this.methodQueue = requireNonNull(methodQueue);
-    }
-
-    /**
-     * Create a new instance.
-     * @param methodQueue A queue used to enforce HTTP protocol semantics related to request/response lengths.
-     * @param headersEncodedSizeAccumulator Used to calculate an exponential moving average of the encoded size of the
-     * initial line and the headers for a guess for future buffer allocations.
-     * @param trailersEncodedSizeAccumulator  Used to calculate an exponential moving average of the encoded size of
-     * the trailers for a guess for future buffer allocations.
-     */
-    HttpResponseEncoder(Queue<HttpRequestMethod> methodQueue,
-                        int headersEncodedSizeAccumulator, int trailersEncodedSizeAccumulator) {
-        this(methodQueue, headersEncodedSizeAccumulator, trailersEncodedSizeAccumulator,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER);
+        this.onResponse = requireNonNull(onResponse);
     }
 
     @Override
@@ -90,11 +83,12 @@ final class HttpResponseEncoder extends HttpObjectEncoder<HttpResponseMetaData> 
     }
 
     @Override
-    protected void encodeInitialLine(Buffer stBuffer, HttpResponseMetaData message) {
+    protected void encodeInitialLine(ChannelHandlerContext ctx, Buffer stBuffer, HttpResponseMetaData message) {
         message.version().writeTo(stBuffer);
         stBuffer.writeByte(SP);
         message.status().writeTo(stBuffer);
         stBuffer.writeShort(CRLF_SHORT);
+        onResponse.onResponse(ctx, message.status());
     }
 
     @Override
@@ -151,5 +145,23 @@ final class HttpResponseEncoder extends HttpObjectEncoder<HttpResponseMetaData> 
             return true;
         }
         return status.code() == NO_CONTENT.code() || status.code() == NOT_MODIFIED.code();
+    }
+
+    @Override
+    protected boolean isInterim(final HttpResponseMetaData msg) {
+        return msg.status().statusClass() == INFORMATIONAL_1XX;
+    }
+
+    /**
+     * Notifies when a response is sent.
+     */
+    interface OnResponse {
+
+        /**
+         * Notifies which {@link HttpResponseStatus.StatusClass} a response belongs to.
+         *
+         * @param status returned status code of the response
+         */
+        void onResponse(ChannelHandlerContext ctx, HttpResponseStatus status);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -29,8 +29,10 @@ import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
+import io.servicetalk.http.api.HttpHeaderNames;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -54,6 +56,9 @@ import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponential
 import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffFullJitter;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.http.api.HeaderUtils.DEFAULT_HEADER_FILTER;
+import static io.servicetalk.http.api.HttpHeaderNames.EXPECT;
+import static io.servicetalk.http.api.HttpHeaderValues.CONTINUE;
+import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static java.time.Duration.ofDays;
@@ -232,7 +237,7 @@ public final class RetryingHttpRequesterFilter
      * {@link HttpResponseException}s are user-provided errors, resulting from an {@link HttpRequestMetaData}, through
      * the {@link Builder#responseMapper(Function)}.
      */
-    public static final class HttpResponseException extends RuntimeException {
+    public static class HttpResponseException extends RuntimeException {
 
         private static final long serialVersionUID = -7182949760823647710L;
 
@@ -254,6 +259,12 @@ public final class RetryingHttpRequesterFilter
         @Deprecated
         public final String message;
 
+        /**
+         * Create a new instance.
+         *
+         * @param message the description message.
+         * @param metaData received response meta-data.
+         */
         public HttpResponseException(final String message, final HttpResponseMetaData metaData) {
             super(message);
             this.metaData = requireNonNull(metaData);
@@ -569,10 +580,16 @@ public final class RetryingHttpRequesterFilter
      * To configure the maximum number of retry attempts see {@link #maxTotalRetries(int)}.
      */
     public static final class Builder {
+
+        private static final Function<HttpResponseMetaData, HttpResponseException> EXPECTATION_FAILED_MAPPER =
+                metaData -> EXPECTATION_FAILED.equals(metaData.status()) ?
+                        new ExpectationFailedException("Expectation failed", metaData) : null;
+
         private boolean waitForLb = true;
         private boolean ignoreSdErrors;
 
         private int maxTotalRetries = 4;
+        private boolean retryExpectationFailed;
 
         @Nullable
         private Function<HttpResponseMetaData, HttpResponseException> responseMapper;
@@ -646,7 +663,7 @@ public final class RetryingHttpRequesterFilter
          * retry behaviour through {@link #retryResponses(BiFunction)}.
          *
          * @param mapper a {@link Function} that maps a {@link HttpResponseMetaData} to an
-         * {@link HttpResponseException}.
+         * {@link HttpResponseException} or returns {@code null} if there is no mapping for response meta-data.
          * @return {@code this}
          */
         public Builder responseMapper(final Function<HttpResponseMetaData, HttpResponseException> mapper) {
@@ -687,6 +704,20 @@ public final class RetryingHttpRequesterFilter
         public Builder retryIdempotentRequests(
                 final BiFunction<HttpRequestMetaData, IOException, BackOffPolicy> mapper) {
             this.retryIdempotentRequests = requireNonNull(mapper);
+            return this;
+        }
+
+        /**
+         * Retries {@link HttpResponseStatus#EXPECTATION_FAILED} response without {@link HttpHeaderNames#EXPECT} header.
+         *
+         * @param retryExpectationFailed if {@code true}, filter will automatically map
+         * {@link HttpResponseStatus#EXPECTATION_FAILED} into {@link ExpectationFailedException} and retry a request
+         * without {@link HttpHeaderNames#EXPECT} header.
+         * @return {@code this}.
+         * @see <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1">Expect</a>
+         */
+        public Builder retryExpectationFailed(boolean retryExpectationFailed) {
+            this.retryExpectationFailed = retryExpectationFailed;
             return this;
         }
 
@@ -748,6 +779,18 @@ public final class RetryingHttpRequesterFilter
          * @return A new retrying {@link RetryingHttpRequesterFilter}
          */
         public RetryingHttpRequesterFilter build() {
+            final boolean retryExpectationFailed = this.retryExpectationFailed;
+            final Function<HttpResponseMetaData, HttpResponseException> thisResponseMapper = this.responseMapper;
+            final Function<HttpResponseMetaData, HttpResponseException> responseMapper;
+            if (retryExpectationFailed) {
+                responseMapper = thisResponseMapper == null ? EXPECTATION_FAILED_MAPPER : metaData -> {
+                    final HttpResponseException e = thisResponseMapper.apply(metaData);
+                    return e == null ? EXPECTATION_FAILED_MAPPER.apply(metaData) : e;
+                };
+            } else {
+                responseMapper = thisResponseMapper;
+            }
+
             final BiFunction<HttpRequestMetaData, RetryableException, BackOffPolicy> retryRetryableExceptions =
                     this.retryRetryableExceptions;
             final BiFunction<HttpRequestMetaData, IOException, BackOffPolicy> retryIdempotentRequests =
@@ -766,6 +809,12 @@ public final class RetryingHttpRequesterFilter
                             if (backOffPolicy != NO_RETRIES) {
                                 return backOffPolicy;
                             }
+                        }
+
+                        if (retryExpectationFailed && throwable instanceof ExpectationFailedException &&
+                                requestMetaData.headers().containsIgnoreCase(EXPECT, CONTINUE)) {
+                            requestMetaData.headers().remove(EXPECT);
+                            return BackOffPolicy.ofImmediate();
                         }
 
                         if (retryIdempotentRequests != null && throwable instanceof IOException

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -37,6 +37,7 @@ import javax.net.ssl.SNIHostName;
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.HeaderUtils.LAST_CHUNK_PREDICATE;
+import static io.servicetalk.http.netty.HeaderUtils.OBJ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
 import static java.util.Objects.requireNonNull;
@@ -69,7 +70,8 @@ final class StreamingConnectionFactory {
                 executionContext.executor(), LAST_CHUNK_PREDICATE, closeHandler, tcpConfig.flushStrategy(),
                         tcpConfig.idleTimeoutMs(), initializer.andThen(new HttpClientChannelInitializer(
                         getByteBufAllocator(executionContext.bufferAllocator()), h1Config, closeHandler)),
-                executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true), HTTP_1_1, channel);
+                executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true, OBJ_EXPECT_CONTINUE),
+                HTTP_1_1, channel);
     }
 
     static ReadOnlyTcpClientConfig withSslConfigPeerHost(Object resolvedRemoteAddress,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
@@ -1,0 +1,621 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.BlockingIterator;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.http.api.BlockingStreamingHttpService;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpConnection;
+import io.servicetalk.http.api.HttpPayloadWriter;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpRequestFactory;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.RedirectConfigBuilder;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestFactory;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
+import static io.servicetalk.http.api.HttpHeaderNames.EXPECT;
+import static io.servicetalk.http.api.HttpHeaderNames.LOCATION;
+import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
+import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
+import static io.servicetalk.http.api.HttpHeaderValues.CONTINUE;
+import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
+import static io.servicetalk.http.api.HttpResponseStatus.ACCEPTED;
+import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
+import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
+import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
+import static io.servicetalk.logging.api.LogLevel.TRACE;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.lang.String.valueOf;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class ExpectContinueTest {
+
+    @RegisterExtension
+    static final ExecutionContextExtension SERVER_CTX =
+            ExecutionContextExtension.cached("server-io", "server-executor");
+    @RegisterExtension
+    static final ExecutionContextExtension CLIENT_CTX =
+            ExecutionContextExtension.cached("client-io", "client-executor");
+
+    private static final String PAYLOAD = "hello";
+    private static final String FAIL = "fail";
+
+    private final CountDownLatch requestReceived = new CountDownLatch(1);
+    private final CountDownLatch sendContinue = new CountDownLatch(1);
+    private final CountDownLatch returnResponse = new CountDownLatch(1);
+    private final BlockingQueue<StreamingHttpResponse> responses = new LinkedBlockingDeque<>();
+
+    private static Stream<Arguments> arguments() {
+        return Stream.of(Arguments.of(HTTP_1, false),
+                Arguments.of(HTTP_1, true),
+                Arguments.of(HttpProtocol.HTTP_2, false),
+                Arguments.of(HttpProtocol.HTTP_2, true));
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinue(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, allocator);
+
+            returnResponse.countDown();
+            assertResponse(OK, PAYLOAD + PAYLOAD);
+
+            sendFollowUpRequest(connection, withCL, allocator, OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinueAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get().asConnection()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            Future<HttpResponse> responseFuture = connection.request(
+                    newRequest(connection, withCL, false, PAYLOAD + PAYLOAD, allocator)).toFuture();
+            requestReceived.await();
+            sendContinue.countDown();
+            returnResponse.countDown();
+            HttpResponse response = responseFuture.get();
+            assertThat(response.status(), is(OK));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(PAYLOAD + PAYLOAD));
+
+            sendFollowUpRequest(connection.asStreamingConnection(), withCL,
+                    allocator, OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinueThenFailure(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            requestReceived.countDown();
+            sendContinue.await();
+            StringBuilder sb = new StringBuilder();
+            request.payloadBody().forEach(chunk -> sb.append(chunk.toString(US_ASCII)));
+            returnResponse.await();
+            try (HttpPayloadWriter<Buffer> writer = response.status(UNPROCESSABLE_ENTITY).sendMetaData()) {
+                writer.write(ctx.executionContext().bufferAllocator().fromAscii(sb));
+            }
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, allocator);
+
+            returnResponse.countDown();
+            assertResponse(UNPROCESSABLE_ENTITY, PAYLOAD + PAYLOAD);
+
+            sendFollowUpRequest(connection, withCL, allocator, UNPROCESSABLE_ENTITY);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinueThenFailureThenRequestPayload(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            requestReceived.countDown();
+            sendContinue.await();
+            BlockingIterator<Buffer> iterator = request.payloadBody().iterator();
+            returnResponse.await();
+            try (HttpPayloadWriter<Buffer> writer = response.status(UNPROCESSABLE_ENTITY).sendMetaData()) {
+                while (iterator.hasNext()) {
+                    Buffer next = iterator.next();
+                    if (next != null) {
+                        writer.write(next);
+                    }
+                }
+            }
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            payload.awaitSubscribed();
+
+            returnResponse.countDown();
+            StreamingHttpResponse response = responses.take();
+            assertThat(response.status(), is(UNPROCESSABLE_ENTITY));
+
+            payload.onNext(allocator.fromAscii(PAYLOAD));
+            payload.onNext(allocator.fromAscii(PAYLOAD));
+            payload.onComplete();
+            assertThat(response.toResponse().toFuture().get().payloadBody().toString(US_ASCII),
+                    equalTo(PAYLOAD + PAYLOAD));
+
+            sendFollowUpRequest(connection, withCL, allocator, UNPROCESSABLE_ENTITY);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectContinueConnectionClose(HttpProtocol protocol, boolean withCL) throws Exception {
+        assumeTrue(protocol == HTTP_1);
+        try (ServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload).setHeader(CONNECTION, CLOSE))
+                    .subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, connection.executionContext().bufferAllocator());
+
+            returnResponse.countDown();
+            assertResponse(OK, PAYLOAD + PAYLOAD);
+
+            connection.onClose().toFuture().get();
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverRespondsWithSuccess(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+                requestReceived.countDown();
+                returnResponse.await();
+                response.status(ACCEPTED);
+                try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                    for (Buffer chunk : request.payloadBody()) {
+                        writer.write(chunk);
+                    }
+                }
+            });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            returnResponse.countDown();
+
+            StreamingHttpResponse response = responses.take();
+            assertThat(response.status(), is(ACCEPTED));
+            sendRequestPayload(payload, allocator);
+            assertThat(response.toResponse().toFuture().get().payloadBody().toString(US_ASCII),
+                    equalTo(PAYLOAD + PAYLOAD));
+
+            sendFollowUpRequest(connection, withCL, allocator, ACCEPTED);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverRespondsWithSuccessAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            requestReceived.countDown();
+            returnResponse.await();
+            response.status(ACCEPTED);
+            try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                for (Buffer chunk : request.payloadBody()) {
+                    writer.write(chunk);
+                }
+            }
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get().asConnection()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            returnResponse.countDown();
+            HttpResponse response = connection.request(newRequest(connection, withCL, false, PAYLOAD + PAYLOAD,
+                    allocator)).toFuture().get();
+            assertThat(response.status(), is(ACCEPTED));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(PAYLOAD + PAYLOAD));
+
+            sendFollowUpRequest(connection.asStreamingConnection(), withCL, allocator, ACCEPTED);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverRespondsWithRedirect(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            if ("/redirect".equals(request.requestTarget())) {
+                response.status(PERMANENT_REDIRECT);
+                response.setHeader(LOCATION, "/");
+                response.sendMetaData().close();
+                return;
+            }
+            requestReceived.countDown();
+            sendContinue.await();
+            StringBuilder sb = new StringBuilder();
+            request.payloadBody().forEach(chunk -> sb.append(chunk.toString(US_ASCII)));
+            returnResponse.await();
+            try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                writer.write(ctx.executionContext().bufferAllocator().fromAscii(sb));
+            }
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol, new RedirectingHttpRequesterFilter(
+                     new RedirectConfigBuilder()
+                             .allowedMethods(POST)
+                             .headersToRedirect(CONTENT_LENGTH, TRANSFER_ENCODING, EXPECT)
+                             .redirectPayloadBody(true)
+                             .build()));
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, false, payload).requestTarget("/redirect"))
+                    .subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, allocator);
+
+            returnResponse.countDown();
+            assertResponse(OK, PAYLOAD + PAYLOAD);
+
+            sendFollowUpRequest(connection, withCL, allocator, OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectationFailed(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, true, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            returnResponse.countDown();
+            assertResponse(EXPECTATION_FAILED, "");
+            assertThat("Unexpected subscribe to payload body on expectation failed",
+                    payload.isSubscribed(), is(false));
+
+            sendContinue.countDown();
+            sendFollowUpRequest(connection, withCL, connection.executionContext().bufferAllocator(), OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectationFailedAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get().asConnection()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            Future<HttpResponse> responseFuture = connection.request(
+                    newRequest(connection, withCL, true, PAYLOAD + PAYLOAD, allocator)).toFuture();
+            requestReceived.await();
+            sendContinue.countDown();
+            returnResponse.countDown();
+            HttpResponse response = responseFuture.get();
+            assertThat(response.status(), is(EXPECTATION_FAILED));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(""));
+
+            sendFollowUpRequest(connection.asStreamingConnection(), withCL, allocator, OK);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void expectationFailedConnectionClose(HttpProtocol protocol, boolean withCL) throws Exception {
+        assumeTrue(protocol == HTTP_1);
+        try (ServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, true, payload).setHeader(CONNECTION, CLOSE))
+                    .subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            returnResponse.countDown();
+            assertResponse(EXPECTATION_FAILED, "");
+            assertThat("Unexpected subscribe to payload body on expectation failed",
+                    payload.isSubscribed(), is(false));
+
+            connection.onClose().toFuture().get();
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverError(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+                requestReceived.countDown();
+                returnResponse.await();
+                if (request.headers().contains(EXPECT, CONTINUE)) {
+                    response.status(INTERNAL_SERVER_ERROR);
+                }
+                response.sendMetaData().close();
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            connection.request(newRequest(connection, withCL, true, payload)).subscribe(responses::add);
+            requestReceived.await();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            returnResponse.countDown();
+            assertResponse(INTERNAL_SERVER_ERROR, "");
+
+            // send a follow-up request on the same connection:
+            connection.request(connection.get("/")).subscribe(responses::add);
+            assertResponse(OK, "");
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void serverErrorAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol, (ctx, request, response) -> {
+            requestReceived.countDown();
+            returnResponse.await();
+            if (request.headers().contains(EXPECT, CONTINUE)) {
+                response.status(INTERNAL_SERVER_ERROR);
+            }
+            response.sendMetaData().close();
+        });
+             StreamingHttpClient client = createClient(serverContext, protocol);
+             HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get().asConnection()) {
+            BufferAllocator allocator = connection.executionContext().bufferAllocator();
+
+            Future<HttpResponse> responseFuture = connection.request(
+                    newRequest(connection, withCL, false, PAYLOAD + PAYLOAD, allocator)).toFuture();
+            requestReceived.await();
+            returnResponse.countDown();
+            HttpResponse response = responseFuture.get();
+            assertThat(response.status(), is(INTERNAL_SERVER_ERROR));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(""));
+
+            // send a follow-up request on the same connection:
+            response = connection.request(connection.get("/")).toFuture().get();
+            assertThat(response.status(), is(OK));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(""));
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void retryExpectationFailed(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol);
+             StreamingHttpClient client = createClient(serverContext, protocol,
+                     new RetryingHttpRequesterFilter.Builder().retryExpectationFailed(true).build())) {
+
+            TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+            client.request(newRequest(client, withCL, true, payload)).subscribe(responses::add);
+            requestReceived.await();
+            returnResponse.countDown();
+
+            assertThat("Unexpected subscribe to payload body before 100 (Continue)",
+                    payload.isSubscribed(), is(false));
+            sendContinue.countDown();
+            sendRequestPayload(payload, client.executionContext().bufferAllocator());
+            assertResponse(OK, PAYLOAD + PAYLOAD);
+        }
+    }
+
+    @ParameterizedTest(name = "protocol={0} withCL={1}")
+    @MethodSource("arguments")
+    void retryExpectationFailedAggregated(HttpProtocol protocol, boolean withCL) throws Exception {
+        try (ServerContext serverContext = startServer(protocol);
+             HttpClient client = createClient(serverContext, protocol,
+                     new RetryingHttpRequesterFilter.Builder().retryExpectationFailed(true).build()).asClient()) {
+
+            Future<HttpResponse> responseFuture = client.request(newRequest(client, withCL, true, PAYLOAD + PAYLOAD,
+                    client.executionContext().bufferAllocator())).toFuture();
+            requestReceived.await();
+            sendContinue.countDown();
+            returnResponse.countDown();
+            HttpResponse response = responseFuture.get();
+            assertThat(response.status(), is(OK));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(PAYLOAD + PAYLOAD));
+        }
+    }
+
+    private ServerContext startServer(HttpProtocol protocol) throws Exception {
+        return startServer(protocol, (ctx, request, response) -> {
+                    requestReceived.countDown();
+                    if (request.headers().containsIgnoreCase(EXPECT, CONTINUE) &&
+                            request.headers().contains(FAIL, "true")) {
+                        returnResponse.await();
+                        response.status(EXPECTATION_FAILED).setHeader(CONTENT_LENGTH, ZERO);
+                        response.sendMetaData().close();
+                        return;
+                    }
+                    sendContinue.await();
+                    StringBuilder sb = new StringBuilder();
+                    request.payloadBody().forEach(chunk -> sb.append(chunk.toString(US_ASCII)));
+                    returnResponse.await();
+                    try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                        writer.write(ctx.executionContext().bufferAllocator().fromAscii(sb));
+                    }
+                });
+    }
+
+    private static ServerContext startServer(HttpProtocol protocol,
+                                                 BlockingStreamingHttpService service) throws Exception {
+        return HttpServers.forAddress(localAddress(0))
+                .ioExecutor(SERVER_CTX.ioExecutor())
+                .executor(SERVER_CTX.executor())
+                .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true)
+                .protocols(protocol.config)
+                .listenBlockingStreamingAndAwait(service);
+    }
+
+    private static StreamingHttpClient createClient(ServerContext serverContext, HttpProtocol protocol) {
+        return createClient(serverContext, protocol, null);
+    }
+
+    private static StreamingHttpClient createClient(ServerContext serverContext,
+                                                    HttpProtocol protocol,
+                                                    @Nullable StreamingHttpClientFilterFactory filterFactory) {
+        final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                        .ioExecutor(CLIENT_CTX.ioExecutor())
+                        .executor(CLIENT_CTX.executor())
+                        .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true)
+                        .protocols(protocol.config);
+        if (filterFactory != null) {
+            builder.appendClientFilter(filterFactory);
+        }
+        return builder.buildStreaming();
+    }
+
+    private static StreamingHttpRequest newRequest(StreamingHttpRequestFactory factory,
+                                                   boolean withCL, boolean fail,
+                                                   Publisher<Buffer> payload) {
+        return factory.post("/")
+                .setHeader(EXPECT, CONTINUE)
+                .setHeader(withCL ? CONTENT_LENGTH : TRANSFER_ENCODING,
+                        withCL ? valueOf(PAYLOAD.length() * 2) : CHUNKED)
+                .setHeader(FAIL, valueOf(fail))
+                .payloadBody(payload);
+    }
+
+    private static HttpRequest newRequest(HttpRequestFactory factory,
+                                          boolean withCL, boolean fail,
+                                          String payload,
+                                          BufferAllocator allocator) {
+        return factory.post("/")
+                .setHeader(EXPECT, CONTINUE)
+                .setHeader(withCL ? CONTENT_LENGTH : TRANSFER_ENCODING,
+                        withCL ? valueOf(PAYLOAD.length() * 2) : CHUNKED)
+                .setHeader(FAIL, valueOf(fail))
+                .payloadBody(allocator.fromAscii(payload));
+    }
+
+    private static void sendRequestPayload(TestPublisher<Buffer> payload, BufferAllocator alloc) {
+        payload.awaitSubscribed();
+        payload.onNext(alloc.fromAscii(PAYLOAD));
+        payload.onNext(alloc.fromAscii(PAYLOAD));
+        payload.onComplete();
+    }
+
+    private void sendFollowUpRequest(StreamingHttpRequester requester, boolean withCL,
+                                     BufferAllocator alloc, HttpResponseStatus expectedStatus) throws Exception {
+        TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
+        requester.request(newRequest(requester, withCL, false, payload)).subscribe(responses::add);
+        sendRequestPayload(payload, alloc);
+        assertResponse(expectedStatus, PAYLOAD + PAYLOAD);
+    }
+
+    private void assertResponse(HttpResponseStatus expectedStatus, String expectedPayload) throws Exception {
+        StreamingHttpResponse response = responses.take();
+        assertThat(response.status(), is(expectedStatus));
+        assertThat(response.toResponse().toFuture().get().payloadBody().toString(US_ASCII), equalTo(expectedPayload));
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -119,7 +119,8 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
 
     @Override
     EmbeddedChannel newEmbeddedChannel() {
-        return new EmbeddedChannel(new HttpRequestEncoder(new ArrayDeque<>(), 256, 256));
+        return new EmbeddedChannel(new HttpRequestEncoder(new ArrayDeque<>(), new ArrayDeque<>(), 256, 256,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }
 
     @Override
@@ -412,7 +413,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                                             channel2 -> {
                                                 serverChannelRef.compareAndSet(null, channel2);
                                                 serverChannelLatch.countDown();
-                                            }), defaultStrategy(), mock(Protocol.class), observer, false),
+                                            }), defaultStrategy(), mock(Protocol.class), observer, false, __ -> false),
                             connection -> { }).toFuture().get());
             ReadOnlyHttpClientConfig cConfig = new HttpClientConfig().asReadOnly();
             assert cConfig.h1Config() != null;
@@ -441,7 +442,8 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                                                                     serverCloseTrigger.onComplete();
                                                                 }
                                                             }
-                                                        })), defaultStrategy(), HTTP_1_1, connectionObserver, true);
+                                                        })), defaultStrategy(), HTTP_1_1, connectionObserver, true,
+                                        __ -> false);
                             },
                             NoopTransportObserver.INSTANCE).toFuture().get());
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -38,6 +38,7 @@ import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.netty.HttpResponseDecoder.Signal;
 
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.HttpResponseDecoder.Signal.REQUEST_SIGNAL;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static java.lang.Integer.toHexString;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -70,13 +72,24 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class HttpResponseDecoderTest extends HttpObjectDecoderTest {
 
+    private static final class PollLikePeakArrayDeque<T> extends ArrayDeque<T> {
+        private static final long serialVersionUID = -8160337336374186819L;
+
+        @Override
+        public T poll() {
+            return peek();  // Prevent taking an element out of the queue to allow reuse for multiple tests
+        }
+    }
+
     private final Queue<HttpRequestMethod> methodQueue = new ArrayDeque<>();
 
     private final EmbeddedChannel channel = newChannel(false);
     private final EmbeddedChannel channelSpecException = newChannel(true);
 
     private EmbeddedChannel newChannel(boolean allowLFWithoutCR) {
-        return new EmbeddedChannel(new HttpResponseDecoder(methodQueue,
+        final ArrayDeque<Signal> signalsQueue = new PollLikePeakArrayDeque<>();
+        signalsQueue.offer(REQUEST_SIGNAL);
+        return new EmbeddedChannel(new HttpResponseDecoder(methodQueue, signalsQueue,
                 getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
                 false, allowLFWithoutCR, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseEncoderTest.java
@@ -40,6 +40,8 @@ import static io.servicetalk.http.api.HttpHeaderValues.KEEP_ALIVE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.HttpResponseEncoder.NOOP_ON_RESPONSE;
+import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static java.lang.Integer.toHexString;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -52,7 +54,8 @@ class HttpResponseEncoderTest extends HttpEncoderTest<HttpResponseMetaData> {
 
     @Override
     EmbeddedChannel newEmbeddedChannel() {
-        return new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256));
+        return new EmbeddedChannel(new HttpResponseEncoder(new ArrayDeque<>(), 256, 256,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NOOP_ON_RESPONSE));
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
@@ -100,7 +100,8 @@ class NettyPipelinedConnectionTest {
         final DefaultNettyConnection<Integer, Integer> connection =
                 DefaultNettyConnection.<Integer, Integer>initChannel(channel, DEFAULT_ALLOCATOR,
                 immediate(), obj -> true, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), null,
-                channel2 -> { }, defaultStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true)
+                channel2 -> {
+                }, defaultStrategy(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
                         .toFuture().get();
         requester = new NettyPipelinedConnection<>(connection);
     }

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
@@ -115,7 +115,7 @@ final class TcpConnectorTest extends AbstractTcpServerTest {
                                     ctx.fireChannelActive();
                                 }
                             });
-                        }, CLIENT_CTX.executionStrategy(), mock(Protocol.class), connectionObserver, true),
+                        }, CLIENT_CTX.executionStrategy(), mock(Protocol.class), connectionObserver, true, __ -> false),
                 NoopTransportObserver.INSTANCE).toFuture().get();
         connection.closeAsync().toFuture().get();
 

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -96,7 +96,7 @@ final class TcpClient {
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
                         new TcpClientChannelInitializer(config, connectionObserver).andThen(
                                 channel2 -> channel2.pipeline().addLast(BufferHandler.INSTANCE)),
-                        executionContext.executionStrategy(), TCP, connectionObserver, true),
+                        executionContext.executionStrategy(), TCP, connectionObserver, true, __ -> false),
                 observer);
     }
 

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -88,7 +88,7 @@ public class TcpServer {
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
                         new TcpServerChannelInitializer(config, connectionObserver)
                                 .andThen(getChannelInitializer(service, executionContext)), executionStrategy, TCP,
-                        connectionObserver, false),
+                        connectionObserver, false, __ -> false),
                 serverConnection -> service.apply(serverConnection)
                         .beforeOnError(throwable -> LOGGER.error("Error handling a connection.", throwable))
                         .beforeFinally(() -> serverConnection.closeAsync().subscribe())

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelOutboundListener.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelOutboundListener.java
@@ -28,11 +28,24 @@ interface ChannelOutboundListener {
     void channelWritable();
 
     /**
+     * Signals that further write operations can be continued.
+     */
+    void continueWriting();
+
+    /**
      * Notification that the channel's outbound side has been closed and will no longer accept writes.
      * <p>
      * Always called from the event loop thread.
      */
     void channelOutboundClosed();
+
+    /**
+     * Request to terminate the source of data, without affecting a state of the channel.
+     * <p>
+     * Could happen if protocol supports termination/cancellation of the data it supposes to send, and the channel can
+     * be reused for next requests.
+     */
+    void terminateSource();
 
     /**
      * Notification that the channel has been closed.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -89,10 +89,11 @@ public abstract class CloseHandler {
     /**
      * Signal end of outbound payload, including the {@link ChannelPromise} associated with the last write. Must be
      * called from the {@link EventLoop} for the {@link Channel}.
-     * @param promise The {@link ChannelPromise} associated with the last write operation.
+     * @param promise The {@link ChannelPromise} associated with the last write operation or {@code null} if payload
+     * ends without a write operation (aborted/cancelled).
      * @param ctx {@link ChannelHandlerContext}
      */
-    public abstract void protocolPayloadEndOutbound(ChannelHandlerContext ctx, ChannelPromise promise);
+    public abstract void protocolPayloadEndOutbound(ChannelHandlerContext ctx, @Nullable ChannelPromise promise);
 
     /**
      * Signal inbound close command observed, to be emitted from the {@link EventLoop} for the {@link Channel}.
@@ -293,7 +294,8 @@ public abstract class CloseHandler {
         }
 
         @Override
-        public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, final ChannelPromise promise) {
+        public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx,
+                                               @Nullable final ChannelPromise promise) {
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NonPipelinedCloseHandler.java
@@ -75,12 +75,18 @@ final class NonPipelinedCloseHandler extends CloseHandler {
     }
 
     @Override
-    public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, final ChannelPromise promise) {
+    public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, @Nullable final ChannelPromise promise) {
+        if (promise == null) {
+            protocolPayloadEndOutbound0(ctx);
+            return;
+        }
         ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
-        promise.addListener(f -> {
-            state = unset(state, WRITE);
-            outboundEventCheckClose(ctx.channel(), closeEvent);
-        });
+        promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
+    }
+
+    private void protocolPayloadEndOutbound0(final ChannelHandlerContext ctx) {
+        state = unset(state, WRITE);
+        outboundEventCheckClose(ctx.channel(), closeEvent);
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -180,17 +180,23 @@ class RequestResponseCloseHandler extends CloseHandler {
     }
 
     @Override
-    public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, final ChannelPromise promise) {
+    public void protocolPayloadEndOutbound(final ChannelHandlerContext ctx, @Nullable final ChannelPromise promise) {
+        if (promise == null) {
+            protocolPayloadEndOutbound0(ctx);
+            return;
+        }
         if (isClient || (closeEvent != null && pending == 0)) {
             ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
         }
-        promise.addListener(f -> {
-            state = unset(state, WRITE);
-            final CloseEvent evt = this.closeEvent;
-            if (evt != null) {
-                closeChannelHalfOrFullyOnPayloadEnd(ctx.channel(), evt, false);
-            }
-        });
+        promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
+    }
+
+    private void protocolPayloadEndOutbound0(final ChannelHandlerContext ctx) {
+        state = unset(state, WRITE);
+        final CloseEvent evt = this.closeEvent;
+        if (evt != null) {
+            closeChannelHalfOrFullyOnPayloadEnd(ctx.channel(), evt, false);
+        }
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
@@ -104,10 +105,13 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
     private final CloseHandler closeHandler;
     private final WriteObserver observer;
     private final boolean isClient;
+    private final Predicate<Object> shouldWait;
+    private boolean shouldWaitFlag;
 
     WriteStreamSubscriber(Channel channel, WriteDemandEstimator demandEstimator, Subscriber subscriber,
                           CloseHandler closeHandler, WriteObserver observer,
-                          UnaryOperator<Throwable> enrichProtocolError, boolean isClient) {
+                          UnaryOperator<Throwable> enrichProtocolError, boolean isClient,
+                          Predicate<Object> shouldWait) {
         this.eventLoop = requireNonNull(channel.eventLoop());
         this.subscriber = subscriber;
         this.channel = channel;
@@ -116,6 +120,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
         this.closeHandler = closeHandler;
         this.observer = observer;
         this.isClient = isClient;
+        this.shouldWait = requireNonNull(shouldWait);
     }
 
     @Override
@@ -165,7 +170,13 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
             long capacityAfter = channel.bytesBeforeUnwritable();
             observer.itemWritten(msg);
             demandEstimator.onItemWrite(msg, capacityBefore, capacityAfter);
-            requestMoreIfRequired(subscription, capacityAfter);
+            // Client-side always starts a request with request(1) to probe a Channel with meta-data before continuing
+            // to write the payload body, see https://github.com/apple/servicetalk/pull/1644.
+            // Requests that await feedback from the remote peer should not request more until they receive
+            // continueWriting() signal.
+            if (!isClient || !(shouldWaitFlag = shouldWait.test(msg))) {
+                requestMoreIfRequired(subscription, capacityAfter);
+            }
         }
     }
 
@@ -191,13 +202,38 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
     @Override
     public void channelWritable() {
         assert eventLoop.inEventLoop();
-        requestMoreIfRequired(subscription, -1L);
+        final Subscription subscription = this.subscription;
+        if (isClient && subscription != null && !promise.written) {
+            // If nothing was written, make initial requestN
+            initialRequestN(subscription);
+        } else {
+            requestMoreIfRequired(subscription, -1L);
+        }
+    }
+
+    @Override
+    public void continueWriting() {
+        assert eventLoop.inEventLoop();
+        if (shouldWaitFlag) {
+            shouldWaitFlag = false; // Reset the flag to avoid promise.sourceTerminated(null)
+            requestMoreIfRequired(subscription, -1L);
+        }
     }
 
     @Override
     public void channelOutboundClosed() {
         assert eventLoop.inEventLoop();
         promise.sourceTerminated(null);
+    }
+
+    @Override
+    public void terminateSource() {
+        assert eventLoop.inEventLoop();
+        // Terminate the source only if it awaits continuation.
+        if (shouldWaitFlag) {
+            assert promise.activeWrites == 0;   // We never start sending payload body until we receive 100 (Continue)
+            promise.sourceTerminated(null);
+        }
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -76,7 +76,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
                         }
                         ctx.write(msg, promise);
                     }
-                })), NOOP_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, isClient)
+                })), NOOP_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, isClient, __ -> false)
                 .toFuture().get();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -109,7 +109,8 @@ class DefaultNettyConnectionTest {
                     return true;
                 },
                 closeHandlerFactory.apply(channel), defaultFlushStrategy(), null, trailerProtocolEndEventEmitter(),
-                OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get();
+                OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
+                .toFuture().get();
         publisher = new TestPublisher<>();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
@@ -50,7 +50,8 @@ class NettyChannelPublisherRefCountTest {
         channel = new EmbeddedDuplexChannel(false);
         publisher = DefaultNettyConnection.initChannel(channel, DEFAULT_ALLOCATOR, immediate(), x -> false,
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), null, channel2 -> { },
-                OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get()
+                OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
+                .toFuture().get()
                 .read();
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
@@ -97,7 +97,8 @@ class NettyChannelPublisherTest {
                     readRequested = true;
                     super.read(ctx);
                 }
-            }), OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get();
+            }), OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
+                        .toFuture().get();
         publisher = connection.read();
         channel.config().setAutoRead(false);
     }
@@ -145,7 +146,8 @@ class NettyChannelPublisherTest {
                             super.read(ctx);
                         }
                     });
-                }, OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true).toFuture().get();
+                }, OFFLOAD_ALL_STRATEGY, mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
+                .toFuture().get();
         publisher = connection.read();
         channel.config().setAutoRead(false);
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberFutureListenersTest.java
@@ -69,7 +69,7 @@ class WriteStreamSubscriberFutureListenersTest {
         WriteDemandEstimator estimator = WriteDemandEstimators.newDefaultEstimator();
         TestCompletableSubscriber completableSubscriber = new TestCompletableSubscriber();
         subscriber = new WriteStreamSubscriber(channel, estimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         TestSubscription subscription = new TestSubscription();
         subscriber.onSubscribe(subscription);
         assertThat("No items requested.", subscription.requested(), greaterThan(0L));
@@ -173,7 +173,7 @@ class WriteStreamSubscriberFutureListenersTest {
         WriteDemandEstimator estimator = WriteDemandEstimators.newDefaultEstimator();
         TestCompletableSubscriber completableSubscriber = new TestCompletableSubscriber();
         WriteStreamSubscriber subscriber = new WriteStreamSubscriber(mockChannel, estimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         subscriber.onNext(1);
         verifyListenerInvokedWithSuccess(listeners.take());
         subscriber.onNext(2);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberOutOfEventloopTest.java
@@ -46,7 +46,7 @@ class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventloopTest
         CompletableSource.Subscriber completableSubscriber = mock(CompletableSource.Subscriber.class);
         WriteDemandEstimator demandEstimator = mock(WriteDemandEstimator.class);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
     }
 
     @Test
@@ -104,7 +104,7 @@ class WriteStreamSubscriberOutOfEventloopTest extends AbstractOutOfEventloopTest
         };
         WriteDemandEstimator demandEstimator = mock(WriteDemandEstimator.class);
         this.subscriber = new WriteStreamSubscriber(channel, demandEstimator, subscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
 
         this.subscriber.onNext(1);
         this.subscriber.onError(DELIBERATE_EXCEPTION);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriberTest.java
@@ -56,7 +56,7 @@ class WriteStreamSubscriberTest extends AbstractWriteTest {
         super.setUp();
         closeHandler = mock(CloseHandler.class);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber, closeHandler,
-                NoopWriteObserver.INSTANCE, identity(), false);
+                NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         subscription = mock(Subscription.class);
         when(demandEstimator.estimateRequestN(anyLong())).thenReturn(1L);
         subscriber.onSubscribe(subscription);
@@ -114,7 +114,7 @@ class WriteStreamSubscriberTest extends AbstractWriteTest {
     @Test
     void testCancelBeforeOnSubscribe() {
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         subscription = mock(Subscription.class);
         subscriber.cancel();
         subscriber.onSubscribe(subscription);
@@ -133,7 +133,7 @@ class WriteStreamSubscriberTest extends AbstractWriteTest {
     void testRequestMoreBeforeOnSubscribe() {
         reset(completableSubscriber);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), false, __ -> false);
         subscriber.channelWritable();
         subscription = mock(Subscription.class);
         subscriber.onSubscribe(subscription);
@@ -177,7 +177,7 @@ class WriteStreamSubscriberTest extends AbstractWriteTest {
         reset(completableSubscriber, demandEstimator);
         when(demandEstimator.estimateRequestN(anyLong())).thenReturn(10L);
         subscriber = new WriteStreamSubscriber(channel, demandEstimator, completableSubscriber,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), true);
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, NoopWriteObserver.INSTANCE, identity(), true, __ -> false);
         subscription = mock(Subscription.class);
         subscriber.onSubscribe(subscription);
         verify(subscription).request(1L);


### PR DESCRIPTION
Motivation:

Add support for `Expect: 100-continue` header to allow users deffer
sending request payload body until server signals that it's ready to
receive it.

Modification:

- Enhance `HttpObjectEncoder`, `HttpObjectDecoder`,
`AbstractH2DuplexHandler`, their subclasses, and `NettyHttpServer` to
support new feature;
- `DefaultNettyConnection`: add `ContinueUserEvent` and
`CancelWriteUserEvent`;
- `WriteStreamSubscriber`: add `continueWriting()` and
`terminateSource()` to support continuation;
- Fix `WriteStreamSubscriber#channelWritable()` to make
`initialRequestN` if subscription was assigned while a channel was not
writable;
- `RequestResponseCloseHandler` and `NonPipelinedCloseHandler`: fire
`OutboundDataEndEvent` only when it ends outbound data but not when
`CancelWriteUserEvent`;
- `HttpProtocolVersion`: implement `Comparable` interface to allow
easier version number comparison;
- `RetryingHttpRequesterFilter`: add `retryExpectationFailed(boolean)`
feature and public `ExpectationFailedException`;
- Test new behavior;
- Add docs section about `Expect: 100-continue` for http-api module;

Result:

HTTP supports `Expect: 100-continue` feature on client and server sides.