### PR TITLE
`HttpLifecycleObserver`: notify when payload body is requested

### DIFF
--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcToHttpLifecycleObserverBridge.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcToHttpLifecycleObserverBridge.java
@@ -95,6 +95,11 @@ final class GrpcToHttpLifecycleObserverBridge implements HttpLifecycleObserver {
         }
 
         @Override
+        public void onRequestDataRequested(final long n) {
+            observer.onRequestDataRequested(n);
+        }
+
+        @Override
         public void onRequestData(final Buffer data) {
             observer.onRequestData(data);
         }
@@ -130,6 +135,11 @@ final class GrpcToHttpLifecycleObserverBridge implements HttpLifecycleObserver {
             if (grpcStatus != null) {
                 observer.onGrpcStatus(grpcStatus);
             }
+        }
+
+        @Override
+        public void onResponseDataRequested(final long n) {
+            observer.onResponseDataRequested(n);
         }
 
         @Override

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
@@ -70,9 +70,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -236,6 +239,7 @@ class GrpcLifecycleObserverTest {
             inOrder.verify(exchange).onRequest(any(StreamingHttpRequest.class));
         }
         inOrder.verify(exchange).onResponse(any(StreamingHttpResponse.class));
+        verify(response, atLeastOnce()).onResponseDataRequested(anyLong());
         if (!error) {
             inOrder.verify(response).onResponseData(any(Buffer.class));
             inOrder.verify(response).onResponseTrailers(any(HttpHeaders.class));
@@ -258,6 +262,7 @@ class GrpcLifecycleObserverTest {
             }
         }
 
+        verify(request, atLeastOnce()).onRequestDataRequested(anyLong());
         requestInOrder.verify(request).onRequestData(any(Buffer.class));
         requestInOrder.verify(request, never()).onRequestTrailers(any(HttpHeaders.class));
         requestInOrder.verify(request).onRequestComplete();

--- a/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/BiGrpcLifecycleObserver.java
+++ b/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/BiGrpcLifecycleObserver.java
@@ -129,6 +129,15 @@ final class BiGrpcLifecycleObserver implements GrpcLifecycleObserver {
         }
 
         @Override
+        public void onRequestDataRequested(final long n) {
+            try {
+                first.onRequestDataRequested(n);
+            } finally {
+                second.onRequestDataRequested(n);
+            }
+        }
+
+        @Override
         public void onRequestData(final Buffer data) {
             try {
                 first.onRequestData(data);
@@ -182,6 +191,15 @@ final class BiGrpcLifecycleObserver implements GrpcLifecycleObserver {
         private BiGrpcResponseObserver(final GrpcResponseObserver first, final GrpcResponseObserver second) {
             this.first = requireNonNull(first);
             this.second = requireNonNull(second);
+        }
+
+        @Override
+        public void onResponseDataRequested(final long n) {
+            try {
+                first.onResponseDataRequested(n);
+            } finally {
+                second.onResponseDataRequested(n);
+            }
         }
 
         @Override

--- a/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserver.java
+++ b/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserver.java
@@ -96,6 +96,10 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
         }
 
         @Override
+        public void onRequestDataRequested(final long n) {
+        }
+
+        @Override
         public void onRequestData(final Buffer data) {
             requestSize += data.readableBytes();
         }
@@ -129,6 +133,10 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
             assert this.responseMetaData == null;
             this.responseMetaData = responseMetaData;
             return this;
+        }
+
+        @Override
+        public void onResponseDataRequested(final long n) {
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLifecycleObserver.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLifecycleObserver.java
@@ -110,6 +110,17 @@ public interface HttpLifecycleObserver {
     interface HttpRequestObserver {
 
         /**
+         * Callback when subscriber requests {@code n} items of the request payload body.
+         * <p>
+         * May be invoked multiple times. Helps to track when items are requested and when they are
+         * {@link #onRequestData(Buffer) delivered}.
+         *
+         * @param n number of requested items
+         */
+        default void onRequestDataRequested(long n) {   // FIXME: 0.43 - consider removing default impl
+        }
+
+        /**
          * Callback when the request payload body data chunk was observed.
          * <p>
          * May be invoked multiple times if the payload body is split into multiple chunks.
@@ -157,6 +168,16 @@ public interface HttpLifecycleObserver {
      * event will be invoked per response.
      */
     interface HttpResponseObserver {
+
+        /**
+         * Callback when subscriber requests {@code n} items of the response payload body.
+         * <p>
+         * May be invoked multiple times. Helps to track when items are requested and when they are
+         * {@link #onResponseData delivered}.
+         *
+         * @param n number of requested items
+         */
+        void onResponseDataRequested(long n);   // FIXME: 0.43 - consider removing default impl
 
         /**
          * Callback when the response payload body data chunk was observed.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NoopHttpLifecycleObserver.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NoopHttpLifecycleObserver.java
@@ -79,6 +79,10 @@ final class NoopHttpLifecycleObserver implements HttpLifecycleObserver {
         }
 
         @Override
+        public void onRequestDataRequested(final long n) {
+        }
+
+        @Override
         public void onRequestData(final Buffer data) {
         }
 
@@ -105,6 +109,10 @@ final class NoopHttpLifecycleObserver implements HttpLifecycleObserver {
 
         private NoopHttpResponseObserver() {
             // Singleton
+        }
+
+        @Override
+        public void onResponseDataRequested(final long n) {
         }
 
         @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BiHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BiHttpLifecycleObserver.java
@@ -128,6 +128,15 @@ final class BiHttpLifecycleObserver implements HttpLifecycleObserver {
         }
 
         @Override
+        public void onRequestDataRequested(final long n) {
+            try {
+                first.onRequestDataRequested(n);
+            } finally {
+                second.onRequestDataRequested(n);
+            }
+        }
+
+        @Override
         public void onRequestData(final Buffer data) {
             try {
                 first.onRequestData(data);
@@ -181,6 +190,15 @@ final class BiHttpLifecycleObserver implements HttpLifecycleObserver {
         private BiHttpResponseObserver(final HttpResponseObserver first, final HttpResponseObserver second) {
             this.first = requireNonNull(first);
             this.second = requireNonNull(second);
+        }
+
+        @Override
+        public void onResponseDataRequested(final long n) {
+            try {
+                first.onResponseDataRequested(n);
+            } finally {
+                second.onResponseDataRequested(n);
+            }
         }
 
         @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
@@ -92,6 +92,10 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
         }
 
         @Override
+        public void onRequestDataRequested(final long n) {
+        }
+
+        @Override
         public void onRequestData(final Buffer data) {
             requestSize += data.readableBytes();
         }
@@ -125,6 +129,10 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
             assert this.responseMetaData == null;
             this.responseMetaData = responseMetaData;
             return this;
+        }
+
+        @Override
+        public void onResponseDataRequested(final long n) {
         }
 
         @Override


### PR DESCRIPTION
Motivation:

Track how subscriber requests payload body items.

Modifications:

- Add `HttpRequestObserver#onRequestDataRequested(long)`;
- Add `HttpResponseObserver#onResponseDataRequested(long)`;
- Enhance `HttpLifecycleObserverTest` and `GrpcLifecycleObserverTest`;

Result:

Users can track how many items subscriber requests from payload body,
and time difference between requested-delivered items.