### PR TITLE
Add netty-tcnative-boringssl-static runtime dependency

### DIFF
--- a/servicetalk-examples/http/http2/build.gradle
+++ b/servicetalk-examples/http/http2/build.gradle
@@ -27,11 +27,5 @@ dependencies {
   // Users have to use their own certificates instead.
   implementation project(":servicetalk-test-resources")
 
-  // This dependency enables OpenSSL provider that supports ALPN. It's recommended to use OpenSSL provider for the
-  // best SSL performance. Users who prefers to use JDK provider have to make sure their JDK or classpath supports ALPN.
-  // For more information about how to enable ALPN support on JDK,
-  // see https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html
-  runtimeOnly "io.netty:netty-tcnative-boringssl-static"
-
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-examples/http/mutual-tls/build.gradle
+++ b/servicetalk-examples/http/mutual-tls/build.gradle
@@ -27,9 +27,5 @@ dependencies {
   // Users have to use their own certificates instead.
   implementation project(":servicetalk-test-resources")
 
-  // This dependency enables OpenSSL provider that supports ALPN. It's recommended to use OpenSSL provider for the
-  // best SSL performance.
-  runtimeOnly "io.netty:netty-tcnative-boringssl-static"
-
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-examples/http/redirects/build.gradle
+++ b/servicetalk-examples/http/redirects/build.gradle
@@ -29,9 +29,5 @@ dependencies {
   // Users have to use their own certificates instead.
   implementation project(":servicetalk-test-resources")
 
-  // This dependency enables OpenSSL provider that supports ALPN. It's recommended to use OpenSSL provider for the
-  // best SSL performance.
-  runtimeOnly "io.netty:netty-tcnative-boringssl-static"
-
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -64,7 +64,6 @@ dependencies {
   }
   testImplementation "io.grpc:grpc-protobuf"
   testImplementation "io.grpc:grpc-stub"
-  testImplementation "io.netty:netty-tcnative-boringssl-static"
   testImplementation "jakarta.annotation:jakarta.annotation-api:$javaxAnnotationsApiVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -54,7 +54,7 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-utils-internal")
   testImplementation project(":servicetalk-oio-api-internal")
-  testImplementation "io.netty:netty-transport-native-unix-common"s
+  testImplementation "io.netty:netty-transport-native-unix-common"
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -54,8 +54,7 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-utils-internal")
   testImplementation project(":servicetalk-oio-api-internal")
-  testImplementation "io.netty:netty-transport-native-unix-common"
-  testImplementation "io.netty:netty-tcnative-boringssl-static"
+  testImplementation "io.netty:netty-transport-native-unix-common"s
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -39,7 +39,6 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "io.netty:netty-tcnative-boringssl-static"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -42,6 +42,10 @@ dependencies {
   implementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   runtimeOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
   runtimeOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"
+  runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"linux-x86_64")
+  runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"linux-aarch_64")
+  runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"osx-x86_64")
+  runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"osx-aarch_64")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))


### PR DESCRIPTION
Motivation:
netty-tcnative-boringssl-static accelerates TLS and is enabled
if included on the classpath. ServiceTalk include's Netty's bom
which now also includes the compatible tcnative version, so we
can include this dependency to simplify version alignment.

Modifications:
- Add netty-tcnative-boringssl-static runtimeOnly dependency for
  macOS/linux x86-64/aarch-64

Result:
Accelerated TLS without coordinating versions manually.