### PR TITLE
`LoadBalancedStreamingHttpConnection` doesn't need connect strategy

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -233,16 +233,16 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
             ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> connectionFactoryFilter =
                     ctx.builder.connectionFactoryFilter;
-            ExecutionStrategy connectionFactoryStrategy =
+            final ExecutionStrategy connectionFactoryStrategy =
                     ctx.builder.strategyComputation.buildForConnectionFactory();
 
             final SslContext sslContext = roConfig.tcpConfig().sslContext();
             if (roConfig.hasProxy() && sslContext != null) {
                 assert roConfig.connectAddress() != null;
-                ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> proxy =
+                final ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> proxy =
                         new ProxyConnectConnectionFactoryFilter<>(roConfig.connectAddress());
+                assert !proxy.requiredOffloads().hasOffloads();
                 connectionFactoryFilter = proxy.append(connectionFactoryFilter);
-                connectionFactoryStrategy = connectionFactoryStrategy.merge(proxy.requiredOffloads());
             }
 
             final HttpExecutionStrategy builderStrategy = executionContext.executionStrategy();


### PR DESCRIPTION
Motivation:

The `connectStrategy` propagated to `AbstractLBHttpConnectionFactory`
should be used only for `newConnection` operation, but not for the
conversions inside `LoadBalancedStreamingHttpConnection`. That strategy
has to be taken from the `ExecutionContext` that takes into account
all filters that are applied to a reserved connection.

Modifications:

- `LoadBalancedStreamingHttpConnection` uses a strategy from execution
context instead of a `connectStrategy`;
- Validate `protocolBinding` in `AbstractLBHttpConnectionFactory` before
allocating `filterableConnectionFactory`;
- Skip the merge of `connectionFactoryStrategy` with
`ProxyConnectConnectionFactoryFilter` bcz we know the internal filters
never block or modify the strategy;

Result:

`LoadBalancedStreamingHttpConnection` uses the correct strategy for
conversions.