### PR TITLE
Add Publisher.flatMapConcatSingle

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -1395,7 +1395,7 @@ public abstract class Publisher<T> {
      * @return A new {@link Publisher} that emits all items emitted by each single produced by {@code mapper}.
      *
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
-     * @see #flatMapMergeSingle(Function, int) 
+     * @see #flatMapMergeSingle(Function, int)
      */
     public final <R> Publisher<R> flatMapConcatSingle(Function<? super T, ? extends Single<? extends R>> mapper,
                                                       int maxConcurrency) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -885,14 +885,15 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
-     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;.
+     * This method is similar to {@link #map(Function)} but the result is asynchronous and results are unordered. More
+     * specifically, map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all
+     * signals emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
      * <p>
      * To control the amount of concurrent processing done by this operator see
      * {@link #flatMapMergeSingle(Function, int)}.
      * <p>
-     * This method is similar to {@link #map(Function)} but the result is asynchronous, unordered, and provides a data
-     * transformation in sequential programming similar to:
+     * Provides a data transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<R>> futures = ...; // assume this is thread safe
@@ -917,17 +918,19 @@ public abstract class Publisher<T> {
      *
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
      * @see #flatMapMergeSingle(Function, int)
+     * @see #flatMapConcatSingle(Function)
      */
     public final <R> Publisher<R> flatMapMergeSingle(Function<? super T, ? extends Single<? extends R>> mapper) {
         return new PublisherFlatMapSingle<>(this, mapper, false);
     }
 
     /**
-     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
-     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;.
+     * This method is similar to {@link #map(Function)} but the result is asynchronous and results are unordered. More
+     * specifically, map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all
+     * signals emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
      * <p>
-     * This method is similar to {@link #map(Function)} but the result is asynchronous, unordered, and provides a data
-     * transformation in sequential programming similar to:
+     * Provides a data transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<R>> futures = ...; // assume this is thread safe
@@ -954,6 +957,7 @@ public abstract class Publisher<T> {
      * @return A new {@link Publisher} that emits all items emitted by each single produced by {@code mapper}.
      *
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
+     * @see #flatMapConcatSingle(Function, int)
      */
     public final <R> Publisher<R> flatMapMergeSingle(Function<? super T, ? extends Single<? extends R>> mapper,
                                                      int maxConcurrency) {
@@ -1002,6 +1006,7 @@ public abstract class Publisher<T> {
      *
      * @see <a href="https://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
      * @see #flatMapMergeSingleDelayError(Function, int)
+     * @see #flatMapConcatSingleDelayError(Function)
      */
     public final <R> Publisher<R> flatMapMergeSingleDelayError(
             Function<? super T, ? extends Single<? extends R>> mapper) {
@@ -1009,8 +1014,9 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
-     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
+     * This method is similar to {@link #map(Function)} but the result is asynchronous and results are unordered. More
+     * specifically, map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all
+     * signals emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
      * {@link Publisher}&lt;{@link R}&gt;.
      * <p>
      * The behavior is the same as {@link #flatMapMergeSingle(Function, int)} with the exception that if any
@@ -1019,8 +1025,7 @@ public abstract class Publisher<T> {
      * then terminate the returned {@link Publisher} with all errors emitted by the {@link Single}s produced by the
      * {@code mapper}.
      * <p>
-     * This method is similar to {@link #map(Function)} but the result is asynchronous, unordered, and provides a data
-     * transformation in sequential programming similar to:
+     * Provides a data transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<R>> futures = ...; // assume this is thread safe
@@ -1050,6 +1055,7 @@ public abstract class Publisher<T> {
      * @return A new {@link Publisher} that emits all items emitted by each single produced by {@code mapper}.
      *
      * @see <a href="https://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
+     * @see #flatMapConcatSingleDelayError(Function, int)
      */
     public final <R> Publisher<R> flatMapMergeSingleDelayError(
             Function<? super T, ? extends Single<? extends R>> mapper, int maxConcurrency) {
@@ -1057,8 +1063,10 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
-     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;.
+     * This method is similar to {@link #map(Function)} but the result is asynchronous and results are unordered. More
+     * specifically, map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all
+     * signals emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned
+     * {@link Publisher}&lt;{@link R}&gt;.
      * <p>
      * The behavior is the same as {@link #flatMapMergeSingle(Function, int)} with the exception that if any
      * {@link Single} returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not
@@ -1066,8 +1074,7 @@ public abstract class Publisher<T> {
      * then terminate the returned {@link Publisher} with errors emitted by the {@link Single}s produced by the
      * {@code mapper}.
      * <p>
-     * This method is similar to {@link #map(Function)} but the result is asynchronous, unordered, and provides a data
-     * transformation in sequential programming similar to:
+     * Provides a data transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<R>> futures = ...; // assume this is thread safe
@@ -1098,6 +1105,7 @@ public abstract class Publisher<T> {
      * @return A new {@link Publisher} that emits all items emitted by each single produced by {@code mapper}.
      *
      * @see <a href="https://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
+     * @see #flatMapConcatSingleDelayError(Function, int)
      */
     public final <R> Publisher<R> flatMapMergeSingleDelayError(
             Function<? super T, ? extends Single<? extends R>> mapper, int maxConcurrency, int maxDelayedErrorsHint) {
@@ -1322,16 +1330,16 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
-     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;.
-     * Each mapped {@link Single}&lt;{@link R}&gt; maybe subscribed to concurrently but the results are emitted in
-     * the same order as this {@link Publisher}.
+     * This method is similar to {@link #map(Function)} but the result is asynchronous. More specifically, map each
+     * element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals emitted from
+     * each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;. Each mapped
+     * {@link Single}&lt;{@link R}&gt; maybe subscribed to concurrently but the results are emitted in the same order as
+     * this {@link Publisher}.
      * <p>
      * To control the amount of concurrent processing done by this operator see
      * {@link #flatMapConcatSingle(Function, int)}.
      * <p>
-     * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
-     * transformation in sequential programming similar to:
+     * Provides a data transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<R>> futures = ...; // assume this is thread safe
@@ -1352,19 +1360,20 @@ public abstract class Publisher<T> {
      *
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
      * @see #flatMapConcatSingle(Function, int)
+     * @see #flatMapMergeSingle(Function)
      */
     public final <R> Publisher<R> flatMapConcatSingle(Function<? super T, ? extends Single<? extends R>> mapper) {
         return PublisherFlatMapConcatUtils.flatMapConcatSingle(this, mapper);
     }
 
     /**
-     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
-     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;.
-     * Each mapped {@link Single}&lt;{@link R}&gt; maybe subscribed to concurrently but the results are emitted in
-     * the same order as this {@link Publisher}.
+     * This method is similar to {@link #map(Function)} but the result is asynchronous. More specifically, map each
+     * element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals emitted from
+     * each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;. Each mapped
+     * {@link Single}&lt;{@link R}&gt; maybe subscribed to concurrently but the results are emitted in the same order as
+     * this {@link Publisher}.
      * <p>
-     * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
-     * transformation in sequential programming similar to:
+     * Provides a data transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<R>> futures = ...; // assume this is thread safe
@@ -1386,6 +1395,7 @@ public abstract class Publisher<T> {
      * @return A new {@link Publisher} that emits all items emitted by each single produced by {@code mapper}.
      *
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
+     * @see #flatMapMergeSingle(Function, int) 
      */
     public final <R> Publisher<R> flatMapConcatSingle(Function<? super T, ? extends Single<? extends R>> mapper,
                                                       int maxConcurrency) {
@@ -1393,17 +1403,17 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
-     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;.
-     * Each mapped {@link Single}&lt;{@link R}&gt; maybe subscribed to concurrently but the results are emitted in
-     * the same order as this {@link Publisher}.
+     * This method is similar to {@link #map(Function)} but the result is asynchronous. More specifically, map each
+     * element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals emitted from
+     * each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;. Each mapped
+     * {@link Single}&lt;{@link R}&gt; maybe subscribed to concurrently but the results are emitted in the same order as
+     * this {@link Publisher}.
      * <p>
      * The behavior is the same as {@link #flatMapConcatSingle(Function)} with the exception that if any
      * {@link Single} returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not
      * terminate until this {@link Publisher} and all {@link Single}s to terminate.
      * <p>
-     * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
-     * transformation in sequential programming similar to:
+     * Provides a data transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<R>> futures = ...; // assume this is thread safe
@@ -1430,6 +1440,7 @@ public abstract class Publisher<T> {
      *
      * @see <a href="https://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
      * @see #flatMapConcatSingleDelayError(Function, int)
+     * @see #flatMapMergeSingleDelayError(Function)
      */
     public final <R> Publisher<R> flatMapConcatSingleDelayError(
             Function<? super T, ? extends Single<? extends R>> mapper) {
@@ -1437,17 +1448,17 @@ public abstract class Publisher<T> {
     }
 
     /**
-     * Map each element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals
-     * emitted from each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;.
-     * Each mapped {@link Single}&lt;{@link R}&gt; maybe subscribed to concurrently but the results are emitted in
-     * the same order as this {@link Publisher}.
+     * This method is similar to {@link #map(Function)} but the result is asynchronous. More specifically, map each
+     * element of this {@link Publisher} into a {@link Single}&lt;{@link R}&gt; and flatten all signals emitted from
+     * each mapped {@link Single}&lt;{@link R}&gt; into the returned {@link Publisher}&lt;{@link R}&gt;. Each mapped
+     * {@link Single}&lt;{@link R}&gt; maybe subscribed to concurrently but the results are emitted in the same order as
+     * this {@link Publisher}.
      * <p>
      * The behavior is the same as {@link #flatMapConcatSingle(Function)} with the exception that if any
      * {@link Single} returned by {@code mapper}, terminates with an error, the returned {@link Publisher} will not
      * terminate until this {@link Publisher} and all {@link Single}s to terminate.
      * <p>
-     * This method is similar to {@link #map(Function)} but the result is asynchronous, and provides a data
-     * transformation in sequential programming similar to:
+     * Provides a data transformation in sequential programming similar to:
      * <pre>{@code
      *     ExecutorService e = ...;
      *     List<Future<R>> futures = ...; // assume this is thread safe
@@ -1475,6 +1486,7 @@ public abstract class Publisher<T> {
      * @return A new {@link Publisher} that emits all items emitted by each single produced by {@code mapper}.
      *
      * @see <a href="https://reactivex.io/documentation/operators/flatmap.html">ReactiveX flatMap operator.</a>
+     * @see #flatMapMergeSingleDelayError(Function, int)
      */
     public final <R> Publisher<R> flatMapConcatSingleDelayError(
             Function<? super T, ? extends Single<? extends R>> mapper, int maxConcurrency) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatUtils.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Publisher.defer;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
+import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
+import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedSpscQueue;
+import static java.lang.Math.min;
+
+final class PublisherFlatMapConcatUtils {
+    private PublisherFlatMapConcatUtils() {
+    }
+
+    static <T, R> Publisher<R> flatMapConcatSingle(final Publisher<T> publisher,
+                                                   final Function<? super T, ? extends Single<? extends R>> mapper) {
+        return defer(() -> {
+            final Queue<Item<R>> results = newUnboundedSpscQueue(4);
+            final AtomicInteger consumerLock = new AtomicInteger();
+            return publisher.flatMapMergeSingle(orderedMapper(mapper, results, consumerLock))
+                    .shareContextOnSubscribe();
+        });
+    }
+
+    static <T, R> Publisher<R> flatMapConcatSingleDelayError(
+            final Publisher<T> publisher, final Function<? super T, ? extends Single<? extends R>> mapper) {
+        return defer(() -> {
+            final Queue<Item<R>> results = newUnboundedSpscQueue(4);
+            final AtomicInteger consumerLock = new AtomicInteger();
+            return publisher.flatMapMergeSingleDelayError(orderedMapper(mapper, results, consumerLock))
+                    .shareContextOnSubscribe();
+        });
+    }
+
+    static <T, R> Publisher<R> flatMapConcatSingle(final Publisher<T> publisher,
+                                                   final Function<? super T, ? extends Single<? extends R>> mapper,
+                                                   final int maxConcurrency) {
+        return defer(() -> {
+            final Queue<Item<R>> results = newUnboundedSpscQueue(min(8, maxConcurrency));
+            final AtomicInteger consumerLock = new AtomicInteger();
+            return publisher.flatMapMergeSingle(orderedMapper(mapper, results, consumerLock), maxConcurrency)
+                    .shareContextOnSubscribe();
+        });
+    }
+
+    static <T, R> Publisher<R> flatMapConcatSingleDelayError(
+            final Publisher<T> publisher, final Function<? super T, ? extends Single<? extends R>> mapper,
+            final int maxConcurrency) {
+        return defer(() -> {
+            final Queue<Item<R>> results = newUnboundedSpscQueue(min(8, maxConcurrency));
+            final AtomicInteger consumerLock = new AtomicInteger();
+            return publisher.flatMapMergeSingleDelayError(orderedMapper(mapper, results, consumerLock), maxConcurrency)
+                    .shareContextOnSubscribe();
+        });
+    }
+
+    private static <T, R> Function<? super T, Single<? extends R>> orderedMapper(
+            final Function<? super T, ? extends Single<? extends R>> mapper,
+            final Queue<Item<R>> results, final AtomicInteger consumerLock) {
+        return t -> {
+            final Single<? extends R> single = mapper.apply(t);
+            final Item<R> item = new Item<>();
+            results.add(item);
+            return new Single<R>() {
+                @Override
+                protected void handleSubscribe(final SingleSource.Subscriber<? super R> subscriber) {
+                    assert item.subscriber == null; // flatMapMergeSingle only does a single subscribe.
+                    item.subscriber = subscriber;
+                    toSource(single).subscribe(new SingleSource.Subscriber<R>() {
+                        @Override
+                        public void onSubscribe(final Cancellable cancellable) {
+                            subscriber.onSubscribe(cancellable);
+                        }
+
+                        @Override
+                        public void onSuccess(@Nullable final R result) {
+                            item.result = result;
+                            item.terminated = true;
+                            tryPollQueue();
+                        }
+
+                        @Override
+                        public void onError(final Throwable t) {
+                            item.cause = t;
+                            item.terminated = true;
+                            tryPollQueue();
+                        }
+
+                        private void tryPollQueue() {
+                            boolean tryAcquire = true;
+                            while (tryAcquire && tryAcquireLock(consumerLock)) {
+                                try {
+                                    Item<R> i;
+                                    while ((i = results.peek()) != null && i.terminated) {
+                                        results.poll();
+                                        assert i.subscriber != null; // if terminated, must have a subscriber
+                                        if (i.cause != null) {
+                                            i.subscriber.onError(i.cause);
+                                        } else {
+                                            i.subscriber.onSuccess(i.result);
+                                        }
+                                    }
+                                    // flatMapMergeSingle takes care of exception propagation / cleanup
+                                } finally {
+                                    tryAcquire = !releaseLock(consumerLock);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+            // The inner Single will determine if a copy is justified when we subscribe to it.
+            .shareContextOnSubscribe();
+        };
+    }
+
+    private static final class Item<R> {
+        @Nullable
+        SingleSource.Subscriber<? super R> subscriber;
+        @Nullable
+        R result;
+        @Nullable
+        Throwable cause;
+        boolean terminated;
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatUtils.java
@@ -129,7 +129,6 @@ final class PublisherFlatMapConcatUtils {
         }
     }
 
-
     private static final class Item<R> {
         @Nullable
         SingleSource.Subscriber<? super R> subscriber;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatSingleTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+import io.servicetalk.context.api.ContextMap;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,17 +24,24 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
 import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
+import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class PublisherFlatMapConcatSingleTest {
+    private static final ContextMap.Key<String> K1 = ContextMap.Key.newKey("k1", String.class);
+    private static final ContextMap.Key<String> K2 = ContextMap.Key.newKey("k2", String.class);
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestSubscription subscription = new TestSubscription();
     private static Executor executor;
@@ -48,11 +56,11 @@ class PublisherFlatMapConcatSingleTest {
         executor.closeAsync().toFuture().get();
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] begin={0} end={1} maxConcurrency={2} delayError={3}")
     @CsvSource(value = {"0,5,10,false", "0,25,10,false", "0,5,10,true", "0,25,10,true"})
     void orderPreservedInRangeWithConcurrency(int begin, int end, int maxConcurrency, boolean delayError) {
         toSource(concatSingle(Publisher.range(begin, end),
-                i -> executor.timer(ofMillis(1)).toSingle().map(__ -> i + "x"), maxConcurrency, delayError)
+                i -> executor.timer(getDuration()).toSingle().map(__ -> i + "x"), maxConcurrency, delayError)
         ).subscribe(subscriber);
         String[] expected = expected(begin, end);
         subscriber.awaitSubscription().request(expected.length);
@@ -60,12 +68,12 @@ class PublisherFlatMapConcatSingleTest {
         subscriber.awaitOnComplete();
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] begin={0} end={1} maxConcurrency={2} delayError={3}")
     @CsvSource(value = {"0,5,10,false", "0,25,10,false", "0,5,10,true", "0,25,10,true"})
     void errorPropagatedInOrderLast(int begin, int end, int maxConcurrency, boolean delayError) {
         final int endLessOne = end - 1;
         String[] expected = expected(begin, endLessOne);
-        toSource(concatSingle(Publisher.range(begin, end), i -> executor.timer(ofMillis(1)).toSingle().map(__ -> {
+        toSource(concatSingle(Publisher.range(begin, end), i -> executor.timer(getDuration()).toSingle().map(__ -> {
                     if (i == endLessOne) {
                         throw DELIBERATE_EXCEPTION;
                     }
@@ -77,10 +85,10 @@ class PublisherFlatMapConcatSingleTest {
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] begin={0} end={1} maxConcurrency={2} delayError={3}")
     @CsvSource(value = {"0,5,10,false", "0,25,10,false", "0,5,10,true", "0,25,10,true"})
     void errorPropagatedInOrderFirst(int begin, int end, int maxConcurrency, boolean delayError) {
-        toSource(concatSingle(Publisher.range(begin, end), i -> executor.timer(ofMillis(1)).toSingle().map(__ -> {
+        toSource(concatSingle(Publisher.range(begin, end), i -> executor.timer(getDuration()).toSingle().map(__ -> {
                     if (i == begin) {
                         throw DELIBERATE_EXCEPTION;
                     }
@@ -95,7 +103,7 @@ class PublisherFlatMapConcatSingleTest {
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] delayError={0}")
     @ValueSource(booleans = {true, false})
     void cancellationPropagated(boolean delayError) throws InterruptedException {
         TestPublisher<Integer> source = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build(
@@ -120,16 +128,44 @@ class PublisherFlatMapConcatSingleTest {
         subscription.awaitCancelled();
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] delayError={0}")
     @ValueSource(booleans = {true, false})
     void singleTerminalThrows(boolean delayError) {
-        toSource(concatSingle(Publisher.range(0, 2), i -> Single.succeeded(i + "x"), 2, delayError)
+        toSource(concatSingle(Publisher.range(0, 2), i -> succeeded(i + "x"), 2, delayError)
                 .<String>map(x -> {
                     throw DELIBERATE_EXCEPTION;
                 })
         ).subscribe(subscriber);
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] delayError={0}")
+    @ValueSource(booleans = {true, false})
+    void asyncContext(boolean delayError) {
+        assumeFalse(AsyncContext.isDisabled());
+        final int begin = 0;
+        final int end = 2;
+        final int elements = end - begin;
+        AsyncContext.put(K1, "v1");
+        toSource(concatSingle(Publisher.range(begin, end), i -> {
+                    AsyncContext.put(K2, "v2");
+                    return succeeded(i + "x");
+                }, elements, delayError)
+                .map(x -> {
+                    assertThat(AsyncContext.get(K1), equalTo("v1"));
+                    assertThat(AsyncContext.get(K2), equalTo("v2"));
+                    return x;
+                })
+        ).subscribe(subscriber);
+        subscriber.awaitSubscription().request(elements);
+        assertThat(subscriber.takeOnNext(elements), contains(expected(begin, end)));
+        subscriber.awaitOnComplete();
+    }
+
+    private static Duration getDuration() {
+        // Introduce randomness to increase the likelihood of out of order task completion.
+        return ofMillis(ThreadLocalRandom.current().nextInt(5));
     }
 
     private static <T, R> Publisher<R> concatSingle(Publisher<T> publisher, Function<T, Single<R>> mapper,

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatSingleTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.function.Function;
+
+import static io.servicetalk.concurrent.api.Executors.newCachedThreadExecutor;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.time.Duration.ofMillis;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.sameInstance;
+
+class PublisherFlatMapConcatSingleTest {
+    private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
+    private final TestSubscription subscription = new TestSubscription();
+    private static Executor executor;
+
+    @BeforeAll
+    static void beforeClass() {
+        executor = newCachedThreadExecutor();
+    }
+
+    @AfterAll
+    static void afterClass() throws Exception {
+        executor.closeAsync().toFuture().get();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"0,5,10,false", "0,25,10,false", "0,5,10,true", "0,25,10,true"})
+    void orderPreservedInRangeWithConcurrency(int begin, int end, int maxConcurrency, boolean delayError) {
+        toSource(concatSingle(Publisher.range(begin, end),
+                i -> executor.timer(ofMillis(1)).toSingle().map(__ -> i + "x"), maxConcurrency, delayError)
+        ).subscribe(subscriber);
+        String[] expected = expected(begin, end);
+        subscriber.awaitSubscription().request(expected.length);
+        assertThat(subscriber.takeOnNext(expected.length), contains(expected));
+        subscriber.awaitOnComplete();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"0,5,10,false", "0,25,10,false", "0,5,10,true", "0,25,10,true"})
+    void errorPropagatedInOrderLast(int begin, int end, int maxConcurrency, boolean delayError) {
+        final int endLessOne = end - 1;
+        String[] expected = expected(begin, endLessOne);
+        toSource(concatSingle(Publisher.range(begin, end), i -> executor.timer(ofMillis(1)).toSingle().map(__ -> {
+                    if (i == endLessOne) {
+                        throw DELIBERATE_EXCEPTION;
+                    }
+                    return i + "x";
+                }), maxConcurrency, delayError)
+        ).subscribe(subscriber);
+        subscriber.awaitSubscription().request(end - begin);
+        assertThat(subscriber.takeOnNext(expected.length), contains(expected));
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"0,5,10,false", "0,25,10,false", "0,5,10,true", "0,25,10,true"})
+    void errorPropagatedInOrderFirst(int begin, int end, int maxConcurrency, boolean delayError) {
+        toSource(concatSingle(Publisher.range(begin, end), i -> executor.timer(ofMillis(1)).toSingle().map(__ -> {
+                    if (i == begin) {
+                        throw DELIBERATE_EXCEPTION;
+                    }
+                    return i + "x";
+                }), maxConcurrency, delayError)
+        ).subscribe(subscriber);
+        subscriber.awaitSubscription().request(end - begin);
+        if (delayError) {
+            String[] expected = expected(begin + 1, end);
+            assertThat(subscriber.takeOnNext(expected.length), contains(expected));
+        }
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void cancellationPropagated(boolean delayError) throws InterruptedException {
+        TestPublisher<Integer> source = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build(
+                subscriber1 -> {
+            subscriber1.onSubscribe(subscription);
+            return subscriber1;
+        });
+        final TestCancellable cancellable = new TestCancellable();
+        final TestSingle<String> singleSource = new TestSingle.Builder<String>().disableAutoOnSubscribe()
+                .build(subscriber1 -> {
+            subscriber1.onSubscribe(cancellable);
+            return subscriber1;
+        });
+        toSource(concatSingle(source, i -> singleSource, 2, delayError))
+                .subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        subscription.awaitRequestN(1);
+        source.onNext(0);
+        singleSource.awaitSubscribed();
+        subscriber.awaitSubscription().cancel();
+        cancellable.awaitCancelled();
+        subscription.awaitCancelled();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void singleTerminalThrows(boolean delayError) {
+        toSource(concatSingle(Publisher.range(0, 2), i -> Single.succeeded(i + "x"), 2, delayError)
+                .<String>map(x -> {
+                    throw DELIBERATE_EXCEPTION;
+                })
+        ).subscribe(subscriber);
+        subscriber.awaitSubscription().request(1);
+        assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+    }
+
+    private static <T, R> Publisher<R> concatSingle(Publisher<T> publisher, Function<T, Single<R>> mapper,
+                                                    int maxConcurrency, boolean delayError) {
+        return delayError ?
+                publisher.flatMapConcatSingleDelayError(mapper, maxConcurrency) :
+                publisher.flatMapConcatSingle(mapper, maxConcurrency);
+    }
+
+    private static String[] expected(int begin, int end) {
+        String[] expected = new String[end - begin];
+        for (int i = begin; i < end; ++i) {
+            expected[i - begin] = i + "x";
+        }
+        return expected;
+    }
+}

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentUtils.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.internal;
 
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
@@ -76,6 +77,36 @@ public final class ConcurrentUtils {
      */
     public static <T> boolean releaseLock(AtomicIntegerFieldUpdater<T> lockUpdater, T owner) {
         return lockUpdater.getAndSet(owner, CONCURRENT_IDLE) == CONCURRENT_EMITTING;
+    }
+
+    /**
+     * Acquire a lock that is exclusively held with no re-entry, but attempts to acquire the lock while it is
+     * held can be detected by {@link #releaseLock(AtomicInteger)}.
+     * @param lock The {@link AtomicInteger} used to control the lock state.
+     * @return {@code true} if the lock was acquired, {@code false} otherwise.
+     */
+    public static boolean tryAcquireLock(AtomicInteger lock) {
+        for (;;) {
+            final int prevEmitting = lock.get();
+            if (prevEmitting == CONCURRENT_IDLE) {
+                if (lock.compareAndSet(CONCURRENT_IDLE, CONCURRENT_EMITTING)) {
+                    return true;
+                }
+            } else if (lock.compareAndSet(prevEmitting, CONCURRENT_PENDING)) {
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Release a lock that was previously acquired via {@link #tryAcquireLock(AtomicInteger)}.
+     * @param lock The {@link AtomicInteger} used to control the lock state.
+     * @return {@code true} if the lock was released, and no other attempts were made to acquire the lock while it
+     * was held. {@code false} if the lock was released but another attempt was made to acquire the lock before it was
+     * released.
+     */
+    public static boolean releaseLock(AtomicInteger lock) {
+        return lock.getAndSet(CONCURRENT_IDLE) == CONCURRENT_EMITTING;
     }
 
     /**

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapConcatSingleDelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapConcatSingleDelayErrorTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import io.servicetalk.concurrent.api.Single;
 import org.testng.annotations.Test;
 
 @Test
-public class PublisherFlatMapSingleDelayErrorTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+public class PublisherFlatMapConcatSingleDelayErrorTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.flatMapMergeSingleDelayError(Single::succeeded, 10);
+        return publisher.flatMapConcatSingleDelayError(Single::succeeded);
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapConcatSingleTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapConcatSingleTckTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+
+import org.testng.annotations.Test;
+
+@Test
+public class PublisherFlatMapConcatSingleTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+    @Override
+    protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
+        return publisher.flatMapConcatSingle(Single::succeeded);
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeSingleDelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeSingleDelayErrorTckTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2018, 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+
+import org.testng.annotations.Test;
+
+@Test
+public class PublisherFlatMapMergeSingleDelayErrorTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+    @Override
+    protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
+        return publisher.flatMapMergeSingleDelayError(Single::succeeded);
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeSingleTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFlatMapMergeSingleTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import io.servicetalk.concurrent.api.Single;
 import org.testng.annotations.Test;
 
 @Test
-public class PublisherFlatMapSingleTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+public class PublisherFlatMapMergeSingleTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.flatMapMergeSingle(Single::succeeded, 10);
+        return publisher.flatMapMergeSingle(Single::succeeded);
     }
 }


### PR DESCRIPTION
Motivation:
Publisher.flatMapConcatSingle provides similar semantics to
Publisher.flatMapMergeSingle except the results are returned
in the same order as the original Publisher.