### PR TITLE
grpc-protoc fix missing javadoc

### DIFF
--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -601,11 +601,11 @@ final class Generator {
         serviceBuilderSpecBuilder.addMethod(methodBuilder(addService)
                 .addModifiers(PUBLIC)
                 .addAnnotation(Deprecated.class)
-                .addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T)}.", addBlockingService,
+                .addJavadoc("Adds a {@link $T} implementation." + lineSeparator(), state.blockingServiceClass)
+                .addJavadoc(JAVADOC_PARAM + service + " the {@link $T} implementation to add." + lineSeparator(),
                         state.blockingServiceClass)
-                .addJavadoc(lineSeparator())
-                .addJavadoc(JAVADOC_PARAM + service + " the service to add.")
-                .addJavadoc(lineSeparator())
+                .addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T)}." + lineSeparator(), addBlockingService,
+                        state.blockingServiceClass)
                 .addJavadoc(JAVADOC_RETURN + "this.")
                 .returns(builderClass)
                 .addParameter(state.blockingServiceClass, service, FINAL)
@@ -877,14 +877,13 @@ final class Generator {
                             printJavaDocs, (methodName, b) -> {
                                 ClassName inClass = messageTypesMap.get(clientMetaData.methodProto.getInputType());
                                 b.addModifiers(ABSTRACT).addParameter(clientMetaData.className, metadata)
-                                .addAnnotation(Deprecated.class)
-                                .addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T,$T)}." + lineSeparator(),
-                                        methodName,
-                                        GrpcClientMetadata, clientMetaData.methodProto.getClientStreaming() ?
-                                                Publisher : inClass);
+                                .addAnnotation(Deprecated.class);
                                 if (printJavaDocs) {
                                     extractJavaDocComments(state, methodIndex, b);
-                                    b.addJavadoc(JAVADOC_PARAM + metadata +
+                                    b.addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T,$T)}." + lineSeparator(),
+                                            methodName, GrpcClientMetadata,
+                                            clientMetaData.methodProto.getClientStreaming() ? Publisher : inClass)
+                                    .addJavadoc(JAVADOC_PARAM + metadata +
                                             " the metadata associated with this client call." + lineSeparator());
                                 }
                                 return b;
@@ -914,13 +913,13 @@ final class Generator {
                             printJavaDocs, (methodName, b) -> {
                                 ClassName inClass = messageTypesMap.get(clientMetaData.methodProto.getInputType());
                                 b.addModifiers(ABSTRACT).addParameter(clientMetaData.className, metadata)
-                                .addAnnotation(Deprecated.class)
-                                .addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T,$T)}." + lineSeparator(),
-                                    methodName, GrpcClientMetadata, clientMetaData.methodProto.getClientStreaming() ?
-                                                Types.Iterable : inClass);
+                                .addAnnotation(Deprecated.class);
                                 if (printJavaDocs) {
                                     extractJavaDocComments(state, methodIndex, b);
-                                    b.addJavadoc(JAVADOC_PARAM + metadata +
+                                    b.addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T,$T)}." + lineSeparator(),
+                                            methodName, GrpcClientMetadata,
+                                            clientMetaData.methodProto.getClientStreaming() ? Types.Iterable : inClass)
+                                    .addJavadoc(JAVADOC_PARAM + metadata +
                                             " the metadata associated with this client call." + lineSeparator());
                                 }
                                 return b;
@@ -1045,8 +1044,7 @@ final class Generator {
         if (flags.contains(BLOCKING)) {
             if (clientSteaming) {
                 if (flags.contains(CLIENT)) {
-                    methodSpecBuilder.addParameter(ParameterizedTypeName.get(ClassName.get(Iterable.class),
-                            inClass), request, mods);
+                    methodSpecBuilder.addParameter(ParameterizedTypeName.get(Types.Iterable, inClass), request, mods);
                     if (printJavaDocs) {
                         methodSpecBuilder.addJavadoc(JAVADOC_PARAM + request +
                                 " used to send a stream of type {@link $T} to the server." + lineSeparator(), inClass);

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -602,11 +602,12 @@ final class Generator {
                 .addModifiers(PUBLIC)
                 .addAnnotation(Deprecated.class)
                 .addJavadoc("Adds a {@link $T} implementation." + lineSeparator(), state.blockingServiceClass)
+                .addJavadoc(lineSeparator())
                 .addJavadoc(JAVADOC_PARAM + service + " the {@link $T} implementation to add." + lineSeparator(),
                         state.blockingServiceClass)
+                .addJavadoc(JAVADOC_RETURN + "this." + lineSeparator())
                 .addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T)}." + lineSeparator(), addBlockingService,
                         state.blockingServiceClass)
-                .addJavadoc(JAVADOC_RETURN + "this.")
                 .returns(builderClass)
                 .addParameter(state.blockingServiceClass, service, FINAL)
                 .addStatement("return $L($L)", addBlockingService, service)

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -601,8 +601,12 @@ final class Generator {
         serviceBuilderSpecBuilder.addMethod(methodBuilder(addService)
                 .addModifiers(PUBLIC)
                 .addAnnotation(Deprecated.class)
-                .addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T)}." + lineSeparator(), addBlockingService,
+                .addJavadoc(JAVADOC_DEPRECATED + "Use {@link #$L($T)}.", addBlockingService,
                         state.blockingServiceClass)
+                .addJavadoc(lineSeparator())
+                .addJavadoc(JAVADOC_PARAM + service + " the service to add.")
+                .addJavadoc(lineSeparator())
+                .addJavadoc(JAVADOC_RETURN + "this.")
                 .returns(builderClass)
                 .addParameter(state.blockingServiceClass, service, FINAL)
                 .addStatement("return $L($L)", addBlockingService, service)


### PR DESCRIPTION
Motivation:
`addService(BlockingX)` was deprecated and javadocs were
added to indicate this. However we need to add javadocs for
all params/return value or else javadoc lint warnings will
be generated.