### PR TITLE
Publisher#takeUntil cancel before terminate

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2224,11 +2224,37 @@ public abstract class Publisher<T> {
      *
      * @param until {@link Completable}, termination of which, terminates the returned {@link Publisher}.
      * @return A {@link Publisher} that only emits the items till {@code until} {@link Completable} is completed.
-     *
+     * @deprecated Use {@link #takeUntil(Supplier)}.
      * @see <a href="https://reactivex.io/documentation/operators/takeuntil.html">ReactiveX takeUntil operator.</a>
      */
+    @Deprecated
     public final Publisher<T> takeUntil(Completable until) {
-        return new TakeUntilPublisher<>(this, until);
+        return takeUntil(() -> until);
+    }
+
+    /**
+     * Takes elements until {@link Completable} is terminated successfully or with failure.
+     * <p>
+     * This method provides a means to take a limited number of results from this {@link Publisher} and in sequential
+     * programming is similar to:
+     * <pre>{@code
+     *     List<T> results = ...;
+     *     for (T t : resultOfThisPublisher()) {
+     *         if (isCompleted(until)) {
+     *             break;
+     *         }
+     *         takeResults.add(t);
+     *     }
+     *     return results;
+     * }</pre>
+     *
+     * @param untilSupplier {@link Supplier} that is invoked on each subscribe that provides a {@link Completable},
+     * termination of which, terminates the returned {@link Publisher}.
+     * @return A {@link Publisher} that only emits the items till {@code until} {@link Completable} is completed.
+     * @see <a href="https://reactivex.io/documentation/operators/takeuntil.html">ReactiveX takeUntil operator.</a>
+     */
+    public final Publisher<T> takeUntil(Supplier<? extends Completable> untilSupplier) {
+        return new TakeUntilPublisher<>(this, untilSupplier);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TakeUntilPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TakeUntilPublisher.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.internal.ConcurrentSubscription;
 import io.servicetalk.concurrent.internal.ConcurrentTerminalSubscriber;
 
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
@@ -28,20 +29,20 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateS
 import static java.util.Objects.requireNonNull;
 
 final class TakeUntilPublisher<T> extends AbstractSynchronousPublisherOperator<T, T> {
+    private final Supplier<? extends Completable> until;
 
-    private final Completable until;
-
-    TakeUntilPublisher(Publisher<T> original, Completable until) {
+    TakeUntilPublisher(Publisher<T> original, Supplier<? extends Completable> until) {
         super(original);
         this.until = requireNonNull(until);
     }
 
     @Override
     public Subscriber<? super T> apply(Subscriber<? super T> subscriber) {
-        return new TakeUntilSubscriber<>(subscriber, until);
+        return new TakeUntilSubscriber<>(subscriber, until.get());
     }
 
     private static final class TakeUntilSubscriber<T> implements Subscriber<T> {
+        @SuppressWarnings("rawtypes")
         private static final AtomicReferenceFieldUpdater<TakeUntilSubscriber, Cancellable> untilCancellableUpdater =
                 AtomicReferenceFieldUpdater.newUpdater(TakeUntilSubscriber.class, Cancellable.class,
                         "untilCancellable");
@@ -77,15 +78,19 @@ final class TakeUntilPublisher<T> extends AbstractSynchronousPublisherOperator<T
 
                 @Override
                 public void onComplete() {
-                    if (subscriber.processOnComplete()) {
+                    try {
                         cancelDownstreamSubscription();
+                    } finally {
+                        subscriber.processOnComplete();
                     }
                 }
 
                 @Override
                 public void onError(Throwable t) {
-                    if (subscriber.processOnError(t)) {
+                    try {
                         cancelDownstreamSubscription();
+                    } finally {
+                        subscriber.processOnError(t);
                     }
                 }
 
@@ -104,15 +109,19 @@ final class TakeUntilPublisher<T> extends AbstractSynchronousPublisherOperator<T
 
         @Override
         public void onError(Throwable t) {
-            if (subscriber.processOnError(t)) {
+            try {
                 cancelUntil();
+            } finally {
+                subscriber.processOnError(t);
             }
         }
 
         @Override
         public void onComplete() {
-            if (subscriber.processOnComplete()) {
+            try {
                 cancelUntil();
+            } finally {
+                subscriber.processOnComplete();
             }
         }
 
@@ -128,7 +137,7 @@ final class TakeUntilPublisher<T> extends AbstractSynchronousPublisherOperator<T
     private static final class TakeUntilSubscription extends ConcurrentSubscription {
         private final Cancellable cancellable;
 
-        protected TakeUntilSubscription(final Subscription subscription, Cancellable cancellable) {
+        private TakeUntilSubscription(final Subscription subscription, Cancellable cancellable) {
             super(subscription);
             this.cancellable = cancellable;
         }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeUntilPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/TakeUntilPublisherTest.java
@@ -15,10 +15,19 @@
  */
 package io.servicetalk.concurrent.api;
 
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.function.Supplier;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,17 +35,21 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 class TakeUntilPublisherTest {
-
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestSubscription subscription = new TestSubscription();
 
     @Test
     void testUntilComplete() {
-        LegacyTestCompletable completable = new LegacyTestCompletable();
-        Publisher<String> p = publisher.takeUntil(completable);
+        TestCompletable completable = new TestCompletable();
+        Publisher<String> p = publisher.takeUntil(() -> completable);
         toSource(p).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(4);
@@ -49,8 +62,8 @@ class TakeUntilPublisherTest {
 
     @Test
     void testUntilError() {
-        LegacyTestCompletable completable = new LegacyTestCompletable();
-        Publisher<String> p = publisher.takeUntil(completable);
+        TestCompletable completable = new TestCompletable();
+        Publisher<String> p = publisher.takeUntil(() -> completable);
         toSource(p).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(4);
@@ -63,8 +76,8 @@ class TakeUntilPublisherTest {
 
     @Test
     void testEmitsError() {
-        LegacyTestCompletable completable = new LegacyTestCompletable();
-        Publisher<String> p = publisher.takeUntil(completable);
+        TestCompletable completable = new TestCompletable();
+        Publisher<String> p = publisher.takeUntil(() -> completable);
         toSource(p).subscribe(subscriber);
         subscriber.awaitSubscription().request(4);
         publisher.onNext("Hello1");
@@ -75,8 +88,8 @@ class TakeUntilPublisherTest {
 
     @Test
     void testEmitsComplete() {
-        LegacyTestCompletable completable = new LegacyTestCompletable();
-        Publisher<String> p = publisher.takeUntil(completable);
+        TestCompletable completable = new TestCompletable();
+        Publisher<String> p = publisher.takeUntil(() -> completable);
         toSource(p).subscribe(subscriber);
         subscriber.awaitSubscription().request(4);
         publisher.onNext("Hello1");
@@ -85,9 +98,13 @@ class TakeUntilPublisherTest {
     }
 
     @Test
-    void testSubCancelled() {
-        LegacyTestCompletable completable = new LegacyTestCompletable();
-        Publisher<String> p = publisher.takeUntil(completable);
+    void testSubCancelled() throws InterruptedException {
+        TestCancellable cancellable = new TestCancellable();
+        TestCompletable completable = new TestCompletable.Builder().disableAutoOnSubscribe().build(subscriber1 -> {
+            subscriber1.onSubscribe(cancellable);
+            return subscriber1;
+        });
+        Publisher<String> p = publisher.takeUntil(() -> completable);
         toSource(p).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(3);
@@ -95,6 +112,67 @@ class TakeUntilPublisherTest {
         assertThat(subscriber.takeOnNext(2), contains("Hello1", "Hello2"));
         subscriber.awaitSubscription().cancel();
         assertTrue(subscription.isCancelled());
-        completable.verifyCancelled();
+        cancellable.awaitCancelled();
+    }
+
+    @Test
+    void resubscribe() throws InterruptedException {
+        BlockingQueue<CompletableSource.Processor> processors = new LinkedTransferQueue<>();
+        Supplier<Completable> completableSupplier = () -> {
+            CompletableSource.Processor processor = Processors.newCompletableProcessor();
+            processors.add(processor);
+            return fromSource(processor);
+        };
+        TestResubscribePublisher<String> resubscribePublisher = new TestResubscribePublisher<>();
+        @SuppressWarnings("unchecked")
+        Subscriber<String> resubscribeSubscriber = mock(Subscriber.class);
+        @SuppressWarnings("unchecked")
+        Subscriber<String> subscriber = mock(Subscriber.class);
+        doAnswer((Answer<Void>) invocation -> {
+            toSource(resubscribePublisher.takeUntil(completableSupplier)).subscribe(subscriber);
+            return null;
+        }).when(resubscribeSubscriber).onComplete();
+        doAnswer((Answer<Void>) invocation -> {
+            Subscription s = invocation.getArgument(0);
+            s.request(3);
+            return null;
+        }).when(resubscribeSubscriber).onSubscribe(any());
+        doAnswer((Answer<Void>) invocation -> {
+            Subscription s = invocation.getArgument(0);
+            s.request(3);
+            return null;
+        }).when(subscriber).onSubscribe(any());
+
+        toSource(resubscribePublisher.takeUntil(completableSupplier)).subscribe(resubscribeSubscriber);
+
+        TestPublisher<String> testPublisher1 = resubscribePublisher.publisher();
+        TestSubscription testSubscription1 = resubscribePublisher.subscription();
+        CompletableSource.Processor completable1 = processors.take();
+        testSubscription1.awaitRequestN(2);
+        testPublisher1.onNext("Hello1", "Hello2");
+
+        verify(resubscribeSubscriber).onNext("Hello1");
+        verify(resubscribeSubscriber).onNext("Hello2");
+
+        completable1.onComplete();
+        testSubscription1.awaitCancelled();
+
+        verify(resubscribeSubscriber).onComplete();
+        verify(resubscribeSubscriber, never()).onError(any());
+
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any());
+
+        TestPublisher<String> testPublisher2 = resubscribePublisher.publisher();
+        TestSubscription testSubscription2 = resubscribePublisher.subscription();
+        CompletableSource.Processor completable2 = processors.take();
+        testSubscription2.awaitRequestN(2);
+        testPublisher2.onNext("Hello3", "Hello4");
+
+        completable2.onComplete();
+        testSubscription2.awaitCancelled();
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any());
     }
 }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestResubscribePublisher.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestResubscribePublisher.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Wraps {@link TestPublisher} in a way that allows for sequential resubscribes.
+ * @param <T> The type of {@link TestPublisher}.
+ */
+public class TestResubscribePublisher<T> extends Publisher<T> {
+    private final AtomicReference<SubscriberState<T>> state = new AtomicReference<>();
+
+    @Override
+    protected void handleSubscribe(final PublisherSource.Subscriber<? super T> subscriber) {
+        SubscriberState<T> newState = new SubscriberState<>(state, subscriber);
+        SubscriberState<T> currState = state.get();
+        if (state.compareAndSet(null, newState)) {
+            newState.publisher.subscribe(subscriber);
+        } else {
+            deliverErrorFromSource(subscriber, new DuplicateSubscribeException(currState.subscriber, subscriber));
+        }
+    }
+
+    /**
+     * Get the current {@link TestPublisher}.
+     * @return the current {@link TestPublisher}.
+     */
+    public TestPublisher<T> publisher() {
+        return state.get().publisher;
+    }
+
+    /**
+     * Get the current {@link TestSubscription}.
+     * @return the current {@link TestSubscription}.
+     */
+    public TestSubscription subscription() {
+        return state.get().subscription;
+    }
+
+    private static final class SubscriberState<T> {
+        private final PublisherSource.Subscriber<? super T> subscriber;
+        private final TestPublisher<T> publisher;
+        private final TestSubscription subscription;
+
+        SubscriberState(AtomicReference<SubscriberState<T>> state,
+                        PublisherSource.Subscriber<? super T> subscriber) {
+            this.subscriber = requireNonNull(subscriber);
+            this.subscription = new TestSubscription();
+            this.publisher = new TestPublisher.Builder<T>().disableAutoOnSubscribe().build(subscriber1 -> {
+                subscriber1.onSubscribe(new PublisherSource.Subscription() {
+                    @Override
+                    public void request(final long n) {
+                        subscription.request(n);
+                    }
+
+                    @Override
+                    public void cancel() {
+                        try {
+                            subscription.cancel();
+                        } finally {
+                            state.compareAndSet(SubscriberState.this, null);
+                        }
+                    }
+                });
+                return subscriber1;
+            });
+        }
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherTakeUntilTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherTakeUntilTckTest.java
@@ -24,6 +24,6 @@ import org.testng.annotations.Test;
 public class PublisherTakeUntilTckTest extends AbstractPublisherOperatorTckTest<Integer> {
     @Override
     protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.takeUntil(Completable.never());
+        return publisher.takeUntil(Completable::never);
     }
 }


### PR DESCRIPTION
Motivation:
Publisher#takeUntil will terminate downstream before cancelling upstream. There are some sources (e.g. NettyChannelPublisher) that allow resubscribe in a sequential fashion, but in order for this to work cancellation must be first.

Modifications:
- Switch ordering in TakeUtil to cancel before terminate
- Add TestResubscribePublisher utility that wraps TestPublisher which allows for sequential resbuscribes.