### PR TITLE
Update Pitest 1.7.0 → 1.7.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ testngVersion=7.4.0
 hamcrestVersion=2.2
 mockitoCoreVersion=4.3.1
 spotbugsPluginVersion=5.0.6
-pitestPluginVersion=1.7.0
+pitestPluginVersion=1.7.4
 
 apacheDirectoryServerVersion=1.5.7
 commonsLangVersion=2.6

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
@@ -23,7 +23,7 @@ final class Versions {
   static final String CHECKSTYLE_VERSION = "9.2"
   static final String PMD_VERSION = "6.41.0"
   static final String SPOTBUGS_VERSION = "4.7.0"
-  static final String PITEST_VERSION = "1.7.3"
-  static final String PITEST_JUNIT5_PLUGIN_VERSION = "0.15"
+  static final String PITEST_VERSION = "1.7.4"
+  static final String PITEST_JUNIT5_PLUGIN_VERSION = "0.16"
   static final JavaVersion TARGET_VERSION = VERSION_1_8
 }


### PR DESCRIPTION
Motivation:
Updated Pitest plugin for JUnit5 fixes issue with ignored errors. Other
components also out-of-date.
Modifications:
Update Pitest gradle plugin, Pitest library and Pitest JUnit5 plugin.
Result:
Improved Pitest suppport