### PR TITLE
Avoid self-suppression for exceptions

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPubToSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPubToSingle.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUnchecked;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 
 abstract class AbstractPubToSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
     private final Publisher<T> source;
@@ -110,7 +111,7 @@ abstract class AbstractPubToSingle<T> extends AbstractNoHandleSubscribeSingle<T>
                     subscriber.onSubscribe(IGNORE_CANCEL);
                 } catch (Throwable t) {
                     if (terminal instanceof Throwable) {
-                        ((Throwable) terminal).addSuppressed(t);
+                        addSuppressed((Throwable) terminal, t);
                     } else {
                         LOGGER.warn("Unexpected exception from onSubscribe from subscriber {}. Discarding result {}.",
                                 subscriber, terminal, t);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallyCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallyCompletable.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class BeforeFinallyCompletable extends AbstractSynchronousCompletableOperator {
@@ -78,8 +79,7 @@ final class BeforeFinallyCompletable extends AbstractSynchronousCompletableOpera
                     doFinally.onError(cause);
                 }
             } catch (Throwable error) {
-                error.addSuppressed(cause);
-                original.onError(error);
+                original.onError(addSuppressed(error, cause));
                 return;
             }
             original.onError(cause);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallyPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallyPublisher.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class BeforeFinallyPublisher<T> extends AbstractSynchronousPublisherOperator<T, T> {
@@ -93,8 +94,7 @@ final class BeforeFinallyPublisher<T> extends AbstractSynchronousPublisherOperat
                     doFinally.onError(cause);
                 }
             } catch (Throwable err) {
-                err.addSuppressed(cause);
-                original.onError(err);
+                original.onError(addSuppressed(err, cause));
                 return;
             }
             original.onError(cause);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallySingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeFinallySingle.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class BeforeFinallySingle<T> extends AbstractSynchronousSingleOperator<T, T> {
@@ -79,8 +80,7 @@ final class BeforeFinallySingle<T> extends AbstractSynchronousSingleOperator<T, 
                     doFinally.onError(cause);
                 }
             } catch (Throwable err) {
-                err.addSuppressed(cause);
-                original.onError(err);
+                original.onError(addSuppressed(err, cause));
                 return;
             }
             original.onError(cause);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeSubscriberCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeSubscriberCompletable.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 
 import java.util.function.Supplier;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class BeforeSubscriberCompletable extends AbstractSynchronousCompletableOperator {
@@ -67,8 +68,7 @@ final class BeforeSubscriberCompletable extends AbstractSynchronousCompletableOp
             try {
                 subscriber.onError(t);
             } catch (Throwable cause) {
-                t.addSuppressed(cause);
-                original.onError(t);
+                original.onError(addSuppressed(t, cause));
                 return;
             }
             original.onError(t);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeSubscriberPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeSubscriberPublisher.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import java.util.function.Supplier;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class BeforeSubscriberPublisher<T> extends AbstractSynchronousPublisherOperator<T, T> {
@@ -70,8 +71,7 @@ final class BeforeSubscriberPublisher<T> extends AbstractSynchronousPublisherOpe
             try {
                 subscriber.onError(t);
             } catch (Throwable cause) {
-                t.addSuppressed(cause);
-                original.onError(t);
+                original.onError(addSuppressed(t, cause));
                 return;
             }
             original.onError(t);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeSubscriberSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BeforeSubscriberSingle.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 
 import java.util.function.Supplier;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class BeforeSubscriberSingle<T> extends AbstractSynchronousSingleOperator<T, T> {
@@ -66,8 +67,7 @@ final class BeforeSubscriberSingle<T> extends AbstractSynchronousSingleOperator<
             try {
                 subscriber.onError(t);
             } catch (Throwable cause) {
-                t.addSuppressed(cause);
-                original.onError(t);
+                original.onError(addSuppressed(t, cause));
                 return;
             }
             original.onError(t);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableMergeSubscriber.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 abstract class CompletableMergeSubscriber implements Subscriber {
@@ -68,9 +69,7 @@ abstract class CompletableMergeSubscriber implements Subscriber {
                     return;
                 }
             } else {
-                Throwable tmpT = (Throwable) terminalNotification;
-                tmpT.addSuppressed(t);
-                t = tmpT;
+                t = addSuppressed((Throwable) terminalNotification, t);
                 break;
             }
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeCancellable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeCancellable.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.Cancellable;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -56,7 +57,7 @@ final class CompositeCancellable implements Cancellable {
                     if (t == null) {
                         t = tt;
                     } else {
-                        t.addSuppressed(tt);
+                        addSuppressed(t, tt);
                     }
                 }
             }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeExceptionUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeExceptionUtils.java
@@ -17,6 +17,8 @@ package io.servicetalk.concurrent.api;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+
 final class CompositeExceptionUtils {
     /**
      * Default to {@code 1} so {@link Throwable#addSuppressed(Throwable)} will not be used by default.
@@ -33,7 +35,7 @@ final class CompositeExceptionUtils {
         if (newSize < 0) {
             updater.set(owner, Integer.MAX_VALUE);
         } else if (newSize < maxDelayedErrors && original != causeToAdd) {
-            original.addSuppressed(causeToAdd);
+            addSuppressed(original, causeToAdd);
         } else {
             updater.decrementAndGet(owner);
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/OnErrorResumeCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/OnErrorResumeCompletable.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class OnErrorResumeCompletable extends AbstractNoHandleSubscribeCompletable {
@@ -86,8 +87,7 @@ final class OnErrorResumeCompletable extends AbstractNoHandleSubscribeCompletabl
                         requireNonNull(parent.nextFactory.apply(throwable)) :
                         null;
             } catch (Throwable t) {
-                t.addSuppressed(throwable);
-                subscriber.onError(t);
+                subscriber.onError(addSuppressed(t, throwable));
                 return;
             }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/OnErrorResumeSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/OnErrorResumeSingle.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class OnErrorResumeSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
@@ -81,8 +82,7 @@ final class OnErrorResumeSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
             try {
                 next = !resubscribed && predicate.test(throwable) ? requireNonNull(nextFactory.apply(throwable)) : null;
             } catch (Throwable t) {
-                t.addSuppressed(throwable);
-                subscriber.onError(t);
+                subscriber.onError(addSuppressed(t, throwable));
                 return;
             }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
@@ -22,6 +22,7 @@ import java.util.function.BiPredicate;
 import java.util.function.IntPredicate;
 
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 
 /**
  * {@link Publisher} to do {@link Publisher#repeat(IntPredicate)} and {@link Publisher#retry(BiIntPredicate)}
@@ -116,7 +117,7 @@ final class RedoPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
             } catch (Throwable cause) {
                 Throwable originalCause = notification.cause();
                 if (originalCause != null) {
-                    cause.addSuppressed(originalCause);
+                    addSuppressed(cause, originalCause);
                 }
                 subscriber.onError(cause);
                 return;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoWhenPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoWhenPublisher.java
@@ -25,6 +25,7 @@ import java.util.function.BiFunction;
 import java.util.function.IntFunction;
 
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -143,7 +144,7 @@ final class RedoWhenPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
             } catch (Throwable cause) {
                 Throwable originalCause = terminalNotification.cause();
                 if (originalCause != null) {
-                    cause.addSuppressed(originalCause);
+                    addSuppressed(cause, originalCause);
                 }
                 subscriber.onError(cause);
                 return;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetrySingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetrySingle.java
@@ -21,6 +21,8 @@ import io.servicetalk.context.api.ContextMap;
 
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+
 /**
  * A {@link Single} implementation as returned by {@link Single#retry(BiIntPredicate)}.
  *
@@ -97,8 +99,7 @@ final class RetrySingle<T> extends AbstractNoHandleSubscribeSingle<T> {
             try {
                 shouldRetry = retrySingle.shouldRetry.test(++retryCount, t);
             } catch (Throwable cause) {
-                cause.addSuppressed(t);
-                target.onError(cause);
+                target.onError(addSuppressed(cause, t));
                 return;
             }
             if (shouldRetry) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryWhenSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryWhenSingle.java
@@ -22,6 +22,7 @@ import io.servicetalk.context.api.ContextMap;
 
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -104,8 +105,7 @@ final class RetryWhenSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
             try {
                 retryDecider = requireNonNull(retrySingle.shouldRetry.apply(++retryCount, t));
             } catch (Throwable cause) {
-                cause.addSuppressed(t);
-                target.onError(cause);
+                target.onError(addSuppressed(cause, t));
                 return;
             }
 

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -150,7 +151,7 @@ public final class TestCompletable extends Completable implements CompletableSou
             final RuntimeException exception = new RuntimeException("Unexpected exception(s) encountered",
                     exceptions.get(0));
             for (int i = 1; i < exceptions.size(); i++) {
-                exception.addSuppressed(exceptions.get(i));
+                addSuppressed(exception, exceptions.get(i));
             }
             throw exception;
         }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -176,7 +177,7 @@ public final class TestPublisher<T> extends Publisher<T> implements PublisherSou
             final RuntimeException exception = new RuntimeException("Unexpected exception(s) encountered",
                     exceptions.get(0));
             for (int i = 1; i < exceptions.size(); i++) {
-                exception.addSuppressed(exceptions.get(i));
+                addSuppressed(exception, exceptions.get(i));
             }
             throw exception;
         }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.await;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -153,7 +154,7 @@ public final class TestSingle<T> extends Single<T> implements SingleSource<T> {
             final RuntimeException exception = new RuntimeException("Unexpected exception(s) encountered",
                     exceptions.get(0));
             for (int i = 1; i < exceptions.size(); i++) {
-                exception.addSuppressed(exceptions.get(i));
+                addSuppressed(exception, exceptions.get(i));
             }
             throw exception;
         }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TerminalNotification.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TerminalNotification.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.PublisherSource;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -80,8 +81,7 @@ public final class TerminalNotification {
             subscriber.onError(additionalCause);
         } else {
             assert cause != null;
-            cause.addSuppressed(additionalCause);
-            subscriber.onError(cause);
+            subscriber.onError(addSuppressed(cause, additionalCause));
         }
     }
 
@@ -102,8 +102,7 @@ public final class TerminalNotification {
             subscriber.onError(additionalCause);
         } else {
             assert cause != null;
-            cause.addSuppressed(additionalCause);
-            subscriber.onError(cause);
+            subscriber.onError(addSuppressed(cause, additionalCause));
         }
     }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -699,8 +699,9 @@ final class DefaultDnsClient implements DnsClient {
                 try {
                     resolutionObserver.resolutionFailed(cause);
                 } catch (Throwable unexpected) {
+                    addSuppressed(unexpected, cause);
                     LOGGER.warn("Unexpected exception from {} while reporting DNS resolution failure",
-                            resolutionObserver, addSuppressed(unexpected, cause));
+                            resolutionObserver, unexpected);
                 }
             }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -90,6 +90,7 @@ import static io.servicetalk.dns.discovery.netty.ServiceDiscovererUtils.calculat
 import static io.servicetalk.transport.netty.internal.BuilderUtils.datagramChannel;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.socketChannel;
 import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.nio.ByteBuffer.wrap;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -698,9 +699,8 @@ final class DefaultDnsClient implements DnsClient {
                 try {
                     resolutionObserver.resolutionFailed(cause);
                 } catch (Throwable unexpected) {
-                    unexpected.addSuppressed(cause);
                     LOGGER.warn("Unexpected exception from {} while reporting DNS resolution failure",
-                            resolutionObserver, unexpected);
+                            resolutionObserver, addSuppressed(unexpected, cause));
                 }
             }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -126,6 +126,7 @@ import static io.servicetalk.test.resources.DefaultTestCerts.loadServerPem;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static io.servicetalk.transport.api.SslProvider.OPENSSL;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -980,7 +981,7 @@ class ProtocolCompatibilityTest {
                 if (re == null) {
                     re = new RuntimeException("Failure(s) when closing: " + Arrays.toString(acs));
                 }
-                re.addSuppressed(t);
+                addSuppressed(re, t);
             }
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpDataSourceTransformations.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpDataSourceTransformations.java
@@ -40,6 +40,7 @@ import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.System.nanoTime;
 import static java.util.Objects.requireNonNull;
@@ -240,7 +241,7 @@ final class HttpDataSourceTransformations {
                 try {
                     iterator.close();
                 } catch (Throwable cause) {
-                    e.addSuppressed(cause);
+                    addSuppressed(e, cause);
                 }
                 throw e;
             }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
@@ -289,8 +289,8 @@ abstract class AbstractLifecycleObserverHttpFilter implements HttpExecutionStrat
         try {
             onError.accept(t);
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting a '{}' event",
-                    observer, eventName, addSuppressed(unexpected, t));
+            addSuppressed(unexpected, t);
+            LOGGER.warn("Unexpected exception from {} while reporting a '{}' event", observer, eventName, unexpected);
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
@@ -49,6 +49,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 abstract class AbstractLifecycleObserverHttpFilter implements HttpExecutionStrategyInfluencer {
@@ -288,8 +289,8 @@ abstract class AbstractLifecycleObserverHttpFilter implements HttpExecutionStrat
         try {
             onError.accept(t);
         } catch (Throwable unexpected) {
-            unexpected.addSuppressed(t);
-            LOGGER.warn("Unexpected exception from {} while reporting a '{}' event", observer, eventName, unexpected);
+            LOGGER.warn("Unexpected exception from {} while reporting a '{}' event",
+                    observer, eventName, addSuppressed(unexpected, t));
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -376,8 +376,8 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                         try {
                             close(streamChannel, cause);
                         } catch (Throwable unexpected) {
-                            LOGGER.warn("Unexpected exception while handling the original cause",
-                                    addSuppressed(unexpected, cause));
+                            addSuppressed(unexpected, cause);
+                            LOGGER.warn("Unexpected exception while handling the original cause", unexpected);
                         }
                     } else {
                         cleanupWhenError(cause, streamObserver, onCloseRunnable);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -89,6 +89,7 @@ import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forNonPipelined;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
@@ -375,8 +376,8 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                         try {
                             close(streamChannel, cause);
                         } catch (Throwable unexpected) {
-                            unexpected.addSuppressed(cause);
-                            LOGGER.warn("Unexpected exception while handling the original cause", unexpected);
+                            LOGGER.warn("Unexpected exception while handling the original cause",
+                                    addSuppressed(unexpected, cause));
                         }
                     } else {
                         cleanupWhenError(cause, streamObserver, onCloseRunnable);

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
@@ -281,7 +282,7 @@ public final class BeforeFinallyHttpOperator implements SingleOperator<Streaming
                                                     beforeFinally.onError(t);
                                                 }
                                             } catch (Throwable cause) {
-                                                t.addSuppressed(cause);
+                                                addSuppressed(t, cause);
                                             }
                                             subscriber.onError(t);
                                             return;
@@ -298,7 +299,7 @@ public final class BeforeFinallyHttpOperator implements SingleOperator<Streaming
                                         try {
                                             beforeFinally.onError(t);
                                         } catch (Throwable cause) {
-                                            t.addSuppressed(cause);
+                                            addSuppressed(t, cause);
                                         }
                                         try {
                                             subscriber.onError(t);
@@ -398,7 +399,7 @@ public final class BeforeFinallyHttpOperator implements SingleOperator<Streaming
                     return;
                 }
             } catch (Throwable cause) {
-                t.addSuppressed(cause);
+                addSuppressed(t, cause);
             }
             subscriber.onError(t);
         }

--- a/servicetalk-serialization-api/build.gradle
+++ b/servicetalk-serialization-api/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))

--- a/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/DefaultSerializer.java
+++ b/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/DefaultSerializer.java
@@ -35,6 +35,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -326,7 +327,7 @@ public final class DefaultSerializer implements Serializer {
             try {
                 deSerializer.close();
             } catch (SerializationException e) {
-                throwable.addSuppressed(e);
+                addSuppressed(throwable, e);
             }
             throw throwable;
         }
@@ -352,7 +353,7 @@ public final class DefaultSerializer implements Serializer {
             iterator.close(); // May throw in case of incomplete accumulated data
         } catch (Exception e) {
             if (cause != null) {
-                cause.addSuppressed(e);
+                addSuppressed(cause, e);
                 throw cause;
             }
             if (e instanceof SerializationException) {

--- a/servicetalk-test-resources/build.gradle
+++ b/servicetalk-test-resources/build.gradle
@@ -19,11 +19,12 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
-  implementation project(":servicetalk-annotations")
-
   api "org.apache.logging.log4j:log4j-core:$log4jVersion"
   api "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
   api "org.hamcrest:hamcrest:$hamcrestVersion"
+
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-utils-internal")
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 }

--- a/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
+++ b/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
@@ -21,6 +21,7 @@ import org.hamcrest.TypeSafeMatcher;
 
 import java.util.Queue;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.lang.Integer.min;
 
 /**
@@ -57,7 +58,7 @@ public final class TestUtils {
         final AssertionError error = null != message ? new AssertionError(message) : new AssertionError();
         Throwable t;
         while ((t = errors.poll()) != null) {
-            error.addSuppressed(t);
+            addSuppressed(error, t);
         }
 
         throw error;

--- a/servicetalk-transport-api/build.gradle
+++ b/servicetalk-transport-api/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -308,8 +308,8 @@ final class CatchAllTransportObserver implements TransportObserver {
         try {
             runnable.run();
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting a {} event",
-                    observer, eventName, addSuppressed(unexpected, original));
+            addSuppressed(unexpected, original);
+            LOGGER.warn("Unexpected exception from {} while reporting a {} event", observer, eventName, unexpected);
         }
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -37,6 +37,7 @@ import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -307,8 +308,8 @@ final class CatchAllTransportObserver implements TransportObserver {
         try {
             runnable.run();
         } catch (Throwable unexpected) {
-            unexpected.addSuppressed(original);
-            LOGGER.warn("Unexpected exception from {} while reporting a {} event", observer, eventName, unexpected);
+            LOGGER.warn("Unexpected exception from {} while reporting a {} event",
+                    observer, eventName, addSuppressed(unexpected, original));
         }
     }
 }

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -59,6 +59,7 @@ dependencies {
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
+  testFixturesImplementation project(":servicetalk-utils-internal")
   testFixturesImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/Flush.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/Flush.java
@@ -24,6 +24,7 @@ import io.servicetalk.transport.netty.internal.FlushStrategy.WriteEventsListener
 import io.netty.channel.Channel;
 import io.netty.util.concurrent.EventExecutor;
 
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -122,7 +123,7 @@ final class Flush {
             try {
                 writeEventsListener.writeTerminated();
             } catch (Throwable t1) {
-                t.addSuppressed(t1);
+                addSuppressed(t, t1);
             }
             subscriber.onError(t);
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/WriteStreamSubscriber.java
@@ -47,6 +47,7 @@ import static io.servicetalk.transport.netty.internal.ByteMaskUtils.isAllSet;
 import static io.servicetalk.transport.netty.internal.ByteMaskUtils.isAnySet;
 import static io.servicetalk.transport.netty.internal.ByteMaskUtils.set;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.assignConnectionError;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -566,7 +567,7 @@ final class WriteStreamSubscriber implements PublisherSource.Subscriber<Object>,
                     observer.writeFailed(enrichedCause);
                     subscriber.onError(enrichedCause);
                 } catch (Throwable t) {
-                    t.addSuppressed(enrichedCause);
+                    addSuppressed(t, enrichedCause);
                     tryFailureOrLog(t);
                 }
                 if (!isAllSet(state, CHANNEL_CLOSED)) {

--- a/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/EmbeddedDuplexChannel.java
+++ b/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/EmbeddedDuplexChannel.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.netty.channel.ChannelOption.ALLOW_HALF_CLOSURE;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 
 /**
  * {@link EmbeddedChannel} that implements {@link DuplexChannel}.
@@ -313,7 +314,7 @@ public final class EmbeddedDuplexChannel extends EmbeddedChannel implements Dupl
         Throwable shutdownInputCause = shutdownInputFuture.cause();
         if (shutdownOutputCause != null) {
             if (shutdownInputCause != null) {
-                shutdownOutputCause.addSuppressed(shutdownInputCause);
+                addSuppressed(shutdownOutputCause, shutdownInputCause);
             }
             promise.setFailure(shutdownOutputCause);
         } else if (shutdownInputCause != null) {

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ThrowableUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ThrowableUtils.java
@@ -39,9 +39,7 @@ public final class ThrowableUtils {
     public static Throwable combine(@Nullable final Object first, @Nullable final Object second) {
         if (first instanceof Throwable) {
             if (second instanceof Throwable) {
-                final Throwable result = (Throwable) first;
-                result.addSuppressed((Throwable) second);
-                return result;
+                return addSuppressed((Throwable) first, (Throwable) second);
             } else {
                 return (Throwable) first;
             }
@@ -50,5 +48,19 @@ public final class ThrowableUtils {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Adds suppressed exception avoiding self-suppression.
+     *
+     * @param original the original {@link Throwable}
+     * @param suppressed the {@link Throwable} to be suppressed
+     * @return the original {@link Throwable}
+     */
+    public static Throwable addSuppressed(final Throwable original, final Throwable suppressed) {
+        if (original != suppressed) {
+            original.addSuppressed(suppressed);
+        }
+        return original;
     }
 }


### PR DESCRIPTION
Motivation:

In case a processing function re-throws the original exception, we risk
to face `IllegalArgumentException("Self-suppression not permitted)` when
operator adds a re-thrown exception as suppressed.

Modifications:

- Add utility that verifies the suppressed exception is not the same as
the original one;

Result:

No `IllegalArgumentException("Self-suppression not permitted)`.