### PR TITLE
Revert "Update Netty 4.1.79 -> 4.1.80 (#2332)"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ issueManagementUrl=https://github.com/apple/servicetalk/issues
 ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
-nettyVersion=4.1.80.Final
+nettyVersion=4.1.79.Final
 nettyIoUringVersion=0.0.14.Final
 
 jsr305Version=3.0.2


### PR DESCRIPTION
This reverts commit a0c8d6150e1b9eb257728f94777fe85b3e1f977c.

We anticipate another release before updating Netty versions,
and there is a Netty issue that may impact ServiceTalk users:
https://github.com/netty/netty/pull/12743.