### PR TITLE
Add an HTTP example for protobuf serialization

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -5,6 +5,7 @@
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Debugging[Debugging]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Timeout[Timeout]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#SerializationJson[Serialization: JSON]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#SerializationProtobuf[Serialization: Protobuf]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#JAXRS[JAX-RS]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#MetaData[MetaData]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#HTTP2[HTTP/2]

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -118,6 +118,22 @@ with `Content-Type: application/json` and link:{source-root}/servicetalk-example
 All serializers and deserializers defined in
 link:{source-root}/servicetalk-examples/http/serialization/json/src/main/java/io/servicetalk/examples/http/serialization/json/SerializerUtils.java[SerializerUtils].
 
+[#SerializationProtobuf]
+== Serialization: Protobuf
+
+An example similar to "Hello World" examples, which demonstrates
+link:{source-root}/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async[asynchronous-aggregated],
+link:{source-root}/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/streaming[asynchronous-streaming],
+link:{source-root}/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking[blocking-aggregated], and
+link:{source-root}/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/streaming[blocking-streaming]
+client and server with Protobuf serialization of simple proto objects.
+
+Client sends a `POST` request with a Protobuf payload `RequestMessage` and expects a response with
+`Content-Type: application/protobuf` and `ResponseMessage` as a payload
+(link:{source-root}/servicetalk-examples/http/serialization/protobuf/src/main/proto/message.proto[message.proto]).
+All serializers and deserializers defined in
+link:{source-root}/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/SerializerUtils.java[SerializerUtils].
+
 [#JAXRS]
 == JAX-RS
 

--- a/servicetalk-examples/http/serialization/protobuf/build.gradle
+++ b/servicetalk-examples/http/serialization/protobuf/build.gradle
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+  dependencies {
+    classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufGradlePluginVersion"
+  }
+}
+
+apply plugin: "java"
+apply from: "../../../gradle/idea.gradle"
+apply plugin: "com.google.protobuf"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-data-protobuf")
+  implementation project(":servicetalk-http-netty")
+  implementation "com.google.protobuf:protobuf-java:$protobufVersion"
+
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+}
+
+clean {
+  delete protobuf.generatedFilesBaseDir
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/SerializerUtils.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/SerializerUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf;
+
+import io.servicetalk.data.protobuf.ProtobufSerializerFactory;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.ResponseMessage;
+import io.servicetalk.http.api.HttpHeaders;
+import io.servicetalk.http.api.HttpSerializerDeserializer;
+import io.servicetalk.http.api.HttpSerializers;
+import io.servicetalk.http.api.HttpStreamingSerializerDeserializer;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.data.protobuf.ProtobufSerializerFactory.PROTOBUF;
+import static io.servicetalk.http.api.HeaderUtils.hasContentType;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
+import static io.servicetalk.http.api.HttpSerializers.serializer;
+import static io.servicetalk.http.api.HttpSerializers.streamingSerializer;
+
+/**
+ * Utilities to cache serializer instances for request/response protos.
+ * <p>
+ * {@link ProtobufSerializerFactory} produces protocol-agnostic serializer/deserializer. We use {@link HttpSerializers}
+ * utilities to concert it to HTTP-aware variants.
+ */
+public final class SerializerUtils {
+
+    private static final CharSequence APPLICATION_PROTOBUF = newAsciiString("application/protobuf");
+    private static final Consumer<HttpHeaders> CONTENT_TYPE_SETTER =
+            headers -> headers.set(CONTENT_TYPE, APPLICATION_PROTOBUF);
+    private static final Predicate<HttpHeaders> CONTENT_TYPE_VALIDATOR =
+            headers -> hasContentType(headers, APPLICATION_PROTOBUF, null);
+
+    public static final HttpSerializerDeserializer<RequestMessage> REQ_SERIALIZER =
+            serializer(PROTOBUF.serializerDeserializer(RequestMessage.parser()),
+                    CONTENT_TYPE_SETTER, CONTENT_TYPE_VALIDATOR);
+
+    public static final HttpStreamingSerializerDeserializer<RequestMessage> REQ_STREAMING_SERIALIZER =
+            streamingSerializer(PROTOBUF.streamingSerializerDeserializer(RequestMessage.parser()),
+                    CONTENT_TYPE_SETTER, CONTENT_TYPE_VALIDATOR);
+
+    public static final HttpSerializerDeserializer<ResponseMessage> RESP_SERIALIZER =
+            serializer(PROTOBUF.serializerDeserializer(ResponseMessage.parser()),
+                    CONTENT_TYPE_SETTER, CONTENT_TYPE_VALIDATOR);
+
+    public static final HttpStreamingSerializerDeserializer<ResponseMessage> RESP_STREAMING_SERIALIZER =
+            streamingSerializer(PROTOBUF.streamingSerializerDeserializer(ResponseMessage.parser()),
+                    CONTENT_TYPE_SETTER, CONTENT_TYPE_VALIDATOR);
+
+    private SerializerUtils() {
+        // No instances.
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/ProtobufClient.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/ProtobufClient.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.async;
+
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_SERIALIZER;
+
+public final class ProtobufClient {
+    public static void main(String[] args) throws Exception {
+        try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080).build()) {
+            client.request(client.post("/protobuf")
+                    .payloadBody(RequestMessage.newBuilder().setMessage("value").build(), REQ_SERIALIZER))
+                    .whenOnSuccess(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.payloadBody(RESP_SERIALIZER));
+                    })
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for an asynchronous API but is useful
+            // for demonstration purposes.
+                    .toFuture().get();
+        }
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/ProtobufServer.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/ProtobufServer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.async;
+
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.ResponseMessage;
+import io.servicetalk.http.netty.HttpServers;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_SERIALIZER;
+import static io.servicetalk.http.api.HttpHeaderNames.ALLOW;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
+
+public final class ProtobufServer {
+    public static void main(String[] args) throws Exception {
+        HttpServers.forPort(8080)
+                .listenAndAwait((ctx, request, responseFactory) -> {
+                    if (!"/protobuf".equals(request.requestTarget())) {
+                        return succeeded(responseFactory.notFound());
+                    }
+                    if (!POST.equals(request.method())) {
+                        return succeeded(responseFactory.methodNotAllowed().addHeader(ALLOW, POST.name()));
+                    }
+                    RequestMessage req = request.payloadBody(REQ_SERIALIZER);
+                    ResponseMessage resp = ResponseMessage.newBuilder().setLength(req.getMessage().length()).build();
+                    return succeeded(responseFactory.created()
+                            .payloadBody(resp, RESP_SERIALIZER));
+                })
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/ProtobufUrlClient.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/ProtobufUrlClient.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.async;
+
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_SERIALIZER;
+
+public final class ProtobufUrlClient {
+    public static void main(String[] args) throws Exception {
+        try (HttpClient client = HttpClients.forMultiAddressUrl().build()) {
+            client.request(client.post("http://localhost:8080/protobuf")
+                    .payloadBody(ExampleProtos.RequestMessage.newBuilder().setMessage("hello").build(), REQ_SERIALIZER))
+                    .whenOnSuccess(resp -> {
+                        System.out.println(resp.toString((name, value) -> value));
+                        System.out.println(resp.payloadBody(RESP_SERIALIZER));
+                    })
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for an asynchronous API but is useful
+            // for demonstration purposes.
+                    .toFuture().get();
+        }
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/package-info.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.serialization.protobuf.async;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/streaming/ProtobufStreamingClient.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/streaming/ProtobufStreamingClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.async.streaming;
+
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_STREAMING_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_STREAMING_SERIALIZER;
+
+public final class ProtobufStreamingClient {
+    public static void main(String[] args) throws Exception {
+        try (StreamingHttpClient client = HttpClients.forSingleAddress("localhost", 8080).buildStreaming()) {
+            client.request(client.post("/protobuf")
+                    .payloadBody(from("value1", "value22", "value333")
+                                    .map(message -> RequestMessage.newBuilder().setMessage(message).build()),
+                            REQ_STREAMING_SERIALIZER))
+                    .beforeOnSuccess(response -> System.out.println(response.toString((name, value) -> value)))
+                    .flatMapPublisher(resp -> resp.payloadBody(RESP_STREAMING_SERIALIZER))
+                    .whenOnNext(System.out::println)
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for an asynchronous API but is useful
+            // for demonstration purposes.
+                    .toFuture().get();
+        }
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/streaming/ProtobufStreamingServer.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/streaming/ProtobufStreamingServer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.async.streaming;
+
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.ResponseMessage;
+import io.servicetalk.http.netty.HttpServers;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_STREAMING_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_STREAMING_SERIALIZER;
+import static io.servicetalk.http.api.HttpHeaderNames.ALLOW;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
+
+public final class ProtobufStreamingServer {
+    public static void main(String[] args) throws Exception {
+        HttpServers.forPort(8080)
+                .listenStreamingAndAwait((ctx, request, responseFactory) -> {
+                    if (!"/protobuf".equals(request.requestTarget())) {
+                        return succeeded(responseFactory.notFound());
+                    }
+                    if (!POST.equals(request.method())) {
+                        return succeeded(responseFactory.methodNotAllowed().addHeader(ALLOW, POST.name()));
+                    }
+                    return succeeded(responseFactory.created()
+                            .payloadBody(request.payloadBody(REQ_STREAMING_SERIALIZER)
+                            .map(req -> ResponseMessage.newBuilder().setLength(req.getMessage().length()).build()),
+                            RESP_STREAMING_SERIALIZER));
+                })
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/streaming/ProtobufStreamingUrlClient.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/streaming/ProtobufStreamingUrlClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.async.streaming;
+
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_STREAMING_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_STREAMING_SERIALIZER;
+
+public final class ProtobufStreamingUrlClient {
+    public static void main(String[] args) throws Exception {
+        try (StreamingHttpClient client = HttpClients.forMultiAddressUrl().buildStreaming()) {
+            client.request(client.post("http://localhost:8080/protobuf")
+                    .payloadBody(from("value1", "value22", "value333")
+                                    .map(message -> RequestMessage.newBuilder().setMessage(message).build()),
+                            REQ_STREAMING_SERIALIZER))
+                    .beforeOnSuccess(response -> System.out.println(response.toString((name, value) -> value)))
+                    .flatMapPublisher(resp -> resp.payloadBody(RESP_STREAMING_SERIALIZER))
+                    .whenOnNext(System.out::println)
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for an asynchronous API but is useful
+            // for demonstration purposes.
+                    .toFuture().get();
+        }
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/streaming/package-info.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/async/streaming/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.serialization.protobuf.async.streaming;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/BlockingProtobufClient.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/BlockingProtobufClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.blocking;
+
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_SERIALIZER;
+
+public final class BlockingProtobufClient {
+    public static void main(String[] args) throws Exception {
+        try (BlockingHttpClient client = HttpClients.forSingleAddress("localhost", 8080).buildBlocking()) {
+            HttpResponse resp = client.request(client.post("/protobuf")
+                    .payloadBody(RequestMessage.newBuilder().setMessage("value").build(), REQ_SERIALIZER));
+            System.out.println(resp.toString((name, value) -> value));
+            System.out.println(resp.payloadBody(RESP_SERIALIZER));
+        }
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/BlockingProtobufServer.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/BlockingProtobufServer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.blocking;
+
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.ResponseMessage;
+import io.servicetalk.http.netty.HttpServers;
+
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_SERIALIZER;
+import static io.servicetalk.http.api.HttpHeaderNames.ALLOW;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
+
+public final class BlockingProtobufServer {
+    public static void main(String[] args) throws Exception {
+        HttpServers.forPort(8080)
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                    if (!"/protobuf".equals(request.requestTarget())) {
+                        return responseFactory.notFound();
+                    }
+                    if (!POST.equals(request.method())) {
+                        return responseFactory.methodNotAllowed().addHeader(ALLOW, POST.name());
+                    }
+
+                    RequestMessage req = request.payloadBody(REQ_SERIALIZER);
+                    ResponseMessage resp = ResponseMessage.newBuilder().setLength(req.getMessage().length()).build();
+                    return responseFactory.created()
+                            .payloadBody(resp, RESP_SERIALIZER);
+                })
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/BlockingProtobufUrlClient.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/BlockingProtobufUrlClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.blocking;
+
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_SERIALIZER;
+
+public final class BlockingProtobufUrlClient {
+    public static void main(String[] args) throws Exception {
+        try (BlockingHttpClient client = HttpClients.forMultiAddressUrl().buildBlocking()) {
+            HttpResponse resp = client.request(client.post("http://localhost:8080/protobuf")
+                    .payloadBody(RequestMessage.newBuilder().setMessage("value").build(), REQ_SERIALIZER));
+            System.out.println(resp.toString((name, value) -> value));
+            System.out.println(resp.payloadBody(RESP_SERIALIZER));
+        }
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/package-info.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.serialization.protobuf.blocking;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/streaming/BlockingProtobufStreamingClient.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/streaming/BlockingProtobufStreamingClient.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.blocking.streaming;
+
+import io.servicetalk.concurrent.BlockingIterator;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.ResponseMessage;
+import io.servicetalk.http.api.BlockingStreamingHttpClient;
+import io.servicetalk.http.api.BlockingStreamingHttpResponse;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_STREAMING_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_STREAMING_SERIALIZER;
+import static java.util.Arrays.asList;
+
+public final class BlockingProtobufStreamingClient {
+    public static void main(String[] args) throws Exception {
+        try (BlockingStreamingHttpClient client =
+                     HttpClients.forSingleAddress("localhost", 8080).buildBlockingStreaming()) {
+            BlockingStreamingHttpResponse response = client.request(client.post("/protobuf")
+                    .payloadBody(asList(
+                            RequestMessage.newBuilder().setMessage("value1").build(),
+                            RequestMessage.newBuilder().setMessage("value22").build(),
+                            RequestMessage.newBuilder().setMessage("value333").build()),
+                            REQ_STREAMING_SERIALIZER));
+            System.out.println(response.toString((name, value) -> value));
+            // While it's also possible to use for-each, it's recommended to use try-with-resources to make sure that
+            // the full response payload body is drained in case of exceptions
+            try (BlockingIterator<ResponseMessage> payload =
+                         response.payloadBody(RESP_STREAMING_SERIALIZER).iterator()) {
+                while (payload.hasNext()) {
+                    System.out.println(payload.next());
+                }
+            }
+        }
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/streaming/BlockingProtobufStreamingServer.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/streaming/BlockingProtobufStreamingServer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.blocking.streaming;
+
+import io.servicetalk.concurrent.BlockingIterable;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.ResponseMessage;
+import io.servicetalk.http.api.HttpPayloadWriter;
+import io.servicetalk.http.netty.HttpServers;
+
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_STREAMING_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_STREAMING_SERIALIZER;
+import static io.servicetalk.http.api.HttpHeaderNames.ALLOW;
+import static io.servicetalk.http.api.HttpRequestMethod.POST;
+import static io.servicetalk.http.api.HttpResponseStatus.CREATED;
+import static io.servicetalk.http.api.HttpResponseStatus.METHOD_NOT_ALLOWED;
+import static io.servicetalk.http.api.HttpResponseStatus.NOT_FOUND;
+
+public final class BlockingProtobufStreamingServer {
+    public static void main(String[] args) throws Exception {
+        HttpServers.forPort(8080)
+                .listenBlockingStreamingAndAwait((ctx, request, response) -> {
+                    if (!"/protobuf".equals(request.requestTarget())) {
+                        response.status(NOT_FOUND)
+                                .sendMetaData()
+                                .close();
+                    } else if (!POST.equals(request.method())) {
+                        response.status(METHOD_NOT_ALLOWED)
+                                .addHeader(ALLOW, POST.name())
+                                .sendMetaData()
+                                .close();
+                    } else {
+                        BlockingIterable<RequestMessage> values = request.payloadBody(REQ_STREAMING_SERIALIZER);
+
+                        response.status(CREATED);
+                        try (HttpPayloadWriter<ResponseMessage> writer =
+                                     response.sendMetaData(RESP_STREAMING_SERIALIZER)) {
+                            for (RequestMessage req : values) {
+                                writer.write(ResponseMessage.newBuilder().setLength(req.getMessage().length()).build());
+                            }
+                        }
+                    }
+                })
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/streaming/BlockingProtobufStreamingUrlClient.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/streaming/BlockingProtobufStreamingUrlClient.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.protobuf.blocking.streaming;
+
+import io.servicetalk.concurrent.BlockingIterator;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.RequestMessage;
+import io.servicetalk.examples.http.serialization.protobuf.ExampleProtos.ResponseMessage;
+import io.servicetalk.http.api.BlockingStreamingHttpClient;
+import io.servicetalk.http.api.BlockingStreamingHttpResponse;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.REQ_STREAMING_SERIALIZER;
+import static io.servicetalk.examples.http.serialization.protobuf.SerializerUtils.RESP_STREAMING_SERIALIZER;
+import static java.util.Arrays.asList;
+
+public final class BlockingProtobufStreamingUrlClient {
+    public static void main(String[] args) throws Exception {
+        try (BlockingStreamingHttpClient client = HttpClients.forMultiAddressUrl().buildBlockingStreaming()) {
+            BlockingStreamingHttpResponse response = client.request(client.post("http://localhost:8080/protobuf")
+                    .payloadBody(asList(
+                            RequestMessage.newBuilder().setMessage("value1").build(),
+                            RequestMessage.newBuilder().setMessage("value22").build(),
+                            RequestMessage.newBuilder().setMessage("value333").build()),
+                            REQ_STREAMING_SERIALIZER));
+            System.out.println(response.toString((name, value) -> value));
+            // While it's also possible to use for-each, it's recommended to use try-with-resources to make sure that
+            // the full response payload body is drained in case of exceptions
+            try (BlockingIterator<ResponseMessage> payload =
+                         response.payloadBody(RESP_STREAMING_SERIALIZER).iterator()) {
+                while (payload.hasNext()) {
+                    System.out.println(payload.next());
+                }
+            }
+        }
+    }
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/streaming/package-info.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/blocking/streaming/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.serialization.protobuf.blocking.streaming;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/package-info.java
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.serialization.protobuf;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/serialization/protobuf/src/main/proto/message.proto
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/proto/message.proto
@@ -1,0 +1,30 @@
+//
+// Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test.shared;
+
+option java_multiple_files = false;
+option java_package = "io.servicetalk.examples.http.serialization.protobuf";
+option java_outer_classname = "ExampleProtos";
+
+message RequestMessage {
+    string message = 1;
+}
+
+message ResponseMessage {
+    int32 length = 1;
+}

--- a/servicetalk-examples/http/serialization/protobuf/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/serialization/protobuf/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,6 +58,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:http:observer",
         "servicetalk-examples:http:retry",
         "servicetalk-examples:http:serialization:json",
+        "servicetalk-examples:http:serialization:protobuf",
         "servicetalk-examples:http:service-composition",
         "servicetalk-examples:http:uds",
         "servicetalk-examples:http:compression",
@@ -122,6 +123,7 @@ project(":servicetalk-examples:http:opentracing").name = "servicetalk-examples-h
 project(":servicetalk-examples:http:observer").name = "servicetalk-examples-http-observer"
 project(":servicetalk-examples:http:retry").name = "servicetalk-examples-http-retry"
 project(":servicetalk-examples:http:serialization:json").name = "servicetalk-examples-http-serialization-json"
+project(":servicetalk-examples:http:serialization:protobuf").name = "servicetalk-examples-http-serialization-protobuf"
 project(":servicetalk-examples:http:service-composition").name = "servicetalk-examples-http-service-composition"
 project(":servicetalk-examples:http:uds").name = "servicetalk-examples-http-uds"
 project(":servicetalk-examples:http:mutual-tls").name = "servicetalk-examples-http-mutual-tls"


### PR DESCRIPTION
Motivation:

HTTP users who work with protobuf payloads need an example of how to use
`ProtobufSerializerFactory`.

Modifications:

- Add `servicetalk-examples-http-serialization-protobuf` module to
demonstrate use of `ProtobufSerializerFactory` with HTTP;
- Update docs to reference a new example;

Result:

Users can see how to use `ProtobufSerializerFactory` with HTTP.

Depends on #2106 to avoid merge conflicts, review the 2nd commit.