### PR TITLE
Give access to the underlying TCP ConnectionContext from HTTP/2 service

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategies;
@@ -150,6 +151,7 @@ public class NettyPipelinedConnectionBenchmark {
 
     private NettyConnection<Object, Object> newNettyConnection() {
         return new NettyConnection<Object, Object>() {
+
             private final AtomicInteger offloadCount = new AtomicInteger();
             @Override
             public Publisher<Object> read() {
@@ -259,6 +261,12 @@ public class NettyPipelinedConnectionBenchmark {
             @Override
             public Protocol protocol() {
                 return HttpProtocolVersion.HTTP_1_1;
+            }
+
+            @Nullable
+            @Override
+            public ConnectionContext parent() {
+                return null;
             }
 
             @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
@@ -91,6 +91,12 @@ final class DefaultGrpcServiceContext extends DefaultGrpcMetadata implements Grp
         return protocol;
     }
 
+    @Nullable
+    @Override
+    public ConnectionContext parent() {
+        return connectionContext.parent();
+    }
+
     @Override
     public Completable onClose() {
         return connectionContext.onClose();

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
@@ -37,6 +37,7 @@ import io.servicetalk.serializer.api.Serializer;
 import io.servicetalk.serializer.api.StreamingDeserializer;
 import io.servicetalk.serializer.api.StreamingSerializer;
 import io.servicetalk.serializer.utils.FramedDeserializerOperator;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.SslConfig;
 
@@ -192,6 +193,12 @@ final class Utils {
         @Override
         public GrpcProtocol protocol() {
             return InMemoryGrpcProtocol.INSTANCE;
+        }
+
+        @Nullable
+        @Override
+        public ConnectionContext parent() {
+            return null;
         }
 
         @Deprecated

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ParentConnectionContextTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ParentConnectionContextTest.java
@@ -43,6 +43,7 @@ import static java.util.Collections.singleton;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 class ParentConnectionContextTest {
@@ -135,6 +136,7 @@ class ParentConnectionContextTest {
                     parent.localAddress(), is(sameInstance(ctx.localAddress())));
             assertThat("Unexpected remoteAddress",
                     parent.remoteAddress(), is(sameInstance(ctx.remoteAddress())));
+            assertThat("Unexpected parent.parent()", parent.parent(), is(nullValue()));
         } catch (Throwable t) {
             errors.add(t);
         }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ParentConnectionContextTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ParentConnectionContextTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.concurrent.BlockingIterable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.api.GrpcPayloadWriter;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.netty.TesterProto.TestRequest;
+import io.servicetalk.grpc.netty.TesterProto.TestResponse;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterClient;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterService;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
+import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.util.Collections.singleton;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+class ParentConnectionContextTest {
+
+    private final BlockingQueue<Throwable> errors = new LinkedBlockingQueue<>();
+
+    @ParameterizedTest(name = "{index}: blocking={0}")
+    @ValueSource(booleans = {false, true})
+    void test(boolean blocking) throws Exception {
+        try (ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
+                .listenAndAwait(blocking ? new BlockingTesterServiceImpl() : new TesterServiceImpl());
+             BlockingTesterClient client = GrpcClients.forAddress(serverHostAndPort(serverContext))
+                     .buildBlocking(new TesterProto.Tester.ClientFactory())) {
+
+            client.test(TestRequest.getDefaultInstance());
+            client.testBiDiStream(singleton(TestRequest.getDefaultInstance())).forEach(__ -> { /* noop */ });
+            client.testResponseStream(TestRequest.getDefaultInstance()).forEach(__ -> { /* noop */ });
+            client.testRequestStream(singleton(TestRequest.getDefaultInstance()));
+        }
+        assertNoAsyncErrors(errors);
+    }
+
+    private final class TesterServiceImpl implements TesterService {
+
+        @Override
+        public Single<TestResponse> test(GrpcServiceContext ctx, TestRequest request) {
+            assertServiceContext(ctx, errors);
+            return succeeded(TestResponse.getDefaultInstance());
+        }
+
+        @Override
+        public Publisher<TestResponse> testBiDiStream(GrpcServiceContext ctx, Publisher<TestRequest> request) {
+            assertServiceContext(ctx, errors);
+            return request.ignoreElements().concat(from(TestResponse.getDefaultInstance()));
+        }
+
+        @Override
+        public Publisher<TestResponse> testResponseStream(GrpcServiceContext ctx, TestRequest request) {
+            assertServiceContext(ctx, errors);
+            return from(TestResponse.getDefaultInstance());
+        }
+
+        @Override
+        public Single<TestResponse> testRequestStream(GrpcServiceContext ctx, Publisher<TestRequest> request) {
+            assertServiceContext(ctx, errors);
+            return request.ignoreElements().concat(succeeded(TestResponse.getDefaultInstance()));
+        }
+    }
+
+    private final class BlockingTesterServiceImpl implements BlockingTesterService {
+
+        @Override
+        public TestResponse test(GrpcServiceContext ctx, TestRequest request) {
+            assertServiceContext(ctx, errors);
+            return TestResponse.getDefaultInstance();
+        }
+
+        @Override
+        public void testBiDiStream(GrpcServiceContext ctx, BlockingIterable<TestRequest> request,
+                                   GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
+            assertServiceContext(ctx, errors);
+            request.forEach(__ -> { /* noop */ });
+            responseWriter.write(TestResponse.getDefaultInstance());
+            responseWriter.close();
+        }
+
+        @Override
+        public void testResponseStream(GrpcServiceContext ctx, TestRequest request,
+                                       GrpcPayloadWriter<TestResponse> responseWriter) throws Exception {
+            assertServiceContext(ctx, errors);
+            responseWriter.write(TestResponse.getDefaultInstance());
+            responseWriter.close();
+        }
+
+        @Override
+        public TestResponse testRequestStream(GrpcServiceContext ctx, BlockingIterable<TestRequest> request) {
+            assertServiceContext(ctx, errors);
+            request.forEach(__ -> { /* noop */ });
+            return TestResponse.getDefaultInstance();
+        }
+    }
+
+    private static void assertServiceContext(GrpcServiceContext ctx, BlockingQueue<Throwable> errors) {
+        try {
+            assertThat(ctx, is(notNullValue()));
+            ConnectionContext parent = ctx.parent();
+            assertThat("gRPC stream must have reference to its parent ConnectionContext",
+                    parent, is(notNullValue()));
+            assertThat("Unexpected localAddress",
+                    parent.localAddress(), is(sameInstance(ctx.localAddress())));
+            assertThat("Unexpected remoteAddress",
+                    parent.remoteAddress(), is(sameInstance(ctx.remoteAddress())));
+        } catch (Throwable t) {
+            errors.add(t);
+        }
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.SslConfig;
 
 import java.net.SocketAddress;
@@ -91,6 +92,12 @@ public class DelegatingHttpServiceContext extends HttpServiceContext {
     @Override
     public HttpProtocolVersion protocol() {
         return delegate.protocol();
+    }
+
+    @Nullable
+    @Override
+    public ConnectionContext parent() {
+        return delegate.parent();
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnectionContext.java
@@ -27,4 +27,9 @@ public interface HttpConnectionContext extends ConnectionContext {
 
     @Override
     HttpProtocolVersion protocol();
+
+    // Do not override the return type of parent() method to HttpConnectionContext as there is a possibility to have an
+    // HttpConnectionContext over a non-HTTP ConnectionContext. Also, with HttpConnectionContext as a return type it
+    // makes implementation a lot harder because we receive a non-HTTP NettyConnectionContext from the transport and
+    // wrap it later.
 }

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestHttpServiceContext.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestHttpServiceContext.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.AddressUtils;
 
@@ -98,6 +99,12 @@ public class TestHttpServiceContext extends HttpServiceContext {
     @Override
     public HttpProtocolVersion protocol() {
         return HTTP_1_0;
+    }
+
+    @Nullable
+    @Override
+    public ConnectionContext parent() {
+        return null;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
@@ -21,11 +21,14 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.DelegatingConnectionContext;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
 import io.netty.channel.Channel;
+
+import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,6 +53,12 @@ final class DefaultNettyHttpConnectionContext extends DelegatingConnectionContex
     @Override
     public HttpProtocolVersion protocol() {
         return (HttpProtocolVersion) nettyConnectionContext.protocol();
+    }
+
+    @Nullable
+    @Override
+    public ConnectionContext parent() {
+        return nettyConnectionContext.parent();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -40,6 +40,7 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.netty.LoadBalancedStreamingHttpClient.OnStreamClosedRunnable;
 import io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.IgnoreConsumedEvent;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
@@ -348,13 +349,11 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                             closeHandler, streamObserver));
                     DefaultNettyConnection<Object, Object> nettyConnection =
                             DefaultNettyConnection.initChildChannel(streamChannel,
-                                    parentContext.executionContext(),
+                                    parentContext,
                                     closeHandler,
-                                    parentContext.flushStrategyHolder.currentStrategy(),
+                                    parentContext.defaultFlushStrategy(),
                                     parentContext.idleTimeoutMs,
                                     HTTP_2_0,
-                                    parentContext.sslConfig(),
-                                    parentContext.sslSession(),
                                     parentContext.nettyChannel().config(),
                                     streamObserver,
                                     true, OBJ_EXPECT_CONTINUE,
@@ -438,6 +437,12 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
         @Override
         public HttpProtocolVersion protocol() {
             return parentContext.protocol();
+        }
+
+        @Nullable
+        @Override
+        public ConnectionContext parent() {
+            return parentContext.parent();
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -25,6 +25,7 @@ import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
@@ -147,6 +148,12 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
     @Override
     public HttpProtocolVersion protocol() {
         return HTTP_2_0;
+    }
+
+    @Nullable
+    @Override
+    public ConnectionContext parent() {
+        return null;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -165,17 +165,15 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                 // ServiceTalk <-> Netty netty utilities
                                 DefaultNettyConnection<Object, Object> streamConnection =
                                         DefaultNettyConnection.initChildChannel(streamChannel,
-                                                connection.executionContext(),
+                                                connection,
                                                 closeHandler,
                                                 // TODO(scott): after flushStrategy is no longer on the connection
                                                 // level we can use DefaultNettyConnection.initChannel instead of this
                                                 // custom method.
-                                                connection.flushStrategyHolder.currentStrategy(),
+                                                connection.defaultFlushStrategy(),
                                                 connection.idleTimeoutMs,
                                                 HTTP_2_0,
-                                                connection.sslConfig(),
-                                                connection.sslSession(),
-                                                channel.config(),
+                                                connection.nettyChannel().config(),
                                                 streamObserver,
                                                 false, __ -> false,
                                                 NettyHttp2ExceptionUtils::wrapIfNecessary);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -47,6 +47,7 @@ import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
 import io.servicetalk.tcp.netty.internal.TcpServerBinder;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.SslConfig;
@@ -508,6 +509,12 @@ final class NettyHttpServer {
         @Override
         public HttpProtocolVersion protocol() {
             return (HttpProtocolVersion) connection.protocol();
+        }
+
+        @Nullable
+        @Override
+        public ConnectionContext parent() {
+            return connection.parent();
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyPipelinedConnection.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.ConcurrentUtils;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
@@ -164,6 +165,12 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
     @Override
     public Protocol protocol() {
         return connection.protocol();
+    }
+
+    @Nullable
+    @Override
+    public ConnectionContext parent() {
+        return connection.parent();
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ParentConnectionContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ParentConnectionContextTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.BlockingHttpConnection;
+import io.servicetalk.http.api.BlockingStreamingHttpClient;
+import io.servicetalk.http.api.BlockingStreamingHttpConnection;
+import io.servicetalk.http.api.BlockingStreamingHttpResponse;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpConnection;
+import io.servicetalk.http.api.HttpConnectionContext;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.internal.AddressUtils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+class ParentConnectionContextTest {
+
+    private final BlockingQueue<Throwable> errors = new LinkedBlockingQueue<>();
+
+    @ParameterizedTest(name = "{index}: protocol={0}")
+    @EnumSource(HttpProtocol.class)
+    void testAsyncAggregated(HttpProtocol protocol) throws Exception {
+        try (ServerContext serverContext = newServerBuilder(protocol)
+                .listenAndAwait((ctx, request, responseFactory) -> {
+                    assertServiceContext(ctx, protocol, errors);
+                    return succeeded(responseFactory.ok());
+                });
+             HttpClient client = newClientBuilder(serverContext, protocol).build();
+             HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            assertClientConnectionContext(connection.connectionContext());
+            HttpResponse response = connection.request(connection.get("/")).toFuture().get();
+            assertResponse(response);
+        }
+        assertNoAsyncErrors(errors);
+    }
+
+    @ParameterizedTest(name = "{index}: protocol={0}")
+    @EnumSource(HttpProtocol.class)
+    void testAsyncStreaming(HttpProtocol protocol) throws Exception {
+        try (ServerContext serverContext = newServerBuilder(protocol)
+                .listenStreamingAndAwait((ctx, request, responseFactory) -> {
+                    assertServiceContext(ctx, protocol, errors);
+                    return succeeded(responseFactory.ok());
+                });
+             StreamingHttpClient client = newClientBuilder(serverContext, protocol).buildStreaming();
+             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+
+            assertClientConnectionContext(connection.connectionContext());
+            StreamingHttpResponse response = connection.request(connection.get("/")).toFuture().get();
+            assertResponse(response);
+            response.payloadBody().toFuture().get();
+        }
+        assertNoAsyncErrors(errors);
+    }
+
+    @ParameterizedTest(name = "{index}: protocol={0}")
+    @EnumSource(HttpProtocol.class)
+    void testBlockingAggregated(HttpProtocol protocol) throws Exception {
+        try (ServerContext serverContext = newServerBuilder(protocol)
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                    assertServiceContext(ctx, protocol, errors);
+                    return responseFactory.ok();
+                });
+             BlockingHttpClient client = newClientBuilder(serverContext, protocol).buildBlocking();
+             BlockingHttpConnection connection = client.reserveConnection(client.get("/"))) {
+
+            assertClientConnectionContext(connection.connectionContext());
+            HttpResponse response = connection.request(connection.get("/"));
+            assertResponse(response);
+        }
+        assertNoAsyncErrors(errors);
+    }
+
+    @ParameterizedTest(name = "{index}: protocol={0}")
+    @EnumSource(HttpProtocol.class)
+    void testBlockingStreaming(HttpProtocol protocol) throws Exception {
+        try (ServerContext serverContext = newServerBuilder(protocol)
+                .listenBlockingStreamingAndAwait((ctx, request, response) -> {
+                    assertServiceContext(ctx, protocol, errors);
+                    response.sendMetaData().close();
+                });
+             BlockingStreamingHttpClient client = newClientBuilder(serverContext, protocol).buildBlockingStreaming();
+             BlockingStreamingHttpConnection connection = client.reserveConnection(client.get("/"))) {
+
+            assertClientConnectionContext(connection.connectionContext());
+            BlockingStreamingHttpResponse response = connection.request(connection.get("/"));
+            assertResponse(response);
+            response.payloadBody().forEach(__ -> { /* noop */ });
+        }
+        assertNoAsyncErrors(errors);
+    }
+
+    private static void assertResponse(HttpResponseMetaData response) {
+        assertThat(response.status(), is(OK));
+    }
+
+    private static void assertClientConnectionContext(HttpConnectionContext ctx) {
+        assertThat(ctx, is(notNullValue()));
+        assertThat("Unexpected ConnectionContext#parent() for the client connection",
+                ctx.parent(), is(nullValue()));
+    }
+
+    private static void assertServiceContext(HttpServiceContext ctx, HttpProtocol protocol,
+                                             BlockingQueue<Throwable> errors) {
+        try {
+            assertThat(ctx, is(notNullValue()));
+            ConnectionContext parent = ctx.parent();
+            switch (protocol) {
+                case HTTP_1:
+                    assertThat("Unexpected HttpServiceContext#parent() for HTTP/1.x connection",
+                            parent, is(nullValue()));
+                    break;
+                case HTTP_2:
+                    assertThat("HTTP/2 stream must have reference to its parent ConnectionContext",
+                            parent, is(notNullValue()));
+                    assertThat("Unexpected localAddress",
+                            parent.localAddress(), is(sameInstance(ctx.localAddress())));
+                    assertThat("Unexpected remoteAddress",
+                            parent.remoteAddress(), is(sameInstance(ctx.remoteAddress())));
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                            "Unexpected " + HttpProtocol.class.getSimpleName() + ": " + protocol);
+            }
+        } catch (Throwable t) {
+            errors.add(t);
+        }
+    }
+
+    private static HttpServerBuilder newServerBuilder(HttpProtocol protocol) {
+        return HttpServers.forAddress(localAddress(0))
+                .protocols(protocol.config);
+    }
+
+    private static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilder(
+            ServerContext serverContext, HttpProtocol protocol) {
+        return HttpClients.forSingleAddress(AddressUtils.serverHostAndPort(serverContext))
+                .protocols(protocol.config);
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ParentConnectionContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ParentConnectionContextTest.java
@@ -158,6 +158,7 @@ class ParentConnectionContextTest {
                             parent.localAddress(), is(sameInstance(ctx.localAddress())));
                     assertThat("Unexpected remoteAddress",
                             parent.remoteAddress(), is(sameInstance(ctx.remoteAddress())));
+                    assertThat("Unexpected parent.parent()", parent.parent(), is(nullValue()));
                     break;
                 default:
                     throw new IllegalArgumentException(

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionContext.java
@@ -17,8 +17,23 @@ package io.servicetalk.transport.api;
 
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
+import javax.annotation.Nullable;
+
 /**
  * A context for a connection.
  */
 public interface ConnectionContext extends ConnectionInfo, ListenableAsyncCloseable {
+
+    /**
+     * Returns a reference to a parent {@link ConnectionContext} if any.
+     * <p>
+     * This method is useful when multiple virtual streams are multiplexed over a single connection to get access to the
+     * actual {@link ConnectionContext} that represents network.
+     *
+     * @return a reference to a parent {@link ConnectionContext} if any. Otherwise, returns {@code null}.
+     */
+    @Nullable
+    default ConnectionContext parent() {    // FIXME: 0.43 - consider removing default impl
+        return null;
+    }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
@@ -87,6 +87,12 @@ public class DelegatingConnectionContext implements ConnectionContext {
         return delegate.protocol();
     }
 
+    @Nullable
+    @Override
+    public ConnectionContext parent() {
+        return delegate.parent();
+    }
+
     @Override
     public Completable onClose() {
         return delegate.onClose();


### PR DESCRIPTION
Motivation:

Server-side users have access only to HTTP/2 stream `ConnectionContext`
from the `HttpServiceContext`. In some cases, it's important to access
a `ConnectionContext` of the underlying TCP connection.

Modifications:

- Add `@Nullable ConnectionContext#parent()` method;
- Implement support for a new method;
- Add tests;

Result:

Users can access the underlying TCP `ConnectionContext` from the HTTP/2
service endpoint.