### PR TITLE
Decouple multi-address and partitioned client builders from `HttpClientBuildContext`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -35,12 +35,12 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.MultiAddressHttpClientBuilder;
 import io.servicetalk.http.api.RedirectConfig;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
-import io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.HttpClientBuildContext;
 import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
@@ -64,6 +64,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncClo
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.netty.HttpExecutionContextBuilder.setExecutionContext;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -85,7 +86,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder
 
     private static final String HTTPS_SCHEME = HTTPS.toString();
 
-    private final DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builderTemplate;
+    private final Function<HostAndPort, SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress>> builderFactory;
+    private final HttpExecutionContextBuilder executionContextBuilder = new HttpExecutionContextBuilder();
 
     @Nullable
     private HttpHeadersFactory headersFactory;
@@ -95,19 +97,17 @@ final class DefaultMultiAddressUrlHttpClientBuilder
     private SingleAddressInitializer<HostAndPort, InetSocketAddress> singleAddressInitializer;
 
     DefaultMultiAddressUrlHttpClientBuilder(
-            final DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builderTemplate) {
-        this.builderTemplate = requireNonNull(builderTemplate);
+            final Function<HostAndPort, SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress>> bFactory) {
+        this.builderFactory = requireNonNull(bFactory);
     }
 
     @Override
     public StreamingHttpClient buildStreaming() {
         final CompositeCloseable closeables = newCompositeCloseable();
         try {
-            final HttpClientBuildContext<HostAndPort, InetSocketAddress> buildContext = builderTemplate.copyBuildCtx();
-
-            final ClientFactory clientFactory = new ClientFactory(buildContext.builder, singleAddressInitializer);
-
-            final HttpExecutionContext executionContext = buildContext.builder.executionContextBuilder.build();
+            final HttpExecutionContext executionContext = executionContextBuilder.build();
+            final ClientFactory clientFactory = new ClientFactory(builderFactory, executionContext,
+                    singleAddressInitializer);
             final CachingKeyFactory keyFactory = closeables.prepend(new CachingKeyFactory());
             final HttpHeadersFactory headersFactory = this.headersFactory;
             FilterableStreamingHttpClient urlClient = closeables.prepend(
@@ -120,13 +120,8 @@ final class DefaultMultiAddressUrlHttpClientBuilder
             urlClient = redirectConfig == null ? urlClient :
                     new RedirectingHttpRequesterFilter(redirectConfig).create(urlClient);
 
-            HttpExecutionStrategy computedStrategy =
-                    buildContext.builder.computeChainStrategy(executionContext.executionStrategy());
-
-            LOGGER.debug("Client created with base strategy {} → computed strategy {}",
-                    executionContext.executionStrategy(), computedStrategy);
-
-            return new FilterableClientToClient(urlClient, computedStrategy);
+            LOGGER.debug("Multi-address client created with base strategy {}", executionContext.executionStrategy());
+            return new FilterableClientToClient(urlClient, executionContext.executionStrategy());
         } catch (final Throwable t) {
             closeables.closeAsync().subscribe();
             throw t;
@@ -220,32 +215,36 @@ final class DefaultMultiAddressUrlHttpClientBuilder
 
     private static final class ClientFactory implements Function<UrlKey, FilterableStreamingHttpClient> {
         private static final ClientSslConfig DEFAULT_CLIENT_SSL_CONFIG = new ClientSslConfigBuilder().build();
-        private final DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builderTemplate;
+        private final Function<HostAndPort, SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress>>
+                builderFactory;
+        private final HttpExecutionContext executionContext;
         @Nullable
         private final SingleAddressInitializer<HostAndPort, InetSocketAddress> singleAddressInitializer;
 
-        ClientFactory(
-                final DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builderTemplate,
+        ClientFactory(final Function<HostAndPort, SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress>>
+                        builderFactory,
+                final HttpExecutionContext executionContext,
                 @Nullable final SingleAddressInitializer<HostAndPort, InetSocketAddress> singleAddressInitializer) {
-            this.builderTemplate = builderTemplate;
+            this.builderFactory = builderFactory;
+            this.executionContext = executionContext;
             this.singleAddressInitializer = singleAddressInitializer;
         }
 
         @Override
         public StreamingHttpClient apply(final UrlKey urlKey) {
-            // Copy existing builder to prevent changes at runtime when concurrently creating clients for new addresses
-            final HttpClientBuildContext<HostAndPort, InetSocketAddress> buildContext =
-                    builderTemplate.copyBuildCtx(urlKey.hostAndPort);
+            final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                    builderFactory.apply(urlKey.hostAndPort);
 
+            setExecutionContext(builder, executionContext);
             if (HTTPS_SCHEME.equalsIgnoreCase(urlKey.scheme)) {
-                buildContext.builder.sslConfig(DEFAULT_CLIENT_SSL_CONFIG);
+                builder.sslConfig(DEFAULT_CLIENT_SSL_CONFIG);
             }
 
             if (singleAddressInitializer != null) {
-                singleAddressInitializer.initialize(urlKey.scheme, urlKey.hostAndPort, buildContext.builder);
+                singleAddressInitializer.initialize(urlKey.scheme, urlKey.hostAndPort, builder);
             }
 
-            return buildContext.build();
+            return builder.buildStreaming();
         }
     }
 
@@ -330,27 +329,27 @@ final class DefaultMultiAddressUrlHttpClientBuilder
 
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> ioExecutor(final IoExecutor ioExecutor) {
-        builderTemplate.ioExecutor(ioExecutor);
+        executionContextBuilder.ioExecutor(ioExecutor);
         return this;
     }
 
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> executor(final Executor executor) {
-        builderTemplate.executor(executor);
+        executionContextBuilder.executor(executor);
         return this;
     }
 
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> bufferAllocator(
             final BufferAllocator allocator) {
-        builderTemplate.bufferAllocator(allocator);
+        executionContextBuilder.bufferAllocator(allocator);
         return this;
     }
 
     @Override
     public MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> executionStrategy(
             final HttpExecutionStrategy strategy) {
-        builderTemplate.executionStrategy(strategy);
+        executionContextBuilder.executionStrategy(strategy);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -64,7 +64,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncClo
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
-import static io.servicetalk.http.netty.HttpExecutionContextBuilder.setExecutionContext;
+import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.setExecutionContext;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -233,7 +233,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         @Override
         public StreamingHttpClient apply(final UrlKey urlKey) {
             final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
-                    builderFactory.apply(urlKey.hostAndPort);
+                    requireNonNull(builderFactory.apply(urlKey.hostAndPort));
 
             setExecutionContext(builder, executionContext);
             if (HTTPS_SCHEME.equalsIgnoreCase(urlKey.scheme)) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -66,7 +66,7 @@ import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_INIT_DURATION;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_JITTER;
-import static io.servicetalk.http.netty.HttpExecutionContextBuilder.setExecutionContext;
+import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.setExecutionContext;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
@@ -112,7 +112,7 @@ final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttp
 
         final PartitionedClientFactory<U, R, FilterableStreamingHttpClient> clientFactory = (pa, sd) -> {
             // build new context, user may have changed anything on the builder from the filter
-            final SingleAddressHttpClientBuilder<U, R> builder = builderFactory.get();
+            final SingleAddressHttpClientBuilder<U, R> builder = requireNonNull(builderFactory.get());
             builder.serviceDiscoverer(sd);
             setExecutionContext(builder, executionContext);
             if (clientInitializer != null) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -149,6 +149,14 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         retryingHttpRequesterFilter = from.retryingHttpRequesterFilter;
     }
 
+    static <U, R> SingleAddressHttpClientBuilder<U, R> setExecutionContext(
+            final SingleAddressHttpClientBuilder<U, R> builder, final HttpExecutionContext context) {
+        return builder.ioExecutor(context.ioExecutor())
+                .executor(context.executor())
+                .bufferAllocator(context.bufferAllocator())
+                .executionStrategy(context.executionStrategy());
+    }
+
     private static final class HttpClientBuildContext<U, R> {
         final DefaultSingleAddressHttpClientBuilder<U, R> builder;
         private final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> sd;
@@ -384,7 +392,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> proxyAddress(final U proxyAddress) {
+    public DefaultSingleAddressHttpClientBuilder<U, R> proxyAddress(final U proxyAddress) {
         this.proxyAddress = requireNonNull(proxyAddress);
         config.connectAddress(hostToCharSequenceFunction.apply(address));
         return this;
@@ -403,7 +411,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> executionStrategy(final HttpExecutionStrategy strategy) {
+    public DefaultSingleAddressHttpClientBuilder<U, R> executionStrategy(final HttpExecutionStrategy strategy) {
         executionContextBuilder.executionStrategy(strategy);
         return this;
     }
@@ -421,7 +429,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> enableWireLogging(final String loggerName, final LogLevel logLevel,
+    public DefaultSingleAddressHttpClientBuilder<U, R> enableWireLogging(final String loggerName, final LogLevel logLevel,
                                                                   final BooleanSupplier logUserData) {
         config.tcpConfig().enableWireLogging(loggerName, logLevel, logUserData);
         return this;
@@ -443,7 +451,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> appendConnectionFilter(
+    public DefaultSingleAddressHttpClientBuilder<U, R> appendConnectionFilter(
             final Predicate<StreamingHttpRequest> predicate, final StreamingHttpConnectionFilterFactory factory) {
         return appendConnectionFilter(toConditionalConnectionFilterFactory(predicate, factory));
     }
@@ -470,14 +478,14 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> allowDropResponseTrailers(final boolean allowDrop) {
+    public DefaultSingleAddressHttpClientBuilder<U, R> allowDropResponseTrailers(final boolean allowDrop) {
         config.protocolConfigs().allowDropTrailersReadFromTransport(allowDrop);
         return this;
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> appendClientFilter(final Predicate<StreamingHttpRequest> predicate,
-                                                                   final StreamingHttpClientFilterFactory factory) {
+    public DefaultSingleAddressHttpClientBuilder<U, R> appendClientFilter(
+            final Predicate<StreamingHttpRequest> predicate, final StreamingHttpClientFilterFactory factory) {
         if (factory instanceof RetryingHttpRequesterFilter) {
             ensureSingleRetryFilter();
             retryingHttpRequesterFilter = (RetryingHttpRequesterFilter) factory;
@@ -520,7 +528,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
+    public DefaultSingleAddressHttpClientBuilder<U, R> retryServiceDiscoveryErrors(
             final BiIntFunction<Throwable, ? extends Completable> retryStrategy) {
         this.serviceDiscovererRetryStrategy = requireNonNull(retryStrategy);
         return this;
@@ -544,19 +552,19 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> inferPeerHost(boolean shouldInfer) {
+    public DefaultSingleAddressHttpClientBuilder<U, R> inferPeerHost(boolean shouldInfer) {
         config.inferPeerHost(shouldInfer);
         return this;
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> inferPeerPort(boolean shouldInfer) {
+    public DefaultSingleAddressHttpClientBuilder<U, R> inferPeerPort(boolean shouldInfer) {
         config.inferPeerPort(shouldInfer);
         return this;
     }
 
     @Override
-    public SingleAddressHttpClientBuilder<U, R> inferSniHostname(boolean shouldInfer) {
+    public DefaultSingleAddressHttpClientBuilder<U, R> inferSniHostname(boolean shouldInfer) {
         config.inferSniHostname(shouldInfer);
         return this;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -429,8 +429,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     }
 
     @Override
-    public DefaultSingleAddressHttpClientBuilder<U, R> enableWireLogging(final String loggerName, final LogLevel logLevel,
-                                                                  final BooleanSupplier logUserData) {
+    public DefaultSingleAddressHttpClientBuilder<U, R> enableWireLogging(final String loggerName,
+                                                                         final LogLevel logLevel,
+                                                                         final BooleanSupplier logUserData) {
         config.tcpConfig().enableWireLogging(loggerName, logLevel, logUserData);
         return this;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -19,7 +19,6 @@ import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.buffer.api.CharSequences;
 import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
@@ -29,7 +28,6 @@ import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
@@ -58,7 +56,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.net.SocketOption;
 import java.time.Duration;
 import java.util.Collection;
@@ -68,22 +65,16 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import static io.netty.util.NetUtil.toSocketAddressString;
-import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;
-import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
-import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.api.RetryStrategies.retryWithConstantBackoffDeltaJitter;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_2;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalSrvDnsServiceDiscoverer;
 import static io.servicetalk.http.netty.StrategyInfluencerAwareConversions.toConditionalClientFilterFactory;
 import static io.servicetalk.http.netty.StrategyInfluencerAwareConversions.toConditionalConnectionFilterFactory;
 import static java.lang.Integer.parseInt;
 import static java.time.Duration.ofSeconds;
-import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -129,19 +120,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     @Nullable
     private RetryingHttpRequesterFilter retryingHttpRequesterFilter;
 
+    // Do not use this ctor directly, HttpClients is the entry point for creating a new builder.
     DefaultSingleAddressHttpClientBuilder(
             final U address, final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer) {
         this.address = requireNonNull(address);
-        config = new HttpClientConfig();
-        executionContextBuilder = new HttpExecutionContextBuilder();
-        strategyComputation = new ClientStrategyInfluencerChainBuilder();
-        this.loadBalancerFactory = DefaultHttpLoadBalancerFactory.Builder.<R>fromDefaults().build();
-        this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
-    }
-
-    DefaultSingleAddressHttpClientBuilder(
-            final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer) {
-        address = null; // Unknown address - template builder pending override via: copy(address)
         config = new HttpClientConfig();
         executionContextBuilder = new HttpExecutionContextBuilder();
         strategyComputation = new ClientStrategyInfluencerChainBuilder();
@@ -167,35 +149,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         retryingHttpRequesterFilter = from.retryingHttpRequesterFilter;
     }
 
-    private DefaultSingleAddressHttpClientBuilder<U, R> copy() {
-        return new DefaultSingleAddressHttpClientBuilder<>(address, this);
-    }
-
-    private DefaultSingleAddressHttpClientBuilder<U, R> copy(final U address) {
-        return new DefaultSingleAddressHttpClientBuilder<>(requireNonNull(address), this);
-    }
-
-    static DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forHostAndPort(
-            final HostAndPort address) {
-        return new DefaultSingleAddressHttpClientBuilder<>(address, globalDnsServiceDiscoverer());
-    }
-
-    static DefaultSingleAddressHttpClientBuilder<String, InetSocketAddress> forServiceAddress(
-            final String serviceName) {
-        return new DefaultSingleAddressHttpClientBuilder<>(serviceName, globalSrvDnsServiceDiscoverer());
-    }
-
-    static <U, R extends SocketAddress> DefaultSingleAddressHttpClientBuilder<U, R> forResolvedAddress(
-            final U u, final Function<U, R> toResolvedAddressMapper) {
-        ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> sd = new NoopServiceDiscoverer<>(toResolvedAddressMapper);
-        return new DefaultSingleAddressHttpClientBuilder<>(u, sd);
-    }
-
-    static DefaultSingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forUnknownHostAndPort() {
-        return new DefaultSingleAddressHttpClientBuilder<>(globalDnsServiceDiscoverer());
-    }
-
-    static final class HttpClientBuildContext<U, R> {
+    private static final class HttpClientBuildContext<U, R> {
         final DefaultSingleAddressHttpClientBuilder<U, R> builder;
         private final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> sd;
         private final SdStatusCompletable sdStatus;
@@ -226,10 +180,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
         HttpClientConfig httpConfig() {
             return builder.config;
-        }
-
-        StreamingHttpClient build() {
-            return buildStreaming(this);
         }
 
         ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer(
@@ -344,8 +294,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         }
     }
 
-    static StreamingHttpRequestResponseFactory defaultReqRespFactory(ReadOnlyHttpClientConfig roConfig,
-                                                                     BufferAllocator allocator) {
+    private static StreamingHttpRequestResponseFactory defaultReqRespFactory(ReadOnlyHttpClientConfig roConfig,
+                                                                             BufferAllocator allocator) {
         if (roConfig.isH2PriorKnowledge()) {
             H2ProtocolConfig h2Config = roConfig.h2Config();
             assert h2Config != null;
@@ -423,21 +373,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     /**
      * Creates a context before building the client, avoid concurrent changes at runtime.
      */
-    HttpClientBuildContext<U, R> copyBuildCtx() {
-        return buildContext0(null);
-    }
-
-    /**
-     * Creates a context before building the client with a provided address, avoid concurrent changes at runtime.
-     */
-    HttpClientBuildContext<U, R> copyBuildCtx(U address) {
-        assert this.address == null : "Not intended to change the address, only to supply lazily";
-        return buildContext0(address);
-    }
-
-    private HttpClientBuildContext<U, R> buildContext0(@Nullable U address) {
-        final DefaultSingleAddressHttpClientBuilder<U, R> clonedBuilder = address == null ? copy() : copy(address);
-        return new HttpClientBuildContext<>(clonedBuilder,
+    private HttpClientBuildContext<U, R> copyBuildCtx() {
+        return new HttpClientBuildContext<>(new DefaultSingleAddressHttpClientBuilder<>(address, this),
                 this.serviceDiscoverer, this.serviceDiscovererRetryStrategy, this.proxyAddress);
     }
 
@@ -624,16 +561,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         return this;
     }
 
-    /**
-     * returns the required strategy for the added client filters and factories.
-     *
-     * @param strategy the user execution strategy.
-     * @return the required strategy for the added client filters and factories.
-     */
-    HttpExecutionStrategy computeChainStrategy(HttpExecutionStrategy strategy) {
-        return strategyComputation.buildForClient(strategy);
-    }
-
     private static <U> CharSequence toAuthorityForm(final U address) {
         if (address instanceof CharSequence) {
             return (CharSequence) address;
@@ -686,43 +613,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                     config.fallbackPeerPort(parseInt(cs.subSequence(colon + 1, cs.length()).toString()));
                 }
             }
-        }
-    }
-
-    private static final class NoopServiceDiscoverer<UnresolvedAddress, ResolvedAddress>
-            implements ServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
-            ServiceDiscovererEvent<ResolvedAddress>> {
-        private final ListenableAsyncCloseable closeable = emptyAsyncCloseable();
-
-        private final Function<UnresolvedAddress, ResolvedAddress> toResolvedAddressMapper;
-
-        private NoopServiceDiscoverer(final Function<UnresolvedAddress, ResolvedAddress> toResolvedAddressMapper) {
-            this.toResolvedAddressMapper = requireNonNull(toResolvedAddressMapper);
-        }
-
-        @Override
-        public Publisher<Collection<ServiceDiscovererEvent<ResolvedAddress>>> discover(
-                final UnresolvedAddress address) {
-            return Publisher.<Collection<ServiceDiscovererEvent<ResolvedAddress>>>from(
-                    singletonList(new DefaultServiceDiscovererEvent<>(
-                            requireNonNull(toResolvedAddressMapper.apply(address)), AVAILABLE)))
-                    // LoadBalancer will flag a termination of service discoverer Publisher as unexpected.
-                    .concat(never());
-        }
-
-        @Override
-        public Completable onClose() {
-            return closeable.onClose();
-        }
-
-        @Override
-        public Completable closeAsync() {
-            return closeable.closeAsync();
-        }
-
-        @Override
-        public Completable closeAsyncGracefully() {
-            return closeable.closeAsyncGracefully();
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/GlobalDnsServiceDiscoverer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/GlobalDnsServiceDiscoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,12 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.dns.discovery.netty.DefaultDnsServiceDiscovererBuilder;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.HostAndPort;
@@ -25,6 +29,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.function.Function;
+
+import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;
+import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
+import static io.servicetalk.concurrent.api.Publisher.never;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
 
 /**
  * ServiceTalk's shared DNS {@link ServiceDiscoverer} with reasonable defaults for APIs when a user doesn't provide one.
@@ -59,6 +71,19 @@ final class GlobalDnsServiceDiscoverer {
         return SrvClientInitializer.SRV_SD;
     }
 
+    /**
+     * Get the {@link ServiceDiscoverer} that uses the passed function to transform an unresolved to resolved address.
+     *
+     * @param toResolvedAddressMapper {@link Function} to transform an unresolved to resolved address
+     * @param <U> the type of address before resolution (unresolved address)
+     * @param <R> the type of address after resolution (resolved address)
+     * @return {@link ServiceDiscoverer} that uses the passed function to transform an unresolved to resolved address
+     */
+    static <U, R> ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> mappingServiceDiscoverer(
+            final Function<U, R> toResolvedAddressMapper) {
+        return new MappingServiceDiscoverer<>(toResolvedAddressMapper);
+    }
+
     private static final class HostAndPortClientInitializer {
         static final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
                 HOST_PORT_SD = new DefaultDnsServiceDiscovererBuilder().buildARecordDiscoverer();
@@ -82,6 +107,42 @@ final class GlobalDnsServiceDiscoverer {
 
         private SrvClientInitializer() {
             // No instances
+        }
+    }
+
+    static final class MappingServiceDiscoverer<UnresolvedAddress, ResolvedAddress>
+            implements ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, ServiceDiscovererEvent<ResolvedAddress>> {
+
+        private final Function<UnresolvedAddress, ResolvedAddress> toResolvedAddressMapper;
+        private final ListenableAsyncCloseable closeable = emptyAsyncCloseable();
+
+        private MappingServiceDiscoverer(final Function<UnresolvedAddress, ResolvedAddress> toResolvedAddressMapper) {
+            this.toResolvedAddressMapper = requireNonNull(toResolvedAddressMapper);
+        }
+
+        @Override
+        public Publisher<Collection<ServiceDiscovererEvent<ResolvedAddress>>> discover(
+                final UnresolvedAddress address) {
+            return Publisher.<Collection<ServiceDiscovererEvent<ResolvedAddress>>>from(
+                            singletonList(new DefaultServiceDiscovererEvent<>(
+                                    requireNonNull(toResolvedAddressMapper.apply(address)), AVAILABLE)))
+                    // LoadBalancer will flag a termination of service discoverer Publisher as unexpected.
+                    .concat(never());
+        }
+
+        @Override
+        public Completable onClose() {
+            return closeable.onClose();
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return closeable.closeAsync();
+        }
+
+        @Override
+        public Completable closeAsyncGracefully() {
+            return closeable.closeAsyncGracefully();
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
-import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.netty.internal.ExecutionContextBuilder;
 
@@ -71,13 +70,5 @@ final class HttpExecutionContextBuilder extends ExecutionContextBuilder<HttpExec
                 ioExecutor == null ? defaultContextSupplier.get().ioExecutor() : ioExecutor,
                 executor == null ? defaultContextSupplier.get().executor() : executor,
                 strategy == null ? defaultStrategy() : strategy);
-    }
-
-    static <U, R> SingleAddressHttpClientBuilder<U, R> setExecutionContext(
-            final SingleAddressHttpClientBuilder<U, R> builder, final HttpExecutionContext context) {
-        return builder.ioExecutor(context.ioExecutor())
-                .executor(context.executor())
-                .bufferAllocator(context.bufferAllocator())
-                .executionStrategy(context.executionStrategy());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpExecutionContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.netty.internal.ExecutionContextBuilder;
 
@@ -70,5 +71,13 @@ final class HttpExecutionContextBuilder extends ExecutionContextBuilder<HttpExec
                 ioExecutor == null ? defaultContextSupplier.get().ioExecutor() : ioExecutor,
                 executor == null ? defaultContextSupplier.get().executor() : executor,
                 strategy == null ? defaultStrategy() : strategy);
+    }
+
+    static <U, R> SingleAddressHttpClientBuilder<U, R> setExecutionContext(
+            final SingleAddressHttpClientBuilder<U, R> builder, final HttpExecutionContext context) {
+        return builder.ioExecutor(context.ioExecutor())
+                .executor(context.executor())
+                .bufferAllocator(context.bufferAllocator())
+                .executionStrategy(context.executionStrategy());
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -52,9 +52,9 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAnd
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.cached;
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.immediate;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -223,10 +223,10 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
 
     private static void assertExecutionContext(HttpExecutionContext expected, HttpExecutionContext actual) {
         assertThat(actual, is(notNullValue()));
-        assertThat(actual.ioExecutor(), equalTo(expected.ioExecutor()));
-        assertThat(actual.executor(), equalTo(expected.executor()));
-        assertThat(actual.bufferAllocator(), equalTo(expected.bufferAllocator()));
-        assertThat(actual.executionStrategy(), equalTo(expected.executionStrategy()));
+        assertThat(actual.ioExecutor(), is(sameInstance(expected.ioExecutor())));
+        assertThat(actual.executor(), is(sameInstance(expected.executor())));
+        assertThat(actual.bufferAllocator(), is(sameInstance(expected.bufferAllocator())));
+        assertThat(actual.executionStrategy(), is(sameInstance(expected.executionStrategy())));
     }
 
     private static class DelegatingHttpHeadersFactory implements HttpHeadersFactory {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,28 +15,21 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.buffer.netty.BufferAllocators;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
-import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.BlockingHttpRequester;
 import io.servicetalk.http.api.BlockingStreamingHttpRequester;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.HttpExecutionContext;
-import io.servicetalk.http.api.HttpExecutionStrategies;
-import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpRequester;
-import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpRequester;
-import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.HostAndPort;
-import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
@@ -47,15 +40,21 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
+import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_DIRECT_ALLOCATOR;
+import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_HEAP_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNever;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.cached;
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.immediate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -138,73 +137,96 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
     }
 
     @Test
-    void internalClientsUseDifferentExecutionContextWhenConfigured() throws Exception {
-        // Assert prerequisites first.
-        // Use different strategies, as ExecutionContextExtension shares the same strategy.
-        HttpExecutionStrategy internalExecutionStrategy = HttpExecutionStrategies.customStrategyBuilder()
-                .offloadNone().build();
-        HttpExecutionStrategy externalExecutionStrategy = HttpExecutionStrategies.customStrategyBuilder()
-                .offloadAll().build();
-        assertThat(internalExecutionStrategy, not(equalTo(externalExecutionStrategy)));
-
-        BufferAllocator internalBufferAllocator = BufferAllocators.PREFER_DIRECT_ALLOCATOR;
-        BufferAllocator externalBufferAllocator = BufferAllocators.PREFER_HEAP_ALLOCATOR;
-        assertThat(internalBufferAllocator, not(equalTo(externalBufferAllocator)));
-
-        assertThat(CTX.executor(), not(equalTo(INTERNAL_CLIENT_CTX.executor())));
-        assertThat(CTX.ioExecutor(), not(equalTo(INTERNAL_CLIENT_CTX.ioExecutor())));
+    void internalClientsInheritExecutionContext() throws Exception {
+        HttpExecutionContext expectedCtx = new HttpExecutionContextBuilder()
+                .ioExecutor(CTX.ioExecutor())
+                .executor(CTX.executor())
+                .bufferAllocator(PREFER_DIRECT_ALLOCATOR)
+                .executionStrategy(offloadNever())
+                .build();
+        AtomicReference<HttpExecutionContext> actualInternalCtx = new AtomicReference<>();
 
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
                 .executionStrategy(offloadNever())
-                .listenStreamingAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()))) {
-            AtomicReference<BufferAllocator> actualInternalBufferAllocator = new AtomicReference<>();
-            AtomicReference<IoExecutor> actualInternalIoExecutor = new AtomicReference<>();
-            AtomicReference<Executor> actualInternalExecutor = new AtomicReference<>();
-            AtomicReference<ExecutionStrategy> actualInternalExecutionStrategy = new AtomicReference<>();
-
-            final StreamingHttpClient streamingHttpClient = HttpClients.forMultiAddressUrl()
-                    .initializer((scheme, address, builder) ->
-                            builder.executionStrategy(internalExecutionStrategy)
-                                    .executor(INTERNAL_CLIENT_CTX.executor())
-                                    .ioExecutor(INTERNAL_CLIENT_CTX.ioExecutor())
-                                    .bufferAllocator(internalBufferAllocator)
-                                    .executionStrategy(internalExecutionStrategy)
-                                    .appendClientFilter(client -> {
-                                        HttpExecutionContext internalContext = client.executionContext();
-                                        actualInternalBufferAllocator.set(internalContext.bufferAllocator());
-                                        actualInternalExecutor.set(internalContext.executor());
-                                        actualInternalIoExecutor.set(internalContext.ioExecutor());
-                                        actualInternalExecutionStrategy.set(internalContext.executionStrategy());
-                                        return new StreamingHttpClientFilter(client) {
-                                        };
-                                    }))
-                    .executor(CTX.executor())
-                    .ioExecutor(CTX.ioExecutor())
-                    .executionStrategy(externalExecutionStrategy)
-                    .bufferAllocator(externalBufferAllocator)
-                    .buildStreaming();
-
-            assertNotNull(streamingHttpClient);
+                .listenStreamingAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()));
+             BlockingHttpClient blockingHttpClient = HttpClients.forMultiAddressUrl()
+                     .initializer((scheme, address, builder) ->
+                             builder.appendClientFilter(client -> {
+                                 actualInternalCtx.set(client.executionContext());
+                                 return new StreamingHttpClientFilter(client) {
+                                 };
+                             }))
+                     .ioExecutor(expectedCtx.ioExecutor())
+                     .executor(expectedCtx.executor())
+                     .bufferAllocator(expectedCtx.bufferAllocator())
+                     .executionStrategy(expectedCtx.executionStrategy())
+                     .buildBlocking()) {
 
             // Check external client
-            final HttpExecutionContext executionContext = streamingHttpClient.executionContext();
-            assertThat(executionContext.executor(), equalTo(CTX.executor()));
-            assertThat(executionContext.executionStrategy(), equalTo(externalExecutionStrategy));
-            assertThat(executionContext.ioExecutor(), equalTo(CTX.ioExecutor()));
-            assertThat(executionContext.bufferAllocator(), equalTo(CTX.bufferAllocator()));
-
+            assertExecutionContext(expectedCtx, blockingHttpClient.executionContext());
             // Make a request to trigger the filter execution that extracts the execution context.
-            final HostAndPort address = HostAndPort.of((InetSocketAddress) serverContext.listenAddress());
-            streamingHttpClient.reserveConnection(streamingHttpClient.get("http://" + address)).toFuture().get();
-
+            HttpResponse response = blockingHttpClient.request(
+                    blockingHttpClient.get("http://" + serverHostAndPort(serverContext)));
+            assertThat(response.status(), is(OK));
             // Check internal client
-            assertThat(actualInternalBufferAllocator.get(), equalTo(internalBufferAllocator));
-            assertThat(actualInternalExecutor.get(), equalTo(INTERNAL_CLIENT_CTX.executor()));
-            assertThat(actualInternalIoExecutor.get(), equalTo(INTERNAL_CLIENT_CTX.ioExecutor()));
-            assertThat(actualInternalExecutionStrategy.get(), equalTo(internalExecutionStrategy));
-
-            streamingHttpClient.closeAsync().toFuture().get();
+            assertExecutionContext(expectedCtx, actualInternalCtx.get());
         }
+    }
+
+    @Test
+    void internalClientsUseDifferentExecutionContextWhenConfigured() throws Exception {
+        HttpExecutionContext externalCtx = new HttpExecutionContextBuilder()
+                .ioExecutor(CTX.ioExecutor())
+                .executor(CTX.executor())
+                .bufferAllocator(PREFER_HEAP_ALLOCATOR)
+                .executionStrategy(offloadAll())
+                .build();
+
+        HttpExecutionContext internalCtx = new HttpExecutionContextBuilder()
+                .ioExecutor(INTERNAL_CLIENT_CTX.ioExecutor())
+                .executor(INTERNAL_CLIENT_CTX.executor())
+                .bufferAllocator(PREFER_DIRECT_ALLOCATOR)
+                .executionStrategy(offloadNever())
+                .build();
+
+        AtomicReference<HttpExecutionContext> actualInternalCtx = new AtomicReference<>();
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .executionStrategy(offloadNever())
+                .listenStreamingAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()));
+             BlockingHttpClient blockingHttpClient = HttpClients.forMultiAddressUrl()
+                     .initializer((scheme, address, builder) ->
+                             builder.executionStrategy(internalCtx.executionStrategy())
+                                     .executor(internalCtx.executor())
+                                     .ioExecutor(internalCtx.ioExecutor())
+                                     .bufferAllocator(internalCtx.bufferAllocator())
+                                     .appendClientFilter(client -> {
+                                         actualInternalCtx.set(client.executionContext());
+                                         return new StreamingHttpClientFilter(client) {
+                                         };
+                                     }))
+                     .executor(externalCtx.executor())
+                     .ioExecutor(externalCtx.ioExecutor())
+                     .executionStrategy(externalCtx.executionStrategy())
+                     .bufferAllocator(externalCtx.bufferAllocator())
+                     .buildBlocking()) {
+
+            // Check external client
+            assertExecutionContext(externalCtx, blockingHttpClient.executionContext());
+            // Make a request to trigger the filter execution that extracts the execution context.
+            HttpResponse response = blockingHttpClient.request(
+                    blockingHttpClient.get("http://" + serverHostAndPort(serverContext)));
+            assertThat(response.status(), is(OK));
+            // Check internal client
+            assertExecutionContext(internalCtx, actualInternalCtx.get());
+        }
+    }
+
+    private static void assertExecutionContext(HttpExecutionContext expected, HttpExecutionContext actual) {
+        assertThat(actual, is(notNullValue()));
+        assertThat(actual.ioExecutor(), equalTo(expected.ioExecutor()));
+        assertThat(actual.executor(), equalTo(expected.executor()));
+        assertThat(actual.bufferAllocator(), equalTo(expected.bufferAllocator()));
+        assertThat(actual.executionStrategy(), equalTo(expected.executionStrategy()));
     }
 
     private static class DelegatingHttpHeadersFactory implements HttpHeadersFactory {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
-import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.forResolvedAddress;
+import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
@@ -85,8 +85,9 @@ class DefaultSingleAddressHttpClientBuilderTest {
                         .build())
                 .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
              BlockingHttpClient client =
-                     forResolvedAddress(hostNamePrefix + hostName + hostNameSuffix + (port == null ? "" : port),
-                             u -> serverCtx.listenAddress())
+                     forSingleAddress(
+                             GlobalDnsServiceDiscoverer.mappingServiceDiscoverer(u -> serverCtx.listenAddress()),
+                             hostNamePrefix + hostName + hostNameSuffix + (port == null ? "" : port))
                              .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                                      .hostnameVerificationAlgorithm("").build())
                              .buildBlocking()) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilderTest.java
@@ -28,7 +28,6 @@ import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
-import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
@@ -85,9 +84,9 @@ class DefaultSingleAddressHttpClientBuilderTest {
                         .build())
                 .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
              BlockingHttpClient client =
-                     forSingleAddress(
-                             GlobalDnsServiceDiscoverer.mappingServiceDiscoverer(u -> serverCtx.listenAddress()),
-                             hostNamePrefix + hostName + hostNameSuffix + (port == null ? "" : port))
+                     new DefaultSingleAddressHttpClientBuilder<>(
+                             hostNamePrefix + hostName + hostNameSuffix + (port == null ? "" : port),
+                             GlobalDnsServiceDiscoverer.mappingServiceDiscoverer(u -> serverCtx.listenAddress()))
                              .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                                      .hostnameVerificationAlgorithm("").build())
                              .buildBlocking()) {


### PR DESCRIPTION
Motivation:

`DefaultMultiAddressHttpClientBuilder` and
`DefaultPartitionedHttpClientBuilder` use
`DefaultSingleAddressHttpClientBuilder` as a template for underlying
single-address clients. It was helpful before we introduced a
`SingleAddressInitializer` in #1387. Before that, all builders had the
same set of methods and it was nice to reuse the single-address builder
instead of maintaining a similar state at higher level builders. Now,
`SingleAddressInitializer` helps to avoid duplication between builders.
We don't have to use `DefaultSingleAddressHttpClientBuilder` as a
template and can simplify its state by using a factory for
`SingleAddressHttpClientBuilder`.

Modifications:

- `DefaultMultiAddressUrlHttpClientBuilder` and
`DefaultPartitionedHttpClientBuilder` use a factory for
`SingleAddressHttpClientBuilder` instead of
`DefaultSingleAddressHttpClientBuilder` as a template and
`HttpExecutionContextBuilder` for context-related items;
- Remove and hide methods from `DefaultSingleAddressHttpClientBuilder`
that are not used by other builders anymore;
- Add a test to verify `DefaultMultiAddressUrlHttpClientBuilder` sets
execution context items for underlying single-address builders;

Result:

`DefaultSingleAddressHttpClientBuilder` has less pkg-private API,
`DefaultMultiAddressUrlHttpClientBuilder` and
`DefaultPartitionedHttpClientBuilder` create a new single-address
builder on demand, similar to grpc builders.