### PR TITLE
Do not update user's upstream branch

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -182,7 +182,7 @@ if [[ "$BRANCH_NAME" == "$DEFAULT_BRANCH" ]]; then
 fi
 
 $git commit -a -m "Preparing for $nextVersion development"
-$git push -u ${remote_name} "$BRANCH_NAME"
+$git push ${remote_name} "$BRANCH_NAME"
 # Push tag after branch otherwise, CodeQL GH Action will fail.
 $git push ${remote_name} "$version"
 


### PR DESCRIPTION
Motivation:
The `release.sh` script when pushing version update commit updates the
upstream branch.
Modifications:
Push but do not update the upstream branch.
Result:
No unexpected change of upstream.