### PR TITLE
Add `publishOn`/`subscribeOn` `Executor` overload

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1544,6 +1544,23 @@ public abstract class Completable {
     /**
      * Creates a new {@link Completable} that will use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
+     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
+     * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
+     * {@link Executor}. If such an override is required, {@link #publishOnOverride(Executor)} can be used.
+     *
+     * @param executor {@link Executor} to use.
+     * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods on the
+     * {@link Subscriber}.
+     * @deprecated This method is provided for 0.42 compatibility
+     */
+    @Deprecated
+    public final Completable publishOn(io.servicetalk.concurrent.Executor executor) {
+        return PublishAndSubscribeOnCompletables.publishOn(this, (Executor) executor);
+    }
+
+    /**
+     * Creates a new {@link Completable} that will use the passed {@link Executor} to invoke all {@link Subscriber}
+     * methods.
      * This method overrides preceding {@link Executor}s, if any, specified for {@code this} {@link Completable}.
      * That is to say preceding and subsequent operations for this execution chain will use this {@link Executor}.
      * If such an override is not required, {@link #publishOn(Executor)} can be used.
@@ -1557,6 +1574,26 @@ public abstract class Completable {
     @Deprecated
     public final Completable publishOnOverride(Executor executor) {
         return PublishAndSubscribeOnCompletables.publishOnOverride(this, executor);
+    }
+
+    /**
+     * Creates a new {@link Completable} that will use the passed {@link Executor} to invoke the following methods:
+     * <ul>
+     *     <li>All {@link Cancellable} methods.</li>
+     *     <li>The {@link #handleSubscribe(CompletableSource.Subscriber)} method.</li>
+     * </ul>
+     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
+     * {@link Completable}. Only subsequent operations, if any, added in this execution chain will use this
+     * {@link Executor}. If such an override is required, {@link #subscribeOnOverride(Executor)} can be used.
+     *
+     * @param executor {@link Executor} to use.
+     * @return A new {@link Completable} that will use the passed {@link Executor} to invoke all methods of
+     * {@link Cancellable} and {@link #handleSubscribe(CompletableSource.Subscriber)}.
+     * @deprecated This method is provided for 0.42 compatibility
+     */
+    @Deprecated
+    public final Completable subscribeOn(io.servicetalk.concurrent.Executor executor) {
+        return PublishAndSubscribeOnCompletables.subscribeOn(this, (Executor) executor);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2874,6 +2874,23 @@ public abstract class Publisher<T> {
     /**
      * Creates a new {@link Publisher} that will use the passed {@link Executor} to invoke all {@link Subscriber}
      * methods.
+     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
+     * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
+     * {@link Executor}. If such an override is required, {@link #publishOnOverride(Executor)} can be used.
+     *
+     * @param executor {@link Executor} to use.
+     * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods of
+     * {@link Subscriber}.
+     * @deprecated This method is provided for 0.42 compatibility
+     */
+    @Deprecated
+    public final Publisher<T> publishOn(io.servicetalk.concurrent.Executor executor) {
+        return PublishAndSubscribeOnPublishers.publishOn(this, (Executor) executor);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will use the passed {@link Executor} to invoke all {@link Subscriber}
+     * methods.
      * This method overrides preceding {@link Executor}s, if any, specified for {@code this} {@link Publisher}.
      * That is to say preceding and subsequent operations for this execution chain will use this {@link Executor}.
      * If such an override is not required, {@link #publishOn(Executor)} can be used.
@@ -2904,6 +2921,26 @@ public abstract class Publisher<T> {
      */
     public final Publisher<T> subscribeOn(Executor executor) {
         return PublishAndSubscribeOnPublishers.subscribeOn(this, executor);
+    }
+
+    /**
+     * Creates a new {@link Publisher} that will use the passed {@link Executor} to invoke the following methods:
+     * <ul>
+     *     <li>All {@link Subscription} methods.</li>
+     *     <li>The {@link #handleSubscribe(PublisherSource.Subscriber)} method.</li>
+     * </ul>
+     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
+     * {@link Publisher}. Only subsequent operations, if any, added in this execution chain will use this
+     * {@link Executor}. If such an override is required, {@link #subscribeOnOverride(Executor)} can be used.
+     *
+     * @param executor {@link Executor} to use.
+     * @return A new {@link Publisher} that will use the passed {@link Executor} to invoke all methods of
+     * {@link Subscription} and {@link #handleSubscribe(PublisherSource.Subscriber)}.
+     * @deprecated This method is provided for 0.42 compatibility
+     */
+    @Deprecated
+    public final Publisher<T> subscribeOn(io.servicetalk.concurrent.Executor executor) {
+        return PublishAndSubscribeOnPublishers.subscribeOn(this, (Executor) executor);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1508,6 +1508,22 @@ public abstract class Single<T> {
      * @param executor {@link Executor} to use.
      * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods on the
      * {@link Subscriber}.
+     * @deprecated This method is provided for 0.42 compatibility
+     */
+    @Deprecated
+    public final Single<T> publishOn(io.servicetalk.concurrent.Executor executor) {
+        return PublishAndSubscribeOnSingles.publishOn(this, (Executor) executor);
+    }
+
+    /**
+     * Creates a new {@link Single} that will use the passed {@link Executor} to invoke all {@link Subscriber} methods.
+     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
+     * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
+     * {@link Executor}. If such an override is required, {@link #publishOnOverride(Executor)} can be used.
+     *
+     * @param executor {@link Executor} to use.
+     * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods on the
+     * {@link Subscriber}.
      */
     public final Single<T> publishOn(Executor executor) {
         return PublishAndSubscribeOnSingles.publishOn(this, executor);
@@ -1529,6 +1545,26 @@ public abstract class Single<T> {
     @Deprecated
     public final Single<T> publishOnOverride(Executor executor) {
         return PublishAndSubscribeOnSingles.publishOnOverride(this, executor);
+    }
+
+    /**
+     * Creates a new {@link Single} that will use the passed {@link Executor} to invoke the following methods:
+     * <ul>
+     *     <li>All {@link Cancellable} methods.</li>
+     *     <li>The {@link #handleSubscribe(SingleSource.Subscriber)} method.</li>
+     * </ul>
+     * This method does <strong>not</strong> override preceding {@link Executor}s, if any, specified for {@code this}
+     * {@link Single}. Only subsequent operations, if any, added in this execution chain will use this
+     * {@link Executor}. If such an override is required, {@link #subscribeOnOverride(Executor)} can be used.
+     *
+     * @param executor {@link Executor} to use.
+     * @return A new {@link Single} that will use the passed {@link Executor} to invoke all methods of
+     * {@link Cancellable} and {@link #handleSubscribe(SingleSource.Subscriber)}.
+     * @deprecated This method is provided for 0.42 compatibility
+     */
+    @Deprecated
+    public final Single<T> subscribeOn(io.servicetalk.concurrent.Executor executor) {
+        return PublishAndSubscribeOnSingles.subscribeOn(this, (Executor) executor);
     }
 
     /**


### PR DESCRIPTION
Motivation:
The signature of `publishOn(Executor)` and `subscribeOn(Executor)`
methods changed between 0.41 and 0.42 from
`io.servicetalk.concurrent.api.Executor` to the more general parent
type `io.servicetalk.concurrent.api.Executor`. This is a source
compatible change since the new type is a parent of the old type, but
is not a binary compatible change; code compiled against 0.41 will not
run with 0.42 as it will not find the method it expects with the
`io.servicetalk.concurrent.api.Executor` signature.
Modifications:
Add overloads `publishOn(Executor)` and `subscribeOn(Executor)` for
`io.servicetalk.concurrent.Executor`. For binary compatibility with
0.42 it will also be necessary to cast executors to
`io.servicetalk.concurrent.api.Executor` to ensure that the correct
overload is used.
Result:
Improved compatibility with ServiceTalk 0.42