### PR TITLE
`AsciiBuffer.indexOf` returns incorrect result for 2-bytes characters

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AsciiBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AsciiBuffer.java
@@ -114,7 +114,14 @@ final class AsciiBuffer implements CharSequence {
      * @throws NullPointerException if {@code subString} is {@code null}.
      */
     int indexOf(char ch, int start) {
+        if (!singleByte(ch)) {
+            return -1;
+        }
         return buffer.indexOf(start, buffer.writerIndex(), (byte) ch);
+    }
+
+    private static boolean singleByte(char ch) {
+        return ch >>> 8 == 0;
     }
 
     /**

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AsciiBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AsciiBuffer.java
@@ -114,10 +114,7 @@ final class AsciiBuffer implements CharSequence {
      * @throws NullPointerException if {@code subString} is {@code null}.
      */
     int indexOf(char ch, int start) {
-        if (!singleByte(ch)) {
-            return -1;
-        }
-        return buffer.indexOf(start, buffer.writerIndex(), (byte) ch);
+        return singleByte(ch) ? buffer.indexOf(start, buffer.writerIndex(), (byte) ch) : -1;
     }
 
     private static boolean singleByte(char ch) {

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.function.Function;
 
+import static io.servicetalk.buffer.api.CharSequences.indexOf;
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.split;
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
@@ -204,5 +205,28 @@ class CharSequencesTest {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text");
         assertThat("Unexpected result for AsciiBuffer representation",
                 CharSequences.parseLong(newAsciiString(buffer.slice(4, 2))), is(42L));
+    }
+
+    @Test
+    void indexOfAsciiString() {
+        testIndexOf(newAsciiString("text42text"));
+    }
+
+    @Test
+    void indexOfString() {
+        testIndexOf("text42text");
+    }
+
+    @Test
+    void indexOfStringBuilder() {
+        testIndexOf(new StringBuilder().append("text42text"));
+    }
+
+    private static void testIndexOf(CharSequence cs) {
+        assertThat(indexOf(cs, '5', 0), is(-1));
+        assertThat(indexOf(cs, '2', cs.length() - 3), is(-1));
+        assertThat(indexOf(cs, '2', 0), is(5));
+        char twoBytesChar = ('2' << 8) | '2';
+        assertThat(indexOf(cs, twoBytesChar, 0), is(-1));
     }
 }


### PR DESCRIPTION
Motivation:

`AsciiBuffer.indexOf` casts `char` to `byte` by dropping the higher 8 bits. As the result, it may return an index of an ascii character that has the same lower 8 bits.

Modifications:

- Check character length and return `-1` if it's 2-bytes character;

Result:

Correct result when users try to find an index of a 2-bytes character in `AsciiBuffer`. Consistency with other `CharSequence` implementations, like `String` and `StringBuilder`.