### PR TITLE
Use `servicetalk-dependencies` BOM internally

### DIFF
--- a/servicetalk-annotations/build.gradle
+++ b/servicetalk-annotations/build.gradle
@@ -17,5 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation platform(project(":servicetalk-dependencies"))
+
+  implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-benchmarks/build.gradle
+++ b/servicetalk-benchmarks/build.gradle
@@ -22,6 +22,8 @@ plugins {
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
+
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-buffer-netty")
   implementation project(":servicetalk-concurrent-api")
@@ -30,9 +32,9 @@ dependencies {
   implementation project(":servicetalk-http-netty")
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-loadbalancer")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "io.netty:netty-codec-http:$nettyVersion"
-  implementation "org.openjdk.jmh:jmh-core:$jmhCoreVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "io.netty:netty-codec-http"
+  implementation "org.openjdk.jmh:jmh-core"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-concurrent-internal")

--- a/servicetalk-buffer-api/build.gradle
+++ b/servicetalk-buffer-api/build.gradle
@@ -17,11 +17,12 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   implementation project(":servicetalk-annotations")
 
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/servicetalk-buffer-netty/build.gradle
+++ b/servicetalk-buffer-netty/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  api platform("io.netty:netty-bom:$nettyVersion")
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-buffer-api")
@@ -25,8 +25,8 @@ dependencies {
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-client-api-internal/build.gradle
+++ b/servicetalk-client-api-internal/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-client-api")
@@ -25,8 +26,8 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-client-api/build.gradle
+++ b/servicetalk-client-api/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-concurrent-api")
@@ -25,8 +26,8 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-concurrent-api-internal/build.gradle
+++ b/servicetalk-concurrent-api-internal/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-concurrent-api")
@@ -27,8 +28,8 @@ dependencies {
   implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-concurrent-api-test/build.gradle
+++ b/servicetalk-concurrent-api-test/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-concurrent-api")
@@ -25,7 +26,7 @@ dependencies {
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-concurrent-test-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))

--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
@@ -26,8 +27,8 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-concurrent-test-internal")

--- a/servicetalk-concurrent-internal/build.gradle
+++ b/servicetalk-concurrent-internal/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
@@ -25,8 +26,8 @@ dependencies {
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-concurrent-jdkflow/build.gradle
+++ b/servicetalk-concurrent-jdkflow/build.gradle
@@ -30,13 +30,14 @@ compileJava {
 }
 
 dependencies {
+    implementation platform(project(":servicetalk-dependencies"))
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
     api project(":servicetalk-concurrent-api")
 
     implementation project(":servicetalk-annotations")
-    implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "com.google.code.findbugs:jsr305"
+    implementation "org.slf4j:slf4j-api"
 
     testImplementation testFixtures(project(":servicetalk-concurrent-api"))
     testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-concurrent-reactivestreams/build.gradle
+++ b/servicetalk-concurrent-reactivestreams/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-concurrent-api")
@@ -25,8 +26,8 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-serializer-utils")
   implementation project(":servicetalk-buffer-netty")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-concurrent-test-internal/build.gradle
+++ b/servicetalk-concurrent-test-internal/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-concurrent")
@@ -24,7 +25,7 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-test-resources")

--- a/servicetalk-concurrent/build.gradle
+++ b/servicetalk-concurrent/build.gradle
@@ -17,7 +17,8 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   implementation project(":servicetalk-annotations")
 
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-context-api/build.gradle
+++ b/servicetalk-context-api/build.gradle
@@ -17,7 +17,8 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   implementation project(":servicetalk-annotations")
 
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-data-jackson-jersey/build.gradle
+++ b/servicetalk-data-jackson-jersey/build.gradle
@@ -17,12 +17,12 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  implementation platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-data-jackson")
-  api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion" // MediaType, Feature
+  api "jakarta.ws.rs:jakarta.ws.rs-api" // MediaType, Feature
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation project(":servicetalk-annotations")
@@ -34,9 +34,9 @@ dependencies {
   implementation project(":servicetalk-http-router-jersey-internal")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-transport-netty")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
   implementation "org.glassfish.jersey.core:jersey-server"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-data-jackson/build.gradle
+++ b/servicetalk-data-jackson/build.gradle
@@ -17,17 +17,18 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-serialization-api")
   api project(":servicetalk-serializer-api")
-  api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+  api "com.fasterxml.jackson.core:jackson-databind"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-data-protobuf-jersey/build.gradle
+++ b/servicetalk-data-protobuf-jersey/build.gradle
@@ -24,11 +24,11 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 apply plugin: "com.google.protobuf"
 
 dependencies {
-  implementation platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
-  api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion" // MediaType, Feature
+  api "jakarta.ws.rs:jakarta.ws.rs-api" // MediaType, Feature
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation project(":servicetalk-annotations")
@@ -41,10 +41,10 @@ dependencies {
   implementation project(":servicetalk-http-router-jersey-internal")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-transport-netty")
-  implementation "com.google.protobuf:protobuf-java:$protobufVersion"
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.protobuf:protobuf-java"
+  implementation "com.google.code.findbugs:jsr305"
   implementation "org.glassfish.jersey.core:jersey-server"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-data-protobuf/build.gradle
+++ b/servicetalk-data-protobuf/build.gradle
@@ -26,19 +26,20 @@ apply plugin: "com.google.protobuf"
 ideaModule.dependsOn "generateTestProto"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-buffer-api")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-serializer-api")
-  api "com.google.protobuf:protobuf-java:$protobufVersion"
+  api "com.google.protobuf:protobuf-java"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-serialization-api")
   implementation project(":servicetalk-serializer-utils")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
 
   constraints {
-    // Use `api` only for dependencies whose types appear in ServiceTalk API.
     api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
     api "com.google.code.findbugs:jsr305:$jsr305Version"
@@ -39,7 +38,7 @@ dependencies {
     api "com.sun.xml.bind:jaxb-core:$javaxJaxbCoreVersion"
     api "io.opentracing:opentracing-api:$openTracingVersion"
     api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
-    // `spi` and `core` types exposed in `log4j2-mdc-utils`
+    api "org.apache.logging.log4j:log4j-api:$log4jVersion"
     api "org.apache.logging.log4j:log4j-core:$log4jVersion"
     api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
     api "jakarta.xml.bind:jakarta.xml.bind-api:$javaxJaxbApiVersion"
@@ -50,6 +49,7 @@ dependencies {
     api "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
     api "org.slf4j:slf4j-api:$slf4jVersion"
 
+    // Use `runtime` for dependencies which are used ONLY at runtime
     runtime "com.sun.xml.bind:jaxb-impl:$javaxJaxbImplVersion"
     runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
   }

--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -26,12 +26,13 @@ javaPlatform {
 dependencies {
   api platform(project(":servicetalk-bom"))
   api platform("io.netty:netty-bom:${nettyVersion}")
-  api platform("com.fasterxml.jackson:jackson-bom:2.13.2.20220328")
   api platform("com.google.protobuf:protobuf-bom:${protobufVersion}")
   api platform("org.apache.logging.log4j:log4j-bom:${log4jVersion}")
   api platform("org.glassfish.jersey:jersey-bom:${jerseyVersion}")
 
   constraints {
+    // We don't use the jackson-bom because we want to target specifically jackson-databind
+    api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
     api "com.google.code.findbugs:jsr305:$jsr305Version"
     api "com.sun.activation:jakarta.activation:$javaxActivationVersion"

--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -26,7 +26,7 @@ javaPlatform {
 dependencies {
   api platform(project(":servicetalk-bom"))
   api platform("io.netty:netty-bom:${nettyVersion}")
-  api platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}")
+  api platform("com.fasterxml.jackson:jackson-bom:2.13.2.20220328")
   api platform("com.google.protobuf:protobuf-bom:${protobufVersion}")
   api platform("org.apache.logging.log4j:log4j-bom:${log4jVersion}")
   api platform("org.glassfish.jersey:jersey-bom:${jerseyVersion}")

--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -32,26 +32,26 @@ dependencies {
     // Use `api` only for dependencies whose types appear in ServiceTalk API.
     api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
+    api "com.google.code.findbugs:jsr305:$jsr305Version"
     api "com.google.protobuf:protobuf-java:$protobufVersion"
+    api "com.google.protobuf:protobuf-java-util:$protobufVersion"
+    api "com.sun.activation:jakarta.activation:$javaxActivationVersion"
+    api "com.sun.xml.bind:jaxb-core:$javaxJaxbCoreVersion"
     api "io.opentracing:opentracing-api:$openTracingVersion"
     api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
     // `spi` and `core` types exposed in `log4j2-mdc-utils`
     api "org.apache.logging.log4j:log4j-core:$log4jVersion"
     api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
+    api "jakarta.xml.bind:jakarta.xml.bind-api:$javaxJaxbApiVersion"
     // Matchers are exposed by `servicetalk-test-resources`
     api "org.hamcrest:hamcrest:$hamcrestVersion"
+    api "org.jctools:jctools-core:$jcToolsVersion"
+    api "org.openjdk.jmh:jmh-core:$jmhCoreVersion"
     api "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
-    // Use `runtime` for dependencies which are used for implementation
-    runtime "com.google.code.findbugs:jsr305:$jsr305Version"
-    runtime "com.google.protobuf:protobuf-java-util:$protobufVersion"
-    runtime "com.sun.activation:jakarta.activation:$javaxActivationVersion"
-    runtime "com.sun.xml.bind:jaxb-core:$javaxJaxbCoreVersion"
+    api "org.slf4j:slf4j-api:$slf4jVersion"
+
     runtime "com.sun.xml.bind:jaxb-impl:$javaxJaxbImplVersion"
-    runtime "jakarta.xml.bind:jakarta.xml.bind-api:$javaxJaxbApiVersion"
     runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-    runtime "org.jctools:jctools-core:$jcToolsVersion"
-    runtime "org.openjdk.jmh:jmh-core:$jmhCoreVersion"
-    runtime "org.slf4j:slf4j-api:$slf4jVersion"
   }
 }
 

--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  implementation platform("io.netty:netty-bom:$nettyVersion")
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-client-api")
@@ -29,9 +29,9 @@ dependencies {
   implementation project(":servicetalk-transport-netty")
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
   implementation "io.netty:netty-resolver-dns"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "org.slf4j:slf4j-api"
 
   runtimeOnly( group:"io.netty", name:"netty-resolver-dns-native-macos", classifier:"osx-x86_64")
   runtimeOnly( group:"io.netty", name:"netty-resolver-dns-native-macos", classifier:"osx-aarch_64")

--- a/servicetalk-encoding-api-internal/build.gradle
+++ b/servicetalk-encoding-api-internal/build.gradle
@@ -17,8 +17,9 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+    implementation platform(project(":servicetalk-dependencies"))
     api project(":servicetalk-encoding-api")
 
     implementation project(":servicetalk-annotations")
-    implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+    implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-encoding-api/build.gradle
+++ b/servicetalk-encoding-api/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+    implementation platform(project(":servicetalk-dependencies"))
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
     api project(":servicetalk-buffer-api")
@@ -25,8 +26,8 @@ dependencies {
 
     implementation project(":servicetalk-annotations")
     implementation project(":servicetalk-concurrent-internal")
-    implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "com.google.code.findbugs:jsr305"
+    implementation "org.slf4j:slf4j-api"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/servicetalk-encoding-netty/build.gradle
+++ b/servicetalk-encoding-netty/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-    implementation platform("io.netty:netty-bom:$nettyVersion")
+    implementation platform(project(":servicetalk-dependencies"))
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
     api project(":servicetalk-encoding-api")
@@ -26,8 +26,8 @@ dependencies {
     implementation project(":servicetalk-buffer-netty")
     implementation project(":servicetalk-concurrent-internal")
     implementation "io.netty:netty-codec"
-    implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "com.google.code.findbugs:jsr305"
+    implementation "org.slf4j:slf4j-api"
 
     testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
     testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-grpc-api/build.gradle
+++ b/servicetalk-grpc-api/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-concurrent-api")
@@ -35,9 +36,9 @@ dependencies {
   implementation project(":servicetalk-grpc-internal")
   implementation project(":servicetalk-oio-api-internal")
   implementation project(":servicetalk-serializer-utils")
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "com.google.protobuf:protobuf-java:$protobufVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "com.google.protobuf:protobuf-java"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-grpc-internal/build.gradle
+++ b/servicetalk-grpc-internal/build.gradle
@@ -17,13 +17,14 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-http-api")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -24,6 +24,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 apply plugin: "com.google.protobuf"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation enforcedPlatform("io.grpc:grpc-bom:$grpcVersion")
 
@@ -37,9 +38,9 @@ dependencies {
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-utils-internal")
   implementation project(":servicetalk-concurrent-internal")
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "com.google.protobuf:protobuf-java:$protobufVersion"
+  implementation "org.slf4j:slf4j-api"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "com.google.protobuf:protobuf-java"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-grpc-protobuf/build.gradle
+++ b/servicetalk-grpc-protobuf/build.gradle
@@ -26,10 +26,11 @@ apply plugin: "com.google.protobuf"
 ideaModule.dependsOn "generateTestProto"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-grpc-api")
-  api "com.google.protobuf:protobuf-java:$protobufVersion"
+  api "com.google.protobuf:protobuf-java"
   api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
 
   implementation project(":servicetalk-annotations")
@@ -37,8 +38,8 @@ dependencies {
   implementation project(":servicetalk-serializer-api")
   implementation project(":servicetalk-data-protobuf")
   implementation project(":servicetalk-serializer-utils")
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "org.slf4j:slf4j-api"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -22,6 +22,7 @@ plugins {
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   implementation project(":servicetalk-annotations")
@@ -29,7 +30,7 @@ dependencies {
   // Needed for the generated classes
   api project(":servicetalk-data-protobuf")
 
-  compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
+  compileOnly "com.google.code.findbugs:jsr305"
   compileOnly "com.squareup:javapoet:$javaPoetVersion"
 
   testImplementation project(":servicetalk-grpc-api")

--- a/servicetalk-grpc-utils/build.gradle
+++ b/servicetalk-grpc-utils/build.gradle
@@ -17,10 +17,11 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   api project(":servicetalk-grpc-api")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-http-api/build.gradle
+++ b/servicetalk-http-api/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
@@ -39,8 +40,8 @@ dependencies {
   implementation project(":servicetalk-serializer-utils")
   implementation project(":servicetalk-utils-internal")
   implementation project(":servicetalk-oio-api-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -69,4 +69,5 @@ dependencies {
   testFixturesImplementation project(":servicetalk-http-utils")
   testFixturesImplementation project(":servicetalk-test-resources")
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+  testFixturesRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   implementation platform("io.netty:netty-bom:$nettyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
@@ -36,10 +37,10 @@ dependencies {
   implementation project(":servicetalk-transport-netty")
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
   implementation "io.netty:netty-codec-http"
   implementation "io.netty:netty-codec-http2"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-buffer-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))

--- a/servicetalk-http-router-jersey-internal/build.gradle
+++ b/servicetalk-http-router-jersey-internal/build.gradle
@@ -17,15 +17,15 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  implementation platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
+  api platform(project(":servicetalk-dependencies"))
 
   api project(":servicetalk-http-api")
-  api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
+  api "jakarta.ws.rs:jakarta.ws.rs-api"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-utils")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
   implementation "org.glassfish.jersey.core:jersey-common"
 }

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -17,14 +17,14 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  implementation platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
+  api platform(project(":servicetalk-dependencies"))
   testFixturesImplementation platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-http-api")
   api project(":servicetalk-router-api")
-  api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
+  api "jakarta.ws.rs:jakarta.ws.rs-api"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
@@ -33,13 +33,14 @@ dependencies {
   implementation project(":servicetalk-http-router-jersey-internal")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-router-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "com.sun.activation:jakarta.activation:$javaxActivationVersion"
-  implementation "com.sun.xml.bind:jaxb-core:$javaxJaxbCoreVersion"
-  implementation "com.sun.xml.bind:jaxb-impl:$javaxJaxbImplVersion"
-  implementation "jakarta.xml.bind:jakarta.xml.bind-api:$javaxJaxbApiVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "com.sun.activation:jakarta.activation"
+  implementation "com.sun.xml.bind:jaxb-core"
+  implementation "jakarta.xml.bind:jakarta.xml.bind-api"
   implementation "org.glassfish.jersey.core:jersey-server"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "org.slf4j:slf4j-api"
+
+  runtimeOnly "com.sun.xml.bind:jaxb-impl"
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-http-router-predicate/build.gradle
+++ b/servicetalk-http-router-predicate/build.gradle
@@ -17,12 +17,13 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-http-api")
 
   implementation project(":servicetalk-annotations")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-http-security-jersey/build.gradle
+++ b/servicetalk-http-security-jersey/build.gradle
@@ -17,15 +17,15 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  implementation platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
-  api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
+  api "jakarta.ws.rs:jakarta.ws.rs-api"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
   implementation "org.glassfish.jersey.core:jersey-common"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-http-utils/build.gradle
+++ b/servicetalk-http-utils/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-concurrent-api")
@@ -27,8 +28,8 @@ dependencies {
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-buffer-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))

--- a/servicetalk-loadbalancer/build.gradle
+++ b/servicetalk-loadbalancer/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.apache.logging.log4j:log4j-core"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 }

--- a/servicetalk-loadbalancer/build.gradle
+++ b/servicetalk-loadbalancer/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-client-api")
@@ -26,8 +27,8 @@ dependencies {
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-client-api-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-log4j2-mdc-utils/build.gradle
+++ b/servicetalk-log4j2-mdc-utils/build.gradle
@@ -17,14 +17,15 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
-  api "org.apache.logging.log4j:log4j-core:$log4jVersion"
+  api "org.apache.logging.log4j:log4j-core"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-log4j2-mdc-utils/build.gradle
+++ b/servicetalk-log4j2-mdc-utils/build.gradle
@@ -19,22 +19,26 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testFixturesImplementation enforcedPlatform(project(":servicetalk-dependencies"))
 
-  api "org.apache.logging.log4j:log4j-core"
+  api "org.apache.logging.log4j:log4j-api"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-internal")
   implementation "com.google.code.findbugs:jsr305"
+  implementation "org.apache.logging.log4j:log4j-core"
 
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 
-  testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  testFixturesImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+  testFixturesImplementation "com.google.code.findbugs:jsr305"
+  testFixturesImplementation "org.apache.logging.log4j:log4j-core"
+  testFixturesImplementation "org.hamcrest:hamcrest"
+  testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
+  testFixturesRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl"
 }
 
 test {

--- a/servicetalk-log4j2-mdc/build.gradle
+++ b/servicetalk-log4j2-mdc/build.gradle
@@ -17,11 +17,12 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-log4j2-mdc-utils")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-logging-slf4j-internal/build.gradle
+++ b/servicetalk-logging-slf4j-internal/build.gradle
@@ -17,8 +17,10 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+    implementation platform(project(":servicetalk-dependencies"))
+
     api project(":servicetalk-logging-api")
 
     implementation project(":servicetalk-annotations")
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "org.slf4j:slf4j-api"
 }

--- a/servicetalk-oio-api-internal/build.gradle
+++ b/servicetalk-oio-api-internal/build.gradle
@@ -17,9 +17,11 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
+
   api project(":servicetalk-oio-api")
 
   implementation project(":servicetalk-annotations")
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "org.slf4j:slf4j-api"
+  implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-oio-api/build.gradle
+++ b/servicetalk-oio-api/build.gradle
@@ -17,7 +17,8 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   implementation project(":servicetalk-annotations")
 
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-opentracing-asynccontext/build.gradle
+++ b/servicetalk-opentracing-asynccontext/build.gradle
@@ -17,13 +17,14 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-opentracing-inmemory")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-opentracing-http/build.gradle
+++ b/servicetalk-opentracing-http/build.gradle
@@ -42,10 +42,10 @@ dependencies {
   testImplementation project(":servicetalk-opentracing-asynccontext")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-opentracing-log4j2")
-  testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
   testImplementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+  testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-opentracing-http/build.gradle
+++ b/servicetalk-opentracing-http/build.gradle
@@ -17,18 +17,19 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-http-api")
-  api "io.opentracing:opentracing-api:$openTracingVersion"
+  api "io.opentracing:opentracing-api"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-opentracing-inmemory")
   implementation project(":servicetalk-opentracing-inmemory-api")
   implementation project(":servicetalk-opentracing-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-opentracing-inmemory-api/build.gradle
+++ b/servicetalk-opentracing-inmemory-api/build.gradle
@@ -17,10 +17,12 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
+
   api "io.opentracing:opentracing-api:$openTracingVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-opentracing-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 }

--- a/servicetalk-opentracing-inmemory/build.gradle
+++ b/servicetalk-opentracing-inmemory/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-opentracing-inmemory-api")
@@ -26,8 +27,8 @@ dependencies {
   implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-opentracing-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-opentracing-internal/build.gradle
+++ b/servicetalk-opentracing-internal/build.gradle
@@ -17,7 +17,9 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
+
   implementation project(":servicetalk-annotations")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 }

--- a/servicetalk-opentracing-log4j2/build.gradle
+++ b/servicetalk-opentracing-log4j2/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-log4j2-mdc-utils")
@@ -26,10 +27,9 @@ dependencies {
   implementation project(":servicetalk-opentracing-inmemory-api")
   implementation project(":servicetalk-opentracing-internal")
   implementation project(":servicetalk-opentracing-asynccontext")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
-  implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.apache.logging.log4j:log4j-core"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   implementation platform("io.netty:netty-bom:$nettyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
@@ -25,18 +26,17 @@ dependencies {
   api project(":servicetalk-logging-api")
   api project(":servicetalk-http-api")
   api project(":servicetalk-transport-api")
-
-  api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
+  api "io.zipkin.reporter2:zipkin-reporter"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
   implementation "io.netty:netty-codec"
   implementation "io.netty:netty-transport"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-router-api/build.gradle
+++ b/servicetalk-router-api/build.gradle
@@ -17,6 +17,8 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
+
   implementation project(":servicetalk-annotations")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-router-utils-internal/build.gradle
+++ b/servicetalk-router-utils-internal/build.gradle
@@ -17,10 +17,11 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
+
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-router-api")
   implementation project(":servicetalk-transport-api")
-
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-serialization-api/build.gradle
+++ b/servicetalk-serialization-api/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-buffer-api")
@@ -27,7 +28,7 @@ dependencies {
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-serializer-api/build.gradle
+++ b/servicetalk-serializer-api/build.gradle
@@ -17,6 +17,8 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
+
   api project(":servicetalk-buffer-api")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-oio-api")
@@ -24,5 +26,5 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-oio-api-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 }

--- a/servicetalk-serializer-utils/build.gradle
+++ b/servicetalk-serializer-utils/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-serializer-api")
@@ -25,7 +26,7 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -17,6 +17,8 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
+
   testImplementation enforcedPlatform("io.netty:netty-bom:$nettyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation platform("io.netty:netty-bom:$nettyVersion")
@@ -32,8 +34,8 @@ dependencies {
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-transport-netty")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-test-resources/build.gradle
+++ b/servicetalk-test-resources/build.gradle
@@ -17,15 +17,16 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-utils-internal")
 
-  api "org.hamcrest:hamcrest:$hamcrestVersion"
+  api "org.hamcrest:hamcrest"
 
-  implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
-  implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+  implementation "org.apache.logging.log4j:log4j-core"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl"
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 }

--- a/servicetalk-test-resources/build.gradle
+++ b/servicetalk-test-resources/build.gradle
@@ -25,8 +25,5 @@ dependencies {
 
   api "org.hamcrest:hamcrest"
 
-  implementation "org.apache.logging.log4j:log4j-core"
-  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl"
-
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 }

--- a/servicetalk-transport-api/build.gradle
+++ b/servicetalk-transport-api/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
   api project(":servicetalk-buffer-api")
@@ -25,8 +26,8 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  api platform("io.netty:netty-bom:$nettyVersion")
+  api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
 
@@ -32,7 +32,7 @@ dependencies {
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
   implementation "io.netty:netty-transport-native-epoll"
   runtimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-x86_64")
   runtimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-aarch_64")
@@ -46,7 +46,7 @@ dependencies {
   runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"linux-aarch_64")
   runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"osx-x86_64")
   runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"osx-aarch_64")
-  implementation "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "org.slf4j:slf4j-api"
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-transport-netty/build.gradle
+++ b/servicetalk-transport-netty/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  implementation platform("io.netty:netty-bom:$nettyVersion")
+  implementation platform(project(":servicetalk-dependencies"))
 
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-transport-api")
@@ -25,6 +25,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-transport-netty-internal")
-  implementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  implementation "com.google.code.findbugs:jsr305"
   implementation "io.netty:netty-common"
 }

--- a/servicetalk-utils-internal/build.gradle
+++ b/servicetalk-utils-internal/build.gradle
@@ -17,13 +17,14 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+    implementation platform(project(":servicetalk-dependencies"))
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
     implementation project(":servicetalk-annotations")
     implementation project(":servicetalk-buffer-api")
-    implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-    implementation "org.jctools:jctools-core:$jcToolsVersion"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "com.google.code.findbugs:jsr305"
+    implementation "org.jctools:jctools-core"
+    implementation "org.slf4j:slf4j-api"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"


### PR DESCRIPTION
Motivation:
The new `dependencies` BOM introduced in #2210 can be used to improve
the management of external dependencies by reducing use of explicit
versions within the module `build.gradle` files.
Modification:
Use `dependencies` BOM for every module which includes `api` or
`implementation` external dependencies. The BOM is imported as `api`
platform only in cases where the external dependency is also imported
`api`. `implementation` platform is used in cases where the external
dependencies are only `implementation` dependencies themselves.
Result:
Fewer explicit version specifications and better managed dependency
versioning.