### PR TITLE
Add regression tests for netty client factories

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientsCompileTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcClientsCompileTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+
+class GrpcClientsCompileTest {
+    private static final String IGNORE_ADDRESS = "";
+
+    @Test
+    void testGrpcClientsAcceptsCustomServiceDiscovererEvents() {
+        GrpcClients.forAddress(new NullServiceDiscoverer<ServiceDiscovererEvent<InetSocketAddress>>(), IGNORE_ADDRESS);
+        GrpcClients.forAddress(new NullServiceDiscoverer<CustomServiceDiscovererEvent>(), IGNORE_ADDRESS);
+    }
+
+    private interface CustomServiceDiscovererEvent extends ServiceDiscovererEvent<InetSocketAddress> { }
+
+    private static final class NullServiceDiscoverer<E extends ServiceDiscovererEvent<InetSocketAddress>>
+            implements ServiceDiscoverer<String, InetSocketAddress, E> {
+
+        @Override
+        public Publisher<Collection<E>> discover(final String inetSocketAddress) {
+            return Publisher.empty();
+        }
+
+        @Override
+        public Completable onClose() {
+            return Completable.completed();
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return Completable.completed();
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientsCompileTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientsCompileTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,10 +30,19 @@ class HttpClientsCompileTest {
     private static final String IGNORE_ADDRESS = "";
 
     @Test
-    void testGrpcClientsAcceptsCustomServiceDiscovererEvents() {
-        HttpClients.forSingleAddress(
-                new NullServiceDiscoverer<ServiceDiscovererEvent<InetSocketAddress>>(), IGNORE_ADDRESS);
-        HttpClients.forSingleAddress(new NullServiceDiscoverer<CustomServiceDiscovererEvent>(), IGNORE_ADDRESS);
+    void testHttpClientsAcceptsBaseServiceDiscovererEvents() {
+        NullServiceDiscoverer<ServiceDiscovererEvent<InetSocketAddress>> discoverer = new NullServiceDiscoverer<>();
+        SingleAddressHttpClientBuilder<String, InetSocketAddress> builder = HttpClients.forSingleAddress(
+                discoverer, IGNORE_ADDRESS);
+        builder.serviceDiscoverer(discoverer);
+    }
+
+    @Test
+    void testHttpClientsAcceptsCustomServiceDiscovererEvents() {
+        NullServiceDiscoverer<CustomServiceDiscovererEvent> discoverer = new NullServiceDiscoverer<>();
+        SingleAddressHttpClientBuilder<String, InetSocketAddress> builder = HttpClients.forSingleAddress(
+                discoverer, IGNORE_ADDRESS);
+        builder.serviceDiscoverer(discoverer);
     }
 
     private interface CustomServiceDiscovererEvent extends ServiceDiscovererEvent<InetSocketAddress> { }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientsCompileTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientsCompileTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+
+class HttpClientsCompileTest {
+    private static final String IGNORE_ADDRESS = "";
+
+    @Test
+    void testGrpcClientsAcceptsCustomServiceDiscovererEvents() {
+        HttpClients.forSingleAddress(
+                new NullServiceDiscoverer<ServiceDiscovererEvent<InetSocketAddress>>(), IGNORE_ADDRESS);
+        HttpClients.forSingleAddress(new NullServiceDiscoverer<CustomServiceDiscovererEvent>(), IGNORE_ADDRESS);
+    }
+
+    private interface CustomServiceDiscovererEvent extends ServiceDiscovererEvent<InetSocketAddress> { }
+
+    private static final class NullServiceDiscoverer<E extends ServiceDiscovererEvent<InetSocketAddress>>
+            implements ServiceDiscoverer<String, InetSocketAddress, E> {
+
+        @Override
+        public Publisher<Collection<E>> discover(final String inetSocketAddress) {
+            return Publisher.empty();
+        }
+
+        @Override
+        public Completable onClose() {
+            return Completable.completed();
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return Completable.completed();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

We recently expanded the allowed types for the Netty client factories and in
order to prevent a regression we should make sure they are used in a test and
fail the build if the types are narrowed.

Changes:

Create two simple tests that will fail to compile of a regression occurs in the
scope of the allowed types.