### PR TITLE
Add default implementations for deprecated methods

### DIFF
--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -889,7 +889,7 @@ final class Generator {
                     .addMethod(newRpcMethodSpec(clientMetaData.methodProto, EnumSet.of(INTERFACE, CLIENT),
                             printJavaDocs, (methodName, b) -> {
                                 ClassName inClass = messageTypesMap.get(clientMetaData.methodProto.getInputType());
-                                b.addModifiers(ABSTRACT).addParameter(clientMetaData.className, metadata)
+                                b.addModifiers(DEFAULT).addParameter(clientMetaData.className, metadata)
                                 .addAnnotation(Deprecated.class);
                                 if (printJavaDocs) {
                                     extractJavaDocComments(state, methodIndex, b);
@@ -899,7 +899,9 @@ final class Generator {
                                     .addJavadoc(JAVADOC_PARAM + metadata +
                                             " the metadata associated with this client call." + lineSeparator());
                                 }
-                                return b;
+                                return b.addStatement("throw new UnsupportedOperationException(\"This method is not " +
+                                        "implemented by \" + getClass() + \". Consider migrating to an alternative " +
+                                        "method or implement this method if it's required temporarily.\")");
                             }))
                     .addMethod(newRpcMethodSpec(clientMetaData.methodProto, EnumSet.of(INTERFACE, CLIENT),
                             printJavaDocs, (methodName, b) -> {
@@ -925,7 +927,7 @@ final class Generator {
                     .addMethod(newRpcMethodSpec(clientMetaData.methodProto, EnumSet.of(BLOCKING, INTERFACE, CLIENT),
                             printJavaDocs, (methodName, b) -> {
                                 ClassName inClass = messageTypesMap.get(clientMetaData.methodProto.getInputType());
-                                b.addModifiers(ABSTRACT).addParameter(clientMetaData.className, metadata)
+                                b.addModifiers(DEFAULT).addParameter(clientMetaData.className, metadata)
                                 .addAnnotation(Deprecated.class);
                                 if (printJavaDocs) {
                                     extractJavaDocComments(state, methodIndex, b);
@@ -935,7 +937,9 @@ final class Generator {
                                     .addJavadoc(JAVADOC_PARAM + metadata +
                                             " the metadata associated with this client call." + lineSeparator());
                                 }
-                                return b;
+                                return b.addStatement("throw new UnsupportedOperationException(\"This method is not " +
+                                        "implemented by \" + getClass() + \". Consider migrating to an alternative " +
+                                        "method or implement this method if it's required temporarily.\")");
                             }))
                     .addMethod(newRpcMethodSpec(clientMetaData.methodProto, EnumSet.of(BLOCKING, INTERFACE, CLIENT),
                             printJavaDocs, (methodName, b) -> {

--- a/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
@@ -52,6 +52,13 @@
     <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"/>
   </Match>
 
+  <!-- False positive -->
+  <Match>
+    <Class name="io.servicetalk.http.api.ContentCodingHttpServiceFilter"/>
+    <Method name="codingForResponse"/>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+  </Match>
+
   <!-- Intentional reference comparison to avoid re-parsing if no value -->
   <Match>
     <Class name="io.servicetalk.http.api.Uri3986"/>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -133,7 +133,12 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * @deprecated Use {@link #payloadBody(Iterable, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> BlockingStreamingHttpRequest payloadBody(Iterable<T> payloadBody, HttpSerializer<T> serializer);
+    default <T> BlockingStreamingHttpRequest payloadBody(Iterable<T> payloadBody, HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException("BlockingStreamingHttpRequest#payloadBody(Iterable, HttpSerializer) " +
+                "is not supported by " + getClass() + ". This method is deprecated, consider migrating to " +
+                "BlockingStreamingHttpRequest#payloadBody(Iterable, HttpStreamingSerializer) or implement this " +
+                "method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to the result of serialization.
@@ -174,8 +179,13 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * {@link #payloadBody(Iterable, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> BlockingStreamingHttpRequest transformPayloadBody(
-            Function<BlockingIterable<Buffer>, BlockingIterable<T>> transformer, HttpSerializer<T> serializer);
+    default <T> BlockingStreamingHttpRequest transformPayloadBody(
+            Function<BlockingIterable<Buffer>, BlockingIterable<T>> transformer, HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException(
+                "BlockingStreamingHttpRequest#transformPayloadBody(Function, HttpSerializer) is not supported by " +
+                        getClass() + ". This method is deprecated, consider migrating to alternative methods or " +
+                        "implement this method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to the result of
@@ -208,7 +218,12 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * @deprecated Use {@link #payloadBody()} and {@link #payloadBody(Iterable)}.
      */
     @Deprecated
-    BlockingStreamingHttpRequest transformPayloadBody(UnaryOperator<BlockingIterable<Buffer>> transformer);
+    default BlockingStreamingHttpRequest transformPayloadBody(UnaryOperator<BlockingIterable<Buffer>> transformer) {
+        throw new UnsupportedOperationException(
+                "BlockingStreamingHttpRequest#transformPayloadBody(UnaryOperator) is not supported by " + getClass() +
+                        ". This method is deprecated, consider migrating to alternative methods or implement this " +
+                        "method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload transformed to {@link Buffer}s,
@@ -219,7 +234,12 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
      * @deprecated Use {@link #messageBody()} and {@link #messageBody(HttpMessageBodyIterable)}.
      */
     @Deprecated
-    <T> BlockingStreamingHttpRequest transform(TrailersTransformer<T, Buffer> trailersTransformer);
+    default <T> BlockingStreamingHttpRequest transform(TrailersTransformer<T, Buffer> trailersTransformer) {
+        throw new UnsupportedOperationException(
+                "BlockingStreamingHttpRequest#transform(TrailersTransformer) is not supported by " + getClass() +
+                        ". This method is deprecated, consider migrating to alternative methods or implement this " +
+                        "method if it's required temporarily.");
+    }
 
     /**
      * Translates this {@link BlockingStreamingHttpRequest} to a {@link HttpRequest}.
@@ -272,7 +292,11 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
 
     @Deprecated
     @Override
-    BlockingStreamingHttpRequest encoding(ContentCodec encoding);
+    default BlockingStreamingHttpRequest encoding(ContentCodec encoding) {
+        throw new UnsupportedOperationException("BlockingStreamingHttpRequest#encoding(ContentCodec) is not " +
+                "supported by " + getClass() + ". This method is deprecated, consider migrating to provided " +
+                "alternatives or implement this method if it's required temporarily.");
+    }
 
     @Override
     BlockingStreamingHttpRequest contentEncoding(@Nullable BufferEncoder encoder);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.CloseableIteratorBufferAsInputStream;
 import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.encoding.api.ContentCodec;
 
 import java.io.InputStream;
 import java.util.function.Function;
@@ -129,7 +130,12 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * @deprecated Use {@link #payloadBody(Iterable, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> BlockingStreamingHttpResponse payloadBody(Iterable<T> payloadBody, HttpSerializer<T> serializer);
+    default <T> BlockingStreamingHttpResponse payloadBody(Iterable<T> payloadBody, HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException("BlockingStreamingHttpResponse#payloadBody(Iterable, HttpSerializer) " +
+                "is not supported by " + getClass() + ". This method is deprecated, consider migrating to " +
+                "BlockingStreamingHttpResponse#payloadBody(Iterable, HttpStreamingSerializer) or implement this " +
+                "method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload set to the result of serialization.
@@ -170,8 +176,13 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * {@link #payloadBody(Iterable, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> BlockingStreamingHttpResponse transformPayloadBody(
-            Function<BlockingIterable<Buffer>, BlockingIterable<T>> transformer, HttpSerializer<T> serializer);
+    default <T> BlockingStreamingHttpResponse transformPayloadBody(
+            Function<BlockingIterable<Buffer>, BlockingIterable<T>> transformer, HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException(
+                "BlockingStreamingHttpResponse#transformPayloadBody(Function, HttpSerializer) is not supported by " +
+                        getClass() + ". This method is deprecated, consider migrating to alternative methods or " +
+                        "implement this method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to the result of
@@ -204,7 +215,12 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * @deprecated Use {@link #payloadBody()} and {@link #payloadBody(Iterable)}.
      */
     @Deprecated
-    BlockingStreamingHttpResponse transformPayloadBody(UnaryOperator<BlockingIterable<Buffer>> transformer);
+    default BlockingStreamingHttpResponse transformPayloadBody(UnaryOperator<BlockingIterable<Buffer>> transformer) {
+        throw new UnsupportedOperationException(
+                "BlockingStreamingHttpResponse#transformPayloadBody(UnaryOperator) is not supported by " + getClass() +
+                        ". This method is deprecated, consider migrating to alternative methods or implement this " +
+                        "method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link BlockingStreamingHttpResponse} with its underlying payload transformed to {@link Buffer}s,
@@ -215,7 +231,12 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
      * @deprecated Use {@link #messageBody()} and {@link #messageBody(HttpMessageBodyIterable)}.
      */
     @Deprecated
-    <T> BlockingStreamingHttpResponse transform(TrailersTransformer<T, Buffer> trailersTransformer);
+    default <T> BlockingStreamingHttpResponse transform(TrailersTransformer<T, Buffer> trailersTransformer) {
+        throw new UnsupportedOperationException(
+                "BlockingStreamingHttpResponse#transform(TrailersTransformer) is not supported by " + getClass() +
+                        ". This method is deprecated, consider migrating to alternative methods or implement this " +
+                        "method if it's required temporarily.");
+    }
 
     /**
      * Translates this {@link BlockingStreamingHttpResponse} to a {@link HttpResponse}.
@@ -235,6 +256,14 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
 
     @Override
     BlockingStreamingHttpResponse status(HttpResponseStatus status);
+
+    @Deprecated
+    @Override
+    default BlockingStreamingHttpResponse encoding(ContentCodec encoding) {
+        throw new UnsupportedOperationException("BlockingStreamingHttpResponse#encoding(ContentCodec) is not " +
+                "supported by " + getClass() + ". This method is deprecated, consider migrating to provided " +
+                "alternatives or implement this method if it's required temporarily.");
+    }
 
     @Override
     default BlockingStreamingHttpResponse addHeader(final CharSequence name, final CharSequence value) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpServerResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpServerResponse.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.encoding.api.ContentCodec;
 
 import java.io.OutputStream;
 
@@ -49,7 +50,12 @@ public interface BlockingStreamingHttpServerResponse extends HttpResponseMetaDat
      * @deprecated Use {@link #sendMetaData(HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> HttpPayloadWriter<T> sendMetaData(HttpSerializer<T> serializer);
+    default <T> HttpPayloadWriter<T> sendMetaData(HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException("BlockingStreamingHttpServerResponse#sendMetaData(HttpSerializer) " +
+                "is not supported by " + getClass() + ". This method is deprecated, consider migrating to " +
+                "BlockingStreamingHttpServerResponse#sendMetaData(HttpStreamingSerializer) or implement this " +
+                "method if it's required temporarily.");
+    }
 
     /**
      * Sends the {@link HttpResponseMetaData} to the client and returns an {@link HttpPayloadWriter} of type {@link T}
@@ -80,6 +86,13 @@ public interface BlockingStreamingHttpServerResponse extends HttpResponseMetaDat
 
     @Override
     BlockingStreamingHttpServerResponse status(HttpResponseStatus status);
+
+    @Override
+    default BlockingStreamingHttpServerResponse encoding(ContentCodec encoding) {
+        throw new UnsupportedOperationException("BlockingStreamingHttpServerResponse#encoding(ContentCodec) is not " +
+                "supported by " + getClass() + ". This method is deprecated, consider migrating to provided " +
+                "alternatives or implement this method if it's required temporarily.");
+    }
 
     @Override
     default BlockingStreamingHttpServerResponse addHeader(final CharSequence name, final CharSequence value) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -233,6 +233,7 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
         return this;
     }
 
+    @Deprecated
     @Override
     public BlockingStreamingHttpRequest transformPayloadBody(
             final UnaryOperator<BlockingIterable<Buffer>> transformer) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
@@ -120,6 +120,7 @@ final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpR
         return this;
     }
 
+    @Deprecated
     @Override
     public BlockingStreamingHttpResponse transformPayloadBody(
             final UnaryOperator<BlockingIterable<Buffer>> transformer) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpServerResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpServerResponse.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.api;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.encoding.api.ContentCodec;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
@@ -57,6 +58,14 @@ final class DefaultBlockingStreamingHttpServerResponse extends DefaultHttpRespon
     public BlockingStreamingHttpServerResponse status(final HttpResponseStatus status) {
         checkSent();
         super.status(status);
+        return this;
+    }
+
+    @Deprecated
+    @Override
+    public BlockingStreamingHttpServerResponse encoding(final ContentCodec encoding) {
+        checkSent();
+        super.encoding(encoding);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
@@ -77,7 +77,7 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
 
     @Deprecated
     @Override
-    public HttpMetaData encoding(final ContentCodec encoding) {
+    public HttpRequestMetaData encoding(final ContentCodec encoding) {
         super.encoding(encoding);
         return this;
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponseMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpResponseMetaData.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.encoding.api.ContentCodec;
 
 import javax.annotation.Nullable;
 
@@ -45,6 +46,13 @@ class DefaultHttpResponseMetaData extends AbstractHttpMetaData implements HttpRe
     @Override
     public HttpResponseMetaData status(final HttpResponseStatus status) {
         this.status = requireNonNull(status);
+        return this;
+    }
+
+    @Deprecated
+    @Override
+    public HttpResponseMetaData encoding(final ContentCodec encoding) {
+        super.encoding(encoding);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpMetaData.java
@@ -64,20 +64,32 @@ public interface HttpMetaData extends ContextMapHolder {
      * @param encoding The {@link ContentCodec} used for the encoding of the payload.
      * @return {@code this}.
      * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.2.2">Content-Encoding</a>
-     * @deprecated Use {@link HttpRequestMetaData#contentEncoding(BufferEncoder)}.
+     * @deprecated Use {@link HttpRequestMetaData#contentEncoding(BufferEncoder)} for requests and
+     * {@link ContentEncodingHttpServiceFilter} for responses. An example can be found
+     * <a href="https://apple.github.io/servicetalk//servicetalk-examples/0.42/http/index.html#Compression">here</a>.
      */
     @Deprecated
-    HttpMetaData encoding(ContentCodec encoding);
+    default HttpMetaData encoding(ContentCodec encoding) {
+        throw new UnsupportedOperationException("HttpMetaData#encoding(ContentCodec) is not supported by " +
+                getClass() + ". This method is deprecated, consider migrating to provided alternatives or implement " +
+                "this method if it's required temporarily.");
+    }
 
     /**
      * Returns the {@link ContentCodec} used to encode the payload of a request or a response.
      * @return The {@link ContentCodec} used for the encoding of the payload.
      * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.2.2">Content-Encoding</a>
-     * @deprecated Use {@link HttpRequestMetaData#contentEncoding()}.
+     * @deprecated Use {@link HttpRequestMetaData#contentEncoding()} for requests and
+     * {@link ContentEncodingHttpServiceFilter} for responses. An example can be found
+     * <a href="https://apple.github.io/servicetalk//servicetalk-examples/0.42/http/index.html#Compression">here</a>.
      */
     @Deprecated
     @Nullable
-    ContentCodec encoding();
+    default ContentCodec encoding() {
+        throw new UnsupportedOperationException("HttpMetaData#encoding() is not supported by " + getClass() +
+                ". This method is deprecated, consider migrating to provided alternatives or implement " +
+                "this method if it's required temporarily.");
+    }
 
     /**
      * Adds a new header with the specified {@code name} and {@code value}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
@@ -72,7 +72,12 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
      * @deprecated Use {@link #payloadBody(Object, HttpSerializer2)}.
      */
     @Deprecated
-    <T> HttpRequest payloadBody(T pojo, HttpSerializer<T> serializer);
+    default <T> HttpRequest payloadBody(T pojo, HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException("HttpRequest#payloadBody(Object, HttpSerializer) " +
+                "is not supported by " + getClass() + ". This method is deprecated, consider migrating to " +
+                "HttpRequest#payloadBody(Object, HttpSerializer2) or implement this method if it's required " +
+                "temporarily.");
+    }
 
     /**
      * Returns an {@link HttpRequest} with its underlying payload set to the results of serialization of {@code pojo}.
@@ -136,7 +141,11 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
 
     @Deprecated
     @Override
-    HttpRequest encoding(ContentCodec encoding);
+    default HttpRequest encoding(ContentCodec encoding) {
+        throw new UnsupportedOperationException("HttpRequest#encoding(ContentCodec) is not supported by " +
+                getClass() + ". This method is deprecated, consider migrating to provided alternatives or implement " +
+                "this method if it's required temporarily.");
+    }
 
     @Override
     HttpRequest contentEncoding(@Nullable BufferEncoder encoder);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpResponse.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.encoding.api.ContentCodec;
 
 /**
  * An HTTP response. The payload is represented as a single {@link Object}.
@@ -67,7 +68,12 @@ public interface HttpResponse extends HttpResponseMetaData, TrailersHolder {
      * @deprecated Use {@link #payloadBody(Object, HttpSerializer2)}.
      */
     @Deprecated
-    <T> HttpResponse payloadBody(T pojo, HttpSerializer<T> serializer);
+    default <T> HttpResponse payloadBody(T pojo, HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException("HttpResponse#payloadBody(Object, HttpSerializer) " +
+                "is not supported by " + getClass() + ". This method is deprecated, consider migrating to " +
+                "HttpResponse#payloadBody(Object, HttpSerializer2) or implement this method if it's required " +
+                "temporarily.");
+    }
 
     /**
      * Returns an {@link HttpResponse} with its underlying payload set to the results of serialization of {@code pojo}.
@@ -98,6 +104,13 @@ public interface HttpResponse extends HttpResponseMetaData, TrailersHolder {
 
     @Override
     HttpResponse status(HttpResponseStatus status);
+
+    @Override
+    default HttpResponse encoding(ContentCodec encoding) {
+        throw new UnsupportedOperationException("HttpResponse#encoding(ContentCodec) is not supported by " +
+                getClass() + ". This method is deprecated, consider migrating to provided alternatives or implement " +
+                "this method if it's required temporarily.");
+    }
 
     @Override
     default HttpResponse addHeader(final CharSequence name, final CharSequence value) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerChainBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StrategyInfluencerChainBuilder.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @deprecated Merge {@link io.servicetalk.transport.api.ExecutionStrategy} directly instead.
  */
-@Deprecated
+@Deprecated // FIXME: 0.43 - remove deprecated class
 public final class StrategyInfluencerChainBuilder implements ExecutionStrategyInfluencer<HttpExecutionStrategy> {
 
     private final Deque<ExecutionStrategyInfluencer<?>> influencers;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
@@ -98,7 +98,12 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
      * @deprecated Use {@link #payloadBody(Publisher, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> StreamingHttpRequest payloadBody(Publisher<T> payloadBody, HttpSerializer<T> serializer);
+    default <T> StreamingHttpRequest payloadBody(Publisher<T> payloadBody, HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException("StreamingHttpRequest#payloadBody(Publisher, HttpSerializer) " +
+                "is not supported by " + getClass() + ". This method is deprecated, consider migrating to " +
+                "StreamingHttpRequest#payloadBody(Publisher, HttpStreamingSerializer) or implement this " +
+                "method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link StreamingHttpRequest} with its underlying payload set to the result of serialization.
@@ -127,8 +132,13 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
      * @deprecated Use {@link #transformPayloadBody(Function, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> StreamingHttpRequest transformPayloadBody(Function<Publisher<Buffer>, Publisher<T>> transformer,
-                                                  HttpSerializer<T> serializer);
+    default <T> StreamingHttpRequest transformPayloadBody(Function<Publisher<Buffer>, Publisher<T>> transformer,
+                                                  HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException("StreamingHttpRequest#transformPayloadBody(Function, HttpSerializer) " +
+                "is not supported by " + getClass() + ". This method is deprecated, consider migrating to " +
+                "StreamingHttpRequest#transformPayloadBody(Function, HttpStreamingSerializer) or implement this " +
+                "method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link StreamingHttpRequest} with its underlying payload transformed to the result of serialization.
@@ -276,7 +286,11 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
 
     @Deprecated
     @Override
-    StreamingHttpRequest encoding(ContentCodec encoding);
+    default StreamingHttpRequest encoding(ContentCodec encoding) {
+        throw new UnsupportedOperationException("StreamingHttpRequest#encoding(ContentCodec) is not supported by " +
+                getClass() + ". This method is deprecated, consider migrating to provided alternatives or implement " +
+                "this method if it's required temporarily.");
+    }
 
     @Override
     StreamingHttpRequest contentEncoding(@Nullable BufferEncoder encoder);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpResponse.java
@@ -96,7 +96,12 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
      * @deprecated Use {@link #payloadBody(Publisher, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> StreamingHttpResponse payloadBody(Publisher<T> payloadBody, HttpSerializer<T> serializer);
+    default <T> StreamingHttpResponse payloadBody(Publisher<T> payloadBody, HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException("StreamingHttpResponse#payloadBody(Publisher, HttpSerializer) " +
+                "is not supported by " + getClass() + ". This method is deprecated, consider migrating to " +
+                "StreamingHttpResponse#payloadBody(Publisher, HttpStreamingSerializer) or implement this " +
+                "method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link StreamingHttpResponse} with its underlying payload set to the result of serialization.
@@ -125,8 +130,13 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
      * @deprecated Use {@link #transformPayloadBody(Function, HttpStreamingSerializer)}.
      */
     @Deprecated
-    <T> StreamingHttpResponse transformPayloadBody(Function<Publisher<Buffer>, Publisher<T>> transformer,
-                                                   HttpSerializer<T> serializer);
+    default <T> StreamingHttpResponse transformPayloadBody(Function<Publisher<Buffer>, Publisher<T>> transformer,
+                                                   HttpSerializer<T> serializer) {
+        throw new UnsupportedOperationException("StreamingHttpResponse#transformPayloadBody(Function, HttpSerializer)" +
+                " is not supported by " + getClass() + ". This method is deprecated, consider migrating to " +
+                "StreamingHttpResponse#transformPayloadBody(Function, HttpStreamingSerializer) or implement this " +
+                "method if it's required temporarily.");
+    }
 
     /**
      * Returns a {@link StreamingHttpResponse} with its underlying payload transformed to the result of serialization.
@@ -238,7 +248,11 @@ public interface StreamingHttpResponse extends HttpResponseMetaData {
 
     @Deprecated
     @Override
-    StreamingHttpResponse encoding(ContentCodec encoding);
+    default StreamingHttpResponse encoding(ContentCodec encoding) {
+        throw new UnsupportedOperationException("StreamingHttpResponse#encoding(ContentCodec) is not supported by " +
+                getClass() + ". This method is deprecated, consider migrating to provided alternatives or implement " +
+                "this method if it's required temporarily.");
+    }
 
     @Override
     default StreamingHttpResponse addHeader(final CharSequence name, final CharSequence value) {


### PR DESCRIPTION
Motivation:

Without providing a `default` implementation for methods that are
deprecated, users can not avoid using those in the codebase.

Modifications:

- Enhance gRPC code generator to add `default` impl for deprecated
client methods;
- Add all missed `default` implementations for deprecated methods of
`HttpMetaData` and its subclasses;

Result:

Users can avoid depending on deprecated methods in their codebase and
prepare for the next version.