### PR TITLE
Revert backward incompatible changes (api & binary) introduced in #2278

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyController.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyController.java
@@ -16,7 +16,6 @@
 package io.servicetalk.client.api.internal;
 
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.api.Completable;
@@ -28,6 +27,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
+@Deprecated // FIXME: 0.43 - remove deprecated class
 abstract class AbstractRequestConcurrencyController implements RequestConcurrencyController {
     private static final AtomicIntegerFieldUpdater<AbstractRequestConcurrencyController>
             pendingRequestsUpdater = newUpdater(AbstractRequestConcurrencyController.class,

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/AbstractReservableRequestConcurrencyController.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/AbstractReservableRequestConcurrencyController.java
@@ -16,7 +16,6 @@
 package io.servicetalk.client.api.internal;
 
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;
@@ -31,6 +30,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
+@Deprecated // FIXME: 0.43 - remove deprecated class
 abstract class AbstractReservableRequestConcurrencyController implements ReservableRequestConcurrencyController {
     private static final AtomicIntegerFieldUpdater<AbstractReservableRequestConcurrencyController>
             pendingRequestsUpdater = newUpdater(AbstractReservableRequestConcurrencyController.class,

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/IgnoreConsumedEvent.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/IgnoreConsumedEvent.java
@@ -23,7 +23,10 @@ import static java.util.Objects.requireNonNull;
  * A {@link ConsumableEvent} which ignores {@link #eventConsumed()}.
  *
  * @param <T> The type of event.
+ * @deprecated This class is not used by ServiceTalk internal code anymore and will be removed in the future releases.
+ * If you depend on it, consider replica ting this implementation in your codebase.
  */
+@Deprecated // FIXME: 0.43 - remove deprecated class
 public final class IgnoreConsumedEvent<T> implements ConsumableEvent<T> {
     private final T event;
 

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyController.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api.internal;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+/**
+ * An interface which allows controlling reserving connections which maybe used concurrently.
+ *
+ * @deprecated This interface is not used by ServiceTalk internal code anymore and will be removed in the future
+ * releases. If you depend on it, consider replicating this implementation in your codebase or reach out to us
+ * explaining the use-case.
+ */
+@Deprecated // FIXME: 0.43 - remove deprecated interface
+public interface RequestConcurrencyController {
+
+    /**
+     * Result of the {@link #tryRequest()} call.
+     */
+    enum Result {
+        /**
+         * Selecting the resource succeeded.
+         */
+        Accepted,
+        /**
+         * Selecting the resource was denied, but may succeed at later time.
+         */
+        RejectedTemporary,
+        /**
+         * Selecting the resource was denied, and will not succeed at later time.
+         */
+        RejectedPermanently
+    }
+
+    /**
+     * Attempts to reserve a connection for a single request, needs to be followed by {@link #requestFinished()}.
+     * @return {@link Result#Accepted} if this connection is available and reserved for performing a single request.
+     */
+    Result tryRequest();
+
+    /**
+     * Must be called after {@link #tryRequest()} to signify the request has completed. This method should be called
+     * no more than once for each call to {@link #tryRequest()}.
+     * <p>
+     * Generally called from a {@link Publisher#beforeFinally(Runnable)} after a {@link #tryRequest()}.
+     */
+    void requestFinished();
+}

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerMulti.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerMulti.java
@@ -19,10 +19,11 @@ import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
 
+@Deprecated // FIXME: 0.43 - remove deprecated class
 final class RequestConcurrencyControllerMulti extends AbstractRequestConcurrencyController {
     private final int maxRequests;
 

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerOnlySingle.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerOnlySingle.java
@@ -19,10 +19,11 @@ import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
 
+@Deprecated // FIXME: 0.43 - remove deprecated class
 final class RequestConcurrencyControllerOnlySingle extends AbstractRequestConcurrencyController {
     RequestConcurrencyControllerOnlySingle(final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency,
                                            final Completable onClosing) {

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllers.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/RequestConcurrencyControllers.java
@@ -16,14 +16,17 @@
 package io.servicetalk.client.api.internal;
 
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
 /**
  * Factory for common {@link RequestConcurrencyController}s.
+ *
+ * @deprecated This class is not used by ServiceTalk internal code anymore and will be removed in the future releases.
+ * If you depend on it, consider replicating this implementation in your codebase.
  */
-public final class RequestConcurrencyControllers {
+@Deprecated
+public final class RequestConcurrencyControllers {  // FIXME: 0.43 - remove deprecated class
     private RequestConcurrencyControllers() {
         // no instances
     }

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyController.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api.internal;
+
+import io.servicetalk.concurrent.api.Completable;
+
+/**
+ * A {@link RequestConcurrencyController} that also allows to {@link #tryReserve()} a connection for exclusive use.
+ *
+ * @deprecated This interface is not used by ServiceTalk internal code anymore and will be removed in the future
+ * releases. If you depend on it, consider replicating this implementation in your codebase or reach out to us
+ * explaining the use-case.
+ */
+@Deprecated // FIXME: 0.43 - remove deprecated interface
+public interface ReservableRequestConcurrencyController extends RequestConcurrencyController {
+
+    /**
+     * Attempts to reserve a connection for exclusive use until {@link #releaseAsync()} is called.
+     * @return {@code true} if this connection is available and reserved for performing a single request.
+     */
+    boolean tryReserve();
+
+    /**
+     * Must be called (and subscribed to) to signify the reservation has completed after {@link #tryReserve()}.
+     * @return a {@link Completable} for the release.
+     */
+    Completable releaseAsync();
+}

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerMulti.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerMulti.java
@@ -19,10 +19,11 @@ import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
 
+@Deprecated // FIXME: 0.43 - remove deprecated class
 final class ReservableRequestConcurrencyControllerMulti extends AbstractReservableRequestConcurrencyController {
     private final int maxRequests;
 

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerOnlySingle.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerOnlySingle.java
@@ -19,10 +19,11 @@ import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
 
+@Deprecated // FIXME: 0.43 - remove deprecated class
 final class ReservableRequestConcurrencyControllerOnlySingle extends AbstractReservableRequestConcurrencyController {
     ReservableRequestConcurrencyControllerOnlySingle(final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency,
                                                      final Completable onClosing) {

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllers.java
@@ -16,16 +16,18 @@
 package io.servicetalk.client.api.internal;
 
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.RequestConcurrencyController;
-import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
 /**
  * Factory for common {@link ReservableRequestConcurrencyController}s.
+ *
+ * @deprecated This class is not used by ServiceTalk internal code anymore and will be removed in the future releases.
+ * If you depend on it, consider replicating this implementation in your codebase.
  */
+@Deprecated
 public final class ReservableRequestConcurrencyControllers {
-    private ReservableRequestConcurrencyControllers() {
+    private ReservableRequestConcurrencyControllers() { // FIXME: 0.43 - remove deprecated class
         // no instances
     }
 

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyControllerOnlySingleTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/AbstractRequestConcurrencyControllerOnlySingleTest.java
@@ -15,16 +15,15 @@
  */
 package io.servicetalk.client.api.internal;
 
-import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.RejectedTemporary;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerMultiTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerMultiTest.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.client.api.internal;
 
-import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerOnlySingleTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/RequestConcurrencyControllerOnlySingleTest.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.client.api.internal;
 
-import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerMultiTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerMultiTest.java
@@ -15,13 +15,12 @@
  */
 package io.servicetalk.client.api.internal;
 
-import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerOnlySingleTest.java
+++ b/servicetalk-client-api-internal/src/test/java/io/servicetalk/client/api/internal/ReservableRequestConcurrencyControllerOnlySingleTest.java
@@ -15,13 +15,12 @@
  */
 package io.servicetalk.client.api.internal;
 
-import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.internal.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newSingleController;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;

--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -23,7 +23,6 @@ dependencies {
   api project(":servicetalk-client-api")
 
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-client-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-transport-netty")

--- a/servicetalk-http-api/build.gradle
+++ b/servicetalk-http-api/build.gradle
@@ -34,7 +34,6 @@ dependencies {
   api project(":servicetalk-encoding-api")
 
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-client-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-encoding-api-internal")

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.internal.IgnoreConsumedEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
@@ -36,6 +35,7 @@ import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.netty.LoadBalancedStreamingHttpClient.OnStreamClosedRunnable;
+import io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.IgnoreConsumedEvent;
 import io.servicetalk.transport.api.IoThreadFactory;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -39,10 +39,10 @@ import io.netty.channel.Channel;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_1_1;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_2;
+import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 
 final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConsumableEvent;
-import io.servicetalk.client.api.internal.IgnoreConsumedEvent;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.PublisherSource.Processor;
 import io.servicetalk.concurrent.SingleSource;
@@ -40,6 +39,7 @@ import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.netty.LoadBalancedStreamingHttpClient.OnStreamClosedRunnable;
+import io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.IgnoreConsumedEvent;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
@@ -154,9 +154,9 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
 
         private static final Logger LOGGER = LoggerFactory.getLogger(DefaultH2ClientParentConnection.class);
 
-        private static final IgnoreConsumedEvent<Integer> DEFAULT_H2_MAX_CONCURRENCY_EVENT =
+        private static final ConsumableEvent<Integer> DEFAULT_H2_MAX_CONCURRENCY_EVENT =
                 new IgnoreConsumedEvent<>(SMALLEST_MAX_CONCURRENT_STREAMS);
-        private static final IgnoreConsumedEvent<Integer> ZERO_MAX_CONCURRENCY_EVENT = new IgnoreConsumedEvent<>(0);
+        private static final ConsumableEvent<Integer> ZERO_MAX_CONCURRENCY_EVENT = new IgnoreConsumedEvent<>(0);
 
         private final Http2StreamChannelBootstrap bs;
         private final HttpHeadersFactory headersFactory;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -34,8 +34,8 @@ import io.servicetalk.transport.api.TransportObserver;
 import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS;
-import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 
 final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -30,8 +30,8 @@ import io.servicetalk.transport.api.TransportObserver;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.client.api.internal.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.buildStreaming;
 
 final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2018, 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.ConsumableEvent;
+import io.servicetalk.client.api.RequestConcurrencyController;
+import io.servicetalk.client.api.ReservableRequestConcurrencyController;
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
+import io.servicetalk.concurrent.internal.LatestValueSubscriber;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
+import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
+
+/**
+ * Factory for common {@link ReservableRequestConcurrencyController}s.
+ */
+final class ReservableRequestConcurrencyControllers {
+
+    private ReservableRequestConcurrencyControllers() {
+        // no instances
+    }
+
+    /**
+     * Create a new instance of {@link ReservableRequestConcurrencyController}.
+     *
+     * @param maxConcurrency A {@link Publisher} that provides the maximum allowed concurrency updates.
+     * @param onClosing A {@link Completable} that when terminated no more calls to
+     * {@link RequestConcurrencyController#tryRequest()} are expected to succeed.
+     * @param initialMaxConcurrency The initial maximum value for concurrency, until {@code maxConcurrencySetting}
+     * provides data.
+     * @return a new instance of {@link ReservableRequestConcurrencyController}.
+     */
+    static ReservableRequestConcurrencyController newController(
+            final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing,
+            final int initialMaxConcurrency) {
+        return new ReservableRequestConcurrencyControllerMulti(maxConcurrency, onClosing, initialMaxConcurrency);
+    }
+
+    /**
+     * A {@link ConsumableEvent} which ignores {@link #eventConsumed()}.
+     *
+     * @param <T> The type of event.
+     */
+    static final class IgnoreConsumedEvent<T> implements ConsumableEvent<T> {
+        private final T event;
+
+        /**
+         * Create a new instance.
+         *
+         * @param event The event to return from {@link #event()}.
+         */
+        IgnoreConsumedEvent(final T event) {
+            this.event = requireNonNull(event);
+        }
+
+        @Override
+        public T event() {
+            return event;
+        }
+
+        @Override
+        public void eventConsumed() {
+        }
+    }
+
+    private abstract static class AbstractReservableRequestConcurrencyController
+            implements ReservableRequestConcurrencyController {
+        private static final AtomicIntegerFieldUpdater<AbstractReservableRequestConcurrencyController>
+                pendingRequestsUpdater = newUpdater(AbstractReservableRequestConcurrencyController.class,
+                "pendingRequests");
+
+        private static final int STATE_QUIT = -2;
+        private static final int STATE_RESERVED = -1;
+        private static final int STATE_IDLE = 0;
+
+        /*
+         * Following semantics:
+         * STATE_RESERVED if this is reserved.
+         * STATE_QUIT if quit command issued.
+         * STATE_IDLE if connection is not used.
+         * pending request count if none of the above states.
+         */
+        @SuppressWarnings("unused")
+        private volatile int pendingRequests;
+        private final LatestValueSubscriber<Integer> maxConcurrencyHolder;
+
+        AbstractReservableRequestConcurrencyController(
+                final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency,
+                final Completable onClosing) {
+            maxConcurrencyHolder = new LatestValueSubscriber<>();
+            // Subscribe to onClosing() before maxConcurrency, this order increases the chances of capturing the
+            // STATE_QUIT before observing 0 from maxConcurrency which could lead to more ambiguous max concurrency
+            // error messages for the users on connection tear-down.
+            toSource(onClosing).subscribe(new CompletableSource.Subscriber() {
+                @Override
+                public void onSubscribe(Cancellable cancellable) {
+                    // No op
+                }
+
+                @Override
+                public void onComplete() {
+                    pendingRequests = STATE_QUIT;
+                }
+
+                @Override
+                public void onError(Throwable ignored) {
+                    pendingRequests = STATE_QUIT;
+                }
+            });
+            toSource(maxConcurrency
+                    .afterOnNext(ConsumableEvent::eventConsumed)
+                    .map(ConsumableEvent::event)
+            ).subscribe(maxConcurrencyHolder);
+        }
+
+        @Override
+        public final void requestFinished() {
+            pendingRequestsUpdater.decrementAndGet(this);
+        }
+
+        @Override
+        public boolean tryReserve() {
+            return pendingRequestsUpdater.compareAndSet(this, STATE_IDLE, STATE_RESERVED);
+        }
+
+        @Override
+        public Completable releaseAsync() {
+            return new SubscribableCompletable() {
+                @Override
+                protected void handleSubscribe(Subscriber subscriber) {
+                    try {
+                        subscriber.onSubscribe(IGNORE_CANCEL);
+                    } catch (Throwable cause) {
+                        handleExceptionFromOnSubscribe(subscriber, cause);
+                        return;
+                    }
+                    // Ownership is maintained by the caller.
+                    if (pendingRequestsUpdater.compareAndSet(AbstractReservableRequestConcurrencyController.this,
+                            STATE_RESERVED, STATE_IDLE)) {
+                        subscriber.onComplete();
+                    } else {
+                        subscriber.onError(new IllegalStateException("Resource " + this +
+                                (pendingRequests == STATE_QUIT ? " is closed." : " was not reserved.")));
+                    }
+                }
+            };
+        }
+
+        final int lastSeenMaxValue(int defaultValue) {
+            return maxConcurrencyHolder.lastSeenValue(defaultValue);
+        }
+
+        final int pendingRequests() {
+            return pendingRequests;
+        }
+
+        final boolean casPendingRequests(int oldValue, int newValue) {
+            return pendingRequestsUpdater.compareAndSet(this, oldValue, newValue);
+        }
+    }
+
+    private static final class ReservableRequestConcurrencyControllerMulti
+            extends AbstractReservableRequestConcurrencyController {
+        private final int maxRequests;
+
+        ReservableRequestConcurrencyControllerMulti(final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency,
+                                                    final Completable onClosing,
+                                                    int maxRequests) {
+            super(maxConcurrency, onClosing);
+            this.maxRequests = maxRequests;
+        }
+
+        @Override
+        public Result tryRequest() {
+            final int maxConcurrency = lastSeenMaxValue(maxRequests);
+            for (;;) {
+                final int currentPending = pendingRequests();
+                if (currentPending < 0) {
+                    return RejectedPermanently;
+                }
+                if (currentPending >= maxConcurrency) {
+                    return RejectedTemporary;
+                }
+                if (casPendingRequests(currentPending, currentPending + 1)) {
+                    return Accepted;
+                }
+            }
+        }
+    }
+}

--- a/servicetalk-loadbalancer/build.gradle
+++ b/servicetalk-loadbalancer/build.gradle
@@ -26,7 +26,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
-  implementation project(":servicetalk-client-api-internal")
   implementation "com.google.code.findbugs:jsr305"
   implementation "org.slf4j:slf4j-api"
 


### PR DESCRIPTION
Motivation:

#2278 moved `RequestConcurrencyController` and
`ReservableRequestConcurrencyController` from `client-api-internal` to
`client-api` module. This is an API incompatible change for 0.42.x.
Also, it removed
`DefaultHttpLoadBalancerFactory#toLoadBalancedConnection` impl, this
is a binary incompatible change.

Modifications:

- Restore `io.servicetalk.client.api.internal.RequestConcurrencyController`
and `io.servicetalk.client.api.internal.ReservableRequestConcurrencyController`
interfaces and all references to them in `client-api-internal` module;
- Create a pkg-private copy of `ReservableRequestConcurrencyControllers`
inside `http-netty` module that targets public
`io.servicetalk.client.api.ReservableRequestConcurrencyController`;
- Copy tests for `ReservableRequestConcurrencyControllers`;
- Create a pkg-private copy of
`io.servicetalk.client.api.internal.IgnoreConsumedEvent` in `http-netty`
module;
- Deprecate all classes and interfaces in `client-api-internal` module;
- Remove unnecessary references to `servicetalk-client-api-internal`
dependency in modules that don't actually depend on it;

Result:

1. The next 0.42.14 release will be backward compatible with 0.42.13.
2. The whole `servicetalk-client-api-internal` module is deprecated now
and can be removed in future releases.