### PR TITLE
Publisher#flatMapConcatSingle null value concurrency fix

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatUtils.java
@@ -134,6 +134,13 @@ final class PublisherFlatMapConcatUtils {
     private static final class Item<R> {
         @Nullable
         SingleSource.Subscriber<? super R> subscriber;
+        /**
+         * Visibility is provided by {@link OrderedMapper#consumerLockUpdater}. There are multiple producer threads
+         * modifying independent {@link Item}s, but only a single thread consumes and calls {@link #tryTerminate()}.
+         * Since the state is a single reference either the consumer thread sees the state, or it doesn't. If it does
+         * then the item can be consumed and we are done. If it doesn't then the
+         * {@link OrderedMapper#consumerLockUpdater} requires another lock attempt and the state becomes visible.
+         */
         @Nullable
         private Object result;
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SourceToFuture.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SourceToFuture.java
@@ -145,7 +145,7 @@ abstract class SourceToFuture<T> implements Future<T> {
             if (result == null) {
                 setValue(NULL);
             } else if (result instanceof Throwable) {
-                setValue(new ThrowableWrapper(result));
+                setValue(new ThrowableWrapper((Throwable) result));
             } else {
                 setValue(result);
             }
@@ -166,22 +166,6 @@ abstract class SourceToFuture<T> implements Future<T> {
         @Override
         public void onComplete() {
             setValue(NULL);
-        }
-    }
-
-    /**
-     * Used to distinguish succeeded {@code Single<Throwable>} vs failed {@code Single<T>}.
-     */
-    private static final class ThrowableWrapper {
-
-        private final Object throwable;
-
-        ThrowableWrapper(final Object throwable) {
-            this.throwable = throwable;
-        }
-
-        Object unwrap() {
-            return throwable;
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ThrowableWrapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ThrowableWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,17 @@
  */
 package io.servicetalk.concurrent.api;
 
-import javax.annotation.Nullable;
+/**
+ * Used to distinguish between a real object and a {@link Throwable} from terminal error.
+ */
+final class ThrowableWrapper {
+    private final Throwable throwable;
 
-final class SubscriberApiUtils {
-    private static final Object NULL_TOKEN = new Object();
-
-    private SubscriberApiUtils() {
-        // no instances
+    ThrowableWrapper(final Throwable throwable) {
+        this.throwable = throwable;
     }
 
-    static Object wrapNull(@Nullable Object o) {
-        return o == null ? NULL_TOKEN : o;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Nullable
-    static <T> T unwrapNullUnchecked(Object o) {
-        return o == NULL_TOKEN ? null : (T) o;
+    Throwable unwrap() {
+        return throwable;
     }
 }


### PR DESCRIPTION
Motivation:
Publisher#flatMapConcatSingle maintains a queue of elements
on top of Publisher#flatMapSingle to maintain ordering. Elements
within this queue have non-volatile state due to outer concurrency
protections, however there are two independent variables indicating
"terminal type" and "terminal value". This may result in reading
the "terminal type" the "terminal value" may not be visible yet
and return `null`.

Modifications:
- Collapse the 2 variables into a single variable, so when reading
  if it is non-null we have the "type" and "value" visible.

Result:
Fixes https://github.com/apple/servicetalk/issues/2321