### PR TITLE
Remove reference to obsolete gRPC plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -33,11 +33,9 @@ sourceSets {
   main {
     groovy {
       srcDir "../servicetalk-gradle-plugin-internal/src/main/groovy"
-      srcDir "../servicetalk-grpc-gradle-plugin/src/main/groovy"
     }
     resources {
       srcDir "../servicetalk-gradle-plugin-internal/src/main/resources"
-      srcDir "../servicetalk-grpc-gradle-plugin/src/main/resources"
     }
   }
 }


### PR DESCRIPTION
Motivation:
There was formerly a Gradle plugin for gRPC that was removed in 0.32
but references to the plugin still exist in the source code.
Modifications:
Remove references to obsolete gRPC Gradle plugin
Result:
Cleaner source code.