### PR TITLE
Add `ConnectionObserver#connectionWritabilityChanged(boolean)`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -217,6 +217,11 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
+            public void connectionWritabilityChanged(final boolean isWritable) {
+                // AsyncContext is unknown at this point because this event is triggered by network
+            }
+
+            @Override
             public void connectionClosed(final Throwable error) {
                 // AsyncContext is unknown at this point because this event is triggered by network
             }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -94,6 +94,12 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void connectionWritabilityChanged(final boolean isWritable) {
+            first.connectionWritabilityChanged(isWritable);
+            second.connectionWritabilityChanged(isWritable);
+        }
+
+        @Override
         public void connectionClosed(final Throwable error) {
             first.connectionClosed(error);
             second.connectionClosed(error);

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -107,6 +107,12 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void connectionWritabilityChanged(final boolean isWritable) {
+            safeReport(() -> observer.connectionWritabilityChanged(isWritable), observer,
+                    "connection writability changed");
+        }
+
+        @Override
         public void connectionClosed(final Throwable error) {
             safeReport(() -> observer.connectionClosed(error), observer, "connection closed", error);
         }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -90,6 +90,16 @@ public interface ConnectionObserver {
     MultiplexedObserver multiplexedConnectionEstablished(ConnectionInfo info);
 
     /**
+     * Callback when a writable state of the connection changes.
+     *
+     * @param isWritable describes the current state of the connection: {@code true} when the I/O thread will perform
+     * the requested write operation immediately. If {@code false}, write requests will be queued until the I/O thread
+     * is ready to process the queued items and the transport will start applying backpressure.
+     */
+    default void connectionWritabilityChanged(boolean isWritable) { // FIXME: 0.43 - consider removing default impl
+    }
+
+    /**
      * Callback when the connection is closed due to an {@link Throwable error}.
      *
      * @param error an occurred error

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -78,6 +78,10 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void connectionWritabilityChanged(final boolean isWritable) {
+        }
+
+        @Override
         public void connectionClosed(final Throwable error) {
         }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -153,5 +153,11 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
             observer.onFlush();
             ctx.flush();
         }
+
+        @Override
+        public void channelWritabilityChanged(final ChannelHandlerContext ctx) {
+            observer.connectionWritabilityChanged(ctx.channel().isWritable());
+            ctx.fireChannelWritabilityChanged();
+        }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -87,6 +87,10 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void connectionWritabilityChanged(final boolean isWritable) {
+        }
+
+        @Override
         public void connectionClosed(final Throwable error) {
         }
 


### PR DESCRIPTION
Motivation:

Callback helps users to see when channel's writability state changes.

Modifications:

- Add `ConnectionObserver#connectionWritabilityChanged(boolean)`;

Result:

Users can detect inefficient network configuration (too small outbound
socket buffer) or when the remote peer reads slower than expected.