### PR TITLE
Reduce initial size of WriteStreamSubscriber queue

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -340,9 +340,9 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
          * </pre>
          * We assume that no listener for a write is added after that write is completed (a.k.a late listeners).
          * Most of the messages have 3 listeners (headers, one payload body chunk, trailers). Messages with large
-         * streaming payload body may have more listeners. However, the MIN_INITIAL_CAPACITY of ArrayDeque is 8.
+         * streaming payload body may have more listeners.
          */
-        private final Deque<GenericFutureListener<?>> listenersOnWriteBoundaries = new ArrayDeque<>(8);
+        private final Deque<GenericFutureListener<?>> listenersOnWriteBoundaries = new ArrayDeque<>(4);
         private final UnaryOperator<Throwable> enrichProtocolError;
 
         AllWritesPromise(final Channel channel, final UnaryOperator<Throwable> enrichProtocolError) {


### PR DESCRIPTION
Motivation:
WriteStreamSubscriber initial queue size is 8 however
most messages have ~3 items in the stream
{headers, payload, trailers}, and h2 may have 2 items.
We can save memory in most cases by reducing the initial
size from 8 to 4.