### PR TITLE
Add io_uring dependencies with classifiers in `servicetalk-dependencies`

### DIFF
--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-core"
 apply plugin: "java-platform"
 
@@ -40,8 +39,6 @@ dependencies {
 
     // Ideally these come from the Netty BOM
     api "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
-    api "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-x86_64"
-    api "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion:linux-aarch_64"
 
     api "io.opentracing:opentracing-api:$openTracingVersion"
     api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
@@ -96,6 +93,16 @@ publishing {
           system = 'ServiceTalk CI'
           url = "${ciManagementUrl}"
         }
+        // Gradle ignores dependencies constraints with classifiers when it generates pom.xml. To workaround it, we are
+        // forced to use withXml. See https://github.com/gradle/gradle/issues/8561
+        withXml {
+          Node pomNode = asNode()
+          Node dependencies = pomNode.dependencyManagement.dependencies.get(0)
+          addDependency(dependencies, "io.netty.incubator", "netty-incubator-transport-native-io_uring",
+              "${nettyIoUringVersion}", "linux-x86_64")
+          addDependency(dependencies, "io.netty.incubator", "netty-incubator-transport-native-io_uring",
+              "${nettyIoUringVersion}", "linux-aarch_64")
+        }
       }
     }
   }
@@ -124,4 +131,12 @@ if (!!findProperty("signingKey") && !!findProperty("signingPassword")) {
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign publishing.publications.mavenJava
   }
+}
+
+def addDependency(Node dependencies, String groupId, String artifactId, String version, String classifier) {
+  Node dependency = dependencies.appendNode("dependency")
+  dependency.appendNode("groupId", groupId)
+  dependency.appendNode("artifactId", artifactId)
+  dependency.appendNode("version", version)
+  dependency.appendNode("classifier", classifier)
 }


### PR DESCRIPTION
Motivation:

Gradle intentionally skips dependencies constraints with a classifier
when it generates Maven BOM file.
See https://github.com/gradle/gradle/issues/8561.
It negatively affects maven users bcz maven marks
`servicetalk-transport-netty-internal` POM file as invalid:

```
[WARNING] The POM for io.servicetalk:servicetalk-transport-netty-internal:jar:0.42.14 is invalid, transitive dependencies (if any) will not be available: 2 problems were encountered while building the effective model for io.servicetalk:servicetalk-transport-netty-internal:0.42.14
[ERROR] 'dependencies.dependency.version' for io.netty.incubator:netty-incubator-transport-native-io_uring:jar:linux-x86_64 is missing. @
[ERROR] 'dependencies.dependency.version' for io.netty.incubator:netty-incubator-transport-native-io_uring:jar:linux-aarch_64 is missing. @
```

Modifications:
- Use `withXml` to add entries with a classifier explicitly;

Result:

Maven users don't have build issues anymore.