### PR TITLE
Add `mavenCentral()` repository if no repositories are configured

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ if (!repositories) {
       }
     }
     repositories {
+      mavenCentral()
       maven { url "https://plugins.gradle.org/m2/" }
     }
   }


### PR DESCRIPTION
Motivation:

After some environmental changes (possibly #2184), some PRs fail to
resolve dependencies if `mavenCentral()` is not defined in
`build.gradle`.

Modifications:

- Add `mavenCentral()` if no repositories are configured;

Result:

Successful respolution of dependencies, see #2208.