### PR TITLE
Use `IdleTimeoutConnectionFilter` instead of SocketOption by default

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -483,8 +483,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         requireNonNull(factory);
         connectionFilterFactory = appendConnectionFilter(connectionFilterFactory, factory);
         strategyComputation.add(factory);
-        ifHostHeaderHttpRequesterFilter(factory);
-        ifIdleTimeoutConnectionFilter(factory);
+        checkIfHostHeaderHttpRequesterFilter(factory);
+        checkIfIdleTimeoutConnectionFilter(factory);
         return this;
     }
 
@@ -492,18 +492,18 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     public DefaultSingleAddressHttpClientBuilder<U, R> appendConnectionFilter(
             final Predicate<StreamingHttpRequest> predicate, final StreamingHttpConnectionFilterFactory factory) {
         appendConnectionFilter(toConditionalConnectionFilterFactory(predicate, factory));
-        ifHostHeaderHttpRequesterFilter(factory);
-        ifIdleTimeoutConnectionFilter(factory);
+        checkIfHostHeaderHttpRequesterFilter(factory);
+        checkIfIdleTimeoutConnectionFilter(factory);
         return this;
     }
 
-    private void ifHostHeaderHttpRequesterFilter(final Object filter) {
+    private void checkIfHostHeaderHttpRequesterFilter(final Object filter) {
         if (filter instanceof HostHeaderHttpRequesterFilter) {
             addHostHeaderFallbackFilter = false;
         }
     }
 
-    private void ifIdleTimeoutConnectionFilter(final StreamingHttpConnectionFilterFactory factory) {
+    private void checkIfIdleTimeoutConnectionFilter(final StreamingHttpConnectionFilterFactory factory) {
         if (factory instanceof IdleTimeoutConnectionFilter) {
             addIdleTimeoutConnectionFilter = false;
         }
@@ -539,13 +539,13 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     @Override
     public DefaultSingleAddressHttpClientBuilder<U, R> appendClientFilter(
             final Predicate<StreamingHttpRequest> predicate, final StreamingHttpClientFilterFactory factory) {
-        ifRetryingHttpRequesterFilter(factory);
+        checkIfRetryingHttpRequesterFilter(factory);
         appendClientFilter(toConditionalClientFilterFactory(predicate, factory));
-        ifHostHeaderHttpRequesterFilter(factory);
+        checkIfHostHeaderHttpRequesterFilter(factory);
         return this;
     }
 
-    private void ifRetryingHttpRequesterFilter(final StreamingHttpClientFilterFactory factory) {
+    private void checkIfRetryingHttpRequesterFilter(final StreamingHttpClientFilterFactory factory) {
         if (factory instanceof RetryingHttpRequesterFilter) {
             if (retryingHttpRequesterFilter != null) {
                 throw new IllegalStateException("Retrying HTTP requester filter was already found in " +
@@ -566,10 +566,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     public DefaultSingleAddressHttpClientBuilder<U, R> appendClientFilter(
             final StreamingHttpClientFilterFactory factory) {
         requireNonNull(factory);
-        ifRetryingHttpRequesterFilter(factory);
+        checkIfRetryingHttpRequesterFilter(factory);
         clientFilterFactory = appendFilter(clientFilterFactory, factory);
         strategyComputation.add(factory);
-        ifHostHeaderHttpRequesterFilter(factory);
+        checkIfHostHeaderHttpRequesterFilter(factory);
         return this;
     }
 

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/IdleTimeoutConnectionFilter.java
@@ -237,6 +237,7 @@ public final class IdleTimeoutConnectionFilter implements StreamingHttpConnectio
                 }
             }
         }
+
         @Override
         public String toString() {
             return getClass().getSimpleName() + '[' + NANOSECONDS.toMillis(timeoutNs) + " ms](" + delegate() + ')';

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -45,7 +45,7 @@ abstract class AbstractTcpConfig<SslConfigType> {
     @Nullable
     @SuppressWarnings("rawtypes")
     private Map<ChannelOption, Object> options;
-    private long idleTimeoutMs = 300_000L;  // 5 min
+    private long idleTimeoutMs;
     private FlushStrategy flushStrategy = defaultFlushStrategy();
     @Nullable
     private UserDataLoggerConfig wireLoggerConfig;


### PR DESCRIPTION
Motivation:

`ServiceTalkSocketOptions.IDLE_TIMEOUT` currently has the default value of 5 min. This default value makes it harder for users to coordinate between per-request timeout and per-client `IDLE_TIMEOUT`. Example: long-polling requests that use much higher timeout might be interrupted by lower `IDLE_TIMEOUT` value.

Modifications:

- Change the default value for `IDLE_TIMEOUT` to 0;
- If users didn't append `IdleTimeoutConnectionFilter`, configure one by default with 5 min timeout;
- Allow configuring `IdleTimeoutConnectionFilter` with `Duration.ZERO`;
- Add `toString()` impl for `IdleTimeoutConnectionFilter`;

Result:

Long-polling requests are not affected by default `IDLE_TIMEOUT` value, while ST users still have a filter that closes connections that were not used to serve any requests for 5 minutes. To change this value, users should append their own `IdleTimeoutConnectionFilter` with different value. To disable timeouts, users should append
`IdleTimeoutConnectionFilter` with `Duration#ZERO` as a timeout value.