### PR TITLE
RoundRobinLoadBalancer bad host retry use DeltaJitter

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConnection>
         implements LoadBalancerFactory<ResolvedAddress, C> {
 
-    private static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = Duration.ofSeconds(1);
+    private static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = Duration.ofSeconds(5);
+    private static final Duration DEFAULT_HEALTH_CHECK_JITTER = Duration.ofSeconds(3);
     static final int DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD = 5; // higher than default for AutoRetryStrategy
 
     private final int linearSearchSpace;
@@ -114,6 +115,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
         @Nullable
         private Executor backgroundExecutor;
         private Duration healthCheckInterval = DEFAULT_HEALTH_CHECK_INTERVAL;
+        private Duration healthCheckJitter = DEFAULT_HEALTH_CHECK_JITTER;
         private int healthCheckFailedConnectionsThreshold = DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
 
         /**
@@ -174,12 +176,39 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
          * @param interval interval at which a background health check will be scheduled.
          * @return {@code this}.
          * @see #healthCheckFailedConnectionsThreshold(int)
+         * @deprecated Use {@link #healthCheckInterval(Duration, Duration)}.
          */
+        @Deprecated
         public RoundRobinLoadBalancerFactory.Builder<ResolvedAddress, C> healthCheckInterval(Duration interval) {
+            return healthCheckInterval(interval,
+                    interval.compareTo(DEFAULT_HEALTH_CHECK_INTERVAL) <= 0 ? interval.dividedBy(2) :
+                            DEFAULT_HEALTH_CHECK_JITTER);
+        }
+
+        /**
+         * Configure an interval for health checking a host that failed to open connections. If no interval is provided
+         * using this method, a default value will be used.
+         * <p>
+         * {@link #healthCheckFailedConnectionsThreshold(int)} can be used to disable the health checking mechanism
+         * and always consider all hosts for establishing new connections.
+         * @param interval interval at which a background health check will be scheduled.
+         * @param jitter the amount of jitter to apply to each retry {@code interval}.
+         * @return {@code this}.
+         * @see #healthCheckFailedConnectionsThreshold(int)
+         */
+        public RoundRobinLoadBalancerFactory.Builder<ResolvedAddress, C> healthCheckInterval(Duration interval,
+                                                                                             Duration jitter) {
             if (interval.isNegative() || interval.isZero()) {
                 throw new IllegalArgumentException("Health check interval should be greater than 0");
             }
+            if (jitter.isNegative() || jitter.isZero()) {
+                throw new IllegalArgumentException("Jitter interval should be greater than 0");
+            }
+            if (interval.minus(jitter).isNegative() || interval.plus(jitter).isNegative()) {
+                throw new IllegalArgumentException("Jitter plus/minus interval underflow/overflow");
+            }
             this.healthCheckInterval = interval;
+            this.healthCheckJitter = jitter;
             return this;
         }
 
@@ -218,7 +247,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
 
             HealthCheckConfig healthCheckConfig = new HealthCheckConfig(
                             this.backgroundExecutor == null ? SharedExecutor.getInstance() : this.backgroundExecutor,
-                    healthCheckInterval, healthCheckFailedConnectionsThreshold);
+                    healthCheckInterval, healthCheckJitter, healthCheckFailedConnectionsThreshold);
 
             return new RoundRobinLoadBalancerFactory<>(linearSearchSpace, healthCheckConfig);
         }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static java.time.Duration.ofSeconds;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -75,8 +76,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConnection>
         implements LoadBalancerFactory<ResolvedAddress, C> {
 
-    private static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = Duration.ofSeconds(5);
-    private static final Duration DEFAULT_HEALTH_CHECK_JITTER = Duration.ofSeconds(3);
+    private static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = ofSeconds(5);
+    private static final Duration DEFAULT_HEALTH_CHECK_JITTER = ofSeconds(3);
     static final int DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD = 5; // higher than default for AutoRetryStrategy
 
     private final int linearSearchSpace;

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collection;
@@ -88,7 +87,6 @@ import static io.servicetalk.concurrent.internal.TestTimeoutConstants.DEFAULT_TI
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerTest.UnhealthyHostConnectionFactory.UNHEALTHY_HOST_EXCEPTION;
 import static java.time.Duration.ofMillis;
-import static java.time.Duration.ofSeconds;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -87,6 +87,8 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.DEFAULT_TIMEOUT_SECONDS;
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerTest.UnhealthyHostConnectionFactory.UNHEALTHY_HOST_EXCEPTION;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
@@ -525,6 +527,7 @@ abstract class RoundRobinLoadBalancerTest {
         final AtomicInteger scheduleCnt = new AtomicInteger();
         lb = (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>)
                 new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                        .healthCheckInterval(ofMillis(50), ofMillis(10))
                         .healthCheckFailedConnectionsThreshold(1)
                         .backgroundExecutor(new DelegatingExecutor(testExecutor) {
 
@@ -599,7 +602,7 @@ abstract class RoundRobinLoadBalancerTest {
                                 // but we still wait until the health check is scheduled and only then stop retrying.
                                 t instanceof DeliberateException || testExecutor.scheduledTasksPending() == 0,
                         // try to prevent stack overflow
-                        Duration.ofMillis(30), executorForRetries)));
+                        ofMillis(30), executorForRetries)));
             } catch (Exception e) {
                 assertThat(e.getCause(), instanceOf(NoAvailableHostException.class));
             } finally {
@@ -636,6 +639,7 @@ abstract class RoundRobinLoadBalancerTest {
 
         lb = (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>)
                 new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                        .healthCheckInterval(ofMillis(50), ofMillis(10))
                         .backgroundExecutor(testExecutor)
                         .build()
                         .newLoadBalancer("test-service", serviceDiscoveryPublisher, connectionFactory);
@@ -707,6 +711,7 @@ abstract class RoundRobinLoadBalancerTest {
         final DelegatingConnectionFactory connectionFactory) {
         return (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>)
                 new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                        .healthCheckInterval(ofMillis(50), ofMillis(10))
                         .backgroundExecutor(testExecutor)
                         .build()
                         .newLoadBalancer("test-service", serviceDiscoveryPublisher, connectionFactory);


### PR DESCRIPTION
Motivation:
RoundRobinLoadBalancer will put hosts/remote-addresses that
we fail to establish a connection to 5 consecutive times
into a "penalty box" making them ineligible for selection
and in the background retry connection attempts. The retry strategy
uses FullJitter and default of 1 second. This has been observed to
issue many retry attempts (16+) per second which is more frequent
than typically required.

Modifications:
- Switch to using DeltaJitter and increase the default retry duration
  to 5 seconds.