### PR TITLE
Add jitter for the subsequent DNS queries

### DIFF
--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-transport-netty")
   implementation project(":servicetalk-transport-netty-internal")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "io.netty:netty-resolver-dns"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -118,10 +118,10 @@ final class DefaultDnsClient implements DnsClient {
     private final int srvConcurrency;
     private final boolean srvFilterDuplicateEvents;
     private final boolean inactiveEventsOnError;
-    private final long scheduleJitterNanos;
+    private final long ttlJitterNanos;
     private boolean closed;
 
-    DefaultDnsClient(final IoExecutor ioExecutor, final int minTTL, final long scheduleJitterNanos,
+    DefaultDnsClient(final IoExecutor ioExecutor, final int minTTL, final long ttlJitterNanos,
                      final int srvConcurrency, final boolean inactiveEventsOnError,
                      final boolean completeOncePreferredResolved, final boolean srvFilterDuplicateEvents,
                      Duration srvHostNameRepeatInitialDelay, Duration srvHostNameRepeatJitter,
@@ -144,7 +144,7 @@ final class DefaultDnsClient implements DnsClient {
                 srvHostNameRepeatInitialDelay, srvHostNameRepeatJitter, nettyIoExecutor);
         this.ttlCache = new MinTtlCache(new DefaultDnsCache(minTTL, Integer.MAX_VALUE, minTTL), minTTL,
                 nettyIoExecutor);
-        this.scheduleJitterNanos = scheduleJitterNanos;
+        this.ttlJitterNanos = ttlJitterNanos;
         this.observer = observer;
         this.missingRecordStatus = missingRecordStatus;
         asyncCloseable = toAsyncCloseable(graceful -> {
@@ -634,7 +634,7 @@ final class DefaultDnsClient implements DnsClient {
                 assertInEventloop();
 
                 final long delay = ThreadLocalRandom.current()
-                        .nextLong(nanos, addWithOverflowProtection(nanos, scheduleJitterNanos));
+                        .nextLong(nanos, addWithOverflowProtection(nanos, ttlJitterNanos));
                 LOGGER.debug("DnsClient {}, scheduling DNS query for {} after {}ms, original TTL: {}ms.",
                         DefaultDnsClient.this, AbstractDnsPublisher.this, NANOSECONDS.toMillis(delay),
                         NANOSECONDS.toMillis(nanos));

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -53,7 +53,7 @@ public final class DefaultDnsServiceDiscovererBuilder {
     @Nullable
     private Duration queryTimeout;
     private int minTTLSeconds = 10;
-    private Duration jitter = ofSeconds(4);
+    private Duration ttlJitter = ofSeconds(4);
     private int srvConcurrency = 2048;
     private boolean inactiveEventsOnError;
     private boolean completeOncePreferredResolved = true;
@@ -86,12 +86,12 @@ public final class DefaultDnsServiceDiscovererBuilder {
      * The jitter value will be added on top of the TTL value returned from the DNS server to help spread out
      * subsequent DNS queries.
      *
-     * @param jitter The jitter to apply to schedule the next query after TTL.
+     * @param ttlJitter The jitter to apply to schedule the next query after TTL.
      * @return {@code this}.
      */
-    public DefaultDnsServiceDiscovererBuilder jitter(final Duration jitter) {
-        ensurePositive(jitter, "jitter");
-        this.jitter = jitter;
+    public DefaultDnsServiceDiscovererBuilder ttlJitter(final Duration ttlJitter) {
+        ensurePositive(ttlJitter, "jitter");
+        this.ttlJitter = ttlJitter;
         return this;
     }
 
@@ -306,7 +306,7 @@ public final class DefaultDnsServiceDiscovererBuilder {
     DnsClient build() {
         final DnsClient rawClient = new DefaultDnsClient(
                 ioExecutor == null ? globalExecutionContext().ioExecutor() : ioExecutor, minTTLSeconds,
-                jitter.toNanos(), srvConcurrency,
+                ttlJitter.toNanos(), srvConcurrency,
                 inactiveEventsOnError, completeOncePreferredResolved, srvFilterDuplicateEvents,
                 srvHostNameRepeatInitialDelay, srvHostNameRepeatJitter, maxUdpPayloadSize, ndots, optResourceEnabled,
                 queryTimeout, dnsResolverAddressTypes, dnsServerAddressStreamProvider, observer, missingRecordStatus);


### PR DESCRIPTION
Motivation:

Current DNS implementation of the `ServiceDiscoverer` sends new queries
after each TTL expires. This may lead to spikes in load on DNS servers
if many clients align their requests based on the returned TTL value.

Modifications:

- Add jitter for the subsequent DNS queries;
- Allow users to customize jitter value;

Result:

Subsequent DNS queries are spread out in time using jitter.