### PR TITLE
Make io_uring tests on linux more lenient

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.concurrent.internal.TestTimeoutConstants;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpResponse;
@@ -69,7 +70,7 @@ class IoUringTest {
         EventLoopAwareNettyIoExecutor ioUringExecutor = null;
         try {
             IoUringUtils.tryIoUring(true);
-            assumeTrue(IoUringUtils.isAvailable(), "io_uring is unavailable on " +
+            assumeTrue(TestTimeoutConstants.CI || IoUringUtils.isAvailable(), "io_uring is unavailable on " +
                     System.getProperty("os.name") + ' ' + System.getProperty("os.version"));
             IOUring.ensureAvailability();
 


### PR DESCRIPTION
Motivation:

Users may run tests on linux kernel that does not support io_uring. To avoid failure of `IoUringTest.ioUringIsAvailableOnLinux()` we need to run it only when io_uring is available.

Modifications:

- Use `assumeTrue` instead of `assertTrue`;
- Test with & without offloading;

Result:

Users can run tests on any linux kernel without failure due to io_uring unavailability.