### PR TITLE
Add CacheConnectionHttpLoadBalanceFactory

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
@@ -81,14 +81,14 @@ public class RoundRobinLoadBalancerSDEventsBenchmark {
     public LoadBalancer<LoadBalancedConnection> mixed() {
         // RR load balancer synchronously subscribes and will consume all events during construction.
         return new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, LoadBalancedConnection>().build()
-                .newLoadBalancer("benchmark", from(mixedEvents), ConnFactory.INSTANCE);
+                .newLoadBalancerTyped("benchmark", from(mixedEvents), ConnFactory.INSTANCE);
     }
 
     @Benchmark
     public LoadBalancer<LoadBalancedConnection> available() {
         // RR load balancer synchronously subscribes and will consume all events during construction.
         return new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, LoadBalancedConnection>().build()
-                        .newLoadBalancer("benchmark", from(availableEvents), ConnFactory.INSTANCE);
+                        .newLoadBalancerTyped("benchmark", from(availableEvents), ConnFactory.INSTANCE);
     }
 
     private static final class ConnFactory implements ConnectionFactory<InetSocketAddress, LoadBalancedConnection> {

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
@@ -43,8 +43,7 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
      * @param <T> Type of connections created by the passed {@link ConnectionFactory}.
      * @return a new {@link LoadBalancer}.
-     * @deprecated In the future only {@link #newLoadBalancer(String, Publisher, ConnectionFactory)} will remain,
-     * please use that method instead.
+     * @deprecated Use {@link #newLoadBalancerTyped(String, Publisher, ConnectionFactory)}.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     default <T extends C> LoadBalancer<T> newLoadBalancer(
@@ -69,11 +68,35 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
      * @param <T> Type of connections created by the passed {@link ConnectionFactory}.
      * @return a new {@link LoadBalancer}.
+     * @deprecated Use {@link #newLoadBalancerTyped(String, Publisher, ConnectionFactory)}.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     <T extends C> LoadBalancer<T> newLoadBalancer(
             String targetResource,
             Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             ConnectionFactory<ResolvedAddress, T> connectionFactory);
+
+    /**
+     * Create a new {@link LoadBalancer}.
+     *
+     * @param targetResource A {@link String} representation of the target resource for which the created instance
+     * will perform load balancing. Bear in mind, load balancing is performed over the a collection of hosts provided
+     * via the {@code eventPublisher} which may not correspond directly to a single unresolved address, but potentially
+     * a merged collection.
+     * @param eventPublisher A stream of {@link Collection}&lt;{@link ServiceDiscovererEvent}&gt;
+     * which the {@link LoadBalancer} can use to connect to physical hosts. Typically generated
+     * from {@link ServiceDiscoverer#discover(Object) ServiceDiscoverer}.
+     * @param connectionFactory {@link ConnectionFactory} that the returned {@link LoadBalancer} will use to generate
+     * new connections. Returned {@link LoadBalancer} will own the responsibility for this {@link ConnectionFactory}
+     * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
+     * @return a new {@link LoadBalancer}.
+     */
+    default LoadBalancer<C> newLoadBalancerTyped(
+            String targetResource,
+            Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
+            ConnectionFactory<ResolvedAddress, C> connectionFactory) {
+        return newLoadBalancer(targetResource, eventPublisher, connectionFactory);
+    }
 
     @Override
     default ExecutionStrategy requiredOffloads() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpConnection.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Implementation of {@link FilterableStreamingHttpLoadBalancedConnection} that delegates all methods.
+ */
+public class DelegatingFilterableStreamingHttpConnection implements FilterableStreamingHttpLoadBalancedConnection {
+    private final FilterableStreamingHttpLoadBalancedConnection delegate;
+
+    /**
+     * Create a new instance.
+     * @param delegate The instance to delegate to.
+     */
+    public DelegatingFilterableStreamingHttpConnection(final FilterableStreamingHttpLoadBalancedConnection delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public Result tryRequest() {
+        return delegate.tryRequest();
+    }
+
+    @Override
+    public void requestFinished() {
+        delegate.requestFinished();
+    }
+
+    @Override
+    public boolean tryReserve() {
+        return delegate.tryReserve();
+    }
+
+    @Override
+    public int score() {
+        return delegate.score();
+    }
+
+    @Override
+    public Completable closeAsync() {
+        return delegate.closeAsync();
+    }
+
+    @Override
+    public Completable closeAsyncGracefully() {
+        return delegate.closeAsyncGracefully();
+    }
+
+    @Override
+    public Completable onClose() {
+        return delegate.onClose();
+    }
+
+    @Override
+    public HttpConnectionContext connectionContext() {
+        return delegate.connectionContext();
+    }
+
+    @Override
+    public <T> Publisher<? extends T> transportEventStream(final HttpEventKey<T> eventKey) {
+        return delegate.transportEventStream(eventKey);
+    }
+
+    @Override
+    public void close() throws Exception {
+        delegate.close();
+    }
+
+    @Override
+    public void closeGracefully() throws Exception {
+        delegate.closeGracefully();
+    }
+
+    @Override
+    public Completable releaseAsync() {
+        return delegate.releaseAsync();
+    }
+
+    @Override
+    public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
+        return delegate.newRequest(method, requestTarget);
+    }
+
+    @Override
+    public StreamingHttpRequest get(final String requestTarget) {
+        return delegate.get(requestTarget);
+    }
+
+    @Override
+    public StreamingHttpRequest post(final String requestTarget) {
+        return delegate.post(requestTarget);
+    }
+
+    @Override
+    public StreamingHttpRequest put(final String requestTarget) {
+        return delegate.put(requestTarget);
+    }
+
+    @Override
+    public StreamingHttpRequest options(final String requestTarget) {
+        return delegate.options(requestTarget);
+    }
+
+    @Override
+    public StreamingHttpRequest head(final String requestTarget) {
+        return delegate.head(requestTarget);
+    }
+
+    @Override
+    public StreamingHttpRequest trace(final String requestTarget) {
+        return delegate.trace(requestTarget);
+    }
+
+    @Override
+    public StreamingHttpRequest delete(final String requestTarget) {
+        return delegate.delete(requestTarget);
+    }
+
+    @Override
+    public StreamingHttpRequest patch(final String requestTarget) {
+        return delegate.patch(requestTarget);
+    }
+
+    @Override
+    public StreamingHttpRequest connect(final String requestTarget) {
+        return delegate.connect(requestTarget);
+    }
+
+    @Override
+    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+        return delegate.request(request);
+    }
+
+    @Override
+    public HttpExecutionContext executionContext() {
+        return delegate.executionContext();
+    }
+
+    @Override
+    public StreamingHttpResponseFactory httpResponseFactory() {
+        return delegate.httpResponseFactory();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + '(' + delegate + ')';
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpLoadBalancedConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpLoadBalancedConnection.java
@@ -73,6 +73,11 @@ public class DelegatingFilterableStreamingHttpLoadBalancedConnection
     }
 
     @Override
+    public Completable onClosing() {
+        return delegate.onClosing();
+    }
+
+    @Override
     public HttpConnectionContext connectionContext() {
         return delegate.connectionContext();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpLoadBalancedConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpLoadBalancedConnection.java
@@ -24,14 +24,16 @@ import static java.util.Objects.requireNonNull;
 /**
  * Implementation of {@link FilterableStreamingHttpLoadBalancedConnection} that delegates all methods.
  */
-public class DelegatingFilterableStreamingHttpConnection implements FilterableStreamingHttpLoadBalancedConnection {
+public class DelegatingFilterableStreamingHttpLoadBalancedConnection
+        implements FilterableStreamingHttpLoadBalancedConnection {
     private final FilterableStreamingHttpLoadBalancedConnection delegate;
 
     /**
      * Create a new instance.
      * @param delegate The instance to delegate to.
      */
-    public DelegatingFilterableStreamingHttpConnection(final FilterableStreamingHttpLoadBalancedConnection delegate) {
+    public DelegatingFilterableStreamingHttpLoadBalancedConnection(
+            final FilterableStreamingHttpLoadBalancedConnection delegate) {
         this.delegate = requireNonNull(delegate);
     }
 
@@ -162,6 +164,6 @@ public class DelegatingFilterableStreamingHttpConnection implements FilterableSt
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + '(' + delegate + ')';
+        return delegate.toString();
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -237,7 +237,7 @@ public interface HttpLoadBalancerFactory<ResolvedAddress>
 
         @Override
         public String toString() {
-            return getClass().getSimpleName() + '(' + delegate + ", " + controller + ')';
+            return delegate.toString();
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -67,8 +67,7 @@ public interface HttpLoadBalancerFactory<ResolvedAddress>
      * @param concurrencyController {@link ReservableRequestConcurrencyController} to control access to the connection
      * @param context A {@link ContextMap context} of the caller (e.g. request/LB context) or {@code null} if no context
      * @return {@link FilterableStreamingHttpLoadBalancedConnection} for the passed
-     * {@link FilterableStreamingHttpConnection}
-     * provided
+     * {@link FilterableStreamingHttpConnection}.
      */
     default FilterableStreamingHttpLoadBalancedConnection toLoadBalancedConnection(
             FilterableStreamingHttpConnection connection,
@@ -238,7 +237,7 @@ public interface HttpLoadBalancerFactory<ResolvedAddress>
 
         @Override
         public String toString() {
-            return delegate.toString();
+            return getClass().getSimpleName() + '(' + delegate + ", " + controller + ')';
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -89,7 +89,8 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
                 .concat(succeeded(ZERO_MAX_CONCURRENCY_EVENT))
                 .publishOn(executionContext.executionStrategy().isEventOffloaded() ?
                         executionContext.executor() : immediate(),
-                        IoThreadFactory.IoThread::currentThreadIsIoThread);
+                        IoThreadFactory.IoThread::currentThreadIsIoThread)
+                .multicast(1); // Allows multiple Subscribers to consume the event stream.
         this.headersFactory = headersFactory;
         this.allowDropTrailersReadFromTransport = allowDropTrailersReadFromTransport;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -210,7 +210,7 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
 
         @Override
         public String toString() {
-            return getClass().getSimpleName() + '(' + delegate + ')';
+            return delegate.toString();
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -57,12 +57,21 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
         this.strategy = strategy;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
             final String targetResource,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
         return rawFactory.newLoadBalancer(targetResource, eventPublisher, connectionFactory);
+    }
+
+    @Override
+    public LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> newLoadBalancerTyped(
+            final String targetResource,
+            final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
+            final ConnectionFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> connectionFactory) {
+        return rawFactory.newLoadBalancerTyped(targetResource, eventPublisher, connectionFactory);
     }
 
     @Override   // FIXME: 0.43 - remove deprecated method
@@ -201,7 +210,7 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
 
         @Override
         public String toString() {
-            return delegate.toString();
+            return getClass().getSimpleName() + '(' + delegate + ')';
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -289,7 +289,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
             }
 
             final LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> lb =
-                    closeOnException.prepend(ctx.builder.loadBalancerFactory.newLoadBalancer(
+                    closeOnException.prepend(ctx.builder.loadBalancerFactory.newLoadBalancerTyped(
                             targetAddress(ctx),
                             sdEvents,
                             connectionFactory));

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
@@ -187,7 +187,7 @@ final class ReservableRequestConcurrencyControllers {
 
         @Override
         public String toString() {
-            return "pendingRequests: " + pendingRequests + " maxRequests: " + maxConcurrencyHolder.lastSeenValue(-1);
+            return "pendingRequests=" + pendingRequests + " maxRequests=" + maxConcurrencyHolder.lastSeenValue(-1);
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
@@ -184,6 +184,11 @@ final class ReservableRequestConcurrencyControllers {
         final boolean casPendingRequests(int oldValue, int newValue) {
             return pendingRequestsUpdater.compareAndSet(this, oldValue, newValue);
         }
+
+        @Override
+        public String toString() {
+            return "pendingRequests: " + pendingRequests + " maxRequests: " + maxConcurrencyHolder.lastSeenValue(-1);
+        }
     }
 
     private static final class ReservableRequestConcurrencyControllerMulti

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
+import io.servicetalk.http.api.Http2SettingsBuilder;
+import io.servicetalk.http.api.HttpProtocolConfig;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.utils.CacheConnectionHttpLoadBalanceFactory;
+import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
+import io.servicetalk.logging.api.LogLevel;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver;
+
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Single.collectUnordered;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofImmediate;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.lang.Math.ceil;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+final class CacheConnectionHttpLoadBalanceFactoryTest {
+    @ParameterizedTest(name = "{displayName} [{index}] numRequests={0} maxConcurrency={1} clientH2={2} serverH2={3}")
+    @CsvSource(value = {
+            "1, 100, true, true", "2, 2, true, false",
+            "100, 100, true, true", "100, 100, false, true", "100, 100, true, false", "100, 100, false, false",
+            "199, 100, true, true", "201, 100, true, true",
+            "1000, 100, true, true", "1001, 100, true, true"
+    })
+    void h1OrH2(int numRequests, int maxConcurrency, boolean clientPreferH2, boolean serverPreferH2) throws Exception {
+        final H2ProtocolConfig h2ServerProtocol = h2().initialSettings(
+                new Http2SettingsBuilder().maxConcurrentStreams(maxConcurrency).build()).build();
+        final H1ProtocolConfig h1ServerProtocol = h1Default();
+        final H2ProtocolConfig h2ClientProtocol = h2Default();
+        final H1ProtocolConfig h1ClientProtocol = h1().maxPipelinedRequests(maxConcurrency).build();
+
+        CountingConnectionObserver connectionObserver = new CountingConnectionObserver();
+        final AtomicInteger numRetries = new AtomicInteger(0);
+        try (ServerContext ctx = HttpServers.forAddress(localAddress(0))
+                .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                        .build())
+                .protocols(protocolConfigs(serverPreferH2, h1ServerProtocol, h2ServerProtocol))
+                .listenStreamingAndAwait((ctx2, request, responseFactory) ->
+                        succeeded(responseFactory.ok().payloadBody(
+                                ctx2.protocol().equals(HTTP_2_0) ? Publisher.never() : Publisher.empty())));
+             StreamingHttpClient client = HttpClients.forResolvedAddress(serverHostAndPort(ctx))
+                     .sslConfig(new ClientSslConfigBuilder(InsecureTrustManagerFactory.INSTANCE).build())
+                     .protocols(protocolConfigs(clientPreferH2, h1ClientProtocol, h2ClientProtocol))
+                     .enableWireLogging("servicetalk-tests-h2-frame-logger", LogLevel.TRACE, () -> false)
+                     .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(connectionObserver))
+                     .loadBalancerFactory(new CacheConnectionHttpLoadBalanceFactory<>(
+                             DefaultHttpLoadBalancerFactory.Builder.from(
+                                     new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress,
+                                             FilterableStreamingHttpLoadBalancedConnection>().build()).build(),
+                             a -> maxConcurrency))
+                     // The accounting for connection caching and the ConcurrencyController are done at different layers
+                     // so it is possible the connection caching will give a connection to the load balancer that fails
+                     // selection due to ConcurrencyController count being meet.
+                     .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                             .maxTotalRetries(Integer.MAX_VALUE).retryRetryableExceptions(
+                                     (req, e) -> {
+                                         numRetries.incrementAndGet();
+                                         return ofImmediate(Integer.MAX_VALUE);
+                                     }).build())
+                     .buildStreaming()) {
+            List<Single<StreamingHttpResponse>> responseSingles = new ArrayList<>(numRequests);
+            for (int i = 0; i < numRequests; ++i) {
+                // Ideally we can always use Publisher.never() however for http1 requests must complete for us to make
+                // progress on subsequent requests (pipelining).
+                responseSingles.add(client.request(client.get("/" + i).payloadBody(
+                        clientPreferH2 && serverPreferH2 ? Publisher.never() : Publisher.empty())));
+            }
+
+            Collection<StreamingHttpResponse> responses =
+                    collectUnordered(responseSingles, numRequests).toFuture().get();
+            assertThat(responses, hasSize(numRequests));
+            assertThat(connectionObserver.count.get(),
+                    // Initial number of streams is unbound, so we may create more streams on connections before the
+                    // client acknowledges the servers max_concurrent_streams setting update.
+                    lessThanOrEqualTo((int) ceil((double) (numRequests + numRetries.get()) / maxConcurrency)));
+        }
+    }
+
+    private static class CountingConnectionObserver implements TransportObserver {
+        private final AtomicInteger count = new AtomicInteger();
+
+        @Override
+        public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
+            count.incrementAndGet();
+            return NoopTransportObserver.NoopConnectionObserver.INSTANCE;
+        }
+    }
+
+    private static HttpProtocolConfig[] protocolConfigs(boolean preferH2, H1ProtocolConfig h1Config,
+                                                        H2ProtocolConfig h2Config) {
+        return preferH2 ?
+                new HttpProtocolConfig[] {h2Config, h1Config} :
+                new HttpProtocolConfig[] {h1Config, h2Config};
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -569,7 +569,7 @@ class ClientEffectiveStrategyTest {
 
     private static class LoadBalancerFactoryImpl
             implements LoadBalancerFactory<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection> {
-
+        @SuppressWarnings("deprecation")
         @Override
         public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
                 final String targetResource,
@@ -579,6 +579,18 @@ class ClientEffectiveStrategyTest {
             return new RoundRobinLoadBalancerFactory
                     .Builder<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>().build()
                     .newLoadBalancer(targetResource, eventPublisher, connectionFactory);
+        }
+
+        @Override
+        public LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> newLoadBalancerTyped(
+                final String targetResource,
+                final Publisher<? extends Collection<? extends ServiceDiscovererEvent<InetSocketAddress>>>
+                        eventPublisher,
+                final ConnectionFactory<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>
+                        connectionFactory) {
+            return new RoundRobinLoadBalancerFactory
+                    .Builder<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>().build()
+                    .newLoadBalancerTyped(targetResource, eventPublisher, connectionFactory);
         }
 
         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -222,6 +222,7 @@ class RetryingHttpRequesterFilterTest {
         private final LoadBalancerFactory<InetSocketAddress, C> rr =
                 new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, C>().build();
 
+        @SuppressWarnings("deprecation")
         @Override
         public <T extends C> LoadBalancer<T> newLoadBalancer(
                 final String targetResource,
@@ -229,6 +230,16 @@ class RetryingHttpRequesterFilterTest {
                         eventPublisher,
                 final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
             return new InspectingLoadBalancer<>(rr.newLoadBalancer(targetResource, eventPublisher, connectionFactory));
+        }
+
+        @Override
+        public LoadBalancer<C> newLoadBalancerTyped(
+                final String targetResource,
+                final Publisher<? extends Collection<? extends ServiceDiscovererEvent<InetSocketAddress>>>
+                        eventPublisher,
+                final ConnectionFactory<InetSocketAddress, C> connectionFactory) {
+            return new InspectingLoadBalancer<>(
+                    rr.newLoadBalancerTyped(targetResource, eventPublisher, connectionFactory));
         }
 
         @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
@@ -89,6 +89,9 @@ final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
                                             result1.onClose().whenFinally(this::lockRemoveFromMap).subscribe();
                                         }
                                     } catch (Throwable cause) {
+                                        if (result1 != null) {
+                                            result1.closeAsync().subscribe();
+                                        }
                                         subscriber.onError(cause);
                                         return;
                                     }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.DelegatingConnectionFactory;
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource.Subscriber;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.transport.api.TransportObserver;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+import javax.annotation.Nullable;
+
+final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncCloseable>
+        extends DelegatingConnectionFactory<ResolvedAddress, C> {
+    private final Map<ResolvedAddress, Item<C>> map = new HashMap<>();
+    private final ToIntFunction<ResolvedAddress> maxConcurrencyFunc;
+
+    CacheConnectionFactory(final ConnectionFactory<ResolvedAddress, C> delegate,
+                           final ToIntFunction<ResolvedAddress> maxConcurrencyFunc) {
+        super(delegate);
+        this.maxConcurrencyFunc = maxConcurrencyFunc;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Deprecated
+    @Override
+    public Single<C> newConnection(final ResolvedAddress resolvedAddress,
+                                   @Nullable final TransportObserver observer) {
+        return newConnection(resolvedAddress, null, observer);
+    }
+
+    @Override
+    public Single<C> newConnection(final ResolvedAddress resolvedAddress, @Nullable final ContextMap context,
+                                   @Nullable final TransportObserver observer) {
+        return Single.defer(() -> {
+            final int maxConcurrency = maxConcurrencyFunc.applyAsInt(resolvedAddress);
+            if (maxConcurrency <= 1) {
+                // If the concurrency is <=1 there is no use in caching the connection because we won't re-use it.
+                return delegate().newConnection(resolvedAddress, context, observer);
+            }
+
+            Single<C> result;
+            synchronized (map) {
+                final Item<C> item1 = map.get(resolvedAddress);
+                if (item1 == null || (result = item1.addSubscriber(maxConcurrency)) == null) {
+                    final Item<C> item2 = new Item<>();
+                    map.put(resolvedAddress, item2);
+                    result = item2.single = delegate().newConnection(resolvedAddress, context, observer)
+                            // Remove from map in a cancel above cache operator. Cache will only cancel upstream
+                            // after all subscribers have cancelled.
+                            .<C>liftSync(subscriber -> new Subscriber<C>() {
+                                @Override
+                                public void onSubscribe(final Cancellable cancellable) {
+                                    subscriber.onSubscribe(() -> {
+                                        try {
+                                            assert Thread.holdsLock(map);
+                                            map.remove(resolvedAddress, item2);
+                                        } finally {
+                                            cancellable.cancel();
+                                        }
+                                    });
+                                }
+
+                                @Override
+                                public void onSuccess(@Nullable final C result1) {
+                                    try {
+                                        if (result1 == null) {
+                                            lockRemoveFromMap();
+                                        } else {
+                                            result1.onClose().whenFinally(this::lockRemoveFromMap).subscribe();
+                                        }
+                                    } catch (Throwable cause) {
+                                        subscriber.onError(cause);
+                                        return;
+                                    }
+                                    subscriber.onSuccess(result1);
+                                }
+
+                                @Override
+                                public void onError(final Throwable t) {
+                                    lockRemoveFromMap();
+                                    subscriber.onError(t);
+                                }
+
+                                private void lockRemoveFromMap() {
+                                    synchronized (map) {
+                                        map.remove(resolvedAddress, item2);
+                                    }
+                                }
+                            })
+                            .cache()
+                            .liftSync(subscriber -> new Subscriber<C>() {
+                                @Override
+                                public void onSubscribe(final Cancellable cancellable) {
+                                    subscriber.onSubscribe(() -> {
+                                        // Acquire the lock before cache operator processes cancel, so if it results
+                                        // in an upstream cancel we will be holding the lock and able to remove the
+                                        // map entry safely.
+                                        synchronized (map) {
+                                            cancellable.cancel();
+                                        }
+                                    });
+                                }
+
+                                @Override
+                                public void onSuccess(@Nullable final C result1) {
+                                    try {
+                                        subscriber.onSuccess(result1);
+                                    } finally {
+                                        lockRemoveFromMap();
+                                    }
+                                }
+
+                                @Override
+                                public void onError(final Throwable t) {
+                                    try {
+                                        subscriber.onError(t);
+                                    } finally {
+                                        lockRemoveFromMap();
+                                    }
+                                }
+
+                                private void lockRemoveFromMap() {
+                                    // The map will hold the latest re-usable connection attempt for this address and
+                                    // will remove upon connection closure, or when the available concurrency for the
+                                    // pending connection attempt is exceeded. When the single completes we don't need
+                                    // to cache the connection anymore because the LoadBalancer above will cache the
+                                    // connection. This also help keep memory down from the map.
+                                    synchronized (map) {
+                                        map.remove(resolvedAddress, item2);
+                                    }
+                                }
+                            });
+                }
+            }
+
+            return result.shareContextOnSubscribe();
+        });
+    }
+
+    private static final class Item<C> {
+        @Nullable
+        Single<C> single;
+        private int subscriberCount = 1;
+
+        @Nullable
+        Single<C> addSubscriber(int maxSubscriberCount) {
+            if (subscriberCount >= maxSubscriberCount) {
+                return null;
+            }
+            ++subscriberCount;
+            return single;
+        }
+    }
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionHttpLoadBalanceFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionHttpLoadBalanceFactory.java
@@ -130,6 +130,11 @@ public final class CacheConnectionHttpLoadBalanceFactory<ResolvedAddress>
         public Completable onClose() {
             return delegate.onClose();
         }
+
+        @Override
+        public Completable onClosing() {
+            return delegate.onClosing();
+        }
     }
 
     private static final class MaxConcurrencyFilterableStreamingHttpLoadBalancedConnection<RA>

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionHttpLoadBalanceFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionHttpLoadBalanceFactory.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConsumableEvent;
+import io.servicetalk.client.api.LoadBalancer;
+import io.servicetalk.client.api.LoadBalancerFactory;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.http.api.DelegatingFilterableStreamingHttpConnection;
+import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpLoadBalancerFactory;
+import io.servicetalk.transport.api.TransportObserver;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.ToIntFunction;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link HttpLoadBalancerFactory} that will cache successive connection creation attempts and return the same
+ * {@link Single} instead of creating a new connection each time. This is useful when a spike of connections occurs
+ * instead of creating a new connection for each request, if the underlying protocol version supports concurrency
+ * (pipelining, multiplexing) a single connection creation attempt can be used before the connection is actually
+ * established, which will reduce the overall number of connectiosn required.
+ * @param <ResolvableAddress> The resolved address type.
+ */
+public final class CacheConnectionHttpLoadBalanceFactory<ResolvableAddress>
+        implements HttpLoadBalancerFactory<ResolvableAddress> {
+    private final ToIntFunction<ResolvableAddress> maxConcurrencyFunc;
+    private final HttpLoadBalancerFactory<ResolvableAddress> delegate;
+
+    /**
+     * Create a new instance.
+     *
+     * @param delegate The {@link LoadBalancerFactory} to delegate to.
+     * @param maxConcurrencyFunc The default number of maximum concurrency requests per each address.
+     */
+    public CacheConnectionHttpLoadBalanceFactory(final HttpLoadBalancerFactory<ResolvableAddress> delegate,
+                                                 final ToIntFunction<ResolvableAddress> maxConcurrencyFunc) {
+        this.maxConcurrencyFunc = requireNonNull(maxConcurrencyFunc);
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public <T extends FilterableStreamingHttpLoadBalancedConnection> LoadBalancer<T> newLoadBalancer(
+            final String targetResource,
+            final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvableAddress>>> eventPublisher,
+            final ConnectionFactory<ResolvableAddress, T> connectionFactory) {
+        throw new UnsupportedOperationException("Use newLoadBalancerTyped instead.");
+    }
+
+    @Override
+    public LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> newLoadBalancerTyped(
+        final String targetResource,
+        final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvableAddress>>> eventPublisher,
+        final ConnectionFactory<ResolvableAddress, FilterableStreamingHttpLoadBalancedConnection> connectionFactory) {
+        final HttpCacheConnectionFactory<ResolvableAddress> cacheFactory =
+                new HttpCacheConnectionFactory<>(connectionFactory, maxConcurrencyFunc);
+        return delegate.newLoadBalancerTyped(targetResource, eventPublisher,
+                new CacheConnectionFactory<>(cacheFactory, r -> {
+                    ConcurrencyRefCnt v = cacheFactory.maxConcurrentMap.get(r);
+                    return v == null ? maxConcurrencyFunc.applyAsInt(r) : v.concurrency;
+                }));
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return delegate.requiredOffloads();
+    }
+
+    private static final class HttpCacheConnectionFactory<RA>
+            implements ConnectionFactory<RA, FilterableStreamingHttpLoadBalancedConnection> {
+        private final Map<RA, ConcurrencyRefCnt> maxConcurrentMap = new ConcurrentHashMap<>();
+        private final ToIntFunction<RA> maxConcurrencyFunc;
+        private final ConnectionFactory<RA, FilterableStreamingHttpLoadBalancedConnection> delegate;
+
+        private HttpCacheConnectionFactory(
+                final ConnectionFactory<RA, FilterableStreamingHttpLoadBalancedConnection> delegate,
+                final ToIntFunction<RA> maxConcurrencyFunc) {
+            this.delegate = requireNonNull(delegate);
+            this.maxConcurrencyFunc = requireNonNull(maxConcurrencyFunc);
+        }
+
+        @Override
+        public Single<FilterableStreamingHttpLoadBalancedConnection> newConnection(
+                final RA resolvedAddress, @Nullable final ContextMap context,
+                @Nullable final TransportObserver observer) {
+            return delegate.newConnection(resolvedAddress, context, observer)
+                    .map(connection -> new MaxConcurrencyFilterableStreamingHttpConnection<>(connection,
+                            maxConcurrentMap, resolvedAddress, maxConcurrencyFunc));
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return delegate.closeAsync();
+        }
+
+        @Override
+        public Completable closeAsyncGracefully() {
+            return delegate.closeAsyncGracefully();
+        }
+
+        @Override
+        public Completable onClose() {
+            return delegate.onClose();
+        }
+    }
+
+    private static final class MaxConcurrencyFilterableStreamingHttpConnection<RA>
+            extends DelegatingFilterableStreamingHttpConnection {
+        MaxConcurrencyFilterableStreamingHttpConnection(final FilterableStreamingHttpLoadBalancedConnection delegate,
+                                                        final Map<RA, ConcurrencyRefCnt> maxConcurrentMap,
+                                                        final RA resolvedAddress,
+                                                        final ToIntFunction<RA> concurrencyEstimator) {
+            super(delegate);
+            // For each new connection we increment the reference count. Even if the estimate is <=1 we still track
+            // the connection because we could learn the actual concurrency after connections are established and
+            // the protocol is negotiated. For example if the connection supports h1 and h2, and we negotiate h2 we
+            // will likely find out the connection can handle more concurrency.
+            maxConcurrentMap.compute(resolvedAddress, (ra, refCnt) -> refCnt == null ?
+                    new ConcurrencyRefCnt(concurrencyEstimator.applyAsInt(ra), 1) :
+                    new ConcurrencyRefCnt(refCnt.concurrency, refCnt.refCnt + 1));
+            toSource(delegate.<ConsumableEvent<Integer>>transportEventStream(MAX_CONCURRENCY))
+                    .subscribe(new Subscriber<ConsumableEvent<Integer>>() {
+                        @Override
+                        public void onSubscribe(final PublisherSource.Subscription subscription) {
+                            subscription.request(Long.MAX_VALUE);
+                        }
+
+                        @Override
+                        public void onNext(@Nullable final ConsumableEvent<Integer> integerConsumableEvent) {
+                            if (integerConsumableEvent != null) {
+                                final int concurrency = integerConsumableEvent.event();
+                                // Connections may set their max concurrency to 0 before shutting down.
+                                // Map cleanup is done in terminal method.
+                                if (concurrency > 0) {
+                                    maxConcurrentMap.computeIfPresent(resolvedAddress,
+                                            (ra, refCnt) -> new ConcurrencyRefCnt(concurrency, refCnt.refCnt));
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void onError(final Throwable t) {
+                            decrementRefCnt();
+                        }
+
+                        @Override
+                        public void onComplete() {
+                            decrementRefCnt();
+                        }
+
+                        private void decrementRefCnt() {
+                            // When the connection is closed we decrement the reference count.
+                            maxConcurrentMap.computeIfPresent(resolvedAddress, (ra, refCnt) ->
+                                    refCnt.refCnt <= 1 ? null :
+                                            new ConcurrencyRefCnt(refCnt.concurrency, refCnt.refCnt - 1));
+                        }
+                    });
+        }
+    }
+
+    private static final class ConcurrencyRefCnt {
+        final int concurrency;
+        final int refCnt;
+
+        private ConcurrencyRefCnt(final int concurrency, final int refCnt) {
+            this.concurrency = concurrency;
+            this.refCnt = refCnt;
+        }
+    }
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -90,11 +90,21 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
         this.healthCheckConfig = healthCheckConfig;
     }
 
+    @Deprecated
     @Override
     public <T extends C> LoadBalancer<T> newLoadBalancer(
             final String targetResource,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
+        return new RoundRobinLoadBalancer<>(requireNonNull(targetResource), eventPublisher, connectionFactory,
+                linearSearchSpace, healthCheckConfig);
+    }
+
+    @Override
+    public LoadBalancer<C> newLoadBalancerTyped(
+            final String targetResource,
+            final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
+            final ConnectionFactory<ResolvedAddress, C> connectionFactory) {
         return new RoundRobinLoadBalancer<>(requireNonNull(targetResource), eventPublisher, connectionFactory,
                 linearSearchSpace, healthCheckConfig);
     }


### PR DESCRIPTION
Motivation:
When traffic spikes occur ServiceTalk will create as many
new connections as concurrent requests cannot be satisfied
with existing connections. This is common at startup and
results in more connections than necessary for protocols that
support multiple requests in parallel on the same connection
(http/1.x pipelining, h2 multiplexing).

Modifications:
- Add CacheConnectionHttpLoadBalanceFactory which wraps a
  HttpLoadBalancerFactory and will cache connection creation attempts
  according to max concurrent requests supported by the connection.
- LoadBalancerFactory#newLoadBalancer is deprecated in favor of a
  variant that doesn't have generic override on the method. This makes
  it possible for the LoadBalancer implementation to more easily wrap
  the connection and augment behavior if necessary.