### PR TITLE
`HttpResponseObserver`: add default impl for `onResponseDataRequested`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLifecycleObserver.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLifecycleObserver.java
@@ -177,7 +177,8 @@ public interface HttpLifecycleObserver {
          *
          * @param n number of requested items
          */
-        void onResponseDataRequested(long n);   // FIXME: 0.43 - consider removing default impl
+        default void onResponseDataRequested(long n) {  // FIXME: 0.43 - consider removing default impl
+        }
 
         /**
          * Callback when the response payload body data chunk was observed.


### PR DESCRIPTION
Motivation:

When we added two new callbacks in #2230, we forgot to add a default
impl for one of them.

Modifications:

- Add default noop impl for
`HttpResponseObserver#onResponseDataRequested(long)`;

Result:

`HttpResponseObserver` is backward compatible for existing users.