### PR TITLE
Processors.newPublisherProcessor simplify duplicate terminal check

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherProcessorSignalsHolder.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherProcessorSignalsHolder.java
@@ -16,19 +16,20 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.internal.QueueFullException;
-import io.servicetalk.concurrent.internal.TerminalNotification;
 
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.ProcessorBufferUtils.consumeIfTerminal;
+import static io.servicetalk.concurrent.api.ProcessorBufferUtils.consumeNextItem;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
-abstract class AbstractPublisherProcessorSignalsHolder<T, Q extends Queue<Object>> extends AbstractProcessorBuffer
+abstract class AbstractPublisherProcessorSignalsHolder<T, Q extends Queue<Object>>
         implements PublisherProcessorSignalsHolder<T> {
     @SuppressWarnings("rawtypes")
     private static final AtomicIntegerFieldUpdater<AbstractPublisherProcessorSignalsHolder> bufferedUpdater =
@@ -59,18 +60,12 @@ abstract class AbstractPublisherProcessorSignalsHolder<T, Q extends Queue<Object
 
     @Override
     public void terminate() {
-        TerminalNotification terminal = complete();
-        if (tryTerminate(terminal)) {
-            offerSignal(terminal);
-        }
+        offerSignal(complete());
     }
 
     @Override
     public void terminate(final Throwable cause) {
-        TerminalNotification terminal = error(cause);
-        if (tryTerminate(terminal)) {
-            offerSignal(terminal);
-        }
+        offerSignal(error(cause));
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultBlockingProcessorSignalsHolder.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultBlockingProcessorSignalsHolder.java
@@ -15,19 +15,19 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.internal.TerminalNotification;
-
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.ProcessorBufferUtils.consumeIfTerminal;
+import static io.servicetalk.concurrent.api.ProcessorBufferUtils.consumeNextItem;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 
-final class DefaultBlockingProcessorSignalsHolder<T> extends AbstractProcessorBuffer
+final class DefaultBlockingProcessorSignalsHolder<T>
         implements BlockingProcessorSignalsHolder<T> {
     private final BlockingQueue<Object> signals;
 
@@ -42,18 +42,12 @@ final class DefaultBlockingProcessorSignalsHolder<T> extends AbstractProcessorBu
 
     @Override
     public void terminate() throws InterruptedException {
-        TerminalNotification terminal = complete();
-        if (tryTerminate(terminal)) {
-            signals.put(terminal);
-        }
+        signals.put(complete());
     }
 
     @Override
     public void terminate(final Throwable cause) throws InterruptedException {
-        TerminalNotification terminal = error(cause);
-        if (tryTerminate(terminal)) {
-            signals.put(terminal);
-        }
+        signals.put(error(cause));
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ProcessorBufferUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ProcessorBufferUtils.java
@@ -17,22 +17,12 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.internal.TerminalNotification;
 
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUnchecked;
-import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
-abstract class AbstractProcessorBuffer {
-    private static final AtomicReferenceFieldUpdater<AbstractProcessorBuffer,
-            TerminalNotification> terminalUpdater = newUpdater(AbstractProcessorBuffer.class,
-            TerminalNotification.class, "terminal");
-
-    @Nullable
-    private volatile TerminalNotification terminal;
-
-    final boolean tryTerminate(final TerminalNotification notification) {
-        return terminalUpdater.compareAndSet(this, null, notification);
+final class ProcessorBufferUtils {
+    private ProcessorBufferUtils() {
     }
 
     /**


### PR DESCRIPTION
Motivation:
Processors.newPublisherProcessor checks in the thread generating
data if a terminal has already been observed, and discards duplicates.
However the consumer thread also has the same logic which is required
because we cannot deliver signals to the Subscriber after a terminal
signal is delivered.

Modifications:
- Keep the required check in the queue consumer thread which filters
  out duplicate terminal events, remove the check in the producer
  thread. If there is a strict limit applied to the queue size
  this may impact how many items the queue needs to hold.

Result:
Less atomic operations, 1 less class in the hierarchy, and less
memory consumed by Processors.newPublisherProcessor.