### PR TITLE
Add maxSubscriber limit to Completable/Single Processors

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CancellableStack.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CancellableStack.java
@@ -18,7 +18,15 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.Cancellable;
 
 final class CancellableStack implements Cancellable {
-    private final ClosableConcurrentStack<Cancellable> stack = new ClosableConcurrentStack<>();
+    private final ClosableConcurrentStack<Cancellable> stack;
+
+    /**
+     * Create a new instance.
+     * @param maxSizeHint Hint for the maximum size of this stack.
+     */
+    CancellableStack(int maxSizeHint) {
+        stack = new ClosableConcurrentStack<>(maxSizeHint);
+    }
 
     /**
      * {@inheritDoc}
@@ -36,8 +44,9 @@ final class CancellableStack implements Cancellable {
      * or be cancelled immediately if this object's {@link #cancel()} method has already been called.
      * @param toAdd The {@link Cancellable} to add.
      * @return {@code true} if the {@code toAdd} was added. If {@code false} {@link Cancellable#cancel()} is called.
+     * @throws IllegalStateException if the maximum size would be exceeded by inserting this element.
      */
-    boolean add(Cancellable toAdd) {
+    boolean add(Cancellable toAdd) throws IllegalStateException {
         return stack.push(toAdd);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableDynamicCountSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableDynamicCountSubscriber.java
@@ -17,17 +17,17 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
 final class CompletableDynamicCountSubscriber extends CompletableMergeSubscriber {
-    private static final AtomicLongFieldUpdater<CompletableDynamicCountSubscriber> completedCountUpdater =
+    private static final AtomicIntegerFieldUpdater<CompletableDynamicCountSubscriber> completedCountUpdater =
             newUpdater(CompletableDynamicCountSubscriber.class, "completedCount");
-    private volatile long completedCount;
+    private volatile int completedCount;
 
     CompletableDynamicCountSubscriber(Subscriber subscriber, boolean delayError) {
-        super(subscriber, delayError);
+        super(subscriber, delayError, Integer.MAX_VALUE);
     }
 
     @Override
@@ -36,7 +36,7 @@ final class CompletableDynamicCountSubscriber extends CompletableMergeSubscriber
         return completedCountUpdater.decrementAndGet(this) == 0;
     }
 
-    void setExpectedCount(final long count) {
+    void setExpectedCount(final int count) {
         // add the expected amount back, if we come to 0 that means all sources have completed.
         if (completedCountUpdater.addAndGet(this, count) == 0) {
             tryToCompleteSubscriber();

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableFixedCountMergeSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableFixedCountMergeSubscriber.java
@@ -28,7 +28,7 @@ final class CompletableFixedCountMergeSubscriber extends CompletableMergeSubscri
     private volatile int terminatedCount;
 
     CompletableFixedCountMergeSubscriber(Subscriber subscriber, int expectedCount, boolean delayError) {
-        super(subscriber, delayError);
+        super(subscriber, delayError, expectedCount);
         this.expectedCount = expectedCount;
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeSubscriber.java
@@ -35,10 +35,10 @@ abstract class CompletableMergeSubscriber implements Subscriber {
     private final CancellableStack dynamicCancellable;
     private final boolean delayError;
 
-    CompletableMergeSubscriber(Subscriber subscriber, boolean delayError) {
+    CompletableMergeSubscriber(Subscriber subscriber, boolean delayError, int maxCancellables) {
         this.subscriber = subscriber;
         this.delayError = delayError;
-        dynamicCancellable = new CancellableStack();
+        dynamicCancellable = new CancellableStack(maxCancellables);
         subscriber.onSubscribe(dynamicCancellable);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/IterableMergeCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/IterableMergeCompletable.java
@@ -37,7 +37,7 @@ final class IterableMergeCompletable extends AbstractMergeCompletableOperator<Co
 
     @Override
     void doMerge(final CompletableDynamicCountSubscriber subscriber) {
-        long count = 1;
+        int count = 1;
         for (Completable itr : others) {
             ++count;
             itr.subscribeInternal(subscriber);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Processors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Processors.java
@@ -53,6 +53,22 @@ public final class Processors {
     }
 
     /**
+     * Create a new {@link CompletableSource.Processor} that allows for multiple
+     * {@link CompletableSource.Subscriber#subscribe(CompletableSource.Subscriber) subscribes}. The returned
+     * {@link CompletableSource.Processor} provides all the expected API guarantees when used as a
+     * {@link CompletableSource} but does not expect the same guarantees when used as a
+     * {@link CompletableSource.Subscriber}. As an example, users are not expected to call
+     * {@link CompletableSource.Subscriber#onSubscribe(Cancellable)} or they can call any of the
+     * {@link CompletableSource.Subscriber} methods concurrently and/or multiple times.
+     * @param maxSubscribers The maximum amount of {@link CompletableSource.Subscriber} that can be subscribed.
+     * @return a new {@link CompletableSource.Processor} that allows for multiple
+     * {@link CompletableSource.Subscriber#subscribe(CompletableSource.Subscriber) subscribes}.
+     */
+    public static CompletableSource.Processor newCompletableProcessor(int maxSubscribers) {
+        return new CompletableProcessor(maxSubscribers);
+    }
+
+    /**
      * Create a new {@link SingleSource.Processor} that allows for multiple
      * {@link SingleSource.Subscriber#subscribe(SingleSource.Subscriber) subscribes}. The returned
      * {@link SingleSource.Processor} provides all the expected API guarantees when used as a
@@ -68,6 +84,24 @@ public final class Processors {
      */
     public static <T> SingleSource.Processor<T, T> newSingleProcessor() {
         return new SingleProcessor<>();
+    }
+
+    /**
+     * Create a new {@link SingleSource.Processor} that allows for multiple
+     * {@link SingleSource.Subscriber#subscribe(SingleSource.Subscriber) subscribes}. The returned
+     * {@link SingleSource.Processor} provides all the expected API guarantees when used as a
+     * {@link SingleSource} but does not expect the same guarantees when used as a
+     * {@link SingleSource.Subscriber}. As an example, users are not expected to call
+     * {@link SingleSource.Subscriber#onSubscribe(Cancellable)} or they can call any of the
+     * {@link SingleSource.Subscriber} methods concurrently and/or multiple times.
+     * @param maxSubscribers The maximum amount of {@link CompletableSource.Subscriber} that can be subscribed.
+     * @param <T> The {@link SingleSource} type and {@link SingleSource.Subscriber} type of the
+     * {@link SingleSource.Processor}.
+     * @return a new {@link SingleSource.Processor} that allows for multiple
+     * {@link SingleSource.Subscriber#subscribe(SingleSource.Subscriber) subscribes}.
+     */
+    public static <T> SingleSource.Processor<T, T> newSingleProcessor(int maxSubscribers) {
+        return new SingleProcessor<>(maxSubscribers);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/AbstractCompositeCancellableTest.java
@@ -34,13 +34,13 @@ public abstract class AbstractCompositeCancellableTest<T extends Cancellable> {
     @RegisterExtension
     static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
 
-    protected abstract T newCompositeCancellable();
+    protected abstract T newCompositeCancellable(int maxCancellables);
 
     protected abstract boolean add(T composite, Cancellable c);
 
     @Test
     void testCancel() {
-        T c = newCompositeCancellable();
+        T c = newCompositeCancellable(1);
         Cancellable cancellable = mock(Cancellable.class);
         add(c, cancellable);
         c.cancel();
@@ -49,7 +49,7 @@ public abstract class AbstractCompositeCancellableTest<T extends Cancellable> {
 
     @Test
     void testAddPostCancel() {
-        T c = newCompositeCancellable();
+        T c = newCompositeCancellable(1);
         c.cancel();
         Cancellable cancellable = mock(Cancellable.class);
         add(c, cancellable);
@@ -61,7 +61,7 @@ public abstract class AbstractCompositeCancellableTest<T extends Cancellable> {
         final int addThreads = 1000;
         final CyclicBarrier barrier = new CyclicBarrier(addThreads + 1);
         final List<Single<Cancellable>> cancellableSingles = new ArrayList<>(addThreads);
-        T dynamicCancellable = newCompositeCancellable();
+        T dynamicCancellable = newCompositeCancellable(addThreads);
         for (int i = 0; i < addThreads; ++i) {
             cancellableSingles.add(EXECUTOR_RULE.executor().submit(() -> {
                 Cancellable c = mock(Cancellable.class);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CancellableSetTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CancellableSetTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 class CancellableSetTest extends AbstractCompositeCancellableTest<CancellableSet> {
     @Override
-    protected CancellableSet newCompositeCancellable() {
+    protected CancellableSet newCompositeCancellable(int maxCancellables) {
         return new CancellableSet();
     }
 
@@ -38,7 +38,7 @@ class CancellableSetTest extends AbstractCompositeCancellableTest<CancellableSet
 
     @Test
     void testAddAndRemove() {
-        CancellableSet c = newCompositeCancellable();
+        CancellableSet c = newCompositeCancellable(1);
         Cancellable cancellable = mock(Cancellable.class);
         add(c, cancellable);
         c.remove(cancellable);
@@ -48,7 +48,7 @@ class CancellableSetTest extends AbstractCompositeCancellableTest<CancellableSet
 
     @Test
     void duplicateAddDoesNotCancel() {
-        CancellableSet c = newCompositeCancellable();
+        CancellableSet c = newCompositeCancellable(2);
         Cancellable cancellable = mock(Cancellable.class);
         int addCount = 0;
         if (add(c, cancellable)) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ClosableConcurrentStackTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -47,8 +48,8 @@ class ClosableConcurrentStackTest {
 
     @Test
     void singleThreadPushClose() {
-        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
+        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>(itemCount);
         for (int i = 0; i < itemCount; ++i) {
             stack.push(i);
         }
@@ -64,8 +65,8 @@ class ClosableConcurrentStackTest {
 
     @Test
     void singleThreadPushRemove() {
-        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
+        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>(itemCount);
         for (int i = 0; i < itemCount; ++i) {
             stack.push(i);
         }
@@ -77,9 +78,18 @@ class ClosableConcurrentStackTest {
     }
 
     @Test
+    void maxItemCountExceeded() {
+        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>(1);
+        stack.push(1);
+        assertThrows(IllegalStateException.class, () -> stack.push(2));
+        assertTrue(stack.relaxedRemove(1));
+        closeAssertEmpty(stack);
+    }
+
+    @Test
     void concurrentPushClose() throws Exception {
-        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
+        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>(itemCount);
         CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
         List<Completable> completableList = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; ++i) {
@@ -107,8 +117,8 @@ class ClosableConcurrentStackTest {
 
     @Test
     void concurrentPushRemove() throws Exception {
-        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
+        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>(itemCount);
         CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
         List<Completable> completableList = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; ++i) {
@@ -132,8 +142,8 @@ class ClosableConcurrentStackTest {
 
     @Test
     void concurrentPushRemoveDifferentThread() throws Exception {
-        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
+        ClosableConcurrentStack<Integer> stack = new ClosableConcurrentStack<>(itemCount);
         CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
         List<Completable> completableList = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; ++i) {
@@ -157,8 +167,8 @@ class ClosableConcurrentStackTest {
 
     @Test
     void concurrentClosePushRemove() throws Exception {
-        ClosableConcurrentStack<Cancellable> stack = new ClosableConcurrentStack<>();
         final int itemCount = 1000;
+        ClosableConcurrentStack<Cancellable> stack = new ClosableConcurrentStack<>(itemCount);
         CyclicBarrier barrier = new CyclicBarrier(itemCount + 1);
         List<Single<Cancellable>> completableList = new ArrayList<>(itemCount);
         for (int i = 0; i < itemCount; ++i) {


### PR DESCRIPTION
Motivation:
`Processors.new[Single|Completable]Processor` create a `Processor`s
that permit an unbounded number of `Subscriber`s. This may result
in memory pressure in some scenarios where the number of `Subscriber`s
is high.

Modifications:
- `ClosableConcurrentStack` to support `maxSize` to bound
  memory for its use cases.
- Add new methods for `Processors.new[Single|Completable]Processor`
  that allow configuring the maximum number of `Subscriber`s.

Result:
Completable/Single Processors and underlying data structure support
limiting the maximum amount of `Subscriber`s.