### PR TITLE
Add netty-incubator-transport-native-io_uring to servicetalk-dependencies

### DIFF
--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -31,6 +31,11 @@ dependencies {
   api platform("org.glassfish.jersey:jersey-bom:${jerseyVersion}")
 
   constraints {
+    // Ideally this come from the Netty BOM
+    api "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+    runtime "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
+    runtime "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"
+
     // We don't use the jackson-bom because we want to target specifically jackson-databind
     api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"

--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -31,17 +31,18 @@ dependencies {
   api platform("org.glassfish.jersey:jersey-bom:${jerseyVersion}")
 
   constraints {
-    // Ideally this come from the Netty BOM
-    api "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
-    runtime "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
-    runtime "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"
-
     // We don't use the jackson-bom because we want to target specifically jackson-databind
     api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
     api "com.google.code.findbugs:jsr305:$jsr305Version"
     api "com.sun.activation:jakarta.activation:$javaxActivationVersion"
     api "com.sun.xml.bind:jaxb-core:$javaxJaxbCoreVersion"
+
+    // Ideally these come from the Netty BOM
+    api "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+    api "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
+    api "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"
+
     api "io.opentracing:opentracing-api:$openTracingVersion"
     api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
     api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -57,9 +57,9 @@ dependencies {
   testImplementation project(":servicetalk-utils-internal")
   testImplementation project(":servicetalk-oio-api-internal")
   testImplementation "io.netty:netty-transport-native-unix-common"
-  testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
-  testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
-  testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"
+  testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring"
+  testRuntimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", classifier:"linux-x86_64")
+  testRuntimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", classifier:"linux-aarch_64")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-http-netty/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-http-netty/gradle/checkstyle/suppressions.xml
@@ -21,4 +21,5 @@
 <suppressions>
   <suppress checks="FallThrough" files="io[\\/]servicetalk[\\/]http[\\/]netty[\\/]HttpObjectDecoder.java"/>
   <suppress checks="FallThrough" files="io[\\/]servicetalk[\\/]http[\\/]netty[\\/]HttpObjectEncoder.java"/>
+  <suppress checks="LineLength" files="build.gradle"/>
 </suppressions>

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -40,7 +40,7 @@ dependencies {
   implementation "io.netty:netty-transport-native-kqueue"
   runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-x86_64")
   runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-aarch_64")
-  testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring"
+  implementation "io.netty.incubator:netty-incubator-transport-native-io_uring"
   runtimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", classifier:"linux-x86_64")
   runtimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", classifier:"linux-aarch_64")
   runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"linux-x86_64")

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -40,9 +40,9 @@ dependencies {
   implementation "io.netty:netty-transport-native-kqueue"
   runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-x86_64")
   runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-aarch_64")
-  implementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
-  runtimeOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
-  runtimeOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"
+  testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring"
+  runtimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", classifier:"linux-x86_64")
+  runtimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", classifier:"linux-aarch_64")
   runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"linux-x86_64")
   runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"linux-aarch_64")
   runtimeOnly( group:"io.netty", name:"netty-tcnative-boringssl-static", classifier:"osx-x86_64")
@@ -61,7 +61,7 @@ dependencies {
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
   testFixturesImplementation project(":servicetalk-utils-internal")
-  testFixturesImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+  testFixturesImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring"
   testFixturesImplementation "com.google.code.findbugs:jsr305"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-transport-netty-internal/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-transport-netty-internal/gradle/checkstyle/suppressions.xml
@@ -22,4 +22,5 @@
   <!-- The list of test cases must be kept single-line each. -->
   <suppress checks="LineLength"
             files="io[\\/]servicetalk[\\/]transport[\\/]netty[\\/]internal[\\/]RequestResponseCloseHandlerTest.java"/>
+  <suppress checks="LineLength" files="build.gradle"/>
 </suppressions>


### PR DESCRIPTION
Motivation:
netty-incubator-transport-native-io_uring is referenced in multiple projects
and not yet included in Netty's bom. We should include it in the dependency
bom to align versions until Netty provides this.