### PR TITLE
Make routers explicit about offloading behavior

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -93,6 +93,7 @@ import static io.servicetalk.grpc.api.GrpcUtils.setStatusOk;
 import static io.servicetalk.grpc.api.GrpcUtils.validateContentType;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
@@ -161,6 +162,20 @@ final class GrpcRouter {
             @Override
             public Completable closeAsyncGracefully() {
                 return closeable.closeAsyncGracefully();
+            }
+
+
+            /**
+             * {@inheritDoc}
+             * @return {@link HttpExecutionStrategies#offloadAll()} as default safe behavior for predicates and routes.
+             * Apps will typically use {@link HttpExecutionStrategies#offloadNone()} with
+             * {@link io.servicetalk.http.api.HttpServerBuilder#executionStrategy(HttpExecutionStrategy)} in
+             * {@link io.servicetalk.grpc.api.GrpcServerBuilder#initializeHttp(GrpcServerBuilder.HttpInitializer)} to
+             * override if either no offloading is required or diverse strategies are needed for various routes.
+             */
+            @Override
+            public HttpExecutionStrategy requiredOffloads() {
+                return offloadAll();
             }
         }).map(httpServerContext -> new DefaultGrpcServerContext(httpServerContext, executionContext));
     }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -164,7 +164,6 @@ final class GrpcRouter {
                 return closeable.closeAsyncGracefully();
             }
 
-
             /**
              * {@inheritDoc}
              * @return {@link HttpExecutionStrategies#offloadAll()} as default safe behavior for predicates and routes.

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribableSingle;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
+import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpServiceContext;
@@ -65,6 +66,7 @@ import static io.servicetalk.concurrent.api.Completable.failed;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
@@ -170,6 +172,18 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
                 return failed(t);
             }
         });
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return {@link HttpExecutionStrategies#offloadAll()} as default safe behavior. Apps
+     * will typically use {@link HttpExecutionStrategies#offloadNone()} as
+     * {@link io.servicetalk.http.api.HttpServerBuilder#executionStrategy(HttpExecutionStrategy)} to override if either
+     * no offloading is required or diverse strategies are needed for various routes.
+     */
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return offloadAll();
     }
 
     @Override

--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/InOrderRouter.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/InOrderRouter.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.api.AsyncCloseable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -31,6 +32,7 @@ import io.servicetalk.transport.api.IoThreadFactory;
 import java.util.List;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -78,6 +80,18 @@ final class InOrderRouter implements StreamingHttpService {
             }
         }
         return fallbackService.handle(ctx, request, factory);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return {@link HttpExecutionStrategies#offloadAll()} as default safe behavior for predicates and routes. Apps
+     * will typically use {@link HttpExecutionStrategies#offloadNone()} as
+     * {@link io.servicetalk.http.api.HttpServerBuilder#executionStrategy(HttpExecutionStrategy)} to override if either
+     * no offloading is required or diverse strategies are needed for various routes.
+     */
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return offloadAll();
     }
 
     @Override


### PR DESCRIPTION
Motivation:
The `InOrderRouter` (aka predicate router), GRPC and Jersey routers
inherit default `requiredOffloads()` of `offloadAll()` from
`HttpStreamingService`. This behavior should be explicit.
Modifications:
Add implementations of `requiredOffloads()` returning `offloadAll()` with
documentation explaining the behavior and suggestions for handling
non-offloading requirements.
Result:
Explicit rather than implicit behavior.