### PR TITLE
Expose `SslConfig` through `ConnectionInfo`

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
@@ -24,6 +24,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.transport.api.ExecutionContext;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategies;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.GlobalExecutionContext;
@@ -230,6 +231,12 @@ public class NettyPipelinedConnectionBenchmark {
             @Override
             public SocketAddress remoteAddress() {
                 return new InetSocketAddress(0);
+            }
+
+            @Nullable
+            @Override
+            public SslConfig sslConfig() {
+                return null;
             }
 
             @Nullable

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
@@ -20,6 +20,7 @@ import io.servicetalk.encoding.api.ContentCodec;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.SslConfig;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
@@ -54,6 +55,12 @@ final class DefaultGrpcServiceContext extends DefaultGrpcMetadata implements Grp
     @Override
     public SocketAddress remoteAddress() {
         return connectionContext.remoteAddress();
+    }
+
+    @Nullable
+    @Override
+    public SslConfig sslConfig() {
+        return connectionContext.sslConfig();
     }
 
     @Override

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
@@ -38,6 +38,7 @@ import io.servicetalk.serializer.api.StreamingDeserializer;
 import io.servicetalk.serializer.api.StreamingSerializer;
 import io.servicetalk.serializer.utils.FramedDeserializerOperator;
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.SslConfig;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -163,6 +164,12 @@ final class Utils {
         @Override
         public SocketAddress remoteAddress() {
             return InMemorySocketAddress.INSTANCE;
+        }
+
+        @Nullable
+        @Override
+        public SslConfig sslConfig() {
+            return null;
         }
 
         @Nullable

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.transport.api.SslConfig;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
@@ -62,6 +63,12 @@ public class DelegatingHttpServiceContext extends HttpServiceContext {
     @Override
     public SocketAddress remoteAddress() {
         return delegate.remoteAddress();
+    }
+
+    @Nullable
+    @Override
+    public SslConfig sslConfig() {
+        return delegate.sslConfig();
     }
 
     @Override

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestHttpServiceContext.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestHttpServiceContext.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.AddressUtils;
 
 import java.net.SocketAddress;
@@ -69,6 +70,12 @@ public class TestHttpServiceContext extends HttpServiceContext {
     @Override
     public SocketAddress remoteAddress() {
         return remoteAddress;
+    }
+
+    @Nullable
+    @Override
+    public SslConfig sslConfig() {
+        return null;
     }
 
     @Nullable

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -93,7 +93,8 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
                     assert h2Config != null;
                     return H2ClientParentConnectionContext.initChannel(channel, executionContext,
                             h2Config, reqRespFactoryFunc.apply(HttpProtocolVersion.HTTP_2_0), tcpConfig.flushStrategy(),
-                            tcpConfig.idleTimeoutMs(), new H2ClientParentChannelInitializer(h2Config),
+                            tcpConfig.idleTimeoutMs(), tcpConfig.sslConfig(),
+                            new H2ClientParentChannelInitializer(h2Config),
                             connectionObserver, config.allowDropTrailersReadFromTransport());
                 default:
                     return failed(new IllegalStateException("Unknown ALPN protocol negotiated: " + protocol));

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -64,7 +64,7 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
         return TcpConnector.connect(null, resolvedAddress, tcpConfig, true, executionContext,
                 (channel, connectionObserver) -> H2ClientParentConnectionContext.initChannel(channel,
                         executionContext, config.h2Config(), reqRespFactoryFunc.apply(HTTP_2_0),
-                        tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(),
+                        tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(), tcpConfig.sslConfig(),
                         new TcpClientChannelInitializer(tcpConfig, connectionObserver).andThen(
                                 new H2ClientParentChannelInitializer(config.h2Config())), connectionObserver,
                         config.allowDropTrailersReadFromTransport()), observer);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -49,6 +49,7 @@ import io.servicetalk.tcp.netty.internal.TcpServerBinder;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
@@ -169,10 +170,11 @@ final class NettyHttpServer {
         if (h1Config == null) {
             return failed(newH1ConfigException());
         }
+        final ReadOnlyTcpServerConfig tcpConfig = config.tcpConfig();
         return showPipeline(DefaultNettyConnection.initChannel(channel,
                 httpExecutionContext.bufferAllocator(), httpExecutionContext.executor(),
-                httpExecutionContext.ioExecutor(), closeHandler, config.tcpConfig().flushStrategy(),
-                        config.tcpConfig().idleTimeoutMs(),
+                httpExecutionContext.ioExecutor(), closeHandler, tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(),
+                tcpConfig.sslConfig(),
                 initializer.andThen(getChannelInitializer(getByteBufAllocator(httpExecutionContext.bufferAllocator()),
                         h1Config, closeHandler)), httpExecutionContext.executionStrategy(), HTTP_1_1, observer, false,
                         __ -> false)
@@ -478,6 +480,12 @@ final class NettyHttpServer {
         @Override
         public SocketAddress remoteAddress() {
             return connection.remoteAddress();
+        }
+
+        @Nullable
+        @Override
+        public SslConfig sslConfig() {
+            return connection.sslConfig();
         }
 
         @Nullable

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ConcurrentUtils;
 import io.servicetalk.transport.api.ExecutionContext;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
@@ -135,6 +136,12 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
     @Override
     public SocketAddress remoteAddress() {
         return connection.remoteAddress();
+    }
+
+    @Nullable
+    @Override
+    public SslConfig sslConfig() {
+        return connection.sslConfig();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -67,7 +67,7 @@ final class StreamingConnectionFactory {
         final CloseHandler closeHandler = forPipelinedRequestResponse(true, channel.config());
         return showPipeline(DefaultNettyConnection.initChannel(channel, executionContext.bufferAllocator(),
                 executionContext.executor(), executionContext.ioExecutor(), closeHandler,
-                tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(),
+                tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(), tcpConfig.sslConfig(),
                 initializer.andThen(new HttpClientChannelInitializer(
                         getByteBufAllocator(executionContext.bufferAllocator()), h1Config, closeHandler)),
                 executionContext.executionStrategy(), HTTP_1_1, connectionObserver, true, OBJ_EXPECT_CONTINUE),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -182,6 +182,7 @@ class AlpnClientAndServerTest {
 
         try (ReservedBlockingHttpConnection connection = client.reserveConnection(client.get("/"))) {
             assertThat(connection.connectionContext().protocol(), is(expectedProtocol));
+            assertThat(connection.connectionContext().sslConfig(), is(notNullValue()));
             assertThat(connection.connectionContext().sslSession(), is(notNullValue()));
 
             assertResponseAndServiceContext(connection.request(client.get("/")));
@@ -211,6 +212,7 @@ class AlpnClientAndServerTest {
 
         HttpServiceContext serviceCtx = serviceContext.take();
         assertThat(serviceCtx.protocol(), is(expectedProtocol));
+        assertThat(serviceCtx.sslSession(), is(notNullValue()));
         assertThat(serviceCtx.sslSession(), is(notNullValue()));
         assertThat(requestVersion.take(), is(expectedProtocol));
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -423,6 +423,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                             (channel, observer) -> DefaultNettyConnection.initChannel(channel, SEC.bufferAllocator(),
                                     SEC.executor(), SEC.ioExecutor(),
                                     forPipelinedRequestResponse(false, channel.config()), defaultFlushStrategy(), null,
+                                    null,
                                     new TcpServerChannelInitializer(sConfig, observer).andThen(
                                             channel2 -> {
                                                 serverChannelRef.compareAndSet(null, channel2);
@@ -439,8 +440,9 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                                 closeHandlerRef.compareAndSet(null, closeHandler);
                                 return DefaultNettyConnection.initChannel(channel, CEC.bufferAllocator(),
                                         CEC.executor(), CEC.ioExecutor(),
-                                        closeHandler, defaultFlushStrategy(),
-                                        null, new TcpClientChannelInitializer(cConfig.tcpConfig(),
+                                        closeHandler, defaultFlushStrategy(), null,
+                                        cConfig.tcpConfig().sslConfig(),
+                                        new TcpClientChannelInitializer(cConfig.tcpConfig(),
                                                 connectionObserver)
                                                 .andThen(new HttpClientChannelInitializer(
                                                         getByteBufAllocator(CEC.bufferAllocator()),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
@@ -101,7 +101,7 @@ class NettyPipelinedConnectionTest {
         CloseHandler closeHandler = UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
         final DefaultNettyConnection<Integer, Integer> connection =
                 DefaultNettyConnection.<Integer, Integer>initChannel(channel, DEFAULT_ALLOCATOR,
-                immediate(), null, closeHandler, defaultFlushStrategy(), null, channel2 -> {
+                immediate(), null, closeHandler, defaultFlushStrategy(), null, null, channel2 -> {
                     channel2.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                         @Override
                         public void channelRead(ChannelHandlerContext ctx, Object msg) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/Tls13Test.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/Tls13Test.java
@@ -22,6 +22,7 @@ import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.SslProvider;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
@@ -48,6 +49,7 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -98,6 +100,9 @@ class Tls13Test {
             .sslConfig(serverSslBuilder.build())
             .listenBlockingAndAwait((ctx, request, responseFactory) -> {
                 assertThat(request.payloadBody(textSerializerUtf8()), equalTo("request-payload-body"));
+                SslConfig sslConfig = ctx.sslConfig();
+                assertThat(sslConfig, is(notNullValue()));
+                assertThat(sslConfig.sslProtocols(), contains(TLS1_3));
                 SSLSession sslSession = ctx.sslSession();
                 assertThat(sslSession, is(notNullValue()));
                 return responseFactory.ok().payloadBody(sslSession.getProtocol(), textSerializerUtf8());
@@ -117,6 +122,9 @@ class Tls13Test {
                     .sslConfig(clientSslBuilder.build()).buildBlocking();
                  BlockingHttpConnection connection = client.reserveConnection(client.get("/"))) {
 
+                SslConfig sslConfig = connection.connectionContext().sslConfig();
+                assertThat(sslConfig, is(notNullValue()));
+                assertThat(sslConfig.sslProtocols(), contains(TLS1_3));
                 SSLSession sslSession = connection.connectionContext().sslSession();
                 assertThat(sslSession, is(notNullValue()));
                 assertThat(sslSession.getProtocol(), equalTo(TLS1_3));

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -18,7 +18,6 @@ package io.servicetalk.tcp.netty.internal;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.logging.api.UserDataLoggerConfig;
 import io.servicetalk.logging.slf4j.internal.DefaultUserDataLoggerConfig;
-import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
@@ -85,6 +84,11 @@ abstract class AbstractTcpConfig<SslConfigType> {
         return wireLoggerConfig;
     }
 
+    /**
+     * Get the {@link SslConfigType}.
+     *
+     * @return the {@link SslConfigType}, or {@code null} if SSL/TLS is not configured.
+     */
     @Nullable
     public final SslConfigType sslConfig() {
         return sslConfig;
@@ -139,7 +143,7 @@ abstract class AbstractTcpConfig<SslConfigType> {
     /**
      * Add SSL/TLS related config.
      *
-     * @param sslConfig the {@link ServerSslConfig}.
+     * @param sslConfig the {@link SslConfigType}.
      */
     public final void sslConfig(final SslConfigType sslConfig) {
         this.sslConfig = requireNonNull(sslConfig);

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpClientConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpClientConfig.java
@@ -51,6 +51,11 @@ public final class ReadOnlyTcpClientConfig extends AbstractReadOnlyTcpConfig<Cli
         sslContext = config.sslContext;
     }
 
+    /**
+     * Returns the {@link SslContext}.
+     *
+     * @return {@link SslContext}, {@code null} if none specified
+     */
     @Nullable
     @Override
     public SslContext sslContext() {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -40,6 +40,8 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
     private final Map<ChannelOption, Object> listenOptions;
     private final TransportObserver transportObserver;
     @Nullable
+    private final ServerSslConfig sslConfig;
+    @Nullable
     private final SslContext sslContext;
     @Nullable
     private final Mapping<String, SslContext> sniMapping;
@@ -51,7 +53,7 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
         final TransportObserver transportObserver = from.transportObserver();
         this.transportObserver = transportObserver == NoopTransportObserver.INSTANCE ? transportObserver :
                 asSafeObserver(transportObserver);
-        final ServerSslConfig sslConfig = from.sslConfig();
+        this.sslConfig = from.sslConfig();
         final Map<String, ServerSslConfig> sniMap = from.sniConfig();
         if (sniMap != null) {
             if (sslConfig == null) {
@@ -98,6 +100,21 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
         return transportObserver;
     }
 
+    /**
+     * Get the {@link ServerSslConfig}.
+     *
+     * @return the {@link ServerSslConfig}, or {@code null} if SSL/TLS is not configured.
+     */
+    @Nullable
+    public ServerSslConfig sslConfig() {
+        return sslConfig;
+    }
+
+    /**
+     * Returns the {@link SslContext}.
+     *
+     * @return {@link SslContext}, {@code null} if none specified
+     */
     @Nullable
     @Override
     public SslContext sslContext() {

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
@@ -103,7 +103,7 @@ final class TcpConnectorTest extends AbstractTcpServerTest {
                 serverContext.listenAddress(), new TcpClientConfig().asReadOnly(), false,
                 CLIENT_CTX, (channel, connectionObserver) -> DefaultNettyConnection.initChannel(channel,
                         CLIENT_CTX.bufferAllocator(), CLIENT_CTX.executor(), CLIENT_CTX.ioExecutor(), closeHandler,
-                        defaultFlushStrategy(), null, channel2 ->
+                        defaultFlushStrategy(), null, null, channel2 ->
                                 channel2.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                             @Override
                             public void channelRegistered(ChannelHandlerContext ctx) {

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -95,6 +95,7 @@ final class TcpClient {
                 (channel, connectionObserver) -> initChannel(channel,
                         executionContext.bufferAllocator(), executionContext.executor(), executionContext.ioExecutor(),
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
+                        config.sslConfig(),
                         new TcpClientChannelInitializer(config, connectionObserver).andThen(
                                 channel2 -> channel2.pipeline().addLast(BufferHandler.INSTANCE)),
                         executionContext.executionStrategy(), TCP, connectionObserver, true, __ -> false),

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -86,6 +86,7 @@ public class TcpServer {
                 (channel, connectionObserver) -> DefaultNettyConnection.<Buffer, Buffer>initChannel(channel,
                         executionContext.bufferAllocator(), executionContext.executor(), executionContext.ioExecutor(),
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
+                        config.sslConfig(),
                         new TcpServerChannelInitializer(config, connectionObserver)
                                 .andThen(getChannelInitializer(service, executionContext)), executionStrategy, TCP,
                         connectionObserver, false, __ -> false),

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionInfo.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionInfo.java
@@ -40,6 +40,16 @@ public interface ConnectionInfo {
     SocketAddress remoteAddress();
 
     /**
+     * Get the {@link SslConfig} for this connection.
+     *
+     * @return The {@link SslConfig} if SSL/TLS is configured, or {@code null} otherwise.
+     */
+    @Nullable
+    default SslConfig sslConfig() { // FIXME: 0.43 - consider removing default impl
+        throw new UnsupportedOperationException(getClass().getSimpleName() + "does not implement sslConfig()");
+    }
+
+    /**
      * Get the {@link SSLSession} for this connection.
      *
      * @return The {@link SSLSession} if SSL/TLS is enabled, or {@code null} otherwise.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
@@ -62,6 +62,12 @@ public class DelegatingConnectionContext implements ConnectionContext {
 
     @Nullable
     @Override
+    public SslConfig sslConfig() {
+        return delegate.sslConfig();
+    }
+
+    @Nullable
+    @Override
     public SSLSession sslSession() {
         return delegate.sslSession();
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -53,7 +53,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
         channel = new EmbeddedDuplexChannel(false);
         final CloseHandler closeHandler = forPipelinedRequestResponse(isClient, channel.config());
         conn = DefaultNettyConnection.<String, String>initChannel(channel, DEFAULT_ALLOCATOR, immediate(),
-                        null, closeHandler, defaultFlushStrategy(), null,
+                        null, closeHandler, defaultFlushStrategy(), null, null,
                 WIRE_LOGGING_INITIALIZER.andThen(ch -> ch.pipeline().addLast(new ChannelDuplexHandler() {
                     @Override
                     public void channelRead(final ChannelHandlerContext ctx, final Object msg) {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -113,7 +113,8 @@ class DefaultNettyConnectionTest {
         when(demandEstimator.estimateRequestN(anyLong())).then(invocation1 -> (long) requestNext);
         CloseHandler closeHandler = closeHandlerFactory.apply(channel);
         conn = DefaultNettyConnection.<Buffer, Buffer>initChannel(channel, allocator, executor,
-                null, closeHandler, defaultFlushStrategy(), null, trailerProtocolEndEventEmitter(closeHandler),
+                null, closeHandler, defaultFlushStrategy(), null, null,
+                trailerProtocolEndEventEmitter(closeHandler),
                 offloadAll(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
                 .toFuture().get();
         publisher = new TestPublisher<>();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
@@ -50,7 +50,7 @@ class NettyChannelPublisherRefCountTest {
         channel = new EmbeddedDuplexChannel(false);
         publisher = DefaultNettyConnection.initChannel(channel,
                         DEFAULT_ALLOCATOR, immediate(), null, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER,
-                        defaultFlushStrategy(), null, channel2 -> { }, offloadAll(), mock(Protocol.class),
+                        defaultFlushStrategy(), null, null, channel2 -> { }, offloadAll(), mock(Protocol.class),
                         NoopConnectionObserver.INSTANCE, true, __ -> false).toFuture().get()
                 .read();
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
@@ -92,7 +92,7 @@ class NettyChannelPublisherTest {
         CloseHandler closeHandler = UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
         NettyConnection<Integer, Object> connection =
                 DefaultNettyConnection.<Integer, Object>initChannel(channel, DEFAULT_ALLOCATOR,
-                immediate(), null, closeHandler, defaultFlushStrategy(), null, channel ->
+                immediate(), null, closeHandler, defaultFlushStrategy(), null, null, channel ->
                                 channel.pipeline().addLast(new ChannelOutboundHandlerAdapter() {
                 @Override
                 public void read(ChannelHandlerContext ctx) throws Exception {
@@ -127,7 +127,7 @@ class NettyChannelPublisherTest {
         channel = new EmbeddedDuplexChannel(false);
         NettyConnection<Integer, Object> connection = DefaultNettyConnection.<Integer, Object>initChannel(channel,
                 DEFAULT_ALLOCATOR, immediate(), null, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), null,
-                channel -> {
+                null, channel -> {
                     channel.pipeline().addLast(new ChannelDuplexHandler() {
                         @Override
                         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {


### PR DESCRIPTION
Motivation:

`SSLSession` represents the result of SSL negotiation. However, it's
useful to know what `SslConfig` was used to establish the session for
observability or runtime checks.

Modifications:

- Add `ConnectionInfo#sslConfig()` method;
- Propagate `SslConfig` to all `ConnectionInfo` implementations;
- Adjust tests;

Result:

Users have access to `SslConfig` from service or connection
factory/filter.