### PR TITLE
Use gRPC-Java BOM

### DIFF
--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -25,6 +25,7 @@ apply plugin: "com.google.protobuf"
 
 dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testImplementation enforcedPlatform("io.grpc:grpc-bom:$grpcVersion")
 
   api project(":servicetalk-grpc-api")
   api project(":servicetalk-grpc-utils")
@@ -57,12 +58,12 @@ dependencies {
   testImplementation project(":servicetalk-utils-internal")
   testImplementation project(":servicetalk-transport-netty")
   testImplementation project(":servicetalk-serializer-utils")
-  testImplementation "io.grpc:grpc-core:$grpcVersion"
-  testImplementation("io.grpc:grpc-netty:$grpcVersion") {
+  testImplementation "io.grpc:grpc-core"
+  testImplementation("io.grpc:grpc-netty") {
     exclude group: "io.netty"
   }
-  testImplementation "io.grpc:grpc-protobuf:$grpcVersion"
-  testImplementation "io.grpc:grpc-stub:$grpcVersion"
+  testImplementation "io.grpc:grpc-protobuf"
+  testImplementation "io.grpc:grpc-stub"
   testImplementation "io.netty:netty-tcnative-boringssl-static"
   testImplementation "jakarta.annotation:jakarta.annotation-api:$javaxAnnotationsApiVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"


### PR DESCRIPTION
Motivation:
The gRPC Java project provides a BOM file for managing versions of
modules and dependencies. Using the BOM results in more consistent
component resolution.
Modifications:
Use BOM in `build.graddle` as an enforcedPlatform. Remove version
references from most other components to use BOM version.
Result:
Cleaner use of gRPC-Java dependencies.