### PR TITLE
Generate JavaDoc only for API JavaDoc tasks

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
@@ -52,7 +52,7 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
 
         gradle.projectsEvaluated {
           subprojects.findAll {!it.name.contains("examples")}.each { prj ->
-            prj.tasks.withType(Javadoc).each { javadocTask ->
+            prj.tasks.withType(Javadoc).findAll {it.name.equals("javadoc")}.each { javadocTask ->
               source += javadocTask.source
               classpath += javadocTask.classpath
               excludes += javadocTask.excludes


### PR DESCRIPTION
Motivation:
Some modules generate JavaDoc to check that source code they generate
includes conforming JavaDoc. This test JavaDoc should not be included
in the consolidated project JavaDocs.
Modifications:
Filter JavaDoc tasks using task name to include only the default
JavaDoc task.
Result:
Mysterious test code JavaDoc excluded from project JavaDocs.