### PR TITLE
Migrate `ON_CONNECTION_SELECTED_CONSUMER` to request context

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.LoadBalancer;
-import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
@@ -73,7 +72,10 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
         // following the LoadBalancer API which this Client depends upon to ensure the concurrent request count state is
         // correct.
         return loadBalancer.selectConnection(SELECTOR_FOR_REQUEST, request.context()).flatMap(c -> {
-                final Consumer<ConnectionInfo> onConnectionSelected = AsyncContext.get(ON_CONNECTION_SELECTED_CONSUMER);
+                // Do not remove ON_CONNECTION_SELECTED_CONSUMER from the context to track new connection selections for
+                // retries and redirects.
+                final Consumer<ConnectionInfo> onConnectionSelected = request.context()
+                        .get(ON_CONNECTION_SELECTED_CONSUMER);
                 if (onConnectionSelected != null) {
                     onConnectionSelected.accept(c.connectionContext());
                 }


### PR DESCRIPTION
Motivation:

`AbstractLifecycleObserverHttpFilter` uses a secret
`ON_CONNECTION_SELECTED_CONSUMER` context key to capture the selected
connection down the processing chain. Instead of relying on
`AsyncContext` that can be disabled, we can use a context of the request.

Modifications:

- Store `ON_CONNECTION_SELECTED_CONSUMER` in `request.context()` instead
of `AsyncContext`;
- Use `Runnable` to clear the key on exchange finally;

Result:

`AbstractLifecycleObserverHttpFilter` will report `onConnectionSelected`
even if `AsyncContext` is disabled.