### PR TITLE
enable ArchUnit

### DIFF
--- a/servicetalk-gradle-plugin-internal/plugin-config.gradle
+++ b/servicetalk-gradle-plugin-internal/plugin-config.gradle
@@ -23,6 +23,7 @@ dependencies {
   implementation localGroovy()
   implementation "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$props.spotbugsPluginVersion"
   implementation "info.solidsoft.gradle.pitest:gradle-pitest-plugin:$props.pitestPluginVersion"
+  implementation 'com.tngtech.archunit:archunit:0.23.1'
 }
 
 gradlePlugin {

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -214,6 +214,11 @@ final class ProjectUtils {
     configFile.exists() ? configFile : project.file("$project.projectDir/$path")
   }
 
+  static void addArchUnitTask(Project project) {
+    def archUnitTask = project.tasks.register("archunit", ServiceTalkArchUnitTask).get()
+    archUnitTask.dependsOn(project.tasks.findByName("assemble"))
+  }
+
   static void addQualityTask(Project project) {
     project.configure(project) {
       project.task("quality") {

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkArchUnitTask.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkArchUnitTask.groovy
@@ -1,0 +1,40 @@
+package io.servicetalk.gradle.plugin.internal
+
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.core.importer.Location
+import com.tngtech.archunit.core.importer.Locations
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.library.GeneralCodingRules
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class ServiceTalkArchUnitTask extends DefaultTask {
+
+    @TaskAction
+    void runArchUnitRules() {
+        def buildDir = this.project.layout.buildDirectory.get().asFile
+        def locations = new HashSet<Location>();
+        locations.addAll(Locations.ofPackage("io.servicetalk"))
+        locations.addAll(Locations.of(List.of(buildDir.toURL())))
+
+        def classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_JARS)
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importLocations(locations)
+        if (classes.size() > 0) {
+            def rules = setupRules()
+            rules.each {
+                it.check(classes)
+            }
+        }
+    }
+
+    static List<ArchRule> setupRules() {
+        return [
+          GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING,
+          GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME,
+          // TODO : add custom ArchUnit rules here
+        ]
+    }
+}

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkArchUnitTask.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkArchUnitTask.groovy
@@ -25,6 +25,7 @@ class ServiceTalkArchUnitTask extends DefaultTask {
         if (classes.size() > 0) {
             def rules = setupRules()
             rules.each {
+                getLogger().debug("ArchUnit rule: {}", it.getDescription())
                 it.check(classes)
             }
         }

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addManifestAttributes
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addQualityTask
+import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addArchUnitTask
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.createJavadocJarTask
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.createSourcesJarTask
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.locateBuildLevelConfigFile
@@ -49,6 +50,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
     applyPitestPlugin project
     applyPmdPlugin project
     applySpotBugsPlugin project
+    addArchUnitTask project
     addQualityTask project
   }
 

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.javadoc.Javadoc
 
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addQualityTask
+import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addArchUnitTask
 
 final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
   void apply(Project project) {
@@ -27,6 +28,7 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
 
     enforceCheckstyleRoot project
     addJavadocAllTask project
+    addArchUnitTask project
     addQualityTask project
   }
 


### PR DESCRIPTION
Motivation:

On large Java projects, it can be helpful to enforce coding conventions across all modules.
ArchUnit is a library that enables a project to adopt "rules" for the code. These rules can be executed in the CI build.

Modifications:
- add new Gradle task (ServiceTalkArchUnitTask)
- ServiceTalkArchUnitTask is responsible for executing a list of ArchUnit rules

Result:
- `./gradlew clean archunit` enforces all rules defined by the Gradle task.

Reference:

- https://www.archunit.org

- "Stopping entropy with ArchUnit"
https://www.youtube.com/watch?v=AOKqpnCDtWU

![](https://user-images.githubusercontent.com/30938/153723657-14637d5c-5508-4f33-badd-9b1b0aad0fa0.png)
