### PR TITLE
Update Jackson 2.13.4.20221012 -> 2.13.4.20221013

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ jerseyVersion=2.35
 
 reactiveStreamsVersion=1.0.4
 jcToolsVersion=3.3.1-ea
-jacksonVersion=2.13.4.20221012
+jacksonVersion=2.13.4.20221013
 # backward compatible with jackson 2.9+, we do not depend on any new features from later versions.
 
 openTracingVersion=0.33.0


### PR DESCRIPTION
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13