### PR TITLE
Remove `proxy-connection` header from outgoing HTTP/2 messages

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.TE;
 import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.COOKIE;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
@@ -36,6 +37,9 @@ import static io.servicetalk.http.api.HttpHeaderValues.KEEP_ALIVE;
 import static io.servicetalk.http.netty.HeaderUtils.indexOf;
 
 final class H2ToStH1Utils {
+
+    static final CharSequence PROXY_CONNECTION = newAsciiString("proxy-connection");
+
     private H2ToStH1Utils() {
         // no instances.
     }
@@ -140,6 +144,7 @@ final class H2ToStH1Utils {
         h1Headers.remove(KEEP_ALIVE);
         h1Headers.remove(TRANSFER_ENCODING);
         h1Headers.remove(UPGRADE);
+        h1Headers.remove(PROXY_CONNECTION);
 
         // TE header is treated specially https://tools.ietf.org/html/rfc7540#section-8.1.2.2
         // (only value of "trailers" is allowed).


### PR DESCRIPTION
Motivation:

Quote from the spec
(https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2):

  > This means that an intermediary transforming an HTTP/1.x message to
   HTTP/2 will need to remove any header fields nominated by the
   Connection header field, along with the Connection header field
   itself.  Such intermediaries SHOULD also remove other connection-
   specific header fields, such as Keep-Alive, Proxy-Connection,
   Transfer-Encoding, and Upgrade, even if they are not nominated by the
   Connection header field.

`H2ToStH1Utils.h1HeadersToH2Headers()` removes all described headers
except `proxy-connection`.

Modifications:

- Remove `proxy-connection` header from the outgoing HTTP/2 messages;
- Test that HTTP/2 client and server remove prohibited headers;

Result:

Outgoing HTTP/2 messages never contain prohibited `proxy-connection`
header.