### PR TITLE
HTTP/2 set initial settings

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2Settings.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2Settings.java
@@ -29,7 +29,7 @@ public interface Http2Settings {
      * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_HEADER_TABLE_SIZE</a>.
      */
     @Nullable
-    Integer headerTableSize();
+    Long headerTableSize();
 
     /**
      * Get the value for
@@ -38,7 +38,7 @@ public interface Http2Settings {
      * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_CONCURRENT_STREAMS</a>.
      */
     @Nullable
-    Integer maxConcurrentStreams();
+    Long maxConcurrentStreams();
 
     /**
      * Get the value for
@@ -65,7 +65,7 @@ public interface Http2Settings {
      * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>.
      */
     @Nullable
-    Integer maxHeaderListSize();
+    Long maxHeaderListSize();
 
     /**
      * Get the setting value associated with an
@@ -74,11 +74,11 @@ public interface Http2Settings {
      * @return {@code null} if no setting value corresponding {@code identifier} exists, otherwise the value.
      */
     @Nullable
-    Integer settingValue(char identifier);
+    Long settingValue(char identifier);
 
     /**
      * Iterate over all the &lt;identifier, value&gt; tuple in this settings object.
      * @param action Invoked on each &lt;identifier, value&gt; tuple.
      */
-    void forEach(BiConsumer<? super Character, ? super Integer> action);
+    void forEach(BiConsumer<? super Character, ? super Long> action);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2Settings.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2Settings.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+/**
+ * Utilities for <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">HTTP/2 Setting</a>.
+ */
+public final class Http2Settings {
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_HEADER_TABLE_SIZE</a>.
+     */
+    public static final char HEADER_TABLE_SIZE = 0x1;
+
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_ENABLE_PUSH</a>.
+     */
+    public static final char ENABLE_PUSH = 0x2;
+
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
+     *     SETTINGS_MAX_CONCURRENT_STREAMS</a>.
+     */
+    public static final char MAX_CONCURRENT_STREAMS = 0x3;
+
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
+     *     SETTINGS_INITIAL_WINDOW_SIZE</a>.
+     */
+    public static final char INITIAL_WINDOW_SIZE = 0x4;
+
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>.
+     */
+    public static final char MAX_FRAME_SIZE = 0x5;
+
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
+     *     SETTINGS_MAX_HEADER_LIST_SIZE</a>.
+     */
+    public static final char MAX_HEADER_LIST_SIZE = 0x6;
+
+    private Http2Settings() {
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2Settings.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2Settings.java
@@ -15,43 +15,70 @@
  */
 package io.servicetalk.http.api;
 
+import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
+
 /**
- * Utilities for <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">HTTP/2 Setting</a>.
+ * Object representing a <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">HTTP/2 Setting</a> frame.
  */
-public final class Http2Settings {
+public interface Http2Settings {
     /**
-     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_HEADER_TABLE_SIZE</a>.
+     * Get the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_HEADER_TABLE_SIZE</a>.
+     * @return the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_HEADER_TABLE_SIZE</a>.
      */
-    public static final char HEADER_TABLE_SIZE = 0x1;
+    @Nullable
+    Integer headerTableSize();
 
     /**
-     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_ENABLE_PUSH</a>.
+     * Get the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_CONCURRENT_STREAMS</a>.
+     * @return the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_CONCURRENT_STREAMS</a>.
      */
-    public static final char ENABLE_PUSH = 0x2;
+    @Nullable
+    Integer maxConcurrentStreams();
 
     /**
-     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
-     *     SETTINGS_MAX_CONCURRENT_STREAMS</a>.
+     * Get the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>.
+     * @return the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>.
      */
-    public static final char MAX_CONCURRENT_STREAMS = 0x3;
+    @Nullable
+    Integer initialWindowSize();
 
     /**
-     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
-     *     SETTINGS_INITIAL_WINDOW_SIZE</a>.
+     * Get the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>.
+     * @return the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>.
      */
-    public static final char INITIAL_WINDOW_SIZE = 0x4;
+    @Nullable
+    Integer maxFrameSize();
 
     /**
-     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>.
+     * Get the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>.
+     * @return the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>.
      */
-    public static final char MAX_FRAME_SIZE = 0x5;
+    @Nullable
+    Integer maxHeaderListSize();
 
     /**
-     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
-     *     SETTINGS_MAX_HEADER_LIST_SIZE</a>.
+     * Get the setting value associated with an
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">identifier</a>.
+     * @param identifier the <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">identifier</a>.
+     * @return {@code null} if no setting value corresponding {@code identifier} exists, otherwise the value.
      */
-    public static final char MAX_HEADER_LIST_SIZE = 0x6;
+    @Nullable
+    Integer settingValue(char identifier);
 
-    private Http2Settings() {
-    }
+    /**
+     * Iterate over all the &lt;identifier, value&gt; tuple in this settings object.
+     * @param action Invoked on each &lt;identifier, value&gt; tuple.
+     */
+    void forEach(BiConsumer<? super Character, ? super Integer> action);
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2SettingsBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2SettingsBuilder.java
@@ -13,22 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
+package io.servicetalk.http.api;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static io.servicetalk.http.api.Http2Settings.HEADER_TABLE_SIZE;
-import static io.servicetalk.http.api.Http2Settings.INITIAL_WINDOW_SIZE;
-import static io.servicetalk.http.api.Http2Settings.MAX_CONCURRENT_STREAMS;
-import static io.servicetalk.http.api.Http2Settings.MAX_FRAME_SIZE;
-import static io.servicetalk.http.api.Http2Settings.MAX_HEADER_LIST_SIZE;
+import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
 
 /**
  * Builder to help create a {@link Map} for
  * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">HTTP/2 Setting</a>.
  */
 public final class Http2SettingsBuilder {
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_HEADER_TABLE_SIZE</a>.
+     */
+    private static final char HEADER_TABLE_SIZE = 0x1;
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
+     *     SETTINGS_MAX_CONCURRENT_STREAMS</a>.
+     */
+    private static final char MAX_CONCURRENT_STREAMS = 0x3;
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
+     *     SETTINGS_INITIAL_WINDOW_SIZE</a>.
+     */
+    private static final char INITIAL_WINDOW_SIZE = 0x4;
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>.
+     */
+    private static final char MAX_FRAME_SIZE = 0x5;
+    /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
+     *     SETTINGS_MAX_HEADER_LIST_SIZE</a>.
+     */
+    private static final char MAX_HEADER_LIST_SIZE = 0x6;
     private final Map<Character, Integer> settings;
 
     /**
@@ -112,7 +131,71 @@ public final class Http2SettingsBuilder {
      * @return the {@link Map} that represents
      * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">HTTP/2 Setting</a>.
      */
-    public Map<Character, Integer> build() {
-        return settings;
+    public Http2Settings build() {
+        return new DefaultHttp2Settings(settings);
+    }
+
+    private static final class DefaultHttp2Settings implements Http2Settings {
+        private final Map<Character, Integer> settings;
+
+        private DefaultHttp2Settings(final Map<Character, Integer> settings) {
+            this.settings = settings;
+        }
+
+        @Nullable
+        @Override
+        public Integer headerTableSize() {
+            return settings.get(HEADER_TABLE_SIZE);
+        }
+
+        @Nullable
+        @Override
+        public Integer maxConcurrentStreams() {
+            return settings.get(MAX_CONCURRENT_STREAMS);
+        }
+
+        @Nullable
+        @Override
+        public Integer initialWindowSize() {
+            return settings.get(INITIAL_WINDOW_SIZE);
+        }
+
+        @Nullable
+        @Override
+        public Integer maxFrameSize() {
+            return settings.get(MAX_FRAME_SIZE);
+        }
+
+        @Nullable
+        @Override
+        public Integer maxHeaderListSize() {
+            return settings.get(MAX_HEADER_LIST_SIZE);
+        }
+
+        @Nullable
+        @Override
+        public Integer settingValue(final char identifier) {
+            return settings.get(identifier);
+        }
+
+        @Override
+        public void forEach(final BiConsumer<? super Character, ? super Integer> action) {
+            settings.forEach(action);
+        }
+
+        @Override
+        public String toString() {
+            return settings.toString();
+        }
+
+        @Override
+        public int hashCode() {
+            return settings.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof DefaultHttp2Settings && settings.equals(((DefaultHttp2Settings) o).settings);
+        }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2SettingsBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2SettingsBuilder.java
@@ -33,6 +33,10 @@ public final class Http2SettingsBuilder {
      */
     private static final char HEADER_TABLE_SIZE = 0x1;
     /**
+     * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_ENABLE_PUSH</a>.
+     */
+    private static final char ENABLE_PUSH = 0x2;
+    /**
      * Identifier <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">
      *     SETTINGS_MAX_CONCURRENT_STREAMS</a>.
      */
@@ -57,15 +61,7 @@ public final class Http2SettingsBuilder {
      * Create a new instance.
      */
     public Http2SettingsBuilder() {
-        this(8);
-    }
-
-    /**
-     * Create a new instance.
-     * @param initialSize The initial size of the map.
-     */
-    Http2SettingsBuilder(int initialSize) {
-        settings = new HashMap<>(initialSize);
+        settings = new HashMap<>(6);
     }
 
     /**
@@ -208,7 +204,15 @@ public final class Http2SettingsBuilder {
 
         @Override
         public String toString() {
-            return settings.toString();
+            final StringBuilder sb = new StringBuilder(settings.size() * 10);
+            final String separator = ", ";
+            sb.append('{');
+            settings.forEach((identity, value) ->
+                    sb.append(identityToString(identity)).append('=').append(value).append(separator));
+            if (sb.length() > separator.length()) {
+                sb.setLength(sb.length() - separator.length());
+            }
+            return sb.append('}').toString();
         }
 
         @Override
@@ -219,6 +223,25 @@ public final class Http2SettingsBuilder {
         @Override
         public boolean equals(Object o) {
             return o instanceof DefaultHttp2Settings && settings.equals(((DefaultHttp2Settings) o).settings);
+        }
+
+        private static String identityToString(Character identity) {
+            switch (identity) {
+                case HEADER_TABLE_SIZE:
+                    return "HEADER_TABLE_SIZE";
+                case ENABLE_PUSH:
+                    return "ENABLE_PUSH";
+                case MAX_CONCURRENT_STREAMS:
+                    return "MAX_CONCURRENT_STREAMS";
+                case INITIAL_WINDOW_SIZE:
+                    return "INITIAL_WINDOW_SIZE";
+                case MAX_FRAME_SIZE:
+                    return "MAX_FRAME_SIZE";
+                case MAX_HEADER_LIST_SIZE:
+                    return "MAX_HEADER_LIST_SIZE";
+                default:
+                    return identity.toString();
+            }
         }
 
         @Nullable

--- a/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
@@ -136,9 +136,4 @@
     <Field name="h2Settings"/>
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
-  <Match>
-    <Class name="io.servicetalk.http.netty.Http2SettingsBuilder"/>
-    <Method name="build"/>
-    <Bug pattern="EI_EXPOSE_REP"/>
-  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
@@ -131,4 +131,14 @@
     <Method name="handlerAdded"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
+  <Match>
+    <Class name="io.servicetalk.http.netty.H2ProtocolConfigBuilder"/>
+    <Field name="h2Settings"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.netty.Http2SettingsBuilder"/>
+    <Method name="build"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
@@ -84,6 +84,13 @@ public interface H2ProtocolConfig extends HttpProtocolConfig {
     int flowControlQuantum();
 
     /**
+     * Increment to apply to {@link Http2Settings#initialWindowSize()} for the connection stream. This expands the
+     * connection flow control window so a single stream can't consume all the flow control credits.
+     * @return The number of bytes to increment the local flow control window for the connection stream.
+     */
+    int flowControlWindowIncrement();
+
+    /**
      * A policy for sending <a href="https://tools.ietf.org/html/rfc7540#section-6.7">PING frames</a> to the peer.
      */
     interface KeepAlivePolicy {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
@@ -84,9 +84,11 @@ public interface H2ProtocolConfig extends HttpProtocolConfig {
     int flowControlQuantum();
 
     /**
-     * Increment to apply to {@link Http2Settings#initialWindowSize()} for the connection stream. This expands the
-     * connection flow control window so a single stream can't consume all the flow control credits.
-     * @return The number of bytes to increment the local flow control window for the connection stream.
+     * Number of bytes to increment via <a href="https://www.rfc-editor.org/rfc/rfc7540#section-6.9">WINDOW_UPDATE</a>
+     * for the connection. This value is applied on top of {@link Http2Settings#initialWindowSize()} from
+     * {@link #initialSettings()} for the connection (as opposed to individual request streams). This can be helpful to
+     * avoid a single stream consuming all the flow control credits.
+     * @return The number of bytes to increment the local flow control window for the connection.
      */
     int flowControlWindowIncrement();
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
@@ -19,6 +19,7 @@ import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.logging.api.UserDataLoggerConfig;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.function.BiPredicate;
 import javax.annotation.Nullable;
 
@@ -59,6 +60,21 @@ public interface H2ProtocolConfig extends HttpProtocolConfig {
      */
     @Nullable
     KeepAlivePolicy keepAlivePolicy();
+
+    /**
+     * Get a {@link Map} which provides a hint for the initial settings for any h2 connection. Note that some settings
+     * may be ignored if not supported (e.g. push promise).
+     * @return a {@link Map} which provides a hint for the initial settings for any h2 connection. Note that some
+     * settings may be ignored if not supported (e.g. push promise).
+     */
+    Map<Character, Integer> initialSettings();
+
+    /**
+     * Provide a hint on the number of bytes that the flow controller will attempt to give to a stream for each
+     * allocation (assuming the stream has this much eligible data).
+     * @return number of bytes.
+     */
+    int flowControlQuantum();
 
     /**
      * A policy for sending <a href="https://tools.ietf.org/html/rfc7540#section-6.7">PING frames</a> to the peer.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfig.java
@@ -15,11 +15,11 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.http.api.Http2Settings;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.logging.api.UserDataLoggerConfig;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.function.BiPredicate;
 import javax.annotation.Nullable;
 
@@ -62,16 +62,23 @@ public interface H2ProtocolConfig extends HttpProtocolConfig {
     KeepAlivePolicy keepAlivePolicy();
 
     /**
-     * Get a {@link Map} which provides a hint for the initial settings for any h2 connection. Note that some settings
-     * may be ignored if not supported (e.g. push promise).
-     * @return a {@link Map} which provides a hint for the initial settings for any h2 connection. Note that some
-     * settings may be ignored if not supported (e.g. push promise).
+     * Get the {@link Http2Settings} that provides a hint for the initial settings. Note that some settings may be
+     * ignored if not supported (e.g. push promise).
+     * @return the {@link Http2Settings} that provides a hint for the initial settings. Note that some settings may be
+     * ignored if not supported (e.g. push promise).
      */
-    Map<Character, Integer> initialSettings();
+    Http2Settings initialSettings();
 
     /**
      * Provide a hint on the number of bytes that the flow controller will attempt to give to a stream for each
      * allocation (assuming the stream has this much eligible data).
+     * <p>
+     * This maybe useful because the amount of bytes the local peer is permitted to write is limited based upon the
+     * remote peer's flow control window for each stream. Some flow controllers iterate over all streams (and may
+     * consider <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-5.3">stream priority</a>) that have data
+     * pending to write and allow them to write a subset of the available flow control window (aka a "quantum"). The
+     * larger this value may result in increased goodput/throughput on the connection, but increase latency on some
+     * streams (if flow control windows become constrained).
      * @return number of bytes.
      */
     int flowControlQuantum();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.http.api.Http2Settings;
+import io.servicetalk.http.api.Http2SettingsBuilder;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
@@ -22,7 +24,6 @@ import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.logging.api.UserDataLoggerConfig;
 import io.servicetalk.logging.slf4j.internal.DefaultUserDataLoggerConfig;
 
-import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
@@ -38,7 +39,7 @@ import static java.util.Objects.requireNonNull;
  */
 public final class H2ProtocolConfigBuilder {
     private static final BiPredicate<CharSequence, CharSequence> DEFAULT_SENSITIVITY_DETECTOR = (name, value) -> false;
-    private Map<Character, Integer> h2Settings = newDefaultSettingsBuilder().build();
+    private Http2Settings h2Settings = newDefaultSettingsBuilder().build();
     private HttpHeadersFactory headersFactory = H2HeadersFactory.INSTANCE;
     private BiPredicate<CharSequence, CharSequence> headersSensitivityDetector = DEFAULT_SENSITIVITY_DETECTOR;
     @Nullable
@@ -112,7 +113,7 @@ public final class H2ProtocolConfigBuilder {
      * @return {@code this}
      * @see Http2SettingsBuilder
      */
-    public H2ProtocolConfigBuilder initialSettings(Map<Character, Integer> settings) {
+    public H2ProtocolConfigBuilder initialSettings(Http2Settings settings) {
         this.h2Settings = requireNonNull(settings);
         return this;
     }
@@ -157,7 +158,7 @@ public final class H2ProtocolConfigBuilder {
     }
 
     private static final class DefaultH2ProtocolConfig implements H2ProtocolConfig {
-        private final Map<Character, Integer> h2Settings;
+        private final Http2Settings h2Settings;
         private final HttpHeadersFactory headersFactory;
         private final BiPredicate<CharSequence, CharSequence> headersSensitivityDetector;
         @Nullable
@@ -166,7 +167,7 @@ public final class H2ProtocolConfigBuilder {
         private final KeepAlivePolicy keepAlivePolicy;
         private final int flowControlQuantum;
 
-        DefaultH2ProtocolConfig(final Map<Character, Integer> h2Settings,
+        DefaultH2ProtocolConfig(final Http2Settings h2Settings,
                                 final HttpHeadersFactory headersFactory,
                                 final BiPredicate<CharSequence, CharSequence> headersSensitivityDetector,
                                 @Nullable final UserDataLoggerConfig frameLoggerConfig,
@@ -203,7 +204,7 @@ public final class H2ProtocolConfigBuilder {
         }
 
         @Override
-        public Map<Character, Integer> initialSettings() {
+        public Http2Settings initialSettings() {
             return h2Settings;
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.http.api.Http2Settings;
 import io.servicetalk.logging.api.UserDataLoggerConfig;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 
@@ -23,25 +24,31 @@ import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 
-import java.util.function.BiPredicate;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.logging.slf4j.internal.Slf4jFixedLevelLoggers.newLogger;
 
 final class H2ServerParentChannelInitializer implements ChannelInitializer {
+    private static final io.netty.handler.codec.http2.Http2Settings DEFAULT_NETTY_SETTINGS =
+            io.netty.handler.codec.http2.Http2Settings.defaultSettings();
     private final H2ProtocolConfig config;
     private final io.netty.channel.ChannelInitializer<Http2StreamChannel> streamChannelInitializer;
+    private final io.netty.handler.codec.http2.Http2Settings nettySettings;
 
     H2ServerParentChannelInitializer(
             final H2ProtocolConfig config,
             final io.netty.channel.ChannelInitializer<Http2StreamChannel> streamChannelInitializer) {
         this.config = config;
         this.streamChannelInitializer = streamChannelInitializer;
+        final Map<Character, Integer> h2Settings = config.initialSettings();
+        nettySettings = h2Settings.isEmpty() ? DEFAULT_NETTY_SETTINGS : toNettySettings(h2Settings);
     }
 
     @Override
     public void init(final Channel channel) {
-        final Http2FrameCodecBuilder multiplexCodecBuilder = new OptimizedHttp2FrameCodecBuilder(true)
+        final Http2FrameCodecBuilder multiplexCodecBuilder =
+                new OptimizedHttp2FrameCodecBuilder(true, config.flowControlQuantum())
                 // We do not want close to trigger graceful closure (go away), instead when user triggers a graceful
                 // close, we do the appropriate go away handling.
                 .decoupleCloseAndGoAway(true)
@@ -49,15 +56,13 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
                 .autoAckPingFrame(false)
                 // We don't want to rely upon Netty to manage the graceful close timeout, because we expect
                 // the user to apply their own timeout at the call site.
-                .gracefulShutdownTimeoutMillis(-1);
-
-        final BiPredicate<CharSequence, CharSequence> headersSensitivityDetector =
-                config.headersSensitivityDetector();
-        multiplexCodecBuilder.headerSensitivityDetector(headersSensitivityDetector::test);
+                .gracefulShutdownTimeoutMillis(-1)
+                .initialSettings(nettySettings)
+                .headerSensitivityDetector(config.headersSensitivityDetector()::test);
 
         initFrameLogger(multiplexCodecBuilder, config.frameLoggerConfig());
 
-        // TODO(scott): more configuration. header validation, settings stream, etc...
+        // TODO(scott): more configuration. header validation, etc...
 
         channel.pipeline().addLast(multiplexCodecBuilder.build(), new Http2MultiplexHandler(streamChannelInitializer));
     }
@@ -69,5 +74,35 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
                     new ServiceTalkHttp2FrameLogger(newLogger(frameLoggerConfig.loggerName(),
                             frameLoggerConfig.logLevel()), frameLoggerConfig.logUserData()));
         }
+    }
+
+    static io.netty.handler.codec.http2.Http2Settings toNettySettings(Map<Character, Integer> h2Settings) {
+        io.netty.handler.codec.http2.Http2Settings nettySettings = new io.netty.handler.codec.http2.Http2Settings();
+        h2Settings.forEach((identifier, value) -> {
+            switch (identifier) {
+                case Http2Settings.HEADER_TABLE_SIZE:
+                    nettySettings.headerTableSize(value);
+                    break;
+                case Http2Settings.ENABLE_PUSH:
+                    nettySettings.pushEnabled(value != 0);
+                    break;
+                case Http2Settings.MAX_CONCURRENT_STREAMS:
+                    nettySettings.maxConcurrentStreams(value);
+                    break;
+                case Http2Settings.INITIAL_WINDOW_SIZE:
+                    nettySettings.initialWindowSize(value);
+                    break;
+                case Http2Settings.MAX_FRAME_SIZE:
+                    nettySettings.maxFrameSize(value);
+                    break;
+                case Http2Settings.MAX_HEADER_LIST_SIZE:
+                    nettySettings.maxHeaderListSize(value);
+                    break;
+                default:
+                    nettySettings.put(identifier, Long.valueOf(value));
+                    break;
+            }
+        });
+        return nettySettings;
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -20,18 +20,16 @@ import io.servicetalk.logging.api.UserDataLoggerConfig;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 
 import io.netty.channel.Channel;
+import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 
-import java.util.Map;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.logging.slf4j.internal.Slf4jFixedLevelLoggers.newLogger;
 
 final class H2ServerParentChannelInitializer implements ChannelInitializer {
-    private static final io.netty.handler.codec.http2.Http2Settings DEFAULT_NETTY_SETTINGS =
-            io.netty.handler.codec.http2.Http2Settings.defaultSettings();
     private final H2ProtocolConfig config;
     private final io.netty.channel.ChannelInitializer<Http2StreamChannel> streamChannelInitializer;
     private final io.netty.handler.codec.http2.Http2Settings nettySettings;
@@ -41,8 +39,8 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
             final io.netty.channel.ChannelInitializer<Http2StreamChannel> streamChannelInitializer) {
         this.config = config;
         this.streamChannelInitializer = streamChannelInitializer;
-        final Map<Character, Integer> h2Settings = config.initialSettings();
-        nettySettings = h2Settings.isEmpty() ? DEFAULT_NETTY_SETTINGS : toNettySettings(h2Settings);
+        final Http2Settings h2Settings = config.initialSettings();
+        nettySettings = toNettySettings(h2Settings);
     }
 
     @Override
@@ -76,26 +74,26 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
         }
     }
 
-    static io.netty.handler.codec.http2.Http2Settings toNettySettings(Map<Character, Integer> h2Settings) {
+    static io.netty.handler.codec.http2.Http2Settings toNettySettings(Http2Settings h2Settings) {
         io.netty.handler.codec.http2.Http2Settings nettySettings = new io.netty.handler.codec.http2.Http2Settings();
         h2Settings.forEach((identifier, value) -> {
             switch (identifier) {
-                case Http2Settings.HEADER_TABLE_SIZE:
+                case Http2CodecUtil.SETTINGS_HEADER_TABLE_SIZE:
                     nettySettings.headerTableSize(value);
                     break;
-                case Http2Settings.ENABLE_PUSH:
+                case Http2CodecUtil.SETTINGS_ENABLE_PUSH:
                     nettySettings.pushEnabled(value != 0);
                     break;
-                case Http2Settings.MAX_CONCURRENT_STREAMS:
+                case Http2CodecUtil.SETTINGS_MAX_CONCURRENT_STREAMS:
                     nettySettings.maxConcurrentStreams(value);
                     break;
-                case Http2Settings.INITIAL_WINDOW_SIZE:
+                case Http2CodecUtil.SETTINGS_INITIAL_WINDOW_SIZE:
                     nettySettings.initialWindowSize(value);
                     break;
-                case Http2Settings.MAX_FRAME_SIZE:
+                case Http2CodecUtil.SETTINGS_MAX_FRAME_SIZE:
                     nettySettings.maxFrameSize(value);
                     break;
-                case Http2Settings.MAX_HEADER_LIST_SIZE:
+                case Http2CodecUtil.SETTINGS_MAX_HEADER_LIST_SIZE:
                     nettySettings.maxHeaderListSize(value);
                     break;
                 default:

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/Http2SettingsBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/Http2SettingsBuilder.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.servicetalk.http.api.Http2Settings.HEADER_TABLE_SIZE;
+import static io.servicetalk.http.api.Http2Settings.INITIAL_WINDOW_SIZE;
+import static io.servicetalk.http.api.Http2Settings.MAX_CONCURRENT_STREAMS;
+import static io.servicetalk.http.api.Http2Settings.MAX_FRAME_SIZE;
+import static io.servicetalk.http.api.Http2Settings.MAX_HEADER_LIST_SIZE;
+
+/**
+ * Builder to help create a {@link Map} for
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">HTTP/2 Setting</a>.
+ */
+public final class Http2SettingsBuilder {
+    private final Map<Character, Integer> settings;
+
+    /**
+     * Create a new instance.
+     */
+    public Http2SettingsBuilder() {
+        this(8);
+    }
+
+    /**
+     * Create a new instance.
+     * @param initialSize The initial size of the map.
+     */
+    Http2SettingsBuilder(int initialSize) {
+        settings = new HashMap<>(initialSize);
+    }
+
+    /**
+     * Set the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_HEADER_TABLE_SIZE</a>.
+     *
+     * @param value The value.
+     * @return {@code this}.
+     */
+    public Http2SettingsBuilder headerTableSize(int value) {
+        settings.put(HEADER_TABLE_SIZE, value);
+        return this;
+    }
+
+    /**
+     * Set the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_CONCURRENT_STREAMS</a>.
+     *
+     * @param value The value.
+     * @return {@code this}.
+     */
+    public Http2SettingsBuilder maxConcurrentStreams(int value) {
+        settings.put(MAX_CONCURRENT_STREAMS, value);
+        return this;
+    }
+
+    /**
+     * Set the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>.
+     *
+     * @param value The value.
+     * @return {@code this}.
+     */
+    public Http2SettingsBuilder initialWindowSize(int value) {
+        settings.put(INITIAL_WINDOW_SIZE, value);
+        return this;
+    }
+
+    /**
+     * Set the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>.
+     *
+     * @param value The value.
+     * @return {@code this}.
+     */
+    public Http2SettingsBuilder maxFrameSize(int value) {
+        settings.put(MAX_FRAME_SIZE, value);
+        return this;
+    }
+
+    /**
+     * Set the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a>.
+     *
+     * @param value The value.
+     * @return {@code this}.
+     */
+    public Http2SettingsBuilder maxHeaderListSize(int value) {
+        settings.put(MAX_HEADER_LIST_SIZE, value);
+        return this;
+    }
+
+    /**
+     * Build the {@link Map} that represents
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">HTTP/2 Setting</a>.
+     * @return the {@link Map} that represents
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">HTTP/2 Setting</a>.
+     */
+    public Map<Character, Integer> build() {
+        return settings;
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -15,11 +15,13 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.http.api.Http2Settings;
 import io.servicetalk.http.api.HttpProtocolConfig;
 
 import java.util.List;
 import javax.annotation.Nullable;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_ENABLE_PUSH;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -105,6 +107,12 @@ final class HttpConfig {
         if (this.h2Config != null) {
             throw new IllegalArgumentException("Duplicated configuration for HTTP/2 was found");
         }
+        final Http2Settings settings = h2Config.initialSettings();
+        final Long pushEnabled = settings.settingValue(SETTINGS_ENABLE_PUSH);
+        if (pushEnabled != null && pushEnabled != 0) {
+            throw new IllegalArgumentException("Http2Settings push is enabled but not supported. settings=" + settings);
+        }
+
         this.h2Config = h2Config;
         supportedAlpnProtocols = h1Config == null ? singletonList(h2Config.alpnId()) :
                 unmodifiableList(asList(h1Config.alpnId(), h2Config.alpnId()));

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpProtocolConfigs.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpProtocolConfigs.java
@@ -15,9 +15,8 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.http.api.Http2Settings;
 import io.servicetalk.http.api.HttpProtocolConfig;
-
-import java.util.Map;
 
 /**
  * Factory methods for {@link HttpProtocolConfig}s and builders for their customization.
@@ -74,7 +73,7 @@ public final class HttpProtocolConfigs {
      * default values as described in
      * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">HTTP/2 Settings</a>. Some identifiers
      * maybe overridden for safety or performance reasons and are subject to change. For more control use
-     * {@link H2ProtocolConfigBuilder#initialSettings(Map)}.
+     * {@link H2ProtocolConfigBuilder#initialSettings(Http2Settings)}.
      *
      * @return {@link H2ProtocolConfigBuilder}
      */

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpProtocolConfigs.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpProtocolConfigs.java
@@ -17,6 +17,8 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.HttpProtocolConfig;
 
+import java.util.Map;
+
 /**
  * Factory methods for {@link HttpProtocolConfig}s and builders for their customization.
  */
@@ -52,6 +54,11 @@ public final class HttpProtocolConfigs {
     /**
      * Returns {@link H2ProtocolConfig} with the default configuration for
      * <a href="https://tools.ietf.org/html/rfc7540">HTTP/2</a>.
+     * <p>
+     * Note this doesn't necessarily provide {@link H2ProtocolConfig#initialSettings()} that corresponds to
+     * default values as described in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">HTTP/2 Settings</a>. Some identifiers
+     * maybe overridden for safety or performance reasons and are subject to change. For more control use {@link #h2()}.
      *
      * @return {@link H2ProtocolConfig} with the default configuration for
      * <a href="https://tools.ietf.org/html/rfc7540">HTTP/2</a>
@@ -62,6 +69,12 @@ public final class HttpProtocolConfigs {
 
     /**
      * Returns a builder for {@link H2ProtocolConfig}.
+     * <p>
+     * Note this doesn't necessarily provide {@link H2ProtocolConfig#initialSettings()} that corresponds to
+     * default values as described in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">HTTP/2 Settings</a>. Some identifiers
+     * maybe overridden for safety or performance reasons and are subject to change. For more control use
+     * {@link H2ProtocolConfigBuilder#initialSettings(Map)}.
      *
      * @return {@link H2ProtocolConfigBuilder}
      */


### PR DESCRIPTION
Motivaiton:
There is no way to define initial values for
[http/2 settings](https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2).

Modifications:
- Enhance H2ProtocolConfigBuilder to accept Map<Character, Integer> to
  set the initial settings values.
- Set the default value of settings with bound max header list size
  and 1mb default initial flow control window.