### PR TITLE
Reduce initial queue size for h1 pipelined connection

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
@@ -79,7 +79,7 @@ public class NettyPipelinedConnectionBenchmark {
     @Setup(Level.Trial)
     public void setup() throws ExecutionException, InterruptedException {
         executorService = Executors.newCachedThreadPool();
-        pipelinedConnection = new NettyPipelinedConnection<>(newNettyConnection());
+        pipelinedConnection = new NettyPipelinedConnection<>(newNettyConnection(), 32);
         prewarmExecutorThreads(executorService, 5);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedStreamingHttpConnection.java
@@ -32,7 +32,7 @@ final class PipelinedStreamingHttpConnection
                                      final HttpExecutionContext executionContext,
                                      final StreamingHttpRequestResponseFactory reqRespFactory,
                                      final boolean allowDropTrailersReadFromTransport) {
-        super(new NettyPipelinedConnection<>(connection),
+        super(new NettyPipelinedConnection<>(connection, config.maxPipelinedRequests()),
                 config.maxPipelinedRequests(), executionContext, reqRespFactory, config.headersFactory(),
                 allowDropTrailersReadFromTransport);
     }


### PR DESCRIPTION
Motivation:
NettyPipelinedConnection provides pipelined request/response
support on the client. It uses 2 queues: 1 for writes and 1
for reads. The initial queue sizes are not set and therefore
the default value of 1024 is selected. This number should be
correlated to the max number of pipelined requests expected
(which is often 1). This initial queue size is wasteful and
consumes extra memory per connection.

Modifications:
- Correlate queue size to max pipelined requests in
  NettyPipelinedConnection.

Result:
Less memory usage for h1 connections.