### PR TITLE
Make `HttpLifecycleObserverServiceFilter` constructor public

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpLifecycleObserverServiceFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpLifecycleObserverServiceFilter.java
@@ -55,7 +55,7 @@ public final class HttpLifecycleObserverServiceFilter extends AbstractLifecycleO
      *
      * @param observer The {@link HttpLifecycleObserver observer} implementation that consumes HTTP lifecycle events.
      */
-    HttpLifecycleObserverServiceFilter(final HttpLifecycleObserver observer) {
+    public HttpLifecycleObserverServiceFilter(final HttpLifecycleObserver observer) {
         super(observer, false);
     }
 


### PR DESCRIPTION
Motivation:

#2051 made `HttpLifecycleObserverServiceFilter` class public, but forgot
to make its constructor public too.

Modifications:

- Make `HttpLifecycleObserverServiceFilter` constructor public;

Result:

Users can create an instance of `HttpLifecycleObserverServiceFilter`
to use it with `appendServiceFilter(...)`.