### PR TITLE
Let users move `GrpcLifecycleObserver` in the filter chain

### DIFF
--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverRequesterFilter.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverRequesterFilter.java
@@ -31,6 +31,8 @@ import io.servicetalk.http.utils.RedirectingHttpRequesterFilter;
  * (which can be configured using {@link GrpcClientBuilder#initializeHttp(GrpcClientBuilder.HttpInitializer)})
  * to account for all work done by other filters. If it's preferred to get visibility in all retried or redirected
  * requests, consider adding it after {@link RetryingHttpRequesterFilter} or {@link RedirectingHttpRequesterFilter}.
+ * If it's preferred to get visibility to information populated by other filters (like tracing keys), it can be appended
+ * after those filters.
  */
 public final class GrpcLifecycleObserverRequesterFilter extends HttpLifecycleObserverRequesterFilter {
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverServiceFilter.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverServiceFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.grpc.api.GrpcLifecycleObserver;
+import io.servicetalk.grpc.api.GrpcServerBuilder;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+import io.servicetalk.http.netty.HttpLifecycleObserverServiceFilter;
+
+/**
+ * An HTTP service filter that tracks events during gRPC request/response lifecycle.
+ * <p>
+ * The recommended approach is to use {@link GrpcServerBuilder#lifecycleObserver(GrpcLifecycleObserver)} to configure
+ * an observer that captures entire state of the request processing. In cases when an observer should be moved down in
+ * a filter chain or applied conditionally, this filter can be used.
+ * <p>
+ * This filter is recommended to be appended as the first filter at the
+ * {@link HttpServerBuilder#appendNonOffloadingServiceFilter(StreamingHttpServiceFilterFactory)}
+ * or {@link  HttpServerBuilder#appendServiceFilter(StreamingHttpServiceFilterFactory)}
+ * (which can be configured using {@link GrpcServerBuilder#initializeHttp(GrpcServerBuilder.HttpInitializer)})
+ * to account for all work done by other filters. If it's preferred to get visibility to information populated by other
+ * filters (like tracing keys), it can be appended after those filters.
+ */
+public final class GrpcLifecycleObserverServiceFilter extends HttpLifecycleObserverServiceFilter {
+
+    /**
+     * Create a new instance.
+     *
+     * @param observer The {@link GrpcLifecycleObserver observer} implementation that consumes gRPC lifecycle events.
+     */
+    public GrpcLifecycleObserverServiceFilter(final GrpcLifecycleObserver observer) {
+        super(new GrpcToHttpLifecycleObserverBridge(observer));
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
@@ -161,6 +161,12 @@ abstract class AbstractLifecycleObserverHttpFilter implements HttpExecutionStrat
         return HttpExecutionStrategies.offloadNone();
     }
 
+    @Override
+    public final HttpExecutionStrategy influenceStrategy(final HttpExecutionStrategy strategy) {
+        // no influence since we do not block and the observer is not expected to block either
+        return strategy;
+    }
+
     private static final class ExchangeContext implements TerminalSignalConsumer {
 
         private static final AtomicIntegerFieldUpdater<ExchangeContext> remainingUpdater =

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpLifecycleObserverServiceFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpLifecycleObserverServiceFilter.java
@@ -47,7 +47,7 @@ import io.servicetalk.http.utils.TimeoutHttpServiceFilter;
  * {@link HttpExceptionMapperServiceFilter} right after this filter to make sure all {@link Throwable}(s) are mapped
  * into an HTTP response.
  */
-public final class HttpLifecycleObserverServiceFilter extends AbstractLifecycleObserverHttpFilter implements
+public class HttpLifecycleObserverServiceFilter extends AbstractLifecycleObserverHttpFilter implements
             StreamingHttpServiceFilterFactory {
 
     /**
@@ -60,7 +60,7 @@ public final class HttpLifecycleObserverServiceFilter extends AbstractLifecycleO
     }
 
     @Override
-    public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+    public final StreamingHttpServiceFilter create(final StreamingHttpService service) {
         return new StreamingHttpServiceFilter(service) {
             @Override
             public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,


### PR DESCRIPTION
Motivation:

gRPC users can not use `HttpLifecycleObserverServiceFilter` to install
`GrpcLifecycleObserver` because `onGrpcStatus` won't be invoked.
Sometimes, it's necessary to see the state of other filters from inside
the observer.

Modifications:

- Make `HttpLifecycleObserverServiceFilter` extensible as a class, but
keep all its methods `final`;
- Add `GrpcLifecycleObserverServiceFilter`;

Result:

Users can install `GrpcLifecycleObserver` anywhere in a filter chain.