### PR TITLE
Introduce public API FilterableReservedControlledStreamingHttpLoadBalancedConnection

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyController.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyController.java
@@ -16,6 +16,7 @@
 package io.servicetalk.client.api.internal;
 
 import io.servicetalk.client.api.ConsumableEvent;
+import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.api.Completable;

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/AbstractReservableRequestConcurrencyController.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/AbstractReservableRequestConcurrencyController.java
@@ -16,6 +16,7 @@
 package io.servicetalk.client.api.internal;
 
 import io.servicetalk.client.api.ConsumableEvent;
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerMulti.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerMulti.java
@@ -19,9 +19,9 @@ import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
 
 final class RequestConcurrencyControllerMulti extends AbstractRequestConcurrencyController {
     private final int maxRequests;

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerOnlySingle.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerOnlySingle.java
@@ -19,9 +19,9 @@ import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
 
 final class RequestConcurrencyControllerOnlySingle extends AbstractRequestConcurrencyController {
     RequestConcurrencyControllerOnlySingle(final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency,

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllers.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllers.java
@@ -16,6 +16,7 @@
 package io.servicetalk.client.api.internal;
 
 import io.servicetalk.client.api.ConsumableEvent;
+import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerMulti.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerMulti.java
@@ -19,9 +19,9 @@ import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
 
 final class ReservableRequestConcurrencyControllerMulti extends AbstractReservableRequestConcurrencyController {
     private final int maxRequests;

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerOnlySingle.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerOnlySingle.java
@@ -19,9 +19,9 @@ import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
 
 final class ReservableRequestConcurrencyControllerOnlySingle extends AbstractReservableRequestConcurrencyController {
     ReservableRequestConcurrencyControllerOnlySingle(final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency,

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllers.java
@@ -16,6 +16,8 @@
 package io.servicetalk.client.api.internal;
 
 import io.servicetalk.client.api.ConsumableEvent;
+import io.servicetalk.client.api.RequestConcurrencyController;
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyControllerMultiTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyControllerMultiTest.java
@@ -15,15 +15,16 @@
  */
 package io.servicetalk.client.api.internal;
 
+import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyControllerOnlySingleTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyControllerOnlySingleTest.java
@@ -15,15 +15,16 @@
  */
 package io.servicetalk.client.api.internal;
 
+import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerMultiTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerMultiTest.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.client.api.internal;
 
+import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerOnlySingleTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerOnlySingleTest.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.client.api.internal;
 
+import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerMultiTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerMultiTest.java
@@ -15,12 +15,13 @@
  */
 package io.servicetalk.client.api.internal;
 
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerOnlySingleTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerOnlySingleTest.java
@@ -15,12 +15,13 @@
  */
 package io.servicetalk.client.api.internal;
 
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newSingleController;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/RequestConcurrencyController.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/RequestConcurrencyController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.client.api.internal;
+package io.servicetalk.client.api;
 
 import io.servicetalk.concurrent.api.Publisher;
 

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ReservableRequestConcurrencyController.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ReservableRequestConcurrencyController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.client.api.internal;
+package io.servicetalk.client.api;
 
 import io.servicetalk.concurrent.api.Completable;
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FilterableReservedControlledStreamingHttpLoadBalancedConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FilterableReservedControlledStreamingHttpLoadBalancedConnection.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
+
+/**
+ * A {@link FilterableStreamingHttpLoadBalancedConnection} that supports concurrency controls
+ * {@link ReservableRequestConcurrencyController}.
+ */
+public interface FilterableReservedControlledStreamingHttpLoadBalancedConnection
+        extends FilterableStreamingHttpLoadBalancedConnection, ReservedStreamingHttpConnection,
+                ReservableRequestConcurrencyController {
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
@@ -18,7 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.internal.ReservableRequestConcurrencyController;
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableReservedControlledStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -48,7 +49,7 @@ import static io.servicetalk.transport.api.TransportObservers.asSafeObserver;
 import static java.util.Objects.requireNonNull;
 
 abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
-        implements ConnectionFactory<ResolvedAddress, LoadBalancedStreamingHttpConnection> {
+        implements ConnectionFactory<ResolvedAddress, FilterableReservedControlledStreamingHttpLoadBalancedConnection> {
 
     @Nullable
     final StreamingHttpConnectionFilterFactory connectionFilterFunction;
@@ -113,7 +114,7 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
     }
 
     @Override
-    public final Single<LoadBalancedStreamingHttpConnection> newConnection(
+    public final Single<FilterableReservedControlledStreamingHttpLoadBalancedConnection> newConnection(
             final ResolvedAddress resolvedAddress, @Nullable final TransportObserver observer) {
         return filterableConnectionFactory.newConnection(resolvedAddress, observer)
                 .map(conn -> {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -17,7 +17,7 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.internal.ReservableRequestConcurrencyController;
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -32,6 +32,7 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.FilterableReservedControlledStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -277,7 +278,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
             final HttpExecutionStrategy executionStrategy = executionContext.executionStrategy();
             // closed by the LoadBalancer
-            final ConnectionFactory<R, LoadBalancedStreamingHttpConnection> connectionFactory;
+            final ConnectionFactory<R, FilterableReservedControlledStreamingHttpLoadBalancedConnection>
+                    connectionFactory;
             final StreamingHttpRequestResponseFactory reqRespFactory = defaultReqRespFactory(roConfig,
                     executionContext.bufferAllocator());
 
@@ -307,7 +309,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                         ctx.builder.loadBalancerFactory::toLoadBalancedConnection);
             }
 
-            final LoadBalancer<LoadBalancedStreamingHttpConnection> lb =
+            final LoadBalancer<FilterableReservedControlledStreamingHttpLoadBalancedConnection> lb =
                     closeOnException.prepend(ctx.builder.loadBalancerFactory.newLoadBalancer(
                             targetAddress(ctx),
                             sdEvents,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -17,7 +17,7 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.internal.ReservableRequestConcurrencyController;
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.http.netty.AbstractLifecycleObserverHttpFilter.ON_CONNECTION_SELECTED_CONSUMER;
 import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.requestExecutionStrategy;
 import static java.util.Objects.requireNonNull;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
+import io.servicetalk.http.api.FilterableReservedControlledStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -47,19 +48,20 @@ import static java.util.function.Function.identity;
 
 final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpClient {
 
-    private static final Predicate<LoadBalancedStreamingHttpConnection>
+    private static final Predicate<FilterableReservedControlledStreamingHttpLoadBalancedConnection>
             SELECTOR_FOR_REQUEST = conn -> conn.tryRequest() == Accepted;
-    private static final Predicate<LoadBalancedStreamingHttpConnection>
-            SELECTOR_FOR_RESERVE = LoadBalancedStreamingHttpConnection::tryReserve;
+    private static final Predicate<FilterableReservedControlledStreamingHttpLoadBalancedConnection>
+            SELECTOR_FOR_RESERVE = FilterableReservedControlledStreamingHttpLoadBalancedConnection::tryReserve;
 
     // TODO Proto specific LB after upgrade and worry about SSL
     private final HttpExecutionContext executionContext;
-    private final LoadBalancer<LoadBalancedStreamingHttpConnection> loadBalancer;
+    private final LoadBalancer<FilterableReservedControlledStreamingHttpLoadBalancedConnection> loadBalancer;
     private final StreamingHttpRequestResponseFactory reqRespFactory;
 
-    LoadBalancedStreamingHttpClient(final HttpExecutionContext executionContext,
-                                    final LoadBalancer<LoadBalancedStreamingHttpConnection> loadBalancer,
-                                    final StreamingHttpRequestResponseFactory reqRespFactory) {
+    LoadBalancedStreamingHttpClient(
+            final HttpExecutionContext executionContext,
+            final LoadBalancer<FilterableReservedControlledStreamingHttpLoadBalancedConnection> loadBalancer,
+            final StreamingHttpRequestResponseFactory reqRespFactory) {
         this.executionContext = requireNonNull(executionContext);
         this.loadBalancer = requireNonNull(loadBalancer);
         this.reqRespFactory = requireNonNull(reqRespFactory);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
@@ -16,7 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.LoadBalancer;
-import io.servicetalk.client.api.internal.ReservableRequestConcurrencyController;
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
@@ -44,8 +44,9 @@ import static java.util.Objects.requireNonNull;
 /**
  * Makes the wrapped {@link StreamingHttpConnection} aware of the {@link LoadBalancer}.
  */
-final class LoadBalancedStreamingHttpConnection implements FilterableStreamingHttpLoadBalancedConnection,
-                   ReservedStreamingHttpConnection, ReservableRequestConcurrencyController,
+public class LoadBalancedStreamingHttpConnection
+        implements FilterableStreamingHttpLoadBalancedConnection, ReservedStreamingHttpConnection,
+                   ReservableRequestConcurrencyController,
                    // Since we do not have filters for reserved connection, we rely on the original implementation to
                    // be an influencer hence we can try to correctly delegate when possible.
                    // Reserved connection given to the user will use the correct strategy and influencer chain since
@@ -55,7 +56,7 @@ final class LoadBalancedStreamingHttpConnection implements FilterableStreamingHt
     private final FilterableStreamingHttpLoadBalancedConnection filteredConnection;
     private final HttpExecutionStrategy connectStrategy;
 
-    LoadBalancedStreamingHttpConnection(FilterableStreamingHttpLoadBalancedConnection filteredConnection,
+    public LoadBalancedStreamingHttpConnection(FilterableStreamingHttpLoadBalancedConnection filteredConnection,
                                         ReservableRequestConcurrencyController limiter,
                                         HttpExecutionStrategy connectStrategy) {
         this.filteredConnection = filteredConnection;
@@ -146,6 +147,14 @@ final class LoadBalancedStreamingHttpConnection implements FilterableStreamingHt
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         return connectStrategy;
+    }
+
+    public FilterableStreamingHttpLoadBalancedConnection unwrap() {
+        return filteredConnection;
+    }
+
+    public ReservableRequestConcurrencyController limiter() {
+        return limiter;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpConnection.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableReservedControlledStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpEventKey;
@@ -29,7 +30,6 @@ import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.ReservedBlockingHttpConnection;
 import io.servicetalk.http.api.ReservedBlockingStreamingHttpConnection;
 import io.servicetalk.http.api.ReservedHttpConnection;
-import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
@@ -44,9 +44,8 @@ import static java.util.Objects.requireNonNull;
 /**
  * Makes the wrapped {@link StreamingHttpConnection} aware of the {@link LoadBalancer}.
  */
-public class LoadBalancedStreamingHttpConnection
-        implements FilterableStreamingHttpLoadBalancedConnection, ReservedStreamingHttpConnection,
-                   ReservableRequestConcurrencyController,
+final class LoadBalancedStreamingHttpConnection
+        implements FilterableReservedControlledStreamingHttpLoadBalancedConnection,
                    // Since we do not have filters for reserved connection, we rely on the original implementation to
                    // be an influencer hence we can try to correctly delegate when possible.
                    // Reserved connection given to the user will use the correct strategy and influencer chain since
@@ -56,7 +55,7 @@ public class LoadBalancedStreamingHttpConnection
     private final FilterableStreamingHttpLoadBalancedConnection filteredConnection;
     private final HttpExecutionStrategy connectStrategy;
 
-    public LoadBalancedStreamingHttpConnection(FilterableStreamingHttpLoadBalancedConnection filteredConnection,
+    LoadBalancedStreamingHttpConnection(FilterableStreamingHttpLoadBalancedConnection filteredConnection,
                                         ReservableRequestConcurrencyController limiter,
                                         HttpExecutionStrategy connectStrategy) {
         this.filteredConnection = filteredConnection;
@@ -147,14 +146,6 @@ public class LoadBalancedStreamingHttpConnection
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         return connectStrategy;
-    }
-
-    public FilterableStreamingHttpLoadBalancedConnection unwrap() {
-        return filteredConnection;
-    }
-
-    public ReservableRequestConcurrencyController limiter() {
-        return limiter;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -17,7 +17,7 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.internal.ReservableRequestConcurrencyController;
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;


### PR DESCRIPTION
Motivation:

At the lack of extra context available at connection creation time, it's useful to
allow for extentibility of LoadBalancedStreamingHttpConnection (implementation) to support extension points to mimic/wrap it.

Modifications:

Introduced `FilterableReservedControlledStreamingHttpLoadBalancedConnection` that `LoadBalancedStreamingHttpConnection` now implements, along with internal classes moved to support this new public API..

Result:

Netty LB connection has a public interface now, allowing additional override/delegate behavior in various flows.