### PR TITLE
refactor io_uring unit test

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -9,12 +9,10 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11, 17 ]
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         include:
           - os: ubuntu-latest
             gradle-command: sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
-          - os: macos-latest
-            gradle-command: ./gradlew --no-daemon --parallel clean test
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -9,12 +9,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11, 17 ]
-        os: [ ubuntu-latest, macos-latest ]
-        include:
-          - os: ubuntu-latest
-            gradle-command: sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
-          - os: macos-latest
-            gradle-command: ./gradlew --no-daemon --parallel clean test
+        os: [ ubuntu-latest ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
@@ -37,10 +32,16 @@ jobs:
           minimum-size: 8GB
           maximum-size: 16GB
       - name: Build and Test
+        shell: bash
         env:
           CI: true
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
-        run: ${{ matrix.gradle-command }}
+        run: |
+          if [ "${{ matrix.os }}" = "Linux" ]; then
+            sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
+          else
+            ./gradlew --no-daemon --parallel clean test
+          fi
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -35,7 +35,8 @@ jobs:
         env:
           CI: true
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
-        run: ./gradlew --parallel clean test
+        run: |
+            sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -10,9 +10,6 @@ jobs:
       matrix:
         java: [ 8, 11, 17 ]
         os: [ ubuntu-latest ]
-        include:
-          - os: ubuntu-latest
-            gradle-command: sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
@@ -34,11 +31,18 @@ jobs:
         with:
           minimum-size: 8GB
           maximum-size: 16GB
-      - name: Build and Test
+      - name: Build and Test (Linux)
+        if: runner.os == 'Linux'
         env:
           CI: true
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
-        run: ${{ matrix.gradle-command }}
+        run:  sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
+      - name: Build and Test (non-Linux)
+        if: runner.os != 'Linux'
+        env:
+          CI: true
+          JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+        run: ./gradlew --no-daemon --parallel clean test
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -9,7 +9,12 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11, 17 ]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest ]
+        include:
+          - os: ubuntu-latest
+            gradle-command: sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
+          - os: macos-latest
+            gradle-command: ./gradlew --no-daemon --parallel clean test
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
@@ -32,16 +37,10 @@ jobs:
           minimum-size: 8GB
           maximum-size: 16GB
       - name: Build and Test
-        shell: bash
         env:
           CI: true
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
-        run: |
-          if [ "${{ matrix.os }}" = "Linux" ]; then
-            sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
-          else
-            ./gradlew --no-daemon --parallel clean test
-          fi
+        run: ${{ matrix.gradle-command }}
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -9,7 +9,12 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11, 17 ]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest ]
+        include:
+          - os: ubuntu-latest
+            gradle-command: sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
+          - os: macos-latest
+            gradle-command: ./gradlew --no-daemon --parallel clean test
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
@@ -35,8 +40,7 @@ jobs:
         env:
           CI: true
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
-        run: |
-            sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
+        run: ${{ matrix.gradle-command }}
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Build with Gradle
         env:
           CI: true
-        run: ./gradlew --parallel clean quality
+        run: |
+            sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean quality"
       - name: Upload CheckStyle Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -4,15 +4,10 @@ on:
     branches: [ main, '0.41', '0.42' ]
 jobs:
   quality:
-    name: quality ${{ matrix.java }} ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         java: [ 8, 11, 17 ]
-        os: [ ubuntu-latest ]
-        include:
-          - os: ubuntu-latest
-            gradle-command: sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean quality"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
@@ -29,7 +24,7 @@ jobs:
       - name: Build with Gradle
         env:
           CI: true
-        run: ${{ matrix.gradle-command }}
+        run: ./gradlew --parallel clean quality
       - name: Upload CheckStyle Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -4,10 +4,15 @@ on:
     branches: [ main, '0.41', '0.42' ]
 jobs:
   quality:
-    runs-on: ubuntu-latest
+    name: quality ${{ matrix.java }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         java: [ 8, 11, 17 ]
+        os: [ ubuntu-latest ]
+        include:
+          - os: ubuntu-latest
+            gradle-command: sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean quality"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
@@ -24,8 +29,7 @@ jobs:
       - name: Build with Gradle
         env:
           CI: true
-        run: |
-            sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean quality"
+        run: ${{ matrix.gradle-command }}
       - name: Upload CheckStyle Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -56,7 +56,7 @@ jobs:
           fi
 
           # Execute the gradlew command to publish the build
-          ./gradlew --parallel -PreleaseBuild=true$FIRST_GRADLE_TARGETS && ./gradlew -PreleaseBuild=true$SECOND_GRADLE_TARGETS
+          sudo env "PATH=$PATH" "FIRST_GRADLE_TARGETS=$FIRST_GRADLE_TARGETS" "SECOND_GRADLE_TARGETS=$SECOND_GRADLE_TARGETS" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel -PreleaseBuild=true$FIRST_GRADLE_TARGETS && ./gradlew --no-daemon -PreleaseBuild=true$SECOND_GRADLE_TARGETS"
       - name: Publish Test Results
         if: always()
         uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -57,7 +57,7 @@ jobs:
           fi
 
           # Execute the gradlew command to publish the build
-          ./gradlew --parallel$FIRST_GRADLE_TARGETS && ./gradlew$SECOND_GRADLE_TARGETS
+          sudo env "PATH=$PATH" "FIRST_GRADLE_TARGETS=$FIRST_GRADLE_TARGETS" "SECOND_GRADLE_TARGETS=$SECOND_GRADLE_TARGETS" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel$FIRST_GRADLE_TARGETS && ./gradlew --no-daemon$SECOND_GRADLE_TARGETS"
       - name: Publish Test Results
         if: always()
         uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -57,6 +57,8 @@ dependencies {
   testImplementation "io.netty:netty-transport-native-unix-common"
   testImplementation "io.netty:netty-tcnative-boringssl-static"
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+  testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
+  testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
@@ -33,7 +33,6 @@ import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
@@ -48,7 +48,14 @@ class IoUringTest {
     @EnabledOnOs(value = { MAC })
     void ioUringIsNotAvailableOnMacOs() {
         assertFalse(IOUring.isAvailable());
-        assertFalse(IoUringUtils.isAvailable());
+        try {
+            IoUringUtils.tryIoUring(false);
+            assertFalse(IoUringUtils.isAvailable());
+            IoUringUtils.tryIoUring(true);
+            assertFalse(IoUringUtils.isAvailable());
+        } finally {
+            IoUringUtils.tryIoUring(false);
+        }
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
@@ -61,11 +61,11 @@ class IoUringTest {
     @Test
     @EnabledOnOs(value = { LINUX })
     void ioUringIsAvailableOnLinux() throws Exception {
-        IOUring.ensureAvailability();
         EventLoopAwareNettyIoExecutor ioUringExecutor = null;
         try {
             IoUringUtils.tryIoUring(true);
             assertTrue(IoUringUtils.isAvailable());
+            IOUring.ensureAvailability();
 
             ioUringExecutor = NettyIoExecutors.createIoExecutor(2, "io-uring");
             assertThat(ioUringExecutor.eventLoopGroup(), is(instanceOf(IOUringEventLoopGroup.class)));
@@ -79,7 +79,7 @@ class IoUringTest {
                 HttpRequest request = client.post(SVC_ECHO).payloadBody("bonjour!", textSerializerUtf8());
                 HttpResponse response = client.request(request);
                 assertThat(response.status(), is(OK));
-                assertThat(response.payloadBody().toString(UTF_8), is("bonjour!"));
+                assertThat(response.payloadBody(textSerializerUtf8()), is("bonjour!"));
             }
         } finally {
             IoUringUtils.tryIoUring(false);


### PR DESCRIPTION
Motivation:

io_uring is a new asynchronous I/O API for Linux that provides
significant performance improvements for I/O operations. Netty
implements it through netty-incubator-transport-io_uring module.

servicetalk's CI build runs the IOUring test, but it has not been validating io_uring properly.

Modifications:

- add `ulimit -l 65536` to GitHub Actions workflows
- use junit `EnabledOnOs` annotation to designate OS specific tests
- update assertions to ensure IOUring behavior

Result:

- IOUringTest passes in GitHub Actions CI

Reference:

- https://github.com/actions/virtual-environments/issues/4683

