### PR TITLE
Conditionally use ioExecutor timer for retry

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoWhenPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoWhenPublisher.java
@@ -41,11 +41,12 @@ final class RedoWhenPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
 
     /**
      * New instance.
-     *  @param original {@link Publisher} on which this operator is applied.
+     *
+     * @param original {@link Publisher} on which this operator is applied.
      * @param shouldRedo {@link BiFunction} to create a {@link Completable} that determines whether to redo the
      * operation.
      * @param forRetry If redo has to be done for error i.e. it is used for retry. If {@code true} completion for
- * original source will complete the subscriber. Otherwise, error will send the error to the subscriber.
+     * original source will complete the subscriber. Otherwise, error will send the error to the subscriber.
      */
     RedoWhenPublisher(Publisher<T> original, BiFunction<Integer, TerminalNotification, Completable> shouldRedo,
                       boolean forRetry) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -133,7 +133,8 @@ public final class RetryingHttpRequesterFilter
          */
         private ContextAwareRetryingHttpClientFilter(final FilterableStreamingHttpClient delegate) {
             super(delegate);
-            this.executor = delegate.executionContext().executor();
+            this.executor = delegate.executionContext().executionStrategy().hasOffloads() ?
+                    delegate.executionContext().executor() : delegate.executionContext().ioExecutor();
         }
 
         void inject(@Nullable final Publisher<Object> lbEventStream,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/LoadBalancerReadyHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/LoadBalancerReadyHttpClientTest.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.TestCompletable;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpClient;
@@ -55,6 +56,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
 import static io.servicetalk.http.api.FilterFactoryUtils.appendClientFilterFactory;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -102,6 +104,8 @@ class LoadBalancerReadyHttpClientTest {
             .when(mockReservedConnection).newRequest(any(), any());
         doAnswer((Answer<StreamingHttpResponseFactory>) invocation -> reqRespFactory)
                 .when(mockReservedConnection).httpResponseFactory();
+        doAnswer((Answer<HttpExecutionStrategy>) invocation -> offloadAll())
+                .when(mockExecutionCtx).executionStrategy();
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The `RetryingHttpRequesterFilter` uses the context executor timer for
scheduling retry attempt. If offloading is disabled it should use the
context ioExecutor timer instead.
Modifications:
Use the appropriate timer based upon context execution strategy.
Result:
Retry timer will not use the context executor for scheduled retries if
offloading is disabled.