### PR TITLE
Add missing javadoc for `HttpHeadersFactory#validateNames()`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeadersFactory.java
@@ -47,6 +47,11 @@ public interface HttpHeadersFactory {
         return newTrailers();
     }
 
+    /**
+     * Determine if header names should be validated during parsing into {@link HttpHeaders}s.
+     *
+     * @return {@code true} if header names should be validated during parsing into {@link HttpHeaders}s.
+     */
     default boolean validateNames() {
         // We do not know behavior of a custom HttpHeadersFactory, but assume it validates header names.
         // This helps to make sure we always validate HTTP/2 headers by default inside Netty pipeline.


### PR DESCRIPTION
Motivation:

Forgot to add javadoc when this method was added in #2392.