### PR TITLE
Add client `RetryingHttpRequesterFilter` example

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -12,6 +12,7 @@
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Observer[Observer]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#OpenTracing[OpenTracing]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Redirects[Redirects]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#Retries[Retries]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#uds[Unix Domain Sockets]
 ** xref:{page-version}@servicetalk-examples::http/service-composition.adoc[Service Composition]
 * xref:{page-version}@servicetalk-examples::grpc/index.adoc[gRPC]

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -83,7 +83,7 @@ receives a response greeting the posted name as a single content.
 == Debugging
 
 Extends the async "Hello World" example to demonstrate some useful features available
- for debugging ServiceTalk applications. You should read and understand the async "Hello World"
+ for debugging ServiceTalk applications. You should read and understand the async <<_hello_world,"Hello World">>
  example first to understand the additions this example adds. No separate example is needed
  for the other API variants as the usage of the debugging features are the same for all API
  styles.
@@ -207,9 +207,9 @@ Using the following classes:
 == Redirects
 
 Extends the async "Hello World" example to demonstrate different ways that users can support redirects in ServiceTalk
-applications. You should read and understand the async "Hello World" example first to understand the additions this
-example adds. No separate example is needed for the other API variants as the usage of the debugging features are the
-same for all API styles.
+applications. You should read and understand the <<_hello_world,"Hello World" example>> first to understand the
+additions this example adds. No separate example is needed for the other API variants as the usage of the redirect
+features are the same for all API styles.
 
 * link:{source-root}/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/RedirectingServer.java[RedirectingServer] -
 Starts two servers, one of them (HTTP) redirects to another (HTTPS).
@@ -220,6 +220,23 @@ Async `Hello World` example that demonstrates how redirects can be handled autom
 It demonstrates how users can preserve headers and payload body of the original request while redirecting to non-relative locations.
 * link:{source-root}/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/ManualRedirectClient.java[ManualRedirectClient.java] -
 Async `Hello World` example that demonstrates how redirects can be handled manually between multiple single-address clients.
+
+[#Retries]
+== Retries
+
+Extends the async "Hello World" example to demonstrate basic cliest request retry functionality. You should read and
+understand the async <<_hello_world,"Hello World" example>> first to understand the additions this example adds. No
+separate example is needed for the other API variants as the usage of the debugging features are the same for all API
+styles.
+
+* link:{source-root}/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryServer.java[RetryServer] -
+A special "flaky" `Hello World` server that alternates "509" Gateway Timeout and "200" Success responses for client
+requests to demonstrate client retry.
+* link:{source-root}/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryClient.java[RetryClient.java] -
+Async `Hello World` example that demonstrates how retry can be requested for a single-address client.
+* link:{source-root}/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryUrlClient.java[RetryUrlClient.java] -
+Async `Hello World` example that demonstrates how retry can be requested for a multi-address client.
+
 
 [#HTTP2]
 == HTTP/2

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -83,8 +83,8 @@ receives a response greeting the posted name as a single content.
 == Debugging
 
 Extends the async "Hello World" example to demonstrate some useful features available
- for debugging ServiceTalk applications. You should read and understand the async <<_hello_world,"Hello World">>
- example first to understand the additions this example adds. No separate example is needed
+ for debugging ServiceTalk applications. You should read and understand the async <<HelloWorld,"Hello World" example>>
+ first to understand the additions this example adds. No separate example is needed
  for the other API variants as the usage of the debugging features are the same for all API
  styles.
 
@@ -96,7 +96,7 @@ Extends the async "Hello World" example to demonstrate some useful features avai
 == Timeout
 
 Extends the async "Hello World" example to demonstrate the use of timeout filters and operators. You should read and
- understand the async "Hello World" example first to understand the additions this example adds. No separate example is
+ understand the async <<HelloWorld,"Hello World" example>> first to understand the additions this example adds. No separate example is
  needed for the other API variants as the usage of the timeout features are the same for all API styles.
 
 * link:{source-root}/servicetalk-examples/http/timeout/src/main/java/io/servicetalk/examples/http/timeout/TimeoutServer.java[TimeoutServer] - the async `Hello World!` server client enhanced to use timeout capabilities.
@@ -207,7 +207,7 @@ Using the following classes:
 == Redirects
 
 Extends the async "Hello World" example to demonstrate different ways that users can support redirects in ServiceTalk
-applications. You should read and understand the <<_hello_world,"Hello World" example>> first to understand the
+applications. You should read and understand the <<HelloWorld,"Hello World" example>> first to understand the
 additions this example adds. No separate example is needed for the other API variants as the usage of the redirect
 features are the same for all API styles.
 
@@ -225,7 +225,7 @@ Async `Hello World` example that demonstrates how redirects can be handled manua
 == Retries
 
 Extends the async "Hello World" example to demonstrate basic cliest request retry functionality. You should read and
-understand the async <<_hello_world,"Hello World" example>> first to understand the additions this example adds. No
+understand the async <<HelloWorld,"Hello World" example>> first to understand the additions this example adds. No
 separate example is needed for the other API variants as the usage of the debugging features are the same for all API
 styles.
 

--- a/servicetalk-examples/http/retry/build.gradle
+++ b/servicetalk-examples/http/retry/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-http-netty")
+
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}

--- a/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryClient.java
+++ b/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryClient.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.retry;
+
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.http.netty.RetryingHttpRequesterFilter;
+
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+
+/**
+ * Extends the Async "Hello World" client to immediately retry requests that get a 5XX response. Two attempts will be
+ * made before failure.
+ */
+public final class RetryClient {
+    public static void main(String[] args) throws Exception {
+        try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080)
+                .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                        .responseMapper((httpResponseMetaData -> {
+                            // If the response status is 500-599 then request a retry
+                            HttpResponseStatus.StatusClass status = httpResponseMetaData.status().statusClass();
+                            return HttpResponseStatus.StatusClass.SERVER_ERROR_5XX == status ?
+                                    new RetryingHttpRequesterFilter.HttpResponseException(
+                                            "Retry 5XX", httpResponseMetaData)
+                                    // Not a 5XX response, someone else can deal with it.
+                                    : null;
+                        }))
+                        .retryResponses((meta, error) -> RetryingHttpRequesterFilter.BackOffPolicy.ofImmediate(2))
+                        .build())
+                .build()) {
+            client.request(client.get("/sayHello"))
+                    .whenOnSuccess(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.payloadBody(textSerializerUtf8()));
+                    })
+                    // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+                    // before the response has been processed. This isn't typical usage for an asynchronous API but is useful
+                    // for demonstration purposes.
+                    .toFuture().get();
+        }
+    }
+}

--- a/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryServer.java
+++ b/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryServer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.retry;
+
+import io.servicetalk.http.netty.HttpServers;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+
+/**
+ * A "flaky" Hello World server that alternates between responding with "504" Gateway Timeout errors and "200" success.
+ */
+public final class RetryServer {
+    public static void main(String[] args) throws Exception {
+        AtomicLong responseCounter = new AtomicLong();
+        HttpServers.forPort(8080)
+                .listenAndAwait((ctx, request, responseFactory) ->
+                            // half of all requests will fail with gateway timeout
+                            succeeded((responseCounter.incrementAndGet() % 2L) == 0L ?
+                                    responseFactory.ok().payloadBody("Hello World!", textSerializerUtf8()) :
+                                    responseFactory.gatewayTimeout()))
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryUrlClient.java
+++ b/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryUrlClient.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.retry;
+
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.http.netty.RetryingHttpRequesterFilter;
+
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+
+/**
+ * Extends the Async "Hello World" client to immediately retry requests that get a 5XX response. Two attempts will be
+ * made before failure.
+ */
+public final class RetryUrlClient {
+    public static void main(String[] args) throws Exception {
+        try (HttpClient client = HttpClients.forMultiAddressUrl().initializer((scheme, address, builder) -> {
+            builder.appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                    .responseMapper((httpResponseMetaData -> {
+                        // If the response status is 500-599 then request a retry
+                        HttpResponseStatus.StatusClass status = httpResponseMetaData.status().statusClass();
+                        return HttpResponseStatus.StatusClass.SERVER_ERROR_5XX == status ?
+                                new RetryingHttpRequesterFilter.HttpResponseException(
+                                        "Retry 5XX", httpResponseMetaData)
+                                // Not a 5XX response, someone else can deal with it.
+                                : null;
+                    }))
+                    .retryResponses((meta, error) -> RetryingHttpRequesterFilter.BackOffPolicy.ofImmediate(2))
+                    .build()
+            );
+        }).build()) {
+            client.request(client.get("http://localhost:8080/sayHello"))
+                    .whenOnSuccess(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.payloadBody(textSerializerUtf8()));
+                    })
+                    // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+                    // before the response has been processed. This isn't typical usage for an asynchronous API but is useful
+                    // for demonstration purposes.
+                    .toFuture().get();
+        }
+    }
+}

--- a/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryUrlClient.java
+++ b/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/RetryUrlClient.java
@@ -16,29 +16,25 @@
 package io.servicetalk.examples.http.retry;
 
 import io.servicetalk.http.api.HttpClient;
-import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.http.netty.RetryingHttpRequesterFilter;
 
+import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SERVER_ERROR_5XX;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
 
 /**
- * Extends the Async "Hello World" client to immediately retry requests that get a 5XX response. Two attempts will be
- * made before failure.
+ * Extends the Async "Hello World" client to immediately retry requests that get a 5XX response. Up to three attempts
+ * * will be made, one initial attempt and up to two retries, before failure.
  */
 public final class RetryUrlClient {
     public static void main(String[] args) throws Exception {
         try (HttpClient client = HttpClients.forMultiAddressUrl().initializer((scheme, address, builder) -> {
             builder.appendClientFilter(new RetryingHttpRequesterFilter.Builder()
-                    .responseMapper((httpResponseMetaData -> {
-                        // If the response status is 500-599 then request a retry
-                        HttpResponseStatus.StatusClass status = httpResponseMetaData.status().statusClass();
-                        return HttpResponseStatus.StatusClass.SERVER_ERROR_5XX == status ?
-                                new RetryingHttpRequesterFilter.HttpResponseException(
-                                        "Retry 5XX", httpResponseMetaData)
-                                // Not a 5XX response, someone else can deal with it.
-                                : null;
-                    }))
+                    .responseMapper(httpResponseMetaData -> SERVER_ERROR_5XX.contains(httpResponseMetaData.status()) ?
+                            // Response status is 500-599, we request a retry
+                            new RetryingHttpRequesterFilter.HttpResponseException("Retry 5XX", httpResponseMetaData) :
+                            // Not a 5XX response, we do not know whether retry is required
+                            null)
                     .retryResponses((meta, error) -> RetryingHttpRequesterFilter.BackOffPolicy.ofImmediate(2))
                     .build()
             );

--- a/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/package-info.java
+++ b/servicetalk-examples/http/retry/src/main/java/io/servicetalk/examples/http/retry/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.retry;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/retry/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/retry/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -665,7 +665,8 @@ public final class RetryingHttpRequesterFilter
          * retry behaviour through {@link #retryResponses(BiFunction)}.
          *
          * @param mapper a {@link Function} that maps a {@link HttpResponseMetaData} to an
-         * {@link HttpResponseException} or returns {@code null} if there is no mapping for response meta-data.
+         * {@link HttpResponseException} or returns {@code null} if there is no mapping for response meta-data. The mapper should return null if no retry is needed or, if it cannot be
+         * determined that a retry is needed.
          * @return {@code this}
          */
         public Builder responseMapper(final Function<HttpResponseMetaData, HttpResponseException> mapper) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -666,7 +666,7 @@ public final class RetryingHttpRequesterFilter
          *
          * @param mapper a {@link Function} that maps a {@link HttpResponseMetaData} to an
          * {@link HttpResponseException} or returns {@code null} if there is no mapping for response meta-data. The
-         * mapper should return null if no retry is needed or if it cannot be determined that a retry is needed.
+         * mapper should return {@code null} if no retry is needed or if it cannot be determined that a retry is needed.
          * @return {@code this}
          */
         public Builder responseMapper(final Function<HttpResponseMetaData, HttpResponseException> mapper) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -665,8 +665,8 @@ public final class RetryingHttpRequesterFilter
          * retry behaviour through {@link #retryResponses(BiFunction)}.
          *
          * @param mapper a {@link Function} that maps a {@link HttpResponseMetaData} to an
-         * {@link HttpResponseException} or returns {@code null} if there is no mapping for response meta-data. The mapper should return null if no retry is needed or, if it cannot be
-         * determined that a retry is needed.
+         * {@link HttpResponseException} or returns {@code null} if there is no mapping for response meta-data. The
+         * mapper should return null if no retry is needed or if it cannot be determined that a retry is needed.
          * @return {@code this}
          */
         public Builder responseMapper(final Function<HttpResponseMetaData, HttpResponseException> mapper) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -56,6 +56,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:http:metadata",
         "servicetalk-examples:http:opentracing",
         "servicetalk-examples:http:observer",
+        "servicetalk-examples:http:retry",
         "servicetalk-examples:http:serialization",
         "servicetalk-examples:http:service-composition",
         "servicetalk-examples:http:uds",
@@ -119,6 +120,7 @@ project(":servicetalk-examples:http:jaxrs").name = "servicetalk-examples-http-ja
 project(":servicetalk-examples:http:metadata").name = "servicetalk-examples-http-metadata"
 project(":servicetalk-examples:http:opentracing").name = "servicetalk-examples-http-opentracing"
 project(":servicetalk-examples:http:observer").name = "servicetalk-examples-http-observer"
+project(":servicetalk-examples:http:retry").name = "servicetalk-examples-http-retry"
 project(":servicetalk-examples:http:serialization").name = "servicetalk-examples-http-serialization"
 project(":servicetalk-examples:http:service-composition").name = "servicetalk-examples-http-service-composition"
 project(":servicetalk-examples:http:uds").name = "servicetalk-examples-http-uds"


### PR DESCRIPTION
Motivation:
Users have requested a usage sample for client retry filter
Modifications:
Adds an HTTP example for the client `RetryingHttpRequesterFilter` retry
filter.
Result:
Additional usage example available for users.