### PR TITLE
Single#concatPropagateCancel(Publisher) to force cancel propagation

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -766,7 +766,7 @@ public abstract class Single<T> {
      * @see #concat(Publisher, boolean)
      */
     public final Publisher<T> concat(Publisher<? extends T> next) {
-        return new SingleConcatWithPublisher<>(this, next, false);
+        return concat(next, false);
     }
 
     /**
@@ -793,7 +793,29 @@ public abstract class Single<T> {
      * all elements from {@code next} {@link Publisher}.
      */
     public final Publisher<T> concat(Publisher<? extends T> next, boolean deferSubscribe) {
-        return new SingleConcatWithPublisher<>(this, next, deferSubscribe);
+        return new SingleConcatWithPublisher<>(this, next, deferSubscribe, false);
+    }
+
+    /**
+     * Returns a {@link Publisher} that first emits the result of this {@link Single} and then subscribes and emits all
+     * elements from {@code next} {@link Publisher}. Any error emitted by this {@link Single} or {@code next}
+     * {@link Publisher} is forwarded to the returned {@link Publisher}.
+     * <p>
+     * This method provides a means to sequence the execution of two asynchronous sources and in sequential programming
+     * is similar to:
+     * <pre>{@code
+     *     List<T> results = new ...;
+     *     results.add(resultOfThisSingle());
+     *     results.addAll(nextStream());
+     *     return results;
+     * }</pre>
+     * @param next {@link Publisher} to concat. will be subscribed to and cancelled if this {@link Publisher} is
+     * cancelled or terminates with {@link Subscriber#onError(Throwable)}.
+     * @return New {@link Publisher} that first emits the result of this {@link Single} and then subscribes and emits
+     * all elements from {@code next} {@link Publisher}.
+     */
+    public final Publisher<T> concatPropagateCancel(Publisher<? extends T> next) {
+        return new SingleConcatWithPublisher<>(this, next, false, true);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -764,6 +764,7 @@ public abstract class Single<T> {
      * @return New {@link Publisher} that first emits the result of this {@link Single} and then subscribes and emits
      * all elements from {@code next} {@link Publisher}.
      * @see #concat(Publisher, boolean)
+     * @see #concatPropagateCancel(Publisher)
      */
     public final Publisher<T> concat(Publisher<? extends T> next) {
         return concat(next, false);
@@ -797,9 +798,8 @@ public abstract class Single<T> {
     }
 
     /**
-     * Returns a {@link Publisher} that first emits the result of this {@link Single} and then subscribes and emits all
-     * elements from {@code next} {@link Publisher}. Any error emitted by this {@link Single} or {@code next}
-     * {@link Publisher} is forwarded to the returned {@link Publisher}.
+     * This method is like {@link #concat(Completable)} except {@code next} will be subscribed to and cancelled if this
+     * {@link Publisher} is cancelled or terminates with {@link Subscriber#onError(Throwable)}.
      * <p>
      * This method provides a means to sequence the execution of two asynchronous sources and in sequential programming
      * is similar to:
@@ -809,10 +809,11 @@ public abstract class Single<T> {
      *     results.addAll(nextStream());
      *     return results;
      * }</pre>
-     * @param next {@link Publisher} to concat. will be subscribed to and cancelled if this {@link Publisher} is
+     * @param next {@link Publisher} to concat. Will be subscribed to and cancelled if this {@link Publisher} is
      * cancelled or terminates with {@link Subscriber#onError(Throwable)}.
      * @return New {@link Publisher} that first emits the result of this {@link Single} and then subscribes and emits
      * all elements from {@code next} {@link Publisher}.
+     * @see #concat(Completable)
      */
     public final Publisher<T> concatPropagateCancel(Publisher<? extends T> next) {
         return new SingleConcatWithPublisher<>(this, next, false, true);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/SingleConcatWithPublisherTest.java
@@ -27,9 +27,8 @@ import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,12 +41,16 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.api.single.SingleConcatWithPublisherTest.ConcatMode.CONCAT;
+import static io.servicetalk.concurrent.api.single.SingleConcatWithPublisherTest.ConcatMode.DEFER_SUBSCRIBE;
+import static io.servicetalk.concurrent.api.single.SingleConcatWithPublisherTest.ConcatMode.PROPAGATE_CANCEL;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -61,46 +64,62 @@ class SingleConcatWithPublisherTest {
     private TestSingle<Integer> source = new TestSingle.Builder<Integer>().disableAutoOnSubscribe().build();
     private TestPublisher<Integer> next = new TestPublisher.Builder<Integer>().disableAutoOnSubscribe().build();
 
-    void setUp(boolean deferSubscribe) {
-        setUp(deferSubscribe, false);
+    enum ConcatMode {
+        CONCAT, DEFER_SUBSCRIBE, PROPAGATE_CANCEL
     }
 
-    void setUp(boolean deferSubscribe, boolean propagateCancel) {
-        toSource(propagateCancel ? source.concatPropagateCancel(next) : source.concat(next, deferSubscribe))
-                .subscribe(subscriber);
+    void setUp(ConcatMode mode) {
+        toSource(mode == PROPAGATE_CANCEL ?
+                source.concatPropagateCancel(next) :
+                source.concat(next, mode == DEFER_SUBSCRIBE))
+            .subscribe(subscriber);
         source.onSubscribe(cancellable);
         subscriber.awaitSubscription();
     }
 
     @SuppressWarnings("unused")
     private static Stream<Arguments> invalidRequestN() {
-        return Stream.of(Arguments.of(false, -1),
-                Arguments.of(false, 0),
-                Arguments.of(true, -1),
-                Arguments.of(true, 0));
+        return Stream.of(
+                Arguments.of(CONCAT, -1),
+                Arguments.of(CONCAT, 0),
+                Arguments.of(DEFER_SUBSCRIBE, -1),
+                Arguments.of(DEFER_SUBSCRIBE, 0),
+                Arguments.of(PROPAGATE_CANCEL, -1),
+                Arguments.of(PROPAGATE_CANCEL, 0));
+    }
+
+    @SuppressWarnings("unused")
+    private static Stream<Arguments> modeAndError() {
+        return Stream.of(
+                Arguments.of(CONCAT, true),
+                Arguments.of(CONCAT, false),
+                Arguments.of(DEFER_SUBSCRIBE, true),
+                Arguments.of(DEFER_SUBSCRIBE, false),
+                Arguments.of(PROPAGATE_CANCEL, true),
+                Arguments.of(PROPAGATE_CANCEL, false));
     }
 
     @SuppressWarnings("unused")
     private static Collection<Arguments> onNextErrorPropagatedParams() {
         List<Arguments> args = new ArrayList<>();
-        for (boolean deferSubscribe : asList(false, true)) {
-            for (boolean propagateCancel : asList(false, true)) {
-                for (long requestN : asList(1, 2)) {
-                    for (boolean singleCompletesFirst : asList(false, true)) {
-                        args.add(Arguments.of(deferSubscribe, propagateCancel, requestN, singleCompletesFirst));
-                    }
+        for (ConcatMode mode : ConcatMode.values()) {
+            for (long requestN : asList(1, 2)) {
+                for (boolean singleCompletesFirst : asList(false, true)) {
+                    args.add(Arguments.of(mode, requestN, singleCompletesFirst));
                 }
             }
         }
         return args;
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0} propagateCancel={1} requestN={2} singleCompletesFirst={3}")
+    @ParameterizedTest(name = "mode={0} requestN={2} singleCompletesFirst={3}")
     @MethodSource("onNextErrorPropagatedParams")
-    void onNextErrorPropagated(boolean deferSubscribe, boolean propagateCancel, long n, boolean singleCompletesFirst)
+    void onNextErrorPropagated(ConcatMode mode, long n, boolean singleCompletesFirst)
             throws Exception {
-        toSource((propagateCancel ? source.concatPropagateCancel(next) : source.concat(next, deferSubscribe))
-                .<Integer>map(x -> {
+        toSource((mode == PROPAGATE_CANCEL ?
+                source.concatPropagateCancel(next) :
+                source.concat(next, mode == DEFER_SUBSCRIBE))
+            .<Integer>map(x -> {
             throw DELIBERATE_EXCEPTION;
         })).subscribe(subscriber);
         source.onSubscribe(cancellable);
@@ -113,7 +132,7 @@ class SingleConcatWithPublisherTest {
             source.onSuccess(1);
         }
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
-        if (propagateCancel) {
+        if (mode == PROPAGATE_CANCEL) {
             next.awaitSubscribed();
             next.onSubscribe(subscription);
             subscription.awaitCancelled();
@@ -122,11 +141,11 @@ class SingleConcatWithPublisherTest {
         }
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void bothCompletion(boolean deferSubscribe) {
-        setUp(deferSubscribe);
-        long requested = triggerNextSubscribe(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void bothCompletion(ConcatMode mode) {
+        setUp(mode);
+        long requested = triggerNextSubscribe(mode);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(2);
         assertThat("Unexpected items requested.", subscription.requested(), is(requested - 1 + 2));
@@ -136,84 +155,85 @@ class SingleConcatWithPublisherTest {
         subscriber.awaitOnComplete();
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void sourceCompletionNextError(boolean deferSubscribe) {
-        setUp(deferSubscribe);
-        triggerNextSubscribe(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void sourceCompletionNextError(ConcatMode mode) {
+        setUp(mode);
+        triggerNextSubscribe(mode);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         next.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.takeOnNext(), is(1));
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0} invalidRequestN={1}")
+    @ParameterizedTest(name = "mode={0} invalidRequestN={1}")
     @MethodSource("invalidRequestN")
-    void invalidRequestNBeforeNextSubscribe(boolean deferSubscribe, long invalidRequestN) {
-        setUp(deferSubscribe);
+    void invalidRequestNBeforeNextSubscribe(ConcatMode mode, long invalidRequestN) {
+        setUp(mode);
         subscriber.awaitSubscription().request(invalidRequestN);
         source.onSuccess(1);
         assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void invalidRequestNWithInlineSourceCompletion(boolean deferSubscribe) {
-        toSource(succeeded(1).concat(empty(), deferSubscribe)).subscribe(subscriber);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void invalidRequestNWithInlineSourceCompletion(ConcatMode mode) {
+        toSource(mode == PROPAGATE_CANCEL ?
+                succeeded(1).concatPropagateCancel(empty()) :
+                succeeded(1).concat(empty(), mode == DEFER_SUBSCRIBE)).subscribe(subscriber);
         subscriber.awaitSubscription().request(-1);
         assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void invalidRequestAfterNextSubscribe(boolean deferSubscribe) {
-        setUp(deferSubscribe);
-        triggerNextSubscribe(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void invalidRequestAfterNextSubscribe(ConcatMode mode) {
+        setUp(mode);
+        triggerNextSubscribe(mode);
         subscriber.awaitSubscription().request(-1);
         assertThat("Invalid request-n not propagated.", subscription.requested(), is(lessThan(0L)));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void multipleInvalidRequest(boolean deferSubscribe) {
-        setUp(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void multipleInvalidRequest(ConcatMode mode) {
+        setUp(mode);
         subscriber.awaitSubscription().request(-1);
         subscriber.awaitSubscription().request(-10);
         assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0} invalidRequestN={1}")
+    @ParameterizedTest(name = "mode={0} invalidRequestN={1}")
     @MethodSource("invalidRequestN")
-    void invalidThenValidRequest(boolean deferSubscribe, long invalidRequestN) {
-        setUp(deferSubscribe);
+    void invalidThenValidRequest(ConcatMode mode, long invalidRequestN) {
+        setUp(mode);
         subscriber.awaitSubscription().request(invalidRequestN);
         subscriber.awaitSubscription().request(1);
         assertThat(subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
         assertThat(cancellable.isCancelled(), is(true));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void request0PropagatedAfterSuccess(boolean deferSubscribe) {
-        setUp(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void request0PropagatedAfterSuccess(ConcatMode mode) {
+        setUp(mode);
         source.onSuccess(1);
-        subscriber.awaitSubscription().request(deferSubscribe ? 2 : 1); // get the success from the Single
+        subscriber.awaitSubscription().request(mode == DEFER_SUBSCRIBE ? 2 : 1); // get the success from the Single
         assertThat("Next source not subscribed.", next.isSubscribed(), is(true));
         next.onSubscribe(subscription);
-        assertThat(subscription.requested(), is(deferSubscribe ? 1L : 0L));
+        assertThat(subscription.requested(), is(mode == DEFER_SUBSCRIBE ? 1L : 0L));
         subscriber.awaitSubscription().request(0);
         assertThat("Invalid request-n not propagated " + subscription, subscription.requestedEquals(0),
                 is(true));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0} propagateCancel={1} error={2}")
-    @CsvSource(value = {"false,false,false", "false,true,false", "false,true,true", "true,false,false",
-            "true,true,false", "true,true,true"})
-    void sourceError(boolean deferSubscribe, boolean propagateCancel, boolean error) throws InterruptedException {
-        setUp(deferSubscribe, propagateCancel);
+    @ParameterizedTest(name = "mode={0} error={1}")
+    @MethodSource("modeAndError")
+    void sourceError(ConcatMode mode, boolean error) throws InterruptedException {
+        setUp(mode);
         source.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
-        if (propagateCancel) {
+        if (mode == PROPAGATE_CANCEL) {
             next.awaitSubscribed();
             next.onSubscribe(subscription);
             subscription.awaitCancelled();
@@ -229,17 +249,23 @@ class SingleConcatWithPublisherTest {
         }
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0} propagateCancel={1} error={2}")
-    @CsvSource(value = {"false,false,false", "false,true,false", "false,true,true", "true,false,false",
-            "true,true,false", "true,true,true"})
-    void cancelSource(boolean deferSubscribe, boolean propagateCancel, boolean error) throws InterruptedException {
-        setUp(deferSubscribe, propagateCancel);
+    @ParameterizedTest(name = "mode={0} error={1}")
+    @MethodSource("modeAndError")
+    void cancelSource(ConcatMode mode, boolean error) throws InterruptedException {
+        setUp(mode);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         Subscription subscription1 = subscriber.awaitSubscription();
         subscription1.request(2);
         subscription1.cancel();
         assertThat("Original single not cancelled.", cancellable.isCancelled(), is(true));
-        if (propagateCancel) {
+
+        if (error) {
+            source.onError(DELIBERATE_EXCEPTION);
+        } else {
+            source.onSuccess(1);
+        }
+
+        if (mode == PROPAGATE_CANCEL) {
             next.awaitSubscribed();
             next.onSubscribe(subscription);
             subscription.awaitCancelled();
@@ -249,49 +275,61 @@ class SingleConcatWithPublisherTest {
             } else {
                 next.onComplete();
             }
+
+            // It is not required that no terminal is delivered after cancel but verifies the current implementation for
+            // thread safety on the subscriber and to avoid duplicate terminals.
+            assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         } else {
             assertThat(next.isSubscribed(), is(false));
+
             if (error) {
-                source.onError(new DeliberateException());
+                assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
             } else {
-                source.onSuccess(1);
+                // It is not required that no terminal is delivered after cancel but verifies the current implementation
+                // for thread safety on the subscriber and to avoid duplicate terminals.
+                assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
             }
-            assertThat(next.isSubscribed(), is(false));
         }
-        // It is not required that no terminal is delivered after cancel but verifies the current implementation for
-        // thread safety on the subscriber and to avoid duplicate terminals.
-        assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void cancelSourcePostRequest(boolean deferSubscribe) {
-        setUp(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void cancelSourcePostRequest(ConcatMode mode) {
+        setUp(mode);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().request(1);
         subscriber.awaitSubscription().cancel();
         assertThat("Original single not cancelled.", cancellable.isCancelled(), is(true));
-        assertThat("Next source subscribed unexpectedly.", next.isSubscribed(), is(false));
+        assertThat("Next source subscribed unexpectedly.", next.isSubscribed(), is(mode == PROPAGATE_CANCEL));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void cancelNext(boolean deferSubscribe) {
-        setUp(deferSubscribe);
-        triggerNextSubscribe(deferSubscribe);
+    @ParameterizedTest(name = "mode={0} error={1}")
+    @MethodSource("modeAndError")
+    void cancelNext(ConcatMode mode, boolean error) {
+        setUp(mode);
+        triggerNextSubscribe(mode);
         assertThat(subscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         subscriber.awaitSubscription().cancel();
         assertThat("Original single cancelled unexpectedly.", cancellable.isCancelled(), is(false));
         assertThat("Next source not cancelled.", subscription.isCancelled(), is(true));
+
+        assertThat(subscriber.takeOnNext(), equalTo(1));
+        if (error) {
+            next.onError(DELIBERATE_EXCEPTION);
+            assertThat(subscriber.awaitOnError(), sameInstance(DELIBERATE_EXCEPTION));
+        } else {
+            next.onComplete();
+            subscriber.awaitOnComplete();
+        }
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void zeroIsNotRequestedOnTransitionToSubscription(boolean deferSubscribe) {
-        setUp(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void zeroIsNotRequestedOnTransitionToSubscription(ConcatMode mode) {
+        setUp(mode);
         subscriber.awaitSubscription().request(1);
         source.onSuccess(1);
-        if (deferSubscribe) {
+        if (mode == DEFER_SUBSCRIBE) {
             assertThat(next.isSubscribed(), is(false));
             subscriber.awaitSubscription().request(1);
             assertThat(next.isSubscribed(), is(true));
@@ -304,14 +342,14 @@ class SingleConcatWithPublisherTest {
         }
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void publisherSubscribeBlockDemandMakesProgress(boolean deferSubscribe) {
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void publisherSubscribeBlockDemandMakesProgress(ConcatMode mode) {
         source = new TestSingle<>();
         next = new TestPublisher.Builder<Integer>().build(sub1 -> {
             sub1.onSubscribe(subscription);
             try {
-                // Simulate the a blocking operation on demand, like ConnectablePayloadWriter.
+                // Simulate a blocking operation on demand, like ConnectablePayloadWriter.
                 subscription.awaitRequestN(1);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -319,7 +357,7 @@ class SingleConcatWithPublisherTest {
             }
             return sub1;
         });
-        setUp(deferSubscribe);
+        setUp(mode);
 
         source.onSuccess(10);
         // Give at least 2 demand so there is enough to unblock the awaitRequestN and deliver data below.
@@ -331,10 +369,10 @@ class SingleConcatWithPublisherTest {
         subscriber.awaitOnComplete();
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void onErrorAfterInvalidRequestN(boolean deferSubscribe) {
-        setUp(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void onErrorAfterInvalidRequestN(ConcatMode mode) {
+        setUp(mode);
         source.onSuccess(1);
         subscriber.awaitSubscription().request(2L);
         assertThat("Unexpected next element.", subscriber.takeOnNext(), is(1));
@@ -352,10 +390,10 @@ class SingleConcatWithPublisherTest {
                 subscriber.awaitOnError(), instanceOf(IllegalArgumentException.class));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void singleCompletesWithNull(boolean deferSubscribe) {
-        setUp(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void singleCompletesWithNull(ConcatMode mode) {
+        setUp(mode);
         source.onSuccess(null);
         subscriber.awaitSubscription().request(2);
         assertThat("Next source not subscribed.", next.isSubscribed(), is(true));
@@ -365,10 +403,10 @@ class SingleConcatWithPublisherTest {
         subscriber.awaitOnComplete();
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void demandAccumulatedBeforeSingleCompletes(boolean deferSubscribe) {
-        setUp(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void demandAccumulatedBeforeSingleCompletes(ConcatMode mode) {
+        setUp(mode);
         subscriber.awaitSubscription().request(3L);
         assertThat("Next source subscribed unexpectedly.", next.isSubscribed(), is(false));
         assertThat(subscription.requested(), is(0L));
@@ -385,10 +423,10 @@ class SingleConcatWithPublisherTest {
         subscriber.awaitOnComplete();
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void requestOneThenMore(boolean deferSubscribe) {
-        setUp(deferSubscribe);
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void requestOneThenMore(ConcatMode mode) {
+        setUp(mode);
         subscriber.awaitSubscription().request(1L);
         subscriber.awaitSubscription().request(1L);
         assertThat(subscription.requested(), is(0L));
@@ -403,13 +441,15 @@ class SingleConcatWithPublisherTest {
         subscriber.awaitOnComplete();
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void reentryWithMoreDemand(boolean deferSubscribe) {
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void reentryWithMoreDemand(ConcatMode mode) {
         List<Integer> emitted = new ArrayList<>();
         boolean[] completed = {false};
-        toSource(succeeded(1).concat(from(2), deferSubscribe)).subscribe(new Subscriber<Integer>() {
-
+        toSource(mode == PROPAGATE_CANCEL ?
+                succeeded(1).concatPropagateCancel(from(2)) :
+                succeeded(1).concat(from(2), mode == DEFER_SUBSCRIBE)
+        ).subscribe(new Subscriber<Integer>() {
             @Nullable
             private Subscription subscription;
 
@@ -440,13 +480,14 @@ class SingleConcatWithPublisherTest {
         assertThat(completed[0], is(true));
     }
 
-    @ParameterizedTest(name = "deferSubscribe={0}")
-    @ValueSource(booleans = {false, true})
-    void cancelledDuringFirstOnNext(boolean deferSubscribe) {
+    @ParameterizedTest(name = "mode={0}")
+    @EnumSource(ConcatMode.class)
+    void cancelledDuringFirstOnNext(ConcatMode mode) {
         List<Integer> emitted = new ArrayList<>();
         boolean[] terminated = {false};
-        toSource(succeeded(1).concat(never(), deferSubscribe)).subscribe(new Subscriber<Integer>() {
-
+        toSource(mode == PROPAGATE_CANCEL ?
+                succeeded(1).concatPropagateCancel(never()) :
+                succeeded(1).concat(never(), mode == DEFER_SUBSCRIBE)).subscribe(new Subscriber<Integer>() {
             @Nullable
             private Subscription subscription;
 
@@ -478,10 +519,11 @@ class SingleConcatWithPublisherTest {
         assertThat(terminated[0], is(false));
     }
 
-    private long triggerNextSubscribe(boolean deferSubscribe) {
-        final long n = deferSubscribe ? 2 : 1;
+    private long triggerNextSubscribe(ConcatMode mode) {
+        final long n = mode == DEFER_SUBSCRIBE ? 2 : 1;
         subscriber.awaitSubscription().request(n);
         source.onSuccess(1);
+        next.awaitSubscribed();
         next.onSubscribe(subscription);
         return n;
     }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleConcatWithPublisherDeferSubscribePropagateCancelTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleConcatWithPublisherDeferSubscribePropagateCancelTckTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import org.testng.annotations.Test;
+
+@Test
+public class SingleConcatWithPublisherDeferSubscribePropagateCancelTckTest extends SingleConcatWithPublisherTckTest {
+
+    @Override
+    boolean propagateCancel() {
+        return true;
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleConcatWithPublisherPropagateCancelTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleConcatWithPublisherPropagateCancelTckTest.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.reactivestreams.tck;
 import org.testng.annotations.Test;
 
 @Test
-public class SingleConcatWithPublisherDeferSubscribePropagateCancelTckTest extends SingleConcatWithPublisherTckTest {
+public class SingleConcatWithPublisherPropagateCancelTckTest extends SingleConcatWithPublisherTckTest {
 
     @Override
     boolean propagateCancel() {

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleConcatWithPublisherTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleConcatWithPublisherTckTest.java
@@ -20,10 +20,16 @@ import io.servicetalk.concurrent.api.Single;
 
 import org.testng.annotations.Test;
 
+import static io.servicetalk.concurrent.reactivestreams.tck.TckUtils.newPublisher;
+
 @Test
 public class SingleConcatWithPublisherTckTest extends AbstractSingleTckTest<Integer> {
 
     boolean deferSubscribe() {
+        return false;
+    }
+
+    boolean propagateCancel() {
         return false;
     }
 
@@ -32,8 +38,9 @@ public class SingleConcatWithPublisherTckTest extends AbstractSingleTckTest<Inte
         if (elements < 2) {
             return Single.succeeded(1).toPublisher();
         }
-        return Single.succeeded(1)
-                .concat(TckUtils.newPublisher(TckUtils.requestNToInt(elements) - 1), deferSubscribe());
+        Single<Integer> s = Single.succeeded(1);
+        Publisher<Integer> p = newPublisher(TckUtils.requestNToInt(elements) - 1);
+        return propagateCancel() ? s.concatPropagateCancel(p) : s.concat(p, deferSubscribe());
     }
 
     @Override


### PR DESCRIPTION
Motivation:
In some scenarios concat is used where the right hand side has assocated state that is desirable to always trigger (concat payload body to meta data for http response processing). Regular concat will not subscribe if the Single terminates with onError or is cancelled which will prevent terminal event visibility.