### PR TITLE
Fix incorrect link in `Expect: 100-continue` docs

### DIFF
--- a/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/index.adoc
@@ -278,7 +278,7 @@ implement a filter to accept or reject requests before processing their payload 
 TIP: The interim response is not propagated as a response
 returned by the client because the client has to wait for a final status code returned by the server. There are a couple
 of other ways how to get visibility into interim response: using wire-logging for HTTP/1.x or frame-logging for HTTP/2
-(see link:{source-root}/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java[DebuggingClient]
+(see link:{source-root}/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java[DebuggingExampleClient]
 as an example) or by monitoring when
 link:{source-root}/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java[WriteObserver]
 signals that more items are requested to write.


### PR DESCRIPTION
Motivation:

Docs section about `Expect: 100-continue` points to grpc example instead
of http example.

Modifications:

- Change reference from grpc `DebuggingClient` to http
`DebuggingExampleClient`;

Result:

Correct link, 0.42 branch doesn't fail during link validation step.