### PR TITLE
Deprecate `io.servicetalk.client.api.internal.DefaultPartitionedClientGroup`

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
@@ -60,7 +60,11 @@ import static java.util.Objects.requireNonNull;
  * @param <U> the type of address before resolution (unresolved address)
  * @param <R> the type of address after resolution (resolved address)
  * @param <Client> the type of client to connect to the partitions
+ * @deprecated We are unaware of anyone using "partition" feature and plan to remove it in future releases.
+ * If you depend on it, consider using {@link ClientGroup} as an alternative or reach out to the maintainers describing
+ * the use-case.
  */
+@Deprecated // FIXME: 0.43 - remove deprecated class
 public final class DefaultPartitionedClientGroup<U, R, Client extends ListenableAsyncCloseable>
         implements ClientGroup<PartitionAttributes, Client> {
 
@@ -69,7 +73,11 @@ public final class DefaultPartitionedClientGroup<U, R, Client extends Listenable
      * @param <U> the type of address before resolution (unresolved address)
      * @param <R> the type of address after resolution (resolved address)
      * @param <Client> the type of client to connect to the partitions
+     * @deprecated We are unaware of anyone using "partition" feature and plan to remove it in future releases.
+     * If you depend on it, consider using {@link ClientGroup} as an alternative or reach out to the maintainers
+     * describing the use-case.
      */
+    @Deprecated
     @FunctionalInterface
     public interface PartitionedClientFactory<U, R, Client> {
         /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -70,6 +70,7 @@ import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.se
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
+@Deprecated // FIXME: 0.43 - remove deprecated class
 final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttpClientBuilder<U, R> {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPartitionedHttpClientBuilder.class);
 


### PR DESCRIPTION
Motivation:

#2131 and #2267 deprecate partitioned HTTP client and classes required
for its impl, but `DefaultPartitionedClientGroup` is still not
deprecated.

Modifications:

- Deprecate
`io.servicetalk.client.api.internal.DefaultPartitionedClientGroup`;

Result:

All (hopefully) classes related to "partitioned" client are deprecated
now.