### PR TITLE
H2 conversion support OWS for connection header csv

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -159,20 +159,20 @@ final class H2ToStH1Utils {
         Iterator<? extends CharSequence> connectionItr = h1Headers.valuesIterator(CONNECTION);
         if (connectionItr.hasNext()) {
             do {
-                String connectionHeader = connectionItr.next().toString();
+                CharSequence connectionHeader = connectionItr.next();
                 connectionItr.remove();
-                int i = connectionHeader.indexOf(',');
+                int i = indexOf(connectionHeader, ',', 0);
                 if (i != -1) {
                     int start = 0;
                     do {
-                        h1Headers.remove(connectionHeader.substring(start, i));
+                        h1Headers.remove(connectionHeader.subSequence(start, i));
                         start = i + 1;
                         // Skip OWS
                         if (start < connectionHeader.length() && connectionHeader.charAt(start) == ' ') {
                             ++start;
                         }
-                    } while (start < connectionHeader.length() && (i = connectionHeader.indexOf(',', start)) != -1);
-                    h1Headers.remove(connectionHeader.substring(start));
+                    } while (start < connectionHeader.length() && (i = indexOf(connectionHeader, ',', start)) != -1);
+                    h1Headers.remove(connectionHeader.subSequence(start, connectionHeader.length()));
                 } else {
                     h1Headers.remove(connectionHeader);
                 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -167,6 +167,10 @@ final class H2ToStH1Utils {
                     do {
                         h1Headers.remove(connectionHeader.substring(start, i));
                         start = i + 1;
+                        // Skip OWS
+                        if (start < connectionHeader.length() && connectionHeader.charAt(start) == ' ') {
+                            ++start;
+                        }
                     } while (start < connectionHeader.length() && (i = connectionHeader.indexOf(',', start)) != -1);
                     h1Headers.remove(connectionHeader.substring(start));
                 } else {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -1444,7 +1444,7 @@ class H2PriorKnowledgeFeatureParityTest {
                 }, __ -> { }, identity());
         InetSocketAddress serverAddress = (InetSocketAddress) serverAcceptorChannel.localAddress();
         try (BlockingHttpClient client = forSingleAddress(HostAndPort.of(serverAddress))
-                .protocols(HttpProtocol.HTTP_2.config)
+                .protocols(HttpProtocol.HTTP_2.configOtherHeaderFactory)
                 .enableWireLogging("servicetalk-tests-wire-logger", LogLevel.TRACE, () -> true)
                 .executionStrategy(clientExecutionStrategy)
                 .buildBlocking()) {
@@ -1458,7 +1458,7 @@ class H2PriorKnowledgeFeatureParityTest {
     void h2LayerFiltersOutProhibitedH1HeadersOnServerSide() throws Exception {
         setUp(DEFAULT, true);
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
-                .protocols(HttpProtocol.HTTP_2.config)
+                .protocols(HttpProtocol.HTTP_2.configOtherHeaderFactory)
                 .enableWireLogging("servicetalk-tests-wire-logger", LogLevel.TRACE, () -> true)
                 .listenBlockingAndAwait((ctx, request, responseFactory) -> addProhibitedHeaders(responseFactory.ok()));
              BlockingHttpClient client = forSingleAddress(serverHostAndPort(serverContext))


### PR DESCRIPTION
Motivation:
H2 doesn't support the connection header, and must remove all headers that are referenced in the value of the conneciton header. In the event the connection header contains a CSV we should support OWS.