### PR TITLE
grpc-protoc javadoc testing updates

### DIFF
--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -115,6 +115,7 @@ clean {
 }
 
 task testJavadoc(type: Javadoc) {
+  enabled = !JavaVersion.current().isJava8() // jdk8 has a javadoc lint check bug, skip it.
   dependsOn tasks.compileTestJava
 
   source = protobuf.generatedFilesBaseDir

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -121,10 +121,9 @@ task testJavadoc(type: Javadoc) {
   exclude "**/*.desc"
   classpath = sourceSets.test.compileClasspath
   destinationDir = file("$buildDir/tmp/testjavadoc")
-  options.addBooleanOption("Xdoclint:syntax", true)
-  options.addBooleanOption("Xdoclint:html", true)
-  options.addBooleanOption("Xdoclint:accessibility", true)
-  // Don't use Xdoclint:missing for now because not all methods/types have javadocs.
+  options.addBooleanOption("Xwerror", true)
+  options.addBooleanOption("Xdoclint:all,-missing", true)
+  options.addBooleanOption("protected", true)
 }
 
 test.finalizedBy(testJavadoc)


### PR DESCRIPTION
Motivation:
The grpc-protoc plugin generates javadoc but uses
inconsistent options to validate relative to the
main project options. We should make the options
consistent.