### PR TITLE
Call japicmp.sh from release.sh

### DIFF
--- a/docs/generation/.gitignore
+++ b/docs/generation/.gitignore
@@ -9,3 +9,4 @@
 /*.iws
 .DS_Store
 package-lock.json
+package.json

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,16 +21,26 @@ cd ..
 set -eu
 
 function usage() {
-  echo "Usage: $0 next_version"
+  echo "Usage: $0 old_version next_version [branch_name]"
+  echo "old_version - the previous version to run japicmp against. 'skip' to skip japicmp"
   echo "next_version - the next version to update gradle.properties, expected -SNAPSHOT suffix"
+  echo "branch_name - the branch name to release from (default is 'main')"
+  echo "Example to release 0.42.10: $0 0.42.9 0.42.11-SNAPSHOT"
 }
 
-if [ "$#" -ne "1" ]; then
+if [ "$#" -ne "2" ]; then
     usage
     exit 1
 fi
 
-nextVersion="$1"
+oldVersion="$1"
+nextVersion="$2"
+
+if [ "$#" -gt "2" ]; then
+  branchName="$3"
+else
+  branchName="main"
+fi
 
 if ( echo "$nextVersion" | grep -qv "SNAPSHOT" ); then
     echo "Expected next version to be a SNAPSHOT version"
@@ -54,6 +64,23 @@ if ( echo "$version" | grep -q "SNAPSHOT" ); then
     exit 1
 fi
 
+if [ -z "${DRYRUN:-}" ]; then
+    gradle_build_args="--no-build-cache --warning-mode all --refresh-dependencies clean build publishToMavenLocal"
+else
+    gradle_build_args="build publishToMavenLocal"
+    echo "DRYRUN mode is enabled, using cached build."
+fi
+
+echo "Building local artifacts..."
+./gradlew ${gradle_build_args}
+
+if [[ "$oldVersion" == "skip" ]]; then
+  echo "Skipping japicmp"
+else
+  echo "Running japicmp of local artifacts (which will be released as $version) against old version $oldVersion..."
+  ./scripts/japicmp.sh $oldVersion
+fi
+
 echo "Releasing version $version"
 version_majorminor="${version%.*}"
 
@@ -70,10 +97,10 @@ else
 fi
 
 $git fetch -p
-if $git rev-parse --quiet --verify main > /dev/null; then
-    $git checkout main
+if $git rev-parse --quiet --verify ${branchName} > /dev/null; then
+    $git checkout ${branchName}
 else
-    $git checkout --track ${remote_name}/main
+    $git checkout --track ${remote_name}/${branchName}
 fi
 $git pull
 $git log -n1
@@ -103,7 +130,6 @@ fi
 
 $git commit -a -m "Release $version"
 $git tag "$version" -m "Release $version"
-$git push ${remote_name} "$version"
 
 echo "Preparing repository for next development version $nextVersion"
 
@@ -128,6 +154,8 @@ for file in docs/modules/ROOT/nav.adoc */docs/modules/ROOT/nav.adoc; do
 done
 
 $git commit -a -m "Preparing for $nextVersion development"
-$git push ${remote_name} main
+$git push -u ${remote_name} "$branchName"
+# Push tag after branch otherwise, CodeQL GH Action will fail.
+$git push ${remote_name} "$version"
 
 ./scripts/publish-docs.sh "$version_majorminor"


### PR DESCRIPTION
Motivation:
japicmp.sh is a standalone script that must be
manually run which is easy to forget.

Modifications:
- add branch name support to release.sh
- build locally
- call japicmp.sh by default