### PR TITLE
`InOrderRouter` does not require offloading

### DIFF
--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/InOrderRouter.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/InOrderRouter.java
@@ -31,6 +31,7 @@ import io.servicetalk.transport.api.IoThreadFactory;
 import java.util.List;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -88,5 +89,11 @@ final class InOrderRouter implements StreamingHttpService {
     @Override
     public Completable closeAsyncGracefully() {
         return closeable.closeAsyncGracefully();
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        // We require no prior offloading and will handle offloading routes that require it.
+        return offloadNone();
     }
 }

--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/dsl/RouteStarter.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/dsl/RouteStarter.java
@@ -130,7 +130,7 @@ public interface RouteStarter {
     /**
      * Begin a route that matches {@link StreamingHttpRequest}s with a user-specified {@code predicate}.
      *
-     * @param predicate the predicate to evaluate against requests.
+     * @param predicate the predicate to evaluate against requests. This predicate must not block.
      * @return {@link RouteContinuation} for the next steps of building a route.
      */
     RouteContinuation when(Predicate<StreamingHttpRequest> predicate);
@@ -140,6 +140,7 @@ public interface RouteStarter {
      * {@code predicate}.
      *
      * @param predicate the predicate to evaluate against the request and connection context.
+     *                  This predicate must not block
      * @return {@link RouteContinuation} for the next steps of building a route.
      */
     RouteContinuation when(BiPredicate<ConnectionContext, StreamingHttpRequest> predicate);


### PR DESCRIPTION
Motivation:
The `InOrderRouter` did not formerly implement
`HttpExecutionStrategyInfluencer` and as a result it received full
offloading. It requires no offloading and will manually offload for
routes which specify requiring offloading.
Modifications:
Specify `offloadsNone()` as `requiredStrategy()` and adjust test
expectations that no offloading of predicate will be expected by
default. Update documentation to indicate that predicate
implementations must not block.
Result:
Potentially more efficient `InOrderRouter` which does less offloading
by default.