### PR TITLE
Allow no SP after status-code for HTTP/1.x responses

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -69,6 +69,11 @@ class HttpRequestDecoderTest extends HttpObjectDecoderTest {
     }
 
     @Override
+    boolean isDecodingRequest() {
+        return true;
+    }
+
+    @Override
     String startLine() {
         return "GET / HTTP/1.1";
     }


### PR DESCRIPTION
Motivation:

While RFC7230, section 3.1.2
(https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.2) requires a
`SP` before a `reason-phrase`, even if it's an empty phrase, many
implementations don't include that `SP` character. Many clients parse a
response without trailing `SP` character with no error. Those
implementations are:
 - Apache HTTP Client
 - JDK HttpClient
 - Netty
 - Tomcat (https://bz.apache.org/bugzilla/show_bug.cgi?id=60362)
 - Go HttpClient (https://github.com/golang/go/commit/d71d08af5ab15c7b166d92a31219c4c218438841#diff-0e6945dfde3e4dcaba7cfd394a85328b8137c42e152b4486dbfb6756ad69a779R145-R146)
 - Rust HttpClient (https://github.com/hyperium/http/issues/345)
 - httpd with Passenger (https://bugzilla.redhat.com/show_bug.cgi?id=1032733)

Moreover, neither HTTP/2 nor HTTP/3 support reason-phrase. For this
reasons, many HTTP/1.x implementations (Tomcat, Rust, etc.) decided to
drop including the reason-phrase in serialized response for performance
reasons. Instead, they use the reason-phrase defined by RFC for all
known status codes and use `Unknown` for non-standard status codes.

Modifications:

- `HttpObjectDecoder`: second `SP` is optional for `HttpResponseDecoder`;
- Enhance tests to verify new behavior;

Result:

ServiceTalk HttpClient parses responses with no `SP` after status code.
Example: `HTTP/1.1 200\r\n`.