### PR TITLE
Null check result of `HttpServerBuilder` supplier

### DIFF
--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -95,7 +95,7 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     // Do not use this ctor directly, GrpcServers is the entry point for creating a new builder.
     DefaultGrpcServerBuilder(final Supplier<HttpServerBuilder> httpServerBuilderSupplier) {
         this.httpServerBuilderSupplier = () ->
-                Objects.requireNonNull(httpServerBuilderSupplier.get(), "supplier result was null")
+                requireNonNull(httpServerBuilderSupplier.get(), "Supplier<HttpServerBuilder> result was null")
                     .protocols(h2Default()).allowDropRequestTrailers(true);
     }
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -55,7 +55,6 @@ import java.net.SocketOption;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -95,7 +95,7 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     // Do not use this ctor directly, GrpcServers is the entry point for creating a new builder.
     DefaultGrpcServerBuilder(final Supplier<HttpServerBuilder> httpServerBuilderSupplier) {
         this.httpServerBuilderSupplier = () ->
-                Objects.requireNonNull(httpServerBuilderSupplier.get(), "httpServerBuilderSupplier was null")
+                Objects.requireNonNull(httpServerBuilderSupplier.get(), "supplier result was null")
                     .protocols(h2Default()).allowDropRequestTrailers(true);
     }
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -55,6 +55,7 @@ import java.net.SocketOption;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -93,8 +94,9 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
 
     // Do not use this ctor directly, GrpcServers is the entry point for creating a new builder.
     DefaultGrpcServerBuilder(final Supplier<HttpServerBuilder> httpServerBuilderSupplier) {
-        this.httpServerBuilderSupplier = () -> httpServerBuilderSupplier.get()
-                .protocols(h2Default()).allowDropRequestTrailers(true);
+        this.httpServerBuilderSupplier = () ->
+                Objects.requireNonNull(httpServerBuilderSupplier.get(), "httpServerBuilderSupplier was null")
+                    .protocols(h2Default()).allowDropRequestTrailers(true);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
`DefaultGrpcServerBuilder` invokes a provided Supplier without checking
the result for null. A `NullPointerException` will occur, but will not
include context about what was null.
Modifications:
Add `Objects.requireNonNull` check when invoking `Supplier`
Result:
Better diagnostic for failed Supplier.