### PR TITLE
Clarify expectations for `TransportObserver` implementations

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLifecycleObserver.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLifecycleObserver.java
@@ -24,11 +24,11 @@ import io.servicetalk.transport.api.IoExecutor;
  * An observer interface that provides visibility into HTTP lifecycle events.
  * <p>
  * In order to deliver events at accurate time, callbacks on this interface can be invoked from the {@link IoExecutor}.
- * Implementation of this observer <b>must</b> be non-blocking. If the
- * consumer of events may block (uses a blocking library or
- * <a href="https://logging.apache.org/log4j/2.x/manual/async.html">logger configuration is not async</a>), it has to
- * offload publications to another {@link Executor} <b>after</b> capturing timing of events. If blocking code is
- * executed inside callbacks without offloading, it will negatively impact {@link IoExecutor}.
+ * Implementation of this observer <b>must</b> be non-blocking. If the consumer of events may block (uses a blocking
+ * library or <a href="https://logging.apache.org/log4j/2.x/manual/async.html">logger configuration is not async</a>),
+ * it has to offload publications to another {@link Executor} <b>after</b> capturing timing of events. If blocking code
+ * is executed inside callbacks without offloading, it will negatively impact {@link IoExecutor} and overall performance
+ * of the application.
  * <p>
  * To install this observer for the server use {@link HttpServerBuilder#lifecycleObserver(HttpLifecycleObserver)}, for
  * the client use {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)} with

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObserver.java
@@ -15,12 +15,20 @@
  */
 package io.servicetalk.transport.api;
 
+import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.transport.api.NoopTransportObserver.NoopConnectionObserver;
 
 import javax.annotation.Nullable;
 
 /**
  * An observer interface that provides visibility into transport events.
+ * <p>
+ * In order to deliver events at accurate time, callbacks on this interface can be invoked from the {@link IoExecutor}.
+ * Implementation of this observer <b>must</b> be non-blocking. If the consumer of events may block (uses a blocking
+ * library or <a href="https://logging.apache.org/log4j/2.x/manual/async.html">logger configuration is not async</a>),
+ * it has to offload publications to another {@link Executor} <b>after</b> capturing timing of events. If blocking code
+ * is executed inside callbacks without offloading, it will negatively impact {@link IoExecutor} and overall performance
+ * of the application.
  */
 public interface TransportObserver {
 


### PR DESCRIPTION
Motivation:

`TransportObserver` does not clarify if users can block or not inside
their implementations.

Modifications:

- Copy offloading requirements from `HttpLifecycleObserver` to
`TransportObserver`;

Result:

`TransportObserver` javadoc clarifies expectations for non-blocking
implementations and suggests to do manual offloading if necessary.