### PR TITLE
Return `ExecutionContext` with correct strategy

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClientBuilder.java
@@ -30,7 +30,7 @@ import io.servicetalk.transport.api.IoExecutor;
 interface HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> {
 
     /**
-     * Sets the {@link Executor} for all connections created from this builder.
+     * Sets the {@link Executor} for all clients created from this builder.
      *
      * @param executor {@link IoExecutor} to use.
      * @return {@code this}.
@@ -38,7 +38,7 @@ interface HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> {
     HttpClientBuilder<U, R, SDE> executor(Executor executor);
 
     /**
-     * Sets the {@link IoExecutor} for all connections created from this builder.
+     * Sets the {@link IoExecutor} for all clients created from this builder.
      *
      * @param ioExecutor {@link IoExecutor} to use.
      * @return {@code this}.
@@ -46,7 +46,7 @@ interface HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> {
     HttpClientBuilder<U, R, SDE> ioExecutor(IoExecutor ioExecutor);
 
     /**
-     * Sets the {@link BufferAllocator} for all connections created from this builder.
+     * Sets the {@link BufferAllocator} for all clients created from this builder.
      *
      * @param allocator {@link BufferAllocator} to use.
      * @return {@code this}.
@@ -54,9 +54,12 @@ interface HttpClientBuilder<U, R, SDE extends ServiceDiscovererEvent<R>> {
     HttpClientBuilder<U, R, SDE> bufferAllocator(BufferAllocator allocator);
 
     /**
-     * Sets the {@link HttpExecutionStrategy} for all connections created from this builder.
+     * Sets the {@link HttpExecutionStrategy} to be used for client callbacks when executing client requests for all
+     * clients created from this builder.
      *
-     * @param strategy {@link HttpExecutionStrategy} to use.
+     * @param strategy {@link HttpExecutionStrategy} to use. If callbacks to the application code may block then those
+     * callbacks must request to be offloaded.
+     *
      * @return {@code this}.
      * @see HttpExecutionStrategies
      */

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractBlockingStreamingHttpRequesterTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractBlockingStreamingHttpRequesterTest.java
@@ -36,6 +36,7 @@ import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -75,6 +76,7 @@ public abstract class AbstractBlockingStreamingHttpRequesterTest {
     void setup() {
         MockitoAnnotations.initMocks(this);
         when(mockExecutionCtx.executor()).thenReturn(immediate());
+        when(mockExecutionCtx.executionStrategy()).thenReturn(defaultStrategy());
         when(mockCtx.executionContext()).thenReturn(mockExecutionCtx);
         when(mockIterable.iterator()).thenReturn(mockIterator);
     }

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
@@ -44,6 +44,7 @@ import static io.servicetalk.http.api.AbstractHttpRequesterFilterTest.SecurityTy
 import static io.servicetalk.http.api.AbstractHttpRequesterFilterTest.SecurityType.Secure;
 import static io.servicetalk.http.api.FilterFactoryUtils.appendClientFilterFactory;
 import static io.servicetalk.http.api.FilterFactoryUtils.appendConnectionFilterFactory;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -90,6 +91,7 @@ public abstract class AbstractHttpRequesterFilterTest {
     }
 
     protected void setUp(SecurityType security) {
+        lenient().when(mockExecutionContext.executionStrategy()).thenReturn(defaultStrategy());
         lenient().when(mockConnectionContext.sslSession()).thenAnswer(__ -> {
             switch (security) {
                 case Secure:

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -121,7 +121,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
                     new RedirectingHttpRequesterFilter(redirectConfig).create(urlClient);
 
             LOGGER.debug("Multi-address client created with base strategy {}", executionContext.executionStrategy());
-            return new FilterableClientToClient(urlClient, executionContext.executionStrategy());
+            return new FilterableClientToClient(urlClient, executionContext);
         } catch (final Throwable t) {
             closeables.closeAsync().subscribe();
             throw t;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -132,7 +132,7 @@ final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttp
                         executionContext, partitionMapFactory);
 
         LOGGER.debug("Partitioned client created with base strategy {}", executionContext.executionStrategy());
-        return new FilterableClientToClient(partitionedClient, executionContext.executionStrategy());
+        return new FilterableClientToClient(partitionedClient, executionContext);
     }
 
     private static final class DefaultPartitionedStreamingHttpClientFilter<U, R> implements


### PR DESCRIPTION
Motivation:
`FilterableClientToClient` uses a provided `HttpExecutionStrategy` with
the underlying client but the `executionContext()` method returns an
`ExecutionContext` of the underlying client rather than the context and
strategy it is using.
Modifications:
Accept an `ExecutionContext` rather than an `ExecutionStrategy` and
return the context for `executionContext()`.
Result:
Accurate `executionContext()` result.