### PR TITLE
Clarify AsyncContext concurrency docs

### DIFF
--- a/servicetalk-concurrent-api/docs/modules/ROOT/pages/async-context.adoc
+++ b/servicetalk-concurrent-api/docs/modules/ROOT/pages/async-context.adoc
@@ -145,18 +145,31 @@ examples below:
 [source, java]
 ----
 Publisher<String> publisher = ...;
+AsyncContext.put(KEY, 10); // (1) put a value into AsyncContext before a .subscribe(..)
 publisher
-.flatMapSingle(v -> {
-  // (1) AsyncContext will be saved before the async boundary
+.flatMapMergeSingle(v -> {
+  Integer contextValue = AsyncContext.get(KEY);
+  assert contextValue == 10 || contextValue == 30; // (2) Subscriber chain may see either value.
 
   // AsyncContext will be copied/isolated when this async source is subscribed to
-  client.request(/*do something with v*/)
-)
+  return client.request(/*do something with v*/)
+               .map(x -> {
+                    AsyncContext.put(KEY, 20); // (3) put a new value for the same key
+                    return x;
+                });
+})
 .map(v -> {
-  // AsyncContext before the async boundary (1) is restored
+  Integer contextValue = AsyncContext.get(KEY);
+  assert contextValue == 10 || contextValue == 30;
 
-  // Note that modifications made to AsyncContext here may introduce concurrency
-  // and be visible before the async boundary above (1).
+  // `publisher` may emit more items, and if it does then `flatMapMergeSingle` `Function` may be invoked concurrently
+  // with this code. This is because `client.request(..)`` may complete on a different thread than `publisher` is
+  // delivering data on. This code has access to the same map as (2) which may result in concurrent modifications on
+  // `AsyncContext`. This is allowed by `AsyncContext` but may not be obvious due to modifications made "later" in the
+  // operator chain being visible "earlier" in the operator chain.
+  AsyncContext.put(KEY, 30);
+
+  return v;
 })
 ----
 
@@ -167,11 +180,11 @@ visible outside the asynchronous boundary.
 ----
 Executor executor = ...
 
-AsyncContext.put(key, "foo")
+AsyncContext.put(KEY, "foo");
 executor.execute(() -> {
-  AsyncContext.put(key, "bar")
+  AsyncContext.put(KEY, "bar");
 });
-String value = AsyncContext.get(key);
+String value = AsyncContext.get(KEY);
 // value maybe "foo" or "bar" due to concurrent modifications
 ----
 

--- a/servicetalk-concurrent-api/docs/modules/ROOT/pages/async-context.adoc
+++ b/servicetalk-concurrent-api/docs/modules/ROOT/pages/async-context.adoc
@@ -146,19 +146,18 @@ examples below:
 ----
 Publisher<String> publisher = ...;
 AsyncContext.put(KEY, 10); // (1) put a value into AsyncContext before a .subscribe(..)
-publisher
-.flatMapMergeSingle(v -> {
+publisher.flatMapMergeSingle(v -> {
   Integer contextValue = AsyncContext.get(KEY);
   assert contextValue == 10 || contextValue == 30; // (2) Subscriber chain may see either value.
 
-  // AsyncContext will be copied/isolated when this async source is subscribed to
+  // AsyncContext will be copied/isolated when this async source is subscribed to. Changes to the AsyncContext map from
+  // async operators on inner operator chain will therefore not be visible in the outer operator chain.
   return client.request(/*do something with v*/)
                .map(x -> {
                     AsyncContext.put(KEY, 20); // (3) put a new value for the same key
                     return x;
                 });
-})
-.map(v -> {
+}).map(v -> {
   Integer contextValue = AsyncContext.get(KEY);
   assert contextValue == 10 || contextValue == 30;
 

--- a/servicetalk-concurrent-api/docs/modules/ROOT/pages/async-context.adoc
+++ b/servicetalk-concurrent-api/docs/modules/ROOT/pages/async-context.adoc
@@ -150,8 +150,8 @@ publisher.flatMapMergeSingle(v -> {
   Integer contextValue = AsyncContext.get(KEY);
   assert contextValue == 10 || contextValue == 30; // (2) Subscriber chain may see either value.
 
-  // AsyncContext will be copied/isolated when this async source is subscribed to. Changes to the AsyncContext map from
-  // async operators on inner operator chain will therefore not be visible in the outer operator chain.
+  // AsyncContext will be copied when Single.subscribe(..) is called. Changes to the AsyncContext map from operators on
+  // the inner Single operator chain will therefore not be visible in the outer Publisher operator chain.
   return client.request(/*do something with v*/)
                .map(x -> {
                     AsyncContext.put(KEY, 20); // (3) put a new value for the same key
@@ -162,7 +162,7 @@ publisher.flatMapMergeSingle(v -> {
   assert contextValue == 10 || contextValue == 30;
 
   // `publisher` may emit more items, and if it does then `flatMapMergeSingle` `Function` may be invoked concurrently
-  // with this code. This is because `client.request(..)`` may complete on a different thread than `publisher` is
+  // with this code. This is because `client.request(..)` may complete on a different thread than `publisher` is
   // delivering data on. This code has access to the same map as (2) which may result in concurrent modifications on
   // `AsyncContext`. This is allowed by `AsyncContext` but may not be obvious due to modifications made "later" in the
   // operator chain being visible "earlier" in the operator chain.


### PR DESCRIPTION
Modifications:
async-context.adoc provides some examples to describe
control flow and potential concurrent modification scenarios.
The example with the operator flow doesn't provide enough
explanation to understand the expected control flow.

Modifications:
- Add more comments to the example and code which
  shows expected values on key modified "later" in the
  operator chain.