### PR TITLE
Use `jackson-bom` instead of `jackson-databind`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,8 +48,7 @@ jerseyVersion=2.35
 
 reactiveStreamsVersion=1.0.4
 jcToolsVersion=3.3.1-ea
-jacksonVersion=2.13.4
-# This is used for jackson-databind version only
+jacksonVersion=2.13.4.20221012
 # backward compatible with jackson 2.9+, we do not depend on any new features from later versions.
 
 openTracingVersion=0.33.0

--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -25,13 +25,12 @@ javaPlatform {
 dependencies {
   api platform(project(":servicetalk-bom"))
   api platform("io.netty:netty-bom:${nettyVersion}")
+  api(platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}"))
   api platform("com.google.protobuf:protobuf-bom:${protobufVersion}")
   api platform("org.apache.logging.log4j:log4j-bom:${log4jVersion}")
   api platform("org.glassfish.jersey:jersey-bom:${jerseyVersion}")
 
   constraints {
-    // We don't use the jackson-bom because we want to target specifically jackson-databind
-    api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
     api "com.google.code.findbugs:jsr305:$jsr305Version"
     api "com.sun.activation:jakarta.activation:$javaxActivationVersion"


### PR DESCRIPTION
Motivation:

It's a good practice to use boms when possible to let users manage dependencies easier. Even if we depend only on a single dependency from jackson scope, it has other transitive jackson dependencies in it.