### PR TITLE
servicetalk-bom to include internal depdencies as API

### DIFF
--- a/servicetalk-bom/build.gradle
+++ b/servicetalk-bom/build.gradle
@@ -19,10 +19,12 @@ apply plugin: "java-platform"
 
 description="ServiceTalk BOM that includes all modules"
 
-rootProject.subprojects.findAll { !it.name.endsWith("-bom") && !it.name.endsWith("-dependencies") &&
-                                            !it.name.contains("examples") &&
-                                          !it.name.equals("grpc") && !it.name.equals("http") }.each {
-    dependencies.constraints.add(it.name.endsWith("-internal") ? "runtime" : "api", it )
+rootProject.subprojects.findAll { !it.name.endsWith("-bom") &&
+                                  !it.name.endsWith("-dependencies") &&
+                                  !it.name.contains("examples") &&
+                                  !it.name.equals("grpc") &&
+                                  !it.name.equals("http") }.each {
+    dependencies.constraints.add("api", it)
 }
 
 // Keep publishing and signing configuration in sync with ServiceTalkLibraryPlugin.groovy from


### PR DESCRIPTION
Motivation:
servicetalk-bom currently has `-internal` dependencies as `runtime`. This means
that projects which do depend upon these artifacts for implementation purposes
don't inherit the version from the bom. This can be problematic if the version
of ServiceTalk isn't directly specified by the project but instead inherited
through another bom (multi-level bom). In this case without `api` depdencies
the application must again manually track versions which the bom is intended
to avoid.