### PR TITLE
Implement `ServiceDiscoverer#toString()` for DefaultDnsServiceDiscoverer

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsClients.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsClients.java
@@ -68,6 +68,11 @@ final class DnsClients {
             public Publisher<Collection<ServiceDiscovererEvent<InetSocketAddress>>> discover(final String s) {
                 return dns.dnsSrvQuery(s);
             }
+
+            @Override
+            public String toString() {
+                return "DefaultDnsServiceDiscoverer{recordTypes=[SRV]}";
+            }
         };
     }
 
@@ -104,6 +109,11 @@ final class DnsClients {
                 return dns.dnsQuery(hostAndPort.hostName())
                         .map(events -> mapEventList(events,
                                 inetAddress -> new InetSocketAddress(inetAddress, hostAndPort.port())));
+            }
+
+            @Override
+            public String toString() {
+                return "DefaultDnsServiceDiscoverer{recordTypes=[A,AAAA]}";
             }
         };
     }


### PR DESCRIPTION
Motivation:

A `ServiceDiscoverer` returned from `DefaultDnsServiceDiscovererBuilder`
is an anonymous class without a proper name. To let users log what type
of `ServiceDiscoverer` they have a reference to, implement `toString()`.

Modifications:

- Implement `toString()` for `DnsClients`;

Result:

Users can log what `ServiceDiscoverer` they have reference to.