### PR TITLE
HTTP/2 handlers should throw `Http2Exception` and send RST_STREAM frame

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
@@ -434,6 +434,5 @@ class AbstractH2DuplexHandlerTest {
             when(streamMock.id()).thenReturn(3);
             return streamMock;
         }
-
     }
 }


### PR DESCRIPTION
Motivation:

Classes that extend `AbstractH2DuplexHandler` validate incoming HTTP/2
messages and if there are any protocol-specific errors (missing or
invalid headers) throws `IllegalArgumentException`. This later
translates into `RST_STREAM(CANCEL)`. Instead, HTTP/2 spec says that
in case of malformed message `RST_STREAM(PROTOCOL_ERROR)` must be sent.
We should also use `Http2Exception` type to propagate streamId and
error code to the users.

Modifications:

- In `AbstractH2DuplexHandler`s, replace all `IllegalArgumentException`
with `Http2Exception`;
- Write `RST_STREAM(PROTOCOL_ERROR)` before throwing an exception;

Result:

HTTP/2 behavior aligned with the spec, users see more detailed exception
type.