### PR TITLE
Validate HTTP method name matches the token format

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
@@ -34,7 +34,7 @@ import static io.servicetalk.http.api.HeaderUtils.domainMatches;
 import static io.servicetalk.http.api.HeaderUtils.isSetCookieNameMatches;
 import static io.servicetalk.http.api.HeaderUtils.parseCookiePair;
 import static io.servicetalk.http.api.HeaderUtils.pathMatches;
-import static io.servicetalk.http.api.HeaderUtils.validateCookieTokenAndHeaderName;
+import static io.servicetalk.http.api.HeaderUtils.validateToken;
 import static io.servicetalk.http.api.HttpHeaderNames.COOKIE;
 import static io.servicetalk.http.api.HttpHeaderNames.SET_COOKIE;
 import static java.util.Collections.emptyIterator;
@@ -588,7 +588,7 @@ final class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> impl
      * @param name The filed-name to validate.
      */
     private static void validateHeaderName(final CharSequence name) {
-        validateCookieTokenAndHeaderName(name);
+        validateToken(name);
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -26,7 +26,7 @@ import static io.servicetalk.buffer.api.CharSequences.equalsIgnoreCaseLower;
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.parseLong;
 import static io.servicetalk.http.api.HeaderUtils.validateCookieNameAndValue;
-import static io.servicetalk.http.api.HeaderUtils.validateCookieTokenAndHeaderName;
+import static io.servicetalk.http.api.HeaderUtils.validateToken;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.Lax;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.None;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.Strict;
@@ -172,7 +172,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                         }
                         name = setCookieString.subSequence(begin, i);
                         if (validateContent) {
-                            validateCookieTokenAndHeaderName(name);
+                            validateToken(name);
                         }
                         parseState = ParseState.ParsingValue;
                     } else if (parseState == ParseState.Unknown) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -259,16 +259,19 @@ public final class HeaderUtils {
     }
 
     /**
-     * Validate {@code key} is valid <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-name</a>
-     * (aka <a href="https://tools.ietf.org/html/rfc2616#section-2.2">token</a>) and a
-     * valid <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">field-name</a> of a
-     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2">header-field</a>. Both of these
-     * formats have the same restrictions.
+     * Validate a <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> contains only allowed
+     * characters.
+     * <p>
+     * The <a href="https://tools.ietf.org/html/rfc2616#section-2.2">token</a> format is used for variety of HTTP
+     * components, like  <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-name</a>,
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">field-name</a> of a
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2">header-field</a>, or
+     * <a href="https://tools.ietf.org/html/rfc7231#section-4">request method</a>.
      *
-     * @param key the cookie name or header name to validate.
+     * @param token the token to validate.
      */
-    static void validateCookieTokenAndHeaderName(final CharSequence key) {
-        forEachByte(key, HeaderUtils::validateToken);
+    static void validateToken(final CharSequence token) {
+        forEachByte(token, HeaderUtils::validateTokenChar);
     }
 
     static void validateHeaderValue(final CharSequence value) {
@@ -777,7 +780,7 @@ public final class HeaderUtils {
      *
      * @param value the character to validate.
      */
-    private static boolean validateToken(final byte value) {
+    private static boolean validateTokenChar(final byte value) {
         // HEADER
         // header-field   = field-name ":" OWS field-value OWS
         //

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpRequestMethodTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpRequestMethodTest.java
@@ -25,12 +25,14 @@ import static io.servicetalk.http.api.HttpRequestMethod.OPTIONS;
 import static io.servicetalk.http.api.HttpRequestMethod.PATCH;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.api.HttpRequestMethod.PUT;
+import static io.servicetalk.http.api.HttpRequestMethod.Properties.NONE;
 import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 import static io.servicetalk.http.api.HttpRequestMethod.of;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class HttpRequestMethodTest {
 
@@ -50,5 +52,11 @@ class HttpRequestMethodTest {
     @Test
     void testOfStringReturnsNullForUnknownMethod() {
         assertThat(of("UNKNOWN"), is(nullValue()));
+    }
+
+    @Test
+    void validatesName() {
+        assertThrows(IllegalArgumentException.class, () -> of("", NONE));
+        assertThrows(IllegalArgumentException.class, () -> of("<GET>", NONE));
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -991,7 +991,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         return value == SP || value == HT;
     }
 
-    private static boolean isVCHAR(final byte value) {
+    static boolean isVCHAR(final byte value) {
         return value >= '!' && value <= '~';
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
@@ -26,7 +26,6 @@ import io.servicetalk.utils.internal.IllegalCharacterException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.DecoderException;
 import io.netty.util.ByteProcessor;
 
 import java.util.Queue;
@@ -45,11 +44,7 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> im
         if (isWS(value)) {
             return false;
         }
-        ensureUpperCase(value);
-        return true;
-    };
-    private static final ByteProcessor ENSURE_UPPER_CASE = value -> {
-        ensureUpperCase(value);
+        ensureVCHAR(value);
         return true;
     };
 
@@ -78,20 +73,16 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> im
         try {
             buffer.forEachByte(FIND_WS_AFTER_METHOD_NAME);
         } catch (IllegalCharacterException cause) {
-            throw newInvalidMethodException(cause);
+            throw new StacklessDecoderException(
+                    "Invalid start-line: must contain only visible characters", cause);
         }
     }
 
-    private static DecoderException newInvalidMethodException(final IllegalCharacterException cause) {
-        return new StacklessDecoderException(
-                "Invalid start-line: HTTP request method must contain only upper case letters", cause);
-    }
-
-    private static void ensureUpperCase(final byte value) {
-        // As per the RFC, request method is case-sensitive, and all valid methods are uppercase.
-        // https://tools.ietf.org/html/rfc7231#section-4.1
-        if (value < 'A' || value > 'Z') {
-            throw new IllegalCharacterException(value, "A-Z (0x41-0x5a)");
+    private static void ensureVCHAR(final byte value) {
+        // As per the RFC, start-line begins with visible characters
+        // https://tools.ietf.org/html/rfc7230#section-3.1.1
+        if (!isVCHAR(value)) {
+            throw new IllegalCharacterException(value, "VCHAR (0x21-0x7e)");
         }
     }
 
@@ -113,11 +104,11 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> im
             return method;
         }
         try {
-            buffer.forEachByte(start, length, ENSURE_UPPER_CASE);
-        } catch (IllegalCharacterException cause) {
-            throw newInvalidMethodException(cause);
+            return HttpRequestMethod.of(methodName, NONE);
+        } catch (IllegalArgumentException cause) {
+            throw new StacklessDecoderException(
+                    "Invalid start-line: HTTP request method must follow a valid token format", cause);
         }
-        return HttpRequestMethod.of(methodName, NONE);
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -49,9 +49,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -154,10 +154,15 @@ abstract class HttpObjectDecoderTest {
 
     final void assertDecoderExceptionWithCause(String msg, String expectedExceptionMsg,
                                                EmbeddedChannel channel) {
+        assertDecoderExceptionWithCause(msg, expectedExceptionMsg, IllegalCharacterException.class, channel);
+    }
+
+    final <T extends Throwable> void assertDecoderExceptionWithCause(String msg, String expectedExceptionMsg,
+                                                                     Class<T> causeType, EmbeddedChannel channel) {
         DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
         assertThat(e.getMessage(), startsWith(expectedExceptionMsg));
-        assertThat(e.getCause(), is(instanceOf(IllegalCharacterException.class)));
-        assertThat(e.getCause().getMessage(), not(isEmptyString()));
+        assertThat(e.getCause(), is(instanceOf(causeType)));
+        assertThat(e.getCause().getMessage(), not(is(emptyString())));
         assertThat(channel().inboundMessages(), is(empty()));
     }
 
@@ -203,7 +208,7 @@ abstract class HttpObjectDecoderTest {
     }
 
     @Nullable
-    final HttpHeaders assertPayloadSize(int expectedPayloadSize, EmbeddedChannel channel) {
+    static HttpHeaders assertPayloadSize(int expectedPayloadSize, EmbeddedChannel channel) {
         int actualPayloadSize = 0;
         Object item;
         for (;;) {


### PR DESCRIPTION
Motivation:

RFC7230, section 3.1.1 defines `method = token`. Currently, there is
no validation for the name format in `HttpRequestMethod`. HTTP/1.1
validation currently requires all uppercase letters. While the standard
HTTP methods are all uppercase, there are other standardized method that
contain tchar:
https://www.iana.org/assignments/http-methods/http-methods.xhtml

Modifications:

- Move validation of the method name from `HttpRequestDecoder` to
`HttpRequestMethod` ctor;
- Update tests to match new behavior;

Result:

HTTP/1.1 supports all method names from IANA registry.
All other protocols and use-cases get consistent method name validation.