### PR TITLE
`NettyIoThread` should implement `ContextMapHolder`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IoThreadFactory.java
@@ -16,6 +16,8 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.api.AsyncContextMap;
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.context.api.ContextMapHolder;
 import io.servicetalk.transport.netty.internal.IoThreadFactory.NettyIoThread;
 
 import io.netty.util.concurrent.FastThreadLocalThread;
@@ -90,8 +92,10 @@ public class IoThreadFactory implements java.util.concurrent.ThreadFactory,
     }
 
     static final class NettyIoThread extends FastThreadLocalThread
-            implements io.servicetalk.transport.api.IoThreadFactory.IoThread {
+            implements io.servicetalk.transport.api.IoThreadFactory.IoThread, ContextMapHolder {
 
+        @Nullable
+        private ContextMap context;
         @Nullable
         private AsyncContextMap asyncContextMap;
 
@@ -108,6 +112,18 @@ public class IoThreadFactory implements java.util.concurrent.ThreadFactory,
         @Override
         public AsyncContextMap asyncContextMap() {
             return asyncContextMap;
+        }
+
+        @Nullable
+        @Override
+        public ContextMap context() {
+            return context;
+        }
+
+        @Override
+        public NettyIoThread context(@Nullable final ContextMap context) {
+            this.context = context;
+            return this;
         }
     }
 }


### PR DESCRIPTION
Motivation:

#1910 could not change
`io.servicetalk.transport.api.IoThreadFactory.IoThread` to extend
`ContextMapHolder` to keep it backward compatible. But the internal
`NettyIoThread` must implement `ContextMapHolder`. Otherwise, all
netty threads go through slow path of managing `AsyncContext`.

Modifications:

- `NettyIoThread` implements `ContextMapHolder`;

Result:

All instances of `NettyIoThread`s go through the fast path of operating
with `ContextMap`.