### PR TITLE
Use `servicetalk-grpc-protoc-all` for pom.xml

### DIFF
--- a/servicetalk-examples/grpc/helloworld/pom.xml
+++ b/servicetalk-examples/grpc/helloworld/pom.xml
@@ -54,6 +54,7 @@
                   <groupId>io.servicetalk</groupId>
                   <artifactId>servicetalk-grpc-protoc</artifactId>
                   <version>${servicetalk.version}</version>
+                  <classifier>all</classifier>
                   <mainClass>io.servicetalk.grpc.protoc.Main</mainClass>
                 </protocPlugin>
               </protocPlugins>


### PR DESCRIPTION
Motivation:

`build.gradle` for grpc example uses `servicetalk-grpc-protoc-all`
artifact, but `pom.xml` uses `servicetalk-grpc-protoc`. After #2209,
maven example does not work anymore:

```
servicetalk-grpc-protoc_out: ServiceTalk code generation failed:
   java.lang.NoClassDefFoundError: com/squareup/javapoet/ClassName
```

Modifications:

- Use `<classifier>all</classifier>` to let maven use an uber jar;

Result:

Maven build works for grpc example.

Related:

https://github.com/servicetalk/examples/pull/1