### PR TITLE
Make ServiceTalk protoc plugin extensible

### DIFF
--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -127,5 +127,5 @@ task testJavadoc(type: Javadoc) {
 test.finalizedBy(testJavadoc)
 
 test {
-  systemProperty 'generatedFilesBaseDir', "$buildDir/generated/sources/proto"
+  systemProperty 'generatedFilesBaseDir', protobuf.generatedFilesBaseDir
 }

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -78,6 +78,8 @@ protobuf {
   }
   generateProtoTasks {
     all().each { task ->
+      task.generateDescriptorSet = true
+      task.descriptorSetOptions.includeImports = true
       task.inputs
           .file(pluginJar)
           .withNormalizer(ClasspathNormalizer)
@@ -113,6 +115,7 @@ task testJavadoc(type: Javadoc) {
   dependsOn tasks.compileTestJava
 
   source = protobuf.generatedFilesBaseDir
+  exclude "**/*.desc"
   classpath = sourceSets.test.compileClasspath
   destinationDir = file("$buildDir/tmp/testjavadoc")
   options.addBooleanOption("Xdoclint:syntax", true)
@@ -122,3 +125,7 @@ task testJavadoc(type: Javadoc) {
 }
 
 test.finalizedBy(testJavadoc)
+
+test {
+  systemProperty 'generatedFilesBaseDir', "$buildDir/generated/sources/proto"
+}

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/FileDescriptor.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/FileDescriptor.java
@@ -67,7 +67,6 @@ final class FileDescriptor implements GenerationContext {
     private final List<TypeSpec.Builder> serviceClassBuilders;
     private final Set<String> reservedJavaTypeName = new HashSet<>();
     private final Map<TypeSpec.Builder, ServiceDescriptorProto> protoForServiceBuilder;
-    static final String INSERTION_POINT_FORMAT = "// @@protoc_insertion_point(service_scope:%s)";
 
     /**
      * A single protoc file for which we will be generating classes
@@ -100,7 +99,7 @@ final class FileDescriptor implements GenerationContext {
         reservedJavaTypeName.add(outerClassName);
 
         serviceClassBuilders = new ArrayList<>(protoFile.getServiceCount());
-        protoForServiceBuilder = new HashMap<>(protoFile.getServiceCount());
+        protoForServiceBuilder = new HashMap<>();
     }
 
     String protoFileName() {
@@ -128,10 +127,10 @@ final class FileDescriptor implements GenerationContext {
         return protoFile.getSourceCodeInfo();
     }
 
-    private void addMessageTypes(final List<DescriptorProto> messageTypes,
-                                 final @Nullable String parentProtoScope,
-                                 final String parentJavaScope,
-                                 final Map<String, ClassName> messageTypesMap) {
+    private static void addMessageTypes(final List<DescriptorProto> messageTypes,
+                                        @Nullable final String parentProtoScope,
+                                        final String parentJavaScope,
+                                        final Map<String, ClassName> messageTypesMap) {
         messageTypes.forEach(t -> {
             final String protoTypeName = parentProtoScope != null ?
                     (parentProtoScope + '.' + t.getName()) : '.' + t.getName();
@@ -233,12 +232,13 @@ final class FileDescriptor implements GenerationContext {
     }
 
     private String addInsertionPoint(String content, String name) {
-        String fqn = protoPackageName != null ? protoPackageName + "." + name : name;
-        content = content.replaceAll(
-            "class __" + fqn + " \\{\n *}",
-            String.format(INSERTION_POINT_FORMAT, fqn)
-        );
+        String fqn = protoPackageName != null ? protoPackageName + '.' + name : name;
+        content = content.replaceAll("class __" + fqn + " \\{\n *}", insertionPoint(fqn));
         return content;
+    }
+
+    static String insertionPoint(final String fqn) {
+        return "// @@protoc_insertion_point(service_scope:" + fqn + ')';
     }
 
     private static void insertSingleFileContent(final String content, String fileName,

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -242,11 +242,12 @@ final class Generator {
     /**
      * Generate Service class for the provided proto service descriptor.
      *
+     *
      * @param serviceProto The service descriptor.
      * @param serviceIndex The index of the service within the current file (0 based).
      * @return The service class builder
      */
-    TypeSpec.Builder generate(final ServiceDescriptorProto serviceProto, final int serviceIndex) {
+    TypeSpec.Builder generate(FileDescriptor f, final ServiceDescriptorProto serviceProto, final int serviceIndex) {
         final String name = context.deconflictJavaTypeName(
                 sanitizeIdentifier(serviceProto.getName(), false) + Service);
         final State state = new State(serviceProto, name, serviceIndex);
@@ -265,8 +266,16 @@ final class Generator {
         addClientMetadata(state, serviceClassBuilder);
         addClientInterfaces(state, serviceClassBuilder);
         addClientFactory(state, serviceClassBuilder);
+        // this empty class is a placeholder and get replaced with insertion point comment
+        serviceClassBuilder.addType(TypeSpec.classBuilder("__" + serviceFQN(f, serviceProto)).build());
 
         return serviceClassBuilder;
+    }
+
+    private String serviceFQN(FileDescriptor f, ServiceDescriptorProto serviceDescriptorProto) {
+        return f.getProtoPackageName() != null ?
+            f.getProtoPackageName() + "." + serviceDescriptorProto.getName() :
+            serviceDescriptorProto.getName();
     }
 
     private TypeSpec.Builder addSerializationProviderInit(final State state,

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Main.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Main.java
@@ -138,7 +138,7 @@ public final class Main {
                 List<ServiceDescriptorProto> serviceDescriptorProtoList = f.protoServices();
                 for (int i = 0; i < serviceDescriptorProtoList.size(); ++i) {
                     ServiceDescriptorProto serviceDescriptor = serviceDescriptorProtoList.get(i);
-                    generator.generate(serviceDescriptor, i);
+                    generator.generate(f, serviceDescriptor, i);
                 }
                 f.writeTo(responseBuilder);
             }

--- a/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/InsertionPointTest.java
+++ b/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/InsertionPointTest.java
@@ -29,7 +29,7 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.util.List;
 
-import static io.servicetalk.grpc.protoc.FileDescriptor.INSERTION_POINT_FORMAT;
+import static io.servicetalk.grpc.protoc.FileDescriptor.insertionPoint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,19 +40,19 @@ class InsertionPointTest {
         List<CodeGeneratorResponse.File> files = generate("test_multi.proto");
         assertEquals(2, files.size());
 
-        assertTrue(files.get(0).getContent().contains(String.format(INSERTION_POINT_FORMAT, "test.multi.Tester")));
-        assertTrue(files.get(1).getContent().contains(String.format(INSERTION_POINT_FORMAT, "test.multi.Tester2")));
+        assertTrue(files.get(0).getContent().contains(insertionPoint("test.multi.Tester")));
+        assertTrue(files.get(1).getContent().contains(insertionPoint("test.multi.Tester2")));
     }
 
     @Test
     void insertionPointExistsInSingleFile() throws IOException {
         List<CodeGeneratorResponse.File> files = generate("test_single.proto");
         assertEquals(3, files.size());
-        assertTrue(files.get(1).getContent().contains(String.format(INSERTION_POINT_FORMAT, "test.single.Greeter")));
-        assertTrue(files.get(2).getContent().contains(String.format(INSERTION_POINT_FORMAT, "test.single.Fareweller")));
+        assertTrue(files.get(1).getContent().contains(insertionPoint("test.single.Greeter")));
+        assertTrue(files.get(2).getContent().contains(insertionPoint("test.single.Fareweller")));
     }
 
-    private List<CodeGeneratorResponse.File> generate(String file) throws IOException {
+    private static List<CodeGeneratorResponse.File> generate(String file) throws IOException {
         final CodeGeneratorRequest.Builder reqBuilder = CodeGeneratorRequest.newBuilder();
         reqBuilder.addAllProtoFile(getFileDescriptorSet().getFileList());
         reqBuilder.addFileToGenerate(file);
@@ -66,7 +66,7 @@ class InsertionPointTest {
      * @return generator response
      * @throws IOException throws exception if it fails to get hold of descriptor set
      */
-    private CodeGeneratorResponse executePlugin(CodeGeneratorRequest request) throws IOException {
+    private static CodeGeneratorResponse executePlugin(CodeGeneratorRequest request) throws IOException {
         // make stdin with request
         ByteArrayOutputStream tempCollector = new ByteArrayOutputStream();
         request.writeTo(tempCollector);
@@ -97,7 +97,8 @@ class InsertionPointTest {
      * @throws IOException throws exception if it fails to locate descriptor set on file system
      */
     static DescriptorProtos.FileDescriptorSet getFileDescriptorSet() throws IOException {
-        String baseDir = System.getProperty("generatedFilesBaseDir");
+        String baseDir = System.getProperty("generatedFilesBaseDir",
+                "servicetalk-grpc-protoc/build/generated/sources/proto");
         File descriptorSet = new File(baseDir + "/test/descriptor_set.desc");
         assertTrue(descriptorSet.exists());
         byte[] data = Files.readAllBytes(descriptorSet.toPath());

--- a/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/InsertionPointTest.java
+++ b/servicetalk-grpc-protoc/src/test/java/io/servicetalk/grpc/protoc/InsertionPointTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.protoc;
+
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.util.List;
+
+import static io.servicetalk.grpc.protoc.FileDescriptor.INSERTION_POINT_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InsertionPointTest {
+
+    @Test
+    void insertionPointExistsInMultiFiles() throws IOException {
+        List<CodeGeneratorResponse.File> files = generate("test_multi.proto");
+        assertEquals(2, files.size());
+
+        assertTrue(files.get(0).getContent().contains(String.format(INSERTION_POINT_FORMAT, "test.multi.Tester")));
+        assertTrue(files.get(1).getContent().contains(String.format(INSERTION_POINT_FORMAT, "test.multi.Tester2")));
+    }
+
+    @Test
+    void insertionPointExistsInSingleFile() throws IOException {
+        List<CodeGeneratorResponse.File> files = generate("test_single.proto");
+        assertEquals(3, files.size());
+        assertTrue(files.get(1).getContent().contains(String.format(INSERTION_POINT_FORMAT, "test.single.Greeter")));
+        assertTrue(files.get(2).getContent().contains(String.format(INSERTION_POINT_FORMAT, "test.single.Fareweller")));
+    }
+
+    private List<CodeGeneratorResponse.File> generate(String file) throws IOException {
+        final CodeGeneratorRequest.Builder reqBuilder = CodeGeneratorRequest.newBuilder();
+        reqBuilder.addAllProtoFile(getFileDescriptorSet().getFileList());
+        reqBuilder.addFileToGenerate(file);
+        CodeGeneratorResponse codeGeneratorResponse = executePlugin(reqBuilder.build());
+        return codeGeneratorResponse.getFileList();
+    }
+
+    /**
+     * Executes protoc servicetalk plugin
+     * @param request generator request
+     * @return generator response
+     * @throws IOException throws exception if it fails to get hold of descriptor set
+     */
+    private CodeGeneratorResponse executePlugin(CodeGeneratorRequest request) throws IOException {
+        // make stdin with request
+        ByteArrayOutputStream tempCollector = new ByteArrayOutputStream();
+        request.writeTo(tempCollector);
+        ByteArrayInputStream stdinWithRequest = new ByteArrayInputStream(tempCollector.toByteArray());
+
+        // hold stdout into this after plugin execution
+        ByteArrayOutputStream stdoutWithResponse = new ByteArrayOutputStream();
+
+        InputStream stdin = System.in;
+        PrintStream stdout = System.out;
+        try {
+            // prepare stdin and stdout for the plugin execution
+            System.setIn(stdinWithRequest);
+            System.setOut(new PrintStream(stdoutWithResponse));
+            // execute plugin
+            Main.main();
+            return CodeGeneratorResponse.parseFrom(stdoutWithResponse.toByteArray());
+        } finally {
+            // restore
+            System.setIn(stdin);
+            System.setOut(stdout);
+        }
+    }
+
+    /**
+     * This descriptor file is expected to be generated at build time by the protoc plugin
+     * @return descriptor fileset
+     * @throws IOException throws exception if it fails to locate descriptor set on file system
+     */
+    static DescriptorProtos.FileDescriptorSet getFileDescriptorSet() throws IOException {
+        String baseDir = System.getProperty("generatedFilesBaseDir");
+        File descriptorSet = new File(baseDir + "/test/descriptor_set.desc");
+        assertTrue(descriptorSet.exists());
+        byte[] data = Files.readAllBytes(descriptorSet.toPath());
+        return DescriptorProtos.FileDescriptorSet.parseFrom(data);
+    }
+}


### PR DESCRIPTION
### Summary of change in one line.
Adds plugin insertion point (comment) into servicetalk generated service classes.
### Motivation:
When we want to enrich ServiceTalk generated service classes with additional functionality, this insertion point enables to add such code.
### Why is this change being made?
When we want to enrich ServiceTalk generated service classes with additional functionality, this insertion point enables to add such code.
### Modifications:

- List the changes
Since JavaPoet has no way to add a comment within a class, Added an empty type as place holder and replaced it with the comment before adding the content to CodeGeneratorResponse

### Result:

What is the result of this change?
Every ServiceTalk generated service class will have following comment towards the end of the class.
```
// @@protoc_insertion_point(service_scope:<fully qualified name of service>)
```