### PR TITLE
`TimeoutHttpRequesterFilter` as a connection filter causes `ClosedChannelException`

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,11 +158,8 @@ public final class TimeoutHttpServiceFilter extends AbstractTimeoutHttpFilter
             public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                         final StreamingHttpRequest request,
                                                         final StreamingHttpResponseFactory responseFactory) {
-                HttpExecutionContext executionContext = ctx.executionContext();
                 return TimeoutHttpServiceFilter.this.withTimeout(request,
-                        r -> delegate().handle(ctx, r, responseFactory),
-                        executionContext.executionStrategy().hasOffloads() ?
-                                executionContext.executor() : executionContext.ioExecutor());
+                        r -> delegate().handle(ctx, r, responseFactory), ctx.executionContext());
             }
         };
     }

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,14 +27,19 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 
+import org.junit.jupiter.api.Timeout;
+
 import java.time.Duration;
 import java.util.function.BiFunction;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Timeout(3)
 public class TimeoutHttpRequesterFilterTest extends AbstractTimeoutHttpFilterTest {
 
     @Override
@@ -67,9 +72,12 @@ public class TimeoutHttpRequesterFilterTest extends AbstractTimeoutHttpFilterTes
 
         HttpConnectionContext connectionContext = mock(HttpConnectionContext.class);
         when(connectionContext.executionContext()).thenReturn(executionContext);
+        when(connectionContext.protocol()).thenReturn(HTTP_1_1);
         FilterableStreamingHttpConnection connection = mock(FilterableStreamingHttpConnection.class);
+        when(connection.connectionContext()).thenReturn(connectionContext);
         when(connection.executionContext()).thenReturn(executionContext);
         when(connection.request(any())).thenReturn(responseSingle);
+        when(connection.closeAsync()).thenReturn(completed());
 
         StreamingHttpRequester requester = filterFactory.create(connection);
         return requester.request(mock(StreamingHttpRequest.class));


### PR DESCRIPTION
Motivation:

If applied as a connection-level filter, it skips the logic defined in
`LoadBalancedStreamingHttpClient` for the cancellation. Cancel will be
scheduled on the event-loop, then `onError` is propagated.
`LoadBalancedStreamingHttpClient` will mark the request as finished, it
won’t see cancel. As the result, the same connection can be selected for
another request, and users see `ClosedChannelException`.

Modifications:

- For `StreamingHttpConnectionFilterFactory` variant used for HTTP/1.X
connections, apply `BeforeFinallyHttpOperator` with `cancel` callback
similar to `LoadBalancedStreamingHttpClient`;
- Enhance mocks to account for new behavior;
- Move the common logic of extracting a fallback executor as a static
method in `AbstractTimeoutHttpFilter`;

Result:

HTTP/1.X requests don't fail with `ClosedChannelException` if a previous
request on the same connection times out.