### PR TITLE
fix: servicetalk-data-jackson dependency scopes

### DIFF
--- a/servicetalk-data-jackson-jersey/build.gradle
+++ b/servicetalk-data-jackson-jersey/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   testImplementation enforcedPlatform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
+  api project(":servicetalk-data-jackson")
   api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion" // MediaType, Feature
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
@@ -28,7 +29,6 @@ dependencies {
   implementation project(":servicetalk-buffer-netty")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
-  implementation project(":servicetalk-data-jackson")
   implementation project(":servicetalk-http-api")
   implementation project(":servicetalk-http-router-jersey")
   implementation project(":servicetalk-http-router-jersey-internal")

--- a/servicetalk-data-jackson/build.gradle
+++ b/servicetalk-data-jackson/build.gradle
@@ -19,16 +19,14 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
+  api project(":servicetalk-serialization-api")
+  api project(":servicetalk-serializer-api")
   api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-  api project(":servicetalk-buffer-api")
-  api project(":servicetalk-concurrent-api")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation project(":servicetalk-serialization-api")
-  implementation project(":servicetalk-serializer-api")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))


### PR DESCRIPTION
Motivation:

The `servicetalk-data-jackson-jersey` module exposes types that are
located in the `servicetalk-data-jackson` module. Similarly, the
`servicetalk-data-jackson` module exposes types that are in the
`servicetalk-serializer-api` and `servicetalk-serialization-api` modules.
Dependencies that contain types exposed in a module's API should be imported using `api` scope but currently these dependencies are imported using only `implementation` scope. Attempting to use the types results in a `ClassNotFoundException`.

Modifications:

- Change `servicetalk-data-jackson` to an `api` dependency of `servicetalk-data-jackson-jersey`
- Change `servicetalk-serializer-api` and `servicetalk-serialization-api` to `api` dependencies of `servicetalk-data-jackson`

Result:

Consumers of the `servicetalk-data-jackson-jersey` and `servicetalk-data-jackson` modules will be able to reference all types exposed in these modules' APIs without class not found errors or the need to explicitly import `servicetalk-data-jackson`, `servicetalk-serializer-api` or `servicetalk-serialization-api` modules.