### PR TITLE
Throw error when score is invoked on a connection that doesn't support it.

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -119,8 +119,11 @@ public interface HttpLoadBalancerFactory<ResolvedAddress>
                 final FilterableStreamingHttpConnection delegate,
                 final ReservableRequestConcurrencyController controller) {
             this(delegate, controller, () -> {
-                throw new UnsupportedOperationException("This type of connection doesn't support scoring. " +
-                        "Connection scoring is only available through scoring supported load balancers.");
+                throw new UnsupportedOperationException(
+                        DefaultFilterableStreamingHttpLoadBalancedConnection.class.getName() +
+                                " doesn't support scoring. " + ScoreSupplier.class.getName() +
+                                " is only available through " + HttpLoadBalancerFactory.class.getSimpleName() +
+                                " implementations that support scoring.");
             });
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -119,7 +119,10 @@ public interface HttpLoadBalancerFactory<ResolvedAddress>
         public DefaultFilterableStreamingHttpLoadBalancedConnection(
                 final FilterableStreamingHttpConnection delegate,
                 final ReservableRequestConcurrencyController controller) {
-            this(delegate, controller, () -> MAX_VALUE);
+            this(delegate, controller, () -> {
+                throw new UnsupportedOperationException("This type of connection doesn't support scoring. " +
+                        "Connection scoring is only available through scoring supported load balancers.");
+            });
         }
 
         /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import static io.servicetalk.http.api.HttpApiConversions.toReservedBlockingConnection;
 import static io.servicetalk.http.api.HttpApiConversions.toReservedBlockingStreamingConnection;
 import static io.servicetalk.http.api.HttpApiConversions.toReservedConnection;
-import static java.lang.Integer.MAX_VALUE;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
+import io.servicetalk.client.api.ScoreSupplier;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
@@ -141,8 +142,11 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
 
         @Override
         public int score() {
-            throw new UnsupportedOperationException("This type of connection doesn't support scoring. " +
-                    "Connection scoring is only available through scoring supported load balancers.");
+            throw new UnsupportedOperationException(
+                   DefaultFilterableStreamingHttpLoadBalancedConnection.class.getName() +
+                           " doesn't support scoring. " + ScoreSupplier.class.getName() +
+                           " is only available through " + HttpLoadBalancerFactory.class.getSimpleName() +
+                           " implementations that support scoring.");
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -37,7 +37,6 @@ import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
 
 import java.util.Collection;
 
-import static java.lang.Integer.MAX_VALUE;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -142,7 +142,8 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
 
         @Override
         public int score() {
-            return MAX_VALUE;
+            throw new UnsupportedOperationException("This type of connection doesn't support scoring. " +
+                    "Connection scoring is only available through scoring supported load balancers.");
         }
 
         @Override


### PR DESCRIPTION
Motivation:

Different load-balancer implementations can support connection scores or not.
Due to common interfaces it would be easy for a user to mix scoring protocol agnostic load-balancer with a non scoring
protocol specific wrapper, without knowing that the configuration was wrong, either in built or run times.

Modifications:

Let default implementations of `score()` throw an error instead, thus making visible the misuse during runtime.

Result:

Better misconfiguration visibility