### PR TITLE
Link to `servicetalk/examples` repo

### DIFF
--- a/servicetalk-examples/README.adoc
+++ b/servicetalk-examples/README.adoc
@@ -3,8 +3,7 @@
 This repository is a collection of examples on how to use different facets of ServiceTalk.
 See the https://docs.servicetalk.io/[ServiceTalk docs] for more information.
 
-Note that these projects use direct references to other ServiceTalk projects,
-as shown here:
+Note that these projects use direct references to other ServiceTalk projects, as shown here:
 
 [source,groovy]
 ----
@@ -13,15 +12,16 @@ implementation project(":servicetalk-http-netty")
 implementation project(":servicetalk-http-utils")
 ----
 
-In actual user projects, ServiceTalk modules would be referenced via standard artifacts coordinates,
-with the versions managed thanks to the provided BOM, as demonstrated here:
+Standalone projects using ServiceTalk will reference the ServiceTalk modules using standard artifacts coordinates as
+shown below. A separate https://github.com/servicetalk/examples[ServiceTalk examples repository] demonstrates how to
+reference ServiceTalk modules in typical projects.
 
 [source,groovy]
 ----
-// `servicetalk-bom` brings consistent versions of ServiceTalk modules.
-implementation platform("io.servicetalk:servicetalk-bom:$serviceTalkVersion")
+// `servicetalk-dependencies` brings consistent versions of ServiceTalk modules and required external dependencies
+implementation platform("io.servicetalk:servicetalk-dependencies:$serviceTalkVersion")
 
-// The version for all ServiceTalk dependencies will be resolved based on information in `servicetalk-bom`.
+// The version for all ServiceTalk dependencies will be resolved based on information in `servicetalk-dependencies`.
 implementation "io.servicetalk:servicetalk-annotations"
 implementation "io.servicetalk:servicetalk-http-netty"
 implementation "io.servicetalk:servicetalk-http-utils"


### PR DESCRIPTION
Motivation:
The `servicetalk/examples` repository contains examples of standalone
Gradle and Maven projects that import ServiceTalk without using the
related module "project" notation but use the more typical artifact
coordinate notation. We should provide a link to those examples.
Modifications:
Add reference to `[servicetalk-examples](https://github.com/servicetalk/examples)`
repository.
Result:
More linking between examples.