### PR TITLE
CompositeCloseable: prepend doesn't respect ordering

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
@@ -202,7 +202,7 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
     }
 
     private static final class Operand {
-        final Deque<AsyncCloseable> closables = new ArrayDeque<>(2);
+        final Deque<AsyncCloseable> closables = new ArrayDeque<>(4);
         final boolean isMerge;
 
         Operand(boolean isMerge) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultCompositeCloseable.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.function.Function;
@@ -175,13 +174,13 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
 
     private void appendCloseableDelayError(final AsyncCloseable closeable) {
         final Operand operand = getOrAddConcatOperand(true);
-        operand.closables.add(closeable);
+        operand.closables.addLast(closeable);
         resetState();
     }
 
     private void prependCloseableDelayError(final AsyncCloseable closeable) {
         final Operand operand = getOrAddConcatOperand(false);
-        operand.closables.add(closeable);
+        operand.closables.addFirst(closeable);
         resetState();
     }
 
@@ -203,8 +202,8 @@ final class DefaultCompositeCloseable implements CompositeCloseable {
     }
 
     private static final class Operand {
-        private final List<AsyncCloseable> closables = new ArrayList<>(4);
-        private final boolean isMerge;
+        final Deque<AsyncCloseable> closables = new ArrayDeque<>(2);
+        final boolean isMerge;
 
         Operand(boolean isMerge) {
             this.isMerge = isMerge;


### PR DESCRIPTION
Motivation:

`DefaultCompositeCloseable` does not respect ordering if `prepend`
operation is invoked after `append`. It causes issues when the ordering
matters for closeable resources that depend upon each other.

Modifications:

- Change `Operand.closables` to `ArrayDeque`;
- Use `addFirst` for `prepend` operation;
- Test ordiring for "prepend after append" and "prepend after merge";

Result:

Correct ordering of invoking `AsyncCloseable`s if `prepend` is used
after `append`.