### PR TITLE
OpenTelemetry scope: log stacktrace only when debug mode is enabled

### DIFF
--- a/servicetalk-opentelemetry-asynccontext/src/main/java/io/servicetalk/opentelemetry/asynccontext/ServiceTalkContextStoreProvider.java
+++ b/servicetalk-opentelemetry-asynccontext/src/main/java/io/servicetalk/opentelemetry/asynccontext/ServiceTalkContextStoreProvider.java
@@ -68,9 +68,15 @@ public final class ServiceTalkContextStoreProvider implements ContextStorageProv
             return () -> {
                 final Context current = current();
                 if (current != toAttach) {
-                    logger.info(
-                            "Context {} in storage not the expected context {}, Scope.close() was not called correctly",
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(
+                            "Context {} in storage isn't the expected context {}, Scope wasn't closed correctly",
                             current, toAttach, new Throwable("stacktrace"));
+                    } else {
+                        logger.info(
+                            "Context {} in storage isn't the expected context {}, Scope wasn't closed correctly",
+                            current, toAttach);
+                    }
                 }
                 if (beforeAttach == null) {
                     contextMap.remove(SCOPE_KEY);


### PR DESCRIPTION
Motivation:

`ServiceTalkContextStorage`, similar to the original `ThreadLocalContextStorage` logs when the `Scope` was not closed correctly. However, it allocates a new exception to capture the stacktrace on every log level.

Modifications:

- Allocate exception only when `debug` logging level is enabled;

Result:

Less overhead when logging is disabled.