### PR TITLE
`Single.concatDeferSubscribe(Publisher)` instead of `Single.concat(Publisher, boolean)`

### DIFF
--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleConcatWithPublisherTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/SingleConcatWithPublisherTckTest.java
@@ -40,7 +40,8 @@ public class SingleConcatWithPublisherTckTest extends AbstractSingleTckTest<Inte
         }
         Single<Integer> s = Single.succeeded(1);
         Publisher<Integer> p = newPublisher(TckUtils.requestNToInt(elements) - 1);
-        return propagateCancel() ? s.concatPropagateCancel(p) : s.concat(p, deferSubscribe());
+        return propagateCancel() ? s.concatPropagateCancel(p) :
+                deferSubscribe() ? s.concatDeferSubscribe(p) : s.concat(p);
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -177,7 +177,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
                 } else {
                     // Defer subscribe to the messageBody until transport requests it to allow clients retry failed
                     // requests with non-replayable messageBody
-                    flatRequest = Single.<Object>succeeded(request).concat(messageBody, /* deferSubscribe */ true);
+                    flatRequest = Single.<Object>succeeded(request).concatDeferSubscribe(messageBody);
                     if (shouldAppendTrailers(connectionContext().protocol(), request)) {
                         flatRequest = flatRequest.scanWith(HeaderUtils::appendTrailersMapper);
                     }


### PR DESCRIPTION
Motivation:

Boolean arguments for operators are harder to read, especially when number of possible boolean args is growing.

Modifications:

- Introduce `Single.concatDeferSubscribe(Publisher)` that behaves like `Single.concat(Publisher, true)`;
- Deprecate `Single.concat(Publisher, boolean)`;

Result:

Clear behavior based on operator name, consistency with `concatPropagateCancel`.