### PR TITLE
Expand allowed types to accommodate custom service discoverer events

### DIFF
--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
@@ -182,8 +182,8 @@ public final class GrpcClients {
      * @see GrpcClientBuilderProvider
      */
     public static <U, R>
-    GrpcClientBuilder<U, R> forAddress(final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer,
-                                       final U address) {
+    GrpcClientBuilder<U, R> forAddress(
+            final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer, final U address) {
         return applyProviders(address,
                 new DefaultGrpcClientBuilder<>(() -> HttpClients.forSingleAddress(serviceDiscoverer, address)));
     }

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcClients.java
@@ -182,7 +182,7 @@ public final class GrpcClients {
      * @see GrpcClientBuilderProvider
      */
     public static <U, R>
-    GrpcClientBuilder<U, R> forAddress(final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer,
+    GrpcClientBuilder<U, R> forAddress(final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer,
                                        final U address) {
         return applyProviders(address,
                 new DefaultGrpcClientBuilder<>(() -> HttpClients.forSingleAddress(serviceDiscoverer, address)));

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
@@ -171,7 +171,7 @@ public class DelegatingSingleAddressHttpClientBuilder<U, R> implements SingleAdd
 
     @Override
     public SingleAddressHttpClientBuilder<U, R> serviceDiscoverer(
-            final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer) {
+            final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer) {
         delegate = delegate.serviceDiscoverer(serviceDiscoverer);
         return this;
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -306,7 +306,7 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * @return {@code this}.
      */
     SingleAddressHttpClientBuilder<U, R> serviceDiscoverer(
-            ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer);
+            ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer);
 
     /**
      * Sets a retry strategy to retry errors emitted by {@link ServiceDiscoverer}.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -575,7 +575,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
     @Override
     public DefaultSingleAddressHttpClientBuilder<U, R> serviceDiscoverer(
-            final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer) {
+            final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer) {
         this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
         return this;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -112,7 +112,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     final HttpExecutionContextBuilder executionContextBuilder;
     private final ClientStrategyInfluencerChainBuilder strategyComputation;
     private HttpLoadBalancerFactory<R> loadBalancerFactory;
-    private ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer;
+    private ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer;
     private Function<U, CharSequence> hostToCharSequenceFunction =
             DefaultSingleAddressHttpClientBuilder::toAuthorityForm;
     private boolean addHostHeaderFallbackFilter = true;
@@ -132,7 +132,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
     // Do not use this ctor directly, HttpClients is the entry point for creating a new builder.
     DefaultSingleAddressHttpClientBuilder(
-            final U address, final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer) {
+            final U address, final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer) {
         this.address = requireNonNull(address);
         config = new HttpClientConfig();
         executionContextBuilder = new HttpExecutionContextBuilder();
@@ -170,7 +170,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
     private static final class HttpClientBuildContext<U, R> {
         final DefaultSingleAddressHttpClientBuilder<U, R> builder;
-        private final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> sd;
+        private final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> sd;
         private final SdStatusCompletable sdStatus;
 
         @Nullable
@@ -180,7 +180,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
         HttpClientBuildContext(
                 final DefaultSingleAddressHttpClientBuilder<U, R> builder,
-                final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> sd,
+                final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> sd,
                 @Nullable final BiIntFunction<Throwable, ? extends Completable> serviceDiscovererRetryStrategy,
                 @Nullable final U proxyAddress) {
             this.builder = builder;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -131,7 +131,7 @@ public final class HttpClients {
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     public static MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forMultiAddressUrl(
-            final ServiceDiscoverer<HostAndPort, InetSocketAddress, ? extends ServiceDiscovererEvent<InetSocketAddress>>
+            final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
                     serviceDiscoverer) {
         return applyProviders(
                 new DefaultMultiAddressUrlHttpClientBuilder(address -> forSingleAddress(serviceDiscoverer, address)));

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -131,7 +131,7 @@ public final class HttpClients {
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     public static MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forMultiAddressUrl(
-            final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
+            final ServiceDiscoverer<HostAndPort, InetSocketAddress, ? extends ServiceDiscovererEvent<InetSocketAddress>>
                     serviceDiscoverer) {
         return applyProviders(
                 new DefaultMultiAddressUrlHttpClientBuilder(address -> forSingleAddress(serviceDiscoverer, address)));
@@ -274,7 +274,7 @@ public final class HttpClients {
      * @see SingleAddressHttpClientBuilderProvider
      */
     public static <U, R> SingleAddressHttpClientBuilder<U, R> forSingleAddress(
-            final ServiceDiscoverer<U, R, ServiceDiscovererEvent<R>> serviceDiscoverer,
+            final ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer,
             final U address) {
         return applyProviders(address, new DefaultSingleAddressHttpClientBuilder<>(address, serviceDiscoverer));
     }


### PR DESCRIPTION
Motivation:

The types in the client builders are too restrictive and prevent us from using
them with custom ServiceDiscoverers with custom ServiceDiscovererEvent
implementations.

Changes:

Open up the types so we can use these APIs with a larger selection of custom
ServiceDiscoverers. This change is not breaking.