### PR TITLE
Resolve javadocAll errors

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
@@ -42,8 +42,8 @@ import static java.util.Objects.requireNonNull;
  * invoked for every {@link #subscribe(Subscriber)} invocation, and the result is used as the delegate for subsequent
  * {@link #onSubscribe(Cancellable)}, {@link #onComplete()}, and
  * {@link #onError(Throwable)} calls. See {@link Builder} for more information.
- *
- * <h3>Defaults</h3>
+ * <p>
+ * Defaults:
  * <ul>
  * <li>Allows sequential but not concurrent subscribers.</li>
  * <li>Sends {@link #onSubscribe(Cancellable)} automatically when subscribed to.</li>

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
@@ -41,7 +41,8 @@ import static java.util.Objects.requireNonNull;
  * invoked for every {@link #subscribe(Subscriber)} invocation, and the result is used as the delegate for subsequent
  * {@link #onSubscribe(Subscription)}, {@link #onNext(Object[])}, {@link #onComplete()}, and
  * {@link #onError(Throwable)} calls. See {@link Builder} for more information.
- * <h3>Defaults</h3>
+ * <p>
+ * Defaults:
  * <ul>
  *     <li>Allows sequential but not concurrent subscribers.</li>
  *     <li>Asserts that {@link #onNext(Object[])} is not called without sufficient demand.</li>

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
@@ -41,8 +41,8 @@ import static java.util.Objects.requireNonNull;
  * invoked for every {@link #subscribe(Subscriber)} invocation, and the result is used as the delegate for subsequent
  * {@link #onSubscribe(Cancellable)}, {@link #onSuccess(Object)}, and
  * {@link #onError(Throwable)} calls. See {@link Builder} for more information.
- *
- * <h3>Defaults</h3>
+ * <p>
+ * Defaults:
  * <ul>
  *     <li>Allows sequential but not concurrent subscribers.</li>
  *     <li>Sends {@link #onSubscribe(Cancellable)} automatically when subscribed to.</li>

--- a/servicetalk-grpc-health/build.gradle
+++ b/servicetalk-grpc-health/build.gradle
@@ -82,10 +82,6 @@ sourceSets {
   }
 }
 
-javadoc {
-  exclude "**/${generatedJavaPkg.replace('.', '/')}/**"
-}
-
 protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:$protobufVersion"

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/GenerationContext.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/GenerationContext.java
@@ -17,13 +17,11 @@ package io.servicetalk.grpc.protoc;
 
 import com.google.protobuf.DescriptorProtos.MethodDescriptorProto;
 import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
-import com.squareup.javapoet.TypeSpec;
 
 interface GenerationContext {
     /**
-     * Return a canonical and unique type name based upon the provided type name.
-     * The returned name will not conflict with any other identically named types
-     * in the same context.
+     * Return a canonical and unique type name based upon the provided type name. The returned name will not conflict
+     * with any other identically named types in the same context.
      *
      * @param name The Java type name to deconflict
      * @return The deconflicted, possibly unchanged, Java type name.
@@ -31,14 +29,32 @@ interface GenerationContext {
     String deconflictJavaTypeName(String name);
 
     /**
-     * Create and return the builder for a service class described by the provided
-     * descriptor. The builder will be registered for the destination file and the
-     * generator responsible for filling in the builder will
+     * Return a qualified, canonical, and unique type name based upon the provided type name. The returned name will not
+     * conflict with any other identically named types in the same context.
+     *
+     * @param outerClassName The outer class name that contains this type. This will be used to generate a
+     * more fully qualified return value.
+     * @param name The Java type name to deconflict
+     * @return Deconflicted, possibly unchanged, Java type name that is qualified with the outer java
+     * package+typename+{@code outerClassName} scope.
+     */
+    String deconflictJavaTypeName(String outerClassName, String name);
+
+    /**
+     * Create and return the builder for a service class described by the provided descriptor. The builder will be
+     * registered for the destination file and the generator responsible for filling in the builder will
      *
      * @param serviceProto The service descriptor being created.
      * @return a new builder for the service class
      */
-    TypeSpec.Builder newServiceClassBuilder(ServiceDescriptorProto serviceProto);
+    ServiceClassBuilder newServiceClassBuilder(ServiceDescriptorProto serviceProto);
 
+    /**
+     * Get the <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md">gRPC H2 path</a> for a method.
+     * @param serviceProto protobuf descriptor for the service.
+     * @param methodProto protobuf descriptor for the method.
+     * @return the <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md">gRPC H2 path</a> for a
+     * method.
+     */
     String methodPath(ServiceDescriptorProto serviceProto, MethodDescriptorProto methodProto);
 }

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/ServiceClassBuilder.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/ServiceClassBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.protoc;
+
+import com.squareup.javapoet.TypeSpec;
+
+final class ServiceClassBuilder {
+    final TypeSpec.Builder builder;
+    final String className;
+
+    ServiceClassBuilder(final TypeSpec.Builder builder, final String className) {
+        this.builder = builder;
+        this.className = className;
+    }
+}

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
@@ -51,6 +51,7 @@ final class Words {
     static final String methodDescriptor = "methodDescriptor";
     static final String methodDescriptors = methodDescriptor + "s";
     static final String Service = "Service";
+    static final String Client = "Client";
     static final String Blocking = "Blocking";
     static final String Builder = "Builder";
     static final String Call = "Call";


### PR DESCRIPTION
Motivation:
The release.sh script runs `javadocAll` task on JDK17 which
found a few errors.

Motivation:
- JDK8 javadoc generation has an erroneous
  `warning - @link can't find` from generated code.
  Workaround the issue by using canonical type name in the link.
- Remove `h3` usage in Test sources
- Remove exclude of generated code that is linked in javadocs
  from non-generated code.