### PR TITLE
HTTP/2 avoid premature connection closure when negotiating via ALPN

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpKeepAlive.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpKeepAlive.java
@@ -42,7 +42,13 @@ enum HttpKeepAlive {
     // In the interest of performance we are not accommodating for the spec allowing multiple header fields
     // or comma-separated values for the Connection header. See: https://tools.ietf.org/html/rfc7230#section-3.2.2
     static HttpKeepAlive responseKeepAlive(final HttpMetaData metaData) {
-        if (HTTP_1_1.equals(metaData.version())) {
+        // If multiple protocols are supported we don't know which protocol will be negotiated. Treat any major
+        // protocol >= 2 the same.
+        if (metaData.version().major() >= 2) {
+            // https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.2
+            // HTTP/2 does not use the Connection header field to indicate connection-specific header fields...
+            return KEEP_ALIVE_NO_HEADER;
+        } else if (HTTP_1_1.equals(metaData.version())) {
             return metaData.headers().containsIgnoreCase(CONNECTION, CLOSE) ?
                     CLOSE_ADD_HEADER : KEEP_ALIVE_NO_HEADER;
         } else if (HTTP_1_0.equals(metaData.version())) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -186,6 +186,10 @@ class AlpnClientAndServerTest {
             assertThat(connection.connectionContext().sslSession(), is(notNullValue()));
 
             assertResponseAndServiceContext(connection.request(client.get("/")));
+            // When using ALPN the request factory selection is deferred until after the connection is established, so
+            // the protocol on the requests may be "http/1.x" but we may actually be speaking http/2. In either case
+            // keep-alive should be enabled, the connection shouldn't be closed, and subsequent requests should succeed.
+            assertResponseAndServiceContext(connection.request(client.get("/")));
         }
     }
 


### PR DESCRIPTION
Motivation:
ServiceTalk can negotiate http/1.x or http/2 through ALPN when TLS
is enabled. ServiceTalk doesn't know which request factory to use
until the protocol negotiation completes. It is possible that the
http/1.x request factory is used when speaking http/2.x which may
result in premature connection closure due to keep alive logic bug.

Modifications:
- http/2+ should be treated as always using keep alive and doesn't
  use connection specific keep alive headers [1].

[1] https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.2