### PR TITLE
Add PayloadSizeLimitingHttpRequesterFilter

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExceptionMapperServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExceptionMapperServiceFilter.java
@@ -27,6 +27,7 @@ import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatus.PAYLOAD_TOO_LARGE;
 import static io.servicetalk.http.api.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static io.servicetalk.http.api.HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
 
@@ -82,6 +83,8 @@ public final class HttpExceptionMapperServiceFilter implements StreamingHttpServ
             status = UNSUPPORTED_MEDIA_TYPE;
             LOGGER.error("Failed to deserialize or serialize for connection={}, request='{} {} {}'. Returning: {}",
                     ctx, request.method(), request.requestTarget(), request.version(), status, cause);
+        } else if (cause instanceof PayloadTooLargeException) {
+            status = PAYLOAD_TOO_LARGE;
         } else {
             status = INTERNAL_SERVER_ERROR;
             LOGGER.error("Unexpected exception during service processing for connection={}, request='{} {} {}'. " +

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PayloadTooLargeException.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PayloadTooLargeException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.utils;
+package io.servicetalk.http.api;
 
 /**
  * Indication that the payload was too large and failed to process.

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/MutableInt.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/MutableInt.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+final class MutableInt {
+    int value;
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+
+import java.util.function.Function;
+
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+
+/**
+ * Limits the response payload size for a request. The filter will throw an exception which may result in
+ * stream/connection closure.
+ */
+public final class PayloadSizeLimitingHttpRequesterFilter implements
+                        StreamingHttpClientFilterFactory, StreamingHttpConnectionFilterFactory,
+                        HttpExecutionStrategyInfluencer {
+    private final int maxResponsePayloadSize;
+
+    /**
+     * Create a new instance.
+     * @param maxResponsePayloadSize The maximum response payload size allowed.
+     */
+    public PayloadSizeLimitingHttpRequesterFilter(int maxResponsePayloadSize) {
+        if (maxResponsePayloadSize < 0) {
+            throw new IllegalArgumentException("maxResponsePayloadSize: " + maxResponsePayloadSize + " (expected >0)");
+        }
+        this.maxResponsePayloadSize = maxResponsePayloadSize;
+    }
+
+    @Override
+    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
+        return new StreamingHttpClientFilter(client) {
+            @Override
+            protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                            final StreamingHttpRequest request) {
+                return applyLimit(request, delegate::request);
+            }
+        };
+    }
+
+    @Override
+    public StreamingHttpConnectionFilter create(final FilterableStreamingHttpConnection connection) {
+        return new StreamingHttpConnectionFilter(connection) {
+            @Override
+            public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                return applyLimit(request, super::request);
+            }
+        };
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return offloadNone();
+    }
+
+    private Single<StreamingHttpResponse> applyLimit(
+            StreamingHttpRequest request, Function<StreamingHttpRequest, Single<StreamingHttpResponse>> delegator) {
+        return delegator.apply(request).map(response -> response.transformPayloadBody(publisher ->
+                Publisher.defer(() -> {
+                    final MutableInt responsePayloadSize = new MutableInt();
+                    return publisher.beforeOnNext(buff -> {
+                        if (maxResponsePayloadSize - responsePayloadSize.value < buff.readableBytes()) {
+                            throw new PayloadTooLongException("Maximum payload size=" + maxResponsePayloadSize +
+                                    " current payload size=" + responsePayloadSize.value +
+                                    " new buffer size=" + buff.readableBytes());
+                        }
+                        responsePayloadSize.value += buff.readableBytes();
+                    }).shareContextOnSubscribe();
+                })));
+    }
+
+    static final class PayloadTooLongException extends IllegalStateException {
+        private static final long serialVersionUID = 7332745010452084915L;
+
+        PayloadTooLongException(String message) {
+            super(message);
+        }
+    }
+
+    private static final class MutableInt {
+        int value;
+    }
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilter.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.PayloadTooLargeException;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilter;

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilter.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.utils;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.PayloadTooLargeException;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.http.utils.PayloadSizeLimitingHttpRequesterFilter.newLimiter;
+
+/**
+ * Limits the request payload size. The filter will throw an exception which may result in stream/connection closure.
+ * A {@link PayloadTooLargeException} will be thrown when the maximum payload size is exceeded.
+ */
+public final class PayloadSizeLimitingHttpServiceFilter implements StreamingHttpServiceFilterFactory {
+    private final int maxRequestPayloadSize;
+
+    /**
+     * Create a new instance.
+     * @param maxRequestPayloadSize The maximum request payload size allowed.
+     */
+    public PayloadSizeLimitingHttpServiceFilter(int maxRequestPayloadSize) {
+        if (maxRequestPayloadSize < 0) {
+            throw new IllegalArgumentException("maxRequestPayloadSize: " + maxRequestPayloadSize + " (expected >=0)");
+        }
+        this.maxRequestPayloadSize = maxRequestPayloadSize;
+    }
+
+    @Override
+    public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+        return new StreamingHttpServiceFilter(service) {
+            @Override
+            public Single<StreamingHttpResponse> handle(
+                    final HttpServiceContext ctx, final StreamingHttpRequest request,
+                    final StreamingHttpResponseFactory responseFactory) {
+                return super.handle(ctx,
+                        // We could use transformPayloadBody to convert into Buffers, but transformMessageBody has
+                        // slightly less overhead. Since this implementation is internal to ServiceTalk we take the more
+                        // advanced route.
+                        request.transformMessageBody(newLimiter(maxRequestPayloadSize)), responseFactory);
+            }
+        };
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return offloadNone();
+    }
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadTooLargeException.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadTooLargeException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+/**
+ * Indication that the payload was too large and failed to process.
+ */
+public final class PayloadTooLargeException extends RuntimeException {
+    private static final long serialVersionUID = 7332745010452084915L;
+
+    /**
+     * Create a new instance.
+     * @param message The message to include in the description.
+     */
+    public PayloadTooLargeException(String message) {
+        super(message);
+    }
+}

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilterTest.java
@@ -27,6 +27,7 @@ import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.PayloadTooLargeException;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilterTest.java
@@ -54,8 +54,7 @@ class PayloadSizeLimitingHttpRequesterFilterTest {
     @Test
     void lessThanMaxAllowed() throws ExecutionException, InterruptedException {
         new PayloadSizeLimitingHttpRequesterFilter(100).create(mockTransport(99))
-                .request(REQ_RESP_FACTORY.get("/"))
-                .toFuture().get()
+                .request(REQ_RESP_FACTORY.get("/")).toFuture().get()
                 .payloadBody().toFuture().get();
     }
 

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilterTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.FilterableReservedStreamingHttpConnection;
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.utils.PayloadSizeLimitingHttpRequesterFilter.PayloadTooLongException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
+import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class PayloadSizeLimitingHttpRequesterFilterTest {
+    private static final StreamingHttpRequestResponseFactory REQ_RESP_FACTORY =
+            new DefaultStreamingHttpRequestResponseFactory(DEFAULT_ALLOCATOR, INSTANCE, HTTP_1_1);
+    private static final HttpExecutionContext MOCK_EXECUTION_CTX = mock(HttpExecutionContext.class);
+
+    @Test
+    void lessThanMaxAllowed() throws ExecutionException, InterruptedException {
+        new PayloadSizeLimitingHttpRequesterFilter(100).create(mockTransport(99))
+                .request(REQ_RESP_FACTORY.get("/"))
+                .toFuture().get()
+                .payloadBody().toFuture().get();
+    }
+
+    @Test
+    void moreThanMaxRejected() {
+        ExecutionException e = assertThrows(ExecutionException.class,
+                () -> new PayloadSizeLimitingHttpRequesterFilter(100).create(mockTransport(101))
+                        .request(REQ_RESP_FACTORY.get("/")).toFuture().get()
+                        .payloadBody().toFuture().get());
+        assertThat(e.getCause(), instanceOf(PayloadTooLongException.class));
+    }
+
+    private static FilterableStreamingHttpClient mockTransport(int responsePayloadSize) {
+        return new FilterableStreamingHttpClient() {
+            private final ListenableAsyncCloseable closeable = emptyAsyncCloseable();
+            @Override
+            public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
+                    final HttpRequestMetaData metaData) {
+                return failed(new UnsupportedOperationException());
+            }
+
+            @Override
+            public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                return Single.succeeded(REQ_RESP_FACTORY.ok().transformPayloadBody(pub ->
+                        Publisher.defer(() -> {
+                            Buffer[] buffers = new Buffer[responsePayloadSize];
+                            for (int i = 0; i < responsePayloadSize; ++i) {
+                                buffers[i] = DEFAULT_ALLOCATOR.fromAscii("a");
+                            }
+                            return pub.concat(Publisher.from(buffers))
+                                    .shareContextOnSubscribe();
+                        })));
+            }
+
+            @Override
+            public HttpExecutionContext executionContext() {
+                return MOCK_EXECUTION_CTX;
+            }
+
+            @Override
+            public StreamingHttpResponseFactory httpResponseFactory() {
+                return REQ_RESP_FACTORY;
+            }
+
+            @Override
+            public Completable onClose() {
+                return closeable.onClose();
+            }
+
+            @Override
+            public Completable closeAsync() {
+                return closeable.closeAsync();
+            }
+
+            @Override
+            public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
+                return REQ_RESP_FACTORY.newRequest(method, requestTarget);
+            }
+        };
+    }
+}

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilterTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.utils;
 
 import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.PayloadTooLargeException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.http.api.HttpServiceContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.ExecutionException;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.utils.PayloadSizeLimitingHttpRequesterFilterTest.REQ_RESP_FACTORY;
+import static io.servicetalk.http.utils.PayloadSizeLimitingHttpRequesterFilterTest.newBufferPublisher;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class PayloadSizeLimitingHttpServiceFilterTest {
+    @ParameterizedTest
+    @ValueSource(ints = {99, 100})
+    void lessThanEqToMaxAllowed(int payloadLen) throws ExecutionException, InterruptedException {
+        new PayloadSizeLimitingHttpServiceFilter(100)
+                .create((ctx, request, responseFactory) ->
+                        succeeded(responseFactory.ok().payloadBody(request.payloadBody())))
+                .handle(mock(HttpServiceContext.class),
+                        REQ_RESP_FACTORY.post("/").payloadBody(newBufferPublisher(payloadLen, DEFAULT_ALLOCATOR)),
+                        REQ_RESP_FACTORY).toFuture().get()
+                .payloadBody().toFuture().get();
+    }
+
+    @Test
+    void moreThanMaxRejected() {
+        ExecutionException e = assertThrows(ExecutionException.class,
+                () -> new PayloadSizeLimitingHttpServiceFilter(100)
+                        .create((ctx, request, responseFactory) ->
+                                succeeded(responseFactory.ok().payloadBody(request.payloadBody())))
+                        .handle(mock(HttpServiceContext.class),
+                                REQ_RESP_FACTORY.post("/").payloadBody(newBufferPublisher(101, DEFAULT_ALLOCATOR)),
+                                REQ_RESP_FACTORY).toFuture().get()
+                        .payloadBody().toFuture().get());
+        assertThat(e.getCause(), instanceOf(PayloadTooLargeException.class));
+    }
+}


### PR DESCRIPTION
Motivation:
In some cases it is useful to be able to limit the
response payload size. For example when using aggregated
APIs the user may not want to allow larger response
payloads.

Modifications:
- Add PayloadSizeLimitingHttpRequesterFilter which applies
  a limit to the response payload size.