### PR TITLE
Introduce `IdleTimeoutConnectionFilter` as alternative to `IDLE_TIMEOUT`

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/RequestRejectedException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/RequestRejectedException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api;
+
+import io.servicetalk.transport.api.RetryableException;
+
+import java.io.IOException;
+
+/**
+ * Thrown when a request was rejected before processing by the transport layer.
+ */
+public class RequestRejectedException extends IOException implements RetryableException {
+    private static final long serialVersionUID = 5270586295780544459L;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message.
+     */
+    public RequestRejectedException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message.
+     * @param cause the cause.
+     */
+    public RequestRejectedException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilter.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.Executor;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ExecutionContext;
+import io.servicetalk.transport.api.RetryableException;
+import io.servicetalk.transport.api.ServiceTalkSocketOptions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.channels.ClosedChannelException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Single.defer;
+import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static java.lang.Integer.MIN_VALUE;
+import static java.time.Duration.ZERO;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * A connection-level filter that closes idle connections.
+ * <p>
+ * This filter is an alternative to {@link ServiceTalkSocketOptions#IDLE_TIMEOUT} at L7 layer. It helps to close idle
+ * connections that were not used to send any requests for the specified duration without affecting any in-flight
+ * requests.
+ * <ul>
+ *     <li>Connections that have in-flight requests are considered "in-use".</li>
+ *     <li>If response payload body was not consumed, the connection is still considered "in-use" and does not start
+ *     counting the timer.</li>
+ * </ul>
+ */
+public final class IdleTimeoutConnectionFilter implements StreamingHttpConnectionFilterFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdleTimeoutConnectionFilter.class);
+
+    private static final Cancellable CANCELLED = () -> { };
+
+    private final long timeoutNs;
+    @Nullable
+    private final Executor timeoutExecutor;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param timeout timeout duration after which an idle connection is closed
+     */
+    IdleTimeoutConnectionFilter(final Duration timeout) {
+        this.timeoutNs = ensurePositive(timeout).toNanos();
+        this.timeoutExecutor = null;
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param timeout timeout duration after which an idle connection is closed
+     * @param timeoutExecutor the {@link Executor} to use for scheduling the timer notifications
+     */
+    IdleTimeoutConnectionFilter(final Duration timeout, final Executor timeoutExecutor) {
+        this.timeoutNs = ensurePositive(timeout).toNanos();
+        this.timeoutExecutor = requireNonNull(timeoutExecutor);
+    }
+
+    private static Duration ensurePositive(final Duration timeout) {
+        if (ZERO.compareTo(timeout) >= 0) {
+            throw new IllegalArgumentException("timeout: " + timeout.toNanos() + " ns (expected: >0)");
+        }
+        return timeout;
+    }
+
+    private static Executor contextExecutor(ExecutionContext<HttpExecutionStrategy> context) {
+        return context.executionStrategy().hasOffloads() ? context.executor() : context.ioExecutor();
+    }
+
+    @Override
+    public StreamingHttpConnectionFilter create(final FilterableStreamingHttpConnection connection) {
+        return new ConnectionIdleTimeoutFilterImpl(connection, timeoutNs,
+                timeoutExecutor != null ? timeoutExecutor : contextExecutor(connection.executionContext()));
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return offloadNone();
+    }
+
+    private static final class ConnectionIdleTimeoutFilterImpl extends StreamingHttpConnectionFilter
+            implements Runnable {
+
+        private static final AtomicIntegerFieldUpdater<ConnectionIdleTimeoutFilterImpl> requestsUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(ConnectionIdleTimeoutFilterImpl.class, "requests");
+        private static final AtomicReferenceFieldUpdater<ConnectionIdleTimeoutFilterImpl, Cancellable>
+                timeoutTaskUpdater = AtomicReferenceFieldUpdater.newUpdater(ConnectionIdleTimeoutFilterImpl.class,
+                Cancellable.class, "timeoutTask");
+
+        private volatile int requests;
+        @Nullable
+        private volatile Cancellable timeoutTask;
+
+        private final long timeoutNs;
+        private final Executor timeoutExecutor;
+
+        // While it may look like "volatile" is not required for this variable for "happens-before" visibility because
+        // we always write to "requests" after updating "lastResponseTime" and read "requests" before reading
+        // "lastResponseTime", non-volatile writes to "long" variables are not atomic and may result in incorrect
+        // reading of the value when 2 threads race.
+        private volatile long lastResponseTime;
+
+        ConnectionIdleTimeoutFilterImpl(final FilterableStreamingHttpConnection connection,
+                                        final long timeoutNs,
+                                        final Executor timeoutExecutor) {
+            super(connection);
+            this.timeoutNs = timeoutNs;
+            this.timeoutExecutor = timeoutExecutor;
+            connection.onClose().whenFinally(this::cancelTask).subscribe();
+            this.lastResponseTime = nanoTime();
+            timeoutTask = this.timeoutExecutor.schedule(this, timeoutNs, NANOSECONDS);
+        }
+
+        private long nanoTime() {
+            return timeoutExecutor.currentTime(NANOSECONDS);
+        }
+
+        private void cancelTask() {
+            final Cancellable oldTask = timeoutTaskUpdater.getAndSet(this, CANCELLED);
+            if (oldTask != null) {
+                oldTask.cancel();
+            }
+        }
+
+        @Override
+        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+            return defer(() -> {
+                final int inFlightRequests = requestsUpdater.incrementAndGet(this);
+                if (inFlightRequests < 0) {
+                    // To mitigate the tiny risk of going into positive numbers with Integer.MAX_VALUE concurrent
+                    // requests (unrealistic), reset the counter back to MIN_VALUE.
+                    requests = MIN_VALUE;
+                    return failed(new RetryableClosedChannelException(delegate(), timeoutNs));
+                }
+                return delegate().request(request)
+                        .liftSync(new BeforeFinallyHttpOperator(() -> {
+                            // It's acceptable to use 2 volatile variables instead of a single object state here. Even
+                            // if 2 threads race between updating "lastResponseTime" and "requests", the delay for a new
+                            // timer task will be close to "timeoutNs".
+                            requestsUpdater.updateAndGet(this, prev -> {
+                                if (prev > 1) {
+                                    return prev - 1;
+                                }
+                                assert prev == 1 : "Unexpected requests value: " + prev;
+                                lastResponseTime = nanoTime();
+                                return 0;
+                            });
+                        })).shareContextOnSubscribe();
+            });
+        }
+
+        private void updateIdleTimeout(final long delayNs) {
+            final Cancellable newTask = timeoutExecutor.schedule(this, delayNs, NANOSECONDS);
+            if (!timeoutTaskUpdater.compareAndSet(this, null, newTask)) {
+                assert timeoutTask == CANCELLED : "Unexpected timeoutTask: " + timeoutTask;
+                newTask.cancel();    // Connection was closed, cancel the new task
+            }
+        }
+
+        @Override
+        public void run() {
+            final Cancellable oldTask = timeoutTaskUpdater.getAndSet(this, null);
+            if (oldTask == CANCELLED) {
+                // Connection already closed
+                return;
+            }
+            for (;;) {
+                final long requests = this.requests;
+                if (requests > 0) {
+                    // Reschedule timeout:
+                    updateIdleTimeout(timeoutNs);
+                    return;
+                } else if (requests == 0) {
+                    final long nextDelayNs = timeoutNs - (nanoTime() - lastResponseTime);
+                    if (nextDelayNs <= 0) {
+                        if (requestsUpdater.compareAndSet(this, 0, MIN_VALUE)) {
+                            FilterableStreamingHttpConnection connection = delegate();
+                            LOGGER.debug("Closing connection {} after {} ms of inactivity",
+                                    connection, NANOSECONDS.toMillis(timeoutNs));
+                            connection.closeAsync().subscribe();
+                            return;
+                        }
+                    } else {
+                        updateIdleTimeout(nextDelayNs);
+                        return;
+                    }
+                } else {
+                    // Should never happen. Keep it just in case to prevent infinite loop.
+                    return;
+                }
+            }
+        }
+    }
+
+    private static final class RetryableClosedChannelException extends ClosedChannelException
+            implements RetryableException {
+        private static final long serialVersionUID = 5678979395131901139L;
+        private final String message;
+
+        RetryableClosedChannelException(final FilterableStreamingHttpConnection connection, final long timeoutNs) {
+            this.message = "Connection " + connection + " was closed due to " +
+                    NANOSECONDS.toMillis(timeoutNs) + " ms of inactivity";
+        }
+
+        @Override
+        public String getMessage() {
+            return message;
+        }
+    }
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilter.java
@@ -58,6 +58,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  *     <li>Connections that have in-flight requests are considered "in-use".</li>
  *     <li>If response payload body was not consumed, the connection is still considered "in-use" and does not start
  *     counting the timer.</li>
+ *     <li>A single connection can not process more than {@link Integer#MAX_VALUE} concurrent requests.</li>
  * </ul>
  */
 public final class IdleTimeoutConnectionFilter implements StreamingHttpConnectionFilterFactory {

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilter.java
@@ -72,7 +72,7 @@ public final class IdleTimeoutConnectionFilter implements StreamingHttpConnectio
      *
      * @param timeout timeout duration after which an idle connection is closed
      */
-    IdleTimeoutConnectionFilter(final Duration timeout) {
+    public IdleTimeoutConnectionFilter(final Duration timeout) {
         this.timeoutNs = ensurePositive(timeout).toNanos();
         this.timeoutExecutor = null;
     }
@@ -83,7 +83,7 @@ public final class IdleTimeoutConnectionFilter implements StreamingHttpConnectio
      * @param timeout timeout duration after which an idle connection is closed
      * @param timeoutExecutor the {@link Executor} to use for scheduling the timer notifications
      */
-    IdleTimeoutConnectionFilter(final Duration timeout, final Executor timeoutExecutor) {
+    public IdleTimeoutConnectionFilter(final Duration timeout, final Executor timeoutExecutor) {
         this.timeoutNs = ensurePositive(timeout).toNanos();
         this.timeoutExecutor = requireNonNull(timeoutExecutor);
     }
@@ -126,10 +126,8 @@ public final class IdleTimeoutConnectionFilter implements StreamingHttpConnectio
         private final long timeoutNs;
         private final Executor timeoutExecutor;
 
-        // While it may look like "volatile" is not required for this variable for "happens-before" visibility because
-        // we always write to "requests" after updating "lastResponseTime" and read "requests" before reading
-        // "lastResponseTime", non-volatile writes to "long" variables are not atomic and may result in incorrect
-        // reading of the value when 2 threads race.
+        // The "volatile" here is not for general visibility but to prevent non-atomic treatment of long:
+        // https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.7
         private volatile long lastResponseTime;
 
         ConnectionIdleTimeoutFilterImpl(final FilterableStreamingHttpConnection connection,

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilterTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.SingleSource.Processor;
+import io.servicetalk.concurrent.api.TestExecutor;
+import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.channels.ClosedChannelException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
+import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
+import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
+import static java.time.Duration.ofMillis;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IdleTimeoutConnectionFilterTest {
+
+    private static final StreamingHttpRequest REQUEST = mock(StreamingHttpRequest.class);
+    private static final StreamingHttpRequest REQUEST_SUCCESS = mock(StreamingHttpRequest.class);
+    private static final StreamingHttpRequest REQUEST_FAIL = mock(StreamingHttpRequest.class);
+    private static final StreamingHttpResponse RESPONSE = newResponse(OK, HTTP_1_1,
+            DefaultHttpHeadersFactory.INSTANCE.newHeaders(), DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE);
+    private static final Throwable DELIBERATE_EXCEPTION = new RuntimeException("DELIBERATE_EXCEPTION");
+    private static final long TIMEOUT_MILLIS = 60_000;
+
+    private final TestExecutor executor = new TestExecutor();
+    private final FilterableStreamingHttpConnection connection = mock(FilterableStreamingHttpConnection.class);
+    private final AtomicInteger closedTimes = new AtomicInteger();
+    private final FilterableStreamingHttpConnection filteredConnection;
+
+    IdleTimeoutConnectionFilterTest() {
+        CompletableSource.Processor onClose = newCompletableProcessor();
+        when(connection.onClose()).thenReturn(fromSource(onClose));
+        when(connection.closeAsync()).thenReturn(completed().whenFinally(() -> {
+            onClose.onComplete();
+            closedTimes.incrementAndGet();
+        }));
+        HttpExecutionContext ctx = mock(HttpExecutionContext.class);
+        when(ctx.executor()).thenReturn(executor);
+        when(connection.executionContext()).thenReturn(ctx);
+        filteredConnection = new IdleTimeoutConnectionFilter(ofMillis(TIMEOUT_MILLIS), executor).create(connection);
+
+        when(connection.request(REQUEST_SUCCESS)).thenReturn(succeeded(RESPONSE));
+        when(connection.request(REQUEST_FAIL)).thenReturn(failed(DELIBERATE_EXCEPTION));
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        executor.closeAsync().toFuture().get();
+    }
+
+    @Test
+    public void negativeTimeout() {
+        assertThrows(IllegalArgumentException.class, () -> new IdleTimeoutConnectionFilter(ofMillis(-1)));
+    }
+
+    @Test
+    public void zeroTimeout() {
+        assertThrows(IllegalArgumentException.class, () -> new IdleTimeoutConnectionFilter(Duration.ZERO));
+    }
+
+    @Test
+    public void noRequests() {
+        executor.advanceTimeBy(TIMEOUT_MILLIS, MILLISECONDS);
+        assertClosedOnce();
+        assertClosedChannelException();
+    }
+
+    @Test
+    public void closedManually() {
+        filteredConnection.closeAsync().subscribe();
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS, MILLISECONDS);
+        assertClosedOnce();
+    }
+
+    @Test
+    public void hadSuccessfulResponse() {
+        executor.advanceTimeByNoExecuteTasks(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertSuccessfulResponse();
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertNotClosed();
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertClosedOnce();
+
+        assertClosedChannelException();
+    }
+
+    @Test
+    public void hadFailedResponse() {
+        executor.advanceTimeByNoExecuteTasks(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertFailedResponse();
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertNotClosed();
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertClosedOnce();
+
+        assertClosedChannelException();
+    }
+
+    @Test
+    public void twoConcurrentRequests() {
+        executor.advanceTimeByNoExecuteTasks(TIMEOUT_MILLIS / 2, MILLISECONDS);
+
+        // Send the 1st request that doesn't receive a response:
+        Processor<StreamingHttpResponse, StreamingHttpResponse> firstResponseProcessor = newSingleProcessor();
+        when(connection.request(REQUEST)).thenReturn(fromSource(firstResponseProcessor));
+        TestSingleSubscriber<StreamingHttpResponse> responseSubscriber = new TestSingleSubscriber<>();
+        toSource(filteredConnection.request(REQUEST)).subscribe(responseSubscriber);
+        assertThat(responseSubscriber.pollTerminal(1, MILLISECONDS), is(nullValue()));
+
+        // Send the 2nd request:
+        assertSuccessfulResponse();
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS, MILLISECONDS);
+        assertNotClosed();  // we still have the 1st "in-flight" request
+
+        // Complete the 1st request:
+        firstResponseProcessor.onSuccess(RESPONSE);
+        assertResponse(responseSubscriber);
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertNotClosed();  // timeout was reset after completion of the 1st request
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertClosedOnce();
+
+        assertClosedChannelException();
+    }
+
+    @Test
+    public void inFlightRequest() {
+        executor.advanceTimeByNoExecuteTasks(TIMEOUT_MILLIS / 2, MILLISECONDS);
+
+        Processor<StreamingHttpResponse, StreamingHttpResponse> responseProcessor = newSingleProcessor();
+        when(connection.request(REQUEST)).thenReturn(fromSource(responseProcessor));
+        TestSingleSubscriber<StreamingHttpResponse> responseSubscriber = new TestSingleSubscriber<>();
+        toSource(filteredConnection.request(REQUEST)).subscribe(responseSubscriber);
+        assertThat(responseSubscriber.pollTerminal(1, MILLISECONDS), is(nullValue()));
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS, MILLISECONDS);
+        assertNotClosed();
+
+        responseProcessor.onSuccess(RESPONSE);
+        assertResponse(responseSubscriber);
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertNotClosed();
+
+        executor.advanceTimeBy(TIMEOUT_MILLIS / 2, MILLISECONDS);
+        assertClosedOnce();
+
+        assertClosedChannelException();
+    }
+
+    private void assertClosedOnce() {
+        assertThat(closedTimes.get(), is(1));
+    }
+
+    private void assertNotClosed() {
+        assertThat(closedTimes.get(), is(0));
+    }
+
+    private void assertSuccessfulResponse() {
+        TestSingleSubscriber<StreamingHttpResponse> responseSubscriber = new TestSingleSubscriber<>();
+        toSource(filteredConnection.request(REQUEST_SUCCESS)).subscribe(responseSubscriber);
+        assertResponse(responseSubscriber);
+    }
+
+    private static void assertResponse(TestSingleSubscriber<StreamingHttpResponse> responseSubscriber) {
+        StreamingHttpResponse response = responseSubscriber.awaitOnSuccess();
+        assertThat(response, is(notNullValue()));
+        assertThat(response, is(RESPONSE));
+        response.payloadBody().ignoreElements().subscribe();
+    }
+
+    private void assertFailedResponse() {
+        TestSingleSubscriber<StreamingHttpResponse> responseSubscriber = new TestSingleSubscriber<>();
+        toSource(filteredConnection.request(REQUEST_FAIL)).subscribe(responseSubscriber);
+        assertThat(responseSubscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+    }
+
+    private void assertClosedChannelException() {
+        TestSingleSubscriber<StreamingHttpResponse> responseSubscriber = new TestSingleSubscriber<>();
+        toSource(filteredConnection.request(REQUEST)).subscribe(responseSubscriber);
+        assertThat(responseSubscriber.awaitOnError(), instanceOf(ClosedChannelException.class));
+    }
+}

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilterTest.java
@@ -86,29 +86,29 @@ class IdleTimeoutConnectionFilterTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         executor.closeAsync().toFuture().get();
     }
 
     @Test
-    public void negativeTimeout() {
+    void negativeTimeout() {
         assertThrows(IllegalArgumentException.class, () -> new IdleTimeoutConnectionFilter(ofMillis(-1)));
     }
 
     @Test
-    public void zeroTimeout() {
+    void zeroTimeout() {
         assertThrows(IllegalArgumentException.class, () -> new IdleTimeoutConnectionFilter(Duration.ZERO));
     }
 
     @Test
-    public void noRequests() {
+    void noRequests() {
         executor.advanceTimeBy(TIMEOUT_MILLIS, MILLISECONDS);
         assertClosedOnce();
         assertClosedChannelException();
     }
 
     @Test
-    public void closedManually() {
+    void closedManually() {
         filteredConnection.closeAsync().subscribe();
 
         executor.advanceTimeBy(TIMEOUT_MILLIS, MILLISECONDS);
@@ -116,7 +116,7 @@ class IdleTimeoutConnectionFilterTest {
     }
 
     @Test
-    public void hadSuccessfulResponse() {
+    void hadSuccessfulResponse() {
         executor.advanceTimeByNoExecuteTasks(TIMEOUT_MILLIS / 2, MILLISECONDS);
         assertSuccessfulResponse();
 
@@ -130,7 +130,7 @@ class IdleTimeoutConnectionFilterTest {
     }
 
     @Test
-    public void hadFailedResponse() {
+    void hadFailedResponse() {
         executor.advanceTimeByNoExecuteTasks(TIMEOUT_MILLIS / 2, MILLISECONDS);
         assertFailedResponse();
 
@@ -144,7 +144,7 @@ class IdleTimeoutConnectionFilterTest {
     }
 
     @Test
-    public void twoConcurrentRequests() {
+    void twoConcurrentRequests() {
         executor.advanceTimeByNoExecuteTasks(TIMEOUT_MILLIS / 2, MILLISECONDS);
 
         // Send the 1st request that doesn't receive a response:
@@ -174,7 +174,7 @@ class IdleTimeoutConnectionFilterTest {
     }
 
     @Test
-    public void inFlightRequest() {
+    void inFlightRequest() {
         executor.advanceTimeByNoExecuteTasks(TIMEOUT_MILLIS / 2, MILLISECONDS);
 
         Processor<StreamingHttpResponse, StreamingHttpResponse> responseProcessor = newSingleProcessor();


### PR DESCRIPTION
Motivation:

When `IDLE_TIMEOUT` is used as a mechanism to close unused (excess)
connections, it introduces a risk to impact long-polling requests. Users
always have to coordinate request timeout value with `IDLE_TIMEOUT`
value.

Modifications:

- Add `IdleTimeoutConnectionFilter` and tests;

Result:

Users can still close excess connection without interference with
long-polling requests.