### PR TITLE
`HeaderUtils`: fix problems with missing space after semicolon

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.plugins.quality.Pmd
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
 
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addManifestAttributes
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addQualityTask
@@ -204,7 +205,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
 
   private static void configureTests(Project project) {
     project.configure(project) {
-      test {
+      tasks.withType(Test).all {
         useJUnitPlatform()
         // expected format for timeout: <number>[ns|μs|ms|s|m|h|d])
         def junit5DefaultTimeout = Boolean.valueOf(System.getenv("CI") ?: "false") ? "30s" : "10s"

--- a/servicetalk-http-api/build.gradle
+++ b/servicetalk-http-api/build.gradle
@@ -75,7 +75,9 @@ sourceSets {
       compileClasspath += main.output + test.output
       runtimeClasspath += main.output + test.output
       srcDirs("src/test")
+      include "**/DefaultHttpSetCookiesTest.java"
       include "**/DefaultHttpSetCookiesRfc6265Test.java"
+      include "**/LegacyCookieParsingTest.java"
     }
   }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpCookiePair.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.api;
 
 import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
 import static io.servicetalk.buffer.api.CharSequences.contentEquals;
-import static io.servicetalk.buffer.api.CharSequences.indexOf;
 import static io.servicetalk.http.api.HeaderUtils.validateCookieNameAndValue;
 
 /**
@@ -51,21 +50,6 @@ public final class DefaultHttpCookiePair implements HttpCookiePair {
         this.name = cookieName;
         this.value = cookieValue;
         this.isWrapped = isWrapped;
-    }
-
-    /**
-     * Parse a <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-pair</a> from {@code sequence}.
-     * @param sequence The {@link CharSequence} that contains a
-     * <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-pair</a>.
-     *
-     * @param nameStart The index were the <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-name</a>
-     * starts in {@code sequence}.
-     * @param valueEnd The end index (exclusive) of the
-     * <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-pair</a> in {@code sequence}.
-     * @return a {@link HttpCookiePair} parsed from {@code sequence}.
-     */
-    static HttpCookiePair parseCookiePair(final CharSequence sequence, int nameStart, int valueEnd) {
-        return parseCookiePair(sequence, nameStart, indexOf(sequence, '=', nameStart) - nameStart, valueEnd);
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -31,7 +31,6 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
 import static io.servicetalk.buffer.api.CharSequences.contentEquals;
 import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.CharSequences.forEachByte;
@@ -136,47 +135,6 @@ public final class HeaderUtils {
             }
             return sb.append(']').toString();
         }
-    }
-
-    static boolean equals(final HttpHeaders lhs, final HttpHeaders rhs) {
-        if (lhs.size() != rhs.size()) {
-            return false;
-        }
-
-        if (lhs == rhs) {
-            return true;
-        }
-
-        // The regular iterator is not suitable for equality comparisons because the overall ordering is not
-        // in any specific order relative to the content of this MultiMap.
-        for (final CharSequence name : lhs.names()) {
-            final Iterator<? extends CharSequence> valueItr = lhs.valuesIterator(name);
-            final Iterator<? extends CharSequence> h2ValueItr = rhs.valuesIterator(name);
-            while (valueItr.hasNext() && h2ValueItr.hasNext()) {
-                if (!contentEquals(valueItr.next(), h2ValueItr.next())) {
-                    return false;
-                }
-            }
-            if (valueItr.hasNext() != h2ValueItr.hasNext()) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    static int hashCode(final HttpHeaders headers) {
-        if (headers.isEmpty()) {
-            return 0;
-        }
-        int result = HASH_CODE_SEED;
-        for (final CharSequence key : headers.names()) {
-            result = 31 * result + caseInsensitiveHashCode(key);
-            final Iterator<? extends CharSequence> valueItr = headers.valuesIterator(key);
-            while (valueItr.hasNext()) {
-                result = 31 * result + caseInsensitiveHashCode(valueItr.next());
-            }
-        }
-        return result;
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -568,14 +568,14 @@ public final class HeaderUtils {
                     cookieHeaderValue, nextNextStart, nameLength, semiIndex);
             if (semiIndex > 0) {
                 if (cookieHeaderValue.length() - 2 <= semiIndex) {
-                    if (cookieParsingStrictRfc6265()) {
+                    if (COOKIE_STRICT_RFC_6265) {
                         throw new IllegalArgumentException("cookie '" + next.name() +
                                 "': cookie is not allowed to end with ;");
                     } else {
                         advanceCookieHeaderValue();
                         nextNextStart = 0;
                     }
-                } else if (cookieParsingStrictRfc6265()) {
+                } else if (COOKIE_STRICT_RFC_6265) {
                     // Skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1)
                     if (cookieHeaderValue.charAt(semiIndex + 1) != ' ') {
                         throw new IllegalArgumentException("cookie '" + next.name() +

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -365,6 +365,10 @@ public final class HeaderUtils {
             int semiIndex = nextCookieDelimiter(cookieString, equalsIndex + 1);
             if (nameLen == cookiePairName.length() &&
                     regionMatches(cookiePairName, true, 0, cookieString, start, nameLen)) {
+                if (COOKIE_STRICT_RFC_6265 && semiIndex > 0 && cookieString.length() - 2 <= semiIndex) {
+                    throw new IllegalArgumentException("cookie '" + cookiePairName +
+                            "': cookie is not allowed to end with ;");
+                }
                 return DefaultHttpCookiePair.parseCookiePair(cookieString, start, nameLen, semiIndex);
             } else if (semiIndex < 0) {
                 break;

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookiesRfc6265Test.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookiesRfc6265Test.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.api;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -24,6 +23,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import static io.servicetalk.http.api.DefaultHttpSetCookiesTest.quotesInValuePreserved;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -55,15 +55,15 @@ class DefaultHttpSetCookiesRfc6265Test {
         Exception exception;
 
         exception = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("first"));
-        MatcherAssert.assertThat(exception.getMessage(),
+        assertThat(exception.getMessage(),
                 allOf(containsString("first"), containsString("space is required after ;")));
 
         exception = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("second"));
-        MatcherAssert.assertThat(exception.getMessage(),
+        assertThat(exception.getMessage(),
                 allOf(containsString("second"), containsString("space is required after ;")));
 
         exception = assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("third"));
-        MatcherAssert.assertThat(exception.getMessage(),
+        assertThat(exception.getMessage(),
                 allOf(containsString("third"), containsString("space is required after ;")));
     }
 
@@ -73,5 +73,14 @@ class DefaultHttpSetCookiesRfc6265Test {
         headers.add("set-cookie",
                 "qwerty=\"12345\"; Domain=somecompany.co.uk; Path=/; Expires=Wed, 30 Aug 2019 00:00:00 GMT");
         quotesInValuePreserved(headers);
+    }
+
+    @Test
+    void cookiesWithoutSpaceAfterSemicolon() {
+        final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
+        headers.add("cookie", "firstCookie=v1;b=v2");
+        Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().forEach(c -> { }));
+        assertThat(e.getMessage(), allOf(containsString("a space is required after ;"),
+                containsString("firstCookie")));
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookiesRfc6265Test.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookiesRfc6265Test.java
@@ -17,37 +17,22 @@ package io.servicetalk.http.api;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
-import static io.servicetalk.http.api.DefaultHttpSetCookiesTest.quotesInValuePreserved;
 import static io.servicetalk.http.api.HeaderUtils.COOKIE_STRICT_RFC_6265;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class DefaultHttpSetCookiesRfc6265Test {
     @Test
     void throwIfNoSpaceBeforeCookieAttributeValue() {
+        assumeTrue(COOKIE_STRICT_RFC_6265);
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.add("set-cookie", "first=12345;Extension");
         headers.add("set-cookie", "second=12345;Expires=Mon, 22 Aug 2022 20:12:35 GMT");
         headers.add("set-cookie", "third=\"12345\";Expires=Mon, 22 Aug 2022 20:12:35 GMT");
-        if (COOKIE_STRICT_RFC_6265) {
-            throwIfNoSpaceBeforeCookieAttributeValue(headers);
-        } else {
-            HttpSetCookie setCookie = headers.getSetCookie("first");
-            assertThat(setCookie, notNullValue());
-            assertThat(setCookie.value(), contentEqualTo("12345"));
-            setCookie = headers.getSetCookie("second");
-            assertThat(setCookie, notNullValue());
-            assertThat(setCookie.value(), contentEqualTo("12345"));
-            setCookie = headers.getSetCookie("third");
-            assertThat(setCookie, notNullValue());
-            assertThat(setCookie.value(), contentEqualTo("12345"));
-            assertThat(setCookie.isWrapped(), equalTo(true));
-        }
+        throwIfNoSpaceBeforeCookieAttributeValue(headers);
     }
 
     private static void throwIfNoSpaceBeforeCookieAttributeValue(HttpHeaders headers) {
@@ -67,15 +52,8 @@ class DefaultHttpSetCookiesRfc6265Test {
     }
 
     @Test
-    void spaceAfterQuotedValue() {
-        final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
-        headers.add("set-cookie",
-                "qwerty=\"12345\"; Domain=somecompany.co.uk; Path=/; Expires=Wed, 30 Aug 2019 00:00:00 GMT");
-        quotesInValuePreserved(headers);
-    }
-
-    @Test
     void cookiesWithoutSpaceAfterSemicolon() {
+        assumeTrue(COOKIE_STRICT_RFC_6265);
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.add("cookie", "firstCookie=v1;b=v2");
         Exception e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().forEach(c -> { }));

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookiesTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookiesTest.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
 import static io.servicetalk.http.api.DefaultHttpSetCookie.parseSetCookie;
+import static io.servicetalk.http.api.HeaderUtils.COOKIE_STRICT_RFC_6265;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.Lax;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.None;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.Strict;
@@ -40,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class DefaultHttpSetCookiesTest {
     @Test
@@ -427,7 +429,7 @@ class DefaultHttpSetCookiesTest {
         quotesInValuePreserved(headers);
     }
 
-    static void quotesInValuePreserved(HttpHeaders headers) {
+    private static void quotesInValuePreserved(HttpHeaders headers) {
         final HttpSetCookie cookie = headers.getSetCookie("qwerty");
         assertNotNull(cookie);
         assertThat(cookie.isWrapped(), is(true));
@@ -736,6 +738,7 @@ class DefaultHttpSetCookiesTest {
 
     @Test
     void mustTolerateNoSpaceBeforeCookieAttributeValue() {
+        assumeFalse(COOKIE_STRICT_RFC_6265);
         final HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
         headers.add("set-cookie", "first=12345;Extension");
         headers.add("set-cookie", "second=12345;Expires=Mon, 22 Aug 2022 20:12:35 GMT");

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LegacyCookieParsingTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LegacyCookieParsingTest.java
@@ -216,7 +216,7 @@ class LegacyCookieParsingTest {
 
     // Client cookie (SET_COOKIE header) decoder tests
     @Test
-    public void testDecodingSingleCookieV0() {
+    void testDecodingSingleCookieV0() {
         String cookieString = "myCookie=myValue;expires="
                 + DateFormatter.format(new Date(System.currentTimeMillis() + 50000))
                 + ";path=/apathsomewhere;domain=.adomainsomewhere;secure;SameSite=None";
@@ -237,7 +237,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingSingleCookieV0ExtraParamsIgnored() {
+    void testDecodingSingleCookieV0ExtraParamsIgnored() {
         String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;" +
                 "domain=.adomainsomewhere;secure;comment=this is a comment;version=0;" +
                 "commentURL=http://aurl.com;port=\"80,8080\";discard;";
@@ -247,7 +247,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingSingleCookieV1() {
+    void testDecodingSingleCookieV1() {
         String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;domain=.adomainsomewhere"
                 + ";secure;comment=this is a comment;version=1;";
         assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies(), contains(new DefaultHttpSetCookie(
@@ -255,7 +255,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingSingleCookieV1ExtraParamsIgnored() {
+    void testDecodingSingleCookieV1ExtraParamsIgnored() {
         String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;"
                 + "domain=.adomainsomewhere;secure;comment=this is a comment;version=1;"
                 + "commentURL=http://aurl.com;port='80,8080';discard;";
@@ -264,7 +264,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingSingleCookieV2() {
+    void testDecodingSingleCookieV2() {
         String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;"
                 + "domain=.adomainsomewhere;secure;comment=this is a comment;version=2;"
                 + "commentURL=http://aurl.com;port=\"80,8080\";discard;";
@@ -273,7 +273,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingComplexCookie() {
+    void testDecodingComplexCookie() {
         String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;"
                 + "domain=.adomainsomewhere;secure;comment=this is a comment;version=2;"
                 + "commentURL=\"http://aurl.com\";port='80,8080';discard;";
@@ -286,7 +286,7 @@ class LegacyCookieParsingTest {
      * Use of commas as delimiters is an RFC 2965 syntax, but it never allowed trailing commas
      */
     @Test
-    public void testDecodingQuotedCookie() {
+    void testDecodingQuotedCookie() {
         HttpSetCookie cookie = headers.add(SET_COOKIE, "a=\"\"").getSetCookie("a");
         assertEquals("a", cookie.name());
         assertEquals("", cookie.value());
@@ -297,7 +297,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingGoogleAnalyticsCookie() {
+    void testDecodingGoogleAnalyticsCookie() {
         String source = "ARPT=LWUKQPSWRTUN04CKKJI; "
                 + "kw-2E343B92-B097-442c-BFA5-BE371E0325A2=unfinished furniture; "
                 + "__utma=48461872.1094088325.1258140131.1258140131.1258140131.1; "
@@ -312,7 +312,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingLongDates() {
+    void testDecodingLongDates() {
         Calendar cookieDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         cookieDate.set(9999, Calendar.DECEMBER, 31, 23, 59, 59);
         String source = "Format=EU; expires=Fri, 31-Dec-9999 23:59:59 GMT; path=/";
@@ -328,7 +328,7 @@ class LegacyCookieParsingTest {
      * and that means they are allowed in cookie values. Previously, parsing such a cookie would throw an exception.
      */
     @Test
-    public void testDecodingValueWithCommaDoesNotFail() {
+    void testDecodingValueWithCommaDoesNotFail() {
         String source = "UserCookie=timeZoneName=(GMT+04:00) Moscow, St. Petersburg, Volgograd&promocode=&region=BE;"
                 + " expires=Sat, 01-Dec-2012 10:53:31 GMT; path=/";
 
@@ -340,7 +340,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingWeirdNames1() {
+    void testDecodingWeirdNames1() {
         String source = "path=; expires=Mon, 01-Jan-1990 00:00:00 GMT; path=/; domain=.www.google.com";
         headers.add(SET_COOKIE, source);
         HttpSetCookie cookie = headers.getSetCookie("path");
@@ -351,7 +351,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingWeirdNames2() {
+    void testDecodingWeirdNames2() {
         String source = "HTTPOnly=";
         headers.add(SET_COOKIE, source);
         HttpSetCookie cookie = headers.getSetCookie("HTTPOnly");
@@ -361,7 +361,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingValuesWithCommasAndEqualsFails() {
+    void testDecodingValuesWithCommasAndEqualsFails() {
         headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders(); // Enable validation
         String source = "A=v=1&lg=en-US,it-IT,it&intl=it&np=1;T=z=E";
         headers.add(SET_COOKIE, source);
@@ -369,7 +369,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingInvalidValuesWithCommaAtStart() {
+    void testDecodingInvalidValuesWithCommaAtStart() {
         headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders(); // Enable validation
         headers.add(SET_COOKIE, ",");
         assertThrows(IllegalArgumentException.class, () -> headers.getSetCookies().iterator().next());
@@ -382,7 +382,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testDecodingLongValue() {
+    void testDecodingLongValue() {
         String longValue =
                 "b___$Q__$ha__<NC=MN(F__%#4__<NC=MN(F__2_d____#=IvZB__2_F____'=KqtH__2-9____" +
                         "'=IvZM__3f:____$=HbQW__3g'____%=J^wI__3g-____%=J^wI__3g1____$=HbQW__3g2____" +
@@ -436,7 +436,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testIgnoreEmptyDomain() {
+    void testIgnoreEmptyDomain() {
         String emptyDomain = "sessionid=OTY4ZDllNTgtYjU3OC00MWRjLTkzMWMtNGUwNzk4MTY0MTUw;Domain=;Path=/";
         headers.add(SET_COOKIE, emptyDomain);
         HttpSetCookie cookie = headers.getSetCookie("sessionid");
@@ -445,7 +445,7 @@ class LegacyCookieParsingTest {
     }
 
     @Test
-    public void testIgnoreEmptyPath() {
+    void testIgnoreEmptyPath() {
         String emptyPath = "sessionid=OTY4ZDllNTgtYjU3OC00MWRjLTkzMWMtNGUwNzk4MTY0MTUw;Domain=;Path=";
         headers.add(SET_COOKIE, emptyPath);
         HttpSetCookie cookie = headers.getSetCookie("sessionid");

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LegacyCookieParsingTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LegacyCookieParsingTest.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.servicetalk.http.api;
+
+import io.netty.handler.codec.DateFormatter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
+import static io.servicetalk.http.api.HttpHeaderNames.COOKIE;
+import static io.servicetalk.http.api.HttpHeaderNames.SET_COOKIE;
+import static io.servicetalk.http.api.HttpSetCookie.SameSite.None;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests from the old Netty 4.1 ClientCookieDecoder and ServerCookieDecoder.
+ * Those decoders were tested on cookie formats for older RFCs.
+ * We recreate those tests here, to verify that we're still compatible with those formats.
+ */
+class LegacyCookieParsingTest {
+
+    private static final HttpHeadersFactory NO_VALIDATION = new DefaultHttpHeadersFactory(false, false, false);
+    HttpHeaders headers;
+
+    @BeforeEach
+    void createHeaders() {
+        headers = NO_VALIDATION.newHeaders();
+    }
+
+    // Server cookie (COOKIE header) decoder tests
+    @Test
+    void decodingSingleServerCookie() {
+        headers.add(COOKIE, "myCookie=myValue");
+        assertThat(headers.getCookies(), iterableWithSize(1));
+        assertThat(headers.getCookies(), contains(new DefaultHttpCookiePair("myCookie", "myValue")));
+    }
+
+    @Test
+    void decodingMultipleServerCookies() {
+        String c1 = "myCookie=myValue;";
+        String c2 = "myCookie2=myValue2;";
+        String c3 = "myCookie3=myValue3;";
+        headers.add(COOKIE, c1 + c2 + c3);
+        assertThat(headers.getCookies(), iterableWithSize(3));
+        assertThat(headers.getCookies(), containsInAnyOrder(
+                new DefaultHttpCookiePair("myCookie", "myValue"),
+                new DefaultHttpCookiePair("myCookie2", "myValue2"),
+                new DefaultHttpCookiePair("myCookie3", "myValue3")));
+    }
+
+    @Test
+    void decodingMultipleSameNamedServerCookies() {
+        String c1 = "myCookie=myValue;";
+        String c2 = "myCookie=myValue2;";
+        String c3 = "myCookie=myValue3;";
+        headers.add(COOKIE, c1 + c2 + c3);
+        assertThat(headers.getCookies(), iterableWithSize(3));
+        assertThat(headers.getCookies(), containsInAnyOrder(
+                new DefaultHttpCookiePair("myCookie", "myValue"),
+                new DefaultHttpCookiePair("myCookie", "myValue2"),
+                new DefaultHttpCookiePair("myCookie", "myValue3")));
+    }
+
+    @Test
+    void decodingGoogleAnalyticsServerCookie() {
+        String source = "ARPT=LWUKQPSWRTUN04CKKJI; " +
+                "kw-2E343B92-B097-442c-BFA5-BE371E0325A2=unfinished_furniture; " +
+                "__utma=48461872.1094088325.1258140131.1258140131.1258140131.1; " +
+                "__utmb=48461872.13.10.1258140131; __utmc=48461872; " +
+                "__utmz=48461872.1258140131.1.1.utmcsr=overstock.com|utmccn=(referral)|" +
+                "utmcmd=referral|utmcct=/Home-Garden/Furniture/Clearance/clearance/32/dept.html";
+        Iterable<? extends HttpCookiePair> cookies = headers.add(COOKIE, source).getCookies();
+        assertThat(cookies, containsInAnyOrder(
+                new DefaultHttpCookiePair("ARPT", "LWUKQPSWRTUN04CKKJI"),
+                new DefaultHttpCookiePair("kw-2E343B92-B097-442c-BFA5-BE371E0325A2", "unfinished_furniture"),
+                new DefaultHttpCookiePair("__utma", "48461872.1094088325.1258140131.1258140131.1258140131.1"),
+                new DefaultHttpCookiePair("__utmb", "48461872.13.10.1258140131"),
+                new DefaultHttpCookiePair("__utmc", "48461872"),
+                new DefaultHttpCookiePair("__utmz", "48461872.1258140131.1.1.utmcsr=overstock.com|utmccn=(referral)|" +
+                        "utmcmd=referral|utmcct=/Home-Garden/Furniture/Clearance/clearance/32/dept.html")));
+    }
+
+    @Test
+    void decodingLongServerCookieValue() {
+        String longValue =
+                "b___$Q__$ha__<NC=MN(F__%#4__<NC=MN(F__2_d____#=IvZB__2_F____'=KqtH__2-9____" +
+                        "'=IvZM__3f:____$=HbQW__3g'____%=J^wI__3g-____%=J^wI__3g1____$=HbQW__3g2____" +
+                        "$=HbQW__3g5____%=J^wI__3g9____$=HbQW__3gT____$=HbQW__3gX____#=J^wI__3gY____" +
+                        "#=J^wI__3gh____$=HbQW__3gj____$=HbQW__3gr____$=HbQW__3gx____#=J^wI__3h_____" +
+                        "$=HbQW__3h$____#=J^wI__3h'____$=HbQW__3h_____$=HbQW__3h0____%=J^wI__3h1____" +
+                        "#=J^wI__3h2____$=HbQW__3h4____$=HbQW__3h7____$=HbQW__3h8____%=J^wI__3h:____" +
+                        "#=J^wI__3h@____%=J^wI__3hB____$=HbQW__3hC____$=HbQW__3hL____$=HbQW__3hQ____" +
+                        "$=HbQW__3hS____%=J^wI__3hU____$=HbQW__3h[____$=HbQW__3h^____$=HbQW__3hd____" +
+                        "%=J^wI__3he____%=J^wI__3hf____%=J^wI__3hg____$=HbQW__3hh____%=J^wI__3hi____" +
+                        "%=J^wI__3hv____$=HbQW__3i/____#=J^wI__3i2____#=J^wI__3i3____%=J^wI__3i4____" +
+                        "$=HbQW__3i7____$=HbQW__3i8____$=HbQW__3i9____%=J^wI__3i=____#=J^wI__3i>____" +
+                        "%=J^wI__3iD____$=HbQW__3iF____#=J^wI__3iH____%=J^wI__3iM____%=J^wI__3iS____" +
+                        "#=J^wI__3iU____%=J^wI__3iZ____#=J^wI__3i]____%=J^wI__3ig____%=J^wI__3ij____" +
+                        "%=J^wI__3ik____#=J^wI__3il____$=HbQW__3in____%=J^wI__3ip____$=HbQW__3iq____" +
+                        "$=HbQW__3it____%=J^wI__3ix____#=J^wI__3j_____$=HbQW__3j%____$=HbQW__3j'____" +
+                        "%=J^wI__3j(____%=J^wI__9mJ____'=KqtH__=SE__<NC=MN(F__?VS__<NC=MN(F__Zw`____" +
+                        "%=KqtH__j+C__<NC=MN(F__j+M__<NC=MN(F__j+a__<NC=MN(F__j_.__<NC=MN(F__n>M____" +
+                        "'=KqtH__s1X____$=MMyc__s1_____#=MN#O__ypn____'=KqtH__ypr____'=KqtH_#%h_____" +
+                        "%=KqtH_#%o_____'=KqtH_#)H6__<NC=MN(F_#*%'____%=KqtH_#+k(____'=KqtH_#-E_____" +
+                        "'=KqtH_#1)w____'=KqtH_#1)y____'=KqtH_#1*M____#=KqtH_#1*p____'=KqtH_#14Q__<N" +
+                        "C=MN(F_#14S__<NC=MN(F_#16I__<NC=MN(F_#16N__<NC=MN(F_#16X__<NC=MN(F_#16k__<N" +
+                        "C=MN(F_#17@__<NC=MN(F_#17A__<NC=MN(F_#1Cq____'=KqtH_#7)_____#=KqtH_#7)b____" +
+                        "#=KqtH_#7Ww____'=KqtH_#?cQ____'=KqtH_#His____'=KqtH_#Jrh____'=KqtH_#O@M__<N" +
+                        "C=MN(F_#O@O__<NC=MN(F_#OC6__<NC=MN(F_#Os.____#=KqtH_#YOW____#=H/Li_#Zat____" +
+                        "'=KqtH_#ZbI____%=KqtH_#Zbc____'=KqtH_#Zbs____%=KqtH_#Zby____'=KqtH_#Zce____" +
+                        "'=KqtH_#Zdc____%=KqtH_#Zea____'=KqtH_#ZhI____#=KqtH_#ZiD____'=KqtH_#Zis____" +
+                        "'=KqtH_#Zj0____#=KqtH_#Zj1____'=KqtH_#Zj[____'=KqtH_#Zj]____'=KqtH_#Zj^____" +
+                        "'=KqtH_#Zjb____'=KqtH_#Zk_____'=KqtH_#Zk6____#=KqtH_#Zk9____%=KqtH_#Zk<____" +
+                        "'=KqtH_#Zl>____'=KqtH_#]9R____$=H/Lt_#]I6____#=KqtH_#]Z#____%=KqtH_#^*N____" +
+                        "#=KqtH_#^:m____#=KqtH_#_*_____%=J^wI_#`-7____#=KqtH_#`T>____'=KqtH_#`T?____" +
+                        "'=KqtH_#`TA____'=KqtH_#`TB____'=KqtH_#`TG____'=KqtH_#`TP____#=KqtH_#`U_____" +
+                        "'=KqtH_#`U/____'=KqtH_#`U0____#=KqtH_#`U9____'=KqtH_#aEQ____%=KqtH_#b<)____" +
+                        "'=KqtH_#c9-____%=KqtH_#dxC____%=KqtH_#dxE____%=KqtH_#ev$____'=KqtH_#fBi____" +
+                        "#=KqtH_#fBj____'=KqtH_#fG)____'=KqtH_#fG+____'=KqtH_#g<d____'=KqtH_#g<e____" +
+                        "'=KqtH_#g=J____'=KqtH_#gat____#=KqtH_#s`D____#=J_#p_#sg?____#=J_#p_#t<a____" +
+                        "#=KqtH_#t<c____#=KqtH_#trY____$=JiYj_#vA$____'=KqtH_#xs_____'=KqtH_$$rO____" +
+                        "#=KqtH_$$rP____#=KqtH_$(_%____'=KqtH_$)]o____%=KqtH_$_@)____'=KqtH_$_k]____" +
+                        "'=KqtH_$1]+____%=KqtH_$3IO____%=KqtH_$3J#____'=KqtH_$3J.____'=KqtH_$3J:____" +
+                        "#=KqtH_$3JH____#=KqtH_$3JI____#=KqtH_$3JK____%=KqtH_$3JL____'=KqtH_$3JS____" +
+                        "'=KqtH_$8+M____#=KqtH_$99d____%=KqtH_$:Lw____#=LK+x_$:N@____#=KqtG_$:NC____" +
+                        "#=KqtG_$:hW____'=KqtH_$:i[____'=KqtH_$:ih____'=KqtH_$:it____'=KqtH_$:kO____" +
+                        "'=KqtH_$>*B____'=KqtH_$>hD____+=J^x0_$?lW____'=KqtH_$?ll____'=KqtH_$?lm____" +
+                        "%=KqtH_$?mi____'=KqtH_$?mx____'=KqtH_$D7]____#=J_#p_$D@T____#=J_#p_$V<g____" +
+                        "'=KqtH";
+        Iterable<? extends HttpCookiePair> cookies = headers.add(COOKIE, "bh=\"" + longValue + "\";").getCookies();
+        assertThat(cookies, iterableWithSize(1));
+        assertThat(cookies, contains(new DefaultHttpCookiePair("bh", longValue)));
+    }
+
+    /**
+     * Note: here we're deviating from Netty 4.1. We don't support RFC 2965 cookies anymore.
+     */
+    @Test
+    void decodingOldRFC2965Cookies() {
+        String source = "$Version=\"1\"; " +
+                "Part_Number1=\"Riding_Rocket_0023\"; $Path=\"/acme/ammo\"; " +
+                "Part_Number2=\"Rocket_Launcher_0001\"; $Path=\"/acme\"";
+
+        Iterable<? extends HttpCookiePair> cookies = headers.add(COOKIE, source).getCookies();
+        assertThat(cookies, containsInAnyOrder(
+                new DefaultHttpCookiePair("$Version", "1"), // Would be hidden in RFC 2965
+                new DefaultHttpCookiePair("Part_Number1", "Riding_Rocket_0023"),
+                new DefaultHttpCookiePair("$Path", "/acme/ammo"), // Would be hidden in RFC 2965
+                new DefaultHttpCookiePair("Part_Number2", "Rocket_Launcher_0001"),
+                new DefaultHttpCookiePair("$Path", "/acme"))); // Would be hidden in RFC 2965
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void rejectServerCookieWithSemicolonInValue() {
+        headers.add(COOKIE, "name=\"foo;bar\";");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> headers.getCookies().iterator().hasNext());
+        assertThat(e.getMessage(), containsString("The ; character cannot appear in quoted cookie values"));
+
+        e = assertThrows(IllegalArgumentException.class, () -> headers.getCookies().iterator().next());
+        assertThat(e.getMessage(), containsString("The ; character cannot appear in quoted cookie values"));
+    }
+
+    @Test
+    void caseSensitiveServerCookieNames() {
+        Iterable<? extends HttpCookiePair> cookies = headers.add(COOKIE, "session_id=a; Session_id=b;").getCookies();
+        assertThat(cookies, containsInAnyOrder(
+                new DefaultHttpCookiePair("Session_id", "b"),
+                new DefaultHttpCookiePair("session_id", "a")));
+    }
+
+    // Client cookie (SET_COOKIE header) decoder tests
+    @Test
+    public void testDecodingSingleCookieV0() {
+        String cookieString = "myCookie=myValue;expires="
+                + DateFormatter.format(new Date(System.currentTimeMillis() + 50000))
+                + ";path=/apathsomewhere;domain=.adomainsomewhere;secure;SameSite=None";
+
+        HttpSetCookie cookie = headers.add(SET_COOKIE, cookieString).getSetCookie("myCookie");
+        assertNotNull(cookie);
+        assertEquals("myValue", cookie.value());
+        assertEquals(".adomainsomewhere", cookie.domain());
+        assertNotEquals(Long.MIN_VALUE, cookie.maxAge(),
+                "maxAge should be defined when parsing cookie " + cookieString);
+        assertNull(cookie.maxAge());
+        assertNotNull(cookie.expires());
+        assertEquals("/apathsomewhere", cookie.path());
+        assertTrue(cookie.isSecure());
+
+        assertThat(cookie, is(instanceOf(DefaultHttpSetCookie.class)));
+        assertEquals(None, cookie.sameSite());
+    }
+
+    @Test
+    public void testDecodingSingleCookieV0ExtraParamsIgnored() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;" +
+                "domain=.adomainsomewhere;secure;comment=this is a comment;version=0;" +
+                "commentURL=http://aurl.com;port=\"80,8080\";discard;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies(), contains(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L,
+                None, false, true, false)));
+    }
+
+    @Test
+    public void testDecodingSingleCookieV1() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;domain=.adomainsomewhere"
+                + ";secure;comment=this is a comment;version=1;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies(), contains(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L, None, false, true, false)));
+    }
+
+    @Test
+    public void testDecodingSingleCookieV1ExtraParamsIgnored() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;"
+                + "domain=.adomainsomewhere;secure;comment=this is a comment;version=1;"
+                + "commentURL=http://aurl.com;port='80,8080';discard;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies(), contains(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L, None, false, true, false)));
+    }
+
+    @Test
+    public void testDecodingSingleCookieV2() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;"
+                + "domain=.adomainsomewhere;secure;comment=this is a comment;version=2;"
+                + "commentURL=http://aurl.com;port=\"80,8080\";discard;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies(), contains(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L, None, false, true, false)));
+    }
+
+    @Test
+    public void testDecodingComplexCookie() {
+        String cookieString = "myCookie=myValue;max-age=50;path=/apathsomewhere;"
+                + "domain=.adomainsomewhere;secure;comment=this is a comment;version=2;"
+                + "commentURL=\"http://aurl.com\";port='80,8080';discard;";
+        assertThat(headers.add(SET_COOKIE, cookieString).getSetCookies(), contains(new DefaultHttpSetCookie(
+                "myCookie", "myValue", "/apathsomewhere", ".adomainsomewhere", null, 50L, None, false, true, false)));
+    }
+
+    /**
+     * Note: deviating from Netty 4.1 test, where the strings had a trailing comma ','.
+     * Use of commas as delimiters is an RFC 2965 syntax, but it never allowed trailing commas
+     */
+    @Test
+    public void testDecodingQuotedCookie() {
+        HttpSetCookie cookie = headers.add(SET_COOKIE, "a=\"\"").getSetCookie("a");
+        assertEquals("a", cookie.name());
+        assertEquals("", cookie.value());
+
+        cookie = headers.add(SET_COOKIE, "b=\"1\"").getSetCookie("b");
+        assertEquals("b", cookie.name());
+        assertEquals("1", cookie.value());
+    }
+
+    @Test
+    public void testDecodingGoogleAnalyticsCookie() {
+        String source = "ARPT=LWUKQPSWRTUN04CKKJI; "
+                + "kw-2E343B92-B097-442c-BFA5-BE371E0325A2=unfinished furniture; "
+                + "__utma=48461872.1094088325.1258140131.1258140131.1258140131.1; "
+                + "__utmb=48461872.13.10.1258140131; __utmc=48461872; "
+                + "__utmz=48461872.1258140131.1.1.utmcsr=overstock.com|utmccn=(referral)|"
+                + "utmcmd=referral|utmcct=/Home-Garden/Furniture/Clearance,/clearance,/32/dept.html";
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("ARPT");
+
+        assertEquals("ARPT", cookie.name());
+        assertEquals("LWUKQPSWRTUN04CKKJI", cookie.value());
+    }
+
+    @Test
+    public void testDecodingLongDates() {
+        Calendar cookieDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        cookieDate.set(9999, Calendar.DECEMBER, 31, 23, 59, 59);
+        String source = "Format=EU; expires=Fri, 31-Dec-9999 23:59:59 GMT; path=/";
+
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("Format");
+        assertNotNull(cookie);
+        assertNotNull(cookie.expires());
+    }
+
+    /**
+     * Deviating from the old cookie parser. Since obsoleting RFC 2965, commas are no longer a field delimiter,
+     * and that means they are allowed in cookie values. Previously, parsing such a cookie would throw an exception.
+     */
+    @Test
+    public void testDecodingValueWithCommaDoesNotFail() {
+        String source = "UserCookie=timeZoneName=(GMT+04:00) Moscow, St. Petersburg, Volgograd&promocode=&region=BE;"
+                + " expires=Sat, 01-Dec-2012 10:53:31 GMT; path=/";
+
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("UserCookie");
+        assertThat(cookie, equalTo(new DefaultHttpSetCookie(
+                "UserCookie", "timeZoneName=(GMT+04:00) Moscow, St. Petersburg, Volgograd&promocode=&region=BE",
+                "/", null, "Sat, 01-Dec-2012 10:53:31 GMT", null, None, false, false, false)));
+    }
+
+    @Test
+    public void testDecodingWeirdNames1() {
+        String source = "path=; expires=Mon, 01-Jan-1990 00:00:00 GMT; path=/; domain=.www.google.com";
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("path");
+        assertNotNull(cookie);
+        assertEquals("path", cookie.name());
+        assertEquals("", cookie.value());
+        assertEquals("/", cookie.path());
+    }
+
+    @Test
+    public void testDecodingWeirdNames2() {
+        String source = "HTTPOnly=";
+        headers.add(SET_COOKIE, source);
+        HttpSetCookie cookie = headers.getSetCookie("HTTPOnly");
+        assertNotNull(cookie);
+        assertEquals("HTTPOnly", cookie.name());
+        assertEquals("", cookie.value());
+    }
+
+    @Test
+    public void testDecodingValuesWithCommasAndEqualsFails() {
+        headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders(); // Enable validation
+        String source = "A=v=1&lg=en-US,it-IT,it&intl=it&np=1;T=z=E";
+        headers.add(SET_COOKIE, source);
+        assertThrows(IllegalArgumentException.class, () -> headers.getSetCookie("A"));
+    }
+
+    @Test
+    public void testDecodingInvalidValuesWithCommaAtStart() {
+        headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders(); // Enable validation
+        headers.add(SET_COOKIE, ",");
+        assertThrows(IllegalArgumentException.class, () -> headers.getSetCookies().iterator().next());
+        headers.clear();
+        headers.add(SET_COOKIE, ",a");
+        assertThrows(IllegalArgumentException.class, () -> headers.getSetCookies().iterator().next());
+        headers.clear();
+        headers.add(SET_COOKIE, ",a=a");
+        assertThrows(IllegalArgumentException.class, () -> headers.getSetCookies().iterator().next());
+    }
+
+    @Test
+    public void testDecodingLongValue() {
+        String longValue =
+                "b___$Q__$ha__<NC=MN(F__%#4__<NC=MN(F__2_d____#=IvZB__2_F____'=KqtH__2-9____" +
+                        "'=IvZM__3f:____$=HbQW__3g'____%=J^wI__3g-____%=J^wI__3g1____$=HbQW__3g2____" +
+                        "$=HbQW__3g5____%=J^wI__3g9____$=HbQW__3gT____$=HbQW__3gX____#=J^wI__3gY____" +
+                        "#=J^wI__3gh____$=HbQW__3gj____$=HbQW__3gr____$=HbQW__3gx____#=J^wI__3h_____" +
+                        "$=HbQW__3h$____#=J^wI__3h'____$=HbQW__3h_____$=HbQW__3h0____%=J^wI__3h1____" +
+                        "#=J^wI__3h2____$=HbQW__3h4____$=HbQW__3h7____$=HbQW__3h8____%=J^wI__3h:____" +
+                        "#=J^wI__3h@____%=J^wI__3hB____$=HbQW__3hC____$=HbQW__3hL____$=HbQW__3hQ____" +
+                        "$=HbQW__3hS____%=J^wI__3hU____$=HbQW__3h[____$=HbQW__3h^____$=HbQW__3hd____" +
+                        "%=J^wI__3he____%=J^wI__3hf____%=J^wI__3hg____$=HbQW__3hh____%=J^wI__3hi____" +
+                        "%=J^wI__3hv____$=HbQW__3i/____#=J^wI__3i2____#=J^wI__3i3____%=J^wI__3i4____" +
+                        "$=HbQW__3i7____$=HbQW__3i8____$=HbQW__3i9____%=J^wI__3i=____#=J^wI__3i>____" +
+                        "%=J^wI__3iD____$=HbQW__3iF____#=J^wI__3iH____%=J^wI__3iM____%=J^wI__3iS____" +
+                        "#=J^wI__3iU____%=J^wI__3iZ____#=J^wI__3i]____%=J^wI__3ig____%=J^wI__3ij____" +
+                        "%=J^wI__3ik____#=J^wI__3il____$=HbQW__3in____%=J^wI__3ip____$=HbQW__3iq____" +
+                        "$=HbQW__3it____%=J^wI__3ix____#=J^wI__3j_____$=HbQW__3j%____$=HbQW__3j'____" +
+                        "%=J^wI__3j(____%=J^wI__9mJ____'=KqtH__=SE__<NC=MN(F__?VS__<NC=MN(F__Zw`____" +
+                        "%=KqtH__j+C__<NC=MN(F__j+M__<NC=MN(F__j+a__<NC=MN(F__j_.__<NC=MN(F__n>M____" +
+                        "'=KqtH__s1X____$=MMyc__s1_____#=MN#O__ypn____'=KqtH__ypr____'=KqtH_#%h_____" +
+                        "%=KqtH_#%o_____'=KqtH_#)H6__<NC=MN(F_#*%'____%=KqtH_#+k(____'=KqtH_#-E_____" +
+                        "'=KqtH_#1)w____'=KqtH_#1)y____'=KqtH_#1*M____#=KqtH_#1*p____'=KqtH_#14Q__<N" +
+                        "C=MN(F_#14S__<NC=MN(F_#16I__<NC=MN(F_#16N__<NC=MN(F_#16X__<NC=MN(F_#16k__<N" +
+                        "C=MN(F_#17@__<NC=MN(F_#17A__<NC=MN(F_#1Cq____'=KqtH_#7)_____#=KqtH_#7)b____" +
+                        "#=KqtH_#7Ww____'=KqtH_#?cQ____'=KqtH_#His____'=KqtH_#Jrh____'=KqtH_#O@M__<N" +
+                        "C=MN(F_#O@O__<NC=MN(F_#OC6__<NC=MN(F_#Os.____#=KqtH_#YOW____#=H/Li_#Zat____" +
+                        "'=KqtH_#ZbI____%=KqtH_#Zbc____'=KqtH_#Zbs____%=KqtH_#Zby____'=KqtH_#Zce____" +
+                        "'=KqtH_#Zdc____%=KqtH_#Zea____'=KqtH_#ZhI____#=KqtH_#ZiD____'=KqtH_#Zis____" +
+                        "'=KqtH_#Zj0____#=KqtH_#Zj1____'=KqtH_#Zj[____'=KqtH_#Zj]____'=KqtH_#Zj^____" +
+                        "'=KqtH_#Zjb____'=KqtH_#Zk_____'=KqtH_#Zk6____#=KqtH_#Zk9____%=KqtH_#Zk<____" +
+                        "'=KqtH_#Zl>____'=KqtH_#]9R____$=H/Lt_#]I6____#=KqtH_#]Z#____%=KqtH_#^*N____" +
+                        "#=KqtH_#^:m____#=KqtH_#_*_____%=J^wI_#`-7____#=KqtH_#`T>____'=KqtH_#`T?____" +
+                        "'=KqtH_#`TA____'=KqtH_#`TB____'=KqtH_#`TG____'=KqtH_#`TP____#=KqtH_#`U_____" +
+                        "'=KqtH_#`U/____'=KqtH_#`U0____#=KqtH_#`U9____'=KqtH_#aEQ____%=KqtH_#b<)____" +
+                        "'=KqtH_#c9-____%=KqtH_#dxC____%=KqtH_#dxE____%=KqtH_#ev$____'=KqtH_#fBi____" +
+                        "#=KqtH_#fBj____'=KqtH_#fG)____'=KqtH_#fG+____'=KqtH_#g<d____'=KqtH_#g<e____" +
+                        "'=KqtH_#g=J____'=KqtH_#gat____#=KqtH_#s`D____#=J_#p_#sg?____#=J_#p_#t<a____" +
+                        "#=KqtH_#t<c____#=KqtH_#trY____$=JiYj_#vA$____'=KqtH_#xs_____'=KqtH_$$rO____" +
+                        "#=KqtH_$$rP____#=KqtH_$(_%____'=KqtH_$)]o____%=KqtH_$_@)____'=KqtH_$_k]____" +
+                        "'=KqtH_$1]+____%=KqtH_$3IO____%=KqtH_$3J#____'=KqtH_$3J.____'=KqtH_$3J:____" +
+                        "#=KqtH_$3JH____#=KqtH_$3JI____#=KqtH_$3JK____%=KqtH_$3JL____'=KqtH_$3JS____" +
+                        "'=KqtH_$8+M____#=KqtH_$99d____%=KqtH_$:Lw____#=LK+x_$:N@____#=KqtG_$:NC____" +
+                        "#=KqtG_$:hW____'=KqtH_$:i[____'=KqtH_$:ih____'=KqtH_$:it____'=KqtH_$:kO____" +
+                        "'=KqtH_$>*B____'=KqtH_$>hD____+=J^x0_$?lW____'=KqtH_$?ll____'=KqtH_$?lm____" +
+                        "%=KqtH_$?mi____'=KqtH_$?mx____'=KqtH_$D7]____#=J_#p_$D@T____#=J_#p_$V<g____" +
+                        "'=KqtH";
+
+        headers.add(SET_COOKIE, "bh=\"" + longValue + "\";");
+        HttpSetCookie cookie = headers.getSetCookie("bh");
+        assertEquals("bh", cookie.name());
+        assertEquals(longValue, cookie.value());
+    }
+
+    @Test
+    public void testIgnoreEmptyDomain() {
+        String emptyDomain = "sessionid=OTY4ZDllNTgtYjU3OC00MWRjLTkzMWMtNGUwNzk4MTY0MTUw;Domain=;Path=/";
+        headers.add(SET_COOKIE, emptyDomain);
+        HttpSetCookie cookie = headers.getSetCookie("sessionid");
+        assertNotNull(cookie);
+        assertThat(cookie.domain(), contentEqualTo(""));
+    }
+
+    @Test
+    public void testIgnoreEmptyPath() {
+        String emptyPath = "sessionid=OTY4ZDllNTgtYjU3OC00MWRjLTkzMWMtNGUwNzk4MTY0MTUw;Domain=;Path=";
+        headers.add(SET_COOKIE, emptyPath);
+        HttpSetCookie cookie = headers.getSetCookie("sessionid");
+        assertNotNull(cookie);
+        assertThat(cookie.path(), contentEqualTo(""));
+    }
+}

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LegacyCookieParsingTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/LegacyCookieParsingTest.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
+import static io.servicetalk.http.api.HeaderUtils.COOKIE_STRICT_RFC_6265;
 import static io.servicetalk.http.api.HttpHeaderNames.COOKIE;
 import static io.servicetalk.http.api.HttpHeaderNames.SET_COOKIE;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.None;
@@ -55,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Tests from the old Netty 4.1 ClientCookieDecoder and ServerCookieDecoder.
@@ -81,6 +83,7 @@ class LegacyCookieParsingTest {
 
     @Test
     void decodingMultipleServerCookies() {
+        assumeFalse(COOKIE_STRICT_RFC_6265);
         String c1 = "myCookie=myValue;";
         String c2 = "myCookie2=myValue2;";
         String c3 = "myCookie3=myValue3;";
@@ -94,6 +97,7 @@ class LegacyCookieParsingTest {
 
     @Test
     void decodingMultipleSameNamedServerCookies() {
+        assumeFalse(COOKIE_STRICT_RFC_6265);
         String c1 = "myCookie=myValue;";
         String c2 = "myCookie=myValue2;";
         String c3 = "myCookie=myValue3;";
@@ -126,6 +130,7 @@ class LegacyCookieParsingTest {
 
     @Test
     void decodingLongServerCookieValue() {
+        assumeFalse(COOKIE_STRICT_RFC_6265);
         String longValue =
                 "b___$Q__$ha__<NC=MN(F__%#4__<NC=MN(F__2_d____#=IvZB__2_F____'=KqtH__2-9____" +
                         "'=IvZM__3f:____$=HbQW__3g'____%=J^wI__3g-____%=J^wI__3g1____$=HbQW__3g2____" +
@@ -208,6 +213,7 @@ class LegacyCookieParsingTest {
 
     @Test
     void caseSensitiveServerCookieNames() {
+        assumeFalse(COOKIE_STRICT_RFC_6265);
         Iterable<? extends HttpCookiePair> cookies = headers.add(COOKIE, "session_id=a; Session_id=b;").getCookies();
         assertThat(cookies, containsInAnyOrder(
                 new DefaultHttpCookiePair("Session_id", "b"),

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -114,6 +114,9 @@ final class H2ToStH1Utils {
                         if (i + 1 < nextCookie.length() && nextCookie.charAt(i + 1) != ' ') {
                             throwNoSpaceAfterCookieCrumb(cookieCrumb);
                         }
+                        if (nextCookie.length() - 2 <= i) {
+                            throwNotAllowedToEndWithSemicolon(cookieCrumb);
+                        }
                         // skip 2 characters "; " (see https://tools.ietf.org/html/rfc6265#section-4.2.1).
                         start = i + 2;
                     } while (start >= 0 && start < nextCookie.length() &&
@@ -143,6 +146,12 @@ final class H2ToStH1Utils {
         final CharSequence name = nameEnd > 0 ? cookieCrumb.subSequence(0, nameEnd) : cookieCrumb;
         throw new IllegalArgumentException("cookie " + name +
                 " must have a space after ; in cookie attribute-value lists");
+    }
+
+    private static void throwNotAllowedToEndWithSemicolon(CharSequence cookieCrumb) {
+        final int nameEnd = indexOf(cookieCrumb, '=', 0);
+        final CharSequence name = nameEnd > 0 ? cookieCrumb.subSequence(0, nameEnd) : cookieCrumb;
+        throw new IllegalArgumentException("cookie '" + name + "': cookie is not allowed to end with ;");
     }
 
     static Http2Headers h1HeadersToH2Headers(HttpHeaders h1Headers) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -366,10 +366,10 @@ class H2PriorKnowledgeFeatureParityTest {
                     "name1=value1; name2=value2; name3=value3" :
                     "name1=value1;name2=value2;name3=value3";
             if (endsWithSemi) {
-                requestCookie = requestCookie + ';';
+                requestCookie += ';';
             }
             request.addHeader(COOKIE, requestCookie);
-            if (COOKIE_STRICT_RFC_6265 && !strictRfc6265) {
+            if (COOKIE_STRICT_RFC_6265 && (!strictRfc6265 || endsWithSemi)) {
                 if (h2PriorKnowledge) {
                     // h2 does cookie parsing to expand/compress cookie crumbs.
                     assertThat(
@@ -380,7 +380,7 @@ class H2PriorKnowledgeFeatureParityTest {
                     HttpResponse response = client.request(request);
                     CharSequence responseCookie = response.headers().get(COOKIE);
                     assertNotNull(responseCookie);
-                    assertThrows(IllegalArgumentException.class, () -> response.headers().getCookie("name2"));
+                    assertThrows(IllegalArgumentException.class, () -> response.headers().getCookie("name3"));
                 }
             } else {
                 HttpResponse response = client.request(request);
@@ -395,6 +395,15 @@ class H2PriorKnowledgeFeatureParityTest {
                 cookie = response.headers().getCookie("name3");
                 assertNotNull(cookie);
                 assertEquals("value3", cookie.value());
+                // if (COOKIE_STRICT_RFC_6265 && endsWithSemi) {
+                //     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                //             () -> response.headers().getCookie("name3"));
+                //     assertThat(e.getMessage(), is("cookie 'name3': cookie is not allowed to end with ;"));
+                // } else {
+                //     cookie = response.headers().getCookie("name3");
+                //     assertNotNull(cookie);
+                //     assertEquals("value3", cookie.value());
+                // }
             }
         }
     }


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/pull/12833 adds additional 3 commits to fix problems with missing space after semicolon and adds more tests.

Modifications:

- Port changes made in the last 3 commits of Netty PR;
- Remove unused internal methods;
- Consistently throw `cookie is not allowed to end with ;` from anywhere we parse cookies;
- Include `DefaultHttpSetCookiesTest` and `LegacyCookieParsingTest` for `testProps`;
- Apply all settings we have to `test` task to `testProps` too: timeout, logging, args, etc;

Result:

Correct parsing of cookies without SP after a semicolon.