### PR TITLE
Use more external dependency BOM files

### DIFF
--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -26,24 +26,23 @@ javaPlatform {
 dependencies {
   api platform(project(":servicetalk-bom"))
   api platform("io.netty:netty-bom:${nettyVersion}")
-  api platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
+  api platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}")
+  api platform("com.google.protobuf:protobuf-bom:${protobufVersion}")
+  api platform("org.apache.logging.log4j:log4j-bom:${log4jVersion}")
+  api platform("org.glassfish.jersey:jersey-bom:${jerseyVersion}")
 
   constraints {
     // Use `api` only for dependencies whose types appear in ServiceTalk API.
-    api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
-    api "com.google.protobuf:protobuf-java:$protobufVersion"
     api "io.opentracing:opentracing-api:$openTracingVersion"
     api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
     // `spi` and `core` types exposed in `log4j2-mdc-utils`
-    api "org.apache.logging.log4j:log4j-core:$log4jVersion"
     api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
     // Matchers are exposed by `servicetalk-test-resources`
     api "org.hamcrest:hamcrest:$hamcrestVersion"
     api "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
     // Use `runtime` for dependencies which are used for implementation
     runtime "com.google.code.findbugs:jsr305:$jsr305Version"
-    runtime "com.google.protobuf:protobuf-java-util:$protobufVersion"
     runtime "com.sun.activation:jakarta.activation:$javaxActivationVersion"
     runtime "com.sun.xml.bind:jaxb-core:$javaxJaxbCoreVersion"
     runtime "com.sun.xml.bind:jaxb-impl:$javaxJaxbImplVersion"


### PR DESCRIPTION
Motivation:
Whenever possible, external dependencies should be imported through
their BOM files for optimal management of versioning and transitive
dependencies.
Modifications:
Add additional BOM files for Jackson, protobuf, Log4J and Jersey.
Result:
Improve resolution of external dependencies.