### PR TITLE
Publisher#flatMapMerge allow terminal propagation after invalid demand

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CacheSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CacheSingle.java
@@ -18,6 +18,7 @@ package io.servicetalk.concurrent.api;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.internal.ArrayUtils;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
+import io.servicetalk.concurrent.internal.SubscriberUtils;
 import io.servicetalk.concurrent.internal.TerminalNotification;
 import io.servicetalk.context.api.ContextMap;
 
@@ -293,7 +294,7 @@ final class CacheSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
                         break;
                     }
                 } else {
-                    logDuplicateTerminal(this);
+                    SubscriberUtils.logDuplicateTerminalOnSuccess(this, result);
                     break;
                 }
             }
@@ -318,7 +319,7 @@ final class CacheSingle<T> extends AbstractNoHandleSubscribeSingle<T> {
                         break;
                     }
                 } else {
-                    logDuplicateTerminal(this);
+                    logDuplicateTerminal(this, t);
                     break;
                 }
             }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeExceptionUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeExceptionUtils.java
@@ -17,8 +17,6 @@ package io.servicetalk.concurrent.api;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
-
 final class CompositeExceptionUtils {
     /**
      * Default to {@code 1} so {@link Throwable#addSuppressed(Throwable)} will not be used by default.
@@ -35,7 +33,8 @@ final class CompositeExceptionUtils {
         if (newSize < 0) {
             updater.set(owner, Integer.MAX_VALUE);
         } else if (newSize < maxDelayedErrors && original != causeToAdd) {
-            addSuppressed(original, causeToAdd);
+            // We ensure original is not equal to causeToAdd, safe to add suppressed.
+            original.addSuppressed(causeToAdd);
         } else {
             updater.decrementAndGet(owner);
         }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SubscriberUtils.java
@@ -338,7 +338,18 @@ public final class SubscriberUtils {
      * @param <T> The type of {@link PublisherSource.Subscriber}.
      */
     public static <T> void logDuplicateTerminal(PublisherSource.Subscriber<T> subscriber) {
-        logDuplicateTerminal0(subscriber);
+        logDuplicateTerminal0(subscriber, null);
+    }
+
+    /**
+     * Log if the ReactiveStreams specification has been violated related to out of order
+     * {@link PublisherSource.Subscriber#onSubscribe(PublisherSource.Subscription)} or duplicate terminal signals.
+     * @param subscriber The {@link PublisherSource.Subscriber}.
+     * @param cause The cause from {@link PublisherSource.Subscriber#onError(Throwable)}.
+     * @param <T> The type of {@link PublisherSource.Subscriber}.
+     */
+    public static <T> void logDuplicateTerminal(PublisherSource.Subscriber<T> subscriber, Throwable cause) {
+        logDuplicateTerminal0(subscriber, cause);
     }
 
     /**
@@ -348,15 +359,37 @@ public final class SubscriberUtils {
      * @param <T> The type of {@link SingleSource.Subscriber}.
      */
     public static <T> void logDuplicateTerminal(SingleSource.Subscriber<T> subscriber) {
-        logDuplicateTerminal0(subscriber);
+        logDuplicateTerminal0(subscriber, null);
     }
 
-    private static void logDuplicateTerminal0(Object subscriber) {
+    /**
+     * Log if the ReactiveStreams specification has been violated related to out of order
+     * {@link SingleSource.Subscriber#onSubscribe(Cancellable)} or duplicate terminal signals.
+     * @param subscriber The {@link SingleSource.Subscriber}.
+     * @param onSuccess The signal delivered to {@link SingleSource.Subscriber#onSuccess(Object)}.
+     * @param <T> The type of {@link SingleSource.Subscriber}.
+     */
+    public static <T> void logDuplicateTerminalOnSuccess(SingleSource.Subscriber<T> subscriber, @Nullable T onSuccess) {
+        logDuplicateTerminal0(subscriber, new IllegalStateException("ignoring onSuccess: " + onSuccess));
+    }
+
+    /**
+     * Log if the ReactiveStreams specification has been violated related to out of order
+     * {@link SingleSource.Subscriber#onSubscribe(Cancellable)} or duplicate terminal signals.
+     * @param subscriber The {@link SingleSource.Subscriber}.
+     * @param cause The cause from {@link SingleSource.Subscriber#onError(Throwable)}.
+     * @param <T> The type of {@link SingleSource.Subscriber}.
+     */
+    public static <T> void logDuplicateTerminal(SingleSource.Subscriber<T> subscriber, Throwable cause) {
+        logDuplicateTerminal0(subscriber, cause);
+    }
+
+    private static void logDuplicateTerminal0(Object subscriber, @Nullable Throwable cause) {
         LOGGER.warn("onSubscribe not called before terminal or duplicate terminal on Subscriber {}", subscriber,
                 new IllegalStateException(
                         "onSubscribe not called before terminal or duplicate terminal on Subscriber " + subscriber +
                         " forbidden see: " +
                         "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.9" +
-                        "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.7"));
+                        "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#1.7", cause));
     }
 }


### PR DESCRIPTION
Motivation:
Publisher#flatMapMerge has internal state that tracks demand. This state is used to drive the internal state machine and prevents invalid demand to avoid internal state being corrupted. However this code didn't always allow for the subsequent terminal (e.g. likely onError) to be propagated downstream which may result in a hang.

Modifications:
- FlatMapPublisherSubscriber demand tracking shouldn't prevent terminal if there is too many items delivered.
- Remove conditionals that are unnecessary for needsDemand because the call sites know if demand is required.