### PR TITLE
Remove special `defaultStrategy()` merge method

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionStrategy.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcExecutionStrategy.java
@@ -19,7 +19,7 @@ import io.servicetalk.http.api.HttpExecutionStrategy;
 
 import static java.util.Objects.requireNonNull;
 
-final class DefaultGrpcExecutionStrategy implements GrpcExecutionStrategy {
+class DefaultGrpcExecutionStrategy implements GrpcExecutionStrategy {
 
     private final HttpExecutionStrategy delegate;
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -25,10 +25,20 @@ import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
 public final class GrpcExecutionStrategies {
 
     private static final GrpcExecutionStrategy NEVER_OFFLOAD_STRATEGY =
-            new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.offloadNever());
+            new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.offloadNever()) {
+                @Override
+                public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
+                    return this;
+                }
+            };
 
     private static final GrpcExecutionStrategy DEFAULT_GRPC_EXECUTION_STRATEGY =
-            new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.defaultStrategy());
+            new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.defaultStrategy()) {
+                @Override
+                public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
+                    return other;
+                }
+            };
 
     private GrpcExecutionStrategies() {
         // No instances
@@ -37,9 +47,8 @@ public final class GrpcExecutionStrategies {
     /**
      * A special default {@link GrpcExecutionStrategy} that offloads all actions unless merged with another strategy
      * that requires less offloading. The intention of this strategy is to provide a safe default if no strategy is
-     * specified; it should not be returned by
-     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()}, which should return
-     * {@link HttpExecutionStrategy#offloadNone()} or {@link HttpExecutionStrategy#offloadAll()} instead.
+     * specified; it should not be returned by {@link HttpExecutionStrategyInfluencer#requiredOffloads()} which should
+     * return the actual required offloads.
      *
      * @return Default {@link GrpcExecutionStrategy}.
      */

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -92,6 +92,7 @@ import static io.servicetalk.grpc.api.GrpcUtils.setStatus;
 import static io.servicetalk.grpc.api.GrpcUtils.setStatusOk;
 import static io.servicetalk.grpc.api.GrpcUtils.validateContentType;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
@@ -384,7 +385,7 @@ final class GrpcRouter {
                         public Completable closeAsyncGracefully() {
                             return route.closeAsyncGracefully();
                         }
-                    }, executionStrategy == null ? HttpExecutionStrategies.defaultStrategy() : executionStrategy),
+                    }, executionStrategy == null ? defaultStrategy() : executionStrategy),
                     () -> toStreaming(route), () -> toRequestStreamingRoute(route),
                     () -> toResponseStreamingRoute(route), () -> route, route)),
                     // We only assume duplication across blocking and async variant of the same API and not between
@@ -458,9 +459,7 @@ final class GrpcRouter {
 
                             @Override
                             public HttpExecutionStrategy serviceInvocationStrategy() {
-                                return executionStrategy == null ?
-                                        HttpExecutionStrategies.defaultStrategy() :
-                                        executionStrategy;
+                                return executionStrategy == null ? defaultStrategy() : executionStrategy;
                             }
                         };
                     }, () -> route, () -> toRequestStreamingRoute(route), () -> toResponseStreamingRoute(route),
@@ -592,7 +591,7 @@ final class GrpcRouter {
                         public void closeGracefully() throws Exception {
                             route.closeGracefully();
                         }
-                    }, executionStrategy == null ? HttpExecutionStrategies.defaultStrategy() : executionStrategy),
+                    }, executionStrategy == null ? defaultStrategy() : executionStrategy),
                     () -> toStreaming(route), () -> toRequestStreamingRoute(route),
                     () -> toResponseStreamingRoute(route), () -> toRoute(route), route)),
                     // We only assume duplication across blocking and async variant of the same API and not between
@@ -662,7 +661,7 @@ final class GrpcRouter {
                         public void closeGracefully() throws Exception {
                             route.closeGracefully();
                         }
-                    }, executionStrategy == null ? HttpExecutionStrategies.defaultStrategy() : executionStrategy),
+                    }, executionStrategy == null ? defaultStrategy() : executionStrategy),
                     () -> toStreaming(route), () -> toRequestStreamingRoute(route),
                     () -> toResponseStreamingRoute(route), () -> toRoute(route), route)),
                     // We only assume duplication across blocking and async variant of the same API and not between

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ConnectAndHttpExecutionStrategy.java
@@ -20,6 +20,8 @@ import io.servicetalk.transport.api.ExecutionStrategy;
 
 import java.util.Objects;
 
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+
 /**
  * Combines a {@link ConnectExecutionStrategy} and an {@link HttpExecutionStrategy}.
  */
@@ -122,7 +124,8 @@ public final class ConnectAndHttpExecutionStrategy implements ConnectExecutionSt
 
     @Override
     public ConnectAndHttpExecutionStrategy merge(final HttpExecutionStrategy other) {
-        HttpExecutionStrategy merged = httpStrategy.merge(other);
+        HttpExecutionStrategy merged = defaultStrategy() == httpStrategy ?
+                other : defaultStrategy() == other ? httpStrategy : httpStrategy.merge(other);
         return merged == httpStrategy ? this : new ConnectAndHttpExecutionStrategy(connectStrategy, merged);
     }
 
@@ -164,7 +167,7 @@ public final class ConnectAndHttpExecutionStrategy implements ConnectExecutionSt
         return executionStrategy instanceof ConnectAndHttpExecutionStrategy ?
                 (ConnectAndHttpExecutionStrategy) executionStrategy :
                     new ConnectAndHttpExecutionStrategy(
-                            ConnectExecutionStrategy.offloadNone(), HttpExecutionStrategies.defaultStrategy())
+                            ConnectExecutionStrategy.offloadNone(), defaultStrategy())
                             .merge(executionStrategy);
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpExecutionStrategy.java
@@ -140,7 +140,6 @@ enum DefaultHttpExecutionStrategy implements HttpExecutionStrategy {
         }
 
         // merge the offload flags
-
         byte otherOffloads = generateOffloadsFlag(other);
 
         return offloads == (offloads | otherOffloads) ?

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategies.java
@@ -36,11 +36,10 @@ public final class HttpExecutionStrategies {
     }
 
     /**
-     * A special default {@link HttpExecutionStrategy} that offloads all actions unless merged with another strategy
-     * that requires less offloading. The intention of this strategy is to provide a safe default if no strategy is
-     * specified; it should not be returned by
-     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()}, which should return {@link #offloadNone()} or
-     * {@link #offloadAll()} instead.
+     * A special default {@link HttpExecutionStrategy} that provides safe default offloading of actions; the offloading
+     * used is unspecified and dependent upon the usage situation. It may not be merged with other strategies because
+     * the resulting strategy would lose the defaulting behavior. As an additional safety measure all offload query
+     * methods will return true.
      *
      * @return Default {@link HttpExecutionStrategy}.
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
@@ -20,7 +20,6 @@ import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 import java.lang.reflect.Method;
 
 import static io.servicetalk.http.api.DefaultStreamingStrategyInfluencer.DEFAULT_STREAMING_STRATEGY_INFLUENCER;
-import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 
@@ -32,6 +31,9 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
     /**
      * Optionally modify the passed {@link HttpExecutionStrategy} to a new {@link HttpExecutionStrategy} that suits
      * this {@link HttpExecutionStrategyInfluencer}.
+     *
+     * <p>Implementations should not return {@link HttpExecutionStrategies#defaultStrategy()} ()} unless it was also
+     * provided as input.</p>
      *
      * @param strategy {@link HttpExecutionStrategy} to influence.
      * @return {@link HttpExecutionStrategy} that suits this {@link HttpExecutionStrategyInfluencer}
@@ -56,13 +58,12 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
      *
      * <p>The provided default implementation requests offloading of all operations. Implementations that require no
      * offloading should be careful to return {@link HttpExecutionStrategies#offloadNone()} rather than
-     * {@link HttpExecutionStrategies#offloadNever()}.
+     * {@link HttpExecutionStrategies#offloadNever()}. Implementations should avoid returning
+     * {@link HttpExecutionStrategies#defaultStrategy()}, instead returning the strategy they require.
      */
     @Override
     default HttpExecutionStrategy requiredOffloads() {
-        // safe default--implementations are expected to override
-        HttpExecutionStrategy result = influenceStrategy(defaultStrategy());
-        return defaultStrategy() == result ? offloadNone() : result;
+        return influenceStrategy(offloadNone());
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExecutionStrategyInfluencer.java
@@ -32,7 +32,7 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
      * Optionally modify the passed {@link HttpExecutionStrategy} to a new {@link HttpExecutionStrategy} that suits
      * this {@link HttpExecutionStrategyInfluencer}.
      *
-     * <p>Implementations should not return {@link HttpExecutionStrategies#defaultStrategy()} ()} unless it was also
+     * <p>Implementations should not return {@link HttpExecutionStrategies#defaultStrategy()} unless it was also
      * provided as input.</p>
      *
      * @param strategy {@link HttpExecutionStrategy} to influence.
@@ -59,7 +59,8 @@ public interface HttpExecutionStrategyInfluencer extends ExecutionStrategyInflue
      * <p>The provided default implementation requests offloading of all operations. Implementations that require no
      * offloading should be careful to return {@link HttpExecutionStrategies#offloadNone()} rather than
      * {@link HttpExecutionStrategies#offloadNever()}. Implementations should avoid returning
-     * {@link HttpExecutionStrategies#defaultStrategy()}, instead returning the strategy they require.
+     * {@link HttpExecutionStrategies#defaultStrategy()}, instead returning the strategy they require or
+     * {@link HttpExecutionStrategies#offloadAll()} if offloading for all paths is required (safe default).
      */
     @Override
     default HttpExecutionStrategy requiredOffloads() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
@@ -15,6 +15,9 @@
  */
 package io.servicetalk.http.api;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  *  Package private special purpose implementation for {@link HttpExecutionStrategy} to be used across programming model
  *  adapters, should not be made public. Provides a special execution strategy that overrides offloading behavior.
@@ -22,12 +25,10 @@ package io.servicetalk.http.api;
  * @see DefaultHttpExecutionStrategy
  */
 enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
-
     /**
      * Enforces no offloading and maintains this even when merged.
      */
     OFFLOAD_NEVER_STRATEGY {
-
         @Override
         public boolean hasOffloads() {
             return false;
@@ -74,6 +75,8 @@ enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
      */
     DEFAULT_HTTP_EXECUTION_STRATEGY {
 
+        private volatile boolean mergeWarning;
+
         @Override
         public boolean hasOffloads() {
             return true;
@@ -112,7 +115,14 @@ enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
          */
         @Override
         public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
-            throw new UnsupportedOperationException("must not be merged");
+            assert false : "merging defaultStrategy() with other strategies is deprecated";
+            if (!mergeWarning) {
+                mergeWarning = true;
+                LOGGER.warn("merging defaultStrategy() with other strategies is deprecated");
+            }
+            return other;
         }
-    }
+    };
+
+    static final Logger LOGGER = LoggerFactory.getLogger(SpecialHttpExecutionStrategy.class);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
@@ -112,7 +112,7 @@ enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
          */
         @Override
         public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
-            return other;
+            throw new UnsupportedOperationException("must not be merged");
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToBlockingStreamingHttpClient.java
@@ -32,8 +32,7 @@ final class StreamingHttpClientToBlockingStreamingHttpClient implements Blocking
 
     StreamingHttpClientToBlockingStreamingHttpClient(final StreamingHttpClient client,
                                                      final HttpExecutionStrategy strategy) {
-        this.strategy = defaultStrategy() == strategy ?
-                DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY : strategy;
+        this.strategy = defaultStrategy() == strategy ? DEFAULT_BLOCKING_STREAMING_CONNECTION_STRATEGY : strategy;
         this.client = client;
         context = new DelegatingHttpExecutionContext(client.executionContext()) {
             @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
@@ -32,8 +32,7 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
     private final HttpRequestResponseFactory reqRespFactory;
 
     StreamingHttpClientToHttpClient(final StreamingHttpClient client, final HttpExecutionStrategy strategy) {
-        this.strategy = defaultStrategy() == strategy ?
-                DEFAULT_CONNECTION_STRATEGY : strategy;
+        this.strategy = defaultStrategy() == strategy ? DEFAULT_CONNECTION_STRATEGY : strategy;
         this.client = client;
         context = new DelegatingHttpExecutionContext(client.executionContext()) {
             @Override

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategiesTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategiesTest.java
@@ -32,15 +32,6 @@ import static org.mockito.Mockito.when;
 class HttpExecutionStrategiesTest {
 
     @Test
-    void mergeDefaultStrategy() {
-        HttpExecutionStrategy strategy = customStrategyBuilder().offloadAll().build();
-        HttpExecutionStrategy merged = strategy.merge(defaultStrategy());
-        assertThat("merge returned defaultStrategy.", merged, sameInstance(strategy));
-        merged = defaultStrategy().merge(strategy);
-        assertThat("merge returned defaultStrategy.", merged, sameInstance(strategy));
-    }
-
-    @Test
     void defaultShouldOffloadAll() {
         HttpExecutionStrategy strategy = defaultStrategy();
         assertThat("send not offloaded by default.", strategy.isSendOffloaded(), is(true));

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpExecutionStrategyTest.java
@@ -113,7 +113,6 @@ class HttpExecutionStrategyTest {
 
         RequiredOnly requiredOnly = new RequiredOnly();
         assertThat(requiredOnly.requiredOffloads(), sameInstance(MAGIC_REQUIRED_STRATEGY));
-        assertThat(requiredOnly.influenceStrategy(defaultStrategy()), sameInstance(MAGIC_REQUIRED_STRATEGY));
     }
 
     private interface MyOwnDefaultRequiredOffloads extends HttpExecutionStrategyInfluencer {
@@ -129,7 +128,6 @@ class HttpExecutionStrategyTest {
 
         RequiredDefault requiredOnly = new RequiredDefault();
         assertThat(requiredOnly.requiredOffloads(), sameInstance(MAGIC_REQUIRED_STRATEGY));
-        assertThat(requiredOnly.influenceStrategy(defaultStrategy()), sameInstance(MAGIC_REQUIRED_STRATEGY));
     }
 
     @Test
@@ -173,7 +171,6 @@ class HttpExecutionStrategyTest {
         Influence influence = new Influence();
         assertThat(influence.requiredOffloads(), is(offloadSend));
         assertThat(influence.influenceStrategy(offloadNone()), is(offloadSend));
-        assertThat(influence.influenceStrategy(defaultStrategy()), is(offloadSend));
         assertThat(influence.influenceStrategy(offloadSend), is(offloadSend));
     }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StrategyInfluencerChainBuilderTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StrategyInfluencerChainBuilderTest.java
@@ -23,6 +23,7 @@ import org.mockito.InOrder;
 import javax.annotation.Nonnull;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,7 +44,7 @@ class StrategyInfluencerChainBuilderTest {
         HttpExecutionStrategyInfluencer influencer2 = newNoInfluenceInfluencer();
         chain2.append(influencer2);
 
-        defaultStrategy().merge(chain1.build().requiredOffloads());
+        offloadNone().merge(chain1.build().requiredOffloads());
 
         verifyNoInteractions(influencer2);
     }
@@ -84,7 +85,7 @@ class StrategyInfluencerChainBuilderTest {
             chain.append(influencer3);
         }
 
-        defaultStrategy().merge(chain.build().requiredOffloads());
+        offloadNone().merge(chain.build().requiredOffloads());
 
         InOrder inOrder = inOrder(influencer1, influencer2, influencer3);
         inOrder.verify(influencer1).requiredOffloads();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClientStrategyInfluencerChainBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClientStrategyInfluencerChainBuilder.java
@@ -69,11 +69,17 @@ final class ClientStrategyInfluencerChainBuilder {
 
     private void add(String purpose, ExecutionStrategyInfluencer<?> influencer, HttpExecutionStrategy strategy) {
         if (offloadNever() == strategy) {
-            LOGGER.warn("Ignoring illegal {} required strategy ({}) for {}", purpose, strategy, influencer);
+            LOGGER.warn("{}#requiredOffloads() returns offloadNever(), which is unexpected. " +
+                            "offloadNone() should be used instead. " +
+                            "Making automatic adjustment, consider updating the {}.",
+                    influencer, purpose);
             strategy = offloadNone();
         }
         if (defaultStrategy() == strategy) {
-            LOGGER.warn("Ignoring illegal {} required strategy ({}) for {}", purpose, strategy, influencer);
+            LOGGER.warn("{}#requiredOffloads() returns defaultStrategy(), which is unexpected. " +
+                            "offloadAll() (safe default) or more appropriate custom strategy should be used instead." +
+                            "Making automatic adjustment, consider updating the {}.",
+                    influencer, purpose);
             strategy = offloadAll();
         }
         clientChain = null != clientChain ? clientChain.merge(strategy) : strategy;
@@ -90,7 +96,7 @@ final class ClientStrategyInfluencerChainBuilder {
         }
         if (defaultStrategy() == filterOffloads) {
             LOGGER.warn("{}#requiredOffloads() returns defaultStrategy(), which is unexpected. " +
-                            "offloadAll() should be used instead. " +
+                            "offloadAll() (safe default) or more appropriate custom strategy should be used instead." +
                             "Making automatic adjustment, consider updating the filter.",
                     connectionFactoryFilter);
             filterOffloads = offloadAll();
@@ -110,7 +116,7 @@ final class ClientStrategyInfluencerChainBuilder {
         }
         if (defaultStrategy() == filterOffloads) {
             LOGGER.warn("{}#requiredOffloads() returns defaultStrategy(), which is unexpected. " +
-                            "offloadAll() should be used instead. " +
+                            "offloadAll() (safe default) or more appropriate custom strategy should be used instead." +
                             "Making automatic adjustment, consider updating the filter.",
                     connectionFilter);
             filterOffloads = offloadAll();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -170,7 +170,6 @@ abstract class AbstractNettyHttpServerTest {
         // differently.
         final HttpServerBuilder serverBuilder = HttpServers.forAddress(bindAddress)
                 .executor(serverExecutor)
-                .executionStrategy(defaultStrategy())
                 .socketOption(StandardSocketOptions.SO_SNDBUF, 100)
                 .protocols(protocol)
                 .transportObserver(serverTransportObserver)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -60,7 +60,6 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;
-import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
@@ -132,7 +131,6 @@ final class ConnectionCloseHeaderHandlingTest {
                     HttpServers.forAddress(localAddress(0)))
                     .ioExecutor(serverCtx.ioExecutor())
                     .executor(serverCtx.executor())
-                    .executionStrategy(defaultStrategy())
                     .enableWireLogging("servicetalk-tests-wire-logger", TRACE, Boolean.TRUE::booleanValue)
                     .appendConnectionAcceptorFilter(original -> new DelegatingConnectionAcceptor(original) {
                         @Override
@@ -208,7 +206,6 @@ final class ConnectionCloseHeaderHandlingTest {
                     HttpClients.forResolvedAddress(serverContext.listenAddress()))
                     .executor(clientCtx.executor())
                     .ioExecutor(clientCtx.ioExecutor())
-                    .executionStrategy(defaultStrategy())
                     .enableWireLogging("servicetalk-tests-wire-logger", TRACE, () -> true)
                     .buildStreaming();
             connection = client.reserveConnection(client.get("/")).toFuture().get();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -68,7 +68,6 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
         StreamingHttpRequester newRequester = HttpClients.forMultiAddressUrl()
                 .ioExecutor(CTX.ioExecutor())
                 .executor(CTX.executor())
-                .executionStrategy(defaultStrategy())
                 .buildStreaming();
         assertNotNull(newRequester);
         newRequester.closeAsync().toFuture().get();
@@ -90,7 +89,6 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
         BlockingStreamingHttpRequester newBlockingRequester = HttpClients.forMultiAddressUrl()
                 .ioExecutor(CTX.ioExecutor())
                 .executor(CTX.executor())
-                .executionStrategy(defaultStrategy())
                 .buildBlockingStreaming();
         assertNotNull(newBlockingRequester);
         newBlockingRequester.close();
@@ -101,7 +99,6 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
         BlockingHttpRequester newBlockingAggregatedRequester = HttpClients.forMultiAddressUrl()
                 .ioExecutor(CTX.ioExecutor())
                 .executor(CTX.executor())
-                .executionStrategy(defaultStrategy())
                 .buildBlocking();
         assertNotNull(newBlockingAggregatedRequester);
         newBlockingAggregatedRequester.close();
@@ -114,7 +111,6 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
                 ServiceDiscovererEvent<InetSocketAddress>> mockedServiceDiscoverer = mock(ServiceDiscoverer.class);
         StreamingHttpRequester newRequester = HttpClients.forMultiAddressUrl(mockedServiceDiscoverer)
                 .ioExecutor(CTX.ioExecutor())
-                .executionStrategy(defaultStrategy())
                 .buildStreaming();
         newRequester.closeAsync().toFuture().get();
         verify(mockedServiceDiscoverer, never()).closeAsync();

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutFromRequest.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutFromRequest.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 /**
  * A function to determine the appropriate timeout to be used for a given {@link HttpRequestMetaData HTTP request}.
  * The result is a {@link Duration} which may be null if no timeout is to be applied. If the function blocks then
- * {@link #influenceStrategy(HttpExecutionStrategy)} should alter the execution strategy as required.
+ * {@link #requiredOffloads()} should specify the execution strategy as required.
  * @deprecated In areas which require {@link TimeoutFromRequest} use variants that accept
  * {@link java.util.function.BiFunction}&lt;{@link HttpRequestMetaData}, {@link TimeSource}, {@link Duration}&gt;.
  * E.g.:


### PR DESCRIPTION
Motivation:
The `HttpExecutionStrategies.defaultStrategy()` strategy currently
provides a special `merge()` implementation that, rather than merge,
simply returns the other strategy. This behavior is often surprising
and requires specific handling elsewhere to ensure that the strategy
has consistent merging when referenced reflexively.
Modifications:
Replace use of `HttpExecutionStrategies.defaultStrategy().merge()` with
explicit substitution of `defaultStrategy()` with the appropriate
strategy.
Result:
Reduced special behavior in the `HttpExecutionStrategy` implementation
which clarifies the actual interaction and behavior of strategies.