### PR TITLE
Implement `toString()` for `HttpProtocolConfig` and its components

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,8 +88,8 @@ public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
 
     @Override
     public String toString() {
-        return "DefaultHttpHeadersFactory{" +
-                "validateNames=" + validateNames +
+        return getClass().getSimpleName() +
+                "{validateNames=" + validateNames +
                 ", validateCookies=" + validateCookies +
                 ", validateValues=" + validateValues +
                 ", headersArraySizeHint=" + headersArraySizeHint +

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
@@ -85,4 +85,15 @@ public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
     public boolean validateValues() {
         return validateValues;
     }
+
+    @Override
+    public String toString() {
+        return "DefaultHttpHeadersFactory{" +
+                "validateNames=" + validateNames +
+                ", validateCookies=" + validateCookies +
+                ", validateValues=" + validateValues +
+                ", headersArraySizeHint=" + headersArraySizeHint +
+                ", trailersArraySizeHint=" + trailersArraySizeHint +
+                '}';
+    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020, 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,5 +45,14 @@ final class DefaultKeepAlivePolicy implements KeepAlivePolicy {
     @Override
     public boolean withoutActiveStreams() {
         return withoutActiveStreams;
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultKeepAlivePolicy{" +
+                "idleDuration=" + idleDuration +
+                ", ackTimeout=" + ackTimeout +
+                ", withoutActiveStreams=" + withoutActiveStreams +
+                '}';
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultKeepAlivePolicy.java
@@ -49,8 +49,8 @@ final class DefaultKeepAlivePolicy implements KeepAlivePolicy {
 
     @Override
     public String toString() {
-        return "DefaultKeepAlivePolicy{" +
-                "idleDuration=" + idleDuration +
+        return getClass().getSimpleName() +
+                "{idleDuration=" + idleDuration +
                 ", ackTimeout=" + ackTimeout +
                 ", withoutActiveStreams=" + withoutActiveStreams +
                 '}';

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
@@ -211,5 +211,19 @@ public final class H1ProtocolConfigBuilder {
         public H1SpecExceptions specExceptions() {
             return specExceptions;
         }
+
+        @Override
+        public String toString() {
+            return "DefaultH1ProtocolConfig{" +
+                    "alpnId=" + alpnId() +
+                    ", headersFactory=" + headersFactory +
+                    ", maxPipelinedRequests=" + maxPipelinedRequests +
+                    ", maxStartLineLength=" + maxStartLineLength +
+                    ", maxHeaderFieldLength=" + maxHeaderFieldLength +
+                    ", headersEncodedSizeEstimate=" + headersEncodedSizeEstimate +
+                    ", trailersEncodedSizeEstimate=" + trailersEncodedSizeEstimate +
+                    ", specExceptions=" + specExceptions +
+                    '}';
+        }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020, 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -214,8 +214,8 @@ public final class H1ProtocolConfigBuilder {
 
         @Override
         public String toString() {
-            return "DefaultH1ProtocolConfig{" +
-                    "alpnId=" + alpnId() +
+            return getClass().getSimpleName() +
+                    "{alpnId=" + alpnId() +
                     ", headersFactory=" + headersFactory +
                     ", maxPipelinedRequests=" + maxPipelinedRequests +
                     ", maxStartLineLength=" + maxStartLineLength +

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,8 +56,8 @@ public final class H1SpecExceptions {
 
     @Override
     public String toString() {
-        return "H1SpecExceptions{" +
-                "allowPrematureClosureBeforePayloadBody=" + allowPrematureClosureBeforePayloadBody +
+        return getClass().getSimpleName() +
+                "{allowPrematureClosureBeforePayloadBody=" + allowPrematureClosureBeforePayloadBody +
                 ", allowLFWithoutCR=" + allowLFWithoutCR +
                 '}';
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
@@ -54,6 +54,14 @@ public final class H1SpecExceptions {
         return allowLFWithoutCR;
     }
 
+    @Override
+    public String toString() {
+        return "H1SpecExceptions{" +
+                "allowPrematureClosureBeforePayloadBody=" + allowPrematureClosureBeforePayloadBody +
+                ", allowLFWithoutCR=" + allowLFWithoutCR +
+                '}';
+    }
+
     /**
      * Builder for {@link H1SpecExceptions}.
      */

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,8 +95,8 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
 
     @Override
     public String toString() {
-        return "H2HeadersFactory{" +
-                "validateNames=" + validateNames +
+        return getClass().getSimpleName() +
+                "{validateNames=" + validateNames +
                 ", validateCookies=" + validateCookies +
                 ", validateValues=" + validateValues +
                 ", headersArraySizeHint=" + headersArraySizeHint +

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
@@ -20,8 +20,6 @@ import io.servicetalk.http.api.HttpHeadersFactory;
 
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 
-import java.util.function.BiPredicate;
-
 /**
  * A {@link HttpHeadersFactory} optimized for HTTP/2.
  */
@@ -29,8 +27,6 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
 
     private static final boolean DEFAULT_VALIDATE_VALUES = false;
     public static final HttpHeadersFactory INSTANCE = new H2HeadersFactory(true, true, DEFAULT_VALIDATE_VALUES);
-
-    static final BiPredicate<CharSequence, CharSequence> DEFAULT_SENSITIVITY_DETECTOR = (name, value) -> false;
 
     private final boolean validateNames;
     private final boolean validateCookies;
@@ -95,5 +91,16 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
     @Override
     public boolean validateValues() {
         return validateValues;
+    }
+
+    @Override
+    public String toString() {
+        return "H2HeadersFactory{" +
+                "validateNames=" + validateNames +
+                ", validateCookies=" + validateCookies +
+                ", validateValues=" + validateValues +
+                ", headersArraySizeHint=" + headersArraySizeHint +
+                ", trailersArraySizeHint=" + trailersArraySizeHint +
+                '}';
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -26,7 +26,6 @@ import java.util.function.BiPredicate;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.http.netty.H2HeadersFactory.DEFAULT_SENSITIVITY_DETECTOR;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.DISABLE_KEEP_ALIVE;
 import static java.util.Objects.requireNonNull;
 
@@ -36,6 +35,8 @@ import static java.util.Objects.requireNonNull;
  * @see HttpProtocolConfigs#h2()
  */
 public final class H2ProtocolConfigBuilder {
+
+    private static final BiPredicate<CharSequence, CharSequence> DEFAULT_SENSITIVITY_DETECTOR = (name, value) -> false;
 
     private HttpHeadersFactory headersFactory = H2HeadersFactory.INSTANCE;
     private BiPredicate<CharSequence, CharSequence> headersSensitivityDetector = DEFAULT_SENSITIVITY_DETECTOR;
@@ -151,6 +152,18 @@ public final class H2ProtocolConfigBuilder {
         @Override
         public KeepAlivePolicy keepAlivePolicy() {
             return keepAlivePolicy;
+        }
+
+        @Override
+        public String toString() {
+            return "DefaultH2ProtocolConfig{" +
+                    "alpnId=" + alpnId() +
+                    ", headersFactory=" + headersFactory +
+                    ", headersSensitivityDetector=" + (headersSensitivityDetector == DEFAULT_SENSITIVITY_DETECTOR ?
+                            "DEFAULT_SENSITIVITY_DETECTOR" : headersSensitivityDetector.toString()) +
+                    ", frameLoggerConfig=" + frameLoggerConfig +
+                    ", keepAlivePolicy=" + keepAlivePolicy +
+                    '}';
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,8 +156,8 @@ public final class H2ProtocolConfigBuilder {
 
         @Override
         public String toString() {
-            return "DefaultH2ProtocolConfig{" +
-                    "alpnId=" + alpnId() +
+            return getClass().getSimpleName() +
+                    "{alpnId=" + alpnId() +
                     ", headersFactory=" + headersFactory +
                     ", headersSensitivityDetector=" + (headersSensitivityDetector == DEFAULT_SENSITIVITY_DETECTOR ?
                             "DEFAULT_SENSITIVITY_DETECTOR" : headersSensitivityDetector.toString()) +


### PR DESCRIPTION
Motivation:

For easier debugging and visibility of the internal state of the
`HttpProtocolConfig` implementations and its subcomponents.

Modifications:

- Implement `toString()` for `DefaultH1ProtocolConfig`,
`DefaultH2ProtocolConfig`, `DefaultHttpHeadersFactory`,
`H2HeadersFactory`, `DefaultKeepAlivePolicy`, `H1SpecExceptions`;

Result:

Users can log intercepted configurations to see what is inside.