### PR TITLE
Fix flaky `[Http|Grpc]LifecycleObserverTest`

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverTest.java
@@ -173,10 +173,12 @@ class GrpcLifecycleObserverTest {
         try {
             if (client != null) {
                 client.close();
+                client = null;
             }
         } finally {
             if (server != null) {
                 server.close();
+                server = null;
             }
         }
     }
@@ -215,7 +217,10 @@ class GrpcLifecycleObserverTest {
             assertThat(executeRequest.call(), equalTo(CONTENT));
         }
 
+        // Await full termination to make sure no more callbacks will be invoked.
         bothTerminate.await();
+        tearDown();
+
         verifyObservers(true, error, aggregated, clientLifecycleObserver, clientExchangeObserver,
                 clientRequestObserver, clientResponseObserver, clientInOrder, clientRequestInOrder);
         verifyObservers(false, error, aggregated, serverLifecycleObserver, serverExchangeObserver,


### PR DESCRIPTION
Motivation:

It's possible that requesting more data from the payload publisher can race with completion. Subsequent `request(N)` are possible even after both observers terminate.

Modifications:

- Await for client & server shutdown before starting verification of invoked observer callbacks.

Result:

No more events are possible after server shutdown. Verification step sees all observed events.

Resolves #2343.
Resolves #2298.