### PR TITLE
Deprecate public gRPC API that is not used anymore by ST

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientFactory.java
@@ -79,7 +79,7 @@ public abstract class GrpcClientFactory<Client extends GrpcClient<BlockingClient
      */
     @Deprecated
     public GrpcClientFactory<Client, BlockingClient>
-    supportedMessageCodings(List<ContentCodec> codings) {
+    supportedMessageCodings(List<ContentCodec> codings) {   // FIXME: 0.43 - remove deprecated method
         this.supportedCodings = unmodifiableList(new ArrayList<>(codings));
         return this;
     }
@@ -91,7 +91,7 @@ public abstract class GrpcClientFactory<Client extends GrpcClient<BlockingClient
      * {@link io.servicetalk.encoding.api.BufferEncoder}s and {@link io.servicetalk.encoding.api.BufferDecoderGroup}.
      */
     @Deprecated
-    protected List<ContentCodec> supportedMessageCodings() {
+    protected List<ContentCodec> supportedMessageCodings() {    // FIXME: 0.43 - remove deprecated method
         return supportedCodings;
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -24,7 +24,8 @@ import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
  */
 public final class GrpcExecutionStrategies {
 
-    private static final GrpcExecutionStrategy NEVER_OFFLOAD_STRATEGY =
+    @Deprecated
+    private static final GrpcExecutionStrategy NEVER_OFFLOAD_STRATEGY = // FIXME: 0.43 - remove deprecated constant
             new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.offloadNever()) {
                 @Override
                 public HttpExecutionStrategy merge(final HttpExecutionStrategy other) {
@@ -32,8 +33,6 @@ public final class GrpcExecutionStrategies {
                 }
             };
 
-    // FIXME: 0.43 - remove deprecated method
-    @Deprecated
     private static final GrpcExecutionStrategy DEFAULT_GRPC_EXECUTION_STRATEGY =
             new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.defaultStrategy()) {
                 @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -178,7 +178,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @deprecated Use {@link #addRoute(Class, MethodDescriptor, BufferDecoderGroup, List, Route)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addRoute(  // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName, final Route<Req, Resp> route,
             final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -224,7 +224,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @deprecated Use {@link #addRoute(GrpcExecutionStrategy, MethodDescriptor, BufferDecoderGroup, List, Route)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addRoute(  // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy, final Route<Req, Resp> route,
             final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -267,7 +267,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @deprecated Use {@link #addStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, StreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addStreamingRoute( // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final StreamingRoute<Req, Resp> route, final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -314,7 +314,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * StreamingRoute)}
      */
     @Deprecated
-    protected final <Req, Resp> void addStreamingRoute( // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final StreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -358,7 +358,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * {@link #addRequestStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, RequestStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addRequestStreamingRoute(  // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addRequestStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final RequestStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -407,7 +407,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * RequestStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addRequestStreamingRoute(  // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addRequestStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final RequestStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -452,7 +452,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * {@link #addResponseStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, ResponseStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addResponseStreamingRoute( // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addResponseStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final ResponseStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -501,7 +501,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * ResponseStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addResponseStreamingRoute( // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addResponseStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final ResponseStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -545,7 +545,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @deprecated Use {@link #addBlockingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, BlockingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingRoute(  // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addBlockingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final BlockingRoute<Req, Resp> route, final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -593,7 +593,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingRoute(  // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addBlockingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy, final BlockingRoute<Req, Resp> route,
             final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -638,7 +638,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * {@link #addBlockingStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, BlockingStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingStreamingRoute( // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addBlockingStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final BlockingStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -687,7 +687,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingStreamingRoute( // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addBlockingStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final BlockingStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -732,7 +732,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * {@link #addBlockingStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, BlockingStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingRequestStreamingRoute(  // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addBlockingRequestStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final BlockingRequestStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -781,7 +781,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingRequestStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingRequestStreamingRoute(  // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addBlockingRequestStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final BlockingRequestStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -828,7 +828,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingResponseStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingResponseStreamingRoute( // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addBlockingResponseStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final BlockingResponseStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -877,7 +877,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingResponseStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingResponseStreamingRoute( // FIXME: 0.43 - remove deprecated method
+    protected final <Req, Resp> void addBlockingResponseStreamingRoute(// FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final BlockingResponseStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -108,16 +108,24 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * Register all routes contained in the passed {@link Service}.
      *
      * @param service {@link Service} for which routes have to be registered.
+     * @deprecated This method is not used starting from version 0.42.0 (see
+     * <a href="https://github.com/apple/servicetalk/pull/1893">PR#1893</a>), we plan to remove it in future releases.
+     * In case you have a use-case, let us know.
      */
-    protected abstract void registerRoutes(Service service);
+    @Deprecated
+    protected abstract void registerRoutes(Service service);    // FIXME: 0.43 - remove deprecated method
 
     /**
      * Create a new {@link Service} from the passed {@link AllGrpcRoutes}.
      *
      * @param routes {@link AllGrpcRoutes} for which a {@link Service} has to be created.
      * @return {@link Service} containing all the passed routes.
+     * @deprecated This method is not used starting from version 0.42.0 (see
+     * <a href="https://github.com/apple/servicetalk/pull/1893">PR#1893</a>), we plan to remove it in future releases.
+     * In case you have a use-case, let us know.
      */
-    protected abstract Service newServiceFromRoutes(AllGrpcRoutes routes);
+    @Deprecated
+    protected abstract Service newServiceFromRoutes(AllGrpcRoutes routes);  // FIXME: 0.43 - remove deprecated method
 
     static GrpcRoutes<?> merge(GrpcRoutes<?>... allRoutes) {
         final GrpcRouter.Builder[] builders = new GrpcRouter.Builder[allRoutes.length];
@@ -127,11 +135,13 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             errors.addAll(allRoutes[i].errors);
         }
         return new GrpcRoutes<GrpcService>(GrpcRouter.Builder.merge(builders), errors) {
+            @Deprecated
             @Override
             protected void registerRoutes(final GrpcService service) {
                 throw new UnsupportedOperationException("Merged service factory can not register routes.");
             }
 
+            @Deprecated
             @Override
             protected GrpcService newServiceFromRoutes(final AllGrpcRoutes routes) {
                 throw new UnsupportedOperationException("Merged service factory can not create new service.");
@@ -168,7 +178,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @deprecated Use {@link #addRoute(Class, MethodDescriptor, BufferDecoderGroup, List, Route)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addRoute(
+    protected final <Req, Resp> void addRoute(  // FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName, final Route<Req, Resp> route,
             final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -214,7 +224,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @deprecated Use {@link #addRoute(GrpcExecutionStrategy, MethodDescriptor, BufferDecoderGroup, List, Route)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addRoute(
+    protected final <Req, Resp> void addRoute(  // FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy, final Route<Req, Resp> route,
             final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -257,7 +267,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @deprecated Use {@link #addStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, StreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addStreamingRoute(
+    protected final <Req, Resp> void addStreamingRoute( // FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final StreamingRoute<Req, Resp> route, final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -304,7 +314,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * StreamingRoute)}
      */
     @Deprecated
-    protected final <Req, Resp> void addStreamingRoute(
+    protected final <Req, Resp> void addStreamingRoute( // FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final StreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -348,7 +358,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * {@link #addRequestStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, RequestStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addRequestStreamingRoute(
+    protected final <Req, Resp> void addRequestStreamingRoute(  // FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final RequestStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -397,7 +407,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * RequestStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addRequestStreamingRoute(
+    protected final <Req, Resp> void addRequestStreamingRoute(  // FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final RequestStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -442,7 +452,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * {@link #addResponseStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, ResponseStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addResponseStreamingRoute(
+    protected final <Req, Resp> void addResponseStreamingRoute( // FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final ResponseStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -491,7 +501,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * ResponseStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addResponseStreamingRoute(
+    protected final <Req, Resp> void addResponseStreamingRoute( // FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final ResponseStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -535,7 +545,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * @deprecated Use {@link #addBlockingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, BlockingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingRoute(
+    protected final <Req, Resp> void addBlockingRoute(  // FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final BlockingRoute<Req, Resp> route, final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -583,7 +593,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingRoute(
+    protected final <Req, Resp> void addBlockingRoute(  // FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy, final BlockingRoute<Req, Resp> route,
             final Class<Req> requestClass, final Class<Resp> responseClass,
             final GrpcSerializationProvider serializationProvider) {
@@ -628,7 +638,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * {@link #addBlockingStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, BlockingStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingStreamingRoute(
+    protected final <Req, Resp> void addBlockingStreamingRoute( // FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final BlockingStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -677,7 +687,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingStreamingRoute(
+    protected final <Req, Resp> void addBlockingStreamingRoute( // FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final BlockingStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -722,7 +732,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * {@link #addBlockingStreamingRoute(Class, MethodDescriptor, BufferDecoderGroup, List, BlockingStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingRequestStreamingRoute(
+    protected final <Req, Resp> void addBlockingRequestStreamingRoute(  // FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final BlockingRequestStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -771,7 +781,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingRequestStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingRequestStreamingRoute(
+    protected final <Req, Resp> void addBlockingRequestStreamingRoute(  // FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final BlockingRequestStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -818,7 +828,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingResponseStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingResponseStreamingRoute(
+    protected final <Req, Resp> void addBlockingResponseStreamingRoute( // FIXME: 0.43 - remove deprecated method
             final String path, final Class<?> serviceClass, final String methodName,
             final BlockingResponseStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -867,7 +877,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
      * BlockingResponseStreamingRoute)}.
      */
     @Deprecated
-    protected final <Req, Resp> void addBlockingResponseStreamingRoute(
+    protected final <Req, Resp> void addBlockingResponseStreamingRoute( // FIXME: 0.43 - remove deprecated method
             final String path, final GrpcExecutionStrategy executionStrategy,
             final BlockingResponseStreamingRoute<Req, Resp> route, final Class<Req> requestClass,
             final Class<Resp> responseClass, final GrpcSerializationProvider serializationProvider) {
@@ -1358,8 +1368,13 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
 
     /**
      * A collection of route corresponding to the enclosing {@link GrpcRoutes}.
+     *
+     * @deprecated This class is not used starting from version 0.42.0 (see
+     * <a href="https://github.com/apple/servicetalk/pull/1893">PR#1893</a>), we plan to remove it in future releases.
+     * In case you have a use-case, let us know.
      */
-    protected interface AllGrpcRoutes extends AsyncCloseable {
+    @Deprecated
+    protected interface AllGrpcRoutes extends AsyncCloseable {  // FIXME: 0.43 - remove deprecated interface
 
         /**
          * Returns the registered {@link StreamingRoute} for the passed {@code path}. If a route with a different

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFilterFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFilterFactory.java
@@ -31,7 +31,7 @@ import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
  */
 @FunctionalInterface
 @Deprecated
-public interface GrpcServiceFilterFactory<Filter extends Service, Service> {
+public interface GrpcServiceFilterFactory<Filter extends Service, Service> {// FIXME: 0.43 - remove deprecated interface
 
     /**
      * Create a {@link Filter} using the provided {@link Service}.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFilterFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceFilterFactory.java
@@ -31,7 +31,7 @@ import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
  */
 @FunctionalInterface
 @Deprecated
-public interface GrpcServiceFilterFactory<Filter extends Service, Service> {// FIXME: 0.43 - remove deprecated interface
+public interface GrpcServiceFilterFactory<Filter extends Service, Service> { // FIXME: 0.43-remove deprecated interface
 
     /**
      * Create a {@link Filter} using the provided {@link Service}.

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -544,9 +544,10 @@ final class Generator {
                         .returns(state.serviceFactoryClass)
                         .addStatement("return new $T(this)", state.serviceFactoryClass)
                         .build())
-                .addMethod(methodBuilder("newServiceFromRoutes")
+                .addMethod(methodBuilder("newServiceFromRoutes")    // FIXME: 0.43 - remove deprecated method
                         .addModifiers(PROTECTED)
                         .addAnnotation(Override.class)
+                        .addAnnotation(Deprecated.class)
                         .returns(serviceFromRoutesClass)
                         .addParameter(AllGrpcRoutes, routes, FINAL)
                         .addStatement("return new $T($L)", serviceFromRoutesClass, routes)
@@ -632,6 +633,7 @@ final class Generator {
         final MethodSpec.Builder registerRoutesMethodSpecBuilder = methodBuilder(registerRoutes)
                 .addModifiers(PROTECTED)
                 .addAnnotation(Override.class)
+                .addAnnotation(Deprecated.class)    // FIXME: 0.43 - remove deprecated method
                 .addParameter(state.serviceClass, service, FINAL);
 
         state.serviceProto.getMethodList().stream()
@@ -997,12 +999,14 @@ final class Generator {
         return serviceClassBuilder;
     }
 
+    // FIXME: 0.43 - remove deprecated class
     private TypeSpec newServiceFromRoutesClassSpec(final ClassName serviceFromRoutesClass,
                                                    final List<RpcInterface> rpcInterfaces,
                                                    final ClassName serviceClass) {
         final TypeSpec.Builder serviceFromRoutesSpecBuilder = classBuilder(serviceFromRoutesClass)
                 .addModifiers(PRIVATE, STATIC, FINAL)
                 .addSuperinterface(serviceClass)
+                .addAnnotation(Deprecated.class)
                 .addField(AsyncCloseable, closeable, PRIVATE, FINAL);
 
         final MethodSpec.Builder serviceFromRoutesConstructorBuilder = constructorBuilder()


### PR DESCRIPTION
Motivation:

#1893 removed support of gRPC Filters and stopped using some of the
public/protected API that were targeted for filters. Some of these APIs
were not marked as `@Deprecated` and were not removed before 0.42
release.

Modifications:

- Mark `GrpcRoutes#registerRoutes` and `GrpcRoutes#newServiceFromRoutes`
methods as deprecated;
- Mark `GrpcRoutes.AllGrpcRoutes` interface as deprecated;
- Add reminding `FIXME` comments to make sure we remove all deprecations
in 0.43;

Result:

Unused code is marked as deprecated and can be removed in the next
release.