### PR TITLE
Deprecate internal classes related to partitioning

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/DefaultPartitionAttributesBuilder.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/DefaultPartitionAttributesBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.client.api.internal.partition;
 
+import io.servicetalk.client.api.ClientGroup;
 import io.servicetalk.client.api.partition.DuplicateAttributeException;
 import io.servicetalk.client.api.partition.PartitionAttributes;
 import io.servicetalk.client.api.partition.PartitionAttributes.Key;
@@ -35,7 +36,12 @@ import static java.util.Arrays.copyOf;
  * {@link PartitionAttributes}. The goals are to provide fast {@link Object#equals(Object)} and
  * {@link Object#hashCode()} which do not require intermediate object allocation and pointer traversal
  * (e.g. {@link Iterator}).
+ *
+ * @deprecated We are unaware of anyone using "partition" feature and plan to remove it in future releases.
+ * If you depend on it, consider using {@link ClientGroup} as an alternative or reach out to the maintainers describing
+ * the use-case.
  */
+@Deprecated
 public final class DefaultPartitionAttributesBuilder implements PartitionAttributesBuilder {
     private static final int PARENT_MASK = ~0x1;
     private Object[] keyValueArray;

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMap.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMap.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.client.api.internal.partition;
 
+import io.servicetalk.client.api.ClientGroup;
 import io.servicetalk.client.api.partition.PartitionAttributes;
 import io.servicetalk.client.api.partition.PartitionAttributesBuilder;
 import io.servicetalk.client.api.partition.PartitionMap;
@@ -42,8 +43,13 @@ import static java.util.Objects.requireNonNull;
 /**
  * A {@link PartitionMap} that creates the full power set using the individual attributes in
  * {@link PartitionAttributes}es to create partitions for each {@link #add(PartitionAttributes)}.
+ *
  * @param <T> The partition type.
+ * @deprecated We are unaware of anyone using "partition" feature and plan to remove it in future releases.
+ * If you depend on it, consider using {@link ClientGroup} as an alternative or reach out to the maintainers describing
+ * the use-case.
  */
+@Deprecated
 public final class PowerSetPartitionMap<T extends AsyncCloseable> implements PartitionMap<T> {
     private static final byte CLOSED_GRACEFULLY = 1;
     private static final byte HARD_CLOSE = 2;

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMapFactory.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMapFactory.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.client.api.internal.partition;
 
+import io.servicetalk.client.api.ClientGroup;
 import io.servicetalk.client.api.partition.PartitionAttributes;
 import io.servicetalk.client.api.partition.PartitionMap;
 import io.servicetalk.client.api.partition.PartitionMapFactory;
@@ -24,7 +25,12 @@ import java.util.function.Function;
 
 /**
  * A {@link PartitionMapFactory} that generates {@link PowerSetPartitionMap} type objects.
+ *
+ * @deprecated We are unaware of anyone using "partition" feature and plan to remove it in future releases.
+ * If you depend on it, consider using {@link ClientGroup} as an alternative or reach out to the maintainers describing
+ * the use-case.
  */
+@Deprecated
 public final class PowerSetPartitionMapFactory implements PartitionMapFactory {
     /**
      * Singleton instance.


### PR DESCRIPTION
Motivation:

All public classes and interfaces that target partitioning feature were
deprecated in #2131.

Modification:

- Deprecate everything inside
`io.servicetalk.client.api.internal.partition` package;

Result:

All internal classes related to partitioning are deprecated too.