### PR TITLE
Allow override of the `HttpHeadersFactory` for multi-address and partitioned clients

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ public interface MultiAddressHttpClientBuilder<U, R> extends HttpClientBuilder<U
     @Override
     MultiAddressHttpClientBuilder<U, R> ioExecutor(IoExecutor ioExecutor);
 
+    @Override
     MultiAddressHttpClientBuilder<U, R> executor(Executor executor);
 
     @Override
@@ -73,6 +74,18 @@ public interface MultiAddressHttpClientBuilder<U, R> extends HttpClientBuilder<U
 
     @Override
     MultiAddressHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);
+
+    /**
+     * Sets the {@link HttpHeadersFactory} to be used for creating {@link HttpHeaders} for new requests.
+     *
+     * @param headersFactory {@link HttpHeadersFactory} to be used for creating {@link HttpHeaders} for new requests
+     * @return {@code this}
+     */
+    default MultiAddressHttpClientBuilder<U, R> headersFactory(HttpHeadersFactory headersFactory) {
+        // FIXME: 0.43 - remove default implementation
+        throw new UnsupportedOperationException(
+                "MultiAddressHttpClientBuilder#headersFactory(HttpHeadersFactory) is not supported by " + getClass());
+    }
 
     /**
      * Set a function which can customize options for each {@link StreamingHttpClient} that is built.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionHttpClientBuilderConfigurator.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionHttpClientBuilderConfigurator.java
@@ -26,7 +26,7 @@ import io.servicetalk.client.api.partition.PartitionAttributes;
  */
 @Deprecated
 @FunctionalInterface
-public interface PartitionHttpClientBuilderConfigurator<U, R> {
+public interface PartitionHttpClientBuilderConfigurator<U, R> { // FIXME: 0.43 - remove deprecated interface
 
     /**
      * Configures the passed {@link SingleAddressHttpClientBuilder} for a given set of {@link PartitionAttributes}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/PartitionedHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,6 +86,18 @@ public interface PartitionedHttpClientBuilder<U, R> // FIXME: 0.43 - remove depr
 
     @Override
     PartitionedHttpClientBuilder<U, R> bufferAllocator(BufferAllocator allocator);
+
+    /**
+     * Sets the {@link HttpHeadersFactory} to be used for creating {@link HttpHeaders} for new requests.
+     *
+     * @param headersFactory {@link HttpHeadersFactory} to be used for creating {@link HttpHeaders} for new requests
+     * @return {@code this}
+     */
+    default PartitionedHttpClientBuilder<U, R> headersFactory(HttpHeadersFactory headersFactory) {
+        // FIXME: 0.43 - remove default implementation
+        throw new UnsupportedOperationException(
+                "PartitionedHttpClientBuilder#headersFactory(HttpHeadersFactory) is not supported by " + getClass());
+    }
 
     /**
      * Sets a {@link ServiceDiscoverer} to resolve addresses of remote servers to connect to.


### PR DESCRIPTION
Motivation:

A client instance is also used to create a request object because it
implements a request-response factory. Users of multi-address and
partitioned clients always use `DefaultHttpHeadersFactory.INSTANCE`.
There is no easy way to override headers factory. Use-cases: change
header name/value validation, preset some headers, etc.

Modifications:

- Add `MultiAddressHttpClientBuilder#headersFactory(HttpHeadersFactory)`
- Add `PartitionedHttpClientBuilder#headersFactory(HttpHeadersFactory)`
- Implement new methods;
- Test new feature for `MultiAddressHttpClientBuilder`;

Result:

Users of multi-address and partitioned clients can override the default
`HttpHeadersFactory`.