### PR TITLE
Always set default `ServiceTalkSocketOptions#IDLE_TIMEOUT`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -93,7 +93,7 @@ import static java.util.Objects.requireNonNull;
 
 final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
     private H2ClientParentConnectionContext(Channel channel, HttpExecutionContext executionContext,
-                                            FlushStrategy flushStrategy, Long idleTimeoutMs,
+                                            FlushStrategy flushStrategy, long idleTimeoutMs,
                                             @Nullable final SslConfig sslConfig,
                                             final KeepAliveManager keepAliveManager) {
         super(channel, executionContext, flushStrategy, idleTimeoutMs, sslConfig, keepAliveManager);
@@ -106,7 +106,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                                         H2ProtocolConfig config,
                                                         StreamingHttpRequestResponseFactory reqRespFactory,
                                                         FlushStrategy parentFlushStrategy,
-                                                        Long idleTimeoutMs,
+                                                        long idleTimeoutMs,
                                                         @Nullable SslConfig sslConfig,
                                                         ChannelInitializer initializer,
                                                         ConnectionObserver observer,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -93,7 +93,7 @@ import static java.util.Objects.requireNonNull;
 
 final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
     private H2ClientParentConnectionContext(Channel channel, HttpExecutionContext executionContext,
-                                            FlushStrategy flushStrategy, @Nullable Long idleTimeoutMs,
+                                            FlushStrategy flushStrategy, Long idleTimeoutMs,
                                             @Nullable final SslConfig sslConfig,
                                             final KeepAliveManager keepAliveManager) {
         super(channel, executionContext, flushStrategy, idleTimeoutMs, sslConfig, keepAliveManager);
@@ -106,7 +106,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                                         H2ProtocolConfig config,
                                                         StreamingHttpRequestResponseFactory reqRespFactory,
                                                         FlushStrategy parentFlushStrategy,
-                                                        @Nullable Long idleTimeoutMs,
+                                                        Long idleTimeoutMs,
                                                         @Nullable SslConfig sslConfig,
                                                         ChannelInitializer initializer,
                                                         ConnectionObserver observer,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -71,13 +71,12 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
     private final KeepAliveManager keepAliveManager;
     @Nullable
     private final SslConfig sslConfig;
-    @Nullable
     final Long idleTimeoutMs;
     @Nullable
     private SSLSession sslSession;
 
     H2ParentConnectionContext(final Channel channel, final HttpExecutionContext executionContext,
-                              final FlushStrategy flushStrategy, @Nullable final Long idleTimeoutMs,
+                              final FlushStrategy flushStrategy, final Long idleTimeoutMs,
                               @Nullable final SslConfig sslConfig,
                               final KeepAliveManager keepAliveManager) {
         super(channel, executionContext.executor());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -71,12 +71,12 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
     private final KeepAliveManager keepAliveManager;
     @Nullable
     private final SslConfig sslConfig;
-    final Long idleTimeoutMs;
+    final long idleTimeoutMs;
     @Nullable
     private SSLSession sslSession;
 
     H2ParentConnectionContext(final Channel channel, final HttpExecutionContext executionContext,
-                              final FlushStrategy flushStrategy, final Long idleTimeoutMs,
+                              final FlushStrategy flushStrategy, final long idleTimeoutMs,
                               @Nullable final SslConfig sslConfig,
                               final KeepAliveManager keepAliveManager) {
         super(channel, executionContext.executor());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -64,7 +64,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
     private final SocketAddress listenAddress;
     private H2ServerParentConnectionContext(final Channel channel, final HttpExecutionContext executionContext,
                                             final FlushStrategy flushStrategy,
-                                            @Nullable final Long idleTimeoutMs,
+                                            final Long idleTimeoutMs,
                                             @Nullable final SslConfig sslConfig,
                                             final SocketAddress listenAddress,
                                             final KeepAliveManager keepAliveManager) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -64,7 +64,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
     private final SocketAddress listenAddress;
     private H2ServerParentConnectionContext(final Channel channel, final HttpExecutionContext executionContext,
                                             final FlushStrategy flushStrategy,
-                                            final Long idleTimeoutMs,
+                                            final long idleTimeoutMs,
                                             @Nullable final SslConfig sslConfig,
                                             final SocketAddress listenAddress,
                                             final KeepAliveManager keepAliveManager) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionContextSocketOptionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpConnectionContextSocketOptionTest.java
@@ -80,18 +80,18 @@ class HttpConnectionContextSocketOptionTest {
 
     @ParameterizedTest(name = "protocol={0}")
     @EnumSource(HttpProtocol.class)
-    void stIdleTimeoutSocketOptionIsNull(HttpProtocol protocol) throws Exception {
-        testSocketOption(ServiceTalkSocketOptions.IDLE_TIMEOUT, is(nullValue()), equalTo("null"), null, protocol);
+    void stIdleTimeoutSocketOptionIsZero(HttpProtocol protocol) throws Exception {
+        testSocketOption(ServiceTalkSocketOptions.IDLE_TIMEOUT, is(0L), equalTo("0"), 0L, protocol);
     }
 
-    private <T> void testSocketOption(SocketOption<T> socketOption, Matcher<Object> clientMatcher,
-                                      Matcher<Object> serverMatcher, HttpProtocol protocol) throws Exception {
+    private static <T> void testSocketOption(SocketOption<T> socketOption, Matcher<Object> clientMatcher,
+                                             Matcher<Object> serverMatcher, HttpProtocol protocol) throws Exception {
         testSocketOption(socketOption, clientMatcher, serverMatcher, null, protocol);
     }
 
-    private <T> void testSocketOption(SocketOption<T> socketOption, Matcher<Object> clientMatcher,
-                                      Matcher<Object> serverMatcher, @Nullable Long idleTimeoutMs,
-                                      HttpProtocol protocol)
+    private static <T> void testSocketOption(SocketOption<T> socketOption, Matcher<Object> clientMatcher,
+                                             Matcher<Object> serverMatcher, @Nullable Long idleTimeoutMs,
+                                             HttpProtocol protocol)
         throws Exception {
         try (ServerContext serverContext = startServer(idleTimeoutMs, socketOption, protocol);
              BlockingHttpClient client = newClient(serverContext, idleTimeoutMs, protocol);
@@ -104,8 +104,8 @@ class HttpConnectionContextSocketOptionTest {
         }
     }
 
-    private <T> ServerContext startServer(@Nullable Long idleTimeoutMs, SocketOption<T> socketOption,
-                                          HttpProtocol protocol) throws Exception {
+    private static <T> ServerContext startServer(@Nullable Long idleTimeoutMs, SocketOption<T> socketOption,
+                                                 HttpProtocol protocol) throws Exception {
         final HttpServerBuilder builder = HttpServers.forAddress(localAddress(0))
                 .protocols(protocol.config);
         if (idleTimeoutMs != null) {
@@ -115,8 +115,8 @@ class HttpConnectionContextSocketOptionTest {
                 .payloadBody(valueOf(ctx.socketOption(socketOption)), textSerializerUtf8()));
     }
 
-    private BlockingHttpClient newClient(ServerContext serverContext, @Nullable Long idleTimeoutMs,
-                                         HttpProtocol protocol) {
+    private static BlockingHttpClient newClient(ServerContext serverContext, @Nullable Long idleTimeoutMs,
+                                                HttpProtocol protocol) {
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
                 HttpClients.forSingleAddress(serverHostAndPort(serverContext))
                         .protocols(protocol.config);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -422,7 +422,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                             SEC, null,
                             (channel, observer) -> DefaultNettyConnection.initChannel(channel, SEC.bufferAllocator(),
                                     SEC.executor(), SEC.ioExecutor(),
-                                    forPipelinedRequestResponse(false, channel.config()), defaultFlushStrategy(), null,
+                                    forPipelinedRequestResponse(false, channel.config()), defaultFlushStrategy(), 0L,
                                     null,
                                     new TcpServerChannelInitializer(sConfig, observer).andThen(
                                             channel2 -> {
@@ -440,7 +440,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                                 closeHandlerRef.compareAndSet(null, closeHandler);
                                 return DefaultNettyConnection.initChannel(channel, CEC.bufferAllocator(),
                                         CEC.executor(), CEC.ioExecutor(),
-                                        closeHandler, defaultFlushStrategy(), null,
+                                        closeHandler, defaultFlushStrategy(), 0L,
                                         cConfig.tcpConfig().sslConfig(),
                                         new TcpClientChannelInitializer(cConfig.tcpConfig(),
                                                 connectionObserver)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyPipelinedConnectionTest.java
@@ -101,7 +101,7 @@ class NettyPipelinedConnectionTest {
         CloseHandler closeHandler = UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
         final DefaultNettyConnection<Integer, Integer> connection =
                 DefaultNettyConnection.<Integer, Integer>initChannel(channel, DEFAULT_ALLOCATOR,
-                immediate(), null, closeHandler, defaultFlushStrategy(), null, null, channel2 -> {
+                immediate(), null, closeHandler, defaultFlushStrategy(), 0L, null, channel2 -> {
                     channel2.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                         @Override
                         public void channelRead(ChannelHandlerContext ctx, Object msg) {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
@@ -37,8 +37,7 @@ import static java.util.Collections.unmodifiableMap;
 abstract class AbstractReadOnlyTcpConfig<SecurityConfig> {
     @SuppressWarnings("rawtypes")
     private final Map<ChannelOption, Object> options;
-    @Nullable
-    private final Long idleTimeoutMs;
+    private final long idleTimeoutMs;
     private final FlushStrategy flushStrategy;
     @Nullable
     private final UserDataLoggerConfig wireLoggerConfig;
@@ -77,8 +76,7 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig> {
      *
      * @return idle timeout in milliseconds
      */
-    @Nullable
-    public final Long idleTimeoutMs() {
+    public final long idleTimeoutMs() {
         return idleTimeoutMs;
     }
 

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -45,8 +45,7 @@ abstract class AbstractTcpConfig<SslConfigType> {
     @Nullable
     @SuppressWarnings("rawtypes")
     private Map<ChannelOption, Object> options;
-    @Nullable
-    private Long idleTimeoutMs;
+    private long idleTimeoutMs = 300_000L;  // 5 min
     private FlushStrategy flushStrategy = defaultFlushStrategy();
     @Nullable
     private UserDataLoggerConfig wireLoggerConfig;
@@ -70,8 +69,7 @@ abstract class AbstractTcpConfig<SslConfigType> {
         return options;
     }
 
-    @Nullable
-    final Long idleTimeoutMs() {
+    final long idleTimeoutMs() {
         return idleTimeoutMs;
     }
 
@@ -109,6 +107,9 @@ abstract class AbstractTcpConfig<SslConfigType> {
         requireNonNull(value);
         if (option == ServiceTalkSocketOptions.IDLE_TIMEOUT) {
             idleTimeoutMs = (Long) value;
+            if (idleTimeoutMs < 0) {
+                throw new IllegalArgumentException("IDLE_TIMEOUT: " + idleTimeoutMs + " (expected>=0)");
+            }
         } else {
             if (options == null) {
                 options = new HashMap<>();

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -66,7 +66,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {
                     sslContext != null && !deferSslHandler, true));
         }
 
-        if (config.idleTimeoutMs() != null) {
+        if (config.idleTimeoutMs() > 0L) {
             delegate = delegate.andThen(new IdleTimeoutInitializer(config.idleTimeoutMs()));
         }
 

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -51,7 +51,7 @@ public class TcpServerChannelInitializer implements ChannelInitializer {
                     new ConnectionObserverInitializer(observer, config.sslContext() != null, false));
         }
 
-        if (config.idleTimeoutMs() != null) {
+        if (config.idleTimeoutMs() > 0L) {
             delegate = delegate.andThen(new IdleTimeoutInitializer(config.idleTimeoutMs()));
         }
 

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpConnectorTest.java
@@ -103,7 +103,7 @@ final class TcpConnectorTest extends AbstractTcpServerTest {
                 serverContext.listenAddress(), new TcpClientConfig().asReadOnly(), false,
                 CLIENT_CTX, (channel, connectionObserver) -> DefaultNettyConnection.initChannel(channel,
                         CLIENT_CTX.bufferAllocator(), CLIENT_CTX.executor(), CLIENT_CTX.ioExecutor(), closeHandler,
-                        defaultFlushStrategy(), null, null, channel2 ->
+                        defaultFlushStrategy(), 0L, null, channel2 ->
                                 channel2.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                             @Override
                             public void channelRegistered(ChannelHandlerContext ctx) {

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServiceTalkSocketOptions.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServiceTalkSocketOptions.java
@@ -40,7 +40,7 @@ public final class ServiceTalkSocketOptions {
             new ServiceTalkSocketOption<>("WRITE_BUFFER_THRESHOLD", Integer.class);
 
     /**
-     * Connection idle timeout in milliseconds after which the connection is closed.
+     * Connection idle timeout in milliseconds after which the connection is closed. {@code 0} disables idle timeout.
      */
     public static final SocketOption<Long> IDLE_TIMEOUT = new ServiceTalkSocketOption<>("IDLE_TIMEOUT", Long.class);
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -114,7 +114,6 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     private final CompletableSource.Processor onClosing;
     private final SingleSource.Processor<Throwable, Throwable> transportError = newSingleProcessor();
     private final FlushStrategyHolder flushStrategyHolder;
-    @Nullable
     private final Long idleTimeoutMs;
     private final Protocol protocol;
     @Nullable
@@ -170,7 +169,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     private DefaultNettyConnection(
             Channel channel, ExecutionContext<?> executionContext,
             CloseHandler closeHandler, FlushStrategy flushStrategy,
-            @Nullable Long idleTimeoutMs, Protocol protocol,
+            Long idleTimeoutMs, Protocol protocol,
             @Nullable SslConfig sslConfig, @Nullable SSLSession sslSession,
             @Nullable ChannelConfig parentChannelConfig, DataObserver dataObserver, boolean isClient,
             Predicate<Object> shouldWait, UnaryOperator<Throwable> enrichProtocolError) {
@@ -243,7 +242,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     public static <Read, Write> DefaultNettyConnection<Read, Write> initChildChannel(
             Channel channel, ExecutionContext<?> executionContext,
             CloseHandler closeHandler, FlushStrategy flushStrategy,
-            @Nullable Long idleTimeoutMs, Protocol protocol, @Nullable SSLSession sslSession,
+            Long idleTimeoutMs, Protocol protocol, @Nullable SSLSession sslSession,
             @Nullable ChannelConfig parentChannelConfig, StreamObserver streamObserver, boolean isClient,
             UnaryOperator<Throwable> enrichProtocolError) {
         return initChildChannel(channel, executionContext, closeHandler, flushStrategy, idleTimeoutMs, protocol,
@@ -276,7 +275,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     public static <Read, Write> DefaultNettyConnection<Read, Write> initChildChannel(
             Channel channel, ExecutionContext<?> executionContext,
             CloseHandler closeHandler, FlushStrategy flushStrategy,
-            @Nullable Long idleTimeoutMs, Protocol protocol, @Nullable SSLSession sslSession,
+            Long idleTimeoutMs, Protocol protocol, @Nullable SSLSession sslSession,
             @Nullable ChannelConfig parentChannelConfig, StreamObserver streamObserver, boolean isClient,
             Predicate<Object> shouldWait, UnaryOperator<Throwable> enrichProtocolError) {
         return initChildChannel(channel, executionContext, closeHandler, flushStrategy, idleTimeoutMs, protocol, null,
@@ -307,7 +306,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     public static <Read, Write> DefaultNettyConnection<Read, Write> initChildChannel(
             Channel channel, ExecutionContext<?> executionContext,
             CloseHandler closeHandler, FlushStrategy flushStrategy,
-            @Nullable Long idleTimeoutMs, Protocol protocol,
+            Long idleTimeoutMs, Protocol protocol,
             @Nullable SslConfig sslConfig, @Nullable SSLSession sslSession,
             @Nullable ChannelConfig parentChannelConfig, StreamObserver streamObserver, boolean isClient,
             Predicate<Object> shouldWait, UnaryOperator<Throwable> enrichProtocolError) {
@@ -349,7 +348,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     @Deprecated // FIXME: 0.43 - remove deprecated method
     public static <Read, Write> Single<DefaultNettyConnection<Read, Write>> initChannel(
             Channel channel, BufferAllocator allocator, Executor executor, @Nullable IoExecutor ioExecutor,
-            CloseHandler closeHandler, FlushStrategy flushStrategy, @Nullable Long idleTimeoutMs,
+            CloseHandler closeHandler, FlushStrategy flushStrategy, Long idleTimeoutMs,
             ChannelInitializer initializer, ExecutionStrategy executionStrategy, Protocol protocol,
             ConnectionObserver observer, boolean isClient) {
         return initChannel(channel, allocator, executor, ioExecutor, closeHandler, flushStrategy, idleTimeoutMs,
@@ -383,7 +382,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     @Deprecated // FIXME: 0.43 - remove deprecated method
     public static <Read, Write> Single<DefaultNettyConnection<Read, Write>> initChannel(
             Channel channel, BufferAllocator allocator, Executor executor, @Nullable IoExecutor ioExecutor,
-            CloseHandler closeHandler, FlushStrategy flushStrategy, @Nullable Long idleTimeoutMs,
+            CloseHandler closeHandler, FlushStrategy flushStrategy, Long idleTimeoutMs,
             ChannelInitializer initializer, ExecutionStrategy executionStrategy, Protocol protocol,
             ConnectionObserver observer, boolean isClient, Predicate<Object> shouldWait) {
         return initChannel(channel, allocator, executor, ioExecutor, closeHandler, flushStrategy, idleTimeoutMs, null,
@@ -415,7 +414,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
      */
     public static <Read, Write> Single<DefaultNettyConnection<Read, Write>> initChannel(
             Channel channel, BufferAllocator allocator, Executor executor, @Nullable IoExecutor ioExecutor,
-            CloseHandler closeHandler, FlushStrategy flushStrategy, @Nullable Long idleTimeoutMs,
+            CloseHandler closeHandler, FlushStrategy flushStrategy, Long idleTimeoutMs,
             @Nullable SslConfig sslConfig,
             ChannelInitializer initializer, ExecutionStrategy executionStrategy, Protocol protocol,
             ConnectionObserver observer, boolean isClient, Predicate<Object> shouldWait) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -114,7 +114,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     private final CompletableSource.Processor onClosing;
     private final SingleSource.Processor<Throwable, Throwable> transportError = newSingleProcessor();
     private final FlushStrategyHolder flushStrategyHolder;
-    private final Long idleTimeoutMs;
+    private final long idleTimeoutMs;
     private final Protocol protocol;
     @Nullable
     private final SslConfig sslConfig;
@@ -169,7 +169,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     private DefaultNettyConnection(
             Channel channel, ExecutionContext<?> executionContext,
             CloseHandler closeHandler, FlushStrategy flushStrategy,
-            Long idleTimeoutMs, Protocol protocol,
+            long idleTimeoutMs, Protocol protocol,
             @Nullable SslConfig sslConfig, @Nullable SSLSession sslSession,
             @Nullable ChannelConfig parentChannelConfig, DataObserver dataObserver, boolean isClient,
             Predicate<Object> shouldWait, UnaryOperator<Throwable> enrichProtocolError) {
@@ -235,7 +235,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
      * @param <Write> Type of objects written to the {@link NettyConnection}.
      * @return A {@link Single} that completes with a {@link DefaultNettyConnection} after the channel is activated and
      * ready to use.
-     * @deprecated Use {@code #initChildChannel(Channel, ExecutionContext, CloseHandler, FlushStrategy, Long, Protocol,
+     * @deprecated Use {@code #initChildChannel(Channel, ExecutionContext, CloseHandler, FlushStrategy, long, Protocol,
      * SslConfig, SSLSession, ChannelConfig, StreamObserver, boolean, Predicate, UnaryOperator)}.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
@@ -268,7 +268,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
      * @param <Write> Type of objects written to the {@link NettyConnection}.
      * @return A {@link Single} that completes with a {@link DefaultNettyConnection} after the channel is activated and
      * ready to use.
-     * @deprecated Use {@code #initChildChannel(Channel, ExecutionContext, CloseHandler, FlushStrategy, Long, Protocol,
+     * @deprecated Use {@code #initChildChannel(Channel, ExecutionContext, CloseHandler, FlushStrategy, long, Protocol,
      * SslConfig, SSLSession, ChannelConfig, StreamObserver, boolean, Predicate, UnaryOperator)}.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
@@ -306,7 +306,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     public static <Read, Write> DefaultNettyConnection<Read, Write> initChildChannel(
             Channel channel, ExecutionContext<?> executionContext,
             CloseHandler closeHandler, FlushStrategy flushStrategy,
-            Long idleTimeoutMs, Protocol protocol,
+            long idleTimeoutMs, Protocol protocol,
             @Nullable SslConfig sslConfig, @Nullable SSLSession sslSession,
             @Nullable ChannelConfig parentChannelConfig, StreamObserver streamObserver, boolean isClient,
             Predicate<Object> shouldWait, UnaryOperator<Throwable> enrichProtocolError) {
@@ -343,7 +343,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
      * @return A {@link Single} that completes with a {@link DefaultNettyConnection} after the channel is activated and
      * ready to use.
      * @deprecated Use {@code #initChannel(Channel, BufferAllocator, Executor, IoExecutor, CloseHandler, FlushStrategy,
-     * Long, SslConfig, ChannelInitializer, ExecutionStrategy, Protocol, ConnectionObserver, boolean, Predicate)}.
+     * long, SslConfig, ChannelInitializer, ExecutionStrategy, Protocol, ConnectionObserver, boolean, Predicate)}.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     public static <Read, Write> Single<DefaultNettyConnection<Read, Write>> initChannel(
@@ -377,7 +377,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
      * @return A {@link Single} that completes with a {@link DefaultNettyConnection} after the channel is activated and
      * ready to use.
      * @deprecated Use {@code #initChannel(Channel, BufferAllocator, Executor, IoExecutor, CloseHandler, FlushStrategy,
-     * Long, SslConfig, ChannelInitializer, ExecutionStrategy, Protocol, ConnectionObserver, boolean, Predicate)}.
+     * long, SslConfig, ChannelInitializer, ExecutionStrategy, Protocol, ConnectionObserver, boolean, Predicate)}.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     public static <Read, Write> Single<DefaultNettyConnection<Read, Write>> initChannel(
@@ -414,7 +414,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
      */
     public static <Read, Write> Single<DefaultNettyConnection<Read, Write>> initChannel(
             Channel channel, BufferAllocator allocator, Executor executor, @Nullable IoExecutor ioExecutor,
-            CloseHandler closeHandler, FlushStrategy flushStrategy, Long idleTimeoutMs,
+            CloseHandler closeHandler, FlushStrategy flushStrategy, long idleTimeoutMs,
             @Nullable SslConfig sslConfig,
             ChannelInitializer initializer, ExecutionStrategy executionStrategy, Protocol protocol,
             ConnectionObserver observer, boolean isClient, Predicate<Object> shouldWait) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IdleTimeoutInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IdleTimeoutInitializer.java
@@ -52,6 +52,9 @@ public class IdleTimeoutInitializer implements ChannelInitializer {
      * @param idleTimeoutMillis timeout in milliseconds.
      */
     public IdleTimeoutInitializer(long idleTimeoutMillis) {
+        if (idleTimeoutMillis <= 0L) {
+            throw new IllegalArgumentException("idleTimeoutMillis: " + idleTimeoutMillis + " (expected >0)");
+        }
         timeoutMs = idleTimeoutMillis;
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SocketOptionUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SocketOptionUtils.java
@@ -96,12 +96,13 @@ public final class SocketOptionUtils {
     @Nullable
     @SuppressWarnings("unchecked")
     public static <T> T getOption(final SocketOption<T> option, final ChannelConfig config,
-                                  @Nullable final Long idleTimeoutMs) {
+                                  final Long idleTimeoutMs) {
         @SuppressWarnings("unchecked")
         OptConverter<T> converter = (OptConverter<T>) SOCKET_OPT_MAP.get(option);
         if (converter != null) {
             return (T) converter.toSocketValue.apply(config.getOption(converter.option));
-        } else if (option == ServiceTalkSocketOptions.IDLE_TIMEOUT) {
+        }
+        if (option == ServiceTalkSocketOptions.IDLE_TIMEOUT) {
             return (T) idleTimeoutMs;
         }
         throw unsupported(option);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/AbstractSslCloseNotifyAlertHandlingTest.java
@@ -53,7 +53,7 @@ abstract class AbstractSslCloseNotifyAlertHandlingTest {
         channel = new EmbeddedDuplexChannel(false);
         final CloseHandler closeHandler = forPipelinedRequestResponse(isClient, channel.config());
         conn = DefaultNettyConnection.<String, String>initChannel(channel, DEFAULT_ALLOCATOR, immediate(),
-                        null, closeHandler, defaultFlushStrategy(), null, null,
+                        null, closeHandler, defaultFlushStrategy(), 0L, null,
                 WIRE_LOGGING_INITIALIZER.andThen(ch -> ch.pipeline().addLast(new ChannelDuplexHandler() {
                     @Override
                     public void channelRead(final ChannelHandlerContext ctx, final Object msg) {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/DefaultNettyConnectionTest.java
@@ -113,7 +113,7 @@ class DefaultNettyConnectionTest {
         when(demandEstimator.estimateRequestN(anyLong())).then(invocation1 -> (long) requestNext);
         CloseHandler closeHandler = closeHandlerFactory.apply(channel);
         conn = DefaultNettyConnection.<Buffer, Buffer>initChannel(channel, allocator, executor,
-                null, closeHandler, defaultFlushStrategy(), null, null,
+                null, closeHandler, defaultFlushStrategy(), 0L, null,
                 trailerProtocolEndEventEmitter(closeHandler),
                 offloadAll(), mock(Protocol.class), NoopConnectionObserver.INSTANCE, true, __ -> false)
                 .toFuture().get();

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherRefCountTest.java
@@ -50,7 +50,7 @@ class NettyChannelPublisherRefCountTest {
         channel = new EmbeddedDuplexChannel(false);
         publisher = DefaultNettyConnection.initChannel(channel,
                         DEFAULT_ALLOCATOR, immediate(), null, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER,
-                        defaultFlushStrategy(), null, null, channel2 -> { }, offloadAll(), mock(Protocol.class),
+                        defaultFlushStrategy(), 0L, null, channel2 -> { }, offloadAll(), mock(Protocol.class),
                         NoopConnectionObserver.INSTANCE, true, __ -> false).toFuture().get()
                 .read();
     }

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyChannelPublisherTest.java
@@ -92,7 +92,7 @@ class NettyChannelPublisherTest {
         CloseHandler closeHandler = UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
         NettyConnection<Integer, Object> connection =
                 DefaultNettyConnection.<Integer, Object>initChannel(channel, DEFAULT_ALLOCATOR,
-                immediate(), null, closeHandler, defaultFlushStrategy(), null, null, channel ->
+                immediate(), null, closeHandler, defaultFlushStrategy(), 0L, null, channel ->
                                 channel.pipeline().addLast(new ChannelOutboundHandlerAdapter() {
                 @Override
                 public void read(ChannelHandlerContext ctx) throws Exception {
@@ -126,7 +126,7 @@ class NettyChannelPublisherTest {
         }
         channel = new EmbeddedDuplexChannel(false);
         NettyConnection<Integer, Object> connection = DefaultNettyConnection.<Integer, Object>initChannel(channel,
-                DEFAULT_ALLOCATOR, immediate(), null, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), null,
+                DEFAULT_ALLOCATOR, immediate(), null, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, defaultFlushStrategy(), 0L,
                 null, channel -> {
                     channel.pipeline().addLast(new ChannelDuplexHandler() {
                         @Override


### PR DESCRIPTION
Motivation:

It's a good practice to close excess connections if they become idle.

Modifications:

- Set default `IDLE_TIMEOUT` to 5 min;
- Clarify in javadoc that 0 value disabled idle timeout;
- Remove `@Nullable` annotation for `idleTimeoutMs` in internal classes;

Result:

Users always have `ServiceTalkSocketOptions#IDLE_TIMEOUT` set by
default.

Improves default behavior in conjunctions with #2173.