### PR TITLE
Reduce Publisher/Single retry/repeat allocations

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
@@ -123,6 +123,8 @@ final class RedoPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
             }
 
             if (shouldRedo) {
+                // Either we copy the map up front before subscribe, or we just re-use the same map and let the async
+                // source at the top of the chain reset if necessary. We currently choose the second option.
                 redoPublisher.original.delegateSubscribe(this, contextMap, contextProvider);
             } else {
                 notification.terminate(subscriber);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoWhenPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoWhenPublisher.java
@@ -78,6 +78,8 @@ final class RedoWhenPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
 
             @Override
             public void onComplete() {
+                // Either we copy the map up front before subscribe, or we just re-use the same map and let the async
+                // source at the top of the chain reset if necessary. We currently choose the second option.
                 redoPublisher.original.delegateSubscribe(RedoSubscriber.this, contextMap, contextProvider);
             }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatWhenSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatWhenSingle.java
@@ -84,6 +84,8 @@ final class RepeatWhenSingle<T> extends AbstractNoHandleSubscribePublisher<T> {
                 final long prev = outstandingDemandUpdater.getAndAccumulate(this, n,
                         FlowControlUtils::addWithOverflowProtectionIfNotNegative);
                 if (prev == 0) {
+                    // Either we copy the map up front before subscribe, or we just re-use the same map and let the async
+                    // source at the top of the chain reset if necessary. We currently choose the second option.
                     outer.original.delegateSubscribe(repeatSubscriber, contextMap, contextProvider);
                 }
             } else {
@@ -147,6 +149,9 @@ final class RepeatWhenSingle<T> extends AbstractNoHandleSubscribePublisher<T> {
                             break;
                         } else if (outstandingDemandUpdater.compareAndSet(RepeatSubscription.this, prev, prev - 1)) {
                             if (prev > 1) {
+                                // Either we copy the map up front before subscribe, or we just re-use the same map and
+                                // let the async source at the top of the chain reset if necessary. We currently choose
+                                // the second option.
                                 outer.original.delegateSubscribe(RepeatSubscriber.this, contextMap, contextProvider);
                             }
                             break;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatWhenSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatWhenSingle.java
@@ -84,8 +84,8 @@ final class RepeatWhenSingle<T> extends AbstractNoHandleSubscribePublisher<T> {
                 final long prev = outstandingDemandUpdater.getAndAccumulate(this, n,
                         FlowControlUtils::addWithOverflowProtectionIfNotNegative);
                 if (prev == 0) {
-                    // Either we copy the map up front before subscribe, or we just re-use the same map and let the async
-                    // source at the top of the chain reset if necessary. We currently choose the second option.
+                    // Either we copy the map up front before subscribe, or we just re-use the same map and let the
+                    // async source at the top of the chain reset if necessary. We currently choose the second option.
                     outer.original.delegateSubscribe(repeatSubscriber, contextMap, contextProvider);
                 }
             } else {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetrySingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetrySingle.java
@@ -102,6 +102,8 @@ final class RetrySingle<T> extends AbstractNoHandleSubscribeSingle<T> {
                 return;
             }
             if (shouldRetry) {
+                // Either we copy the map up front before subscribe, or we just re-use the same map and let the async
+                // source at the top of the chain reset if necessary. We currently choose the second option.
                 retrySingle.original.delegateSubscribe(this, contextMap, contextProvider);
             } else {
                 target.onError(t);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryWhenSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryWhenSingle.java
@@ -49,11 +49,26 @@ final class RetryWhenSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
     }
 
     private static final class RetrySubscriber<T> extends RetrySingle.AbstractRetrySubscriber<T> {
-
         private final SequentialCancellable retrySignalCancellable;
         private final RetryWhenSingle<T> retrySingle;
         private final ContextMap contextMap;
         private final AsyncContextProvider contextProvider;
+        private final CompletableSource.Subscriber completableSubscriber = new CompletableSource.Subscriber() {
+            @Override
+            public void onSubscribe(Cancellable completableCancellable) {
+                retrySignalCancellable.nextCancellable(completableCancellable);
+            }
+
+            @Override
+            public void onComplete() {
+                retrySingle.original.delegateSubscribe(RetrySubscriber.this, contextMap, contextProvider);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                target.onError(t);
+            }
+        };
 
         RetrySubscriber(SequentialCancellable cancellable, int redoCount, Subscriber<? super T> subscriber,
                         ContextMap contextMap, AsyncContextProvider contextProvider,
@@ -85,34 +100,14 @@ final class RetryWhenSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
         public void onError(Throwable t) {
             final Completable retryDecider;
             try {
-                retryDecider = requireNonNull(retrySingle.shouldRetry.apply(retryCount + 1, t));
+                retryDecider = requireNonNull(retrySingle.shouldRetry.apply(++retryCount, t));
             } catch (Throwable cause) {
                 cause.addSuppressed(t);
                 target.onError(cause);
                 return;
             }
 
-            retryDecider.subscribeInternal(new CompletableSource.Subscriber() {
-                @Override
-                public void onSubscribe(Cancellable completableCancellable) {
-                    retrySignalCancellable.nextCancellable(completableCancellable);
-                }
-
-                @Override
-                public void onComplete() {
-                    // For the current subscribe operation we want to use contextMap directly, but in the event a
-                    // re-subscribe operation occurs we want to restore the original state of the AsyncContext map, so
-                    // we save a copy upfront.
-                    retrySingle.original.delegateSubscribe(new RetrySubscriber<>(sequentialCancellable,
-                            retryCount + 1, target, contextMap.copy(), contextProvider, retrySingle),
-                            contextMap, contextProvider);
-                }
-
-                @Override
-                public void onError(Throwable t) {
-                    target.onError(t);
-                }
-            });
+            retryDecider.subscribeInternal(completableSubscriber);
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryWhenSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryWhenSingle.java
@@ -61,6 +61,8 @@ final class RetryWhenSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
 
             @Override
             public void onComplete() {
+                // Either we copy the map up front before subscribe, or we just re-use the same map and let the async
+                // source at the top of the chain reset if necessary. We currently choose the second option.
                 retrySingle.original.delegateSubscribe(RetrySubscriber.this, contextMap, contextProvider);
             }
 


### PR DESCRIPTION
Motivation:
RepeatWhenSingle was recently introduced and avoids allocating
new Subscribers for each repeat operation. This helps save
object allocation when the operator is used in a loop. We
should use a consistent strategy for existing Publisher/Single
repeat/retry related operators.

Modifications:
- Redo[When]Publisher and Retry[When]Single no longer allocates
  a new Subscriber on each iteration.
- All the repeat/retry operators now have consistent behavior
  for AsyncContext map which is to re-use it. Previously a copy
  was made before resubscribing, however the old map is no longer
  used after a terminal event anyways so this shouldn't have any
  benefit. Either we copy the map up front before subscribe, or
  we just re-use the same map and let the async source at the top
  of the chain reset if necessary.

Result:
Less object allocation and consistent AsyncContext behavior for
repeat/retry operators.