### PR TITLE
Hide use of `sun.misc.Unsafe` from `javac`

### DIFF
--- a/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeNoZeroingDirectByteBuf.java
+++ b/servicetalk-buffer-netty/src/main/java/io/servicetalk/buffer/netty/UnreleasableUnsafeNoZeroingDirectByteBuf.java
@@ -38,8 +38,8 @@ import static io.servicetalk.utils.internal.PlatformDependent.allocateMemory;
 import static io.servicetalk.utils.internal.PlatformDependent.freeMemory;
 import static io.servicetalk.utils.internal.PlatformDependent.newDirectBuffer;
 import static io.servicetalk.utils.internal.PlatformDependent.reserveMemory;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static io.servicetalk.utils.internal.PlatformDependent.unreserveMemory;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 
 final class UnreleasableUnsafeNoZeroingDirectByteBuf extends UnreleasableUnsafeDirectByteBuf {
 

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent.java
@@ -50,6 +50,7 @@ import org.jctools.util.UnsafeAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -318,7 +319,13 @@ public final class PlatformDependent {
                 // must mark this block as privileged too
                 unsafe = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
                     // force JCTools to initialize unsafe
-                    return UnsafeAccess.UNSAFE;
+                    try {
+                        Field unsafeStatic = UnsafeAccess.class.getDeclaredField("UNSAFE");
+                        return unsafeStatic.get(null);
+                    } catch (IllegalAccessException | NoSuchFieldException e) {
+                        LOGGER.debug("jctools unsafe failed: ", e);
+                        return null;
+                    }
                 });
             }
 

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent0.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent0.java
@@ -150,13 +150,9 @@ final class PlatformDependent0 {
                 Consumer<Throwable> unsafeThrowConsumer =
                         (Consumer<Throwable>) throwExceptionCallSite.getTarget().bindTo(unsafe).invoke();
                 throwConsumer = (t) -> {
-                    try {
-                        // JVM has been observed to crash when passing a null argument.
-                        // See https://github.com/netty/netty/issues/4131.
-                        unsafeThrowConsumer.accept(null != t ? t : new NullPointerException("Throwable was null"));
-                    } catch (Throwable all) {
-                        throwException0(t);
-                    }
+                    // JVM has been observed to crash when passing a null argument.
+                    // See https://github.com/netty/netty/issues/4131.
+                    unsafeThrowConsumer.accept(null != t ? t : new NullPointerException("Throwable was null"));
                 };
                 LOGGER.debug("sun.misc.Unsafe#throwException(Throwable): available");
             } catch (Throwable t) {

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ThrowableUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ThrowableUtils.java
@@ -27,6 +27,19 @@ public final class ThrowableUtils {
     }
 
     /**
+     * Raises an exception bypassing compiler checks for checked exceptions.
+     *
+     * @param t The {@link Throwable} to throw.
+     * @param <T> The expected type
+     * @return nothing actually will be returned from this method because it rethrows the specified exception. Making
+     * this method return an arbitrary type makes the caller method easier as they do not have to add a return statement
+     * after calling this method.
+     */
+    public static <T> T throwException(final Throwable t) {
+        return PlatformDependent0.throwException(t);
+    }
+
+    /**
      * Combine two potential {@link Throwable}s into one.
      * If both parameters are {@link Throwable}, the {@code second} one will be
      * {@link Throwable#addSuppressed(Throwable) suppressed} by the {@code first} one.

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/PlatformDependentTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/PlatformDependentTest.java
@@ -22,7 +22,6 @@ import static java.lang.Boolean.getBoolean;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -40,13 +39,5 @@ class PlatformDependentTest {
         long allocated = PlatformDependent.allocateMemory(1);
         assertThat(allocated, is(Matchers.not(0)));
         PlatformDependent.freeMemory(allocated);
-    }
-
-    @Test
-    void throwException() {
-        assumeTrue(PlatformDependent.hasUnsafe(), "Unsafe absent or disabled");
-        Exception customException = new Exception() {
-        };
-        assertThrows(customException.getClass(), () -> PlatformDependent.throwException(customException));
     }
 }

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/PlatformDependentTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/PlatformDependentTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.utils.internal;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.Boolean.getBoolean;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class PlatformDependentTest {
+
+    @Test
+    void hasUnsafe() {
+        assumeFalse(getBoolean("io.servicetalk.noUnsafe"));
+        assertDoesNotThrow(PlatformDependent::hasUnsafe);
+    }
+
+    @Test
+    void memoryAllocation() {
+        assumeTrue(PlatformDependent.hasUnsafe(), "Unsafe absent or disabled");
+        long allocated = PlatformDependent.allocateMemory(1);
+        assertThat(allocated, is(Matchers.not(0)));
+        PlatformDependent.freeMemory(allocated);
+    }
+
+    @Test
+    void throwException() {
+        assumeTrue(PlatformDependent.hasUnsafe(), "Unsafe absent or disabled");
+        Exception customException = new Exception() {
+        };
+        assertThrows(customException.getClass(), () -> PlatformDependent.throwException(customException));
+    }
+}

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/ThrowableUtilsTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/ThrowableUtilsTest.java
@@ -24,8 +24,17 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class ThrowableUtilTest {
+class ThrowableUtilsTest {
+
+    @Test
+    void throwException() {
+        Exception customException = new Exception("Deliberate Exception") {
+            // use an inner class so that we get a custom exception class
+        };
+        assertThrows(customException.getClass(), () -> ThrowableUtils.throwException(customException));
+    }
 
     @Test
     void combineNonThrowable() {


### PR DESCRIPTION
Motivation:
Attempting to build using a Java 9+ `javac` with the `--release`
option fails because the ServicetTalk source contains references to
the `sun.misc.Unsafe` class. This class is not required by ServiceTalk
for correct execution but the appearance of the class in the source
currently requires that source be compiled with Java 8 or without
the `--release` option.
Modifications:
Use reflection and method handles rather than direct class use for
`sun.misc.Unsafe` to avoid [JDK-8214165](https://bugs.openjdk.org/browse/JDK-8214165).
Result:
ServiceTalk may be compiled using the `javac --release` option.