### PR TITLE
Server control flow should close connection on `DecoderException`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -49,6 +49,7 @@ import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.SslConfig;
+import io.servicetalk.transport.netty.internal.ChannelCloseUtils;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
@@ -283,7 +284,7 @@ final class NettyHttpServer {
                                             meta.headers(), executionContext().bufferAllocator(), payload,
                                             requireTrailerHeader, headersFactory)));
             toSource(handleRequestAndWriteResponse(requestSingle, handleMultipleRequests))
-                    .subscribe(new ErrorLoggingHttpSubscriber(connection));
+                    .subscribe(new ErrorLoggingHttpSubscriber(this));
         }
 
         @Override
@@ -582,9 +583,9 @@ final class NettyHttpServer {
 
         private static final Logger LOGGER = LoggerFactory.getLogger(ErrorLoggingHttpSubscriber.class);
 
-        private final NettyConnection<Object, Object> connection;
+        private final NettyHttpServerConnection connection;
 
-        ErrorLoggingHttpSubscriber(final NettyConnection<Object, Object> connection) {
+        ErrorLoggingHttpSubscriber(final NettyHttpServerConnection connection) {
             this.connection = connection;
         }
 
@@ -619,14 +620,24 @@ final class NettyHttpServer {
         }
 
         private static void logDecoderException(final DecoderException e,
-                                                final NettyConnection<Object, Object> connection) {
-            LOGGER.warn("{} Can not decode a message, no more requests will be received on this {} {}.", connection,
-                    connection.protocol(), HTTP_2_0.equals(connection.protocol()) ? "stream" : "connection", e);
+                                                final NettyHttpServerConnection connection) {
+            final String whatClosing = HTTP_2_0.compareTo(connection.protocol()) <= 0 ? "stream" : "connection";
+            final boolean isOpen = connection.nettyChannel().isOpen();
+            final String closeStatement = isOpen ? ", closing it" : "";
+            LOGGER.warn("{} Can not decode a message, no more requests will be received on this {} {}{} due to:",
+                    connection, connection.protocol(), whatClosing, closeStatement, e);
+            if (isOpen) {
+                ChannelCloseUtils.close(connection.nettyChannel(), e);
+            }
         }
 
-        private static void logUnexpectedException(final Throwable t, NettyConnection<Object, Object> connection) {
-            LOGGER.debug("{} Unexpected error received, closing {} {} due to:", connection, connection.protocol(),
-                    HTTP_2_0.equals(connection.protocol()) ? "stream" : "connection", t);
+        private static void logUnexpectedException(final Throwable t, NettyHttpServerConnection connection) {
+            final String whatClosing = HTTP_2_0.compareTo(connection.protocol()) <= 0 ? "stream" : "connection";
+            LOGGER.debug("{} Unexpected error received, closing {} {} due to:",
+                    connection, connection.protocol(), whatClosing, t);
+            if (connection.nettyChannel().isOpen()) {
+                ChannelCloseUtils.close(connection.nettyChannel(), t);
+            }
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.CompletableSource.Processor;
@@ -33,7 +32,6 @@ import io.servicetalk.concurrent.internal.TerminalNotification;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategies;
-import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpRequestMetaData;
@@ -57,11 +55,11 @@ import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedEx
 import io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer;
 import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
+import io.servicetalk.transport.netty.internal.FlushStrategyHolder;
 import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
-import io.servicetalk.transport.netty.internal.SplittingFlushStrategy;
-import io.servicetalk.transport.netty.internal.SplittingFlushStrategy.FlushBoundaryProvider;
+import io.servicetalk.transport.netty.internal.NettyConnectionContext.FlushStrategyProvider;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
@@ -85,14 +83,11 @@ import javax.net.ssl.SSLSession;
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
-import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
-import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.StreamingHttpRequests.newTransportRequest;
 import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.isSafeToAggregateOrEmpty;
 import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
@@ -103,14 +98,10 @@ import static io.servicetalk.http.netty.HeaderUtils.flatEmptyMessage;
 import static io.servicetalk.http.netty.HeaderUtils.setResponseContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.shouldAppendTrailers;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
-import static io.servicetalk.http.netty.HttpObjectDecoder.getContentLength;
 import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_INBOUND;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
-import static io.servicetalk.transport.netty.internal.FlushStrategies.flushOnEach;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.flushOnEnd;
-import static io.servicetalk.transport.netty.internal.SplittingFlushStrategy.FlushBoundaryProvider.FlushBoundary.End;
-import static io.servicetalk.transport.netty.internal.SplittingFlushStrategy.FlushBoundaryProvider.FlushBoundary.InProgress;
-import static io.servicetalk.transport.netty.internal.SplittingFlushStrategy.FlushBoundaryProvider.FlushBoundary.Start;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 final class NettyHttpServer {
     private static final Logger LOGGER = LoggerFactory.getLogger(NettyHttpServer.class);
@@ -255,7 +246,7 @@ final class NettyHttpServer {
         private final NettyConnection<Object, Object> connection;
         private final HttpHeadersFactory headersFactory;
         private final HttpExecutionContext executionContext;
-        private final SplittingFlushStrategy flushStrategy;
+        private final ChangingFlushStrategy flushStrategy;
         private final boolean drainRequestPayloadBody;
         private final boolean requireTrailerHeader;
 
@@ -278,38 +269,7 @@ final class NettyHttpServer {
                     connection.executionContext().ioExecutor(), connection.executionContext().executor(),
                     HttpExecutionStrategies.offloadNone());
             this.service = service;
-            flushStrategy = new SplittingFlushStrategy(connection.defaultFlushStrategy(),
-                    // h2 may return a single HttpResponseMetaData for an empty response in some scenarios,
-                    // otherwise a trailers object will be included to indicate the end because content-length isn't
-                    // mutually exclusive from trailers in h2.
-                    protocol().major() > 1 ?
-                            itemWritten -> (itemWritten instanceof HttpResponseMetaData &&
-                                        emptyMessageBody((HttpResponseMetaData) itemWritten)) ||
-                                    itemWritten instanceof HttpHeaders ? End : InProgress :
-                    new FlushBoundaryProvider() {
-                        private long contentLength;
-                        @Override
-                        public FlushBoundary detectBoundary(@Nullable final Object itemWritten) {
-                            if (itemWritten instanceof HttpResponseMetaData) {
-                                final HttpResponseMetaData metadata = (HttpResponseMetaData) itemWritten;
-                                contentLength = getContentLength(metadata);
-                                // The content length maybe unknown at this point (e.g. 204 response) but then later
-                                // determined to be 0. In that case we should conservatively use End and rely upon
-                                // adjustForMissingBoundaries to accommodate if more data comes. Otherwise the
-                                // FlushStrategy may not trigger a flush (e.g. flushOnEnd) and if so the response
-                                // won't actually be written.
-                                return contentLength > 0 || (contentLength < 0 &&
-                                        (!emptyMessageBody(metadata) &&
-                                                isTransferEncodingChunked(metadata.headers()))) ? Start : End;
-                            }
-                            if (itemWritten instanceof Buffer) {
-                                return contentLength > 0 &&
-                                        (contentLength -= ((Buffer) itemWritten).readableBytes()) <= 0 ?
-                                        End : InProgress;
-                            }
-                            return itemWritten instanceof HttpHeaders ? End : InProgress;
-                        }
-                    });
+            this.flushStrategy = new ChangingFlushStrategy(new FlushStrategyHolder(connection.defaultFlushStrategy()));
             connection.updateFlushStrategy((current, isCurrentOriginal) -> flushStrategy);
             this.drainRequestPayloadBody = drainRequestPayloadBody;
             this.requireTrailerHeader = requireTrailerHeader;
@@ -338,7 +298,7 @@ final class NettyHttpServer {
 
         private Completable handleRequestAndWriteResponse(final Single<StreamingHttpRequest> requestSingle,
                                                           final boolean handleMultipleRequests) {
-            final Publisher<Object> responseObjectPublisher = requestSingle.flatMapPublisher(rawRequest -> {
+            final Completable exchange = requestSingle.flatMapCompletable(rawRequest -> {
                 // We transform the request and delay the completion of the result flattened stream to avoid
                 // resubscribing to the NettyChannelPublisher before the previous subscriber has terminated. Otherwise
                 // we may attempt to do duplicate subscribe on NettyChannelPublisher, which will result in a connection
@@ -395,11 +355,17 @@ final class NettyHttpServer {
                             };
                         }));
 
+                // Remember the original request method before users can modify it.
                 final HttpRequestMethod requestMethod = request.method();
-                final boolean isHeadRequest = HEAD.equals(request.method());
-                // Don't expect any exceptions from service because it's already wrapped with
-                // ExceptionMapperServiceFilter
-                Publisher<Object> respPublisher = service.handle(this, request, streamingResponseFactory())
+                // We can not concat response flat Publisher with `requestCompletion` or draining because by deferring
+                // stream completion we will defer flushing. We concat with `responseWrite` Completable instead to let
+                // the response go through first. After `responseWrite` completes we can immediately start draining the
+                // request message body because completion of the `responseWrite` means completion of the flat response
+                // stream and completion of the business logic.
+                final Completable responseWrite = connection.write(
+                        // Don't expect any exceptions from service because it's already wrapped with
+                        // HttpExceptionMapperServiceFilter.
+                        service.handle(this, request, streamingResponseFactory())
                         .flatMapPublisher(response -> {
                             if (responseSent != null) {
                                 // While concurrency between 100 (Continue) and the final response is handled in Netty
@@ -408,40 +374,30 @@ final class NettyHttpServer {
                                 // the final response, which may trigger continuation for the next request in pipeline.
                                 responseSent.set(true);
                             }
-                            // SplittingFlushStrategy needs to be aware of protocols constraints in order to determine
-                            // boundaries between responses. However it isn't aware of request data and content-length
-                            // for HEAD requests won't actually be followed by payload. It also has a method
-                            // adjustForMissingBoundaries to accommodate for missing End boundaries, so just flush on
-                            // each. SplittingFlushStrategy should be removed when NettyHttpServer writes per request
-                            // instead of a single stream with repeat() operator, and this code can also be removed.
                             Cancellable c = null;
-                            if (isHeadRequest) {
-                                flushStrategy.updateFlushStrategy(
-                                        (prev, isOriginal) -> isOriginal ? flushOnEach() : prev, 1);
-                            } else {
-                                final FlushStrategy flushStrategy = determineFlushStrategyForApi(response);
-                                if (flushStrategy != null) {
-                                    c = updateFlushStrategy((prev, isOriginal) -> isOriginal ? flushStrategy : prev);
-                                }
+                            final FlushStrategy flushStrategy = determineFlushStrategyForApi(response);
+                            if (flushStrategy != null) {
+                                c = updateFlushStrategy((prev, isOriginal) -> isOriginal ? flushStrategy : prev);
                             }
-
                             Publisher<Object> pub = handleResponse(protocol(), requestMethod, response);
-                            return c == null ? pub : pub.beforeFinally(c::cancel);
-                        });
+                            return (c == null ? pub : pub.beforeFinally(c::cancel))
+                                    // No need to make a copy of the context while consuming response message body.
+                                    .shareContextOnSubscribe();
+                        }));
 
                 if (drainRequestPayloadBody) {
-                    respPublisher = respPublisher.concat(defer(() -> payloadSubscribed.get() ?
-                                    completed() : request.messageBody().ignoreElements()
+                    return responseWrite.concat(defer(() -> (payloadSubscribed.get() ?
                             // Discarding the request payload body is an operation which should not impact the state of
                             // request/response processing. It's appropriate to recover from any error here.
                             // ST may introduce RejectedSubscribeError if user already consumed the request payload body
-                            .onErrorComplete()));
+                            requestCompletion : request.messageBody().ignoreElements().onErrorComplete())
+                            // No need to make a copy of the context in both cases.
+                            .shareContextOnSubscribe()));
+                } else {
+                    return responseWrite.concat(requestCompletion);
                 }
-
-                return respPublisher.concat(requestCompletion);
             });
-            return connection.write(handleMultipleRequests ? responseObjectPublisher.repeat(val -> true) :
-                    responseObjectPublisher);
+            return handleMultipleRequests ? exchange.repeat(__ -> true).ignoreElements() : exchange;
         }
 
         @Nonnull
@@ -671,6 +627,97 @@ final class NettyHttpServer {
         private static void logUnexpectedException(final Throwable t, NettyConnection<Object, Object> connection) {
             LOGGER.debug("{} Unexpected error received, closing {} {} due to:", connection, connection.protocol(),
                     HTTP_2_0.equals(connection.protocol()) ? "stream" : "connection", t);
+        }
+    }
+
+    /**
+     * Simplified variant of {@link io.servicetalk.transport.netty.internal.SplittingFlushStrategy}. Introduced
+     * temporarily until the {@link FlushStrategy} API is re-designed.
+     */
+    private static final class ChangingFlushStrategy implements FlushStrategy {
+        private static final AtomicReferenceFieldUpdater<ChangingFlushStrategy, ChangingWriteEventsListener>
+                listenerUpdater = newUpdater(ChangingFlushStrategy.class, ChangingWriteEventsListener.class,
+                "listener");
+
+        @Nullable
+        private volatile ChangingWriteEventsListener listener;
+
+        private final FlushStrategyHolder flushStrategyHolder;
+
+        private ChangingFlushStrategy(final FlushStrategyHolder flushStrategyHolder) {
+            this.flushStrategyHolder = flushStrategyHolder;
+        }
+
+        Cancellable updateFlushStrategy(FlushStrategyProvider strategyProvider) {
+            return flushStrategyHolder.updateFlushStrategy(strategyProvider);
+        }
+
+        @Override
+        public WriteEventsListener apply(final FlushSender sender) {
+            ChangingWriteEventsListener cListener = listener;
+            if (cListener != null) {
+                return cListener;
+            }
+            ChangingWriteEventsListener l = listenerUpdater.updateAndGet(this,
+                    existing -> existing != null ? existing :
+                            new ChangingWriteEventsListener(sender, flushStrategyHolder));
+            assert l != null;
+            return l;
+        }
+
+        @Override
+        public boolean shouldFlushOnUnwritable() {
+            return flushStrategyHolder.currentStrategy().shouldFlushOnUnwritable();
+        }
+
+        private static final class ChangingWriteEventsListener implements WriteEventsListener {
+
+            private final FlushSender sender;
+            private final FlushStrategyHolder flushStrategyHolder;
+            private final FlushStrategy defaultStrategy;
+            private final WriteEventsListener defaultListener;
+            private WriteEventsListener delegate;
+            private boolean firstWrite = true;
+
+            ChangingWriteEventsListener(final FlushSender sender, final FlushStrategyHolder flushStrategyHolder) {
+                this.sender = sender;
+                this.flushStrategyHolder = flushStrategyHolder;
+                this.defaultStrategy = flushStrategyHolder.currentStrategy();
+                this.defaultListener = defaultStrategy.apply(sender);
+                this.delegate = defaultListener;
+            }
+
+            @Override
+            public void writeStarted() {
+                firstWrite = true;
+                delegate = defaultListener;
+                // Invocation of "delegate.writeStarted()" is intentionally deferred until the first item is written.
+                // This is required to observe any changes for the FlushStrategy inside the service handle method.
+                // Deferring this invocation does not change the contract defined in the javadoc of this method.
+            }
+
+            @Override
+            public void itemWritten(@Nullable final Object written) {
+                if (firstWrite) {
+                    final FlushStrategy currentStrategy = flushStrategyHolder.currentStrategy();
+                    if (currentStrategy != defaultStrategy) {
+                        this.delegate = currentStrategy.apply(sender);
+                    }
+                    delegate.writeStarted();
+                    firstWrite = false;
+                }
+                delegate.itemWritten(written);
+            }
+
+            @Override
+            public void writeTerminated() {
+                delegate.writeTerminated();
+            }
+
+            @Override
+            public void writeCancelled() {
+                delegate.writeCancelled();
+            }
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BuilderUtils.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BuilderUtils.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
@@ -38,18 +37,17 @@ final class BuilderUtils {
         // No instances
     }
 
-    static HttpServerBuilder newLocalServer(ExecutionContext<? extends ExecutionStrategy> ctx,
-                                            HttpProtocol... protocols) {
-        return newLocalServerWithConfigs(ctx, toConfigs(protocols));
+    static HttpServerBuilder newServerBuilder(ExecutionContext<? extends ExecutionStrategy> ctx,
+                                              HttpProtocol... protocols) {
+        return newServerBuilderWithConfigs(ctx, toConfigs(protocols));
     }
 
-    static HttpServerBuilder newLocalServerWithConfigs(ExecutionContext<? extends ExecutionStrategy> ctx,
-                                                       HttpProtocolConfig... protocols) {
+    static HttpServerBuilder newServerBuilderWithConfigs(ExecutionContext<? extends ExecutionStrategy> ctx,
+                                                         HttpProtocolConfig... protocols) {
         HttpServerBuilder builder = HttpServers.forAddress(localAddress(0))
                 .ioExecutor(ctx.ioExecutor())
                 .executor(ctx.executor())
                 .bufferAllocator(ctx.bufferAllocator())
-                .executionStrategy(HttpExecutionStrategy.from(ctx.executionStrategy()))
                 .enableWireLogging("servicetalk-tests-wire-logger", TRACE, Boolean.TRUE::booleanValue)
                 .lifecycleObserver(logging("servicetalk-tests-lifecycle-observer-logger", TRACE));
         if (protocols.length > 0) {
@@ -58,14 +56,14 @@ final class BuilderUtils {
         return builder;
     }
 
-    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClient(
+    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilder(
             ServerContext serverContext,
             ExecutionContext<? extends ExecutionStrategy> ctx,
             HttpProtocol... protocols) {
-        return newClientWithConfigs(serverContext, ctx, toConfigs(protocols));
+        return newClientBuilderWithConfigs(serverContext, ctx, toConfigs(protocols));
     }
 
-    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientWithConfigs(
+    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilderWithConfigs(
             ServerContext serverContext,
             ExecutionContext<? extends ExecutionStrategy> ctx,
             HttpProtocolConfig... protocols) {
@@ -75,7 +73,6 @@ final class BuilderUtils {
                         .ioExecutor(ctx.ioExecutor())
                         .executor(ctx.executor())
                         .bufferAllocator(ctx.bufferAllocator())
-                        .executionStrategy(HttpExecutionStrategy.from(ctx.executionStrategy()))
                         .enableWireLogging("servicetalk-tests-wire-logger", TRACE, Boolean.TRUE::booleanValue)
                         .appendClientFilter(new HttpLifecycleObserverRequesterFilter(
                                 logging("servicetalk-tests-lifecycle-observer-logger", TRACE)));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -75,7 +75,7 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.newSocketAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.cached;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.String.valueOf;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -292,9 +292,10 @@ final class ConnectionCloseHeaderHandlingTest {
                                    boolean noRequestContent, boolean noResponseContent) throws Exception {
             setUp(useUds, viaProxy, awaitRequestPayload);
             String content = "request_content";
+            CharSequence contentLength = noRequestContent ? ZERO : valueOf(content.length());
             StreamingHttpRequest request = connection.newRequest(noRequestContent ? GET : POST, "/first")
                     .setQueryParameter("noResponseContent", valueOf(noResponseContent))
-                    .addHeader(CONTENT_LENGTH, noRequestContent ? ZERO : valueOf(content.length()));
+                    .addHeader(CONTENT_LENGTH, contentLength);
             if (!noRequestContent) {
                 request.payloadBody(connection.connectionContext().executionContext().executor().submit(() -> {
                     try {
@@ -319,7 +320,7 @@ final class ConnectionCloseHeaderHandlingTest {
             assertResponsePayloadBody(response);
             responsePayloadReceived.countDown();
             requestPayloadReceived.await();
-            assertThat(request.headers().get(CONTENT_LENGTH), contentEqualTo(valueOf(requestPayloadSize.get())));
+            assertThat(valueOf(requestPayloadSize.get()), contentEqualTo(contentLength));
 
             awaitConnectionClosed();
             assertClosedChannelException("/second");

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
@@ -72,8 +72,8 @@ import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
-import static io.servicetalk.http.netty.BuilderUtils.newClientWithConfigs;
-import static io.servicetalk.http.netty.BuilderUtils.newLocalServerWithConfigs;
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilderWithConfigs;
+import static io.servicetalk.http.netty.BuilderUtils.newServerBuilderWithConfigs;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -573,7 +573,7 @@ class ExpectContinueTest {
     private static HttpServerContext startServer(HttpProtocol protocol,
                                                  boolean useOtherHeadersFactory,
                                                  BlockingStreamingHttpService service) throws Exception {
-        return newLocalServerWithConfigs(SERVER_CTX,
+        return newServerBuilderWithConfigs(SERVER_CTX,
                 useOtherHeadersFactory ? protocol.configOtherHeadersFactory : protocol.config)
                 .listenBlockingStreamingAndAwait(service);
     }
@@ -586,7 +586,7 @@ class ExpectContinueTest {
     private static StreamingHttpClient createClient(HttpServerContext serverContext,
                                                     HttpProtocol protocol, boolean useOtherHeadersFactory,
                                                     @Nullable StreamingHttpClientFilterFactory filterFactory) {
-        final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder = newClientWithConfigs(
+        final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder = newClientBuilderWithConfigs(
                 serverContext, CLIENT_CTX,
                 useOtherHeadersFactory ? protocol.configOtherHeadersFactory : protocol.config);
         if (filterFactory != null) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
@@ -34,6 +32,7 @@ import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpServerConfig;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -58,11 +57,9 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
 import static io.servicetalk.http.api.StreamingHttpRequests.newTransportRequest;
-import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
 import static io.servicetalk.http.netty.NettyHttpServer.initChannel;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
-import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -71,7 +68,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 class FlushStrategyOnServerTest {
 
     @RegisterExtension
-    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
+    static final ExecutionContextExtension SERVER_CTX =
+            ExecutionContextExtension.cached("server-io", "server-executor")
+                    .setClassLevel(true);
+    @RegisterExtension
+    static final ExecutionContextExtension CLIENT_CTX =
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
+
     private static final String USE_AGGREGATED_RESP = "aggregated-resp";
     private static final String USE_EMPTY_RESP_BODY = "empty-resp-body";
 
@@ -106,8 +110,8 @@ class FlushStrategyOnServerTest {
             return succeeded(resp);
         };
 
-        final DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR,
-                globalExecutionContext().ioExecutor(), EXECUTOR_RULE.executor(), param.executionStrategy);
+        final DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(
+                SERVER_CTX.bufferAllocator(), SERVER_CTX.ioExecutor(), SERVER_CTX.executor(), param.executionStrategy);
 
         final ReadOnlyHttpServerConfig config = new HttpServerConfig().asReadOnly();
         final ReadOnlyTcpServerConfig tcpReadOnly = new TcpServerConfig().asReadOnly();
@@ -130,9 +134,7 @@ class FlushStrategyOnServerTest {
             fail(e);
         }
 
-        client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
-                .protocols(h1Default())
-                .buildBlocking();
+        client = newClientBuilder(serverContext, CLIENT_CTX).buildBlocking();
     }
 
     @AfterEach

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOverrideTest.java
@@ -15,12 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.client.api.ServiceDiscoverer;
-import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.Cancellable;
-import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
@@ -40,23 +35,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;
-import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
-import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
-import static io.servicetalk.transport.netty.internal.ExecutionContextExtension.immediate;
-import static java.util.Collections.singletonList;
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
+import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
@@ -64,7 +54,13 @@ import static org.hamcrest.Matchers.hasSize;
 class FlushStrategyOverrideTest {
 
     @RegisterExtension
-    final ExecutionContextExtension ctx = immediate();
+    static final ExecutionContextExtension SERVER_CTX =
+            ExecutionContextExtension.cached("server-io", "server-executor")
+                    .setClassLevel(true);
+    @RegisterExtension
+    static final ExecutionContextExtension CLIENT_CTX =
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
 
     private StreamingHttpClient client;
     private ServerContext serverCtx;
@@ -74,17 +70,13 @@ class FlushStrategyOverrideTest {
     @BeforeEach
     void setUp() throws Exception {
         service = new FlushingService();
-        serverCtx = HttpServers.forAddress(localAddress(0))
-                .ioExecutor(ctx.ioExecutor())
+        serverCtx = newServerBuilder(SERVER_CTX)
                 .executionStrategy(offloadNone())
                 .listenStreaming(service)
                 .toFuture().get();
-        InetSocketAddress serverAddr = (InetSocketAddress) serverCtx.listenAddress();
-        client = forSingleAddress(new NoopSD(serverAddr), serverAddr)
-                .hostHeaderFallback(false)
-                .ioExecutor(ctx.ioExecutor())
+        client = newClientBuilder(serverCtx, CLIENT_CTX)
                 .executionStrategy(offloadNone())
-                .unresolvedAddressToHost(InetSocketAddress::getHostString)
+                .hostHeaderFallback(false)
                 .buildStreaming();
         conn = client.reserveConnection(client.get("/")).toFuture().get();
     }
@@ -102,7 +94,7 @@ class FlushStrategyOverrideTest {
 
         CountDownLatch reqWritten = new CountDownLatch(1);
         StreamingHttpRequest req = client.get("/flush").payloadBody(from(1, 2, 3)
-                .map(count -> ctx.bufferAllocator().fromAscii("" + count))
+                .map(count -> client.executionContext().bufferAllocator().fromAscii("" + count))
                 .afterFinally(reqWritten::countDown));
 
         Future<? extends Collection<Object>> clientResp = conn.request(req)
@@ -160,44 +152,6 @@ class FlushStrategyOverrideTest {
 
         MockFlushStrategy getLastUsedStrategy() throws InterruptedException {
             return flushStrategies.take();
-        }
-    }
-
-    private static final class NoopSD implements ServiceDiscoverer<InetSocketAddress, InetSocketAddress,
-            ServiceDiscovererEvent<InetSocketAddress>> {
-
-        private final ListenableAsyncCloseable closeable;
-        private final InetSocketAddress serverAddr;
-
-        NoopSD(final InetSocketAddress serverAddr) {
-            this.serverAddr = serverAddr;
-            closeable = emptyAsyncCloseable();
-        }
-
-        @Override
-        public Publisher<Collection<ServiceDiscovererEvent<InetSocketAddress>>> discover(
-                final InetSocketAddress inetSocketAddress) {
-            return from(singletonList(new ServiceDiscovererEvent<InetSocketAddress>() {
-                @Override
-                public InetSocketAddress address() {
-                    return serverAddr;
-                }
-
-                @Override
-                public Status status() {
-                    return AVAILABLE;
-                }
-            }));
-        }
-
-        @Override
-        public Completable onClose() {
-            return closeable.onClose();
-        }
-
-        @Override
-        public Completable closeAsync() {
-            return closeable.closeAsync();
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -176,7 +176,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
             verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
             verify(serverDataObserver, await()).onNewRead();
-            verify(serverDataObserver, await()).onNewWrite();
+            verify(serverReadObserver, await()).requestedToRead(anyLong());
         } else {
             verify(clientConnectionObserver).multiplexedConnectionEstablished(any(ConnectionInfo.class));
             verify(serverConnectionObserver, await()).multiplexedConnectionEstablished(any(ConnectionInfo.class));
@@ -186,9 +186,12 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         assertConnectionClosed();
         verify(clientConnectionObserver).connectionClosed();
         verify(serverConnectionObserver, await()).connectionClosed();
+        if (protocol == HTTP_1) {
+            verify(serverReadObserver, await()).readFailed(any(ClosedChannelException.class));
+        }
 
         verifyNoMoreInteractions(clientTransportObserver, clientDataObserver, clientMultiplexedObserver,
-                serverTransportObserver, serverDataObserver, serverMultiplexedObserver);
+                serverTransportObserver, serverDataObserver, serverMultiplexedObserver, serverReadObserver);
         if (protocol != HTTP_2) {
             // HTTP/2 coded adds additional write/flush events related to connection preface. Also, it may emit more
             // flush events on the pipeline after the connection is closed.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
@@ -52,8 +52,8 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
-import static io.servicetalk.http.netty.BuilderUtils.newClientWithConfigs;
-import static io.servicetalk.http.netty.BuilderUtils.newLocalServer;
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilderWithConfigs;
+import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
 import static io.servicetalk.http.netty.GracefulConnectionClosureHandlingTest.RAW_STRING_SERIALIZER;
 import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
 import static java.lang.Long.MAX_VALUE;
@@ -208,10 +208,10 @@ class ServerPipelineControlFlowTest {
 
     private void test(HttpServerFactory serverFactory, boolean serverHasOffloading, boolean drainRequestPayloadBody,
                       boolean responseHasPayload) throws Exception {
-        try (HttpServerContext serverContext = serverFactory.create(newLocalServer(SERVER_CTX)
+        try (HttpServerContext serverContext = serverFactory.create(newServerBuilder(SERVER_CTX)
                 .executionStrategy(serverHasOffloading ? defaultStrategy() : offloadNone())
                 .drainRequestPayloadBody(drainRequestPayloadBody));
-             StreamingHttpClient client = newClientWithConfigs(serverContext, CLIENT_CTX,
+             StreamingHttpClient client = newClientBuilderWithConfigs(serverContext, CLIENT_CTX,
                      new H1ProtocolConfigBuilder().maxPipelinedRequests(3).build())
                      .buildStreaming();
              StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
@@ -21,19 +21,38 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.Http2Exception;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+import io.servicetalk.http.netty.RetryingHttpRequesterFilter.HttpResponseException;
+import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
@@ -46,23 +65,34 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.DEFAULT_TIMEOUT_SECONDS;
+import static io.servicetalk.http.api.Http2ErrorCode.CANCEL;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
+import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpSerializers.appSerializerAsciiFixLen;
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
 import static io.servicetalk.http.netty.BuilderUtils.newClientBuilderWithConfigs;
 import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
 import static io.servicetalk.http.netty.GracefulConnectionClosureHandlingTest.RAW_STRING_SERIALIZER;
 import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_INBOUND;
 import static java.lang.Long.MAX_VALUE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.time.Duration.ofMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Test the following scenario:
@@ -232,6 +262,118 @@ class ServerPipelineControlFlowTest {
         assertNoAsyncErrors(asyncErrors);
     }
 
+    @Timeout(2)
+    @ParameterizedTest(name = "{displayName} [{index}] protocol={0} serviceApi={1} serverHasOffloading={2}")
+    @MethodSource("data")
+    void testMetaDataError(HttpProtocol protocol, ServiceApi serviceApi,
+                           boolean serverHasOffloading) throws Exception {
+        try (HttpServerContext serverContext = serviceApi.create(newServerBuilder(SERVER_CTX, protocol)
+                .executionStrategy(serverHasOffloading ? defaultStrategy() : offloadNone()));
+             BlockingHttpClient client = newClientBuilder(serverContext, CLIENT_CTX, protocol).buildBlocking()) {
+            IOException e = assertThrows(IOException.class, () -> {
+                switch (protocol) {
+                    case HTTP_1:
+                        // \r\n is illegal inside header values
+                        client.request(client.get("/").setHeader("some-header", "invalid\r\nvalue"));
+                        break;
+                    case HTTP_2:
+                        // TRACE methods can not have content-length header
+                        client.request(client.trace("/").setHeader(CONTENT_LENGTH, ZERO));
+                        break;
+                    default:
+                        throw new AssertionError("Unexpected protocol: " + protocol);
+                }
+            });
+            switch (protocol) {
+                case HTTP_1:
+                    assertThat(e, instanceOf(CloseEventObservedException.class));
+                    assertThat(((CloseEventObservedException) e).event(), is(CHANNEL_CLOSED_INBOUND));
+                    break;
+                case HTTP_2:
+                    assertThat(e, instanceOf(Http2Exception.class));
+                    assertThat(((Http2Exception) e).errorCode(), is(CANCEL));
+                    break;
+                default:
+                    throw new AssertionError("Unexpected protocol: " + protocol);
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] protocol={0} serviceApi={1} serverHasOffloading={2}")
+    @MethodSource("data")
+    void testPayloadBodyError(HttpProtocol protocol, ServiceApi serviceApi,
+                              boolean serverHasOffloading) throws Exception {
+        assumeTrue(serviceApi != ServiceApi.BLOCKING_STREAMING || serverHasOffloading,
+                "BLOCKING_STREAMING service can deadlock without offloading");
+        try (HttpServerContext serverContext = serviceApi.create(newServerBuilder(SERVER_CTX, protocol)
+                .executionStrategy(serverHasOffloading ? defaultStrategy() : offloadNone())
+                .appendServiceFilter(new StreamingHttpServiceFilterFactory() {
+                    @Override
+                    public StreamingHttpServiceFilter create(StreamingHttpService service) {
+                        return new StreamingHttpServiceFilter(service) {
+                            @Override
+                            public Single<StreamingHttpResponse> handle(HttpServiceContext ctx,
+                                                                        StreamingHttpRequest request,
+                                                                        StreamingHttpResponseFactory responseFactory) {
+                                return delegate().handle(ctx, request.transformMessageBody(publisher -> publisher
+                                        .map(item -> {
+                                            throw DELIBERATE_EXCEPTION;
+                                        })), responseFactory);
+                            }
+                        };
+                    }
+
+                    @Override
+                    public HttpExecutionStrategy requiredOffloads() {
+                        return offloadNone();
+                    }
+                }));
+             StreamingHttpClient client = newClientBuilder(serverContext, CLIENT_CTX, protocol).buildStreaming()) {
+            Throwable e = assertThrows(Throwable.class, () -> {
+                StreamingHttpResponse response = client.request(client.post("/")
+                                .payloadBody(from("content"), appSerializerAsciiFixLen()))
+                        .toFuture().get();
+                response.payloadBody().toFuture().get();
+                // Aggregated API can return 500
+                throw new ExecutionException(new HttpResponseException("Response complete", response));
+            });
+            assertThat(e, instanceOf(ExecutionException.class));
+            e = e.getCause();
+            switch (protocol) {
+                case HTTP_1:
+                    assertThat(e, anyOf(instanceOf(CloseEventObservedException.class), instanceOf(IOException.class),
+                            instanceOf(HttpResponseException.class)));
+                    if (e instanceof CloseEventObservedException) {
+                        assertThat(((CloseEventObservedException) e).event(), is(CHANNEL_CLOSED_INBOUND));
+                    }
+                    break;
+                case HTTP_2:
+                    assertThat(e, anyOf(instanceOf(ClosedChannelException.class), instanceOf(Http2Exception.class),
+                            instanceOf(HttpResponseException.class)));
+                    if (e instanceof Http2Exception) {
+                        assertThat(((Http2Exception) e).errorCode(), is(CANCEL));
+                    }
+                    break;
+                default:
+                    throw new AssertionError("Unexpected protocol: " + protocol);
+            }
+            if (e instanceof HttpResponseException) {
+                assertThat(((HttpResponseException) e).metaData().status(), is(INTERNAL_SERVER_ERROR));
+            }
+        }
+    }
+
+    private static List<Arguments> data() {
+        List<Arguments> data = new ArrayList<>();
+        for (HttpProtocol protocol : HttpProtocol.values()) {
+            for (ServiceApi api : ServiceApi.values()) {
+                data.add(Arguments.of(protocol, api, true));
+                data.add(Arguments.of(protocol, api, false));
+            }
+        }
+        return data;
+    }
+
     private static Future<StreamingHttpResponse> requestFuture(StreamingHttpConnection connection, String name) {
         return connection.request(connection.post('/' + name)
                         .payloadBody(connection.executionContext().executor().timer(ofMillis(50))
@@ -264,11 +406,39 @@ class ServerPipelineControlFlowTest {
         HttpServerContext create(HttpServerBuilder builder) throws Exception;
     }
 
-    private static final class StacklessException extends Exception {
-        private static final long serialVersionUID = 6439192160547836620L;
-
-        StacklessException(String msg) {
-            super(msg, null, false, false);
+    private enum ServiceApi implements HttpServerFactory {
+        ASYNC_AGGREGATED {
+            @Override
+            public HttpServerContext create(HttpServerBuilder builder) throws Exception {
+                return builder.listenAndAwait((ctx, request, responseFactory) ->
+                        succeeded(responseFactory.ok().payloadBody(request.payloadBody())));
+            }
+        },
+        ASYNC_STREAMING {
+            @Override
+            public HttpServerContext create(HttpServerBuilder builder) throws Exception {
+                return builder.listenStreamingAndAwait((ctx, request, responseFactory) ->
+                        succeeded(responseFactory.ok().payloadBody(request.payloadBody())));
+            }
+        },
+        BLOCKING_AGGREGATED {
+            @Override
+            public HttpServerContext create(HttpServerBuilder builder) throws Exception {
+                return builder.listenBlockingAndAwait((ctx, request, responseFactory) ->
+                        responseFactory.ok().payloadBody(request.payloadBody()));
+            }
+        },
+        BLOCKING_STREAMING {
+            @Override
+            public HttpServerContext create(HttpServerBuilder builder) throws Exception {
+                return builder.listenBlockingStreamingAndAwait((ctx, request, response) -> {
+                    try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
+                        for (Buffer chunk : request.payloadBody()) {
+                            writer.write(chunk);
+                        }
+                    }
+                });
+            }
         }
     }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
@@ -24,6 +24,7 @@ import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.logging.slf4j.internal.FixedLevelLogger;
 import io.servicetalk.transport.api.ConnectionInfo;
 
+import java.util.Arrays;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.logging.slf4j.internal.Slf4jFixedLevelLoggers.newLogger;
@@ -107,20 +108,23 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
 
         @Override
         public void onRequestComplete() {
-            assert requestResult == null;
-            assert requestMetaData != null;
+            Object current = requestResult;
+            assert current == null : assertResultMsg(current, "requestResult");
+            assert requestMetaData != null : "Request meta-data is not expected to be null on completion";
             requestResult = Result.complete;
         }
 
         @Override
         public void onRequestError(final Throwable cause) {
-            assert requestResult == null;
+            Object current = requestResult;
+            assert current == null : assertResultMsg(current, "requestResult");
             requestResult = cause;
         }
 
         @Override
         public void onRequestCancel() {
-            assert requestResult == null;
+            Object current = requestResult;
+            assert current == null : assertResultMsg(current, "requestResult");
             requestResult = Result.cancelled;
         }
 
@@ -147,7 +151,8 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
 
         @Override
         public void onResponseComplete() {
-            assert responseResult == null;
+            Object current = responseResult;
+            assert current == null : assertResultMsg(current, "responseResult");
             assert responseMetaData != null;
             responseTimeMs = durationMs(startTime);
             responseResult = Result.complete;
@@ -155,14 +160,16 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
 
         @Override
         public void onResponseError(final Throwable cause) {
-            assert responseResult == null;
+            Object current = responseResult;
+            assert current == null : assertResultMsg(current, "responseResult");
             responseTimeMs = durationMs(startTime);
             responseResult = cause;
         }
 
         @Override
         public void onResponseCancel() {
-            assert responseResult == null;
+            Object current = responseResult;
+            assert current == null : assertResultMsg(current, "responseResult");
             responseTimeMs = durationMs(startTime);
             responseResult = Result.cancelled;
         }
@@ -213,6 +220,12 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
 
         private enum Result {
             complete, error, cancelled
+        }
+
+        private static String assertResultMsg(final Object current, final String name) {
+            return "Unexpected " + name + ": " + current + (current instanceof Throwable ?
+                    '\n' + String.join("\n", Arrays.stream(((Throwable) current).getStackTrace())
+                            .map(String::valueOf).toArray(CharSequence[]::new)) : "");
         }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -154,9 +154,7 @@ final class RequestResponseCloseHandler extends CloseHandler {
             protocolPayloadEndOutbound0(ctx);
             return;
         }
-        if (isClient || (closeEvent != null && pending == 0)) {
-            ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
-        }
+        ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
         promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SplittingFlushStrategy.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SplittingFlushStrategy.java
@@ -33,8 +33,11 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
 /**
  * A {@link FlushStrategy} that splits writes into logical write boundaries and manages flush state across those logical
  * write boundaries. Actual flush logic is delegated to an externally provided (and updatable) {@link FlushStrategy}.
+ *
+ * @deprecated This class will be removed in the future releases.
  */
-public final class SplittingFlushStrategy implements FlushStrategy {
+@Deprecated
+public final class SplittingFlushStrategy implements FlushStrategy {    // FIXME: 0.43 - remove deprecated class
     private static final AtomicReferenceFieldUpdater<SplittingFlushStrategy, SplittingWriteEventsListener>
             listenerUpdater = newUpdater(SplittingFlushStrategy.class, SplittingWriteEventsListener.class,
             "listener");
@@ -98,7 +101,10 @@ public final class SplittingFlushStrategy implements FlushStrategy {
 
     /**
      * A provider of {@link FlushBoundary} for each written item.
+     *
+     * @deprecated This interface will be removed in the future releases.
      */
+    @Deprecated
     @FunctionalInterface
     public interface FlushBoundaryProvider {
         /**

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
@@ -17,7 +17,6 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.test.StepVerifiers;
-import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,10 +24,6 @@ import java.nio.channels.ClosedChannelException;
 
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
-import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_INBOUND;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotifyAlertHandlingTest {
 
@@ -62,11 +57,7 @@ class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotifyAlertH
                     closeNotifyAndVerifyClosing();
                     writeSource.onComplete();
                 })
-                .expectErrorConsumed(cause -> {
-                    assertThat("Unexpected write failure cause", cause, instanceOf(CloseEventObservedException.class));
-                    CloseEventObservedException ceoe = (CloseEventObservedException) cause;
-                    assertThat("Unexpected close event", ceoe.event(), is(CHANNEL_CLOSED_INBOUND));
-                })
+                .expectComplete()
                 .verify();
     }
 


### PR DESCRIPTION
Motivation:

#2367 changed server-side control flow. After that, `connection.write` doesn't start before we received a request meta-data. As the result, all errors that happen during parsing of the meta-data do not reach `WriteStreamSubscriber` and can leave a connection in undefined state, when we logged an error but didn't clean up the channel state.

Modifications:

- Close the channel if an error occurs on the `Single` of request meta-data;
- Add tests to verify the expected behavior;

Result:

Channel is closed when an early request error happens, client doesn't hang forever.