### PR TITLE
Tighter dependency for protoc plugin

### DIFF
--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -30,7 +30,6 @@ dependencies {
   api project(":servicetalk-data-protobuf")
 
   compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
-  compileOnly "com.google.protobuf:protobuf-java:$protobufVersion"
   compileOnly "com.squareup:javapoet:$javaPoetVersion"
 
   testImplementation project(":servicetalk-grpc-api")

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
   implementation project(":servicetalk-annotations")
 
-  // runtimeOnly is enough for this module in isolation, but we want transitive modules to include at compile time too.
+  // Needed for the generated classes
   api project(":servicetalk-data-protobuf")
 
   compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
@@ -35,8 +35,6 @@ dependencies {
 
   testImplementation project(":servicetalk-grpc-api")
   testImplementation project(":servicetalk-grpc-protobuf")
-  testImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  testImplementation "com.google.protobuf:protobuf-java:$protobufVersion"
   testImplementation "com.squareup:javapoet:$javaPoetVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -29,12 +29,15 @@ dependencies {
   // runtimeOnly is enough for this module in isolation, but we want transitive modules to include at compile time too.
   api project(":servicetalk-data-protobuf")
 
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "com.google.protobuf:protobuf-java:$protobufVersion"
-  implementation "com.squareup:javapoet:$javaPoetVersion"
+  compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
+  compileOnly "com.google.protobuf:protobuf-java:$protobufVersion"
+  compileOnly "com.squareup:javapoet:$javaPoetVersion"
 
   testImplementation project(":servicetalk-grpc-api")
   testImplementation project(":servicetalk-grpc-protobuf")
+  testImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  testImplementation "com.google.protobuf:protobuf-java:$protobufVersion"
+  testImplementation "com.squareup:javapoet:$javaPoetVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }
@@ -48,6 +51,8 @@ jar {
 }
 
 shadowJar {
+  // includes javaPoet and Google protobufs
+  configurations = [project.configurations.compileClasspath]
   archiveBaseName = project.name
   classifier = 'all'
 }


### PR DESCRIPTION
Motivation:
Currently the `servicetalk-grpc-protoc` module exposes javapoet and
protobuf-java as dependencies though they are used only in the protoc
plugin and are not accurately dependencies of the module.

Modifications:
Use `compileOnly` for protoc plugin dependencies and change shadowJar
to build using `compileClasspath` configuration. The dependencies are
also needed for `testImplementation`.

Result:
Fewer exposed dependencies, especially dependency which is not
actually used by module outside of protoc plugin.