### PR TITLE
Implement `toString()` for `TestPublisherSubscriber#pollTerminal(...)`

### DIFF
--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
@@ -295,7 +295,18 @@ public final class TestPublisherSubscriber<T> implements Subscriber<T> {
     public Supplier<Throwable> pollTerminal(long timeout, TimeUnit unit) {
         if (await(onTerminalLatch, timeout, unit)) {
             assert onTerminal != null;
-            return onTerminal == complete() ? () -> null : onTerminal::cause;
+            return new Supplier<Throwable>() {
+                @Nullable
+                @Override
+                public Throwable get() {
+                    return onTerminal.cause();
+                }
+
+                @Override
+                public String toString() {
+                    return onTerminal.toString();
+                }
+            };
         }
         return null;
     }


### PR DESCRIPTION
Motivation:

We have assertions that expect no terminal signals. When they fail, hamcrest prints a lambda name that is hard to understand.

Modifications:

- Implement `toString()` for the returned `Supplier` from `TestPublisherSubscriber#pollTerminal(...)`;

Result:

Easier to understand what was the terminal signal when assertion fails.