### PR TITLE
Don't disable HTTP 1.1 in debugging example

### DIFF
--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
@@ -30,6 +30,7 @@ import io.grpc.examples.debugging.HelloRequest;
 
 import java.util.function.BooleanSupplier;
 
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
@@ -149,7 +150,7 @@ public final class DebuggingClient {
                          * Be sure to also enable the logger in your logging config file,
                          * {@code log4j2.xml} for this example.
                          */
-                        .protocols(HttpProtocolConfigs.h2()
+                        .protocols(h1Default(), HttpProtocolConfigs.h2()
                                 .enableFrameLogging(
                                         "servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
                                 .build()))

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
@@ -24,6 +24,7 @@ import io.grpc.examples.debugging.HelloReply;
 
 import java.util.function.BooleanSupplier;
 
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
@@ -148,7 +149,7 @@ public final class DebuggingServer {
                              * Be sure to also enable the logger in your logging config file,
                              * {@code log4j2.xml} for this example.
                              */
-                            .protocols(HttpProtocolConfigs.h2()
+                            .protocols(h1Default(), HttpProtocolConfigs.h2()
                                     .enableFrameLogging(
                                             "servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
                                     .build());

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -27,6 +27,7 @@ import io.servicetalk.logging.api.LogLevel;
 import java.util.function.BooleanSupplier;
 
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
@@ -175,7 +176,7 @@ public final class DebuggingExampleClient {
                  * 4. Enables detailed logging of HTTP2 frames.
                  * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
                  */
-                .protocols(HttpProtocolConfigs.h2()
+                .protocols(h1Default(), HttpProtocolConfigs.h2()
                         .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
                         .build())
                 .build()) {

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -27,6 +27,7 @@ import java.util.function.BooleanSupplier;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 
 /**
@@ -170,7 +171,7 @@ public final class DebuggingExampleServer {
                  * 4. Enables detailed logging of HTTP2 frames.
                  * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
                  */
-                .protocols(HttpProtocolConfigs.h2()
+                .protocols(h1Default(), HttpProtocolConfigs.h2()
                         .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
                         .build())
                 .listenAndAwait((ctx, request, responseFactory) -> {


### PR DESCRIPTION
Motivation:
The debugging examples show logging configuration of HTTP1 but do not
enable the protocol in the `protocols()` invocation.
Modifications:
Ensure that HTTP 1.1 is enabled.
Result:
Example is less likely to cause problems if used as cut-and-paste code