### PR TITLE
Deprecate unused `ClientInvoker` interface

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ClientInvoker.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ClientInvoker.java
@@ -25,9 +25,12 @@ import javax.annotation.Nullable;
  * trailers, for the passed {@link StreamingHttpRequest} returns a {@link Single}.
  *
  * @param <State> The {@code state} type to use.
+ * @deprecated There is no use of this interface in our codebase, it will be removed in the future releases. If you
+ * depend on it, consider replicating a similar interface in your codebase.
  */
+@Deprecated
 @FunctionalInterface
-public interface ClientInvoker<State> {
+public interface ClientInvoker<State> { // FIXME: 0.43 - remove deprecated interface
 
     /**
      * Invokes the client.


### PR DESCRIPTION
Motivation:

After simplifying offloading in #1695, `ClientInvoker` interface does
not provide any value and can be removed.

Modifications:

- Remove the remaining pkg-private use of `ClientInvoker`;
- Deprecate `ClientInvoker` interface;

Result:

`ClientInvoker` interface is deprecated and can be removed in the future
releases.