### PR TITLE
H2 TE header parsing bug fix

### DIFF
--- a/servicetalk-buffer-api/build.gradle
+++ b/servicetalk-buffer-api/build.gradle
@@ -29,5 +29,8 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
+  testFixturesImplementation platform(project(":servicetalk-dependencies"))
+  testFixturesImplementation project(":servicetalk-annotations")
+  testFixturesImplementation "com.google.code.findbugs:jsr305"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/servicetalk-buffer-api/src/testFixtures/java/io/servicetalk/buffer/api/Matchers.java
+++ b/servicetalk-buffer-api/src/testFixtures/java/io/servicetalk/buffer/api/Matchers.java
@@ -15,12 +15,19 @@
  */
 package io.servicetalk.buffer.api;
 
+import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
 import static io.servicetalk.buffer.api.CharSequences.contentEquals;
+import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static java.util.Objects.requireNonNull;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 
 /**
  * Custom {@link Matcher}s specific to http-api.
@@ -40,7 +47,6 @@ public final class Matchers {
     public static Matcher<CharSequence> contentEqualTo(final CharSequence expected) {
         requireNonNull(expected);
         return new TypeSafeMatcher<CharSequence>() {
-
             @Override
             protected boolean matchesSafely(final CharSequence item) {
                 return contentEquals(expected, item);
@@ -51,5 +57,39 @@ public final class Matchers {
                 description.appendValue(expected);
             }
         };
+    }
+
+    /**
+     * Matcher which compares in order while ignoring case.
+     * @param items The expected items.
+     * @param <E> {@link CharSequence} type to match.
+     * @return Matcher which compares in order while ignoring case.
+     */
+    @SafeVarargs
+    public static <E extends CharSequence> Matcher<Iterable<? extends E>> containsIgnoreCase(E... items) {
+        final List<Matcher<? super E>> matchers = new ArrayList<>(items.length);
+        for (E item : items) {
+            matchers.add(new CharsEqualsIgnoreCase(item));
+        }
+        return contains(matchers);
+    }
+
+    private static final class CharsEqualsIgnoreCase extends BaseMatcher<CharSequence> {
+        @Nullable
+        private final CharSequence expected;
+
+        private CharsEqualsIgnoreCase(final CharSequence expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        public boolean matches(final Object actual) {
+            return actual instanceof CharSequence && contentEqualsIgnoreCase(expected, (CharSequence) actual);
+        }
+
+        @Override
+        public void describeTo(final Description description) {
+            description.appendValue(expected);
+        }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.buffer.api.CharSequences;
 import io.servicetalk.http.api.HttpHeaders;
 
 import io.netty.handler.codec.http.HttpHeaderNames;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -122,9 +122,11 @@ import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderNames.TRAILER;
+import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
+import static io.servicetalk.buffer.api.Matchers.containsIgnoreCase;
 import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
@@ -139,6 +141,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.COOKIE;
 import static io.servicetalk.http.api.HttpHeaderNames.EXPECT;
 import static io.servicetalk.http.api.HttpHeaderNames.SET_COOKIE;
+import static io.servicetalk.http.api.HttpHeaderNames.TE;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.UPGRADE;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
@@ -319,6 +322,67 @@ class H2PriorKnowledgeFeatureParityTest {
             cookie = response.headers().getCookie("name3");
             assertNotNull(cookie);
             assertEquals("value3", cookie.value());
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] client={0}, h2PriorKnowledge={1}")
+    @MethodSource("clientExecutors")
+    void teHeaderOnlyAllowsTrailers(HttpTestExecutionStrategy strategy, boolean h2PriorKnowledge) throws Exception {
+        setUp(strategy, h2PriorKnowledge);
+        InetSocketAddress serverAddress = bindHttpEchoServer();
+        try (BlockingHttpClient client = forSingleAddress(HostAndPort.of(serverAddress))
+                .protocols(h2PriorKnowledge ? h2Default() : h1Default())
+                .executionStrategy(clientExecutionStrategy).buildBlocking()) {
+            // Test individual headers
+            HttpRequest request = client.get("/");
+            request.addHeader(TE, "foo");
+            request.addHeader(TE, TRAILERS);
+            request.addHeader(TE, "bar");
+            HttpResponse response = client.request(request);
+            assertThat(response.headers().values(TE), h2PriorKnowledge ?
+                    containsIgnoreCase(TRAILERS) : containsIgnoreCase("foo", TRAILERS, "bar"));
+
+            // Test single header value, comma separated trailers last
+            request = client.get("/");
+            request.addHeader(TE, "foo," + TRAILERS);
+            response = client.request(request);
+            assertThat(response.headers().values(TE), h2PriorKnowledge ?
+                    containsIgnoreCase(TRAILERS) : containsIgnoreCase("foo," + TRAILERS));
+
+            // Test single header value, comma separated trailers last with OWS
+            request = client.get("/");
+            request.addHeader(TE, "foo, " + TRAILERS);
+            response = client.request(request);
+            assertThat(response.headers().values(TE), h2PriorKnowledge ?
+                    containsIgnoreCase(TRAILERS) : containsIgnoreCase("foo, " + TRAILERS));
+
+            // Test single header value, comma separated trailers first
+            request = client.get("/");
+            request.addHeader(TE, TRAILERS + ",foo");
+            response = client.request(request);
+            assertThat(response.headers().values(TE), h2PriorKnowledge ?
+                    containsIgnoreCase(TRAILERS) : containsIgnoreCase(TRAILERS + ",foo"));
+
+            // Test single header value, comma separated trailers first with OWS
+            request = client.get("/");
+            request.addHeader(TE, TRAILERS + ", foo");
+            response = client.request(request);
+            assertThat(response.headers().values(TE), h2PriorKnowledge ?
+                    containsIgnoreCase(TRAILERS) : containsIgnoreCase(TRAILERS + ", foo"));
+
+            // Test single header value, comma separated trailers middle
+            request = client.get("/");
+            request.addHeader(TE, "foo," + TRAILERS + ",bar");
+            response = client.request(request);
+            assertThat(response.headers().values(TE), h2PriorKnowledge ?
+                    containsIgnoreCase(TRAILERS) : containsIgnoreCase("foo," + TRAILERS + ",bar"));
+
+            // Test single header value, comma separated trailers middle with OWS
+            request = client.get("/");
+            request.addHeader(TE, "foo, " + TRAILERS + ", bar");
+            response = client.request(request);
+            assertThat(response.headers().values(TE), h2PriorKnowledge ?
+                    containsIgnoreCase(TRAILERS) : containsIgnoreCase("foo, " + TRAILERS + ", bar"));
         }
     }
 
@@ -1712,6 +1776,7 @@ class H2PriorKnowledgeFeatureParityTest {
                         resp.setHeader(TRANSFER_ENCODING, transferEncoding);
                     }
                     resp.headers().set(COOKIE, request.headers().valuesIterator(COOKIE));
+                    resp.headers().set(TE, request.headers().valuesIterator(TE));
                     return succeeded(resp);
                 }).toFuture().get();
         return (InetSocketAddress) h1ServerContext.listenAddress();


### PR DESCRIPTION
Motivation:
HTTP/2 has special rules that TE header is only allowed to have a value of `trailers`. The sanitizing of the TE headers may have infinite looped in some scenarios.