### PR TITLE
Override `toString()` for delegating connections

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -230,5 +230,10 @@ public interface HttpLoadBalancerFactory<ResolvedAddress>
         public ReservedBlockingHttpConnection asBlockingConnection() {
             return toReservedBlockingConnection(this, executionContext().executionStrategy());
         }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -273,7 +273,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     }
 
     @Override
-    public String toString() {
+    public final String toString() {
         return getClass().getName() + '(' + connectionContext + ')';
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -193,5 +193,10 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
         public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
             return delegate.newRequest(method, requestTarget);
         }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

#2278 added a new connection wrapper
`DefaultFilterableStreamingHttpLoadBalancedConnection` that does not
implement `toString()`. It hides the channel id in RRLB logs.

Modifications:

- Implement `toString()` for
`DefaultFilterableStreamingHttpLoadBalancedConnection` in
`HttpLoadBalancerFactory` and `DefaultHttpLoadBalancerFactory`;
- Make `AbstractStreamingHttpConnection#toString()` final;

Result:

RRLB logs include channel id.