### PR TITLE
Changing instances of ExecutorExtension to static

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/BufferStrategiesTest.java
@@ -77,7 +77,7 @@ import static org.mockito.Mockito.when;
 class BufferStrategiesTest {
 
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_EXTENSION = withCachedExecutor().setClassLevel(true);
+    static final ExecutorExtension<Executor> EXEC = withCachedExecutor().setClassLevel(true);
 
     @RegisterExtension
     final ExecutorExtension<TestExecutor> testExecutorExtension = withTestExecutor();
@@ -110,7 +110,7 @@ class BufferStrategiesTest {
                 .ignoreElements().subscribe();
         CyclicBarrier accumulateAndTimerStarted = new CyclicBarrier(2);
 
-        Future<Object> timersFuture = EXECUTOR_EXTENSION.executor().submit(() -> {
+        Future<Object> timersFuture = EXEC.executor().submit(() -> {
             accumulateAndTimerStarted.await();
             while (boundariesDone.getCount() > 0) {
                 timers.take().onComplete();
@@ -118,7 +118,7 @@ class BufferStrategiesTest {
             return null;
         }).toFuture();
 
-        Future<Object> accumulateFuture = EXECUTOR_EXTENSION.executor().submit(() -> {
+        Future<Object> accumulateFuture = EXEC.executor().submit(() -> {
             accumulateAndTimerStarted.await();
             int boundariesReceived = 0;
             Iterator<Integer> itemsToPopulate = items.iterator();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.verify;
 
 class CompletableMergeWithPublisherTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = withCachedExecutor().setClassLevel(true);
     private final TestSubscription subscription = new TestSubscription();
     private final TestPublisher<String> publisher = new TestPublisher.Builder<String>()
             .disableAutoOnSubscribe().build();
@@ -390,8 +390,8 @@ class CompletableMergeWithPublisherTest {
         TestCompletable completable = new TestCompletable.Builder().disableAutoOnSubscribe().build();
         TestCancellable testCancellable = new TestCancellable();
         CountDownLatch latch = new CountDownLatch(1);
-        toSource(applyMerge(completable.publishOn(executorExtension.executor()), delayError,
-                            publisher.publishOn(executorExtension.executor())).afterOnNext(item -> {
+        toSource(applyMerge(completable.publishOn(EXEC.executor()), delayError,
+                            publisher.publishOn(EXEC.executor())).afterOnNext(item -> {
             // The goal of this test is to have the Completable terminate, but have onNext signals from the Publisher be
             // delayed on the Executor. Even in this case the merge operator should correctly sequence the onComplete to
             // the downstream subscriber until after all the onNext events have completed.
@@ -436,7 +436,7 @@ class CompletableMergeWithPublisherTest {
         TestCompletable completable = new TestCompletable();
         toSource(applyMerge(completable, delayError)).subscribe(subscriber);
         publisher.onSubscribe(subscription);
-        Future<Void> f = executorExtension.executor().submit(() -> {
+        Future<Void> f = EXEC.executor().submit(() -> {
             try {
                 barrier.await();
             } catch (Exception e) {
@@ -480,7 +480,7 @@ class CompletableMergeWithPublisherTest {
         }).when(mockSubscriber).onNext(any());
         toSource(applyMerge(completable, delayError)).subscribe(mockSubscriber);
         publisher.onSubscribe(subscription);
-        Future<Void> f = executorExtension.executor().submit(() -> {
+        Future<Void> f = EXEC.executor().submit(() -> {
             try {
                 nextLatch2.await();
             } catch (Exception e) {
@@ -573,7 +573,7 @@ class CompletableMergeWithPublisherTest {
         }).when(mockSubscriber).onNext(any());
         toSource(applyMerge(completable, delayError)).subscribe(mockSubscriber);
         publisher.onSubscribe(subscription);
-        Future<Void> f = executorExtension.executor().submit(() -> {
+        Future<Void> f = EXEC.executor().submit(() -> {
             try {
                 nextLatch2.await();
             } catch (Exception e) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
@@ -45,9 +45,11 @@ class SingleAmbWithAsyncTest {
     private static final int BEFORE_ON_SUBSCRIBE_KEY_VAL_2 = 3;
 
     @RegisterExtension
-    final ExecutorExtension<Executor> firstExec = withCachedExecutor(FIRST_EXECUTOR_THREAD_NAME_PREFIX);
+    static final ExecutorExtension<Executor> FIRST_EXEC = withCachedExecutor(FIRST_EXECUTOR_THREAD_NAME_PREFIX)
+            .setClassLevel(true);
     @RegisterExtension
-    final ExecutorExtension<Executor> secondExec = withCachedExecutor(SECOND_EXECUTOR_THREAD_NAME_PREFIX);
+    static final ExecutorExtension<Executor> SECOND_EXEC = withCachedExecutor(SECOND_EXECUTOR_THREAD_NAME_PREFIX)
+            .setClassLevel(true);
 
     @Test
     void offloadSuccessFromFirst() throws Exception {
@@ -168,8 +170,8 @@ class SingleAmbWithAsyncTest {
 
     private int testOffloadSecond(String completeOn, final Single<Integer> first, final Single<Integer> second)
             throws Exception {
-        return first.publishOn(firstExec.executor())
-                .ambWith(second.publishOn(secondExec.executor()))
+        return first.publishOn(FIRST_EXEC.executor())
+                .ambWith(second.publishOn(SECOND_EXEC.executor()))
                 .beforeFinally(() ->
                         assertThat("Unexpected thread.", Thread.currentThread().getName(),
                                 startsWith(completeOn)))
@@ -177,8 +179,8 @@ class SingleAmbWithAsyncTest {
     }
 
     private int testContextFromSubscribe(final Single<Integer> first, final Single<Integer> second) throws Exception {
-        return first.publishOn(firstExec.executor())
-                .ambWith(second.publishOn(secondExec.executor()))
+        return first.publishOn(FIRST_EXEC.executor())
+                .ambWith(second.publishOn(SECOND_EXEC.executor()))
                 .beforeFinally(() ->
                         assertThat("Unexpected context value.", AsyncContext.get(BEFORE_SUBSCRIBE_KEY),
                                 is(BEFORE_SUBSCRIBE_KEY_VAL)))
@@ -191,8 +193,8 @@ class SingleAmbWithAsyncTest {
 
     private int testContextFromOnSubscribe(final Single<Integer> first, final Single<Integer> second) throws Exception {
         return first.beforeOnSubscribe(__ -> AsyncContext.put(BEFORE_ON_SUBSCRIBE_KEY, BEFORE_ON_SUBSCRIBE_KEY_VAL))
-                .publishOn(firstExec.executor())
-                .ambWith(second.publishOn(secondExec.executor()))
+                .publishOn(FIRST_EXEC.executor())
+                .ambWith(second.publishOn(SECOND_EXEC.executor()))
                 .beforeFinally(() ->
                         assertThat("Unexpected context value.",
                                 AsyncContext.get(BEFORE_ON_SUBSCRIBE_KEY),
@@ -202,8 +204,8 @@ class SingleAmbWithAsyncTest {
 
     private int testContextFromSecondSubscribe(final Single<Integer> first, final Single<Integer> second)
             throws Exception {
-        return first.publishOn(firstExec.executor())
-                .ambWith(second.publishOn(secondExec.executor())
+        return first.publishOn(FIRST_EXEC.executor())
+                .ambWith(second.publishOn(SECOND_EXEC.executor())
                         .liftSync(subscriber -> {
                             // Modify value for the same key, this update should not be visible back in the original
                             // chain
@@ -224,8 +226,8 @@ class SingleAmbWithAsyncTest {
     private int testContextFromSecondOnSubscribe(final Single<Integer> first, final Single<Integer> second)
             throws Exception {
         return first.beforeOnSubscribe(__ -> AsyncContext.put(BEFORE_ON_SUBSCRIBE_KEY, BEFORE_ON_SUBSCRIBE_KEY_VAL))
-                .publishOn(firstExec.executor())
-                .ambWith(second.publishOn(secondExec.executor())
+                .publishOn(FIRST_EXEC.executor())
+                .ambWith(second.publishOn(SECOND_EXEC.executor())
                         .beforeOnSubscribe(__ ->
                                 AsyncContext.put(BEFORE_ON_SUBSCRIBE_KEY, BEFORE_ON_SUBSCRIBE_KEY_VAL_2)))
                 .beforeFinally(() ->

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToPublisherTest.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.sameInstance;
 
 class CompletableToPublisherTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     private TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
 
@@ -76,7 +76,7 @@ class CompletableToPublisherTest {
             }
         })
                 .afterCancel(analyzed::countDown)
-                .subscribeOn(executorExtension.executor())
+                .subscribeOn(EXEC.executor())
                 .<String>toPublisher())
                 .subscribe(subscriber);
         TestCancellable cancellable = new TestCancellable();
@@ -133,7 +133,7 @@ class CompletableToPublisherTest {
         final Thread testThread = currentThread();
         CountDownLatch analyzed = new CountDownLatch(1);
         CountDownLatch receivedOnSubscribe = new CountDownLatch(1);
-        toSource(completable.publishOn(executorExtension.executor())
+        toSource(completable.publishOn(EXEC.executor())
                 .beforeOnComplete(() -> {
                     if (currentThread() == testThread) {
                         errors.add(new AssertionError("Invalid thread invoked onComplete " +

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CompletableToSingleTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 class CompletableToSingleTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     private TestSingleSubscriber<Void> subscriber = new TestSingleSubscriber<>();
 
@@ -55,7 +55,7 @@ class CompletableToSingleTest {
                         currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorExtension.executor()).toSingle().subscribe(__ -> { }).cancel();
+        }).subscribeOn(EXEC.executor()).toSingle().subscribe(__ -> { }).cancel();
         analyzed.await();
         assertThat("Unexpected errors observed: " + errors, errors, hasSize(0));
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubFirstOrErrorTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 class PubFirstOrErrorTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher<>();
 
@@ -55,7 +55,7 @@ class PubFirstOrErrorTest {
     @Test
     void asyncSingleItemCompleted() throws Exception {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
-        executorExtension.executor().submit(() -> {
+        EXEC.executor().submit(() -> {
             publisher.onNext("hello");
             publisher.onComplete();
         }).toFuture().get();
@@ -65,7 +65,7 @@ class PubFirstOrErrorTest {
     @Test
     void asyncMultipleItemCompleted() throws Exception {
         toSource(publisher.firstOrError()).subscribe(listenerRule);
-        executorExtension.executor().submit(() -> {
+        EXEC.executor().submit(() -> {
             publisher.onNext("foo", "bar");
             publisher.onComplete();
         }).toFuture().get();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToCompletableIgnoreTest.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.is;
 
 class PubToCompletableIgnoreTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
     private final TestCompletableSubscriber listenerRule = new TestCompletableSubscriber();
 
     @Test
@@ -95,7 +95,7 @@ class PubToCompletableIgnoreTest {
                         currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorExtension.executor()).ignoreElements().toFuture().get();
+        }).subscribeOn(EXEC.executor()).ignoreElements().toFuture().get();
         analyzed.await();
         assertNoAsyncErrors(errors);
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToSingleFirstOrElseTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/PubToSingleFirstOrElseTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PubToSingleFirstOrElseTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestSubscription subscription = new TestSubscription();
@@ -128,7 +128,7 @@ class PubToSingleFirstOrElseTest {
                         currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorExtension.executor()).firstOrElse(() -> {
+        }).subscribeOn(EXEC.executor()).firstOrElse(() -> {
             throw new NoSuchElementException();
         }).toFuture().get();
         analyzed.await();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CompletionStageAsyncContextTest.java
@@ -42,9 +42,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CompletionStageAsyncContextTest {
     private static final ContextMap.Key<Integer> K1 = newKey("k1", Integer.class);
-    @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor(ST_THREAD_PREFIX_NAME);
     private static final String ST_THREAD_PREFIX_NAME = "st-exec-thread";
+    @RegisterExtension
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor(ST_THREAD_PREFIX_NAME)
+            .setClassLevel(true);
     private static final String JDK_THREAD_NAME_PREFIX = "jdk-thread";
     private static final AtomicInteger threadCount = new AtomicInteger();
     private static ExecutorService jdkExecutor;
@@ -68,7 +69,7 @@ class CompletionStageAsyncContextTest {
     void beforeTest() {
         AsyncContext.clear();
         testSource = new LegacyTestSingle<>(true, true);
-        source = testSource.publishOn(executorExtension.executor());
+        source = testSource.publishOn(EXEC.executor());
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ConcatWithCompletableTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 class ConcatWithCompletableTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
     private final TestSingleSubscriber<String> listener = new TestSingleSubscriber<>();
     private LegacyTestSingle<String> single = new LegacyTestSingle<>();
     private LegacyTestCompletable completable = new LegacyTestCompletable();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ReduceSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/ReduceSingleTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class ReduceSingleTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     private final TestSingleSubscriber<String> listenerRule = new TestSingleSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher<>();
@@ -125,7 +125,7 @@ class ReduceSingleTest {
                                               currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorExtension.executor()).collect(ArrayList::new, (objects, s) -> {
+        }).subscribeOn(EXEC.executor()).collect(ArrayList::new, (objects, s) -> {
             objects.add(s);
             return objects;
         }).toFuture().get();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleFlatMapPublisherTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class SingleFlatMapPublisherTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestPublisher<String> publisher = new TestPublisher.Builder<String>()
@@ -161,7 +161,7 @@ final class SingleFlatMapPublisherTest {
                     }
                     analyzed.countDown();
                 })
-                .subscribeOn(executorExtension.executor())
+                .subscribeOn(EXEC.executor())
                 .flatMapPublisher(t -> Publisher.never())
                 .forEach(__ -> { }).cancel();
         analyzed.await();

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletableTest.java
@@ -30,7 +30,7 @@ import static java.lang.Thread.currentThread;
 
 class SingleToCompletableTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     @Test
     void subscribeOnOriginalIsPreserved() throws InterruptedException {
@@ -43,7 +43,7 @@ class SingleToCompletableTest {
                         currentThread()));
             }
             analyzed.countDown();
-        }).subscribeOn(executorExtension.executor()).toCompletable().subscribe().cancel();
+        }).subscribeOn(EXEC.executor()).toCompletable().subscribe().cancel();
         analyzed.await();
         assertNoAsyncErrors("Unexpected errors observed: " + errors, errors);
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToCompletionStageTest.java
@@ -58,14 +58,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SingleToCompletionStageTest {
+    private static final String ST_THREAD_PREFIX_NAME = "st-exec-thread";
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor(ST_THREAD_PREFIX_NAME);
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor(ST_THREAD_PREFIX_NAME)
+            .setClassLevel(true);
 
     private LegacyTestSingle testSingle;
     private Single<String> source;
     private static ExecutorService jdkExecutor;
     private static final AtomicInteger threadCount = new AtomicInteger();
-    private static final String ST_THREAD_PREFIX_NAME = "st-exec-thread";
     private static final String JDK_THREAD_NAME_PREFIX = "jdk-thread";
     private static final String JDK_FORK_JOIN_THREAD_NAME_PREFIX = "ForkJoinPool";
     private static final String COMPLETABLE_FUTURE_THREAD_PER_TASK_NAME_PREFIX = "Thread-";
@@ -87,7 +88,7 @@ class SingleToCompletionStageTest {
     @BeforeEach
     void beforeTest() {
         testSingle = new LegacyTestSingle<>(true, true);
-        source = testSingle.publishOn(executorExtension.executor());
+        source = testSingle.publishOn(EXEC.executor());
     }
 
     @Test

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToFutureTest.java
@@ -65,7 +65,7 @@ class SingleToFutureTest extends AbstractToFutureTest<Integer> {
     @Test
     void testSucceededNull() throws Exception {
         Future<Integer> future = toFuture();
-        exec.executor().schedule(() -> source.onSuccess(null), 10, MILLISECONDS);
+        EXEC.executor().schedule(() -> source.onSuccess(null), 10, MILLISECONDS);
         assertThat(future.get(), is(nullValue()));
         assertThat(future.isDone(), is(true));
         assertThat(future.isCancelled(), is(false));
@@ -76,7 +76,7 @@ class SingleToFutureTest extends AbstractToFutureTest<Integer> {
     void testSucceededThrowable() throws Exception {
         TestSingle<Throwable> throwableSingle = new TestSingle<>();
         Future<Throwable> future = throwableSingle.toFuture();
-        exec.executor().schedule(() -> throwableSingle.onSuccess(DELIBERATE_EXCEPTION), 10, MILLISECONDS);
+        EXEC.executor().schedule(() -> throwableSingle.onSuccess(DELIBERATE_EXCEPTION), 10, MILLISECONDS);
         assertThat(future.get(), is(DELIBERATE_EXCEPTION));
         assertThat(future.isDone(), is(true));
         assertThat(future.isCancelled(), is(false));

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleToPublisherTest.java
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.sameInstance;
 class SingleToPublisherTest {
 
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
     private final TestPublisherSubscriber<String> verifier = new TestPublisherSubscriber<>();
 
@@ -138,7 +138,7 @@ class SingleToPublisherTest {
                 errors.add(new AssertionError("Invalid thread invoked cancel. Thread: " +
                         currentThread()));
             }
-        }).afterCancel(analyzed::countDown).subscribeOn(executorExtension.executor()).toPublisher())
+        }).afterCancel(analyzed::countDown).subscribeOn(EXEC.executor()).toPublisher())
                 .subscribe(subscriber);
         TestCancellable cancellable = new TestCancellable();
         single.onSubscribe(cancellable); // waits till subscribed.
@@ -221,7 +221,7 @@ class SingleToPublisherTest {
         final Thread testThread = currentThread();
         CountDownLatch analyzed = new CountDownLatch(1);
         CountDownLatch receivedOnSubscribe = new CountDownLatch(1);
-        toSource(single.publishOn(executorExtension.executor())
+        toSource(single.publishOn(EXEC.executor())
                 .beforeOnSuccess(__ -> {
                     if (currentThread() == testThread) {
                         errors.add(new AssertionError("Invalid thread invoked onSuccess " +

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriberTest.java
@@ -45,8 +45,7 @@ import static org.mockito.Mockito.verify;
 
 class ConcurrentTerminalSubscriberTest {
     @RegisterExtension
-    final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor();
-
+    static final ExecutorExtension<Executor> EXEC = ExecutorExtension.withCachedExecutor().setClassLevel(true);
     private final TestPublisher<Integer> publisher =
             new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
     private final TestSubscription subscription = new TestSubscription();
@@ -187,7 +186,7 @@ class ConcurrentTerminalSubscriberTest {
         ConcurrentTerminalSubscriber<Integer> subscriber = new ConcurrentTerminalSubscriber<>(mockSubscriber);
         publisher.subscribe(subscriber);
         publisher.onSubscribe(subscription);
-        executorExtension.executor().execute(() -> {
+        EXEC.executor().execute(() -> {
             if (firstOnComplete) {
                 publisher.onComplete();
             } else {
@@ -251,7 +250,7 @@ class ConcurrentTerminalSubscriberTest {
         publisher.subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscription.awaitRequestN(1);
-        executorExtension.executor().execute(() -> publisher.onNext(1));
+        EXEC.executor().execute(() -> publisher.onNext(1));
         onNextEnterBarrier.await();
         if (onComplete) {
             publisher.onComplete();
@@ -298,7 +297,7 @@ class ConcurrentTerminalSubscriberTest {
 
         ConcurrentTerminalSubscriber<Integer> subscriber = new ConcurrentTerminalSubscriber<>(mockSubscriber);
         publisher.subscribe(subscriber);
-        executorExtension.executor().execute(() -> publisher.onSubscribe(subscription));
+        EXEC.executor().execute(() -> publisher.onSubscribe(subscription));
         subscription.awaitRequestN(1);
         if (onNext) {
             publisher.onNext(1);


### PR DESCRIPTION
Motivation:

To potentially reduce the overhead of instantiating the ExecutorExtension class repeatedly between test cases.

Modifications:
Changed instances of ExecutorExtension to static

Result:

All instances of the ExecutorExtension are now static inside servicetalk-concurrent-api module test classes.