### PR TITLE
Increase object count in CompositeClosableTest

### DIFF
--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeClosableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompositeClosableTest.java
@@ -34,7 +34,7 @@ final class CompositeClosableTest {
     void sameOperationDoesNotSOE(boolean merge, boolean gracefully) throws Exception {
         AsyncCloseable mockClosable = newMock("asyncCloseable");
         CompositeCloseable compositeCloseable = newCompositeCloseable();
-        for (int i = 0; i < 10000; ++i) {
+        for (int i = 0; i < 100000; ++i) {
             if (merge) {
                 compositeCloseable.merge(mockClosable);
             } else {
@@ -54,7 +54,7 @@ final class CompositeClosableTest {
     void alternatingOperationSOE(boolean gracefully) {
         AsyncCloseable mockClosable = newMock("asyncCloseable");
         CompositeCloseable compositeCloseable = newCompositeCloseable();
-        for (int i = 0; i < 10000; ++i) {
+        for (int i = 0; i < 100000; ++i) {
             if ((i & 1) == 0) {
                 compositeCloseable.merge(mockClosable);
             } else {


### PR DESCRIPTION
Motivation:
CompositeClosableTest.alternatingOperationSOE on macOS M1 machine
doesn't stack overflow, and therefore the test fails.

Modifications:
- Add more objects to increase likelihood of SOE.