### PR TITLE
Run scheduled tests with Netty 4.1.X-SNAPSHOT

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -1,0 +1,36 @@
+name: Test with the latest Netty 4.1.X-SNAPSHOT
+on:
+  schedule:
+    - cron: '0 15 * * 1-5'
+jobs:
+  build:
+    name: Netty snapshot on JDK ${{ matrix.java }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        java: [ 8 ]
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'zulu'
+          cache: 'gradle'
+      - name: Print JDK Version
+        run: java -version
+      - name: Make gradlew Executable
+        run: chmod +x gradlew
+      - name: Build and Test
+        env:
+          JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+          ORG_GRADLE_PROJECT_nettyVersion: 4.1.+
+        run:  sudo -E env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel clean test"
+      - name: Publish Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results-${{ matrix.os }}-${{ matrix.java }}
+          path: '**/build/test-results/test/TEST-*.xml'

--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -16,6 +16,8 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
+ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
+
 dependencies {
   implementation platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
@@ -32,8 +34,11 @@ dependencies {
   implementation "io.netty:netty-resolver-dns"
   implementation "org.slf4j:slf4j-api"
 
-  runtimeOnly( group:"io.netty", name:"netty-resolver-dns-native-macos", classifier:"osx-x86_64")
-  runtimeOnly( group:"io.netty", name:"netty-resolver-dns-native-macos", classifier:"osx-aarch_64")
+  if (!project.ext.isNettySnapshot) {
+    // Netty doesn't publish snapshots for macos artifacts
+    runtimeOnly( group:"io.netty", name:"netty-resolver-dns-native-macos", classifier:"osx-x86_64")
+    runtimeOnly( group:"io.netty", name:"netty-resolver-dns-native-macos", classifier:"osx-aarch_64")
+  }
 
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -16,6 +16,8 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
+ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
+
 dependencies {
   implementation platform(project(":servicetalk-dependencies"))
 
@@ -53,8 +55,11 @@ dependencies {
   testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-x86_64")
   testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-aarch_64")
   testFixturesImplementation "io.netty:netty-transport-native-kqueue"
-  testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-x86_64")
-  testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-aarch_64")
+  if (!project.ext.isNettySnapshot) {
+    // Netty doesn't publish snapshots for macos artifacts
+    testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-x86_64")
+    testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-aarch_64")
+  }
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -17,7 +17,6 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
-println("!!! $nettyVersion")
 
 dependencies {
   api platform(project(":servicetalk-dependencies"))

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -16,6 +16,9 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
+ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
+println("!!! $nettyVersion")
+
 dependencies {
   api platform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
@@ -38,8 +41,11 @@ dependencies {
   runtimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-x86_64")
   runtimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-aarch_64")
   implementation "io.netty:netty-transport-native-kqueue"
-  runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-x86_64")
-  runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-aarch_64")
+  if (!project.ext.isNettySnapshot) {
+    // Netty doesn't publish snapshots for macos artifacts
+    runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-x86_64")
+    runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-aarch_64")
+  }
   implementation "io.netty.incubator:netty-incubator-transport-native-io_uring"
   runtimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", classifier:"linux-x86_64")
   runtimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", classifier:"linux-aarch_64")


### PR DESCRIPTION
Motivation:

To catch any issues with newer Netty releases, run a scheduled job to test ServiceTalk with the latest netty 4.1.X-SNAPSHOT.

Modifications:

- Adjust `build.gradle` files to exclude macos-specific artifacts when we build with a netty snapshot;
- Add CI job to run with Netty 4.1.+;

Result:

Regular tests with the latest Netty snapshot.