### PR TITLE
Let `ConnectionFactory` see difference between proxied and direct connections

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/DefaultContextMap.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/DefaultContextMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.api;
+package io.servicetalk.concurrent.internal;
 
-import io.servicetalk.concurrent.internal.ContextMapUtils;
 import io.servicetalk.context.api.ContextMap;
 
 import java.util.HashMap;
@@ -26,11 +25,19 @@ import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-final class DefaultContextMap implements ContextMap {
+/**
+ * Default implementation of {@link ContextMap}.
+ * <p>
+ * Note: it's not concurrent!
+ */
+public final class DefaultContextMap implements ContextMap {
 
     private final HashMap<Key<?>, Object> theMap;
 
-    DefaultContextMap() {
+    /**
+     * Creates a new instance.
+     */
+    public DefaultContextMap() {
         theMap = new HashMap<>(4); // start with a smaller table
     }
 

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/DefaultContextMap.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/DefaultContextMap.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Default implementation of {@link ContextMap}.
  * <p>
- * Note: it's not concurrent!
+ * Note: it's not thread-safe!
  */
 public final class DefaultContextMap implements ContextMap {
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractHttpMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractHttpMetaData.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.http.api;
 
+import io.servicetalk.concurrent.internal.DefaultContextMap;
 import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.encoding.api.ContentCodec;
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.context.api.ContextMap.Key;
+import io.servicetalk.transport.api.ConnectionInfo;
 
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
 
@@ -32,6 +33,19 @@ public final class HttpContextKeys {
      */
     public static final Key<HttpExecutionStrategy> HTTP_EXECUTION_STRATEGY_KEY =
             newKey("HTTP_EXECUTION_STRATEGY_KEY", HttpExecutionStrategy.class);
+
+    /**
+     * When opening a connection to a proxy, this key tells what is the actual (unresolved) target address behind the
+     * proxy this connection will be established to.
+     * <p>
+     * To distinguish between a
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling#http_tunneling">secure
+     * HTTP proxy tunneling</a> and a clear text HTTP proxy, check presence of {@link ConnectionInfo#sslConfig()}.
+     *
+     * @see SingleAddressHttpClientBuilder#proxyAddress(Object)
+     */
+    public static final Key<Object> HTTP_TARGET_ADDRESS_BEHIND_PROXY =
+            newKey("HTTP_TARGET_ADDRESS_BEHIND_PROXY", Object.class);
 
     private HttpContextKeys() {
         // No instances

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020, 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,15 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+import static io.servicetalk.http.api.HttpContextKeys.HTTP_TARGET_ADDRESS_BEHIND_PROXY;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
@@ -51,6 +54,8 @@ import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_
  */
 final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends FilterableStreamingHttpConnection>
         implements ConnectionFactoryFilter<ResolvedAddress, C> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConnectConnectionFactoryFilter.class);
 
     private final String connectAddress;
 
@@ -71,17 +76,26 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
 
         @Override
         public Single<C> newConnection(final ResolvedAddress resolvedAddress,
-                                       @Nullable final ContextMap context,
+                                       @Nullable ContextMap context,
                                        @Nullable final TransportObserver observer) {
-            return delegate().newConnection(resolvedAddress, context, observer).flatMap(c -> {
-                try {
-                    return c.request(c.connect(connectAddress).addHeader(CONTENT_LENGTH, ZERO))
-                            .flatMap(response -> handleConnectResponse(c, response))
-                            // Close recently created connection in case of any error while it connects to the proxy:
-                            .onErrorResume(t -> c.closeAsync().concat(failed(t)));
-                } catch (Throwable t) {
-                    return c.closeAsync().concat(failed(t));
+            return Single.defer(() -> {
+                if (context == null) {
+                    // context = new DefaultContextMap();
                 }
+                logUnexpectedAddress(context.put(HTTP_TARGET_ADDRESS_BEHIND_PROXY, connectAddress),
+                        connectAddress, LOGGER);
+                return delegate().newConnection(resolvedAddress, context, observer).flatMap(c -> {
+                    try {
+                        return c.request(c.connect(connectAddress).addHeader(CONTENT_LENGTH, ZERO))
+                                .flatMap(response -> handleConnectResponse(c, response))
+                                // Close recently created connection in case of any error while it connects to the
+                                // proxy:
+                                .onErrorResume(t -> c.closeAsync().concat(failed(t)));
+                        // We do not apply shareContextOnSubscribe() here to isolate a context for `CONNECT` request.
+                    } catch (Throwable t) {
+                        return c.closeAsync().concat(failed(t));
+                    }
+                }).shareContextOnSubscribe();
             });
         }
 
@@ -118,6 +132,13 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
             // There is no need to apply offloading explicitly (despite completing `processor` on the EventLoop)
             // because `payloadBody()` will be offloaded according to the strategy for the request.
             return response.messageBody().ignoreElements().concat(fromSource(processor));
+        }
+    }
+
+    static void logUnexpectedAddress(@Nullable final Object current, final Object expected, final Logger logger) {
+        if (current != null && !expected.equals(current)) {
+            logger.info("Observed unexpected value for {}: {}, overridden with: {}",
+                    HTTP_TARGET_ADDRESS_BEHIND_PROXY, current, expected);
         }
     }
 


### PR DESCRIPTION
Motivation:
The connection initialization sequence is different for secure HTTP proxy
tunnels.  It's necessary for the `ConnectionFactory` and
`TransportObserver` to know if the `newConnection(...)` is being invoked for
a regular connection or a proxy tunnel in order to correctly count timing
of events.

Modifications:

- Introduce new `HttpContextKeys#HTTP_TARGET_ADDRESS_BEHIND_PROXY` key;
- Enhance `ProxyConnectConnectionFactoryFilter` and
`AbsoluteAddressHttpRequesterFilter` to fill in the value for
`HTTP_TARGET_ADDRESS_BEHIND_PROXY`;
- Enhance proxy tests to verify that the key value always present;

Result:

Users can distinguish attempts to open direct connections and
connections through a proxy.

Depends on #2168, review starting from the 2nd commit.