### PR TITLE
Move gRPC server deadline filter, allow custom insertion order

### DIFF
--- a/servicetalk-grpc-api/build.gradle
+++ b/servicetalk-grpc-api/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   implementation project(":servicetalk-encoding-api-internal")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-router-utils-internal")
   implementation project(":servicetalk-utils-internal")
   implementation project(":servicetalk-grpc-internal")

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcClientBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.grpc.api;
 
 import java.time.Duration;
+import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,8 +61,9 @@ public class DelegatingGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R
     }
 
     @Override
-    public GrpcClientBuilder<U, R> appendTimeoutFilter(final boolean append) {
-        delegate = delegate.appendTimeoutFilter(append);
+    public GrpcClientBuilder<U, R> defaultTimeout(@Nullable final Duration defaultTimeout,
+                                                  final boolean appendTimeoutFilter) {
+        delegate = delegate.defaultTimeout(defaultTimeout, appendTimeoutFilter);
         return this;
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcClientBuilder.java
@@ -60,6 +60,12 @@ public class DelegatingGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R
     }
 
     @Override
+    public GrpcClientBuilder<U, R> appendTimeoutFilter(final boolean append) {
+        delegate = delegate.appendTimeoutFilter(append);
+        return this;
+    }
+
+    @Override
     public <Client extends GrpcClient<?>> Client build(final GrpcClientFactory<Client, ?> clientFactory) {
         return delegate.build(clientFactory);
     }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcServerBuilder.java
@@ -18,6 +18,7 @@ package io.servicetalk.grpc.api;
 import io.servicetalk.concurrent.api.Single;
 
 import java.time.Duration;
+import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -59,8 +60,9 @@ public class DelegatingGrpcServerBuilder implements GrpcServerBuilder {
     }
 
     @Override
-    public GrpcServerBuilder appendTimeoutFilter(final boolean append) {
-        delegate = delegate.appendTimeoutFilter(append);
+    public GrpcServerBuilder defaultTimeout(@Nullable final Duration defaultTimeout,
+                                            final boolean appendTimeoutFilter) {
+        delegate = delegate.defaultTimeout(defaultTimeout, appendTimeoutFilter);
         return this;
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcServerBuilder.java
@@ -59,6 +59,12 @@ public class DelegatingGrpcServerBuilder implements GrpcServerBuilder {
     }
 
     @Override
+    public GrpcServerBuilder appendTimeoutFilter(final boolean append) {
+        delegate = delegate.appendTimeoutFilter(false);
+        return this;
+    }
+
+    @Override
     public GrpcServerBuilder lifecycleObserver(final GrpcLifecycleObserver lifecycleObserver) {
         delegate = delegate.lifecycleObserver(lifecycleObserver);
         return this;

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DelegatingGrpcServerBuilder.java
@@ -60,7 +60,7 @@ public class DelegatingGrpcServerBuilder implements GrpcServerBuilder {
 
     @Override
     public GrpcServerBuilder appendTimeoutFilter(final boolean append) {
-        delegate = delegate.appendTimeoutFilter(false);
+        delegate = delegate.appendTimeoutFilter(append);
         return this;
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 
 import java.time.Duration;
 
@@ -71,6 +72,23 @@ public interface GrpcClientBuilder<U, R> {
      * @return {@code this}.
      */
     GrpcClientBuilder<U, R> defaultTimeout(Duration defaultTimeout);
+
+    /**
+     * Determine if a filter will be inserted by this builder that enforces the
+     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout deadline
+     * propagation</a>.
+     * <p>
+     * To insert {@link GrpcFilters#newGrpcDeadlineClientFilterFactory()} in your preferred order use
+     * {@link #initializeHttp} and
+     * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)}.
+     * <p>
+     * {@link #defaultTimeout(Duration)} is independent of this method, and may still inject state (even if no timeout
+     * is applied locally because this {@code append} is {@code false} and no timeout filter is appended).
+     * @param append {@code true} if this builder should append the timeout filter, {@code false} if it should not.
+     * @return {@code this}.
+     * @see GrpcFilters#newGrpcDeadlineClientFilterFactory()
+     */
+    GrpcClientBuilder<U, R> appendTimeoutFilter(boolean append);
 
     /**
      * Builds a <a href="https://www.grpc.io">gRPC</a> client.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -19,6 +19,7 @@ import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 
 import java.time.Duration;
+import javax.annotation.Nullable;
 
 /**
  * A builder for building a <a href="https://www.grpc.io">gRPC</a> client.
@@ -70,28 +71,27 @@ public interface GrpcClientBuilder<U, R> {
      *
      * @param defaultTimeout {@link Duration} of default timeout which must be positive non-zero.
      * @return {@code this}.
+     * @see #defaultTimeout(Duration, boolean)
      */
     GrpcClientBuilder<U, R> defaultTimeout(Duration defaultTimeout);
 
     /**
-     * Determine if a filter will be inserted by this builder that enforces the
-     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout deadline
-     * propagation</a>.
-     * <p>
-     * To insert {@link GrpcFilters#newGrpcDeadlineClientFilterFactory()} in your preferred order use
-     * {@link #initializeHttp} and
+     * Set default timeout during which gRPC calls are expected to complete. This default will be used only if the
+     * request metadata includes no timeout; any value specified in client request will supersede this default.
+     *
+     * @param defaultTimeout {@link Duration} of default timeout which must be positive non-zero, or {@code null} if a
+     * default shouldn't be applied.
+     * @param appendTimeoutFilter {@code true} to append the filter that enforces
+     * <a href="https://grpc.io/blog/deadlines">deadline propagation</a>. {@code false} to not append the filter and
+     * therefore not enforce deadlines. If {@code false} you can manually insert
+     * {@link GrpcFilters#newGrpcDeadlineClientFilterFactory()} in your preferred order use {@link #initializeHttp} and
      * {@link SingleAddressHttpClientBuilder#appendClientFilter(StreamingHttpClientFilterFactory)}.
-     * <p>
-     * {@link #defaultTimeout(Duration)} is independent of this method, and may still inject state (even if no timeout
-     * is applied locally because this {@code append} is {@code false} and no timeout filter is appended).
-     * @param append {@code true} if this builder should append the timeout filter, {@code false} if it should not.
      * @return {@code this}.
      * @see GrpcFilters#newGrpcDeadlineClientFilterFactory()
      */
-    default GrpcClientBuilder<U, R> appendTimeoutFilter(boolean append) {
+    default GrpcClientBuilder<U, R> defaultTimeout(@Nullable Duration defaultTimeout, boolean appendTimeoutFilter) {
         // FIXME: 0.43 - remove default implementation
-        throw new UnsupportedOperationException(
-                "GrpcClientBuilder#appendTimeoutFilter(boolean) is not supported by " + getClass());
+        throw new UnsupportedOperationException("method not supported by " + getClass());
     }
 
     /**

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -88,7 +88,11 @@ public interface GrpcClientBuilder<U, R> {
      * @return {@code this}.
      * @see GrpcFilters#newGrpcDeadlineClientFilterFactory()
      */
-    GrpcClientBuilder<U, R> appendTimeoutFilter(boolean append);
+    default GrpcClientBuilder<U, R> appendTimeoutFilter(boolean append) {
+        // FIXME: 0.43 - remove default implementation
+        throw new UnsupportedOperationException(
+                "GrpcClientBuilder#appendTimeoutFilter(boolean) is not supported by " + getClass());
+    }
 
     /**
      * Builds a <a href="https://www.grpc.io">gRPC</a> client.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExceptionMapperServiceFilter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExceptionMapperServiceFilter.java
@@ -84,9 +84,11 @@ public final class GrpcExceptionMapperServiceFilter implements StreamingHttpServ
                 ctx.executionContext().bufferAllocator(), null);
         final CharSequence codeValue = response.headers().get(GRPC_STATUS);
         assert codeValue != null;
-        LOGGER.error("Unexpected exception during a {} processing for connection={}, request='{} {} {}' was mapped " +
-                        "to grpc-status: {} ({})", what, ctx, request.method(), request.requestTarget(),
-                request.version(), codeValue, fromCodeValue(codeValue), cause);
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Unexpected exception during a {} processing for connection={}, request='{} {} {}' was " +
+                            "mapped to grpc-status: {} ({})", what, ctx, request.method(), request.requestTarget(),
+                    request.version(), codeValue, fromCodeValue(codeValue), cause);
+        }
         return response;
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExceptionMapperServiceFilter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExceptionMapperServiceFilter.java
@@ -33,6 +33,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.grpc.api.GrpcHeaderNames.GRPC_STATUS;
 import static io.servicetalk.grpc.api.GrpcHeaderValues.APPLICATION_GRPC;
 import static io.servicetalk.grpc.api.GrpcStatusCode.fromCodeValue;
+import static io.servicetalk.grpc.api.GrpcStatusException.serverCatchAllShouldLog;
 import static io.servicetalk.grpc.api.GrpcUtils.newErrorResponse;
 
 /**
@@ -82,10 +83,10 @@ public final class GrpcExceptionMapperServiceFilter implements StreamingHttpServ
                                                                     final Throwable cause) {
         final StreamingHttpResponse response = newErrorResponse(responseFactory, APPLICATION_GRPC, cause,
                 ctx.executionContext().bufferAllocator(), null);
-        final CharSequence codeValue = response.headers().get(GRPC_STATUS);
-        assert codeValue != null;
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("Unexpected exception during a {} processing for connection={}, request='{} {} {}' was " +
+        if (serverCatchAllShouldLog(cause)) {
+            final CharSequence codeValue = response.headers().get(GRPC_STATUS);
+            assert codeValue != null;
+            LOGGER.error("Unexpected exception during a {} processing for connection={}, request='{} {} {}' was " +
                             "mapped to grpc-status: {} ({})", what, ctx, request.method(), request.requestTarget(),
                     request.version(), codeValue, fromCodeValue(codeValue), cause);
         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcFilters.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcFilters.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import io.servicetalk.concurrent.TimeSource;
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+import io.servicetalk.http.utils.TimeoutHttpRequesterFilter;
+import io.servicetalk.http.utils.TimeoutHttpServiceFilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.function.BiFunction;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.grpc.internal.DeadlineUtils.GRPC_DEADLINE_KEY;
+import static io.servicetalk.grpc.internal.DeadlineUtils.readTimeoutHeader;
+import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * Utility filters for gRPC.
+ */
+public final class GrpcFilters {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GrpcFilters.class);
+
+    private GrpcFilters() {
+    }
+
+    /**
+     * Create a {@link StreamingHttpClientFilterFactory} that enforces the
+     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout deadline
+     * propagation</a>.
+     * @return {@code this}.
+     */
+    public static StreamingHttpClientFilterFactory newGrpcDeadlineClientFilterFactory() {
+        return new TimeoutHttpRequesterFilter((request, timeSource) -> readTimeoutHeader(request), true);
+    }
+
+    /**
+     * Create a {@link StreamingHttpClientFilterFactory} that enforces the
+     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout deadline
+     * propagation</a>.
+     * @param defaultTimeout The default timeout to apply if not otherwise specified, or {@code null} doesn't apply a
+     * timeout if not specified.
+     * @return {@code this}.
+     */
+    public static StreamingHttpServiceFilterFactory newGrpcDeadlineServerFilterFactory(
+            @Nullable Duration defaultTimeout) {
+        return new TimeoutHttpServiceFilter(grpcDetermineTimeout(
+                defaultTimeout == null ? null : ensurePositive(defaultTimeout, "defaultTimeout")), true);
+    }
+
+    private static BiFunction<HttpRequestMetaData, TimeSource, Duration> grpcDetermineTimeout(
+            @Nullable Duration defaultTimeout) {
+        return (request, timeSource) -> {
+            /*
+             * Return the timeout duration extracted from the GRPC timeout HTTP header if present or default timeout.
+             *
+             * @param request The HTTP request to be used as source of the GRPC timeout header
+             * @return The non-negative timeout duration which may be null
+             */
+            @Nullable
+            Duration requestTimeout = readTimeoutHeader(request);
+            @Nullable
+            Duration timeout = null != requestTimeout ? requestTimeout : defaultTimeout;
+
+            if (null != timeout) {
+                // Store the timeout in the context as a deadline to be used for any client requests created
+                // during the context of handling this request.
+                try {
+                    Long deadline = timeSource.currentTime(NANOSECONDS) + timeout.toNanos();
+                    AsyncContext.put(GRPC_DEADLINE_KEY, deadline);
+                } catch (UnsupportedOperationException ignored) {
+                    LOGGER.debug("Async context disabled, timeouts will not be propagated to client requests");
+                    // ignored -- async context has probably been disabled.
+                    // Timeout propagation will be partially disabled.
+                    // cancel()s will still happen which will accomplish the same effect though less efficiently
+                }
+            }
+
+            return timeout;
+        };
+    }
+}

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcFilters.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcFilters.java
@@ -23,9 +23,6 @@ import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 import io.servicetalk.http.utils.TimeoutHttpRequesterFilter;
 import io.servicetalk.http.utils.TimeoutHttpServiceFilter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Duration;
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
@@ -39,15 +36,13 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * Utility filters for gRPC.
  */
 public final class GrpcFilters {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GrpcFilters.class);
-
     private GrpcFilters() {
     }
 
     /**
      * Create a {@link StreamingHttpClientFilterFactory} that enforces the
-     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout deadline
-     * propagation</a>.
+     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout</a>
+     * <a href="https://grpc.io/blog/deadlines">deadline propagation</a>.
      * @return {@code this}.
      */
     public static StreamingHttpClientFilterFactory newGrpcDeadlineClientFilterFactory() {
@@ -56,10 +51,10 @@ public final class GrpcFilters {
 
     /**
      * Create a {@link StreamingHttpClientFilterFactory} that enforces the
-     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout deadline
-     * propagation</a>.
-     * @param defaultTimeout The default timeout to apply if not otherwise specified, or {@code null} doesn't apply a
-     * timeout if not specified.
+     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout</a>
+     * <a href="https://grpc.io/blog/deadlines">deadline propagation</a>.
+     * @param defaultTimeout The default timeout to apply if not otherwise specified for the request, or {@code null}
+     * doesn't apply a timeout if not specified.
      * @return {@code this}.
      */
     public static StreamingHttpServiceFilterFactory newGrpcDeadlineServerFilterFactory(
@@ -85,15 +80,8 @@ public final class GrpcFilters {
             if (null != timeout) {
                 // Store the timeout in the context as a deadline to be used for any client requests created
                 // during the context of handling this request.
-                try {
-                    Long deadline = timeSource.currentTime(NANOSECONDS) + timeout.toNanos();
-                    AsyncContext.put(GRPC_DEADLINE_KEY, deadline);
-                } catch (UnsupportedOperationException ignored) {
-                    LOGGER.debug("Async context disabled, timeouts will not be propagated to client requests");
-                    // ignored -- async context has probably been disabled.
-                    // Timeout propagation will be partially disabled.
-                    // cancel()s will still happen which will accomplish the same effect though less efficiently
-                }
+                Long deadline = timeSource.currentTime(NANOSECONDS) + timeout.toNanos();
+                AsyncContext.put(GRPC_DEADLINE_KEY, deadline);
             }
 
             return timeout;

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -86,7 +86,11 @@ public interface GrpcServerBuilder {
      * @return {@code this}.
      * @see GrpcFilters#newGrpcDeadlineServerFilterFactory(Duration)
      */
-    GrpcServerBuilder appendTimeoutFilter(boolean append);
+    default GrpcServerBuilder appendTimeoutFilter(boolean append) {
+        // FIXME: 0.43 - remove default implementation
+        throw new UnsupportedOperationException(
+                "GrpcServerBuilder#appendTimeoutFilter(boolean) is not supported by " + getClass());
+    }
 
     /**
      * Sets a {@link GrpcLifecycleObserver} that provides visibility into gRPC lifecycle events.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -67,6 +67,7 @@ public interface GrpcServerBuilder {
      *
      * @param defaultTimeout {@link Duration} of default timeout which must be positive non-zero.
      * @return {@code this}.
+     * @see #defaultTimeout(Duration, boolean)
      */
     GrpcServerBuilder defaultTimeout(Duration defaultTimeout);
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -18,6 +18,7 @@ package io.servicetalk.grpc.api;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 
 import java.time.Duration;
 
@@ -67,6 +68,25 @@ public interface GrpcServerBuilder {
      * @return {@code this}.
      */
     GrpcServerBuilder defaultTimeout(Duration defaultTimeout);
+
+    /**
+     * Determine if a filter will be inserted by this builder that enforces the
+     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout deadline
+     * propagation</a>.
+     * <p>
+     * To insert {@link GrpcFilters#newGrpcDeadlineServerFilterFactory(Duration)} in your preferred order use
+     * {@link #initializeHttp} and
+     * {@link HttpServerBuilder#appendNonOffloadingServiceFilter(StreamingHttpServiceFilterFactory)} (to force ordering
+     * before any offloading filters) or
+     * {@link HttpServerBuilder#appendServiceFilter(StreamingHttpServiceFilterFactory)} (if you require different
+     * ordering).
+     * <p>
+     * {@link #defaultTimeout(Duration)} may be ignored if {@code append} is false.
+     * @param append {@code true} if this builder should append the timeout filter, {@code false} if it should not.
+     * @return {@code this}.
+     * @see GrpcFilters#newGrpcDeadlineServerFilterFactory(Duration)
+     */
+    GrpcServerBuilder appendTimeoutFilter(boolean append);
 
     /**
      * Sets a {@link GrpcLifecycleObserver} that provides visibility into gRPC lifecycle events.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -21,6 +21,7 @@ import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 
 import java.time.Duration;
+import javax.annotation.Nullable;
 
 /**
  * A builder for building a <a href="https://www.grpc.io">gRPC</a> server.
@@ -70,26 +71,25 @@ public interface GrpcServerBuilder {
     GrpcServerBuilder defaultTimeout(Duration defaultTimeout);
 
     /**
-     * Determine if a filter will be inserted by this builder that enforces the
-     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">Timeout deadline
-     * propagation</a>.
-     * <p>
-     * To insert {@link GrpcFilters#newGrpcDeadlineServerFilterFactory(Duration)} in your preferred order use
+     * Set a default timeout during which gRPC calls are expected to complete. This default will be used only if the
+     * request includes no timeout; any value specified in client request will supersede this default.
+     *
+     * @param defaultTimeout {@link Duration} of default timeout which must be positive non-zero, or {@code null} if a
+     * default shouldn't be applied.
+     * @param appendTimeoutFilter {@code true} to append the filter that enforces
+     * <a href="https://grpc.io/blog/deadlines">deadline propagation</a>. {@code false} to not append the filter and
+     * therefore not enforce deadlines. If {@code false} you can manually insert
+     * {@link GrpcFilters#newGrpcDeadlineServerFilterFactory(Duration)} in your preferred order use
      * {@link #initializeHttp} and
      * {@link HttpServerBuilder#appendNonOffloadingServiceFilter(StreamingHttpServiceFilterFactory)} (to force ordering
      * before any offloading filters) or
      * {@link HttpServerBuilder#appendServiceFilter(StreamingHttpServiceFilterFactory)} (if you require different
      * ordering).
-     * <p>
-     * {@link #defaultTimeout(Duration)} may be ignored if {@code append} is false.
-     * @param append {@code true} if this builder should append the timeout filter, {@code false} if it should not.
      * @return {@code this}.
-     * @see GrpcFilters#newGrpcDeadlineServerFilterFactory(Duration)
      */
-    default GrpcServerBuilder appendTimeoutFilter(boolean append) {
+    default GrpcServerBuilder defaultTimeout(@Nullable Duration defaultTimeout, boolean appendTimeoutFilter) {
         // FIXME: 0.43 - remove default implementation
-        throw new UnsupportedOperationException(
-                "GrpcServerBuilder#appendTimeoutFilter(boolean) is not supported by " + getClass());
+        throw new UnsupportedOperationException("method not supported by " + getClass());
     }
 
     /**

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
@@ -147,4 +147,8 @@ public final class GrpcStatusException extends RuntimeException {
 
         return status;
     }
+
+    static boolean serverCatchAllShouldLog(Throwable cause) {
+        return !(cause instanceof TimeoutException || cause instanceof CancellationException);
+    }
 }

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   api project(":servicetalk-grpc-utils")
   api project(":servicetalk-http-netty")
 
-  implementation project(":servicetalk-http-utils")
+  compileOnly project(":servicetalk-http-utils")
   implementation project(":servicetalk-grpc-internal")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-transport-netty-internal")
@@ -52,6 +52,7 @@ dependencies {
   testImplementation project(":servicetalk-encoding-api-internal")
   testImplementation project(":servicetalk-encoding-netty")
   testImplementation project(":servicetalk-grpc-protobuf")
+  testImplementation project(":servicetalk-http-utils")
   testImplementation project(":servicetalk-data-protobuf")
   testImplementation project(":servicetalk-grpc-protoc")
   testImplementation project(":servicetalk-router-utils-internal")

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   api project(":servicetalk-grpc-utils")
   api project(":servicetalk-http-netty")
 
-  compileOnly project(":servicetalk-http-utils")
+  compileOnly project(":servicetalk-http-utils") // only for javadoc references
   implementation project(":servicetalk-grpc-internal")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-transport-netty-internal")

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -75,8 +75,10 @@ final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
     }
 
     @Override
-    public GrpcClientBuilder<U, R> appendTimeoutFilter(final boolean append) {
-        appendTimeoutFilter = append;
+    public GrpcClientBuilder<U, R> defaultTimeout(@Nullable final Duration defaultTimeout,
+                                                  final boolean appendTimeoutFilter) {
+        this.defaultTimeout = defaultTimeout == null ? null : ensurePositive(defaultTimeout, "defaultTimeout");
+        this.appendTimeoutFilter = appendTimeoutFilter;
         return this;
     }
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -16,8 +16,6 @@
 package io.servicetalk.grpc.netty;
 
 import io.servicetalk.buffer.api.BufferAllocator;
-import io.servicetalk.concurrent.TimeSource;
-import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.grpc.api.GrpcBindableService;
@@ -33,14 +31,12 @@ import io.servicetalk.http.api.BlockingStreamingHttpService;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpProtocolConfig;
-import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpService;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
-import io.servicetalk.http.utils.TimeoutHttpServiceFilter;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ConnectionAcceptorFactory;
 import io.servicetalk.transport.api.IoExecutor;
@@ -48,14 +44,10 @@ import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextBuilder;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.SocketOption;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -63,17 +55,12 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.FutureUtils.awaitResult;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.internal.DeadlineUtils.GRPC_DEADLINE_KEY;
-import static io.servicetalk.grpc.internal.DeadlineUtils.readTimeoutHeader;
+import static io.servicetalk.grpc.api.GrpcFilters.newGrpcDeadlineServerFilterFactory;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultGrpcServerBuilder.class);
-
     private final Supplier<HttpServerBuilder> httpServerBuilderSupplier;
     private GrpcServerBuilder.HttpInitializer initializer = builder -> {
         // no-op
@@ -90,6 +77,7 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
      */
     @Nullable
     private Duration defaultTimeout;
+    private boolean appendTimeoutFilter = true;
 
     // Do not use this ctor directly, GrpcServers is the entry point for creating a new builder.
     DefaultGrpcServerBuilder(final Supplier<HttpServerBuilder> httpServerBuilderSupplier) {
@@ -107,6 +95,12 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     @Override
     public GrpcServerBuilder defaultTimeout(Duration defaultTimeout) {
         this.defaultTimeout = ensurePositive(defaultTimeout, "defaultTimeout");
+        return this;
+    }
+
+    @Override
+    public GrpcServerBuilder appendTimeoutFilter(final boolean append) {
+        appendTimeoutFilter = append;
         return this;
     }
 
@@ -164,43 +158,12 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
         interceptor.appendNonOffloadingServiceFilter(GrpcExceptionMapperServiceFilter.INSTANCE);
 
         directCallInitializer.initialize(interceptor);
+        if (appendTimeoutFilter) {
+            interceptor.appendNonOffloadingServiceFilter(newGrpcDeadlineServerFilterFactory(defaultTimeout));
+        }
         initializer.initialize(interceptor);
 
-        interceptor.appendServiceFilter(
-                new TimeoutHttpServiceFilter(grpcDetermineTimeout(defaultTimeout), true));
         return interceptor;
-    }
-
-    private static BiFunction<HttpRequestMetaData, TimeSource, Duration> grpcDetermineTimeout(
-            @Nullable Duration defaultTimeout) {
-        return (HttpRequestMetaData request, TimeSource timeSource) -> {
-                /*
-                * Return the timeout duration extracted from the GRPC timeout HTTP header if present or default timeout.
-                *
-                * @param request The HTTP request to be used as source of the GRPC timeout header
-                * @return The non-negative timeout duration which may be null
-                */
-                @Nullable
-                Duration requestTimeout = readTimeoutHeader(request);
-                @Nullable
-                Duration timeout = null != requestTimeout ? requestTimeout : defaultTimeout;
-
-                if (null != timeout) {
-                    // Store the timeout in the context as a deadline to be used for any client requests created
-                    // during the context of handling this request.
-                    try {
-                        Long deadline = timeSource.currentTime(NANOSECONDS) + timeout.toNanos();
-                        AsyncContext.put(GRPC_DEADLINE_KEY, deadline);
-                    } catch (UnsupportedOperationException ignored) {
-                        LOGGER.debug("Async context disabled, timeouts will not be propagated to client requests");
-                        // ignored -- async context has probably been disabled.
-                        // Timeout propagation will be partially disabled.
-                        // cancel()s will still happen which will accomplish the same effect though less efficiently
-                    }
-                }
-
-                return timeout;
-            };
     }
 
     @Override

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -99,8 +99,10 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     }
 
     @Override
-    public GrpcServerBuilder appendTimeoutFilter(final boolean append) {
-        appendTimeoutFilter = append;
+    public GrpcServerBuilder defaultTimeout(@Nullable final Duration defaultTimeout,
+                                            final boolean appendTimeoutFilter) {
+        this.defaultTimeout = defaultTimeout == null ? null : ensurePositive(defaultTimeout, "defaultTimeout");
+        this.appendTimeoutFilter = appendTimeoutFilter;
         return this;
     }
 

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverRequesterFilter.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcLifecycleObserverRequesterFilter.java
@@ -17,6 +17,7 @@ package io.servicetalk.grpc.netty;
 
 import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.grpc.api.GrpcClientBuilder;
+import io.servicetalk.grpc.api.GrpcFilters;
 import io.servicetalk.grpc.api.GrpcLifecycleObserver;
 import io.servicetalk.grpc.api.GrpcLifecycleObserver.GrpcExchangeObserver;
 import io.servicetalk.http.api.HttpRequestMetaData;
@@ -54,8 +55,8 @@ import java.util.function.UnaryOperator;
  *     <li>As the last
  *     {@link SingleAddressHttpClientBuilder#appendConnectionFilter(StreamingHttpConnectionFilterFactory) connection
  *     filter} if only network interactions should be observed without accounting for work of any other filters.</li>
- *     <li>After {@link TimeoutHttpRequesterFilter} if the timeout event should be observed as
- *     {@link GrpcExchangeObserver#onResponseCancel() cancellation} instead of an
+ *     <li>After {@link TimeoutHttpRequesterFilter} (or {@link GrpcFilters#newGrpcDeadlineClientFilterFactory()}) if the
+ *     timeout event should be observed as {@link GrpcExchangeObserver#onResponseCancel() cancellation} instead of an
  *     {@link GrpcExchangeObserver#onResponseError(Throwable) error}.</li>
  *     <li>Before any filter that populates {@link HttpResponseMetaData#context() response context} or alters
  *     {@link HttpResponseMetaData} if that information has to be available for {@link GrpcExchangeObserver}.</li>

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcTimeoutOrderTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcTimeoutOrderTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.api.GrpcClientBuilder;
+import io.servicetalk.grpc.api.GrpcServerBuilder;
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+import io.servicetalk.transport.api.ServerContext;
+
+import io.grpc.examples.helloworld.Greeter;
+import io.grpc.examples.helloworld.Greeter.BlockingGreeterClient;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.grpc.api.GrpcFilters.newGrpcDeadlineClientFilterFactory;
+import static io.servicetalk.grpc.api.GrpcFilters.newGrpcDeadlineServerFilterFactory;
+import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
+import static io.servicetalk.grpc.netty.GrpcClients.forResolvedAddress;
+import static io.servicetalk.grpc.netty.GrpcServers.forAddress;
+import static io.servicetalk.grpc.netty.GrpcTimeoutOrderTest.NeverStreamingHttpClientFilterFactory.NEVER_CLIENT_FILTER;
+import static io.servicetalk.grpc.netty.GrpcTimeoutOrderTest.NeverStreamingHttpServiceFilterFactory.NEVER_SERVER_FILTER;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static java.time.Duration.ofMillis;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class GrpcTimeoutOrderTest {
+    private static final Duration DEFAULT_TIMEOUT = ofMillis(5);
+
+    @ParameterizedTest(name = "{displayName} [{index}] appendNonOffloading={0} serverBuilderAppendTimeout={1} " +
+            "serverManualAppendTimeout={2}")
+    @CsvSource(value = {"true,true,false", "false,true,false", "false,false,false", "true,false,true",
+                        "true,false,false"})
+    void serverFilterNeverRespondsAppliesDeadline(boolean appendNonOffloading, boolean serverBuilderAppendTimeout,
+                                                  boolean serverManualAppendTimeout)
+            throws Exception {
+        final boolean clientAppliesTimeout = (!serverManualAppendTimeout && !serverBuilderAppendTimeout);
+        try (ServerContext serverContext = applyDefaultTimeout(forAddress(localAddress(0))
+                .appendTimeoutFilter(serverBuilderAppendTimeout)
+                .initializeHttp(builder -> {
+                    if (serverManualAppendTimeout) {
+                        if (appendNonOffloading) {
+                            builder.appendNonOffloadingServiceFilter(
+                                    newGrpcDeadlineServerFilterFactory(DEFAULT_TIMEOUT));
+                        } else {
+                            builder.appendServiceFilter(newGrpcDeadlineServerFilterFactory(DEFAULT_TIMEOUT));
+                        }
+                    }
+                    if (appendNonOffloading) {
+                        builder.appendNonOffloadingServiceFilter(NEVER_SERVER_FILTER);
+                    } else {
+                        builder.appendServiceFilter(NEVER_SERVER_FILTER);
+                    }
+                }), serverBuilderAppendTimeout ? DEFAULT_TIMEOUT : null)
+                .listenAndAwait((Greeter.GreeterService) (ctx, request) ->
+                        succeeded(HelloReply.newBuilder().setMessage("hello " + request.getName()).build()));
+             BlockingGreeterClient client = applyDefaultTimeout(forResolvedAddress(serverContext.listenAddress())
+                     .appendTimeoutFilter(clientAppliesTimeout), clientAppliesTimeout ? DEFAULT_TIMEOUT : null)
+                     .buildBlocking(new Greeter.ClientFactory())) {
+            assertThat(assertThrows(GrpcStatusException.class, () ->
+                            client.sayHello(HelloRequest.newBuilder().setName("world").build())
+                    ).status().code(), equalTo(clientAppliesTimeout ? UNKNOWN : DEADLINE_EXCEEDED));
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] builderEnableTimeout={0}")
+    @ValueSource(booleans = {true, false})
+    void clientNeverRespondsAppliesDeadline(boolean builderEnableTimeout)
+            throws Exception {
+        try (ServerContext serverContext = forAddress(localAddress(0))
+                .appendTimeoutFilter(false)
+                .listenAndAwait((Greeter.GreeterService) (ctx, request) ->
+                        succeeded(HelloReply.newBuilder().setMessage("hello " + request.getName()).build()));
+             BlockingGreeterClient client = forResolvedAddress(serverContext.listenAddress())
+                     .appendTimeoutFilter(builderEnableTimeout)
+                     .defaultTimeout(DEFAULT_TIMEOUT)
+                     .initializeHttp(builder -> {
+                         if (!builderEnableTimeout) {
+                             builder.appendClientFilter(newGrpcDeadlineClientFilterFactory());
+                         }
+                         builder.appendClientFilter(NEVER_CLIENT_FILTER);
+                     })
+                     .buildBlocking(new Greeter.ClientFactory())) {
+            assertThat(assertThrows(GrpcStatusException.class, () ->
+                    client.sayHello(HelloRequest.newBuilder().setName("world").build())
+            ).status().code(), equalTo(UNKNOWN));
+        }
+    }
+
+    private static GrpcServerBuilder applyDefaultTimeout(GrpcServerBuilder builder, @Nullable Duration defaultTimeout) {
+        return defaultTimeout != null ? builder.defaultTimeout(defaultTimeout) : builder;
+    }
+
+    private static <T> GrpcClientBuilder<T, T> applyDefaultTimeout(GrpcClientBuilder<T, T> builder,
+                                                                   @Nullable Duration defaultTimeout) {
+        return defaultTimeout != null ? builder.defaultTimeout(defaultTimeout) : builder;
+    }
+
+    static final class NeverStreamingHttpClientFilterFactory implements StreamingHttpClientFilterFactory {
+        static final StreamingHttpClientFilterFactory NEVER_CLIENT_FILTER = new NeverStreamingHttpClientFilterFactory();
+
+        private NeverStreamingHttpClientFilterFactory() {
+        }
+
+        @Override
+        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
+            return new StreamingHttpClientFilter(client) {
+                @Override
+                protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                                final StreamingHttpRequest request) {
+                    return Single.never();
+                }
+            };
+        }
+
+        @Override
+        public HttpExecutionStrategy requiredOffloads() {
+            return offloadNone();
+        }
+    }
+
+    static final class NeverStreamingHttpServiceFilterFactory implements StreamingHttpServiceFilterFactory {
+        static final StreamingHttpServiceFilterFactory NEVER_SERVER_FILTER =
+                new NeverStreamingHttpServiceFilterFactory();
+
+        private NeverStreamingHttpServiceFilterFactory() {
+        }
+
+        @Override
+        public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+            return new StreamingHttpServiceFilter(service) {
+                @Override
+                public Single<StreamingHttpResponse> handle(
+                        final HttpServiceContext ctx, final StreamingHttpRequest request,
+                        final StreamingHttpResponseFactory responseFactory) {
+                    return Single.never();
+                }
+            };
+        }
+
+        @Override
+        public HttpExecutionStrategy requiredOffloads() {
+            return offloadNone();
+        }
+    }
+}

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcTimeoutOrderTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcTimeoutOrderTest.java
@@ -51,7 +51,6 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.grpc.api.GrpcFilters.newGrpcDeadlineClientFilterFactory;
 import static io.servicetalk.grpc.api.GrpcFilters.newGrpcDeadlineServerFilterFactory;
 import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
-import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
 import static io.servicetalk.grpc.netty.GrpcClients.forResolvedAddress;
 import static io.servicetalk.grpc.netty.GrpcServers.forAddress;
 import static io.servicetalk.grpc.netty.GrpcTimeoutOrderTest.NeverStreamingHttpClientFilterFactory.NEVER_CLIENT_FILTER;
@@ -125,11 +124,9 @@ final class GrpcTimeoutOrderTest {
 
     private static void assertGrpcTimeout(Executable executable, boolean clientSideTimeout) {
         GrpcStatusException e = assertThrows(GrpcStatusException.class, executable);
+        assertThat(e.status().code(), equalTo(DEADLINE_EXCEEDED));
         if (clientSideTimeout) {
-            assertThat(e.status().code(), equalTo(UNKNOWN));
             assertThat(e.getCause(), instanceOf(TimeoutException.class));
-        } else {
-            assertThat(e.status().code(), equalTo(DEADLINE_EXCEEDED));
         }
     }
 


### PR DESCRIPTION
Motivation:
The default insertion order for gRPC deadline filter is after user filters. If a user's filter deadlocks the timeout will never be applied.

Some use cases may necessitate applying the deadline timeout filter in a custom order (e.g. relative to retries). There is currently no way to customize the append ordering.

Modifications:
- Move the gRPC server deadline filter to the beginning of the filter chain so timeouts are applied regardless if user filter code hangs.
- Add appendTimeoutFilter method to gRPC client and server builder to give users control over filter append ordering.
- Introduce GrpcFilters utility class to create the filters that apply deadline propagation.