### PR TITLE
Use `compileJava` `options.release`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import io.servicetalk.gradle.plugin.internal.Versions
+
 if (!repositories) {
   allprojects {
     buildscript {
@@ -43,7 +45,9 @@ subprojects {
   task printJavaTargetCompatibility {
     doLast {
       if (project.parent == project.rootProject) {
-        println("version: " + project.properties.targetCompatibility + " name: " + project.name)
+        def javaLanguage = (project.tasks.withType(JavaCompile)?.findByName("compileJava")?.options?.release?.get()) ?:
+            Integer.parseInt(Versions.TARGET_VERSION.getMajorVersion())
+        println("version: " + javaLanguage + " name: " + project.name)
       }
     }
   }

--- a/docs/generation/gradle.properties
+++ b/docs/generation/gradle.properties
@@ -16,7 +16,11 @@
 
 # suppress inspection "UnusedProperty" for whole file
 
+# build configuration
 org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.java.installations.auto-download=false
 
 antoraVersion=2.3.4
 jsoupVersion=1.14.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
+org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-Xms2g -Xmx4g -dsa -da -ea:io.servicetalk... -XX:+HeapDumpOnOutOfMemoryError
 
 # project metadata used for publications

--- a/servicetalk-buffer-api/build.gradle
+++ b/servicetalk-buffer-api/build.gradle
@@ -28,5 +28,6 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/servicetalk-concurrent-jdkflow/build.gradle
+++ b/servicetalk-concurrent-jdkflow/build.gradle
@@ -16,17 +16,24 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-if (!JavaVersion.current().isJava9Compatible()) {
+// Required version for module
+def javaLanguageVersion = JavaVersion.VERSION_1_9
+
+if (!JavaVersion.current().isCompatibleWith(javaLanguageVersion)) {
     project.tasks.all { task -> task.enabled = false }
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_9
-    targetCompatibility = JavaVersion.VERSION_1_9
+    sourceCompatibility = javaLanguageVersion
+    targetCompatibility = javaLanguageVersion
 }
 
 compileJava {
-    options.compilerArgs.addAll(['--release', '9'])
+    options.release = Integer.parseInt(javaLanguageVersion.getMajorVersion())
+}
+
+compileTestJava {
+    options.release = compileJava.options.release
 }
 
 dependencies {

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -19,7 +19,6 @@ import com.github.spotbugs.snom.SpotBugsTask
 import info.solidsoft.gradle.pitest.PitestTask
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
@@ -62,25 +61,27 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
       sourceCompatibility = TARGET_VERSION
       targetCompatibility = TARGET_VERSION
 
-      def javaLanguageVersion = Integer.parseInt(TARGET_VERSION.getMajorVersion())
+      def javaRelease = Integer.parseInt(TARGET_VERSION.getMajorVersion())
 
       if (JavaVersion.current().isJava9Compatible()) {
         compileJava {
-          options.release = javaLanguageVersion
+          options.release = javaRelease
         }
         compileTestJava {
-          options.release = javaLanguageVersion
+          options.release = javaRelease
         }
 
-        // Not every project has compileTestFixturesJava task so we have to configure on addition
-        project.tasks.whenTaskAdded { Task task ->
-          if (task.getName().equals("compileTestFixturesJava")) {
-            JavaCompile compileJavaTestFixturesTask = task
-            // we have no control over order in which `whenTaskAdded` actions are applied
+        // Not every project has compileTestFixturesJava task so we have to defer attempting configuration
+        project.afterEvaluate {
+          def compileTasks = project.tasks.withType(JavaCompile)
+          def compileJavaTask = compileTasks?.findByName("compileJava")
+          def compileJavaTestFixturesTask = compileTasks?.findByName("compileTestFixturesJava")
+          if (null != compileJavaTask && null != compileJavaTestFixturesTask) {
+            def useRelease = compileJavaTask?.options?.release?.getOrNull() ?: javaRelease
             // if another action has set a higher language version, never reduce it.
             if (compileJavaTestFixturesTask?.options?.release?.getOrNull() == null ||
-                compileJavaTestFixturesTask.options.release.get() < javaLanguageVersion) {
-              compileJavaTestFixturesTask.options.release = javaLanguageVersion
+                compileJavaTestFixturesTask.options.release.get() < useRelease) {
+              compileJavaTestFixturesTask.options.release = useRelease
             }
           }
         }


### PR DESCRIPTION
Motivation:
Using `sourceCompatibility` and `targetCompatibility` for specifying
Java version does not always produce correct module metadata because
the setting is quite sensitive to order of operations.
Modifications:
Use `options.release` whenever build JDK is >= Java 9. To support `javac`
compilation using the `--release` option it is necessary to hide direct use
of the `sun.misc.Unsafe` class as this class is not provided in the symbols
used for compiling.
Result:
Correct Java variant versions exported in module files