### PR TITLE
Explain wire/frame logging `logUserData`

### DIFF
--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
@@ -43,7 +43,9 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * </ol>
  * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
  * example {@code log4j2.xml} is used by both the client and server and configures the
- * ({@code servicetalk-examples-wire-logger} logger at {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level.
+ * {@code servicetalk-examples-wire-logger} and {@code servicetalk-examples-h2-frame-logger} loggers at
+ * {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level. Wire logging is configured to include logging of all
+ * user data contained in the payload, see {@link #LOG_USER_DATA}.
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>
@@ -108,6 +110,15 @@ public final class DebuggingClient {
          */
         // AsyncContext.disable();
     }
+
+    /**
+     * If {@link Boolean#TRUE} then all user data in the payload will be logged in addition to the protocol metadata.
+     * If {@link Boolean#FALSE} then protocol operations will be logged, but user data contents will be omitted.
+     *
+     * <p>This implementation uses a constant function to enable or disable logging of user data, your implementation
+     * could selectively choose to log user data based upon application state or context.</p>
+     */
+    static final BooleanSupplier LOG_USER_DATA = Boolean.TRUE::booleanValue;
 
     public static void main(String[] args) throws Exception {
         try (BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
@@ -110,14 +110,16 @@ public final class DebuggingServer {
     }
 
     /**
-     * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
-     * {@code Boolean.TRUE::booleanValue}.
+     * Logging of protocol user data is disabled to reduce output but can be enabled by using
+     * {@code Boolean.TRUE::booleanValue}. Logging user data may expose sensitive content contained in the headers or
+     * payload body. Care and consideration should be taken before enabling this feature on production systems.
      *
-     * <p>If {@link Boolean#TRUE} then all user data in the payload will be logged in addition to the protocol metadata.
-     * <p>If {@link Boolean#FALSE} then protocol operations will be logged, but user data contents will be omitted.
+     * <p>If {@link Boolean#TRUE} then all user data in the headers and payload bodies will be logged in addition to
+     * network events.
+     * <p>If {@link Boolean#FALSE} then only network events will be logged, but user data contents will be omitted.
      *
      * <p>This implementation uses a constant function to enable or disable logging of user data, your implementation
-     * could selectively choose to log user data based upon application state or context.</p>
+     * could selectively choose at runtime to log user data based upon application state or context.</p>
      */
     static final BooleanSupplier LOG_USER_DATA = Boolean.FALSE::booleanValue;
 

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
@@ -37,7 +37,9 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * </ol>
  * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
  * example {@code log4j2.xml} is used by both the client and server and configures the
- * ({@code servicetalk-examples-wire-logger} logger at {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level.
+ * {@code servicetalk-examples-wire-logger} and {@code servicetalk-examples-h2-frame-logger} loggers at
+ * {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level. Wire logging is configured to include logging of all
+ * user data contained in the payload, see {@link #LOG_USER_DATA}.
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>
@@ -107,6 +109,18 @@ public final class DebuggingServer {
         // AsyncContext.disable();
     }
 
+    /**
+     * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+     * {@code Boolean.TRUE::booleanValue}.
+     *
+     * <p>If {@link Boolean#TRUE} then all user data in the payload will be logged in addition to the protocol metadata.
+     * <p>If {@link Boolean#FALSE} then protocol operations will be logged, but user data contents will be omitted.
+     *
+     * <p>This implementation uses a constant function to enable or disable logging of user data, your implementation
+     * could selectively choose to log user data based upon application state or context.</p>
+     */
+    static final BooleanSupplier LOG_USER_DATA = Boolean.FALSE::booleanValue;
+
     public static void main(String[] args) throws Exception {
         GrpcServers.forPort(8080)
                 .initializeHttp(builder -> {
@@ -125,18 +139,16 @@ public final class DebuggingServer {
                              * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                              * {@code Boolean.TRUE::booleanValue}.
                              */
-                            .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.FALSE::booleanValue)
+                            .enableWireLogging("servicetalk-examples-wire-logger", TRACE, LOG_USER_DATA)
 
                             /*
                              * 4. Enables detailed logging of HTTP2 frames, but not frame contents.
                              * Be sure to also enable the logger in your logging config file,
                              * {@code log4j2.xml} for this example.
-                             * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
-                             * {@code Boolean.TRUE::booleanValue}.
                              */
                             .protocols(HttpProtocolConfigs.h2()
                                     .enableFrameLogging(
-                                            "servicetalk-examples-h2-frame-logger", TRACE, Boolean.FALSE::booleanValue)
+                                            "servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
                                     .build());
                 })
                 .listenAndAwait((BlockingGreeterService) (ctx, request) ->

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -40,7 +40,9 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * </ol>
  * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
  * example {@code log4j2.xml} is used by both the client and server and configures the
- * ({@code servicetalk-examples-wire-logger} logger at {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level.
+ * {@code servicetalk-examples-wire-logger} and {@code servicetalk-examples-h2-frame-logger} loggers at
+ * {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level. Wire logging is configured to include logging of all
+ * user data contained in the payload, see {@link #LOG_USER_DATA}.
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>
@@ -141,6 +143,15 @@ public final class DebuggingExampleClient {
         // AsyncContext.disable();
     }
 
+    /**
+     * If {@link Boolean#TRUE} then all user data in the payload will be logged in addition to the protocol metadata.
+     * If {@link Boolean#FALSE} then protocol operations will be logged, but user data contents will be omitted.
+     *
+     * <p>This implementation uses a constant function to enable or disable logging of user data, your implementation
+     * could selectively choose to log user data based upon application state or context.</p>
+     */
+    static final BooleanSupplier LOG_USER_DATA = Boolean.TRUE::booleanValue;
+
     public static void main(String... args) throws Exception {
         try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080)
                 /*
@@ -154,14 +165,14 @@ public final class DebuggingExampleClient {
                  * 3. Enables detailed logging of I/O and I/O states.
                  * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
                  */
-                .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                .enableWireLogging("servicetalk-examples-wire-logger", TRACE, LOG_USER_DATA)
 
                 /*
                  * 4. Enables detailed logging of HTTP2 frames.
                  * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
                  */
                 .protocols(HttpProtocolConfigs.h2()
-                        .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
+                        .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
                         .build())
                 .build()) {
             client.request(client.post("/sayHello").payloadBody("George", textSerializerUtf8()))

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -144,11 +144,15 @@ public final class DebuggingExampleClient {
     }
 
     /**
-     * If {@link Boolean#TRUE} then all user data in the payload will be logged in addition to the protocol metadata.
-     * If {@link Boolean#FALSE} then protocol operations will be logged, but user data contents will be omitted.
+     * Log all protocol user data. Logging user data may expose sensitive content contained in the headers or payload
+     * body. Care and consideration should be taken before enabling this feature on production systems.
+     *
+     * <p>If {@link Boolean#TRUE} then all user data in the headers and payload bodies will be logged in addition to
+     * network events.
+     * <p>If {@link Boolean#FALSE} then only network events will be logged, but user data contents will be omitted.
      *
      * <p>This implementation uses a constant function to enable or disable logging of user data, your implementation
-     * could selectively choose to log user data based upon application state or context.</p>
+     * could selectively choose at runtime to log user data based upon application state or context.</p>
      */
     static final BooleanSupplier LOG_USER_DATA = Boolean.TRUE::booleanValue;
 

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -40,7 +40,9 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * </ol>
  * <p>The wire and frame logging features require that you configure a logger with an appropriate log level. For this
  * example {@code log4j2.xml} is used by both the client and server and configures the
- * ({@code servicetalk-examples-wire-logger} logger at {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level.
+ * {@code servicetalk-examples-wire-logger} and {@code servicetalk-examples-h2-frame-logger} loggers at
+ * {@link io.servicetalk.logging.api.LogLevel#TRACE TRACE} level. Wire logging is configured to include logging of all
+ * user data contained in the payload, see {@link #LOG_USER_DATA}.
  *
  * <p>When configured correctly the output should be similar to the following:
  * <pre>
@@ -136,6 +138,15 @@ public final class DebuggingExampleServer {
         // AsyncContext.disable();
     }
 
+    /**
+     * If {@link Boolean#TRUE} then all user data in the payload will be logged in addition to the protocol metadata.
+     * If {@link Boolean#FALSE} then protocol operations will be logged, but user data contents will be omitted.
+     *
+     * <p>This implementation uses a constant function to enable or disable logging of user data, your implementation
+     * could selectively choose to log user data based upon application state or context.</p>
+     */
+    static final BooleanSupplier LOG_USER_DATA = Boolean.FALSE::booleanValue;
+
     public static void main(String... args) throws Exception {
         HttpServers.forPort(8080)
                 /*
@@ -149,14 +160,14 @@ public final class DebuggingExampleServer {
                  * 3. Enables detailed logging of I/O and I/O states.
                  * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
                  */
-                .enableWireLogging("servicetalk-examples-wire-logger", TRACE, Boolean.TRUE::booleanValue)
+                .enableWireLogging("servicetalk-examples-wire-logger", TRACE, LOG_USER_DATA)
 
                 /*
                  * 4. Enables detailed logging of HTTP2 frames.
                  * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
                  */
                 .protocols(HttpProtocolConfigs.h2()
-                        .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, Boolean.TRUE::booleanValue)
+                        .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
                         .build())
                 .listenAndAwait((ctx, request, responseFactory) -> {
                     String who = request.payloadBody(textSerializerUtf8());

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -139,13 +139,17 @@ public final class DebuggingExampleServer {
     }
 
     /**
-     * If {@link Boolean#TRUE} then all user data in the payload will be logged in addition to the protocol metadata.
-     * If {@link Boolean#FALSE} then protocol operations will be logged, but user data contents will be omitted.
+     * Log all protocol user data. Logging user data may expose sensitive content contained in the headers or payload
+     * body. Care and consideration should be taken before enabling this feature on production systems.
+     *
+     * <p>If {@link Boolean#TRUE} then all user data in the headers and payload bodies will be logged in addition to
+     * network events.
+     * <p>If {@link Boolean#FALSE} then only network events will be logged, but user data contents will be omitted.
      *
      * <p>This implementation uses a constant function to enable or disable logging of user data, your implementation
-     * could selectively choose to log user data based upon application state or context.</p>
+     * could selectively choose at runtime to log user data based upon application state or context.</p>
      */
-    static final BooleanSupplier LOG_USER_DATA = Boolean.FALSE::booleanValue;
+    static final BooleanSupplier LOG_USER_DATA = Boolean.TRUE::booleanValue;
 
     public static void main(String... args) throws Exception {
         HttpServers.forPort(8080)

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/package-info.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.debugging;
 
-apply plugin: "java"
-apply from: "../../gradle/idea.gradle"
-
-dependencies {
-  implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-http-netty")
-
-  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-}
+import io.servicetalk.annotations.ElementsAreNonnullByDefault; /**
+ * Async "Hello World" example extended to demonstrate configuring of debugging features.
+ */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -100,7 +100,7 @@ public interface HttpServerBuilder {
      * @param loggerName The name of the logger to log wire events.
      * @param logLevel The level to log at.
      * @param logUserData {@code true} to include user data (e.g. data, headers, etc.). {@code false} to exclude user
-     * data and log only network events.
+     * data and log only network events. This method is invoked for each data object allowing for dynamic behavior.
      * @return {@code this}.
      */
     HttpServerBuilder enableWireLogging(String loggerName, LogLevel logLevel, BooleanSupplier logUserData);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -75,7 +75,7 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * @param loggerName The name of the logger to log wire events.
      * @param logLevel The level to log at.
      * @param logUserData {@code true} to include user data (e.g. data, headers, etc.). {@code false} to exclude user
-     * data and log only network events.
+     * data and log only network events. This method is invoked for each data object allowing for dynamic behavior.
      * @return {@code this}.
      */
     SingleAddressHttpClientBuilder<U, R> enableWireLogging(String loggerName,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -80,7 +80,7 @@ public final class H2ProtocolConfigBuilder {
      * @param loggerName provides the logger to log HTTP/2 frames.
      * @param logLevel the level to log HTTP/2 frames.
      * @param logUserData {@code true} to include user data (e.g. data, headers, etc.). {@code false} to exclude user
-     * data and log only network events.
+     * data and log only network events. This method is invoked for each data object allowing for dynamic behavior.
      * @return {@code this}
      */
     public H2ProtocolConfigBuilder enableFrameLogging(final String loggerName,

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
@@ -154,7 +154,7 @@ public final class UdpReporter extends Component implements Reporter<Span>, Asyn
          * @param loggerName The name of the logger to log wire events.
          * @param logLevel The level to log at.
          * @param logUserData {@code true} to include user data. {@code false} to exclude user data and log only
-         * network events.
+         * network events. This method is invoked for each data object allowing for dynamic behavior.
          * @return {@code this}
          */
         public Builder enableWireLogging(String loggerName, LogLevel logLevel, BooleanSupplier logUserData) {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -123,12 +123,12 @@ abstract class AbstractTcpConfig<SslConfigType> {
     }
 
     /**
-     * Enable wire-logging for all connections. All wire events will be logged at trace level.
+     * Enable wire-logging for all connections.
      *
      * @param loggerName provides the logger to log data/events to/from the wire.
      * @param logLevel the level to log data/events to/from the wire.
      * @param logUserData {@code true} to include user data (e.g. data, headers, etc.). {@code false} to exclude user
-     * data and log only network events.
+     * data and log only network events. This method is invoked for each data object allowing for dynamic behavior.
      */
     public final void enableWireLogging(final String loggerName,
                                         final LogLevel logLevel,


### PR DESCRIPTION
Motivation:
The current debugging examples include a minimal explanation of the
`logUserData` feature of `enableWireLogging` and `enableFrameLogging`
which could be expanded to clarify the use.
Modifications:
Additional explanation of `logUserData` by provided by defining a
`LOG_USER_DATA` constant with JavaDoc
Result:
Improved examples.