### PR TITLE
grpc-protoc addService -> addBlockingService

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -1058,7 +1058,7 @@ class ProtocolCompatibilityTest {
                 .listenAndAwait(new ServiceFactory.Builder()
                         .bufferDecoderGroup(serviceTalkDecompression(compression))
                         .bufferEncoders(serviceTalkCompressions(compression))
-                        .addService(new BlockingCompatService() {
+                        .addBlockingService(new BlockingCompatService() {
                             @Override
                             public void bidirectionalStreamingCall(
                                     final GrpcServiceContext ctx, final BlockingIterable<CompatRequest> request,

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -123,6 +123,7 @@ import static io.servicetalk.grpc.protoc.Words.RPC_PATH;
 import static io.servicetalk.grpc.protoc.Words.Rpc;
 import static io.servicetalk.grpc.protoc.Words.Service;
 import static io.servicetalk.grpc.protoc.Words.To;
+import static io.servicetalk.grpc.protoc.Words.addBlockingService;
 import static io.servicetalk.grpc.protoc.Words.addService;
 import static io.servicetalk.grpc.protoc.Words.bind;
 import static io.servicetalk.grpc.protoc.Words.bufferDecoderGroup;
@@ -597,7 +598,17 @@ final class Generator {
                 .addStatement("return this")
                 .build());
 
-        final MethodSpec.Builder addBlockingServiceMethodSpecBuilder = methodBuilder(addService)
+        serviceBuilderSpecBuilder.addMethod(methodBuilder(addService)
+                .addModifiers(PUBLIC)
+                .addAnnotation(Deprecated.class)
+                .addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T)}." + lineSeparator(), addBlockingService,
+                        state.blockingServiceClass)
+                .returns(builderClass)
+                .addParameter(state.blockingServiceClass, service, FINAL)
+                .addStatement("return $L($L)", addBlockingService, service)
+                .build());
+
+        final MethodSpec.Builder addBlockingServiceMethodSpecBuilder = methodBuilder(addBlockingService)
                 .addModifiers(PUBLIC)
                 .returns(builderClass)
                 .addParameter(state.blockingServiceClass, service, FINAL);

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
@@ -37,6 +37,7 @@ final class Words {
     static final String rpc = "rpc";
     static final String initSerializationProvider = "initSerializationProvider";
     static final String addService = "addService";
+    static final String addBlockingService = "addBlockingService";
     static final String registerRoutes = "registerRoutes";
     static final String service = "service";
     static final String strategy = "strategy";


### PR DESCRIPTION
Motivation:
The generated code to build a service has two methods
with the same name:

* `addService(X)`
* `addService(BlockingX)`

The method overloading approach requires that folks cast their
services if they are implemented as lambdas. We can avoid
this ambiguity by qualifying the method name to:

* `addBlockingService(BlockingX)`