### PR TITLE
Minor improvement in Github action names

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -4,7 +4,7 @@ on:
     branches: [ main, '0.41', '0.42' ]
 jobs:
   build:
-    name: Build JDK ${{ matrix.java }} ${{ matrix.os }}
+    name: JDK ${{ matrix.java }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -4,6 +4,7 @@ on:
     branches: [ main, '0.41', '0.42' ]
 jobs:
   quality:
+    name: JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -3,7 +3,6 @@ on: [push, pull_request]
 
 jobs:
   validation:
-    name: "Gradle wrapper validation"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
Motivation:
Our GitHub action names have some duplicate info when displayed
in PRB builds (e.g. `PR Builder / Build JDK 8 ubuntu-latest`)
and also not consistent between PRB and PRQ.