### PR TITLE
DefaultBlockingHttp objects to use cast and shareContextOnSubscribe

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -201,8 +201,9 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
         original.payloadHolder().messageBody(defer(() -> {
             HttpMessageBodyIterator<Buffer> body = messageBody.iterator();
             return fromIterable(() -> body)
-                    .map(o -> (Object) o)
-                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull)));
+                    .cast(Object.class)
+                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull).shareContextOnSubscribe()))
+                    .shareContextOnSubscribe();
         }));
         return this;
     }
@@ -213,8 +214,9 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
         original.payloadHolder().messageBody(defer(() -> {
             HttpMessageBodyIterator<T> body = messageBody.iterator();
             return from(serializer.serialize(headers(), () -> body, original.payloadHolder().allocator()))
-                    .map(o -> (Object) o)
-                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull)));
+                    .cast(Object.class)
+                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull).shareContextOnSubscribe()))
+                    .shareContextOnSubscribe();
         }));
         return this;
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -24,7 +24,6 @@ import io.servicetalk.encoding.api.ContentCodec;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
@@ -34,6 +33,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.fromInputStream;
 import static io.servicetalk.concurrent.api.Publisher.fromIterable;
 import static io.servicetalk.http.api.BlockingStreamingHttpMessageBodyUtils.newMessageBody;
+import static io.servicetalk.http.api.DefaultBlockingStreamingHttpResponse.fromFilterNull;
 
 final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRequest
         implements BlockingStreamingHttpRequest {
@@ -202,7 +202,7 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
             HttpMessageBodyIterator<Buffer> body = messageBody.iterator();
             return fromIterable(() -> body)
                     .cast(Object.class)
-                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull).shareContextOnSubscribe()))
+                    .concat(defer(() -> fromFilterNull(body.trailers()).shareContextOnSubscribe()))
                     .shareContextOnSubscribe();
         }));
         return this;
@@ -215,7 +215,7 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
             HttpMessageBodyIterator<T> body = messageBody.iterator();
             return from(serializer.serialize(headers(), () -> body, original.payloadHolder().allocator()))
                     .cast(Object.class)
-                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull).shareContextOnSubscribe()))
+                    .concat(defer(() -> fromFilterNull(body.trailers()).shareContextOnSubscribe()))
                     .shareContextOnSubscribe();
         }));
         return this;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
@@ -90,8 +90,9 @@ final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpR
         original.payloadHolder().messageBody(defer(() -> {
             HttpMessageBodyIterator<Buffer> body = messageBody.iterator();
             return fromIterable(() -> body)
-                    .map(o -> (Object) o)
-                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull)));
+                    .cast(Object.class)
+                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull)).shareContextOnSubscribe())
+                    .shareContextOnSubscribe();
         }));
         return this;
     }
@@ -102,8 +103,9 @@ final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpR
         original.payloadHolder().messageBody(defer(() -> {
             HttpMessageBodyIterator<T> body = messageBody.iterator();
             return from(serializer.serialize(headers(), () -> body, original.payloadHolder().allocator()))
-                    .map(o -> (Object) o)
-                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull)));
+                    .cast(Object.class)
+                    .concat(defer(() -> from(body.trailers()).filter(Objects::nonNull)).shareContextOnSubscribe())
+                    .shareContextOnSubscribe();
         }));
         return this;
     }


### PR DESCRIPTION
Motivation:
DefaultBlockingStreamingHttp* objects have control flow where they use map and cast to an Object, this can use the `cast` operator. There are also defer operators used that don't need to copy AsyncContext so `shareContextOnSubscribe` can be used to avoid copying.