### PR TITLE
Remove logging for duplicate termination in Jersey router

### DIFF
--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
@@ -427,7 +427,6 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
 
         @Override
         public void onError(final Throwable t) {
-            // ApplicationHandler.handler may throw if shutdown concurrently with request processing
             if (doneUpdater.compareAndSet(this, 0, 1)) {
                 delegate.onError(t);
             }

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/DefaultJerseyStreamingHttpRouter.java
@@ -43,8 +43,6 @@ import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.spi.Container;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -398,8 +396,13 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
         }
     }
 
+    /**
+     * {@link ApplicationHandler#handle(ContainerRequest)} may throw if it has been shutdown concurrently. This class
+     * prevents duplicate terminal signals which would violate <a href="
+     * https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.4/README.md#1.7">Reactive Streams 1.7</a>
+     * @param <T> The type of {@link Subscriber}.
+     */
     private static final class DuplicateTerminateDetectorSingle<T> implements Subscriber<T> {
-        private static final Logger LOGGER = LoggerFactory.getLogger(DuplicateTerminateDetectorSingle.class);
         @SuppressWarnings("rawtypes")
         private static final AtomicIntegerFieldUpdater<DuplicateTerminateDetectorSingle> doneUpdater =
                 newUpdater(DuplicateTerminateDetectorSingle.class, "done");
@@ -419,17 +422,14 @@ final class DefaultJerseyStreamingHttpRouter implements StreamingHttpService {
         public void onSuccess(@Nullable final T result) {
             if (doneUpdater.compareAndSet(this, 0, 1)) {
                 delegate.onSuccess(result);
-            } else {
-                LOGGER.error("duplicate termination in onSuccess {} {}", result, delegate);
             }
         }
 
         @Override
         public void onError(final Throwable t) {
+            // ApplicationHandler.handler may throw if shutdown concurrently with request processing
             if (doneUpdater.compareAndSet(this, 0, 1)) {
                 delegate.onError(t);
-            } else {
-                LOGGER.error("duplicate termination in onError {}", delegate, t);
             }
         }
     }


### PR DESCRIPTION
Motivation:
DefaultJerseyStreamingHttpRouter relies upon the `ContainerResponseWriter` to
terminate the request, and therefore the reactive stream subscriber. However
it wasn't known if there were control flows that may result in duplicate
termination so defensive code was added to guard against this case.
During shutdown it is possible for the `ApplicationHandler#handle(..)` method
to throw and in this case duplicate termination maybe expected. We currently
log an error because this wasn't expected but this raises false alarms and
should be removed.

```
java.lang.IllegalStateException: ServiceLocatorImpl(__HK2_Generated_0,0,891192830) has been shut down
	at org.jvnet.hk2.internal.ServiceLocatorImpl.checkState(ServiceLocatorImpl.java:2370)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getServiceHandleImpl(ServiceLocatorImpl.java:612)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getServiceHandle(ServiceLocatorImpl.java:605)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getServiceHandle(ServiceLocatorImpl.java:623)
	at org.jvnet.hk2.internal.FactoryCreator.getFactoryHandle(FactoryCreator.java:79)
	at org.jvnet.hk2.internal.FactoryCreator.dispose(FactoryCreator.java:149)
	at org.jvnet.hk2.internal.SystemDescriptor.dispose(SystemDescriptor.java:518
	at org.glassfish.jersey.inject.hk2.RequestContext.lambda$findOrCreate$0(RequestContext.java:60)
	at org.glassfish.jersey.internal.inject.ForeignDescriptorImpl.dispose(ForeignDescriptorImpl.java:63)
	at org.glassfish.jersey.inject.hk2.Hk2RequestScope$Instance.remove(Hk2RequestScope.java:126)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.glassfish.jersey.inject.hk2.Hk2RequestScope$Instance.release(Hk2RequestScope.java:143)
	at org.glassfish.jersey.process.internal.RequestScope.release(RequestScope.java:246)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:267)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:234)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:684)
	at io.servicetalk.http.router.jersey.DefaultJerseyStreamingHttpRouter.handle0(DefaultJerseyStreamingHttpRouter.java:261)
```