### PR TITLE
Always encode spans as list in `HttpReporter`

### DIFF
--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
@@ -38,6 +38,7 @@ import zipkin2.reporter.Reporter;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -125,7 +126,8 @@ public final class HttpReporter extends Component implements Reporter<Span>, Asy
         final Publisher<Buffer> spans;
         if (!builder.batchingEnabled) {
             buffer = newPublisherProcessorDropHeadOnOverflow(builder.maxConcurrentReports);
-            spans = fromSource(buffer).map(span -> allocator.wrap(spanEncoder.encode(span)));
+            spans = fromSource(buffer)
+                    .map(span -> allocator.wrap(spanEncoder.encodeList(Collections.singletonList(span))));
         } else {
             // As we send maxConcurrentReports number of parallel requests, each with roughly batchSizeHint number of
             // spans, we hold a maximum of that many Spans in-memory that we can send in parallel to the collector.


### PR DESCRIPTION
Motivation:

Zipkin Collector interface accepts spans always as a list using HTTP or
sequence for gRPC:

- https://zipkin.io/zipkin-api/#/default/post_spans
- https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto#L232

`HttpReporter` reports batched spans as a JSON list or a sequence with
gRPC. Unfortunately, `HttpReporter` behaves differently when batching is
not enabled and submits the encoded span without the enclosing
collection.

Modifications:

- Always encode a `List<Span>` in the `HttpReporter`,
- Removed test alternatives for single value reports and always
  validating a collection is reported.

Result:

The OpenTracing Zipkin Publisher is conformant to the Collector API.