### PR TITLE
Prepare for upgrade to Netty 4.1.84

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2018-2022 Apple Inc. and the ServiceTalk project authors
+# Copyright Â© 2018-2019, 2021-2022 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ issueManagementUrl=https://github.com/apple/servicetalk/issues
 ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
-nettyVersion=4.1.82.Final
+nettyVersion=4.1.84.Final
 nettyIoUringVersion=0.0.15.Final
 
 jsr305Version=3.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright Â© 2018-2019, 2021-2022 Apple Inc. and the ServiceTalk project authors
+# Copyright © 2018-2022 Apple Inc. and the ServiceTalk project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ issueManagementUrl=https://github.com/apple/servicetalk/issues
 ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
-nettyVersion=4.1.84.Final
+nettyVersion=4.1.82.Final
 nettyIoUringVersion=0.0.15.Final
 
 jsr305Version=3.0.2

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
@@ -20,9 +20,7 @@ package io.servicetalk.http.api;
  */
 public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
 
-    private static final boolean DEFAULT_VALIDATE_VALUES = false;
-    public static final HttpHeadersFactory INSTANCE = new DefaultHttpHeadersFactory(true, true,
-            DEFAULT_VALIDATE_VALUES);
+    public static final HttpHeadersFactory INSTANCE = new DefaultHttpHeadersFactory(true, true, false);
 
     private final boolean validateNames;
     private final boolean validateCookies;
@@ -74,6 +72,11 @@ public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
     @Override
     public HttpHeaders newEmptyTrailers() {
         return new DefaultHttpHeaders(0, validateNames, validateCookies, validateValues);
+    }
+
+    @Override
+    public boolean validateNames() {
+        return validateNames;
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeadersFactory.java
@@ -47,6 +47,12 @@ public interface HttpHeadersFactory {
         return newTrailers();
     }
 
+    default boolean validateNames() {
+        // We do not know behavior of a custom HttpHeadersFactory, but assume it validates header names.
+        // This helps to make sure we always validate HTTP/2 headers by default inside Netty pipeline.
+        return true;
+    }
+
     /**
      * Determine if cookies should be validated during parsing into {@link HttpSetCookie}s.
      *

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -57,8 +57,8 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
                 // the user to apply their own timeout at the call site.
                 .gracefulShutdownTimeoutMillis(-1)
                 .initialSettings(nettySettings)
-                // We always validate incoming headers, define this explicitly instead of inheriting a default value.
-                .validateHeaders(true)
+                // Inherit headers validation setting from the HttpHeadersFactory.
+                .validateHeaders(config.headersFactory().validateNames())
                 .headerSensitivityDetector(config.headersSensitivityDetector()::test);
 
         initFrameLogger(multiplexCodecBuilder, config.frameLoggerConfig());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentChannelInitializer.java
@@ -57,6 +57,8 @@ final class H2ClientParentChannelInitializer implements ChannelInitializer {
                 // the user to apply their own timeout at the call site.
                 .gracefulShutdownTimeoutMillis(-1)
                 .initialSettings(nettySettings)
+                // We always validate incoming headers, define this explicitly instead of inheriting a default value.
+                .validateHeaders(true)
                 .headerSensitivityDetector(config.headersSensitivityDetector()::test);
 
         initFrameLogger(multiplexCodecBuilder, config.frameLoggerConfig());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
@@ -25,8 +25,7 @@ import io.netty.handler.codec.http2.DefaultHttp2Headers;
  */
 public final class H2HeadersFactory implements HttpHeadersFactory {
 
-    private static final boolean DEFAULT_VALIDATE_VALUES = false;
-    public static final HttpHeadersFactory INSTANCE = new H2HeadersFactory(true, true, DEFAULT_VALIDATE_VALUES);
+    public static final HttpHeadersFactory INSTANCE = new H2HeadersFactory(true, true, false);
 
     private final boolean validateNames;
     private final boolean validateCookies;
@@ -81,6 +80,11 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
     public HttpHeaders newEmptyTrailers() {
         return new NettyH2HeadersToHttpHeaders(new DefaultHttp2Headers(validateNames, 0),
                 validateCookies, validateValues);
+    }
+
+    @Override
+    public boolean validateNames() {
+        return validateNames;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -59,6 +59,8 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
                 // the user to apply their own timeout at the call site.
                 .gracefulShutdownTimeoutMillis(-1)
                 .initialSettings(nettySettings)
+                // We always validate incoming headers, define this explicitly instead of inheriting a default value.
+                .validateHeaders(true)
                 .headerSensitivityDetector(config.headersSensitivityDetector()::test);
 
         initFrameLogger(multiplexCodecBuilder, config.frameLoggerConfig());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -59,8 +59,8 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
                 // the user to apply their own timeout at the call site.
                 .gracefulShutdownTimeoutMillis(-1)
                 .initialSettings(nettySettings)
-                // We always validate incoming headers, define this explicitly instead of inheriting a default value.
-                .validateHeaders(true)
+                // Inherit headers validation setting from the HttpHeadersFactory.
+                .validateHeaders(config.headersFactory().validateNames())
                 .headerSensitivityDetector(config.headersSensitivityDetector()::test);
 
         initFrameLogger(multiplexCodecBuilder, config.frameLoggerConfig());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -204,10 +204,8 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
         if (httpStatus != null) {
             final int statusCode = httpStatus.code();
             if (!h2Headers.contains(CONTENT_LENGTH)) {
-                if (serverMaySendPayloadBodyFor(statusCode, method)) {
-                    if (fullResponse) {
-                        h2Headers.set(CONTENT_LENGTH, ZERO);
-                    }
+                if (serverMaySendPayloadBodyFor(statusCode, method) && fullResponse) {
+                    h2Headers.set(CONTENT_LENGTH, ZERO);
                 }
             } else if (!responseMayHaveContent(statusCode, method)) {
                 throw protocolError(ctx, streamId, fullResponse, "content-length (" + h2Headers.get(CONTENT_LENGTH) +

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -40,8 +40,6 @@ import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
-import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
-import static io.netty.handler.codec.http.HttpHeaderValues.CHUNKED;
 import static io.netty.handler.codec.http.HttpHeaderValues.ZERO;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.STATUS;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
@@ -209,8 +207,6 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 if (serverMaySendPayloadBodyFor(statusCode, method)) {
                     if (fullResponse) {
                         h2Headers.set(CONTENT_LENGTH, ZERO);
-                    } else {
-                        h2Headers.add(TRANSFER_ENCODING, CHUNKED);
                     }
                 }
             } else if (!responseMayHaveContent(statusCode, method)) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -153,10 +153,8 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
         if (httpMethod != null) {
             final boolean containsContentLength = h2Headers.contains(CONTENT_LENGTH);
             if (clientMaySendPayloadBodyFor(httpMethod)) {
-                if (!containsContentLength) {
-                    if (fullRequest && shouldAddZeroContentLength(httpMethod)) {
-                        h2Headers.set(CONTENT_LENGTH, ZERO);
-                    }
+                if (!containsContentLength && fullRequest && shouldAddZeroContentLength(httpMethod)) {
+                    h2Headers.set(CONTENT_LENGTH, ZERO);
                 }
             } else if (containsContentLength) {
                 throw protocolError(ctx, streamId, fullRequest, "content-length (" + h2Headers.get(CONTENT_LENGTH) +

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -35,8 +35,6 @@ import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
-import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
-import static io.netty.handler.codec.http.HttpHeaderValues.CHUNKED;
 import static io.netty.handler.codec.http.HttpHeaderValues.ZERO;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.AUTHORITY;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.METHOD;
@@ -158,8 +156,6 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                 if (!containsContentLength) {
                     if (fullRequest && shouldAddZeroContentLength(httpMethod)) {
                         h2Headers.set(CONTENT_LENGTH, ZERO);
-                    } else {
-                        h2Headers.add(TRANSFER_ENCODING, CHUNKED);
                     }
                 }
             } else if (containsContentLength) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -332,8 +332,9 @@ final class HeaderUtils {
 
     private static boolean canAddTransferEncodingChunked(final HttpMetaData metaData) {
         final HttpHeaders headers = metaData.headers();
-        return ((chunkedSupported(metaData.version()) && mayHaveTrailers(metaData)) ||
-                !headers.contains(CONTENT_LENGTH)) && !isTransferEncodingChunked(headers);
+        return chunkedSupported(metaData.version()) &&
+                (mayHaveTrailers(metaData) || !headers.contains(CONTENT_LENGTH)) &&
+                !isTransferEncodingChunked(headers);
     }
 
     private static boolean chunkedSupported(final HttpProtocolVersion version) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
@@ -54,6 +54,7 @@ import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
+import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
@@ -142,14 +143,14 @@ class AbstractH2DuplexHandlerTest {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void unexpectedContentLength(Variant variant) {
         setUp(variant);
         unexpectedContentLength(variant, false);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void unexpectedContentLengthEndStream(Variant variant) {
         setUp(variant);
@@ -177,14 +178,14 @@ class AbstractH2DuplexHandlerTest {
         assertThat(e.getMessage(), startsWith("content-length (1) header is not expected"));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void nullContentLengthWhenContentIsNotExpected(Variant variant) {
         setUp(variant);
         nullContentLengthWhenContentIsNotExpected(variant, false);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void nullContentLengthWhenContentIsNotExpectedEndStream(Variant variant) {
         setUp(variant);
@@ -210,14 +211,14 @@ class AbstractH2DuplexHandlerTest {
         assertThat(channel.readInbound(), instanceOf(HttpMetaData.class));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void responseWithContentLengthToHeadRequest(Variant variant) {
         setUp(variant);
         responseWithContentLengthToHeadRequest(variant, false);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void responseWithContentLengthToHeadRequestEndStream(Variant variant) {
         setUp(variant);
@@ -253,14 +254,14 @@ class AbstractH2DuplexHandlerTest {
         assertThat(channel.inboundMessages(), is(empty()));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void noContentLength(Variant variant) {
         setUp(variant);
         noContentLength(variant, false);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void noContentLengthEndStream(Variant variant) {
         setUp(variant);
@@ -275,20 +276,21 @@ class AbstractH2DuplexHandlerTest {
 
         HttpMetaData metaData = channel.readInbound();
         if (endStream) {
-            assertThat(metaData.headers().contains(CONTENT_LENGTH), is(true));
+            assertThat(metaData.headers().get(CONTENT_LENGTH), contentEqualTo(ZERO));
         } else {
-            assertThat(isTransferEncodingChunked(metaData.headers()), is(true));
+            assertThat("Unexpected content-length header", metaData.headers().contains(CONTENT_LENGTH), is(false));
         }
+        assertThat("Unexpected chunked encoding", isTransferEncodingChunked(metaData.headers()), is(false));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void withContentLength(Variant variant) {
         setUp(variant);
         withContentLength(variant, false);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void withContentLengthAndTrailers(Variant variant) {
         setUp(variant);
@@ -321,7 +323,7 @@ class AbstractH2DuplexHandlerTest {
         assertThat(channel.inboundMessages(), is(empty()));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void singleHeadersFrameWithZeroContentLength(Variant variant) {
         setUp(variant);
@@ -341,7 +343,7 @@ class AbstractH2DuplexHandlerTest {
         assertThat(channel.inboundMessages(), is(empty()));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void emptyMessageWrittenAsSingleFrame(Variant variant) {
         setUp(variant);
@@ -367,7 +369,7 @@ class AbstractH2DuplexHandlerTest {
         assertThat("Unexpected outbound messages", channel.outboundMessages(), empty());
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] variant={0}")
     @EnumSource(Variant.class)
     void noDataFramesForEmptyBuffers(Variant variant) {
         setUp(variant);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilderTest.java
@@ -247,6 +247,11 @@ class DefaultMultiAddressUrlHttpClientBuilderTest {
         }
 
         @Override
+        public boolean validateNames() {
+            return delegate.validateNames();
+        }
+
+        @Override
         public boolean validateCookies() {
             return delegate.validateCookies();
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -255,7 +255,6 @@ class H2PriorKnowledgeFeatureParityTest {
                     }
                 }
             }
-
         }
         return data;
     }


### PR DESCRIPTION
Motivation:

Netty 4.1.84 includes https://github.com/netty/netty/pull/12760 which moves validation of connection-related headers for HTTP/2 from `HpackDecoder` to `DefaultHttp2Headers`. This breaks our existing control flow because in case there is no `content-length` header, we always unconditionally add `transfer-encoding: chunked` header that will be removed later in HTTP/2 pipeline if the HTTP/2 is the actual negotiated protocol.

Modification:

- Improve our control flow to take protocol into account when it adds `transfer-encoding: chunked` header;
- Adjust existing tests that target `transfer-encoding: chunked` handling to always use `DefaultHttpHeadersFactory`, even  when testing HTTP/2, it helps to avoid validation in netty's `DefaultHttp2Headers`;

Result:

All tests pass with both versions of netty: 4.1.82 and 4.1.84.