### PR TITLE
`RoundRobinLoadBalancer`: better identify excess connections

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -71,6 +71,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static java.lang.Integer.toHexString;
+import static java.lang.Math.min;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -103,7 +104,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
      * exhausting the full search space without sacrificing too much latency caused by the cost of a CAS operation per
      * selection attempt.
      */
-    private static final int MIN_SEARCH_SPACE = 64;
+    private static final int MIN_RANDOM_SEARCH_SPACE = 64;
 
     /**
      * For larger search spaces, due to the cost of a CAS operation per selection attempt we see diminishing returns for
@@ -113,7 +114,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
      * The current heuristics were chosen based on a set of benchmarks under various circumstances, low connection
      * counts, larger connection counts, low connection churn, high connection churn.
      */
-    private static final float SEARCH_FACTOR = 0.75f;
+    private static final float RANDOM_SEARCH_FACTOR = 0.75f;
 
     @SuppressWarnings("unused")
     private volatile int index;
@@ -123,6 +124,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
     private final Publisher<Object> eventStream;
     private final SequentialCancellable discoveryCancellable = new SequentialCancellable();
     private final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory;
+    private final int linearSearchSpace;
     private final ListenableAsyncCloseable asyncCloseable;
 
     /**
@@ -141,11 +143,13 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             final String targetResourceName,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
+            final int linearSearchSpace,
             @Nullable final HealthCheckConfig healthCheckConfig) {
         this.targetResource = requireNonNull(targetResourceName) + " (instance @" + toHexString(hashCode()) + ')';
         Processor<Object, Object> eventStreamProcessor = newPublisherProcessorDropHeadOnOverflow(32);
         this.eventStream = fromSource(eventStreamProcessor);
         this.connectionFactory = requireNonNull(connectionFactory);
+        this.linearSearchSpace = linearSearchSpace;
 
         toSource(eventPublisher).subscribe(
                 new Subscriber<Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>>() {
@@ -352,21 +356,34 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         Host<ResolvedAddress, C> pickedHost = null;
         for (int i = 0; i < usedHosts.size(); ++i) {
             // for a particular iteration we maintain a local cursor without contention with other requests
-            int localCursor = (cursor + i) % usedHosts.size();
+            final int localCursor = (cursor + i) % usedHosts.size();
             final Host<ResolvedAddress, C> host = usedHosts.get(localCursor);
             assert host != null : "Host can't be null.";
 
             // Try first to see if an existing connection can be used
             final Object[] connections = host.connState.connections;
-            // With small enough search space, attempt all connections.
-            // Back off after exploring most of the search space, it gives diminishing returns.
-            final int attempts = connections.length < MIN_SEARCH_SPACE ?
-                    connections.length : (int) (connections.length * SEARCH_FACTOR);
-            for (int j = 0; j < attempts; ++j) {
+            // Exhaust the linear search space first:
+            final int linearAttempts = min(connections.length, linearSearchSpace);
+            for (int j = 0; j < linearAttempts; ++j) {
                 @SuppressWarnings("unchecked")
-                final C connection = (C) connections[rnd.nextInt(connections.length)];
+                final C connection = (C) connections[j];
                 if (selector.test(connection)) {
                     return succeeded(connection);
+                }
+            }
+            // Try other connections randomly:
+            if (connections.length > linearAttempts) {
+                final int diff = connections.length - linearAttempts;
+                // With small enough search space, attempt number of times equal to number of remaining connections.
+                // Back off after exploring most of the search space, it gives diminishing returns.
+                final int randomAttempts = diff < MIN_RANDOM_SEARCH_SPACE ? diff :
+                        (int) (diff * RANDOM_SEARCH_FACTOR);
+                for (int j = 0; j < randomAttempts; ++j) {
+                    @SuppressWarnings("unchecked")
+                    final C connection = (C) connections[rnd.nextInt(linearAttempts, connections.length)];
+                    if (selector.test(connection)) {
+                        return succeeded(connection);
+                    }
                 }
             }
 


### PR DESCRIPTION
Motivation:

Cold start or traffic spikes can result in opening excess connections to
handle unexpected load. Current selection algorithm in
`RoundRobinLoadBalancer` attempts to pick a random connection. This
approach does not let to decrease number of open connections when
traffic stabilizes.

Modifications:

Introduce `linearSearchSpace` configuration option for
`RoundRobinLoadBalancerFactory` to start a linear search before falling
back to a random selection.

Result:

Allows configuring more predictable selection of the connection. When
configured with `IDLE_TIMEOUT` socket option, helps to reduce the number
of connections that can serve multiplexed or pipelined requests.
Default value of 16 has no performance impact on non-pipelined HTTP/1.1
connections, but significantly reduces latencies for HTTP/2 requests and
number of open HTTP/2 connections. For 1024 concurrent HTTP/2 requests
p99 latency drops down 2.5x times without offloading and 4x with offloading,
number of open connections goes down from ~256 to <10.