### PR TITLE
Exclude internal modules from Maven BOM

### DIFF
--- a/servicetalk-bom/build.gradle
+++ b/servicetalk-bom/build.gradle
@@ -17,9 +17,12 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-core"
 apply plugin: "java-platform"
 
-rootProject.subprojects.findAll { !it.name.contains("bom") && !it.name.contains("examples") &&
-                                          !it.name.equals("grpc") && !it.name.equals("http") }.each {
-  dependencies.constraints.add("api", it)
+rootProject.subprojects.findAll {
+  !it.name.endsWith("-bom") && !it.name.contains("-examples") &&
+          !it.name.equals("grpc") && !it.name.equals("http") &&
+          !it.name.endsWith("-internal")
+}.each {
+  dependencies.constraints.add(JavaPlugin.API_CONFIGURATION_NAME, it)
 }
 
 // Keep publishing and signing configuration in sync with ServiceTalkLibraryPlugin.groovy from

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
@@ -40,7 +40,7 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
   private static void addJavadocAllTask(Project project) {
     project.configure(project) {
       project.task("javadocAll", type: Javadoc) {
-        description = "Consolidate sub-project's Javadoc into a single location"
+        description = "Generate consolidated public API Javadoc"
         group = "documentation"
         destinationDir = file("$buildDir/javadoc")
         // Disable module directories to avoid "undefined" sub-folder bug in JDK11. See:
@@ -51,7 +51,7 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
         }
 
         gradle.projectsEvaluated {
-          subprojects.findAll {!it.name.contains("examples")}.each { prj ->
+          subprojects.findAll {!it.name.contains("examples") && !it.name.endsWith("-internal")}.each { prj ->
             prj.tasks.withType(Javadoc).each { javadocTask ->
               source += javadocTask.source
               classpath += javadocTask.classpath


### PR DESCRIPTION
Motivation:
The ServiceTalk Maven BOM currently includes all modules including
internal modules. The suggested practice for libraries is to include
only modules which are part of the public API.
Modifications:
Filter internal modules from inclusion in BOM
Result:
Published BOM contains only public API modules. Internal modules are
referenced explicitly by modules which depend upon them.