### PR TITLE
Add [Single | Completable].cache operators

### DIFF
--- a/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
@@ -46,6 +46,11 @@
     <Field name="subscribers"/>
     <Bug pattern="VO_VOLATILE_REFERENCE_TO_ARRAY"/>
   </Match>
+  <Match>
+    <Class name="io.servicetalk.concurrent.api.CacheSingle$State"/>
+    <Field name="subscribers"/>
+    <Bug pattern="VO_VOLATILE_REFERENCE_TO_ARRAY"/>
+  </Match>
 
   <!-- In method io.servicetalk.concurrent.api.AsyncContext.<static initializer for AsyncContext>() -->
   <Match>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CacheSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CacheSingle.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.internal.ArrayUtils;
+import io.servicetalk.concurrent.internal.DelayedCancellable;
+import io.servicetalk.concurrent.internal.TerminalNotification;
+import io.servicetalk.context.api.ContextMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Array;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverSuccessFromSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.logDuplicateTerminal;
+import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+final class CacheSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheSingle.class);
+    private static final Subscriber<?>[] EMPTY_SUBSCRIBERS = new Subscriber[0];
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<CacheSingle.State, Subscriber[]>
+            newSubscribersUpdater = newUpdater(CacheSingle.State.class, Subscriber[].class, "subscribers");
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<CacheSingle.State> subscribeCountUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(CacheSingle.State.class, "subscribeCount");
+    private final Single<T> original;
+    private final BiFunction<T, Throwable, Completable> terminalResubscribe;
+    private final int minSubscribers;
+    private final boolean cancelUpstream;
+    private volatile State state = new State();
+
+    CacheSingle(Single<T> original, int minSubscribers, boolean cancelUpstream,
+                BiFunction<T, Throwable, Completable> terminalResubscribe) {
+        if (minSubscribers < 1) {
+            throw new IllegalArgumentException("minSubscribers: " + minSubscribers + " (expected >1)");
+        }
+        this.original = original;
+        this.minSubscribers = minSubscribers;
+        this.cancelUpstream = cancelUpstream;
+        this.terminalResubscribe = requireNonNull(terminalResubscribe);
+    }
+
+    @Override
+    void handleSubscribe(Subscriber<? super T> subscriber, ContextMap contextMap,
+                         AsyncContextProvider contextProvider) {
+        state.addSubscriber(subscriber, contextMap, contextProvider);
+    }
+
+    private final class State implements Subscriber<T> {
+        @SuppressWarnings("unchecked")
+        volatile Subscriber<? super T>[] subscribers = (Subscriber<? super T>[]) EMPTY_SUBSCRIBERS;
+        volatile int subscribeCount;
+        private final DelayedCancellable delayedCancellable = new DelayedCancellable();
+
+        void addSubscriber(Subscriber<? super T> subscriber, ContextMap contextMap,
+                           AsyncContextProvider contextProvider) {
+            final int sCount = subscribeCountUpdater.incrementAndGet(this);
+            final ConcurrentOnSubscribeSubscriber<T> multiSubscriber =
+                    new ConcurrentOnSubscribeSubscriber<>(subscriber);
+            for (;;) {
+                final Subscriber<? super T>[] currSubs = subscribers;
+                if (currSubs.length == 1 && currSubs[0] instanceof TerminalSubscriber) {
+                    @SuppressWarnings("unchecked")
+                    final TerminalSubscriber<T> terminalSubscriber = (TerminalSubscriber<T>) currSubs[0];
+                    terminalSubscriber.safeTerminateFromSource(subscriber);
+                    break;
+                } else {
+                    @SuppressWarnings("unchecked")
+                    Subscriber<? super T>[] newSubs = (Subscriber<? super T>[])
+                            Array.newInstance(Subscriber.class, currSubs.length + 1);
+                    System.arraycopy(currSubs, 0, newSubs, 0, currSubs.length);
+                    newSubs[currSubs.length] = multiSubscriber;
+                    if (newSubscribersUpdater.compareAndSet(this, currSubs, newSubs)) {
+                        // Note we invoke onSubscribe AFTER the subscribers array because the subscription methods
+                        // depend upon this state (cancellation needs the subscriber to be visible in the array). This
+                        // may result in onSuccess(t) or onError(t) being called before onSubscribe() which is
+                        // unexpected for the Subscriber API, but MulticastSubscriber can tolerate this and internally
+                        // queues signals.
+                        multiSubscriber.onSubscribe(() -> removeSubscriber(multiSubscriber));
+                        if (sCount == minSubscribers) {
+                            // This operator has special behavior where it chooses to use the AsyncContext and signal
+                            // offloader from the last subscribe operation.
+                            original.delegateSubscribe(this, contextMap, contextProvider);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        void removeSubscriber(Subscriber<T> subscriber) {
+            for (;;) {
+                final Subscriber<? super T>[] currSubs = subscribers;
+                final int i = ArrayUtils.indexOf(subscriber, currSubs);
+                if (i < 0) {
+                    return;
+                }
+                @SuppressWarnings("unchecked")
+                Subscriber<? super T>[] newSubs = (Subscriber<? super T>[])
+                        Array.newInstance(Subscriber.class, currSubs.length - 1);
+                if (i == 0) {
+                    System.arraycopy(currSubs, 1, newSubs, 0, newSubs.length);
+                } else {
+                    System.arraycopy(currSubs, 0, newSubs, 0, i);
+                    System.arraycopy(currSubs, i + 1, newSubs, i, newSubs.length - i);
+                }
+                if (newSubscribersUpdater.compareAndSet(this, currSubs, newSubs)) {
+                    if (cancelUpstream && newSubs.length == 0) {
+                        // Reset the state when all subscribers have cancelled to allow for re-subscribe.
+                        state = new State();
+                        delayedCancellable.cancel();
+                    }
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            delayedCancellable.delayedCancellable(cancellable);
+        }
+
+        @Override
+        public void onSuccess(@Nullable final T result) {
+            safeTerminalStateReset(result, null);
+            terminate(new TerminalSubscriber<>(null, result), sub -> sub.onSuccess(result));
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            safeTerminalStateReset(null, t);
+            terminate(new TerminalSubscriber<>(t, null), sub -> sub.onError(t));
+        }
+
+        private void terminate(TerminalSubscriber<T> terminalSubscriber, Consumer<Subscriber<? super T>> terminator) {
+            @SuppressWarnings("unchecked")
+            final Subscriber<? super T>[] newSubs = (Subscriber<? super T>[]) Array.newInstance(Subscriber.class, 1);
+            newSubs[0] = terminalSubscriber;
+            for (;;) {
+                final Subscriber<? super T>[] subs = subscribers;
+                if (newSubscribersUpdater.compareAndSet(this, subs, newSubs)) {
+                    Throwable delayedCause = null;
+                    for (final Subscriber<? super T> subscriber : subs) {
+                        try {
+                            terminator.accept(subscriber);
+                        } catch (Throwable cause) {
+                            delayedCause = catchUnexpected(delayedCause, cause);
+                        }
+                    }
+                    if (delayedCause != null) {
+                        throwException(delayedCause);
+                    }
+                    break;
+                }
+            }
+        }
+
+        private void safeTerminalStateReset(@Nullable T value, @Nullable Throwable t) {
+            Completable completable;
+            try {
+                completable = terminalResubscribe.apply(value, t);
+            } catch (Throwable cause) {
+                LOGGER.warn("terminalStateReset {} threw", terminalResubscribe, cause);
+                completable = Completable.never();
+            }
+            completable.whenFinally(() -> state = new State()).subscribe();
+        }
+    }
+
+    private static final class ConcurrentOnSubscribeSubscriber<T> implements Subscriber<T> {
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<ConcurrentOnSubscribeSubscriber, Object> stateUpdater =
+                AtomicReferenceFieldUpdater.newUpdater(ConcurrentOnSubscribeSubscriber.class, Object.class, "state");
+        private static final Object INIT = new Object();
+        private static final Object INVOKING_ON_SUBSCRIBE = new Object();
+        private static final Object WAITING_FOR_TERMINAL = new Object();
+        private static final Object TERMINATED = new Object();
+        private final Subscriber<? super T> delegate;
+        /**
+         * <ul>
+         *     <li>{@code INIT} - no {@link Subscriber} methods invoked</li>
+         *     <li>{@link #INVOKING_ON_SUBSCRIBE} - about to invoke {@link #onSubscribe(Cancellable)}</li>
+         *     <li>{@link #WAITING_FOR_TERMINAL} - {@link #onSubscribe(Cancellable)} has been invoked</li>
+         *     <li>{@link TerminalNotification} - {@link #onError(Throwable)} has been invoked</li>
+         *     <li>{@link #TERMINATED} - a terminal signal has been delivered to {@link #delegate}</li>
+         *     <li>else - {@link #onSuccess(Object)} has been invoked</li>
+         * </ul>
+         */
+        @Nullable
+        private volatile Object state = INIT;
+
+        private ConcurrentOnSubscribeSubscriber(final Subscriber<? super T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            for (;;) {
+                final Object currState = state;
+                if (currState == INIT && stateUpdater.compareAndSet(this, INIT, INVOKING_ON_SUBSCRIBE)) {
+                    try {
+                        delegate.onSubscribe(cancellable);
+                    } finally {
+                        if (!stateUpdater.compareAndSet(this, INVOKING_ON_SUBSCRIBE, WAITING_FOR_TERMINAL)) {
+                            sendTerminal(state); // re-read state which has been changed by another thread.
+                        }
+                    }
+                    break;
+                } else if (currState == WAITING_FOR_TERMINAL || currState == INVOKING_ON_SUBSCRIBE) {
+                    duplicateOnSubscribe(cancellable);
+                    break;
+                } else if (currState == TERMINATED) {
+                    // Either we raced with terminal signal, or this is duplicate onSubscribe after terminal.
+                    // Usage of this class in multicast prevents the latter.
+                    break;
+                } else if (currState != INIT) {
+                    delayedOnSubscribe(currState);
+                    break;
+                }
+            }
+        }
+
+        private void duplicateOnSubscribe(Cancellable cancellable) {
+            try {
+                cancellable.cancel(); // duplicate onSubscribe not supported
+            } finally {
+                logDuplicateTerminal(this);
+            }
+        }
+
+        private void delayedOnSubscribe(@Nullable Object currState) {
+            try {
+                delegate.onSubscribe(IGNORE_CANCEL);
+            } finally {
+                sendTerminal(currState);
+            }
+        }
+
+        private void sendTerminal(@Nullable Object currState) {
+            state = TERMINATED;
+            if (currState instanceof TerminalNotification) {
+                Throwable cause = ((TerminalNotification) currState).cause();
+                assert cause != null;
+                delegate.onError(cause);
+            } else {
+                @SuppressWarnings("unchecked")
+                final T t = (T) currState;
+                delegate.onSuccess(t);
+            }
+        }
+
+        @Override
+        public void onSuccess(@Nullable final T result) {
+            for (;;) {
+                final Object currState = state;
+                if (currState == WAITING_FOR_TERMINAL) {
+                    state = TERMINATED; // onSubscribe already invoked, no need for atomic as no concurrency allowed.
+                    delegate.onSuccess(result);
+                    break;
+                } else if (currState == INIT) {
+                    if (stateUpdater.compareAndSet(this, INIT, TERMINATED)) {
+                        deliverSuccessFromSource(delegate, result);
+                        break;
+                    }
+                } else if (currState == INVOKING_ON_SUBSCRIBE) { // hand off to the onSubscribe thread.
+                    if (stateUpdater.compareAndSet(this, INVOKING_ON_SUBSCRIBE, result)) {
+                        break;
+                    }
+                } else {
+                    logDuplicateTerminal(this);
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            final TerminalNotification terminalNotification = TerminalNotification.error(t);
+            for (;;) {
+                final Object currState = state;
+                if (currState == WAITING_FOR_TERMINAL) {
+                    state = TERMINATED; // onSubscribe already invoked, no need for atomic as no concurrency allowed.
+                    delegate.onError(t);
+                    break;
+                } else if (currState == INIT) {
+                    if (stateUpdater.compareAndSet(this, INIT, TERMINATED)) {
+                        deliverErrorFromSource(delegate, t);
+                        break;
+                    }
+                } else if (currState == INVOKING_ON_SUBSCRIBE) { // hand off to the onSubscribe thread.
+                    if (stateUpdater.compareAndSet(this, INVOKING_ON_SUBSCRIBE, terminalNotification)) {
+                        break;
+                    }
+                } else {
+                    logDuplicateTerminal(this);
+                    break;
+                }
+            }
+        }
+    }
+
+    private static final class TerminalSubscriber<T> implements Subscriber<T> {
+        @Nullable
+        private final Object terminal;
+        private final boolean isSuccess;
+
+        private TerminalSubscriber(@Nullable final Throwable error, @Nullable final T value) {
+            if (error == null) {
+                terminal = value;
+                isSuccess = true;
+            } else {
+                terminal = error;
+                isSuccess = false;
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private void safeTerminateFromSource(Subscriber<? super T> sub) {
+            if (isSuccess) {
+                deliverSuccessFromSource(sub, (T) terminal);
+            } else {
+                assert terminal != null;
+                deliverErrorFromSource(sub, (Throwable) terminal);
+            }
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void onSuccess(@Nullable final T result) {
+            if (isSuccess) {
+                throw new IllegalStateException("terminal signal already received in onSuccess. new: " + result,
+                        (Throwable) terminal);
+            }
+            throw new IllegalStateException("terminal signal already received in onSuccess. old: " + terminal +
+                    " new: " + result);
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            throw new IllegalStateException("duplicate terminal signal in onError. old: " + terminal, t);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1033,6 +1033,114 @@ public abstract class Completable {
     }
 
     /**
+     * Create a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
+     * <p>
+     * In sequential programming this is similar to the following:
+     * <pre>{@code
+     *     Void result = resultOfThisCompletable();
+     *     List<Void> multiResults = ...; // simulating multiple Subscribers
+     *     for (int i = 0; i < expectedSubscribers; ++i) {
+     *         multiResults.add(result);
+     *     }
+     *     return multiResults;
+     * }</pre>
+     * @return a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
+     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
+     * @see #cache(int)
+     */
+    public final Completable cache() {
+        return toSingle().cache().toCompletable();
+    }
+
+    /**
+     * Create a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
+     * <p>
+     * In sequential programming this is similar to the following:
+     * <pre>{@code
+     *     Void result = resultOfThisCompletable();
+     *     List<Void> multiResults = ...; // simulating multiple Subscribers
+     *     for (int i = 0; i < expectedSubscribers; ++i) {
+     *         multiResults.add(result);
+     *     }
+     *     return multiResults;
+     * }</pre>
+     * @param minSubscribers The upstream subscribe operation will not happen until after this many {@link Subscriber}
+     * subscribe to the return value.
+     * @return a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
+     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
+     * @see #cache(int, boolean)
+     */
+    public final Completable cache(int minSubscribers) {
+        return toSingle().cache(minSubscribers).toCompletable();
+    }
+
+    /**
+     * Create a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
+     * <p>
+     * In sequential programming this is similar to the following:
+     * <pre>{@code
+     *     Void result = resultOfThisCompletable();
+     *     List<Void> multiResults = ...; // simulating multiple Subscribers
+     *     for (int i = 0; i < expectedSubscribers; ++i) {
+     *         multiResults.add(result);
+     *     }
+     *     return multiResults;
+     * }</pre>
+     * @param minSubscribers The upstream subscribe operation will not happen until after this many {@link Subscriber}
+     * subscribe to the return value.
+     * @param cancelUpstream {@code true} if upstream should be {@link Cancellable#cancel() cancelled} when all
+     * downstream {@link Subscriber}s cancel. {@code false} means that cancel will not be propagated upstream even if
+     * all downstream {@link Subscriber}s cancel, and the upstream Subscription will stay valid until termination.
+     * @return a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
+     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
+     * @see #cache(int, boolean, Function)
+     */
+    public final Completable cache(int minSubscribers, boolean cancelUpstream) {
+        return toSingle().cache(minSubscribers, cancelUpstream).toCompletable();
+    }
+
+    /**
+     * Create a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
+     * <p>
+     * In sequential programming this is similar to the following:
+     * <pre>{@code
+     *     Void result = resultOfThisCompletable();
+     *     List<Void> multiResults = ...; // simulating multiple Subscribers
+     *     for (int i = 0; i < expectedSubscribers; ++i) {
+     *         multiResults.add(result);
+     *     }
+     *     return multiResults;
+     * }</pre>
+     * @param minSubscribers The upstream subscribe operation will not happen until after this many {@link Subscriber}
+     * subscribe to the return value.
+     * @param cancelUpstream {@code true} if upstream should be {@link Cancellable#cancel() cancelled} when all
+     * downstream {@link Subscriber}s cancel. {@code false} means that cancel will not be propagated upstream even if
+     * all downstream {@link Subscriber}s cancel, and the upstream Subscription will stay valid until termination.
+     * @param terminalResubscribe A {@link Function} that is invoked when a terminal signal arrives from upstream, and
+     * returns a {@link Completable} whose termination resets the state of the returned {@link Completable} and allows
+     * for downstream resubscribing. The argument to this function is as follows:
+     * <ul>
+     *     <li>{@code null} if upstream terminates with {@link Subscriber#onComplete()}</li>
+     *     <li>otherwise the {@link Throwable} from {@link Subscriber#onError(Throwable)}</li>
+     * </ul>
+     * @return a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
+     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
+     */
+    public final Completable cache(int minSubscribers, boolean cancelUpstream,
+                                   Function<Throwable, Completable> terminalResubscribe) {
+        return toSingle().cache(minSubscribers, cancelUpstream, (__, t) -> terminalResubscribe.apply(t))
+                .toCompletable();
+    }
+
+    /**
      * Invokes the {@code onSubscribe} {@link Consumer} argument <strong>before</strong>
      * {@link Subscriber#onSubscribe(Cancellable)} is called for {@link Subscriber}s of the returned
      * {@link Completable}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1046,7 +1046,7 @@ public abstract class Completable {
      *     return multiResults;
      * }</pre>
      * @return a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
-     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
      * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
      * @see #cache(int)
      */
@@ -1070,7 +1070,7 @@ public abstract class Completable {
      * @param minSubscribers The upstream subscribe operation will not happen until after this many {@link Subscriber}
      * subscribe to the return value.
      * @return a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
-     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
      * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
      * @see #cache(int, boolean)
      */
@@ -1097,7 +1097,7 @@ public abstract class Completable {
      * downstream {@link Subscriber}s cancel. {@code false} means that cancel will not be propagated upstream even if
      * all downstream {@link Subscriber}s cancel, and the upstream Subscription will stay valid until termination.
      * @return a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
-     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
      * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
      * @see #cache(int, boolean, Function)
      */
@@ -1131,7 +1131,7 @@ public abstract class Completable {
      *     <li>otherwise the {@link Throwable} from {@link Subscriber#onError(Throwable)}</li>
      * </ul>
      * @return a {@link Completable} that subscribes a single time upstream but allows for multiple downstream
-     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
      * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
      */
     public final Completable cache(int minSubscribers, boolean cancelUpstream,

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
@@ -100,9 +100,8 @@ final class MulticastPublisher<T> extends AbstractNoHandleSubscribePublisher<T> 
         boolean removeSubscriber(final MulticastFixedSubscriber<T> subscriber) {
             for (;;) {
                 final Subscriber<? super T>[] currSubs = subscribers;
-                final int i;
-                if (currSubs.length == 0 || currSubs.length == 1 && currSubs[0] instanceof TerminalSubscriber ||
-                        (i = ArrayUtils.indexOf(subscriber, currSubs)) < 0) {
+                final int i = ArrayUtils.indexOf(subscriber, currSubs);
+                if (i < 0) {
                     // terminated, demandQueue is not thread safe and isn't cleaned up on the Subscriber thread.
                     return false;
                 }
@@ -181,7 +180,7 @@ final class MulticastPublisher<T> extends AbstractNoHandleSubscribePublisher<T> 
                     new MulticastFixedSubscriber<>(this, subscriber, contextMap, contextProvider, sCount);
             for (;;) {
                 final Subscriber<? super T>[] currSubs = subscribers;
-                if (currSubs.length != 0 && currSubs[0] instanceof TerminalSubscriber) {
+                if (currSubs.length == 1 && currSubs[0] instanceof TerminalSubscriber) {
                     ((TerminalSubscriber<?>) currSubs[0]).terminate(subscriber);
                     break;
                 } else {
@@ -232,7 +231,7 @@ final class MulticastPublisher<T> extends AbstractNoHandleSubscribePublisher<T> 
         }
 
         private void onTerminal(@Nullable Throwable t, BiConsumer<Subscriber<? super T>, Throwable> terminator) {
-            safeTerminalStateReset(t).afterFinally(() ->
+            safeTerminalStateReset(t).whenFinally(() ->
                     state = new State(maxQueueSize, minSubscribers)).subscribe();
 
             @SuppressWarnings("unchecked")

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.internal.ConcurrentSubscription;
 import io.servicetalk.concurrent.internal.DelayedSubscription;
 import io.servicetalk.concurrent.internal.FlowControlUtils;
 import io.servicetalk.concurrent.internal.QueueFullException;
+import io.servicetalk.concurrent.internal.SubscriberUtils;
 import io.servicetalk.concurrent.internal.TerminalNotification;
 
 import org.slf4j.Logger;
@@ -608,18 +609,12 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
             public void onComplete() {
                 final int unusedDemand = pendingDemandUpdater.getAndSet(this, -1);
                 if (unusedDemand < 0) {
-                    logDuplicateTerminal();
+                    SubscriberUtils.logDuplicateTerminal(this);
                 } else if (parent.removeSubscriber(this, unusedDemand)) {
                     parent.enqueueAndDrain(complete());
                 } else {
                     parent.tryEmitItem(MAPPED_SOURCE_COMPLETE, this);
                 }
-            }
-
-            private void logDuplicateTerminal() {
-                LOGGER.warn("Duplicate terminal on Subscriber {}", this,
-                        new IllegalStateException("Duplicate terminal on Subscriber " + this + " forbidden see: " +
-                                "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.7"));
             }
         }
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.internal.ConcurrentSubscription;
 import io.servicetalk.concurrent.internal.FlowControlUtils;
 import io.servicetalk.concurrent.internal.QueueFullException;
+import io.servicetalk.concurrent.internal.SubscriberUtils;
 import io.servicetalk.concurrent.internal.TerminalNotification;
 
 import org.slf4j.Logger;
@@ -412,21 +413,12 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
 
             private boolean onSingleTerminated() {
                 if (singleCancellable == null) {
-                    logDuplicateTerminal();
+                    SubscriberUtils.logDuplicateTerminal(this);
                     return false;
                 }
                 cancellableSet.remove(singleCancellable);
                 singleCancellable = null;
                 return decrementActiveMappedSources();
-            }
-
-            private void logDuplicateTerminal() {
-                LOGGER.warn("onSubscribe not called before terminal or duplicate terminal on Subscriber {}", this,
-                        new IllegalStateException(
-                                "onSubscribe not called before terminal or duplicate terminal on Subscriber " + this +
-                                " forbidden see: " +
-                                "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.9" +
-                                "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.7"));
             }
         }
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1071,7 +1071,7 @@ public abstract class Single<T> {
      *     return multiResults;
      * }</pre>
      * @return a {@link Single} that subscribes a single time upstream but allows for multiple downstream
-     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
      * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
      * @see #cache(int)
      */
@@ -1095,7 +1095,7 @@ public abstract class Single<T> {
      * @param minSubscribers The upstream subscribe operation will not happen until after this many {@link Subscriber}
      * subscribe to the return value.
      * @return a {@link Single} that subscribes a single time upstream but allows for multiple downstream
-     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
      * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
      * @see #cache(int, boolean)
      */
@@ -1122,7 +1122,7 @@ public abstract class Single<T> {
      * downstream {@link Subscriber}s cancel. {@code false} means that cancel will not be propagated upstream even if
      * all downstream {@link Subscriber}s cancel, and the upstream Subscription will stay valid until termination.
      * @return a {@link Single} that subscribes a single time upstream but allows for multiple downstream
-     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
      * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
      * @see #cache(int, boolean, BiFunction)
      */
@@ -1152,7 +1152,7 @@ public abstract class Single<T> {
      * returns a {@link Completable} whose termination resets the state of the returned {@link Single} and allows
      * for downstream resubscribing.
      * @return a {@link Single} that subscribes a single time upstream but allows for multiple downstream
-     * {@link Subscriber}s. Signals from upstream will be multicast to each downstream {@link Subscriber}.
+     * {@link Subscriber}s. The terminal signal will be cached and delivered to each downstream {@link Subscriber}.
      * @see <a href="https://reactivex.io/documentation/operators/replay.html">ReactiveX cache operator</a>
      */
     public final Single<T> cache(int minSubscribers, boolean cancelUpstream,

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CacheSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CacheSingleTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Completable.never;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class CacheSingleTest {
+    private TestSingle<Integer> source;
+    private TestSingleSubscriber<Integer> subscriber1;
+    private TestSingleSubscriber<Integer> subscriber2;
+    private TestSingleSubscriber<Integer> subscriber3;
+    private TestCancellable cancellable;
+
+    @BeforeEach
+    void setUp() {
+        cancellable = new TestCancellable();
+        source = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build(subscriber -> {
+            subscriber.onSubscribe(cancellable);
+            return subscriber;
+        });
+        subscriber1 = new TestSingleSubscriber<>();
+        subscriber2 = new TestSingleSubscriber<>();
+        subscriber3 = new TestSingleSubscriber<>();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"true,", "false,1", "false,"})
+    void singleSubscriber(boolean onError, @Nullable Integer value) {
+        toSource(source.cache(1)).subscribe(subscriber1);
+        subscriber1.awaitSubscription();
+        if (onError) {
+            source.onError(DELIBERATE_EXCEPTION);
+            assertThat(subscriber1.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            source.onSuccess(value);
+            assertThat(subscriber1.awaitOnSuccess(), is(value));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void singleSubscriberCancel(boolean cancelUpstream) throws InterruptedException {
+        toSource(source.cache(1, cancelUpstream)).subscribe(subscriber1);
+        Cancellable subscription1 = subscriber1.awaitSubscription();
+        subscription1.cancel();
+        subscription1.cancel(); // multiple cancels should be safe.
+        if (cancelUpstream) {
+            cancellable.awaitCancelled();
+        } else {
+            assertThat(cancellable.isCancelled(), is(false));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void twoSubscribersOneCancelsMultipleTimes(boolean cancelUpstream) throws InterruptedException {
+        Single<Integer> single = source.cache(2, cancelUpstream);
+        toSource(single).subscribe(subscriber1);
+        toSource(single).subscribe(subscriber2);
+        Cancellable subscription1 = subscriber1.awaitSubscription();
+        Cancellable subscription2 = subscriber2.awaitSubscription();
+        subscription1.cancel();
+        subscription1.cancel(); // multiple cancels should be safe.
+        subscription2.cancel();
+        subscription2.cancel(); // multiple cancels should be safe.
+        if (cancelUpstream) {
+            cancellable.awaitCancelled();
+        } else {
+            assertThat(cancellable.isCancelled(), is(false));
+        }
+    }
+
+    @Test
+    void singleSubscriberCancelStillDeliversData() {
+        Single<Integer> single = source.cache(1, false);
+        toSource(single).subscribe(subscriber1);
+        Cancellable subscription1 = subscriber1.awaitSubscription();
+        subscription1.cancel();
+        assertThat(cancellable.isCancelled(), is(false));
+
+        toSource(single).subscribe(subscriber2);
+        Cancellable subscription2 = subscriber2.awaitSubscription();
+
+        source.onSuccess(1); // first subscriber triggered upstream subscribe, we can deliver and signal must be queued.
+        assertThat(subscriber2.awaitOnSuccess(), is(1));
+
+        subscription2.cancel();
+        assertThat(cancellable.isCancelled(), is(false));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"true,", "false,1", "false,"})
+    void twoSubscribersNoData(boolean onError, @Nullable Integer value) {
+        Single<Integer> single = source.cache(2);
+        toSource(single).subscribe(subscriber1);
+        subscriber1.awaitSubscription();
+        toSource(single).subscribe(subscriber2);
+        subscriber2.awaitSubscription();
+
+        if (onError) {
+            source.onError(DELIBERATE_EXCEPTION);
+            assertThat(subscriber1.awaitOnError(), is(DELIBERATE_EXCEPTION));
+            assertThat(subscriber2.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            source.onSuccess(value);
+            assertThat(subscriber1.awaitOnSuccess(), is(value));
+            assertThat(subscriber2.awaitOnSuccess(), is(value));
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"true,", "false,1", "false,"})
+    void twoSubscribersAfterTerminalData(boolean onError, @Nullable Integer value) {
+        Single<Integer> single = source.cache(1, true, (v, t) -> never());
+        toSource(single).subscribe(subscriber1);
+        subscriber1.awaitSubscription();
+        if (onError) {
+            source.onError(DELIBERATE_EXCEPTION);
+            assertThat(subscriber1.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            source.onSuccess(value);
+            assertThat(subscriber1.awaitOnSuccess(), is(value));
+        }
+        toSource(single).subscribe(subscriber2);
+        subscriber2.awaitSubscription();
+        if (onError) {
+            assertThat(subscriber2.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            assertThat(subscriber2.awaitOnSuccess(), is(value));
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"true,true", "true,false", "false,true", "false,false"})
+    void twoSubscribersCancel(boolean firstSubscription, boolean cancelUpstream) {
+        Single<Integer> single = source.cache(2, cancelUpstream);
+        toSource(single).subscribe(subscriber1);
+        Cancellable subscription1 = subscriber1.awaitSubscription();
+        toSource(single).subscribe(subscriber2);
+        Cancellable subscription2 = subscriber2.awaitSubscription();
+        if (firstSubscription) {
+            subscription1.cancel();
+        } else {
+            subscription2.cancel();
+        }
+
+        // Add another subscriber after one of the subscribers has cancelled.
+        toSource(single).subscribe(subscriber3);
+        Cancellable subscription3 = subscriber3.awaitSubscription();
+        source.onSuccess(1);
+
+        // subscriber3 has no demand yet, it shouldn't have any data delivered.
+        assertThat(subscriber3.awaitOnSuccess(), is(1));
+
+        if (firstSubscription) {
+            assertThat(subscriber1.pollTerminal(10, MILLISECONDS), is(nullValue()));
+            assertThat(subscriber2.awaitOnSuccess(), is(1));
+        } else {
+            assertThat(subscriber1.awaitOnSuccess(), is(1));
+            assertThat(subscriber2.pollTerminal(10, MILLISECONDS), is(nullValue()));
+        }
+
+        subscription3.cancel(); // cancel after terminal shouldn't impact anything.
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"true,", "false,1", "false,"})
+    void threeSubscribersOneLateQueueData(boolean onError, @Nullable Integer value) {
+        Single<Integer> single = source.cache(2);
+        toSource(single).subscribe(subscriber1);
+        toSource(single).subscribe(subscriber2);
+        Cancellable localSubscription1 = subscriber1.awaitSubscription();
+        Cancellable localSubscription2 = subscriber2.awaitSubscription();
+
+        if (onError) {
+            source.onError(DELIBERATE_EXCEPTION);
+            assertThat(subscriber1.awaitOnError(), is(DELIBERATE_EXCEPTION));
+            assertThat(subscriber2.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            source.onSuccess(value);
+            assertThat(subscriber1.awaitOnSuccess(), is(value));
+            assertThat(subscriber2.awaitOnSuccess(), is(value));
+        }
+
+        toSource(single).subscribe(subscriber3);
+        Cancellable localSubscription3 = subscriber3.awaitSubscription();
+
+        if (onError) {
+            assertThat(subscriber3.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            assertThat(subscriber3.awaitOnSuccess(), is(value));
+        }
+
+        // cancel after terminal shouldn't impact anything.
+        localSubscription1.cancel();
+        localSubscription2.cancel();
+        localSubscription3.cancel();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"true,true", "true,false", "false,true", "false,false"})
+    void terminalResubscribe(boolean onError, boolean cacheData) {
+        final AtomicBoolean subscribed = new AtomicBoolean();
+        final Integer value = 1;
+        final Integer value2 = 2;
+        Single<Integer> single = Single.defer(() -> {
+            if (subscribed.compareAndSet(false, true)) {
+                return onError ? Single.failed(DELIBERATE_EXCEPTION) : Single.succeeded(value);
+            } else {
+                return Single.succeeded(value2);
+            }
+        }).cache(1, true, cacheData ? (v, t) -> never() : (v, t) -> completed());
+        toSource(single).subscribe(subscriber1);
+        subscriber1.awaitSubscription();
+        if (onError) {
+            assertThat(subscriber1.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            assertThat(subscriber1.awaitOnSuccess(), is(value));
+        }
+
+        toSource(single).subscribe(subscriber2);
+        subscriber2.awaitSubscription();
+        if (cacheData) {
+            if (onError) {
+                assertThat(subscriber2.awaitOnError(), is(DELIBERATE_EXCEPTION));
+            } else {
+                assertThat(subscriber2.awaitOnSuccess(), is(value));
+            }
+        } else {
+            assertThat(subscriber2.awaitOnSuccess(), is(value2));
+        }
+    }
+
+    @Test
+    void inlineCancelFromOnSubscribeToMultipleSubscribers() {
+        Single<Integer> single = Single.succeeded(1).cache(2, false);
+        @SuppressWarnings("unchecked")
+        SingleSource.Subscriber<Integer> sub1 = mock(SingleSource.Subscriber.class);
+        @SuppressWarnings("unchecked")
+        SingleSource.Subscriber<Integer> sub2 = mock(SingleSource.Subscriber.class);
+        doAnswer((Answer<Void>) invocation -> {
+            Cancellable c = invocation.getArgument(0);
+            c.cancel();
+            return null;
+        }).when(sub1).onSubscribe(any());
+        toSource(single).subscribe(sub1);
+        toSource(single).subscribe(sub2);
+
+        verify(sub1, Mockito.never()).onSuccess(any());
+        verify(sub2).onSuccess(eq(1));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"400,401", "400,200", "400,2"})
+    void concurrentSubscribers(int expectedSubscribers, int latchCount) throws Exception {
+        Single<Integer> multicast = source.cache(expectedSubscribers);
+        ExecutorService executorService = new ThreadPoolExecutor(0, expectedSubscribers, 1, SECONDS,
+                new SynchronousQueue<>());
+        try {
+            @SuppressWarnings("unchecked")
+            TestSingleSubscriber<Integer>[] subscribers = (TestSingleSubscriber<Integer>[])
+                    new TestSingleSubscriber[expectedSubscribers];
+            CountDownLatch latch = new CountDownLatch(latchCount);
+            List<Future<?>> futures = new ArrayList<>(subscribers.length);
+            for (int i = 0; i < subscribers.length; ++i) {
+                final TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
+                subscribers[i] = subscriber;
+                futures.add(executorService.submit(() -> {
+                    latch.countDown();
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                    toSource(multicast).subscribe(subscriber);
+                }));
+            }
+
+            latch.countDown();
+            latch.await();
+            source.onSuccess(1);
+
+            for (Future<?> future : futures) {
+                future.get();
+            }
+
+            for (final TestSingleSubscriber<Integer> subscriber : subscribers) {
+                assertThat(subscriber.awaitOnSuccess(), is(1));
+            }
+        } finally {
+            executorService.shutdown();
+        }
+    }
+}

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
@@ -79,9 +79,9 @@ public final class SubscriberUtils {
 
     /**
      * Deliver a terminal complete to a {@link Subscriber} that has not yet had
-     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} called.
-     * @param subscriber The {@link Subscriber} to terminate.
-     * @param <T> The type of {@link Subscriber}.
+     * {@link PublisherSource.Subscriber#onSubscribe(PublisherSource.Subscription)} called.
+     * @param subscriber The {@link PublisherSource.Subscriber} to terminate.
+     * @param <T> The type of {@link PublisherSource.Subscriber}.
      */
     public static <T> void deliverCompleteFromSource(Subscriber<T> subscriber) {
         try {
@@ -127,10 +127,10 @@ public final class SubscriberUtils {
 
     /**
      * Deliver a terminal error to a {@link Subscriber} that has not yet had
-     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)} called.
-     * @param subscriber The {@link Subscriber} to terminate.
+     * {@link PublisherSource.Subscriber#onSubscribe(PublisherSource.Subscription)} called.
+     * @param subscriber The {@link PublisherSource.Subscriber} to terminate.
      * @param cause The terminal event.
-     * @param <T> The type of {@link Subscriber}.
+     * @param <T> The type of {@link PublisherSource.Subscriber}.
      */
     public static <T> void deliverErrorFromSource(Subscriber<T> subscriber, Throwable cause) {
         try {
@@ -176,9 +176,10 @@ public final class SubscriberUtils {
     }
 
     /**
-     * Handle the case when a call to {@link Subscriber#onSubscribe(PublisherSource.Subscription)} throws from a source.
+     * Handle the case when a call to {@link PublisherSource.Subscriber#onSubscribe(PublisherSource.Subscription)}
+     * throws from a source.
      * @param subscriber The {@link Subscriber} that threw an exception from
-     * {@link Subscriber#onSubscribe(PublisherSource.Subscription)}.
+     * {@link PublisherSource.Subscriber#onSubscribe(PublisherSource.Subscription)}.
      * @param cause The exception thrown by {@code subscriber}.
      * @param <T> The type of {@link Subscriber}.
      */
@@ -328,5 +329,34 @@ public final class SubscriberUtils {
         } catch (Throwable t) {
             LOGGER.info("Ignoring exception from cancel {}.", cancellable, t);
         }
+    }
+
+    /**
+     * Log if the ReactiveStreams specification has been violated related to out of order
+     * {@link PublisherSource.Subscriber#onSubscribe(PublisherSource.Subscription)} or duplicate terminal signals.
+     * @param subscriber The {@link PublisherSource.Subscriber}.
+     * @param <T> The type of {@link PublisherSource.Subscriber}.
+     */
+    public static <T> void logDuplicateTerminal(PublisherSource.Subscriber<T> subscriber) {
+        logDuplicateTerminal0(subscriber);
+    }
+
+    /**
+     * Log if the ReactiveStreams specification has been violated related to out of order
+     * {@link SingleSource.Subscriber#onSubscribe(Cancellable)} or duplicate terminal signals.
+     * @param subscriber The {@link SingleSource.Subscriber}.
+     * @param <T> The type of {@link SingleSource.Subscriber}.
+     */
+    public static <T> void logDuplicateTerminal(SingleSource.Subscriber<T> subscriber) {
+        logDuplicateTerminal0(subscriber);
+    }
+
+    private static void logDuplicateTerminal0(Object subscriber) {
+        LOGGER.warn("onSubscribe not called before terminal or duplicate terminal on Subscriber {}", subscriber,
+                new IllegalStateException(
+                        "onSubscribe not called before terminal or duplicate terminal on Subscriber " + subscriber +
+                        " forbidden see: " +
+                        "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.9" +
+                        "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.7"));
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableCacheTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/CompletableCacheTckTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+@Test
+public class CompletableCacheTckTest extends AbstractCompletableTckTest {
+    @Override
+    public Publisher<Object> createServiceTalkPublisher(long elements) {
+        return Completable.completed().cache().toPublisher();
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleCacheTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleCacheTckTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Single;
+
+import org.testng.annotations.Test;
+
+@Test
+public class SingleCacheTckTest extends AbstractSingleOperatorTckTest<Integer> {
+    @Override
+    protected Single<Integer> composeSingle(Single<Integer> single) {
+        return single.cache();
+    }
+}


### PR DESCRIPTION
Motivation:
Some scenarios require that a `Single` or `Completable`
can be subscribed to multiple times. Using `Processors`
requires additional state management outside of the
subscriber/operators chain which must be done with care
to preserve backpressure, cancellation, and lazy semantics.
`Publisher.multicast` isn't directly applicable either
because the terminal value isn't cached and retained for
late subscribers as is often required.

Modifications:
- Add `Single.cache` and `Completable.cache` operators.