### PR TITLE
Avoid direct usage of RuntimeException

### DIFF
--- a/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
@@ -93,9 +93,4 @@
     <Method name="mapOnError"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
-  <Match>
-    <Class name="io.servicetalk.concurrent.api.DefaultExecutor"/>
-    <Method name="shutdownExecutor"/>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-  </Match>
 </FindBugsFilter>

--- a/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
@@ -84,11 +84,6 @@
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
   <Match>
-    <Class name="io.servicetalk.concurrent.api.PublisherAsBlockingIterable$SubscriberAndIterator"/>
-    <Method name="processNext"/>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-  </Match>
-  <Match>
     <Class name="io.servicetalk.concurrent.api.ScanWithMapper"/>
     <Method name="mapOnError"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultExecutor.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Thread.NORM_PRIORITY;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -157,7 +158,7 @@ final class DefaultExecutor extends AbstractExecutor implements Consumer<Runnabl
             try {
                 ((AutoCloseable) jdkExecutor).close();
             } catch (Exception e) {
-                throw new RuntimeException("unexpected exception while closing executor: " + jdkExecutor, e);
+                throwException(e);
             }
         }
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromIterablePublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromIterablePublisher.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Iterator;
 import java.util.concurrent.TimeoutException;
 
-import static io.servicetalk.concurrent.internal.AutoClosableUtils.closeAndReThrowUnchecked;
+import static io.servicetalk.concurrent.internal.AutoClosableUtils.closeAndReThrow;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
@@ -113,7 +113,7 @@ final class FromIterablePublisher<T> extends AbstractSynchronousPublisher<T> {
         public final void cancel() {
             cleanupForCancel();
             if (iterator instanceof AutoCloseable) {
-                closeAndReThrowUnchecked((AutoCloseable) iterator);
+                closeAndReThrow((AutoCloseable) iterator);
             }
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
@@ -39,6 +39,7 @@ import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUncheck
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Math.min;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
@@ -255,10 +256,7 @@ final class PublisherAsBlockingIterable<T> implements BlockingIterable<T> {
                 if (cause == null) {
                     throw new NoSuchElementException();
                 }
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                throw new RuntimeException(cause);
+                throwException(cause);
             }
             return unwrapNullUnchecked(signal);
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherConcatMapIterable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherConcatMapIterable.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.AutoClosableUtils.closeAndReThrowUnchecked;
+import static io.servicetalk.concurrent.internal.AutoClosableUtils.closeAndReThrow;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
@@ -161,7 +161,7 @@ final class PublisherConcatMapIterable<T, U> extends AbstractSynchronousPublishe
 
         private static <U> void tryClose(final Iterator<? extends U> currentIterator) {
             if (currentIterator instanceof AutoCloseable) {
-                closeAndReThrowUnchecked(((AutoCloseable) currentIterator));
+                closeAndReThrow(((AutoCloseable) currentIterator));
             }
         }
 

--- a/servicetalk-concurrent-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-concurrent-internal/gradle/spotbugs/main-exclusions.xml
@@ -38,14 +38,6 @@
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
   <Match>
-    <Class name="io.servicetalk.concurrent.internal.AbstractCloseableIterable$1"/>
-    <Or>
-      <Method name="close"/>
-      <Method name="hasNext"/>
-    </Or>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-  </Match>
-  <Match>
     <Class name="io.servicetalk.concurrent.internal.AutoClosableUtils"/>
     <Method name="closeAndReThrowUnchecked"/>
     <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIterable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIterable.java
@@ -21,6 +21,8 @@ import io.servicetalk.concurrent.CloseableIterator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+
 /**
  * An abstract implementation of {@link CloseableIterable} that wraps an {@link Iterable}.
  *
@@ -58,7 +60,7 @@ public abstract class AbstractCloseableIterable<T> implements CloseableIterable<
                         try {
                             close();
                         } catch (Exception e) {
-                            throw new RuntimeException(e);
+                            throwException(e);
                         }
                     }
                     return false;

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AutoClosableUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AutoClosableUtils.java
@@ -16,6 +16,9 @@
 package io.servicetalk.concurrent.internal;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 
 /**
  * Utilities for {@link AutoCloseable}.
@@ -28,12 +31,28 @@ public final class AutoClosableUtils {
     /**
      * Call {@link AutoCloseable#close()} and re-throw any exceptions as an unchecked exception.
      * @param closeable The object to close.
+     * @deprecated Use {@link #closeAndReThrow(AutoCloseable)}.
      */
+    @Deprecated
     public static void closeAndReThrowUnchecked(AutoCloseable closeable) {
         try {
             closeable.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Call {@link AutoCloseable#close()} and re-throw any exception.
+     * @param closeable The object to close.
+     */
+    public static void closeAndReThrow(AutoCloseable closeable) {
+        try {
+            closeable.close();
+        } catch (Exception e) {
+            throwException(e);
         }
     }
 

--- a/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
@@ -245,11 +245,6 @@
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
   <Match>
-    <Class name="io.servicetalk.http.api.FormUrlEncodedSerializer"/>
-    <Method name="urlEncode"/>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-  </Match>
-  <Match>
     <Or>
       <Class name="io.servicetalk.http.api.HttpClient"/>
       <Class name="io.servicetalk.http.api.HttpConnection"/>

--- a/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
@@ -318,12 +318,4 @@
     <Method name="catchPayloadFailure"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
-  <Match>
-    <Class name="io.servicetalk.http.api.RequestResponseFactories"/>
-    <Or>
-      <Method name="newRequestBlocking"/>
-      <Method name="newResponseBlocking"/>
-    </Or>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedSerializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedSerializer.java
@@ -134,7 +134,7 @@ final class FormUrlEncodedSerializer implements SerializerDeserializer<Map<Strin
         try {
             return URLEncoder.encode(value, charset.name()).getBytes(charset);
         } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException("URLDecoder failed to find Charset: " + charset, e);
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RequestResponseFactories.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RequestResponseFactories.java
@@ -18,7 +18,6 @@ package io.servicetalk.http.api;
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
-import static java.lang.Thread.currentThread;
 
 final class RequestResponseFactories {
 
@@ -123,26 +122,20 @@ final class RequestResponseFactories {
     }
 
     private static HttpRequest newRequestBlocking(StreamingHttpRequestFactory requestFactory,
-                                          HttpRequestMethod method, String requestTarget) {
+                                                  HttpRequestMethod method, String requestTarget) {
         try {
             return requestFactory.newRequest(method, requestTarget).toRequest().toFuture().get();
-        } catch (InterruptedException e) {
-            currentThread().interrupt(); // Reset the interrupted flag.
+        } catch (InterruptedException | ExecutionException e) {
             return throwException(e);
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e);
         }
     }
 
     private static HttpResponse newResponseBlocking(StreamingHttpResponseFactory responseFactory,
-                                            HttpResponseStatus status) {
+                                                    HttpResponseStatus status) {
         try {
             return responseFactory.newResponse(status).toResponse().toFuture().get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e);
+        } catch (InterruptedException | ExecutionException e) {
+            return throwException(e);
         }
     }
 }

--- a/servicetalk-opentracing-zipkin-publisher/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-opentracing-zipkin-publisher/gradle/spotbugs/main-exclusions.xml
@@ -31,10 +31,4 @@
     <Method name="batchSpans"/>
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
-
-  <Match>
-    <Class name="io.servicetalk.opentracing.zipkin.publisher.reporter.UdpReporter"/>
-    <Method name="report"/>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-  </Match>
 </FindBugsFilter>

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
@@ -50,6 +50,7 @@ import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 
 import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
+import static io.netty.util.internal.PlatformDependent.throwException;
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.datagramChannel;
 import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
@@ -215,7 +216,7 @@ public final class UdpReporter extends Component implements Reporter<Span>, Asyn
     @Override
     public void report(final Span span) {
         if (!channel.isActive()) {
-            throw new RuntimeException(StacklessClosedChannelException.newInstance(this.getClass(), "report"));
+            throwException(StacklessClosedChannelException.newInstance(this.getClass(), "report"));
         }
         channel.writeAndFlush(span);
     }

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporterTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporterTest.java
@@ -35,6 +35,7 @@ import zipkin2.codec.SpanBytesDecoder;
 
 import java.io.Closeable;
 import java.net.InetSocketAddress;
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 
@@ -108,7 +109,7 @@ class UdpReporterTest {
             assertThat("Unexpected check state.", reporter.check(), is(OK));
             reporter.close();
             assertThat("Unexpected check state.", reporter.check(), is(not(OK)));
-            assertThrows(RuntimeException.class, () -> reporter.report(newSpan("1")),
+            assertThrows(ClosedChannelException.class, () -> reporter.report(newSpan("1")),
                     "Report post close accepted.");
         }
     }

--- a/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/DefaultSerializerDeserializationTest.java
+++ b/servicetalk-serialization-api/src/test/java/io/servicetalk/serialization/api/DefaultSerializerDeserializationTest.java
@@ -256,8 +256,8 @@ class DefaultSerializerDeserializationTest {
         try {
             iterator.hasNext();
             Assertions.fail();
-        } catch (RuntimeException re) {
-            assertThat("Unexpected exception.", re.getCause(), sameInstance(e));
+        } catch (SerializationException se) {
+            assertThat(se, sameInstance(e));
         }
         verify(deSerializer).close();
     }
@@ -308,8 +308,8 @@ class DefaultSerializerDeserializationTest {
         try {
             deserialized.iterator().hasNext();
             Assertions.fail();
-        } catch (RuntimeException re) {
-            assertThat("Unexpected exception.", re.getCause(), sameInstance(e));
+        } catch (SerializationException se) {
+            assertThat(se, sameInstance(e));
         }
         verify(deSerializer).close();
     }
@@ -331,8 +331,8 @@ class DefaultSerializerDeserializationTest {
         try {
             deserialized.iterator().hasNext();
             Assertions.fail();
-        } catch (RuntimeException re) {
-            assertThat("Unexpected exception.", re.getCause(), sameInstance(e));
+        } catch (SerializationException se) {
+            assertThat(se, sameInstance(e));
         }
         verify(listDeSerializer).close();
     }


### PR DESCRIPTION
Motivation:
In some instances we use APIs that throw checked
exceptions from methods without checked throws
exception in the method signature. In some of these
instances we wrap in a RuntimeException, however
this doesn't provide any insight into the exception
being thrown. Recent spotbugs warnings highlights
these cases.

Modifications:
- DefaultExecutor to rethrow checked exception which
  is used internally to terminate async control flow
- RequestResponseFactories factory methods to rethrow
  checked exceptions.
- Zipkin UdpReporter report method to throw
  ClosedChannelException if already closed.