### PR TITLE
Increase log level when global resources are closed

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
@@ -54,7 +54,8 @@ final class GlobalExecutor extends DelegatingExecutor {
     }
 
     private static void log(final Logger logger, final String name, final String methodName) {
-        logger.debug("Closure of \"{}\" was initiated using {} method. Closing the global instance before " +
-                "closing all resources that use it may result in unexpected behavior.", name, methodName);
+        logger.info("Closure of \"{}\" was initiated using {} method. Closing the global instance before " +
+                "closing all resources that use it may result in unexpected behavior.", name, methodName,
+                new Exception("Stack trace"));
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
@@ -56,6 +56,6 @@ final class GlobalExecutor extends DelegatingExecutor {
     private static void log(final Logger logger, final String name, final String methodName) {
         logger.info("Closure of \"{}\" was initiated using {} method. Closing the global instance before " +
                 "closing all resources that use it may result in unexpected behavior.", name, methodName,
-                new Exception("Stack trace"));
+                new Throwable("Stack trace"));
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
@@ -154,6 +154,6 @@ public final class GlobalExecutionContext {
     private static void log(final Logger logger, final String name, final String methodName) {
         logger.info("Closure of \"{}\" was initiated using {} method. Closing the global instance before " +
                 "closing all resources that use it may result in unexpected behavior.", name, methodName,
-                new Exception("Stack trace"));
+                new Throwable("Stack trace"));
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
@@ -152,7 +152,8 @@ public final class GlobalExecutionContext {
     }
 
     private static void log(final Logger logger, final String name, final String methodName) {
-        logger.debug("Closure of \"{}\" was initiated using {} method. Closing the global instance before " +
-                "closing all resources that use it may result in unexpected behavior.", name, methodName);
+        logger.info("Closure of \"{}\" was initiated using {} method. Closing the global instance before " +
+                "closing all resources that use it may result in unexpected behavior.", name, methodName,
+                new Exception("Stack trace"));
     }
 }


### PR DESCRIPTION
Motivation:

Closing global resources (`IoExecutor` and `Executor`) is unexpected.
Users should have visibility when it happens.

Modifications:

- Change log level from `debug` to `info`;
- Add stack-trace to see where subscribe comes from;

Result:

Users can notice if they unexpectedly closed any of the global
resources.