### PR TITLE
Improve parsing of Set-Cookie headers

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -15,13 +15,12 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.buffer.api.CharSequences;
-
 import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
 import static io.servicetalk.buffer.api.CharSequences.contentEquals;
 import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
+import static io.servicetalk.buffer.api.CharSequences.equalsIgnoreCaseLower;
 import static io.servicetalk.buffer.api.CharSequences.parseLong;
 import static io.servicetalk.http.api.HeaderUtils.validateCookieNameAndValue;
 import static io.servicetalk.http.api.HeaderUtils.validateToken;
@@ -544,10 +543,6 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                 break;
         }
         return null;
-    }
-
-    private static boolean equalsIgnoreCaseLower(char c, char k) {
-        return CharSequences.equalsIgnoreCaseLower(c, k);
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -489,10 +489,8 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                     if (contentEqualsIgnoreCase("path", fieldName)) {
                         return ParseState.ParsingPath;
                     }
-                } else if (len == 6) {
-                    if (contentEqualsIgnoreCase("domain", fieldName)) {
-                        return ParseState.ParsingDomain;
-                    }
+                } else if (len == 6 && contentEqualsIgnoreCase("domain", fieldName)) {
+                    return ParseState.ParsingDomain;
                 }
             } else {
                 if (len == 7) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -39,38 +39,6 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
     private static final String ENCODED_LABEL_SECURE = "; secure";
     private static final String ENCODED_LABEL_SAMESITE = "; samesite=";
 
-    private static ParseState parseStateOf(CharSequence fieldName) {
-        // Try a binary search based on length. We can read length without bounds checks.
-        int len = fieldName.length();
-        if (len >= 4 && len <= 8) {
-            if (len < 7) {
-                if (len == 4) {
-                    if (contentEqualsIgnoreCase("path", fieldName)) {
-                        return ParseState.ParsingPath;
-                    }
-                } else if (len == 6) {
-                    if (contentEqualsIgnoreCase("domain", fieldName)) {
-                        return ParseState.ParsingDomain;
-                    }
-                }
-            } else {
-                if (len == 7) {
-                    if (contentEqualsIgnoreCase("expires", fieldName)) {
-                        return ParseState.ParsingExpires;
-                    }
-                    if (contentEqualsIgnoreCase("max-age", fieldName)) {
-                        return ParseState.ParsingMaxAge;
-                    }
-                } else {
-                    if (contentEqualsIgnoreCase("samesite", fieldName)) {
-                        return ParseState.ParsingSameSite;
-                    }
-                }
-            }
-        }
-        return ParseState.Unknown;
-    }
-
     private final CharSequence name;
     private final CharSequence value;
     @Nullable
@@ -210,7 +178,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                                 i += 3;
                             } else {
                                 // When validation is disabled, we need to check if there's an SP to skip
-                                i += i + 2 < length && setCookieString.charAt(i + 2) == ' '? 3 : 2;
+                                i += i + 2 < length && setCookieString.charAt(i + 2) == ' ' ? 3 : 2;
                             }
                         } else {
                             isWrapped = true;
@@ -510,6 +478,38 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
         ParsingMaxAge,
         ParsingSameSite,
         Unknown
+    }
+
+    private static ParseState parseStateOf(CharSequence fieldName) {
+        // Try a binary search based on length. We can read length without bounds checks.
+        int len = fieldName.length();
+        if (len >= 4 && len <= 8) {
+            if (len < 7) {
+                if (len == 4) {
+                    if (contentEqualsIgnoreCase("path", fieldName)) {
+                        return ParseState.ParsingPath;
+                    }
+                } else if (len == 6) {
+                    if (contentEqualsIgnoreCase("domain", fieldName)) {
+                        return ParseState.ParsingDomain;
+                    }
+                }
+            } else {
+                if (len == 7) {
+                    if (contentEqualsIgnoreCase("expires", fieldName)) {
+                        return ParseState.ParsingExpires;
+                    }
+                    if (contentEqualsIgnoreCase("max-age", fieldName)) {
+                        return ParseState.ParsingMaxAge;
+                    }
+                } else {
+                    if (contentEqualsIgnoreCase("samesite", fieldName)) {
+                        return ParseState.ParsingSameSite;
+                    }
+                }
+            }
+        }
+        return ParseState.Unknown;
     }
 
     @Nullable

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.http.api;
 
+import io.servicetalk.buffer.api.CharSequences;
+
 import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
@@ -545,7 +547,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
     }
 
     private static boolean equalsIgnoreCaseLower(char c, char k) {
-        return c == k || c >= 'A' && c <= 'Z' && c == k - 32;
+        return CharSequences.equalsIgnoreCaseLower(c, k);
     }
 
     /**
@@ -581,6 +583,6 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
 
     private static IllegalArgumentException unexpectedHexValue(int hexValue, int index) {
         return new IllegalArgumentException(
-                "Unexpected hex value at index " + index + ": " + Integer.toHexString(hexValue));
+                "Unexpected hex value at index " + index + ": 0x" + Integer.toHexString(hexValue));
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -341,7 +341,7 @@ public final class HeaderUtils {
     public static boolean isSetCookieNameMatches(final CharSequence setCookieString,
                                                  final CharSequence setCookieName) {
         int equalsIndex = indexOf(setCookieString, '=', 0);
-        return equalsIndex > 0 && setCookieString.length() - 1 > equalsIndex &&
+        return equalsIndex > 0 &&
                 equalsIndex == setCookieName.length() &&
                 regionMatches(setCookieName, true, 0, setCookieString, 0, equalsIndex);
     }
@@ -535,7 +535,7 @@ public final class HeaderUtils {
          * @return the next {@link HttpCookiePair} value for {@link #next()}, or {@code null} if all have been parsed.
          */
         private HttpCookiePair findNext(CharSequence cookieHeaderValue) {
-            int semiIndex = indexOf(cookieHeaderValue, ';', nextNextStart);
+            int semiIndex = nextDelimiter(cookieHeaderValue);
             HttpCookiePair next = DefaultHttpCookiePair.parseCookiePair(cookieHeaderValue, nextNextStart, semiIndex);
             if (semiIndex > 0) {
                 if (cookieHeaderValue.length() - 2 <= semiIndex) {
@@ -550,6 +550,23 @@ public final class HeaderUtils {
                 nextNextStart = 0;
             }
             return next;
+        }
+
+        private int nextDelimiter(CharSequence cookieHeaderValue) {
+            boolean inQuotes = false;
+            int len = cookieHeaderValue.length();
+            for (int i = nextNextStart; i < len; i++) {
+                char value = cookieHeaderValue.charAt(i);
+                if (value == ';') {
+                    if (inQuotes) {
+                        throw new IllegalArgumentException("The ; character cannot appear in quoted cookie values");
+                    }
+                    return i;
+                } else if (value == '"') {
+                    inQuotes = !inQuotes;
+                }
+            }
+            return -1;
         }
     }
 


### PR DESCRIPTION
Motivation:
The parsing of Set-Cookie headers is deviating from the standard in a couple of ways.
- Cookie values are allowed to contain the equals sign character.
- Percentage-prefixed hexadecimal literals are not a thing.
- Only cookie-values need to adhere to the cookie-octet rule.
- Defined but empty values should decode to the empty string rather than null, so we can distinguish between their empty and absent cases.
- When parsing Set-Cookie values, every ; must be followed by a space.
  See the `set-cookie-string` rule in https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1
  The parser should check for this, since it can lead to mis-parsing later data and produce confusing error messages, or the produce a cookie object with wrong data.

Modification:
When the parser decodes the '=' character, it now no longer updates the 'begin' index if the parse state is ParsingValue.
This means the parsed '=' character will be part of the cookie value.

The parse rule for the '%' character has been removed.
The associated validation code has also been removed, as it is no longer used.
This means the '%' character no longer has a special meaning to the parser.

When the parser validates a non-special character (a character that falls into the default case in the parser), the cookie-octet validation function is now only used if the parser is in the ParsingValue state.
Otherwise, we use a new cookie-attribute validation.
Most cookie-attributes need only follow the simple rule of "any CHAR except CTLs or ';'".

The parser already has a final-processing step for non-empty tails.
We add a similar step for when the tail is the empty string.
This way, cookie values, paths, and domains, that are defined but have no value, will be decoded to have the empty string as a value.
This way, we can tell if those attributes were defined but empty, or absent. 

The parser for Set-Cookie HTTP headers now checks that ';' are followed by a space byte.
When cookie validation is enabled, an exception will be thrown when this is not the case.
When cookie validation is disabled, the space byte will no longer be blindly assumed to be there, but instead checked for, and the parser position will be adjusted accordingly.
This allows, e.g. "Set-Cookie: a=b;Expires=Mon, 22 Aug 2022 20:12:35 GMT" to be parsed correctly in non-validating mode.
Previously, the above would have thrown an exception for using a ',' character in an attribute value that do not allow them ("xpires" instead of "Expires").

The parse-state-switching algorithm has been changed.
It no longer relies on a map from attribute name to a parse-state-as-a-char-sequence.
Instead, we do a hard-coded binary search based on the attribute length (which we can read without paying for a bounds-check), and then we compare the field name with what would be expected for that length.
This gives us a significant boost to parsing speed, because we do no hashing, fewer string-compares, fewer memory indirections, and we let the CPU branch predictor do the heavy lifting.
It also takes up less memory as we no longer need the map of AV field names.
We can also remove the awkward ParseStateCharSequence class.

Improve the error message for when a quoted cookie value contains the ';' character, which is not allowed.
This also means we won't run into later errors about unbalanced quotation or the like.

Result:
The parsing of Set-Cookie headers is now more correct, and faster, and has better error reporting.