### PR TITLE
ConnectionFactory-level filters can not migrate to new API of #1956

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/NewToDeprecatedFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/NewToDeprecatedFilter.java
@@ -17,7 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Single;
 
-import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
+import static io.servicetalk.http.api.HttpApiConversions.requestStrategy;
 
 /**
  * Because users can have a mixed set of filters, we should always delegate from the new {@code request} method to the
@@ -103,10 +103,5 @@ final class NewToDeprecatedFilter implements StreamingHttpClientFilterFactory, S
     public HttpExecutionStrategy influenceStrategy(final HttpExecutionStrategy strategy) {
         // No influence since we do not block.
         return strategy;
-    }
-
-    static HttpExecutionStrategy requestStrategy(HttpRequestMetaData metaData, HttpExecutionStrategy fallback) {
-        final HttpExecutionStrategy strategy = metaData.context().get(HTTP_EXECUTION_STRATEGY_KEY);
-        return strategy != null ? strategy : fallback;
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -53,6 +53,7 @@ import static io.servicetalk.http.netty.HeaderUtils.canAddRequestContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.emptyMessageBody;
 import static io.servicetalk.http.netty.HeaderUtils.flatEmptyMessage;
 import static io.servicetalk.http.netty.HeaderUtils.setRequestContentLength;
+import static io.servicetalk.http.netty.NewToDeprecatedFilter.requestStrategy;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.flushOnEnd;
 import static java.util.Objects.requireNonNull;
 
@@ -104,8 +105,14 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
-                                                 final StreamingHttpRequest request) {
+    public final Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+        return defer(() -> request(requestStrategy(request, executionContext().executionStrategy()), request)
+                .shareContextOnSubscribe());
+    }
+
+    @Override
+    public final Single<StreamingHttpResponse> request(final HttpExecutionStrategy strategy,
+                                                       final StreamingHttpRequest request) {
         return defer(() -> {
             final Publisher<Object> flatRequest;
             // See https://tools.ietf.org/html/rfc7230#section-3.3.3

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -494,7 +494,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     }
 
     @Nonnull
-    private MultiAddressHttpClientFilterFactory<HostAndPort> appendClientFilter0(
+    private static MultiAddressHttpClientFilterFactory<HostAndPort> appendClientFilter0(
             final @Nullable MultiAddressHttpClientFilterFactory<HostAndPort> current,
             final MultiAddressHttpClientFilterFactory<HostAndPort> next) {
         return current == null ? next : (group, client) -> current.create(group, next.create(group, client));

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.forUnknownHostAndPort;
+import static io.servicetalk.http.netty.NewToDeprecatedFilter.NEW_TO_DEPRECATED_FILTER;
 import static java.util.function.Function.identity;
 
 /**
@@ -85,7 +86,7 @@ public final class HttpClients {
             final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
                     serviceDiscoverer) {
         return new DefaultMultiAddressUrlHttpClientBuilder(
-                new DefaultSingleAddressHttpClientBuilder<>(serviceDiscoverer));
+                new DefaultSingleAddressHttpClientBuilder<>(serviceDiscoverer, NEW_TO_DEPRECATED_FILTER));
     }
 
     /**
@@ -301,7 +302,7 @@ public final class HttpClients {
     public static <U, R> SingleAddressHttpClientBuilder<U, R> forSingleAddress(
             final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer,
             final U address) {
-        return new DefaultSingleAddressHttpClientBuilder<>(address, serviceDiscoverer);
+        return new DefaultSingleAddressHttpClientBuilder<>(address, serviceDiscoverer, new NewToDeprecatedFilter<>());
     }
 
     /**
@@ -348,6 +349,6 @@ public final class HttpClients {
                             public Completable closeAsyncGracefully() {
                                 return closeable.closeAsyncGracefully();
                             }
-                        }), serviceDiscoverer, partitionAttributesBuilderFactory);
+                        }, new NewToDeprecatedFilter<>()), serviceDiscoverer, partitionAttributesBuilderFactory);
     }
 }


### PR DESCRIPTION
Motivation:

In #1956 `StreamingHttpRequester` defines a new method
`request(StreamingHttpRequest)`. `AbstractStreamingHttpConnection` only
implements the deprecated method that also takes an
`HttpExecutionStrategy`. Users who apply a filter through
`ConnectionFactory` see `UnsupportedOperationException`. Also, if they
have 2+ filters applied through `ConnectionFactory`, they can not mix
deprecated and new API.

Modifications:

- Implement
`AbstractStreamingHttpConnection#request(StreamingHttpRequest)`;
- Enhance `NewToDeprecatedFilter` to be `ConnectionFactoryFilter` too;
- Apply `NewToDeprecatedFilter` when users invoke
`appendConnectionFactoryFilter`;
- Test `appendConnectionFactoryFilter` in `MixedFiltersTest`;

Result:

Users who apply request/response filters through `ConnectionFactory`
can migrate from deprecated to new `request(StreamingHttpRequest)` API.