### PR TITLE
Allow users access `payloadBodyInputStream()` multiple times

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -41,7 +41,7 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     BlockingIterable<Buffer> payloadBody();
 
     /**
-     * Gets the underlying payload as a {@link InputStream}.
+     * Gets the underlying payload as an {@link InputStream}.
      * @return The {@link InputStream} representation of the underlying payload body.
      */
     default InputStream payloadBodyInputStream() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpResponse.java
@@ -38,7 +38,7 @@ public interface BlockingStreamingHttpResponse extends HttpResponseMetaData {
     BlockingIterable<Buffer> payloadBody();
 
     /**
-     * Gets the underlying payload as a {@link InputStream}.
+     * Gets the underlying payload as an {@link InputStream}.
      * @return The {@link InputStream} representation of the underlying payload body.
      */
     default InputStream payloadBodyInputStream() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -38,6 +38,9 @@ import static io.servicetalk.http.api.BlockingStreamingHttpMessageBodyUtils.newM
 final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRequest
         implements BlockingStreamingHttpRequest {
 
+    @Nullable
+    private InputStream inputStream;
+
     DefaultBlockingStreamingHttpRequest(final DefaultStreamingHttpRequest original) {
         super(original);
     }
@@ -154,6 +157,14 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
     @Override
     public BlockingIterable<Buffer> payloadBody() {
         return original.payloadBody().toIterable();
+    }
+
+    @Override
+    public InputStream payloadBodyInputStream() {
+        if (inputStream == null) {
+            inputStream = BlockingStreamingHttpRequest.super.payloadBodyInputStream();
+        }
+        return inputStream;
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Publisher.defer;
 import static io.servicetalk.concurrent.api.Publisher.from;
@@ -35,6 +36,9 @@ import static io.servicetalk.http.api.BlockingStreamingHttpMessageBodyUtils.newM
 final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpResponse
         implements BlockingStreamingHttpResponse {
 
+    @Nullable
+    private InputStream inputStream;
+
     DefaultBlockingStreamingHttpResponse(final DefaultStreamingHttpResponse original) {
         super(original);
     }
@@ -42,6 +46,14 @@ final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpR
     @Override
     public BlockingIterable<Buffer> payloadBody() {
         return original.payloadBody().toIterable();
+    }
+
+    @Override
+    public InputStream payloadBodyInputStream() {
+        if (inputStream == null) {
+            inputStream = BlockingStreamingHttpResponse.super.payloadBodyInputStream();
+        }
+        return inputStream;
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingInputStreamTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingInputStreamTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.http.api.BlockingStreamingHttpClient;
+import io.servicetalk.http.api.BlockingStreamingHttpResponse;
+import io.servicetalk.http.api.HttpPayloadWriter;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+class BlockingStreamingInputStreamTest {
+
+    @Test
+    void testInputStreamCanBeAccessedMultipleTimes() throws Exception {
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .listenBlockingStreamingAndAwait((ctx, request, response) -> {
+                    try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                        int b;
+                        while ((b = request.payloadBodyInputStream().read()) >= 0) {
+                            Buffer buffer = ctx.executionContext().bufferAllocator().newBuffer(1);
+                            buffer.writeByte(b);
+                            writer.write(buffer);
+                        }
+                    }
+                });
+             BlockingStreamingHttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                     .buildBlockingStreaming()) {
+            String content = "content";
+            InputStream payloadIs = new ByteArrayInputStream(content.getBytes(US_ASCII));
+            BlockingStreamingHttpResponse response = client.request(client.post("/")
+                    .payloadBody(payloadIs));
+            StringBuilder sb = new StringBuilder();
+            int b;
+            while ((b = response.payloadBodyInputStream().read()) >= 0) {
+                sb.append((char) b);
+            }
+            assertThat(sb.toString(), is(equalTo(content)));
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Users of the blocking HTTP clients, like Apache HTTP Client, know that it's possible to access entity's `InputStream` multiple times and continue to read the payload body.

Modifications:

- Cache a reference to `InputStream` and return the same instance for subsequent calls in `DefaultBlockingStreamingHttpRequest` and `DefaultBlockingStreamingHttpResponse`;
- Add a test to verify this behavior;

Result:

Users can take `payloadBodyInputStream()` multiple times without seeing `DuplicateSubscribeException`.