### PR TITLE
Fix flaky `H2PriorKnowledgeFeatureParityTest.serverGracefulClose()`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -1197,7 +1197,7 @@ class H2PriorKnowledgeFeatureParityTest {
         h1ServerContext.onClose().subscribe(onServerCloseLatch::countDown);
         h1ServerContext.closeAsyncGracefully().subscribe();
 
-        assertTrue(connectionOnClosingLatch.await(300, MILLISECONDS));
+        connectionOnClosingLatch.await();
 
         try (BlockingHttpClient client2 = forSingleAddress(HostAndPort.of(serverAddress))
             .protocols(h2PriorKnowledge ? h2Default() : h1Default())


### PR DESCRIPTION
Motivation:

The test assumes that graceful closure should be initiated within 300ms. However, on close CI this can take longer.

Modifications:

- Await indefinitely for initialization of the server-side graceful closure;

Result:

`H2PriorKnowledgeFeatureParityTest.serverGracefulClose()` does not fail due to too short await time.