### PR TITLE
Preparing for 0.42.3-SNAPSHOT development

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.jvmargs=-Xms2g -Xmx4g -dsa -da -ea:io.servicetalk... -XX:+HeapDumpOnO
 
 # project metadata used for publications
 group=io.servicetalk
-version=0.43.0-SNAPSHOT
+version=0.42.3-SNAPSHOT
 scmHost=github.com
 scmPath=apple/servicetalk
 issueManagementUrl=https://github.com/apple/servicetalk/issues


### PR DESCRIPTION
Motivation:

Until we have any breaking changes in the `main` branch, it will be
easier to continue 0.42.x development from the `main` to avoid a need
for cherry-picking all commits into `0.42`.
At this point of git history, the `main` and `0.42` branches are
identical except antora-related files which have to be like in the
`main` branch.

I won't rename `0.42` branch for now. We can just leave it as-is until we
need it again.