### PR TITLE
Add http byte[] aggregated example

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -6,6 +6,7 @@
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Timeout[Timeout]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#SerializationJson[Serialization: JSON]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#SerializationProtobuf[Serialization: Protobuf]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#SerializationBytes[Serialization: Bytes]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#JAXRS[JAX-RS]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#MetaData[MetaData]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#HTTP2[HTTP/2]

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -134,6 +134,17 @@ Client sends a `POST` request with a Protobuf payload `RequestMessage` and expec
 All serializers and deserializers defined in
 link:{source-root}/servicetalk-examples/http/serialization/protobuf/src/main/java/io/servicetalk/examples/http/serialization/protobuf/SerializerUtils.java[SerializerUtils].
 
+[#SerializationBytes]
+== Serialization: Bytes
+
+An example similar to "Hello World" examples, which demonstrates
+link:{source-root}/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/blocking[blocking-aggregated]
+client and server with `byte[]` serialization.
+
+Client sends a `GET` request and expects a response that can be deserialized as `byte[]`.
+All serializers and deserializers defined in
+link:{source-root}/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/SerializerUtils.java[SerializerUtils].
+
 [#JAXRS]
 == JAX-RS
 

--- a/servicetalk-examples/http/serialization/bytes/build.gradle
+++ b/servicetalk-examples/http/serialization/bytes/build.gradle
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+apply from: "../../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-http-netty")
+  implementation project(":servicetalk-serializer-utils")
+
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}

--- a/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/SerializerUtils.java
+++ b/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/SerializerUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.bytes;
+
+import io.servicetalk.http.api.HttpSerializerDeserializer;
+import io.servicetalk.http.api.HttpSerializers;
+
+import static io.servicetalk.serializer.utils.ByteArraySerializer.byteArraySerializer;
+
+/**
+ * Utilities to cache serializer instances.
+ */
+public final class SerializerUtils {
+    public static final HttpSerializerDeserializer<byte[]> SERIALIZER =
+            HttpSerializers.serializer(byteArraySerializer(true), headers -> {}, headers -> true);
+
+    private SerializerUtils() {
+    }
+}

--- a/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/blocking/BlockingBytesClient.java
+++ b/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/blocking/BlockingBytesClient.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.bytes.blocking;
+
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.netty.HttpClients;
+
+import static io.servicetalk.examples.http.serialization.bytes.SerializerUtils.SERIALIZER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public final class BlockingBytesClient {
+    public static void main(String[] args) throws Exception {
+        try (BlockingHttpClient client = HttpClients.forSingleAddress("localhost", 8080).buildBlocking()) {
+            HttpResponse resp = client.request(client.get("/bytes"));
+            System.out.println(resp.toString((name, value) -> value));
+            final byte[] bytes = resp.payloadBody(SERIALIZER); // Deserialize the whole payload body as a byte[].
+            System.out.println(new String(bytes, UTF_8)); // convert to String just to print to console.
+        }
+    }
+}

--- a/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/blocking/BlockingPojoServer.java
+++ b/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/blocking/BlockingPojoServer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.serialization.bytes.blocking;
+
+import io.servicetalk.http.netty.HttpServers;
+
+import static io.servicetalk.examples.http.serialization.bytes.SerializerUtils.SERIALIZER;
+import static io.servicetalk.serializer.utils.ByteArraySerializer.byteArraySerializer;
+
+public final class BlockingPojoServer {
+    private static final byte[] BYTES = new byte[] { 'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd' };
+    public static void main(String[] args) throws Exception {
+        HttpServers.forPort(8080)
+                .listenBlockingAndAwait((ctx, request, responseFactory) ->
+                        responseFactory.ok().payloadBody(BYTES, SERIALIZER))
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/blocking/package-info.java
+++ b/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/blocking/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.serialization.bytes.blocking;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/package-info.java
+++ b/servicetalk-examples/http/serialization/bytes/src/main/java/io/servicetalk/examples/http/serialization/bytes/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.serialization.bytes;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/serialization/bytes/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/serialization/bytes/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -61,6 +61,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:http:opentracing",
         "servicetalk-examples:http:observer",
         "servicetalk-examples:http:retry",
+        "servicetalk-examples:http:serialization:bytes",
         "servicetalk-examples:http:serialization:json",
         "servicetalk-examples:http:serialization:protobuf",
         "servicetalk-examples:http:service-composition",
@@ -129,6 +130,7 @@ project(":servicetalk-examples:http:metadata").name = "servicetalk-examples-http
 project(":servicetalk-examples:http:opentracing").name = "servicetalk-examples-http-opentracing"
 project(":servicetalk-examples:http:observer").name = "servicetalk-examples-http-observer"
 project(":servicetalk-examples:http:retry").name = "servicetalk-examples-http-retry"
+project(":servicetalk-examples:http:serialization:bytes").name = "servicetalk-examples-http-serialization-bytes"
 project(":servicetalk-examples:http:serialization:json").name = "servicetalk-examples-http-serialization-json"
 project(":servicetalk-examples:http:serialization:protobuf").name = "servicetalk-examples-http-serialization-protobuf"
 project(":servicetalk-examples:http:service-composition").name = "servicetalk-examples-http-service-composition"


### PR DESCRIPTION
Motivation:
Some times folks want to get the payload body as a `byte[]` and `ByteArraySerializer` can be used for this.