### PR TITLE
Clarify debugging examples with more comments

### DIFF
--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
@@ -152,9 +152,9 @@ public final class DebuggingClient {
                         /*
                          * 4. Enables detailed logging of HTTP/2 frames.
                          *
-                         * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
-                         * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
-                         * visibility without modifying the logger config.
+                         * Be sure to also enable the {@code TRACE} logger in your logging config file (log4j2.xml
+                         *  for this example) or raise the configured logging level (2nd argument) to
+                         *  {@code INFO/WARNING} to get visibility without modifying the logger config.
                          * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                          * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
                          * sensitive information into logs output. Be careful enabling data logging in production

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
@@ -140,7 +140,7 @@ public final class DebuggingClient {
                          * 3. Enables detailed logging of I/O events and I/O states.
                          *
                          * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
-                         * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                         * example) or raise the configured logging level (2nd argument) to INFO/WARNING to get
                          * visibility without modifying the logger config.
                          * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                          * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
@@ -152,9 +152,9 @@ public final class DebuggingClient {
                         /*
                          * 4. Enables detailed logging of HTTP/2 frames.
                          *
-                         * Be sure to also enable the {@code TRACE} logger in your logging config file (log4j2.xml
-                         *  for this example) or raise the configured logging level (2nd argument) to
-                         *  {@code INFO/WARNING} to get visibility without modifying the logger config.
+                         * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
+                         * example) or raise the configured logging level (2nd argument) to INFO/WARNING to get
+                         * visibility without modifying the logger config.
                          * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                          * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
                          * sensitive information into logs output. Be careful enabling data logging in production

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
@@ -129,25 +129,36 @@ public final class DebuggingClient {
         try (BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)
                 .initializeHttp(builder -> builder
                         /*
-                         * 2. Disables most asynchronous offloading to simplify execution tracing. Changing this may
-                         * significantly change application behavior and introduce unexpected blocking. It is most
-                         * useful for being able to directly trace through situations that would normally involve a
+                         * 2. (optional) Disables most asynchronous offloading to simplify execution tracing. Changing
+                         * this may significantly change application behavior and introduce unexpected blocking. It is
+                         * most useful for being able to directly trace through situations that would normally involve a
                          * thread handoff.
                          */
-                        // .executionStrategy(HHttpExecutionStrategies.offloadNever())
+                        // .executionStrategy(HttpExecutionStrategies.offloadNever())
+
                         /*
-                         * 3. Enables detailed logging of I/O and I/O states, but not payload bodies.
-                         * Be sure to also enable the logger in your logging config file,
-                         * {@code log4j2.xml} for this example.
+                         * 3. Enables detailed logging of I/O events and I/O states.
+                         *
+                         * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
+                         * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                         * visibility without modifying the logger config.
                          * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
-                         * {@code Boolean.TRUE::booleanValue}.
+                         * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
+                         * sensitive information into logs output. Be careful enabling data logging in production
+                         * environments.
                          */
                         .enableWireLogging("servicetalk-examples-wire-logger", TRACE, LOG_USER_DATA)
 
                         /*
-                         * 4. Enables detailed logging of HTTP2 frames, but not frame contents.
-                         * Be sure to also enable the logger in your logging config file,
-                         * {@code log4j2.xml} for this example.
+                         * 4. Enables detailed logging of HTTP/2 frames.
+                         *
+                         * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
+                         * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                         * visibility without modifying the logger config.
+                         * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                         * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
+                         * sensitive information into logs output. Be careful enabling data logging in production
+                         * environments.
                          */
                         .protocols(HttpProtocolConfigs.h2()
                                 .enableFrameLogging(

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
@@ -125,34 +125,43 @@ public final class DebuggingServer {
 
     public static void main(String[] args) throws Exception {
         GrpcServers.forPort(8080)
-                .initializeHttp(builder -> {
-                    builder
-                            /*
-                             * 2. Disables most asynchronous offloading to simplify execution tracing. Changing this may
-                             * significantly change application behavior and introduce unexpected blocking. It is most
-                             * useful for being able to directly trace through situations that would normally involve a
-                             * thread handoff.
-                             */
-                            //.executionStrategy(HttpExecutionStrategies.offloadNever())
-                            /*
-                             * 3. Enables detailed logging of I/O and I/O states, but not payload bodies.
-                             * Be sure to also enable the logger in your logging config file,
-                             * {@code log4j2.xml} for this example.
-                             * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
-                             * {@code Boolean.TRUE::booleanValue}.
-                             */
-                            .enableWireLogging("servicetalk-examples-wire-logger", TRACE, LOG_USER_DATA)
+                .initializeHttp(builder -> builder
+                        /*
+                         * 2. (optional) Disables most asynchronous offloading to simplify execution tracing. Changing
+                         * this may significantly change application behavior and introduce unexpected blocking. It is
+                         * most useful for being able to directly trace through situations that would normally involve a
+                         * thread handoff.
+                         */
+                        //.executionStrategy(HttpExecutionStrategies.offloadNever())
 
-                            /*
-                             * 4. Enables detailed logging of HTTP2 frames, but not frame contents.
-                             * Be sure to also enable the logger in your logging config file,
-                             * {@code log4j2.xml} for this example.
-                             */
-                            .protocols(HttpProtocolConfigs.h2()
-                                    .enableFrameLogging(
-                                            "servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
-                                    .build());
-                })
+                        /*
+                         * 3. Enables detailed logging of I/O events and I/O states.
+                         *
+                         * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
+                         * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                         * visibility without modifying the logger config.
+                         * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                         * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
+                         * sensitive information into logs output. Be careful enabling data logging in production
+                         * environments.
+                         */
+                        .enableWireLogging("servicetalk-examples-wire-logger", TRACE, LOG_USER_DATA)
+
+                        /*
+                         * 4. Enables detailed logging of HTTP/2 frames.
+                         *
+                         * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
+                         * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                         * visibility without modifying the logger config.
+                         * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                         * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
+                         * sensitive information into logs output. Be careful enabling data logging in production
+                         * environments.
+                         */
+                        .protocols(HttpProtocolConfigs.h2()
+                                .enableFrameLogging(
+                                        "servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
+                                .build()))
                 .listenAndAwait((BlockingGreeterService) (ctx, request) ->
                         HelloReply.newBuilder().setMessage("Hello " + request.getName()).build())
                 .awaitShutdown();

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
@@ -138,7 +138,7 @@ public final class DebuggingServer {
                          * 3. Enables detailed logging of I/O events and I/O states.
                          *
                          * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
-                         * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                         * example) or raise the configured logging level (2nd argument) to INFO/WARNING to get
                          * visibility without modifying the logger config.
                          * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                          * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
@@ -151,7 +151,7 @@ public final class DebuggingServer {
                          * 4. Enables detailed logging of HTTP/2 frames.
                          *
                          * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
-                         * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                         * example) or raise the configured logging level (2nd argument) to INFO/WARNING to get
                          * visibility without modifying the logger config.
                          * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                          * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak

--- a/servicetalk-examples/http/debugging/build.gradle
+++ b/servicetalk-examples/http/debugging/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   implementation project(":servicetalk-http-netty")
 
   // This dependency brings self-signed TLS certificates for demonstration purposes.
-  // Users have to use their own certificates instead.
+  //  In real applications users have to provide their own certificates instead.
   implementation project(":servicetalk-test-resources")
 
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/http/debugging/build.gradle
+++ b/servicetalk-examples/http/debugging/build.gradle
@@ -21,5 +21,9 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-http-netty")
 
+  // This dependency brings self-signed TLS certificates for demonstration purposes.
+  // Users have to use their own certificates instead.
+  implementation project(":servicetalk-test-resources")
+
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -170,7 +170,7 @@ public final class DebuggingExampleClient {
                  * 3. Enables detailed logging of I/O events and I/O states.
                  *
                  * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
-                 * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                 * example) or raise the configured logging level (2nd argument) to INFO/WARNING to get
                  * visibility without modifying the logger config.
                  * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                  * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
@@ -184,7 +184,7 @@ public final class DebuggingExampleClient {
                  * Use this only if your client communicates over HTTP/2. For HTTP/1.1 use-cases skip this.
                  *
                  * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
-                 * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                 * example) or raise the configured logging level (2nd argument) to INFO/WARNING to get
                  * visibility without modifying the logger config.
                  * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                  * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -159,25 +159,49 @@ public final class DebuggingExampleClient {
     public static void main(String... args) throws Exception {
         try (HttpClient client = HttpClients.forSingleAddress("localhost", 8080)
                 /*
-                 * 2. Disables most asynchronous offloading to simplify execution tracing. Changing this may
-                 * significantly change application behavior and introduce unexpected blocking. It is most useful for
-                 * being able to directly trace through situations that would normally involve a thread handoff.
+                 * 2. (optional) Disables most asynchronous offloading to simplify execution tracing. Changing
+                 * this may significantly change application behavior and introduce unexpected blocking. It is
+                 * most useful for being able to directly trace through situations that would normally involve a
+                 * thread handoff.
                  */
                 // .executionStrategy(HttpExecutionStrategies.offloadNever())
 
                 /*
-                 * 3. Enables detailed logging of I/O and I/O states.
-                 * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                 * 3. Enables detailed logging of I/O events and I/O states.
+                 *
+                 * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
+                 * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                 * visibility without modifying the logger config.
+                 * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                 * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
+                 * sensitive information into logs output. Be careful enabling data logging in production
+                 * environments.
                  */
                 .enableWireLogging("servicetalk-examples-wire-logger", TRACE, LOG_USER_DATA)
 
                 /*
-                 * 4. Enables detailed logging of HTTP2 frames.
-                 * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                 * 4. (optional) Enables detailed logging of HTTP/2 frames.
+                 * Use this only if your client communicates over HTTP/2. For HTTP/1.1 use-cases skip this.
+                 *
+                 * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
+                 * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                 * visibility without modifying the logger config.
+                 * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                 * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
+                 * sensitive information into logs output. Be careful enabling data logging in production
+                 * environments.
                  */
                 .protocols(HttpProtocolConfigs.h2()
                         .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
                         .build())
+                /*
+                 * For ALPN, make sure to supply both HTTP/2 and HTTP/1.X HttpProtocolConfigs and SslConfig.
+                 */
+                // .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build())
+                // .protocols(HttpProtocolConfigs.h2()
+                //         .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
+                //         .build(),
+                //         HttpProtocolConfigs.h1Default())
                 .build()) {
             client.request(client.post("/sayHello").payloadBody("George", textSerializerUtf8()))
                     .whenOnSuccess(resp -> {

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -154,25 +154,50 @@ public final class DebuggingExampleServer {
     public static void main(String... args) throws Exception {
         HttpServers.forPort(8080)
                 /*
-                 * 2. Disables most asynchronous offloading to simplify execution tracing. Changing this may
-                 * significantly change application behavior and introduce unexpected blocking. It is most useful for
-                 * being able to directly trace through situations that would normally involve a thread handoff.
+                 * 2. (optional) Disables most asynchronous offloading to simplify execution tracing. Changing
+                 * this may significantly change application behavior and introduce unexpected blocking. It is
+                 * most useful for being able to directly trace through situations that would normally involve a
+                 * thread handoff.
                  */
                 // .executionStrategy(HttpExecutionStrategies.offloadNever())
 
                 /*
-                 * 3. Enables detailed logging of I/O and I/O states.
-                 * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                 * 3. Enables detailed logging of I/O events and I/O states.
+                 *
+                 * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
+                 * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                 * visibility without modifying the logger config.
+                 * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                 * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
+                 * sensitive information into logs output. Be careful enabling data logging in production
+                 * environments.
                  */
                 .enableWireLogging("servicetalk-examples-wire-logger", TRACE, LOG_USER_DATA)
 
                 /*
-                 * 4. Enables detailed logging of HTTP2 frames.
-                 * Be sure to also enable the logger in your logging config file (log4j2.xml for this example).
+                 * 4. (optional) Enables detailed logging of HTTP/2 frames.
+                 * Use this only if your server communicates over HTTP/2. For HTTP/1.1 use-cases skip this.
+                 *
+                 * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
+                 * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                 * visibility without modifying the logger config.
+                 * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
+                 * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
+                 * sensitive information into logs output. Be careful enabling data logging in production
+                 * environments.
                  */
                 .protocols(HttpProtocolConfigs.h2()
                         .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
                         .build())
+                /*
+                 * For ALPN, make sure to supply both HTTP/2 and HTTP/1.X HttpProtocolConfigs and SslConfig.
+                 */
+                // .sslConfig(new ServerSslConfigBuilder(
+                //         DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).build())
+                // .protocols(HttpProtocolConfigs.h2()
+                //                 .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)
+                //                 .build(),
+                //         HttpProtocolConfigs.h1Default())
                 .listenAndAwait((ctx, request, responseFactory) -> {
                     String who = request.payloadBody(textSerializerUtf8());
                     return succeeded(responseFactory.ok().payloadBody("Hello " + who + "!", textSerializerUtf8()));

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -165,7 +165,7 @@ public final class DebuggingExampleServer {
                  * 3. Enables detailed logging of I/O events and I/O states.
                  *
                  * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
-                 * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                 * example) or raise the configured logging level (2nd argument) to INFO/WARNING to get
                  * visibility without modifying the logger config.
                  * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                  * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak
@@ -179,7 +179,7 @@ public final class DebuggingExampleServer {
                  * Use this only if your server communicates over HTTP/2. For HTTP/1.1 use-cases skip this.
                  *
                  * Be sure to also enable the TRACE logger in your logging config file (log4j2.xml for this
-                 * example) or rise the configured logging level (2nd argument) to INFO/WARNING to get
+                 * example) or raise the configured logging level (2nd argument) to INFO/WARNING to get
                  * visibility without modifying the logger config.
                  * Dumping of protocol bodies is disabled to reduce output but can be enabled by using
                  * {@code Boolean.TRUE::booleanValue} as the 3rd argument. Note that logging all data may leak

--- a/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/debugging/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
     <!-- Additional useful loggers of interest - include relevant loggers in your log4j2.xml file -->
 
     <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
     <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
 
     <!-- Prints default subscriber errors-->

--- a/servicetalk-examples/http/http2/build.gradle
+++ b/servicetalk-examples/http/http2/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   implementation project(":servicetalk-http-netty")
 
   // This dependency brings self-signed TLS certificates for demonstration purposes.
-  // Users have to use their own certificates instead.
+  // In real applications users have to provide their own certificates instead.
   implementation project(":servicetalk-test-resources")
 
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/http/mutual-tls/build.gradle
+++ b/servicetalk-examples/http/mutual-tls/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   implementation project(":servicetalk-http-netty")
 
   // This dependency brings self-signed TLS certificates for demonstration purposes.
-  // Users have to use their own certificates instead.
+  // In real applications users have to provide their own certificates instead.
   implementation project(":servicetalk-test-resources")
 
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/http/redirects/build.gradle
+++ b/servicetalk-examples/http/redirects/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
   // This dependency brings self-signed TLS certificates for demonstration purposes.
-  // Users have to use their own certificates instead.
+  // In real applications users have to provide their own certificates instead.
   implementation project(":servicetalk-test-resources")
 
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"


### PR DESCRIPTION
Motivation:

Users unintentionally copy HTTP/2 configuration when they should debug
only HTTP/1.1 and still ask questions why trace logs are not visible.

Modifications:
- Clarify 2nd and 3rd argument of `enableWireLogging` and
`enableFrameLogging`;
- Clarify that `HttpProtocolConfigs.h2()` is required only for HTTP/2;
- Clarify how to `enableFrameLogging` in case of ALPN;

Result:

More comments for debugging examples.