### PR TITLE
Deprecate `CharSequences.asciiStringIndexOf`

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/CharSequences.java
@@ -211,7 +211,9 @@ public final class CharSequences {
      * @param c The character to find.
      * @param fromIndex The index to start searching (inclusive).
      * @return The index of {@code c} or {@code -1} otherwise.
+     * @deprecated Use {@link #indexOf(CharSequence, char, int)}.
      */
+    @Deprecated // FIXME: 0.43 - make this method private
     public static int asciiStringIndexOf(final CharSequence sequence, char c, int fromIndex) {
         return ((AsciiBuffer) sequence).indexOf(c, fromIndex);
     }


### PR DESCRIPTION
Motivation:

`CharSequences.asciiStringIndexOf` is not used outside of the `CharSequences` class. Users should use `CharSequences#indexOf` instead.

Modifications:

- Deprecate `CharSequences.asciiStringIndexOf`;

Result:

`CharSequences.asciiStringIndexOf` is deprecated and can be made private in future releases.