### PR TITLE
Avoid race when HTTP/1.x request is cancelled at connection level filter

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -163,6 +163,10 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         });
     }
 
+    private void notifyOnClosingImpl() {    // For access from AbstractH2ParentConnection
+        notifyOnClosing();
+    }
+
     final void trackActiveStream(Channel streamChannel) {
         keepAliveManager.trackActiveStream(streamChannel);
     }
@@ -228,7 +232,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         }
 
         private void doChannelClosed(final String method) {
-            parentContext.notifyOnClosing();
+            parentContext.notifyOnClosingImpl();
 
             if (hasSubscriber()) {
                 tryFailSubscriber(StacklessClosedChannelException.newInstance(H2ParentConnectionContext.class, method));
@@ -276,7 +280,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
                 // We trigger the graceful close process here (with no timeout) to make sure the socket is closed once
                 // the existing streams are closed. The MultiplexCodec may simulate a GOAWAY when the stream IDs are
                 // exhausted so we shouldn't rely upon our peer to close the transport.
-                parentContext.keepAliveManager.initiateGracefulClose(parentContext::notifyOnClosing);
+                parentContext.keepAliveManager.initiateGracefulClose(parentContext::notifyOnClosingImpl);
             } else if (msg instanceof Http2PingFrame) {
                 parentContext.keepAliveManager.pingReceived((Http2PingFrame) msg);
             } else if (!(msg instanceof Http2SettingsAckFrame)) { // we ignore SETTINGS(ACK)

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -110,6 +110,7 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
                             }
 
                             @Override
+                            @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")
                             public void cancel() {
                                 // For HTTP/1.x cancellation is handled in AbstractStreamingHttpConnection.
                                 // For HTTP/2 cancellation is handled by OnStreamClosedRunnable owned by the actual
@@ -120,7 +121,6 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
                                 // H2ClientParentConnectionContext prior propagation of the Cancellable down.
                                 if (onStreamClosed != null && onStreamClosed.own()) {
                                     if (!onStreamClosedWarningLogged) {
-                                        //noinspection AssignmentToStaticFieldFromInstanceMethod
                                         onStreamClosedWarningLogged = true;
                                         LOGGER.warn("HttpRequestMetaData#context() was cleared by one of the " +
                                                 "user-defined connection filters. This may result in incorrect " +

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
@@ -124,11 +124,13 @@ final class ReservableRequestConcurrencyControllers {
 
                 @Override
                 public void onComplete() {
+                    assert pendingRequests != STATE_QUIT;
                     pendingRequests = STATE_QUIT;
                 }
 
                 @Override
                 public void onError(Throwable ignored) {
+                    assert pendingRequests != STATE_QUIT;
                     pendingRequests = STATE_QUIT;
                 }
             });

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CloseUtils.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CloseUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
+import io.servicetalk.transport.netty.internal.NettyConnectionContext;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http2.Http2GoAwayFrame;
+
+import java.util.concurrent.CountDownLatch;
+
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.GRACEFUL_USER_CLOSING;
+
+final class CloseUtils {
+
+    private CloseUtils() {
+        // No instances
+    }
+
+    /**
+     * A utility that helps intercept when a graceful closure begins its closing sequence on the event loop.
+     *
+     * @param cc {@link ConnectionContext} to monitor
+     * @param closingStarted a {@link CountDownLatch} to notify
+     */
+    static void onGracefulClosureStarted(ConnectionContext cc, CountDownLatch closingStarted) {
+        NettyConnectionContext nettyCtx = (NettyConnectionContext) cc;
+        if (cc.protocol() == HTTP_1_1) {
+            nettyCtx.transportError().subscribe(t -> {
+                if (t instanceof CloseEventObservedException &&
+                        ((CloseEventObservedException) t).event() == GRACEFUL_USER_CLOSING) {
+                    assert nettyCtx.nettyChannel().eventLoop().inEventLoop();
+                    closingStarted.countDown();
+                }
+            });
+        } else if (cc.protocol() == HTTP_2_0) {
+            ChannelPipeline pipeline = nettyCtx.nettyChannel().pipeline();
+            pipeline.addLast(new ChannelOutboundHandlerAdapter() {
+                @Override
+                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                    if (msg instanceof Http2GoAwayFrame) {
+                        assert nettyCtx.nettyChannel().eventLoop().inEventLoop();
+                        closingStarted.countDown();
+                    }
+                    ctx.write(msg, promise);
+                }
+            });
+        } else {
+            throw new IllegalArgumentException("Unexpected protocol: " + cc.protocol());
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionInfoTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionInfoTest.java
@@ -26,7 +26,6 @@ import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
-import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -70,8 +69,7 @@ class ConnectionInfoTest extends AbstractNettyHttpServerTest {
         assertThat(ctxStr, endsWith(client || protocol == HTTP_1 ? "]" : ")"));
     }
 
-    private static final class CtxInterceptingServiceFilterFactory implements StreamingHttpServiceFilterFactory,
-            ExecutionStrategyInfluencer<HttpExecutionStrategy> {
+    private static final class CtxInterceptingServiceFilterFactory implements StreamingHttpServiceFilterFactory {
 
         final BlockingQueue<String> queue = new LinkedBlockingDeque<>();
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -59,7 +59,6 @@ import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.DelegatingConnectionAcceptor;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
@@ -141,6 +140,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static io.servicetalk.http.netty.CloseUtils.onGracefulClosureStarted;
 import static io.servicetalk.http.netty.H2ToStH1Utils.PROXY_CONNECTION;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
@@ -1577,8 +1577,7 @@ class H2PriorKnowledgeFeatureParityTest {
             serverBuilder.appendConnectionAcceptorFilter(original -> new DelegatingConnectionAcceptor(original) {
                 @Override
                 public Completable accept(final ConnectionContext context) {
-                    ((NettyConnectionContext) context).onClosing()
-                            .whenFinally(connectionOnClosingLatch::countDown).subscribe();
+                    onGracefulClosureStarted(context, connectionOnClosingLatch);
                     return completed();
                 }
             });

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -160,7 +160,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         setUp(CACHED, CACHED_SERVER);
     }
 
-    @ParameterizedTest(name = "protocol={0}")
+    @ParameterizedTest(name = "{displayName} [{index}] protocol={0}")
     @EnumSource(HttpProtocol.class)
     void connectionEstablished(HttpProtocol httpProtocol) throws Exception {
         setUp(httpProtocol);
@@ -196,7 +196,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         }
     }
 
-    @ParameterizedTest(name = "protocol={0}")
+    @ParameterizedTest(name = "{displayName} [{index}] protocol={0}")
     @EnumSource(HttpProtocol.class)
     void echoRequestResponse(HttpProtocol httpProtocol) throws Exception {
         setUp(httpProtocol);
@@ -206,7 +206,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
                 .payloadBody(getChunkPublisherFromStrings(requestContent)), OK, requestContent.length());
     }
 
-    @ParameterizedTest(name = "protocol={0}")
+    @ParameterizedTest(name = "{displayName} [{index}] protocol={0}")
     @EnumSource(HttpProtocol.class)
     void serverHandlerError(HttpProtocol httpProtocol) throws Exception {
         setUp(httpProtocol);
@@ -252,14 +252,14 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         }
     }
 
-    @ParameterizedTest(name = "protocol={0}")
+    @ParameterizedTest(name = "{displayName} [{index}] protocol={0}")
     @EnumSource(HttpProtocol.class)
     void serverFailsResponsePayloadBodyBeforeRead(HttpProtocol httpProtocol) throws Exception {
         setUp(httpProtocol);
         testServerFailsResponsePayloadBody(SVC_ERROR_BEFORE_READ, true);
     }
 
-    @ParameterizedTest(name = "protocol={0}")
+    @ParameterizedTest(name = "{displayName} [{index}] protocol={0}")
     @EnumSource(HttpProtocol.class)
     void serverFailsResponsePayloadBodyDuringRead(HttpProtocol httpProtocol) throws Exception {
         setUp(httpProtocol);
@@ -328,7 +328,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
                 serverDataObserver, serverMultiplexedObserver, serverReadObserver, serverWriteObserver);
     }
 
-    @ParameterizedTest(name = "protocol={0}")
+    @ParameterizedTest(name = "{displayName} [{index}] protocol={0}")
     @EnumSource(HttpProtocol.class)
     void clientFailsRequestPayloadBody(HttpProtocol httpProtocol) throws Exception {
         setUp(httpProtocol);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
@@ -306,6 +306,7 @@ class ResponseCancelTest {
         @SuppressWarnings("unchecked")
         void resume() {
             if (err != null) {
+
                 subscriber.onError(err);
             } else {
                 subscriber.onSuccess(response);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
@@ -306,7 +306,6 @@ class ResponseCancelTest {
         @SuppressWarnings("unchecked")
         void resume() {
             if (err != null) {
-
                 subscriber.onError(err);
             } else {
                 subscriber.onSuccess(response);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
@@ -205,7 +205,7 @@ class ResponseCancelTest {
         sendSecondRequestUsingClient();
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] finishRequest={0}")
+    @ParameterizedTest
     @ValueSource(booleans = {false, true})
     void connectionCancelWaitingForPayloadBody(boolean finishRequest) throws Throwable {
         HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get();
@@ -318,7 +318,7 @@ class ResponseCancelTest {
             ClientTerminationSignal signal = signals.take();
             if (signal.err != null) {
                 signal.subscriber.onError(signal.err);
-                throw new AssertionError("Response terminated with an error", signal.err);
+                throw signal.err;
             } else {
                 signal.subscriber.onSuccess(signal.response);
             }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
@@ -205,7 +205,7 @@ class ResponseCancelTest {
         sendSecondRequestUsingClient();
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] finishRequest={0}")
     @ValueSource(booleans = {false, true})
     void connectionCancelWaitingForPayloadBody(boolean finishRequest) throws Throwable {
         HttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ResponseCancelTest.java
@@ -318,7 +318,7 @@ class ResponseCancelTest {
             ClientTerminationSignal signal = signals.take();
             if (signal.err != null) {
                 signal.subscriber.onError(signal.err);
-                throw signal.err;
+                throw new AssertionError("Response terminated with an error", signal.err);
             } else {
                 signal.subscriber.onSuccess(signal.response);
             }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TimeoutHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TimeoutHttpRequesterFilterTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.TerminalSignalConsumer;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.utils.BeforeFinallyHttpOperator;
+import io.servicetalk.http.utils.TimeoutHttpRequesterFilter;
+import io.servicetalk.transport.netty.internal.NettyConnectionContext;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
+import static io.servicetalk.http.netty.TestServiceStreaming.SVC_NEVER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TimeoutHttpRequesterFilterTest extends AbstractNettyHttpServerTest {
+
+    private enum Event {
+        ON_CLOSING, ON_ERROR, ON_COMPLETE, CANCEL
+    }
+
+    private final AtomicReference<Event> firstEventRef = new AtomicReference<>();
+
+    @Test
+    void onClosingWinsOnError() throws Exception {
+        connectionFilterFactory(appendConnectionFilter(c -> {
+                    ((NettyConnectionContext) c.connectionContext()).onClosing()
+                            .subscribe(() -> firstEventRef.compareAndSet(null, Event.ON_CLOSING));
+                    return new StreamingHttpConnectionFilter(c) {
+                        @Override
+                        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                            return delegate().request(request)
+                                    .liftSync(new BeforeFinallyHttpOperator(new TerminalSignalConsumer() {
+                                        @Override
+                                        public void onComplete() {
+                                            firstEventRef.compareAndSet(null, Event.ON_COMPLETE);
+                                        }
+
+                                        @Override
+                                        public void onError(final Throwable throwable) {
+                                            firstEventRef.compareAndSet(null, Event.ON_ERROR);
+                                        }
+
+                                        @Override
+                                        public void cancel() {
+                                            firstEventRef.compareAndSet(null, Event.CANCEL);
+                                        }
+                                    }));
+                        }
+                    };
+                },
+                new TimeoutHttpRequesterFilter(Duration.ofMillis(100))));
+        setUp(CACHED, CACHED_SERVER);
+
+        StreamingHttpClient client = streamingHttpClient();
+        // Verify that ON_CLOSING always wins
+        for (int i = 0; i < 15; i++) {
+            StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get();
+            String msg = "Unexpected assertion on iteration #" + i;
+            ExecutionException ee = assertThrows(ExecutionException.class,
+                    () -> connection.request(connection.get(SVC_NEVER)).toFuture().get(), msg);
+            assertThat(msg, ee.getCause(), is(instanceOf(TimeoutException.class)));
+            assertThat(msg, firstEventRef.get(), is(Event.ON_CLOSING));
+            // Cancel always closes HTTP/1.x connection, wait for connection to close before trying again
+            connection.onClose().toFuture().get();
+        }
+    }
+
+    private static StreamingHttpConnectionFilterFactory appendConnectionFilter(
+            final StreamingHttpConnectionFilterFactory first,
+            final StreamingHttpConnectionFilterFactory next) {
+        return connection -> first.create(next.create(connection));
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
@@ -93,6 +93,14 @@ public class NettyChannelListenableAsyncCloseable implements PrivilegedListenabl
         onClosing.onComplete();
     }
 
+    /**
+     * Returns a {@link Completable} that notifies when the connection has begun its closing sequence.
+     * <p>
+     * <b>Note:</b>The {@code Completable} is not required to be blocking-safe and should be offloaded if the
+     * {@link CompletableSource.Subscriber} may block.
+     *
+     * @return a {@link Completable} that notifies when the connection has begun its closing sequence.
+     */
     public final Completable onClosing() {
         return fromSource(onClosing);
     }


### PR DESCRIPTION
Motivation:

#2266 (released in 0.42.13) introduces a race between cancel marking a
connection as "closing" (requires a hop to the event-loop), followed by
propagation of `onError` (on the cancel thread) that marks the request
as "finished", and the next request selecting the same connection. This
only affects rare users who cancel at the connection level, users who
use `TimeoutHttpRequesterFilter` as `appendClientFilter` are not
affected.

Modifications:
- Move `onClosing` to `NettyChannelListenableAsyncCloseable`;
- Notify `onClosing` asap for `channelInactive` event;
- Log a warning if `AbstractLBHttpConnectionFactory` can not access
`onClosing` (users incorrectly wrapped a connection);
- Log a warning if `LoadBalancedStreamingHttpClient` takes ownership of
the `OnStreamClosedRunnable` (users prevented propagation of request
context);
- Don't do anything with HTTP/2 connection in
`AbstractStreamingHttpConnection`;
- Improve comments for concurrency control in
`LoadBalancedStreamingHttpClient`, `AbstractStreamingHttpConnection`,
and `H2ClientParentConnectionContext`;
- Add a test for described issue;

Result:

No race for HTTP/1.x users who cancel at the connection level.