### PR TITLE
`TracingHttpServiceFilter` should implement `requiredOffloads()`

### DIFF
--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilter.java
@@ -124,7 +124,6 @@ public class TracingHttpRequesterFilter extends AbstractTracingHttpFilter
 
     @Override
     public HttpExecutionStrategy requiredOffloads() {
-        // No influence since we do not block.
         return HttpExecutionStrategies.offloadNone();
     }
 

--- a/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
+++ b/servicetalk-opentracing-http/src/main/java/io/servicetalk/opentracing/http/TracingHttpServiceFilter.java
@@ -17,6 +17,7 @@ package io.servicetalk.opentracing.http;
 
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
@@ -42,6 +43,7 @@ import static io.opentracing.tag.Tags.HTTP_METHOD;
 import static io.opentracing.tag.Tags.HTTP_URL;
 import static io.opentracing.tag.Tags.SPAN_KIND;
 import static io.opentracing.tag.Tags.SPAN_KIND_SERVER;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 
 /**
  * A {@link StreamingHttpService} that supports open tracing.
@@ -104,6 +106,11 @@ public class TracingHttpServiceFilter extends AbstractTracingHttpFilter implemen
                 return trackRequest(delegate(), ctx, request, responseFactory);
             }
         };
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return offloadNone();
     }
 
     private Single<StreamingHttpResponse> trackRequest(final StreamingHttpService delegate,

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/ExecutionStrategyTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/ExecutionStrategyTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentracing.http;
+
+import io.servicetalk.opentracing.inmemory.DefaultInMemoryTracer;
+
+import io.opentracing.Tracer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ExecutionStrategyTest {
+
+    @Nullable
+    private static Tracer tracer;
+
+    @BeforeAll
+    static void setUp() {
+        tracer = new DefaultInMemoryTracer.Builder(SCOPE_MANAGER).build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (tracer != null) {
+            tracer.close();
+        }
+    }
+
+    @Test
+    void serviceFilter() {
+        assert tracer != null;
+        assertThat(new TracingHttpServiceFilter(tracer, "test").requiredOffloads(), is(offloadNone()));
+    }
+
+    @Test
+    void requesterFilter() {
+        assert tracer != null;
+        assertThat(new TracingHttpRequesterFilter(tracer, "test").requiredOffloads(), is(offloadNone()));
+    }
+}


### PR DESCRIPTION
Motivation:

Currently, `TracingHttpServiceFilter` inherits default implementation of
`requiredOffloads()` which enabled offloading. However, this filter is
non-blocking.

Modifications:

- Implement `TracingHttpServiceFilter#requiredOffloads()` that returns
`offloadNone()` strategy;

Result:

`TracingHttpServiceFilter` correctly identifies itself as a non-blocking
filter.