### PR TITLE
Use filter strategy for streaming async server

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -62,7 +62,6 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.netty.StrategyInfluencerAwareConversions.toConditionalServiceFilterFactory;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
@@ -262,11 +261,7 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
 
     @Override
     public Single<HttpServerContext> listenStreaming(final StreamingHttpService service) {
-        HttpExecutionStrategy serviceStrategy = requiredOffloads(service, defaultStrategy());
-        HttpExecutionStrategy filterStrategy = computeRequiredStrategy(serviceFilters, serviceStrategy);
-        HttpExecutionStrategy useStrategy = defaultStrategy() == strategy ? offloadAll() :
-                strategy.hasOffloads() ? strategy.merge(filterStrategy) : offloadNone();
-        return listenForService(service, useStrategy);
+        return listenForService(service, computeServiceStrategy(service));
     }
 
     @Override
@@ -365,7 +360,7 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
         HttpExecutionStrategy serviceStrategy = requiredOffloads(service, defaultStrategy());
         HttpExecutionStrategy filterStrategy = computeRequiredStrategy(serviceFilters, serviceStrategy);
         return defaultStrategy() == strategy ? filterStrategy :
-                strategy.hasOffloads() ? strategy.merge(filterStrategy) : offloadNone();
+                strategy.hasOffloads() ? strategy.merge(filterStrategy) : strategy;
     }
 
     private static StreamingHttpService applyInternalFilters(StreamingHttpService service,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -62,6 +62,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.netty.StrategyInfluencerAwareConversions.toConditionalServiceFilterFactory;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
@@ -261,7 +262,11 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
 
     @Override
     public Single<HttpServerContext> listenStreaming(final StreamingHttpService service) {
-        return listenForService(service, strategy);
+        HttpExecutionStrategy serviceStrategy = requiredOffloads(service, defaultStrategy());
+        HttpExecutionStrategy filterStrategy = computeRequiredStrategy(serviceFilters, serviceStrategy);
+        HttpExecutionStrategy useStrategy = defaultStrategy() == strategy ? offloadAll() :
+                strategy.hasOffloads() ? strategy.merge(filterStrategy) : offloadNone();
+        return listenForService(service, useStrategy);
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthStrategyInfluencerTest.java
@@ -31,7 +31,6 @@ import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.utils.auth.BasicAuthHttpServiceFilter;
 import io.servicetalk.http.utils.auth.BasicAuthHttpServiceFilter.CredentialsVerifier;
-import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServerContext;
@@ -129,6 +128,7 @@ class BasicAuthStrategyInfluencerTest {
         when(credentialsVerifier.apply(anyString(), anyString())).thenReturn(succeeded("success"));
         when(credentialsVerifier.closeAsync()).thenReturn(completed());
         when(credentialsVerifier.closeAsyncGracefully()).thenReturn(completed());
+        when(credentialsVerifier.requiredOffloads()).thenCallRealMethod();
         CredentialsVerifier<String> verifier = credentialsVerifier;
         if (noOffloadsInfluence) {
             verifier = new InfluencingVerifier(verifier, offloadNone());
@@ -146,8 +146,7 @@ class BasicAuthStrategyInfluencerTest {
         return this.client;
     }
 
-    private static final class OffloadCheckingService implements StreamingHttpService,
-                                                                 ExecutionStrategyInfluencer<HttpExecutionStrategy> {
+    private static final class OffloadCheckingService implements StreamingHttpService {
 
         private enum OffloadPoint {
             ServiceHandle,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
@@ -54,7 +54,6 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
-import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -106,7 +105,7 @@ class ExecutionStrategyInContextTest {
             assert expectedClientStrategy == null;
             expectedClientStrategy = defaultStrategy();
             assert expectedServerStrategy == null;
-            expectedServerStrategy = offloadAll();
+            expectedServerStrategy = offloadNone();
         }
         HttpExecutionStrategy clientStrat = client.executionContext().executionStrategy();
         assertThat("Unexpected client strategy.", clientStrat, equalStrategies(expectedClientStrategy));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExecutionStrategyInContextTest.java
@@ -23,12 +23,18 @@ import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.ReservedBlockingHttpConnection;
 import io.servicetalk.http.api.ReservedBlockingStreamingHttpConnection;
 import io.servicetalk.http.api.ReservedHttpConnection;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 
@@ -48,6 +54,8 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -79,16 +87,26 @@ class ExecutionStrategyInContextTest {
     @ValueSource(booleans = {false, true})
     void testStreaming(boolean customStrategy) throws Exception {
         StreamingHttpClient client = initClientAndServer(builder ->
-                builder.listenStreaming((ctx, request, responseFactory) -> {
-                    serviceStrategyRef.set(ctx.executionContext().executionStrategy());
-                    return succeeded(responseFactory.ok());
+                builder.listenStreaming(new StreamingHttpService() {
+                    @Override
+                    public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                                final StreamingHttpRequest request,
+                                                                final StreamingHttpResponseFactory responseFactory) {
+                        serviceStrategyRef.set(ctx.executionContext().executionStrategy());
+                        return succeeded(responseFactory.ok());
+                    }
+
+                    @Override
+                    public HttpExecutionStrategy requiredOffloads() {
+                        return offloadNone();
+                    }
                 }), customStrategy).buildStreaming();
         clientAsCloseable = client;
         if (!customStrategy) {
             assert expectedClientStrategy == null;
             expectedClientStrategy = defaultStrategy();
             assert expectedServerStrategy == null;
-            expectedServerStrategy = defaultStrategy();
+            expectedServerStrategy = offloadAll();
         }
         HttpExecutionStrategy clientStrat = client.executionContext().executionStrategy();
         assertThat("Unexpected client strategy.", clientStrat, equalStrategies(expectedClientStrategy));
@@ -211,18 +229,18 @@ class ExecutionStrategyInContextTest {
         return clientBuilder;
     }
 
-    static Matcher<HttpExecutionStrategy> equalStrategies(@Nullable HttpExecutionStrategy expected) {
-        return new TypeSafeMatcher<HttpExecutionStrategy>() {
+    static Matcher<ExecutionStrategy> equalStrategies(@Nullable ExecutionStrategy expected) {
+        return new TypeSafeMatcher<ExecutionStrategy>() {
 
             @Override
-            public void describeMismatchSafely(@Nullable HttpExecutionStrategy item, Description mismatchDescription) {
+            public void describeMismatchSafely(@Nullable ExecutionStrategy item, Description mismatchDescription) {
                 mismatchDescription
                         .appendText("was strategy ")
                         .appendValue(item);
             }
 
             @Override
-            protected boolean matchesSafely(final @Nullable HttpExecutionStrategy item) {
+            protected boolean matchesSafely(final @Nullable ExecutionStrategy item) {
                 return Objects.equals(expected, item);
             }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -28,16 +28,21 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoThreadFactory;
-import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 import io.servicetalk.transport.netty.internal.NettyIoThreadFactory;
 
@@ -47,12 +52,14 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
@@ -62,7 +69,10 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.http.netty.HttpServers.forAddress;
@@ -77,46 +87,80 @@ import static java.lang.Thread.currentThread;
 class HttpOffloadingTest {
     private static final HttpExecutionStrategy ALL_BUT_CLOSE_OFFLOAD = HttpExecutionStrategies.customStrategyBuilder()
             .offloadReceiveMetadata().offloadReceiveData().offloadSend().offloadEvent().build();
+    private static final HttpExecutionStrategy OFFLOAD_CLOSE = HttpExecutionStrategies.customStrategyBuilder()
+            .offloadClose().build();
 
     private static final String IO_EXECUTOR_NAME_PREFIX = "io-executor";
 
     @RegisterExtension
     static final ExecutionContextExtension CLIENT_CTX =
-        ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX))
-                .setClassLevel(true);
+            ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX))
+                    .setClassLevel(true);
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
-        ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX))
-                .setClassLevel(true);
-
-    private StreamingHttpConnection httpConnection;
+            ExecutionContextExtension.cached(new NettyIoThreadFactory(IO_EXECUTOR_NAME_PREFIX))
+                    .setClassLevel(true);
     private final Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
     private final CountDownLatch terminated = new CountDownLatch(1);
-    private ServerContext serverContext;
+    @Nullable
+    private StreamingHttpConnection httpConnection;
+    @Nullable
+    private HttpServerContext serverContext;
+    @Nullable
     private OffloadingVerifyingServiceStreaming service;
+    @Nullable
     private StreamingHttpClient client;
 
-    private Predicate<Thread> wrongSubscribeThread = t -> false; // don't care what thread is used.
-    private Predicate<Thread> wrongPublishThread;
+    @Nullable
+    private Predicate<Thread> wrongServerPublishThread;
+    @Nullable
+    private Predicate<Thread> wrongClientPublishThread;
+
+    void setup() throws Exception {
+        setup(true);
+    }
 
     void setup(boolean offloadClose) throws Exception {
-        Thread testThread = Thread.currentThread();
-        wrongPublishThread = offloadClose ?
-                IoThreadFactory.IoThread::isIoThread :
-                (Thread thread) -> thread != testThread && !IoThreadFactory.IoThread.isIoThread(thread);
-        service = new OffloadingVerifyingServiceStreaming();
-        serverContext = forAddress(localAddress(0))
-            .ioExecutor(SERVER_CTX.ioExecutor())
-            .executor(SERVER_CTX.executor())
-            .executionStrategy(offloadClose ? defaultStrategy() : ALL_BUT_CLOSE_OFFLOAD)
-            .listenStreamingAndAwait(service);
+        HttpExecutionStrategy serverStrategy = offloadClose ? defaultStrategy() : ALL_BUT_CLOSE_OFFLOAD;
+        HttpExecutionStrategy clientStrategy = offloadClose ? defaultStrategy() : ALL_BUT_CLOSE_OFFLOAD;
+        setup(offloadAll(), offloadAll(), serverStrategy, offloadClose ? OFFLOAD_CLOSE : offloadNone(),
+                clientStrategy, offloadClose ? OFFLOAD_CLOSE : offloadNone(),
+                hsb -> hsb, sahcb -> sahcb);
+    }
 
-        client = forSingleAddress(serverHostAndPort(serverContext))
-            .ioExecutor(CLIENT_CTX.ioExecutor())
-            .executor(CLIENT_CTX.executor())
-            .executionStrategy(offloadClose ? defaultStrategy() : ALL_BUT_CLOSE_OFFLOAD)
-            .buildStreaming();
+    void setup(final HttpExecutionStrategy serviceStrategy, final HttpExecutionStrategy expectedServerStrategy,
+               final HttpExecutionStrategy serverStrategy, final HttpExecutionStrategy serverOffload,
+               final HttpExecutionStrategy clientStrategy, final HttpExecutionStrategy clientOffload,
+               UnaryOperator<HttpServerBuilder> serverInitializer,
+               UnaryOperator<SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress>> clientInitializer)
+            throws Exception {
+        Thread testThread = Thread.currentThread();
+        wrongServerPublishThread = checkThread(serverStrategy, serverOffload, testThread);
+        wrongClientPublishThread = checkThread(clientStrategy, clientOffload, testThread);
+
+        service = new OffloadingVerifyingServiceStreaming(serviceStrategy, expectedServerStrategy);
+        serverContext = serverInitializer.apply(forAddress(localAddress(0))
+                        .ioExecutor(SERVER_CTX.ioExecutor())
+                        .executor(SERVER_CTX.executor())
+                        .executionStrategy(serverStrategy))
+                .listenStreamingAndAwait(service);
+
+        client = clientInitializer.apply(forSingleAddress(serverHostAndPort(serverContext))
+                        .ioExecutor(CLIENT_CTX.ioExecutor())
+                        .executor(CLIENT_CTX.executor())
+                        .executionStrategy(clientStrategy))
+                .buildStreaming();
         httpConnection = awaitIndefinitelyNonNull(client.reserveConnection(client.get("/")));
+    }
+
+    private Predicate<Thread> checkThread(final HttpExecutionStrategy strategy,
+                                          final HttpExecutionStrategy offloads,
+                                          final Thread testThread) {
+        return offloads.hasOffloads() ?
+                strategy.missing(offloads).hasOffloads() ?
+                        (Thread thread) -> testThread != thread && !IoThreadFactory.IoThread.isIoThread(thread) :
+                        IoThreadFactory.IoThread::isIoThread :
+                t -> false; // don't care what thread is used.
     }
 
     @AfterEach
@@ -131,58 +175,20 @@ class HttpOffloadingTest {
 
     @Test
     void requestResponseIsOffloaded() throws Exception {
-        setup(true);
+        setup();
         final Publisher<Buffer> reqPayload =
-            from(httpConnection.connectionContext().executionContext().bufferAllocator()
-                     .fromAscii("Hello"))
-                .beforeRequest(n -> {
-                    if (wrongPublishThread.test(currentThread())) {
-                        errors.add(new AssertionError("Server response: request-n has incorrect offloading. Thread: "
-                                                      + currentThread().getName()));
-                    }
-                });
+                from(httpConnection.connectionContext().executionContext().bufferAllocator()
+                        .fromAscii("Hello"))
+                        .beforeRequest(n -> {
+                            if (wrongClientPublishThread.test(currentThread())) {
+                                errors.add(new AssertionError(
+                                        "Server response: request-n has incorrect offloading. Thread: "
+                                        + currentThread().getName()));
+                            }
+                        });
         final SingleSource<StreamingHttpResponse> resp = toSource(httpConnection.request(
-            httpConnection.get("/").payloadBody(reqPayload)));
-        resp.subscribe(new SingleSource.Subscriber<StreamingHttpResponse>() {
-            @Override
-            public void onSubscribe(final Cancellable cancellable) {
-                if (wrongPublishThread.test(currentThread())) {
-                    errors.add(new AssertionError(
-                            "Client response single: onSubscribe has incorrect offloading. Thread: "
-                                                  + currentThread().getName()));
-                }
-            }
-
-            @Override
-            public void onSuccess(@Nullable final StreamingHttpResponse result) {
-                if (wrongPublishThread.test(currentThread())) {
-                    errors.add(new AssertionError(
-                            "Client response single: onSuccess has incorrect offloading. Thread: "
-                                                  + currentThread().getName()));
-                }
-                if (result == null) {
-                    errors.add(new AssertionError("Client response is null."));
-                    return;
-                }
-                if (!OK.equals(result.status())) {
-                    errors.add(new AssertionError("Invalid response status: " + result.status()));
-                    return;
-                }
-
-                subscribeTo(errors,
-                            result.payloadBody().afterFinally(terminated::countDown), "Client response payload: ");
-            }
-
-            @Override
-            public void onError(final Throwable t) {
-                if (wrongPublishThread.test(currentThread())) {
-                    errors.add(new AssertionError("Client response single: onError has incorrect offloading. Thread: "
-                                                  + currentThread().getName()));
-                }
-                errors.add(new AssertionError("Client response single: Unexpected error.", t));
-                terminated.countDown();
-            }
-        });
+                httpConnection.post("/").payloadBody(reqPayload)));
+        responseSubscribe(resp);
         terminated.await();
         assertNoAsyncErrors("Unexpected client errors.", errors);
         assertNoAsyncErrors("Unexpected server errors.", service.errors);
@@ -190,38 +196,38 @@ class HttpOffloadingTest {
 
     @Test
     void reserveConnectionIsOffloaded() throws Exception {
-        setup(true);
+        setup();
         toSource(client.reserveConnection(client.get("/")).afterFinally(terminated::countDown))
-            .subscribe(new SingleSource.Subscriber<ReservedStreamingHttpConnection>() {
-                @Override
-                public void onSubscribe(final Cancellable cancellable) {
-                    if (wrongPublishThread.test(currentThread())) {
-                        errors.add(new AssertionError("onSubscribe has incorrect offloading. Thread: "
-                                                      + currentThread().getName()));
+                .subscribe(new SingleSource.Subscriber<ReservedStreamingHttpConnection>() {
+                    @Override
+                    public void onSubscribe(final Cancellable cancellable) {
+                        if (wrongClientPublishThread.test(currentThread())) {
+                            errors.add(new AssertionError("onSubscribe has incorrect offloading. Thread: "
+                                    + currentThread().getName()));
+                        }
                     }
-                }
 
-                @Override
-                public void onSuccess(@Nullable final ReservedStreamingHttpConnection result) {
-                    if (result == null) {
-                        errors.add(new AssertionError("Reserved connection is null."));
-                        return;
+                    @Override
+                    public void onSuccess(@Nullable final ReservedStreamingHttpConnection result) {
+                        if (result == null) {
+                            errors.add(new AssertionError("Reserved connection is null."));
+                            return;
+                        }
+                        if (wrongClientPublishThread.test(currentThread())) {
+                            errors.add(new AssertionError("onSuccess has incorrect offloading. Thread: "
+                                    + currentThread().getName()));
+                        }
                     }
-                    if (wrongPublishThread.test(currentThread())) {
-                        errors.add(new AssertionError("onSuccess has incorrect offloading. Thread: "
-                                                      + currentThread().getName()));
-                    }
-                }
 
-                @Override
-                public void onError(final Throwable t) {
-                    if (wrongPublishThread.test(currentThread())) {
-                        errors.add(new AssertionError("onError has incorrect offloading. Thread: "
-                                                      + currentThread().getName()));
+                    @Override
+                    public void onError(final Throwable t) {
+                        if (wrongClientPublishThread.test(currentThread())) {
+                            errors.add(new AssertionError("onError has incorrect offloading. Thread: "
+                                    + currentThread().getName()));
+                        }
+                        errors.add(new AssertionError("Unexpected error.", t));
                     }
-                    errors.add(new AssertionError("Unexpected error.", t));
-                }
-            });
+                });
         terminated.await();
         assertNoAsyncErrors(errors);
     }
@@ -256,10 +262,10 @@ class HttpOffloadingTest {
 
     @Test
     void clientSettingsStreamIsOffloaded() throws Exception {
-        setup(true);
+        setup();
         subscribeTo(errors,
-                    httpConnection.transportEventStream(MAX_CONCURRENCY).afterFinally(terminated::countDown),
-                    "Client settings stream: ");
+                httpConnection.transportEventStream(MAX_CONCURRENCY).afterFinally(terminated::countDown),
+                "Client settings stream: ");
         httpConnection.closeAsyncGracefully().toFuture().get();
         terminated.await();
         assertNoAsyncErrors(errors);
@@ -293,8 +299,84 @@ class HttpOffloadingTest {
         assertNoAsyncErrors(errors);
     }
 
+    @Test
+    void testStreamingEffectiveStrategy() throws Exception {
+        setup(customStrategyBuilder().offloadReceiveMetadata().build(),
+                customStrategyBuilder()
+                        .offloadReceiveData().offloadReceiveMetadata().offloadClose().offloadEvent().build(),
+                customStrategyBuilder().offloadClose().offloadEvent().build(),
+                offloadNone(),
+                defaultStrategy(), offloadNone(),
+                hsb -> hsb.appendServiceFilter(new StreamingHttpServiceFilterFactory() {
+                    @Override
+                    public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+                        return new StreamingHttpServiceFilter(service);
+                    }
+
+                    @Override
+                    public HttpExecutionStrategy requiredOffloads() {
+                        return customStrategyBuilder().offloadReceiveData().build();
+                    }
+                }),
+                sahcb -> sahcb);
+        final Publisher<Buffer> reqPayload =
+                from(httpConnection.connectionContext().executionContext().bufferAllocator()
+                        .fromAscii("Hello"));
+        final SingleSource<StreamingHttpResponse> response = toSource(httpConnection.request(
+                httpConnection.post("/").payloadBody(reqPayload)));
+        responseSubscribe(response);
+        terminated.await();
+        assertNoAsyncErrors("Unexpected client errors.", errors);
+        assertNoAsyncErrors("Unexpected server errors.", service.errors);
+    }
+
+    void responseSubscribe(SingleSource<StreamingHttpResponse> response) {
+        response.subscribe(new SingleSource.Subscriber<StreamingHttpResponse>() {
+            @Override
+            public void onSubscribe(final Cancellable cancellable) {
+                if (wrongClientPublishThread.test(currentThread())) {
+                    errors.add(new AssertionError(
+                            "Client response single: onSubscribe has incorrect offloading. Thread: "
+                                    + currentThread().getName()));
+                }
+            }
+
+            @Override
+            public void onSuccess(@Nullable final StreamingHttpResponse result) {
+                if (wrongClientPublishThread.test(currentThread())) {
+                    errors.add(new AssertionError(
+                            "Client response single: onSuccess has incorrect offloading. Thread: "
+                                    + currentThread().getName()));
+                }
+                if (result == null) {
+                    errors.add(new AssertionError("Client response is null."));
+                    terminated.countDown();
+                    return;
+                }
+                if (!OK.equals(result.status())) {
+                    errors.add(new AssertionError("Invalid response status: " + result.status()));
+                    terminated.countDown();
+                    return;
+                }
+
+                subscribeTo(errors,
+                        result.payloadBody().afterFinally(terminated::countDown), "Client response payload: ");
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                if (wrongClientPublishThread.test(currentThread())) {
+                    errors.add(new AssertionError("Client response single: onError has incorrect offloading. Thread: "
+                            + currentThread().getName()));
+                }
+                errors.add(new AssertionError("Client response single: Unexpected error.", t));
+                terminated.countDown();
+            }
+        });
+    }
+
     private void subscribeTo(final Completable source) {
-        subscribeTo(errors, source.afterFinally(terminated::countDown), wrongSubscribeThread, wrongPublishThread);
+        subscribeTo(errors, source.afterFinally(terminated::countDown), t -> false, wrongClientPublishThread);
     }
 
     private static void subscribeTo(final Collection<Throwable> errors,
@@ -306,7 +388,7 @@ class HttpOffloadingTest {
             public void onSubscribe(final Cancellable cancellable) {
                 if (wrongSubscribeThread.test(currentThread())) {
                     errors.add(new AssertionError("onSubscribe has incorrect offloading. Thread: "
-                                                  + currentThread().getName()));
+                            + currentThread().getName()));
                 }
             }
 
@@ -314,7 +396,7 @@ class HttpOffloadingTest {
             public void onComplete() {
                 if (wrongPublishThread.test(currentThread())) {
                     errors.add(new AssertionError("onComplete has incorrect offloading. Thread: "
-                                                  + currentThread().getName()));
+                            + currentThread().getName()));
                 }
             }
 
@@ -322,7 +404,7 @@ class HttpOffloadingTest {
             public void onError(final Throwable t) {
                 if (wrongPublishThread.test(currentThread())) {
                     errors.add(new AssertionError("onError has incorrect offloading. Thread: "
-                                                  + currentThread().getName()));
+                            + currentThread().getName()));
                 }
                 errors.add(new AssertionError("Unexpected error.", t));
             }
@@ -335,7 +417,7 @@ class HttpOffloadingTest {
             public void onSubscribe(final Subscription s) {
                 if (currentThreadIsIoThread()) {
                     errors.add(new AssertionError(msgPrefix + " onSubscribe was not offloaded. Thread: "
-                                                  + currentThread().getName()));
+                            + currentThread().getName()));
                 }
                 s.request(MAX_VALUE);
             }
@@ -344,7 +426,7 @@ class HttpOffloadingTest {
             public void onNext(final T integer) {
                 if (currentThreadIsIoThread()) {
                     errors.add(new AssertionError(msgPrefix + " onNext was not offloaded for value: " + integer
-                                                  + ". Thread: " + currentThread().getName()));
+                            + ". Thread: " + currentThread().getName()));
                 }
             }
 
@@ -352,7 +434,7 @@ class HttpOffloadingTest {
             public void onError(final Throwable t) {
                 if (currentThreadIsIoThread()) {
                     errors.add(new AssertionError(msgPrefix + " onError was not offloaded. Thread: "
-                                                  + currentThread().getName()));
+                            + currentThread().getName()));
                 }
                 errors.add(new AssertionError(msgPrefix + " Unexpected error.", t));
             }
@@ -361,7 +443,7 @@ class HttpOffloadingTest {
             public void onComplete() {
                 if (currentThreadIsIoThread()) {
                     errors.add(new AssertionError(msgPrefix + " onComplete was not offloaded. Thread: "
-                                                  + currentThread().getName()));
+                            + currentThread().getName()));
                 }
             }
         });
@@ -370,17 +452,37 @@ class HttpOffloadingTest {
     private static final class OffloadingVerifyingServiceStreaming implements StreamingHttpService {
 
         private final Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
+        private final HttpExecutionStrategy requiredStrategy;
+        private final HttpExecutionStrategy expectStrategy;
+
+        OffloadingVerifyingServiceStreaming() {
+            this(offloadAll(), offloadAll()); // safe default
+        }
+
+        OffloadingVerifyingServiceStreaming(final HttpExecutionStrategy requiredStrategy,
+                                            final HttpExecutionStrategy expectStrategy) {
+            this.requiredStrategy = requiredStrategy;
+            this.expectStrategy = expectStrategy;
+        }
 
         @Override
         public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                     final StreamingHttpRequest request,
                                                     final StreamingHttpResponseFactory factory) {
+            HttpExecutionStrategy notOffloaded = expectStrategy.missing(ctx.executionContext().executionStrategy());
+            if (notOffloaded.hasOffloads()) {
+                errors.add(new AssertionError("Expected: " + expectStrategy +
+                        " Found: " + ctx.executionContext().executionStrategy()));
+            }
+
             if (currentThreadIsIoThread()) {
-                errors.add(new AssertionError("Request: " + request + " received on the eventloop."));
+                Error failure = new AssertionError("Request: " + request + " received on the eventloop.");
+                errors.add(failure);
+                throw failure;
             }
             CountDownLatch latch = new CountDownLatch(1);
             subscribeTo(errors,
-                        request.payloadBody().afterFinally(latch::countDown), "Server request: ");
+                    request.payloadBody().afterFinally(latch::countDown), "Server request: ");
             try {
                 latch.await();
             } catch (InterruptedException e) {
@@ -389,15 +491,20 @@ class HttpOffloadingTest {
                 throwException(e);
             }
             Publisher<Buffer> responsePayload =
-                from(ctx.executionContext().bufferAllocator().fromAscii("Hello"))
-                    .beforeRequest(n -> {
-                        if (currentThreadIsIoThread()) {
-                            errors.add(
-                                new AssertionError("Server response: request-n was not offloaded. Thread: "
-                                                   + currentThread().getName()));
-                        }
-                    });
+                    from(ctx.executionContext().bufferAllocator().fromAscii("Hello"))
+                            .beforeRequest(n -> {
+                                if (currentThreadIsIoThread()) {
+                                    errors.add(
+                                            new AssertionError("Server response: request-n was not offloaded. Thread: "
+                                                    + currentThread().getName()));
+                                }
+                            });
             return succeeded(factory.ok().payloadBody(responsePayload));
+        }
+
+        @Override
+        public HttpExecutionStrategy requiredOffloads() {
+            return requiredStrategy;
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslAndNonSslConnectionsTest.java
@@ -90,6 +90,7 @@ class SslAndNonSslConnectionsTest {
                 });
         when(STREAMING_HTTP_SERVICE.closeAsync()).thenReturn(completed());
         when(STREAMING_HTTP_SERVICE.closeAsyncGracefully()).thenReturn(completed());
+        when(STREAMING_HTTP_SERVICE.requiredOffloads()).thenCallRealMethod();
         serverCtx = HttpServers.forAddress(localAddress(0))
                 .executionStrategy(offloadNone())
                 .listenStreamingAndAwait(STREAMING_HTTP_SERVICE);
@@ -106,6 +107,7 @@ class SslAndNonSslConnectionsTest {
                 });
         when(SECURE_STREAMING_HTTP_SERVICE.closeAsync()).thenReturn(completed());
         when(SECURE_STREAMING_HTTP_SERVICE.closeAsyncGracefully()).thenReturn(completed());
+        when(SECURE_STREAMING_HTTP_SERVICE.requiredOffloads()).thenCallRealMethod();
         secureServerCtx = HttpServers.forAddress(localAddress(0))
                 .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
                         DefaultTestCerts::loadServerKey).build())


### PR DESCRIPTION
Motivation:
Currently the filter strategy is not considered in the computation of
the effective strategy for async streaming servers. This was done
because with a default builder strategy the result could be less
offloading which would be unexpected for that builder strategy.
Modifications:
Consider filter strategy in computing effective strategy for
async streaming servers.
Result:
More predictable offloading behavior.