### PR TITLE
Cleanup `HttpPredicateRouterBuilder`

### DIFF
--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilder.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilder.java
@@ -281,7 +281,7 @@ public final class HttpPredicateRouterBuilder implements RouteStarter {
 
         private RouteStarter thenRouteTo0(final StreamingHttpService route, final HttpExecutionStrategy routeStrategy) {
             assert predicate != null;
-            routes.add(new Route(predicate, route, routeStrategy));
+            routes.add(new Route(predicate, route, null == strategy ? null : routeStrategy));
             // Reset shared state since we have finished current route construction
             predicate = null;
             strategy = null;


### PR DESCRIPTION
Motivation:
Some of the types used by `HttpPredicateRouterBuilder` have changed
resulting in dead code.
Modifications:
Reduce complexity by removing code paths that are now impossible.
Result:
Cleaner, more obvious implementation.