### PR TITLE
Content-Type for Zipkin Protobuf should be application/x-protobuf.

### DIFF
--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
@@ -69,7 +69,7 @@ public final class HttpReporter extends Component implements Reporter<Span>, Asy
     static final String V1_PATH = "/api/v1/spans";
     static final String V2_PATH = "/api/v2/spans";
     static final CharSequence THRIFT_CONTENT_TYPE = newAsciiString("application/x-thrift");
-    static final CharSequence PROTO_CONTENT_TYPE = newAsciiString("application/protobuf");
+    static final CharSequence PROTO_CONTENT_TYPE = newAsciiString("application/x-protobuf");
 
     private final PublisherSource.Processor<Span, Span> buffer;
     private final CompositeCloseable closeable;


### PR DESCRIPTION
Motivation:

Zipkin receiver expects Content-Type of application/x-protobuf.

Why is this change being made?

Correct Content-Type is needed for receivers to correctly identity the payload format.

Modifications:

- HttpReporter's PROTO_CONTENT_TYPE is updated.

Result:

When using Codec.PROTO3, the outbound request to the trace collector will have the correct Content-Type.