### PR TITLE
`LoadBalancer` and `ConnectionFactory`: add a context of the caller

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
@@ -22,6 +22,7 @@ import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
 import io.servicetalk.transport.api.TransportObserver;
 
@@ -98,6 +99,7 @@ public class RoundRobinLoadBalancerSDEventsBenchmark {
 
         @Override
         public Single<LoadBalancedConnection> newConnection(final InetSocketAddress inetSocketAddress,
+                                                            @Nullable final ContextMap context,
                                                             @Nullable final TransportObserver observer) {
             return succeeded(new LoadBalancedConnection() {
                 @Override

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactoryFilter.java
@@ -70,7 +70,8 @@ public interface ConnectionFactoryFilter<ResolvedAddress, C extends ListenableAs
      */
     default ConnectionFactoryFilter<ResolvedAddress, C> append(ConnectionFactoryFilter<ResolvedAddress, C> before) {
         requireNonNull(before);
-        return withStrategy(service -> create(before.create(service)),
+        return withStrategy(service -> create(before.create(
+                new DeprecatedToNewConnectionFactoryFilter<ResolvedAddress, C>().create(service))),
                 this.requiredOffloads().merge(before.requiredOffloads()));
     }
 

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DeprecatedToNewConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DeprecatedToNewConnectionFactoryFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api;
+
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.transport.api.ExecutionStrategy;
+import io.servicetalk.transport.api.TransportObserver;
+
+import javax.annotation.Nullable;
+
+import static io.servicetalk.context.api.ContextMap.Key.newKey;
+
+@Deprecated // FIXME: 0.43 - remove as no longer required
+final class DeprecatedToNewConnectionFactoryFilter<ResolvedAddress, C extends ListenableAsyncCloseable>
+        implements ConnectionFactoryFilter<ResolvedAddress, C> {
+
+    /**
+     * Key that propagates {@link ContextMap} argument between new and deprecated
+     * {@code ConnectionFactory#newConnection(...)} methods.
+     */
+    public static final ContextMap.Key<ContextMap> CONNECTION_FACTORY_CONTEXT_MAP_KEY =
+            newKey("CONNECTION_FACTORY_CONTEXT_MAP_KEY", ContextMap.class);
+
+    @Override
+    public ConnectionFactory<ResolvedAddress, C> create(final ConnectionFactory<ResolvedAddress, C> original) {
+        return new DelegatingConnectionFactory<ResolvedAddress, C>(original) {
+            @Override
+            public Single<C> newConnection(final ResolvedAddress address, @Nullable final TransportObserver observer) {
+                return Single.defer(() -> {
+                    final ContextMap context = AsyncContext.get(CONNECTION_FACTORY_CONTEXT_MAP_KEY);
+                    return delegate().newConnection(address, context, observer).shareContextOnSubscribe();
+                });
+            }
+
+            @Override
+            public Single<C> newConnection(final ResolvedAddress resolvedAddress,
+                                           @Nullable final ContextMap context,
+                                           @Nullable final TransportObserver observer) {
+                return delegate().newConnection(resolvedAddress, context, observer);
+            }
+        };
+    }
+
+    @Override
+    public ExecutionStrategy requiredOffloads() {
+        return ExecutionStrategy.offloadNone();
+    }
+}

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableSingle;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.TransportObserver;
 
@@ -149,12 +150,13 @@ public final class LimitingConnectionFactoryFilter<ResolvedAddress, C extends Li
 
         @Override
         public Single<C> newConnection(final ResolvedAddress resolvedAddress,
+                                       @Nullable final ContextMap context,
                                        @Nullable final TransportObserver observer) {
             return new SubscribableSingle<C>() {
                 @Override
                 protected void handleSubscribe(final Subscriber<? super C> subscriber) {
                     if (limiter.isConnectAllowed(resolvedAddress)) {
-                        toSource(delegate().newConnection(resolvedAddress, observer))
+                        toSource(delegate().newConnection(resolvedAddress, context, observer))
                                 .subscribe(new CountingSubscriber<>(subscriber, limiter, resolvedAddress));
                     } else {
                         deliverErrorFromSource(subscriber, limiter.newConnectionRefusedException(resolvedAddress));

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerReadyEvent.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerReadyEvent.java
@@ -15,19 +15,22 @@
  */
 package io.servicetalk.client.api;
 
+import io.servicetalk.context.api.ContextMap;
+
 import java.util.function.Predicate;
 
 /**
  * A hint from {@link LoadBalancer#eventStream()} that the internal state of the {@link LoadBalancer} is ready such
- * {@link LoadBalancer#selectConnection(Predicate)} is not likely to fail. Note that the return status of
- * {@link LoadBalancer#selectConnection(Predicate)} may depend upon many factors including but not limited to:
+ * {@link LoadBalancer#selectConnection(Predicate, ContextMap)} is not likely to fail. Note that the return status of
+ * {@link LoadBalancer#selectConnection(Predicate, ContextMap)} may depend upon many factors including but not limited
+ * to:
  * <ul>
  *     <li>Instantaneous demand vs the amount of resources (e.g. connections) on hand</li>
  *     <li>If the {@link LoadBalancer} favors queuing requests or "fail fast" behavior</li>
  *     <li>The dynamic nature of host availability may result in no hosts being available</li>
  * </ul>
  * This is meant to emphasize that {@link #isReady()} returning {@code true} doesn't necessarily mean
- * {@link LoadBalancer#selectConnection(Predicate)} will always return successfully.
+ * {@link LoadBalancer#selectConnection(Predicate, ContextMap)} will always return successfully.
  */
 public interface LoadBalancerReadyEvent {
     /**

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/TransportObserverConnectionFactoryFilter.java
@@ -17,6 +17,7 @@ package io.servicetalk.client.api;
 
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.TransportObserver;
 
@@ -65,6 +66,7 @@ public final class TransportObserverConnectionFactoryFilter<ResolvedAddress, C e
         return new DelegatingConnectionFactory<ResolvedAddress, C>(original) {
             @Override
             public Single<C> newConnection(final ResolvedAddress resolvedAddress,
+                                           @Nullable final ContextMap context,
                                            @Nullable final TransportObserver originalObserver) {
                 final TransportObserver newObserver;
                 try {
@@ -72,7 +74,7 @@ public final class TransportObserverConnectionFactoryFilter<ResolvedAddress, C e
                 } catch (Throwable t) {
                     return failed(t);
                 }
-                return delegate().newConnection(resolvedAddress, originalObserver == null ? newObserver :
+                return delegate().newConnection(resolvedAddress, context, originalObserver == null ? newObserver :
                        newObserver == null ? originalObserver : combine(originalObserver, newObserver));
             }
         };

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/ConnectionFactoryFilterTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/ConnectionFactoryFilterTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.client.api;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.transport.api.TransportObserver;
 
 import org.junit.jupiter.api.Test;
@@ -61,9 +62,10 @@ class ConnectionFactoryFilterTest {
 
             @Override
             public Single<ListenableAsyncCloseable> newConnection(final InetSocketAddress unused,
+                                                                  @Nullable final ContextMap context,
                                                                   @Nullable final TransportObserver observer) {
                 connectOrder.add(order);
-                return original.newConnection(unused, observer);
+                return original.newConnection(unused, context, observer);
             }
 
             @Override
@@ -101,6 +103,7 @@ class ConnectionFactoryFilterTest {
                 new ConnectionFactory<InetSocketAddress, ListenableAsyncCloseable>() {
             @Override
             public Single<ListenableAsyncCloseable> newConnection(final InetSocketAddress unused,
+                                                                  @Nullable final ContextMap context,
                                                                   @Nullable final TransportObserver observer) {
                 return Single.succeeded(DUMMY_CLOSABLE);
             }
@@ -118,8 +121,8 @@ class ConnectionFactoryFilterTest {
 
         ConnectionFactory<InetSocketAddress, ListenableAsyncCloseable> factory = combined.create(root);
 
-        ListenableAsyncCloseable connection = factory.newConnection(mock(InetSocketAddress.class),
-                                                            null).toFuture().get();
+        ListenableAsyncCloseable connection = factory.newConnection(mock(InetSocketAddress.class), null, null)
+                .toFuture().get();
 
         assertThat(connection, is(sameInstance(DUMMY_CLOSABLE)));
         assertThat(createOrder, is(hasSize(2)));

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -24,6 +24,7 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.IoExecutor;
@@ -182,7 +183,7 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * builder.
      * <p>
      * Filtering allows you to wrap a {@link ConnectionFactory} and modify behavior of
-     * {@link ConnectionFactory#newConnection(Object, TransportObserver)}.
+     * {@link ConnectionFactory#newConnection(Object, ContextMap, TransportObserver)}.
      * Some potential candidates for filtering include logging and metrics.
      * <p>
      * The order of execution of these filters are in order of append. If 3 filters are added as follows:

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -83,7 +84,8 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
 
                     @Override
                     public Single<FilterableStreamingHttpConnection> newConnection(
-                            final ResolvedAddress ra, @Nullable final TransportObserver observer) {
+                            final ResolvedAddress ra, @Nullable final ContextMap context,
+                            @Nullable final TransportObserver observer) {
                         Single<FilterableStreamingHttpConnection> connection =
                                 newFilterableConnection(ra, observer == null ? NoopTransportObserver.INSTANCE :
                                 asSafeObserver(observer));
@@ -114,8 +116,9 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
 
     @Override
     public final Single<LoadBalancedStreamingHttpConnection> newConnection(
-            final ResolvedAddress resolvedAddress, @Nullable final TransportObserver observer) {
-        return filterableConnectionFactory.newConnection(resolvedAddress, observer)
+            final ResolvedAddress resolvedAddress, @Nullable final ContextMap context,
+            @Nullable final TransportObserver observer) {
+        return filterableConnectionFactory.newConnection(resolvedAddress, context, observer)
                 .map(conn -> {
                     FilterableStreamingHttpConnection filteredConnection =
                             connectionFilterFunction != null ? connectionFilterFunction.create(conn) : conn;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -72,7 +72,7 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
         // LoadBalancer takes ownership of it (e.g. connection initialization) and in that case they will not be
         // following the LoadBalancer API which this Client depends upon to ensure the concurrent request count state is
         // correct.
-        return loadBalancer.selectConnection(SELECTOR_FOR_REQUEST).flatMap(c -> {
+        return loadBalancer.selectConnection(SELECTOR_FOR_REQUEST, request.context()).flatMap(c -> {
                 final Consumer<ConnectionInfo> onConnectionSelected = AsyncContext.get(ON_CONNECTION_SELECTED_CONSUMER);
                 if (onConnectionSelected != null) {
                     onConnectionSelected.accept(c.connectionContext());
@@ -131,7 +131,7 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
     public Single<ReservedStreamingHttpConnection> reserveConnection(final HttpRequestMetaData metaData) {
         return Single.defer(() -> {
             Single<ReservedStreamingHttpConnection> connection =
-                    loadBalancer.selectConnection(SELECTOR_FOR_RESERVE).map(identity());
+                    loadBalancer.selectConnection(SELECTOR_FOR_RESERVE, metaData.context()).map(identity());
             final HttpExecutionStrategy strategy = requestExecutionStrategy(metaData,
                     executionContext().executionStrategy());
             return (strategy.isMetadataReceiveOffloaded() || strategy.isDataReceiveOffloaded() ?

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.client.api.DelegatingConnectionFactory;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -70,8 +71,9 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
 
         @Override
         public Single<C> newConnection(final ResolvedAddress resolvedAddress,
+                                       @Nullable final ContextMap context,
                                        @Nullable final TransportObserver observer) {
-            return delegate().newConnection(resolvedAddress, observer).flatMap(c -> {
+            return delegate().newConnection(resolvedAddress, context, observer).flatMap(c -> {
                 try {
                     return c.request(c.connect(connectAddress).addHeader(CONTENT_LENGTH, ZERO))
                             .flatMap(response -> handleConnectResponse(c, response))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.api.AsyncCloseables;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.DelegatingHttpConnectionContext;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
@@ -161,8 +162,9 @@ class ConnectionFactoryFilterTest {
                 new DelegatingConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection>(original) {
                     @Override
                     public Single<FilterableStreamingHttpConnection> newConnection(
-                            final InetSocketAddress inetSocketAddress, @Nullable final TransportObserver observer) {
-                        return delegate().newConnection(inetSocketAddress, observer).map(filter);
+                            final InetSocketAddress inetSocketAddress, @Nullable final ContextMap context,
+                            @Nullable final TransportObserver observer) {
+                        return delegate().newConnection(inetSocketAddress, context, observer).map(filter);
                     }
                 }, ExecutionStrategy.offloadNone());
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryOffloadingTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.ConnectAndHttpExecutionStrategy;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpClient;
@@ -81,9 +82,10 @@ class ConnectionFactoryOffloadingTest {
 
                                 @Override
                                 public Single<FilterableStreamingHttpConnection> newConnection(
-                                        final SocketAddress socketAddress, @Nullable final TransportObserver observer) {
+                                        final SocketAddress socketAddress, @Nullable final ContextMap context,
+                                        @Nullable final TransportObserver observer) {
                                     factoryThread.set(Thread.currentThread());
-                                    return original.newConnection(socketAddress, observer);
+                                    return original.newConnection(socketAddress, context, observer);
                                 }
 
                                 @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -24,6 +24,7 @@ import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpServerBuilder;
@@ -587,8 +588,9 @@ class GracefulConnectionClosureHandlingTest {
 
         @Override
         public Single<FilterableStreamingHttpConnection> newConnection(ResolvedAddress address,
+                                                                       @Nullable final ContextMap context,
                                                                        @Nullable final TransportObserver observer) {
-            return delegate().newConnection(address, observer).whenOnSuccess(connection ->
+            return delegate().newConnection(address, context, observer).whenOnSuccess(connection ->
                     ((NettyConnectionContext) connection
                             .connectionContext()).onClosing()
                             .whenFinally(onClosing::countDown)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.DelegatingConnectionFactory;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.test.StepVerifiers;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
@@ -104,10 +105,10 @@ class H2ResponseCancelTest extends AbstractNettyHttpServerTest {
                         FilterableStreamingHttpConnection>(factory) {
                     @Override
                     public Single<FilterableStreamingHttpConnection> newConnection(InetSocketAddress inetSocketAddress,
-                              @Nullable TransportObserver observer) {
+                            @Nullable ContextMap context, @Nullable TransportObserver observer) {
                         return defer(() -> {
                             newConnectionsCounter.incrementAndGet();
-                            return delegate().newConnection(inetSocketAddress, observer);
+                            return delegate().newConnection(inetSocketAddress, context, observer);
                         });
                     }
                 }, ExecutionStrategy.offloadNone()));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpAuthConnectionFactoryClientTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.DelegatingConnectionFactory;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -95,8 +96,9 @@ class HttpAuthConnectionFactoryClientTest {
 
         @Override
         public Single<C> newConnection(
-                final ResolvedAddress resolvedAddress, @Nullable final TransportObserver observer) {
-            return super.newConnection(resolvedAddress, observer).flatMap(cnx ->
+                final ResolvedAddress resolvedAddress, @Nullable final ContextMap context,
+                @Nullable final TransportObserver observer) {
+            return delegate().newConnection(resolvedAddress, context, observer).flatMap(cnx ->
                     cnx.request(newTestRequest(cnx, "/auth"))
                             .onErrorResume(cause -> {
                                 cnx.closeAsync().subscribe();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientBuilderTest.java
@@ -85,16 +85,16 @@ class HttpClientBuilderTest extends AbstractEchoServerBasedHttpRequesterTest {
         makeRequestValidateResponseAndClose(requester);
 
         InOrder verifier = inOrder(factory1, factory2);
-        verifier.verify(factory1).newConnection(any(), any());
-        verifier.verify(factory2).newConnection(any(), any());
+        verifier.verify(factory1).newConnection(any(), any(), any());
+        verifier.verify(factory2).newConnection(any(), any(), any());
     }
 
     private static ConnectionFactoryFilter<InetSocketAddress, FilterableStreamingHttpConnection> factoryFilter(
             final ConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection> factory) {
         return ConnectionFactoryFilter.withStrategy(orig -> {
-            when(factory.newConnection(any(), any()))
+            when(factory.newConnection(any(), any(), any()))
                     .thenAnswer(invocation -> orig.newConnection(invocation.getArgument(0),
-                            invocation.getArgument(1)));
+                            invocation.getArgument(1), invocation.getArgument(2)));
             return factory;
         }, HttpExecutionStrategies.offloadNone());
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MixedFiltersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MixedFiltersTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionFactoryFilter;
+import io.servicetalk.client.api.DelegatingConnectionFactory;
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.context.api.ContextMap.Key;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.TransportObserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.context.api.ContextMap.Key.newKey;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+class MixedFiltersTest {
+
+    @SuppressWarnings("unchecked")
+    private static final Key<AtomicReference<StringBuilder>> KEY = (Key<AtomicReference<StringBuilder>>)
+            (Key<?>) newKey("key", AtomicReference.class);
+
+    public static Collection<List<AbstractFactoryFilter>> arguments() {
+        return asList(
+                asList(new MigratedFilter(1)),
+                asList(new DeprecatedFilter(1)),
+                asList(new MigratedFilter(1), new MigratedFilter(2)),
+                asList(new DeprecatedFilter(1), new DeprecatedFilter(2)),
+                asList(new MigratedFilter(1), new DeprecatedFilter(2)),
+                asList(new DeprecatedFilter(1), new MigratedFilter(2)),
+                asList(new MigratedFilter(1), new DeprecatedFilter(2), new MigratedFilter(3)),
+                asList(new DeprecatedFilter(1), new MigratedFilter(2), new DeprecatedFilter(3)));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] filters={0}")
+    @MethodSource("arguments")
+    void testSingleClient(List<AbstractFactoryFilter> filters) throws Exception {
+        String expected = filters.stream()
+                .map(AbstractFactoryFilter::toString)
+                .reduce((first, second) -> first + ',' + second)
+                .get();
+
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok())) {
+            SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                    HttpClients.forSingleAddress(serverHostAndPort(serverContext));
+            filters.forEach(builder::appendConnectionFactoryFilter);
+            try (BlockingHttpClient client = builder.buildBlocking()) {
+                AtomicReference<StringBuilder> ref = new AtomicReference<>(new StringBuilder());
+                AsyncContext.put(KEY, ref);
+                HttpResponse response = client.request(client.get("/"));
+                assertThat(response.status(), is(OK));
+                assertThat(ref.toString(), is(equalTo(expected)));
+            }
+        }
+    }
+
+    private abstract static class AbstractFactoryFilter
+            implements ConnectionFactoryFilter<InetSocketAddress, FilterableStreamingHttpConnection> {
+
+        private final String name;
+
+        AbstractFactoryFilter(int index) {
+            this.name = getClass().getSimpleName() + index;
+        }
+
+        @Override
+        public final String toString() {
+            return name;
+        }
+    }
+
+    private static final class DeprecatedFilter extends AbstractFactoryFilter {
+
+        DeprecatedFilter(int index) {
+            super(index);
+        }
+
+        @Override
+        public ConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection> create(
+                ConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection> cf) {
+            return new DelegatingConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection>(cf) {
+                @Override
+                public Single<FilterableStreamingHttpConnection> newConnection(
+                        InetSocketAddress address, @Nullable TransportObserver observer) {
+                    return Single.defer(() -> {
+                        AtomicReference<StringBuilder> ref = AsyncContext.get(KEY);
+                        if (ref != null) {
+                            if (ref.get().length() > 0) {
+                                ref.get().append(',');
+                            }
+                            ref.get().append(DeprecatedFilter.this);
+                        }
+                        return delegate().newConnection(address, observer).shareContextOnSubscribe();
+                    });
+                }
+            };
+        }
+    }
+
+    private static final class MigratedFilter extends AbstractFactoryFilter {
+
+        MigratedFilter(int index) {
+            super(index);
+        }
+
+        @Override
+        public ConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection> create(
+                ConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection> cf) {
+            return new DelegatingConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection>(cf) {
+                @Override
+                public Single<FilterableStreamingHttpConnection> newConnection(
+                        InetSocketAddress address, @Nullable ContextMap context, @Nullable TransportObserver observer) {
+                    return Single.defer(() -> {
+                        AtomicReference<StringBuilder> ref = AsyncContext.get(KEY);
+                        if (ref != null) {
+                            if (ref.get().length() > 0) {
+                                ref.get().append(',');
+                            }
+                            ref.get().append(MigratedFilter.this);
+                            // Make sure the ContextMap is propagated:
+                            if (context == null) {
+                                ref.get().append("(MISSING_CONTEXT_MAP)");
+                            }
+                        }
+                        return delegate().newConnection(address, context, observer).shareContextOnSubscribe();
+                    });
+                }
+            };
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilterTest.java
@@ -165,9 +165,9 @@ class ProxyConnectConnectionFactoryFilterTest {
     private void subscribeToProxyConnectionFactory(Consumer<FilterableStreamingHttpConnection> onSuccess) {
         @SuppressWarnings("unchecked")
         ConnectionFactory<String, FilterableStreamingHttpConnection> original = mock(ConnectionFactory.class);
-        when(original.newConnection(any(), any())).thenReturn(succeeded(connection));
+        when(original.newConnection(any(), any(), any())).thenReturn(succeeded(connection));
         toSource(new ProxyConnectConnectionFactoryFilter<String, FilterableStreamingHttpConnection>(CONNECT_ADDRESS)
-                .create(original).newConnection(RESOLVED_ADDRESS, null).afterOnSuccess(onSuccess))
+                .create(original).newConnection(RESOLVED_ADDRESS, null, null).afterOnSuccess(onSuccess))
                 .subscribe(subscriber);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource.Processor;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpExecutionStrategies;
@@ -177,10 +178,11 @@ class ResponseCancelTest {
 
         @Override
         public Single<FilterableStreamingHttpConnection> newConnection(final InetSocketAddress inetSocketAddress,
+                                                                       @Nullable final ContextMap context,
                                                                        @Nullable final TransportObserver observer) {
             return defer(() -> {
                 connectionCount.incrementAndGet();
-                return delegate().newConnection(inetSocketAddress, observer);
+                return delegate().newConnection(inetSocketAddress, context, observer);
             });
         }
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseTimeoutTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseTimeoutTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.DelegatingConnectionFactory;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpResponse;
@@ -198,10 +199,11 @@ class ResponseTimeoutTest {
 
         @Override
         public Single<FilterableStreamingHttpConnection> newConnection(final InetSocketAddress inetSocketAddress,
+                                                                       @Nullable final ContextMap context,
                                                                        @Nullable final TransportObserver observer) {
             return defer(() -> {
                 connectionCount.incrementAndGet();
-                return delegate().newConnection(inetSocketAddress, observer);
+                return delegate().newConnection(inetSocketAddress, context, observer);
             });
         }
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryRequestWithNonRepeatablePayloadTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryRequestWithNonRepeatablePayloadTest.java
@@ -21,6 +21,7 @@ import io.servicetalk.client.api.DelegatingConnectionFactory;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.internal.DeliberateException;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpConnectionFilter;
@@ -74,8 +75,9 @@ class RetryRequestWithNonRepeatablePayloadTest extends AbstractNettyHttpServerTe
                 FilterableStreamingHttpConnection>(factory) {
             @Override
             public Single<FilterableStreamingHttpConnection> newConnection(InetSocketAddress address,
+                                                                           @Nullable ContextMap context,
                                                                            @Nullable TransportObserver observer) {
-                return delegate().newConnection(address, observer).map(c -> {
+                return delegate().newConnection(address, context, observer).map(c -> {
                     final Channel channel = ((NettyConnectionContext) c.connectionContext()).nettyChannel();
                     if (protocol == HTTP_1) {
                         // Insert right before HttpResponseDecoder to avoid seeing failed frames on wire logs

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -26,6 +26,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
@@ -234,10 +235,10 @@ class RetryingHttpRequesterFilterTest {
         }
 
         @Override
-        public Single<C> selectConnection(final Predicate<C> selector) {
+        public Single<C> selectConnection(final Predicate<C> selector, @Nullable ContextMap context) {
             return defer(() -> {
                 lbSelectInvoked.incrementAndGet();
-                return delegate.selectConnection(selector);
+                return delegate.selectConnection(selector, context);
             });
         }
 
@@ -271,8 +272,9 @@ class RetryingHttpRequesterFilterTest {
 
         @Override
         public Single<FilterableStreamingHttpConnection> newConnection(final InetSocketAddress inetSocketAddress,
+                                                                       @Nullable final ContextMap context,
                                                                        @Nullable final TransportObserver observer) {
-            return delegate().newConnection(inetSocketAddress, observer)
+            return delegate().newConnection(inetSocketAddress, context, observer)
                     .flatMap(c -> c.closeAsync().concat(succeeded(c)));
         }
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -24,6 +24,7 @@ import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Executors;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.loadbalancer.RoundRobinLoadBalancer.HealthCheckConfig;
 import io.servicetalk.transport.api.ExecutionStrategy;
 
@@ -48,9 +49,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * <li>Round robining is done at address level.</li>
  * <li>Connections are created lazily, without any concurrency control on their creation.
  * This can lead to over-provisioning connections when dealing with a requests surge.</li>
- * <li>Existing connections are reused unless a selector passed to {@link LoadBalancer#selectConnection(Predicate)}
- * suggests otherwise. This can lead to situations where connections will be used to their maximum capacity
- * (for example in the context of pipelining) before new connections are created.</li>
+ * <li>Existing connections are reused unless a selector passed to
+ * {@link LoadBalancer#selectConnection(Predicate, ContextMap)} suggests otherwise. This can lead to situations where
+ * connections will be used to their maximum capacity (for example in the context of pipelining) before new connections
+ * are created.</li>
  * <li>Closed connections are automatically pruned.</li>
  * <li>When {@link Publisher}&lt;{@link ServiceDiscovererEvent}&gt; delivers events with
  * {@link ServiceDiscovererEvent#status()} of value {@link ServiceDiscovererEvent.Status#UNAVAILABLE}, connections

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerRoundRobinLoadBalancerTest.java
@@ -81,13 +81,13 @@ class EagerRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest {
     @Test
     void hostDownGracefullyClosesConnections() throws Exception {
         sendServiceDiscoveryEvents(upEvent("address-1"));
-        TestLoadBalancedConnection host1Conn1 = lb.selectConnection(alwaysNewConnectionFilter()).toFuture().get();
+        TestLoadBalancedConnection host1Conn1 = lb.selectConnection(alwaysNewConnectionFilter(), null).toFuture().get();
 
         sendServiceDiscoveryEvents(upEvent("address-2"));
-        TestLoadBalancedConnection host2Conn1 = lb.selectConnection(alwaysNewConnectionFilter()).toFuture().get();
+        TestLoadBalancedConnection host2Conn1 = lb.selectConnection(alwaysNewConnectionFilter(), null).toFuture().get();
 
         // create another for address-1
-        TestLoadBalancedConnection host1Conn2 = lb.selectConnection(alwaysNewConnectionFilter()).toFuture().get();
+        TestLoadBalancedConnection host1Conn2 = lb.selectConnection(alwaysNewConnectionFilter(), null).toFuture().get();
 
         sendServiceDiscoveryEvents(downEvent("address-1"));
         validateConnectionClosedGracefully(host1Conn1);


### PR DESCRIPTION
Motivation:

`LoadBalancer` and `ConnectionFactory` API is disconnected from  the
caller, lacks context who/why selects/creates a connection, and has no
API to propagate additional information from the caller (request).

Modifications:

- `LoadBalancer`: add new `selectConnection(Predicate, ContextMap)`
method, deprecate `selectConnection(Predicate)`;
- `ConnectionFactory`: add new
`newConnection(Address, ContextMap, TransportObserver)` method,
deprecate `newConnection(Address, TransportObserver)`;
- Migrate all LB/CF implementations and tests to use new API;
- Add `DeprecatedToNewConnectionFactoryFilter` after each user-defined
CF to make sure old/new filters work in the same pipeline;

Result:

Information can be propagated from the caller to the
`LoadBalancer` and `ConnectionFactory`.