### PR TITLE
Add Single.repeatWhen(BiIntFunction<T, Completable>)

### DIFF
--- a/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
@@ -31,10 +31,12 @@
     <Or>
       <Class name="io.servicetalk.concurrent.api.ContextPreservingCompletableFuture"/>
       <Class name="io.servicetalk.concurrent.api.CancelPropagatingCompletableFuture"/>
+      <Class name="io.servicetalk.concurrent.api.RepeatWhenSingle$RedoSubscription$RedoSubscriber"/>
     </Or>
     <Or>
       <Method name="getNow"/>
       <Method name="obtrudeValue"/>
+      <Method name="onSuccess"/>
     </Or>
     <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"/>
   </Match>

--- a/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
@@ -31,7 +31,7 @@
     <Or>
       <Class name="io.servicetalk.concurrent.api.ContextPreservingCompletableFuture"/>
       <Class name="io.servicetalk.concurrent.api.CancelPropagatingCompletableFuture"/>
-      <Class name="io.servicetalk.concurrent.api.RepeatWhenSingle$RedoSubscription$RepeatSubscriber"/>
+      <Class name="io.servicetalk.concurrent.api.RepeatWhenSingle$RepeatSubscription$RepeatSubscriber"/>
     </Or>
     <Or>
       <Method name="getNow"/>

--- a/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
@@ -31,7 +31,7 @@
     <Or>
       <Class name="io.servicetalk.concurrent.api.ContextPreservingCompletableFuture"/>
       <Class name="io.servicetalk.concurrent.api.CancelPropagatingCompletableFuture"/>
-      <Class name="io.servicetalk.concurrent.api.RepeatWhenSingle$RedoSubscription$RedoSubscriber"/>
+      <Class name="io.servicetalk.concurrent.api.RepeatWhenSingle$RedoSubscription$RepeatSubscriber"/>
     </Or>
     <Or>
       <Method name="getNow"/>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatWhenSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatWhenSingle.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.internal.FlowControlUtils;
+import io.servicetalk.concurrent.internal.SequentialCancellable;
+import io.servicetalk.context.api.ContextMap;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+import static io.servicetalk.concurrent.internal.ThrowableUtils.unknownStackTrace;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+
+final class RepeatWhenSingle<T> extends AbstractNoHandleSubscribePublisher<T> {
+    static final Exception END_REPEAT_EXCEPTION = unknownStackTrace(new Exception(), RepeatWhenSingle.class, "<init>");
+    private final Single<T> original;
+    private final BiIntFunction<? super T, ? extends Completable> shouldRedo;
+
+    RepeatWhenSingle(final Single<T> original, final BiIntFunction<? super T, ? extends Completable> shouldRedo) {
+        this.original = original;
+        this.shouldRedo = requireNonNull(shouldRedo);
+    }
+
+    @Override
+    void handleSubscribe(Subscriber<? super T> subscriber,
+                         ContextMap contextMap, AsyncContextProvider contextProvider) {
+        try {
+            subscriber.onSubscribe(new RedoSubscription<>(this, subscriber, contextMap, contextProvider));
+        } catch (Throwable cause) {
+            handleExceptionFromOnSubscribe(subscriber, cause);
+        }
+    }
+
+    private static final class RedoSubscription<T> implements Subscription {
+        @SuppressWarnings("rawtypes")
+        private static final AtomicLongFieldUpdater<RedoSubscription> outstandingDemandUpdater =
+                AtomicLongFieldUpdater.newUpdater(RedoSubscription.class, "outstandingDemand");
+        private static final long TERMINATED = Long.MIN_VALUE;
+        private static final long CANCELLED = TERMINATED + 1;
+        private static final long MIN_INVALID_N = CANCELLED + 1;
+        private final RepeatWhenSingle<T> outer;
+        private final SequentialCancellable sequentialCancellable = new SequentialCancellable();
+        private final Subscriber<? super T> subscriber;
+        private final ContextMap contextMap;
+        private final AsyncContextProvider contextProvider;
+        private volatile long outstandingDemand;
+        private int redoCount;
+
+        private RedoSubscription(final RepeatWhenSingle<T> outer, final Subscriber<? super T> subscriber,
+                                 final ContextMap contextMap, final AsyncContextProvider contextProvider) {
+            this.outer = outer;
+            this.subscriber = subscriber;
+            this.contextMap = contextMap;
+            this.contextProvider = contextProvider;
+        }
+
+        @Override
+        public void request(final long n) {
+            if (isRequestNValid(n)) {
+                final long prev = outstandingDemandUpdater.getAndAccumulate(this, n,
+                        FlowControlUtils::addWithOverflowProtectionIfNotNegative);
+                if (prev == 0) {
+                    outer.original.delegateSubscribe(new RedoSubscriber(), contextMap, contextProvider);
+                }
+            } else {
+                requestNInvalid(n);
+            }
+        }
+
+        private void requestNInvalid(final long n) {
+            for (;;) {
+                final long prev = outstandingDemand;
+                if (prev == TERMINATED) {
+                    break;
+                } else if (prev == 0) {
+                    if (outstandingDemandUpdater.compareAndSet(this, prev, TERMINATED)) {
+                        subscriber.onError(newExceptionForInvalidRequestN(n));
+                    }
+                } else if (outstandingDemandUpdater.compareAndSet(this, prev, sanitize(n))) {
+                    // if cancelled, we may not deliver an error. in this case we don't know if another thread may
+                    // interact with the Subscriber and concurrency control would be more complex, since spec doesn't
+                    // require delivery after cancel we drop it.
+                    break; // hand-off to other thread to deliver the terminal.
+                }
+            }
+        }
+
+        private static long sanitize(final long n) {
+            // The value must be negative because 0 is used to determine if there is no demand and a subscribe should
+            // be done. It can't overlap with our token TERMINAL or CANCEL values either.
+            return n == 0 ? -1 : max(n, MIN_INVALID_N);
+        }
+
+        @Override
+        public void cancel() {
+            for (;;) {
+                final long prev = outstandingDemand;
+                if (prev < 0 || outstandingDemandUpdater.compareAndSet(this, prev, CANCELLED)) {
+                    // prev < 0 means either we are already terminated/cancelled, or there is invalid demand pending.
+                    break;
+                }
+            }
+            sequentialCancellable.cancel();
+        }
+
+        private final class RedoSubscriber implements SingleSource.Subscriber<T> {
+            @Override
+            public void onSubscribe(final Cancellable cancellable) {
+                sequentialCancellable.nextCancellable(cancellable);
+            }
+
+            @Override
+            public void onSuccess(@Nullable final T result) {
+                final Completable redoDecider;
+                try {
+                    subscriber.onNext(result);
+                    redoDecider = requireNonNull(outer.shouldRedo.apply(++redoCount, result));
+                } catch (Throwable cause) {
+                    onErrorInternal(cause);
+                    return;
+                }
+
+                redoDecider.subscribeInternal(new CompletableSource.Subscriber() {
+                    @Override
+                    public void onSubscribe(final Cancellable cancellable) {
+                        sequentialCancellable.nextCancellable(cancellable);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        for (;;) {
+                            final long prev = outstandingDemand;
+                            assert prev != TERMINATED && prev != 0;
+                            if (prev == CANCELLED) {
+                                break;
+                            } else if (prev < 0) {
+                                // This thread owns the subscriber, no concurrency expected, no atomic necessary.
+                                onErrorInternal(newExceptionForInvalidRequestN(prev));
+                                break;
+                            } else if (outstandingDemandUpdater.compareAndSet(RedoSubscription.this,
+                                    prev, prev - 1)) {
+                                if (prev > 1) {
+                                    outer.original.delegateSubscribe(RedoSubscriber.this, contextMap,
+                                            contextProvider);
+                                }
+                                break;
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                        outstandingDemand = TERMINATED;
+                        subscriber.onComplete(); // repeat means an error just terminates normally.
+                    }
+                });
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                onErrorInternal(t);
+            }
+
+            private void onErrorInternal(final Throwable t) {
+                outstandingDemand = TERMINATED;
+                subscriber.onError(t);
+            }
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1023,7 +1023,7 @@ public abstract class Single<T> {
      * @return A {@link Publisher} that emits all items from this {@link Single} and from all re-subscriptions whenever
      * the operation is repeated.
      *
-     * @see <a href="http://reactivex.io/documentation/operatoRepeatWhenSinglers/retry.html">ReactiveX retry operator.</a>
+     * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
      */
     public final Publisher<T> repeatWhen(BiIntFunction<? super T, ? extends Completable> repeatWhen) {
         return new RepeatWhenSingle<>(this, repeatWhen);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -46,6 +46,7 @@ import static io.servicetalk.concurrent.api.Executors.global;
 import static io.servicetalk.concurrent.api.NeverSingle.neverSingle;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
+import static io.servicetalk.concurrent.api.RepeatWhenSingle.END_REPEAT_EXCEPTION;
 import static io.servicetalk.concurrent.api.SingleDoOnUtils.doOnErrorSupplier;
 import static io.servicetalk.concurrent.api.SingleDoOnUtils.doOnSubscribeSupplier;
 import static io.servicetalk.concurrent.api.SingleDoOnUtils.doOnSuccessSupplier;
@@ -951,7 +952,8 @@ public abstract class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX repeat operator.</a>
      */
     public final Publisher<T> repeat(IntPredicate shouldRepeat) {
-        return toPublisher().repeat(shouldRepeat);
+        return repeatWhen((i, __) -> shouldRepeat.test(i) ? Completable.completed() :
+                Completable.failed(END_REPEAT_EXCEPTION));
     }
 
     /**
@@ -988,7 +990,43 @@ public abstract class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
      */
     public final Publisher<T> repeatWhen(IntFunction<? extends Completable> repeatWhen) {
-        return toPublisher().repeatWhen(repeatWhen);
+        return repeatWhen((i, __) -> repeatWhen.apply(i));
+    }
+
+    /**
+     * Re-subscribes to this {@link Single} when it completes and the {@link Completable} returned by the supplied
+     * {@link BiIntFunction} completes successfully.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
+     * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in
+     * sequential programming is similar to:
+     * <pre>{@code
+     *     List<T> results = new ...;
+     *     int i = 0;
+     *     while (true) {
+     *         T result = resultOfThisSingle();
+     *         try {
+     *             repeatWhen.apply(++i, result); // Either throws or completes normally
+     *         } catch (Throwable cause) {
+     *             break;
+     *         }
+     *     }
+     *     return results;
+     * }</pre>
+     * @param repeatWhen {@link BiIntFunction} that given the repeat count and value from the current iteration returns
+     * a {@link Completable}. If this {@link Completable} emits an error repeat is terminated, otherwise,
+     * original {@link Single} is re-subscribed when this {@link Completable} completes.
+     *
+     * @return A {@link Publisher} that emits all items from this {@link Single} and from all re-subscriptions whenever
+     * the operation is repeated.
+     *
+     * @see <a href="http://reactivex.io/documentation/operatoRepeatWhenSinglers/retry.html">ReactiveX retry operator.</a>
+     */
+    public final Publisher<T> repeatWhen(BiIntFunction<? super T, ? extends Completable> repeatWhen) {
+        return new RepeatWhenSingle<>(this, repeatWhen);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -46,7 +46,7 @@ import static io.servicetalk.concurrent.api.Executors.global;
 import static io.servicetalk.concurrent.api.NeverSingle.neverSingle;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
-import static io.servicetalk.concurrent.api.RepeatWhenSingle.END_REPEAT_EXCEPTION;
+import static io.servicetalk.concurrent.api.RepeatWhenSingle.END_REPEAT_COMPLETABLE;
 import static io.servicetalk.concurrent.api.SingleDoOnUtils.doOnErrorSupplier;
 import static io.servicetalk.concurrent.api.SingleDoOnUtils.doOnSubscribeSupplier;
 import static io.servicetalk.concurrent.api.SingleDoOnUtils.doOnSuccessSupplier;
@@ -944,16 +944,44 @@ public abstract class Single<T> {
      *     } while (shouldRepeat.test(++i));
      *     return results;
      * }</pre>
-     * @param shouldRepeat {@link IntPredicate} that given the repeat count determines if the operation should be
-     * repeated.
+     * @param shouldRepeat {@link IntPredicate} that given the repetition count returns {@code true} if the operation
+     * should be repeated.
      * @return A {@link Publisher} that emits all items from this {@link Single} and from all re-subscriptions whenever
      * the operation is repeated.
      *
      * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX repeat operator.</a>
      */
     public final Publisher<T> repeat(IntPredicate shouldRepeat) {
-        return repeatWhen((i, __) -> shouldRepeat.test(i) ? Completable.completed() :
-                Completable.failed(END_REPEAT_EXCEPTION));
+        return repeatWhen((i, __) -> shouldRepeat.test(i) ? Completable.completed() : END_REPEAT_COMPLETABLE);
+    }
+
+    /**
+     * Re-subscribes to this {@link Single} when it completes and the passed {@link IntPredicate} returns {@code true}.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
+     * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
+     * <pre>{@code
+     *     List<T> results = new ...;
+     *     int i = 0;
+     *     T result;
+     *     do {
+     *         result = resultOfThisSingle();
+     *         results.add(result);
+     *     } while (shouldRepeat.test(++i, result));
+     *     return results;
+     * }</pre>
+     * @param shouldRepeat {@link BiIntPredicate} that given the repetition count and value from the current iteration
+     * returns {@code true} if the operation should be repeated.
+     * @return A {@link Publisher} that emits all items from this {@link Single} and from all re-subscriptions whenever
+     * the operation is repeated.
+     *
+     * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX repeat operator.</a>
+     */
+    public final Publisher<T> repeat(BiIntPredicate<? super T> shouldRepeat) {
+        return repeatWhen((i, t) -> shouldRepeat.test(i, t) ? Completable.completed() : END_REPEAT_COMPLETABLE);
     }
 
     /**
@@ -980,7 +1008,7 @@ public abstract class Single<T> {
      *     }
      *     return results;
      * }</pre>
-     * @param repeatWhen {@link IntFunction} that given the repeat count returns a {@link Completable}.
+     * @param repeatWhen {@link IntFunction} that given the repetition count returns a {@link Completable}.
      * If this {@link Completable} emits an error repeat is terminated, otherwise, original {@link Single} is
      * re-subscribed when this {@link Completable} completes.
      *
@@ -1016,8 +1044,8 @@ public abstract class Single<T> {
      *     }
      *     return results;
      * }</pre>
-     * @param repeatWhen {@link BiIntFunction} that given the repeat count and value from the current iteration returns
-     * a {@link Completable}. If this {@link Completable} emits an error repeat is terminated, otherwise,
+     * @param repeatWhen {@link BiIntFunction} that given the repetition count and value from the current iteration
+     * returns a {@link Completable}. If this {@link Completable} emits an error repeat is terminated, otherwise,
      * original {@link Single} is re-subscribed when this {@link Completable} completes.
      *
      * @return A {@link Publisher} that emits all items from this {@link Single} and from all re-subscriptions whenever

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatWhenSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatWhenSingleTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.concurrent.internal.DeliberateException;
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Completable.failed;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class RepeatWhenSingleTest {
+    private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+    private static Executor executor;
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (executor != null) {
+            executor.closeAsync().toFuture().get();
+        }
+    }
+
+    @BeforeAll
+    static void setup() throws Exception {
+        executor = Executors.newCachedThreadExecutor();
+    }
+
+    @Test
+    void repeaterNull() {
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? completed() : null))
+                .subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(2);
+        assertThat(subscriber.takeOnNext(2), contains(1, 2));
+        assertThat(subscriber.awaitOnError(), instanceOf(NullPointerException.class));
+    }
+
+    @Test
+    void repeaterThrows() {
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> {
+                    throw DELIBERATE_EXCEPTION;
+                }))
+                .subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(2);
+        assertThat(subscriber.takeOnNext(), equalTo(1));
+        assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    void invalidDemand() {
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? completed() : failed(new DeliberateException())))
+                .subscribe(subscriber);
+        subscriber.awaitSubscription().request(-1);
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
+    }
+
+    @Test
+    void concurrentInvalidDemand() throws BrokenBarrierException, InterruptedException {
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? executor.submit(() -> {
+                    try {
+                        barrier.await();
+                    } catch (Exception e) {
+                        throw new AssertionError(e);
+                    }
+                }) : failed(new DeliberateException())))
+                .subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(1);
+        barrier.await();
+        s.request(-1);
+        s.request(-1); // test multiple invalid request-n should only terminate one time.
+        assertThat(subscriber.takeOnNext(), equalTo(1));
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
+    }
+
+    @Test
+    void invalidDemandAfterFirst() {
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? completed() : failed(new DeliberateException())))
+                .subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(1);
+        assertThat(subscriber.takeOnNext(), equalTo(1));
+        s.request(-1);
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
+    }
+
+    @Test
+    void singleRepeatAllDemandUpfront() {
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? completed() : failed(new DeliberateException())))
+                .subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(2);
+        assertThat(subscriber.takeOnNext(2), contains(1, 2));
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    void manyRepeatAllDemandUpfront() {
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> repeatCount < 5 ? completed() : failed(new DeliberateException())))
+                .subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(5);
+        assertThat(subscriber.takeOnNext(5), contains(1, 2, 3, 4, 5));
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    void singleRepeatDelayedDemand() {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? executor.submit(() -> {
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                }) : failed(new DeliberateException())))
+                .subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(2);
+        assertThat(subscriber.takeOnNext(), equalTo(1));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), nullValue());
+        latch.countDown();
+        assertThat(subscriber.takeOnNext(), equalTo(2));
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    void singleDelayedRepeat() {
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? completed() : failed(new DeliberateException())))
+                .subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.request(2);
+        assertThat(subscriber.takeOnNext(2), contains(1, 2));
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
+    void reentrantCancellationStopsRepeat() throws InterruptedException {
+        AtomicInteger value = new AtomicInteger();
+        CountDownLatch cancelled = new CountDownLatch(1);
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .whenCancel(cancelled::countDown)
+                .repeatWhen((repeatCount, v) -> completed()))
+                .subscribe(new PublisherSource.Subscriber<Integer>() {
+                    @Override
+                    public void onSubscribe(final Subscription subscription) {
+                        subscriber.onSubscribe(subscription);
+                        subscriber.awaitSubscription().request(Long.MAX_VALUE);
+                    }
+
+                    @Override
+                    public void onNext(@Nullable final Integer integer) {
+                        subscriber.awaitSubscription().cancel(); // cancel inline, should stop repeating
+                        subscriber.onNext(integer);
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                        subscriber.onError(t);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        subscriber.onComplete();
+                    }
+                });
+        assertThat(subscriber.takeOnNext(), equalTo(1));
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), nullValue());
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), nullValue());
+        cancelled.await();
+    }
+
+    @Test
+    void onNextThrows() {
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? completed() : failed(new DeliberateException()))
+                .<Integer>map(x -> {
+                    throw DELIBERATE_EXCEPTION;
+                })).subscribe(subscriber);
+        subscriber.awaitSubscription().request(Long.MAX_VALUE);
+        assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    void secondSingleFailed() {
+        AtomicInteger value = new AtomicInteger();
+        toSource(Single.defer(() -> {
+                    final int v = value.incrementAndGet();
+                    return v == 1 ? Single.succeeded(v) : Single.failed(DELIBERATE_EXCEPTION);
+                })
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? completed() : failed(new DeliberateException())))
+                .subscribe(subscriber);
+        subscriber.awaitSubscription().request(Long.MAX_VALUE);
+        assertThat(subscriber.takeOnNext(), equalTo(1));
+        assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    void cancellationBeforeEmission() throws InterruptedException {
+        AtomicInteger value = new AtomicInteger();
+        CountDownLatch cancelled = new CountDownLatch(1);
+        CountDownLatch onSubscribe = new CountDownLatch(1);
+        toSource(Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .whenCancel(cancelled::countDown)
+                .beforeOnSubscribe(cancellable -> onSubscribe.countDown())
+                .repeatWhen((repeatCount, v) -> repeatCount == 1 ? completed() : failed(new DeliberateException())))
+                .subscribe(subscriber);
+        Subscription s = subscriber.awaitSubscription();
+        s.cancel();
+        s.request(Long.MAX_VALUE);
+        assertThat(subscriber.pollOnNext(10, MILLISECONDS), nullValue());
+        assertThat(subscriber.pollTerminal(10, MILLISECONDS), nullValue());
+
+        // We never subscribe upstream if cancellation happens first.
+        assertThat(onSubscribe.await(10, MILLISECONDS), is(false));
+        assertThat(cancelled.await(10, MILLISECONDS), is(false));
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleRepeatBiPredicateTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleRepeatBiPredicateTckTest.java
@@ -21,19 +21,16 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.concurrent.api.Completable.failed;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 
 @Test
-public class SingleRepeatWhenTckTest extends AbstractPublisherTckTest<Integer> {
+public class SingleRepeatBiPredicateTckTest extends AbstractPublisherTckTest<Integer> {
     @Override
     public Publisher<Integer> createServiceTalkPublisher(final long elements) {
         final AtomicInteger value = new AtomicInteger();
         return defer(() -> succeeded(value.incrementAndGet()))
-                .repeatWhen((i, __) -> i < elements ? completed() : failed(DELIBERATE_EXCEPTION));
+                .repeat((i, __) -> i < elements);
     }
 
     @Override

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleRepeatWhenTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleRepeatWhenTckTest.java
@@ -16,7 +16,6 @@
 package io.servicetalk.concurrent.reactivestreams.tck;
 
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.Single;
 
 import org.testng.annotations.Test;
 
@@ -24,15 +23,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.failed;
+import static io.servicetalk.concurrent.api.Single.defer;
+import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 
 @Test
 public class SingleRepeatWhenTckTest extends AbstractPublisherTckTest<Integer> {
     @Override
     public Publisher<Integer> createServiceTalkPublisher(final long elements) {
-        AtomicInteger value = new AtomicInteger();
-        return Single.defer(() -> Single.succeeded(value.incrementAndGet()))
-                .repeatWhen((repeat, v) -> repeat < elements ? completed() : failed(DELIBERATE_EXCEPTION));
+        final AtomicInteger value = new AtomicInteger();
+        return defer(() -> succeeded(value.incrementAndGet()))
+                .repeatWhen((i, __) -> i < elements ? completed() : failed(DELIBERATE_EXCEPTION));
     }
 
     @Override

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleRepeatWhenTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleRepeatWhenTckTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Completable.failed;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+
+@Test
+public class SingleRepeatWhenTckTest extends AbstractPublisherTckTest<Integer> {
+    @Override
+    public Publisher<Integer> createServiceTalkPublisher(final long elements) {
+        AtomicInteger value = new AtomicInteger();
+        return Single.defer(() -> Single.succeeded(value.incrementAndGet()))
+                .repeatWhen((repeat, v) -> repeat < elements ? completed() : failed(DELIBERATE_EXCEPTION));
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 256;
+    }
+}


### PR DESCRIPTION
Motivation:
The criteria to repeat a Single may depend upon the
termination value. Existing repeat operators in
Single do not expose the value.

Modifications:
- Add Single.repeatWhen(BiIntFunction<T, Completable>)
  operator.
- Change existing Single.repeat* operators to use this
  new implementation instead of converting to Publisher.