### PR TITLE
Default methods that return async sources should not throw

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionFactory.java
@@ -24,6 +24,7 @@ import io.servicetalk.transport.api.TransportObserver;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.DeprecatedToNewConnectionFactoryFilter.CONNECTION_FACTORY_CONTEXT_MAP_KEY;
+import static io.servicetalk.concurrent.api.Single.failed;
 
 /**
  * A factory for creating new connections.
@@ -46,8 +47,9 @@ public interface ConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     default Single<C> newConnection(ResolvedAddress address, @Nullable TransportObserver observer) {
-        throw new UnsupportedOperationException("ConnectionFactory#newConnection(ResolvedAddress, TransportObserver) " +
-                "is not supported by " + getClass());
+        return failed(new UnsupportedOperationException(
+                "ConnectionFactory#newConnection(ResolvedAddress, TransportObserver) is not supported by " +
+                        getClass()));
     }
 
     /**

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancer.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancer.java
@@ -25,6 +25,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.Single.failed;
+
 /**
  * Given multiple {@link SocketAddress}es select the most desired {@link SocketAddress} to use. This is typically used
  * to determine which connection to issue a request to.
@@ -48,8 +50,8 @@ public interface LoadBalancer<C extends LoadBalancedConnection> extends Listenab
      */
     @Deprecated
     default Single<C> selectConnection(Predicate<C> selector) { // FIXME: 0.43 - remove deprecated method
-        throw new UnsupportedOperationException("LoadBalancer#selectConnection(Predicate) is not supported by " +
-                getClass());
+        return failed(new UnsupportedOperationException(
+                "LoadBalancer#selectConnection(Predicate) is not supported by " + getClass()));
     }
 
     /**


### PR DESCRIPTION
Motivation:

#2168 and #2235 added default implementations that throw an exception.
However, those method signatures return an async source.

Modifications:

- Return a `failed` source with an exception instead of throwing;

Result:

Default methods follow async contract.