### PR TITLE
Revert "Make HTTP/1.x server-side control flow consistent with the client-side (#2367)"

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
@@ -27,9 +27,7 @@ import io.servicetalk.grpc.netty.TesterProto.Tester.TesterClient;
 import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.HttpResponseMetaData;
-import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServiceContext;
-import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -40,13 +38,11 @@ import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.utils.BeforeFinallyHttpOperator;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import io.grpc.examples.helloworld.Greeter;
 import io.grpc.examples.helloworld.Greeter.GreeterClient;
 import io.grpc.examples.helloworld.HelloRequest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 
 import java.net.InetSocketAddress;
@@ -79,25 +75,15 @@ import static org.mockito.Mockito.when;
 
 class TrailersOnlyErrorTest {
 
-    @RegisterExtension
-    static final ExecutionContextExtension SERVER_CTX =
-            ExecutionContextExtension.cached("server-io", "server-executor")
-                    .setClassLevel(true);
-    @RegisterExtension
-    static final ExecutionContextExtension CLIENT_CTX =
-            ExecutionContextExtension.cached("client-io", "client-executor")
-                    .setClassLevel(true);
-
     @Test
     void testRouteThrows() throws Exception {
         final BlockingQueue<Throwable> asyncErrors = new LinkedBlockingDeque<>();
         final CountDownLatch responseLatch = new CountDownLatch(1);
         try (ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
-                .initializeHttp(TrailersOnlyErrorTest::applyCtx)
                 .listenAndAwait(new Tester.ServiceFactory(mockTesterService()))) {
 
             final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> applyCtx(builder)
+                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> builder
                             .appendClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors, responseLatch)));
 
             // The server only binds on Tester service, but the client sends a HelloRequest (Greeter service),
@@ -118,11 +104,10 @@ class TrailersOnlyErrorTest {
         setupServiceThrows(service);
 
         try (ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
-                .initializeHttp(TrailersOnlyErrorTest::applyCtx)
                 .listenAndAwait(new Tester.ServiceFactory(service))) {
 
             final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> applyCtx(builder)
+                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> builder
                             .appendClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors, responseLatch)));
 
             try (TesterClient client = clientBuilder.build(new Tester.ClientFactory())) {
@@ -152,11 +137,10 @@ class TrailersOnlyErrorTest {
         setupServiceThrows(service);
 
         try (ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
-                .initializeHttp(TrailersOnlyErrorTest::applyCtx)
                 .listenAndAwait(new Tester.ServiceFactory(service))) {
 
             final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> applyCtx(builder)
+                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> builder
                             .appendClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors, responseLatch)));
 
             try (BlockingTesterClient client = clientBuilder.buildBlocking(new Tester.ClientFactory())) {
@@ -165,8 +149,6 @@ class TrailersOnlyErrorTest {
 
                 verifyException(() -> client.testRequestStream(singleton(TestRequest.newBuilder().build())), UNKNOWN);
                 assertNoAsyncErrors(asyncErrors);
-
-                // Skip testing client.testResponseStream bcz it can not generate Trailers-Only response
 
                 verifyException(() -> client.testBiDiStream(singleton(TestRequest.newBuilder().build()))
                         .iterator().next(), UNKNOWN);
@@ -184,11 +166,10 @@ class TrailersOnlyErrorTest {
         setupServiceSingleThrows(service);
 
         try (ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
-                .initializeHttp(TrailersOnlyErrorTest::applyCtx)
                 .listenAndAwait(new Tester.ServiceFactory(service))) {
 
             final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> applyCtx(builder)
+                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> builder
                             .appendClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors, responseLatch)));
 
             try (TesterClient client = clientBuilder.build(new Tester.ClientFactory())) {
@@ -211,7 +192,6 @@ class TrailersOnlyErrorTest {
         final TesterService service = mockTesterService();
 
         final GrpcServerBuilder serverBuilder = GrpcServers.forAddress(localAddress(0))
-                .initializeHttp(TrailersOnlyErrorTest::applyCtx)
                 .initializeHttp(builder -> builder.appendServiceFilter(svc -> new StreamingHttpServiceFilter(svc) {
                     @Override
                     public Single<StreamingHttpResponse> handle(
@@ -224,7 +204,7 @@ class TrailersOnlyErrorTest {
         try (ServerContext serverContext = serverBuilder.listenAndAwait(new Tester.ServiceFactory(service))) {
 
             final GrpcClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> applyCtx(builder)
+                    GrpcClients.forAddress(serverHostAndPort(serverContext)).initializeHttp(builder -> builder
                             .appendClientFilter(__ -> true, setupResponseVerifierFilter(asyncErrors, responseLatch)));
 
             try (TesterClient client = clientBuilder.build(new Tester.ClientFactory())) {
@@ -261,10 +241,10 @@ class TrailersOnlyErrorTest {
     }
 
     private static TesterService mockTesterService() {
-        TesterService service = mock(TesterService.class);
-        when(service.closeAsync()).thenReturn(completed());
-        when(service.closeAsyncGracefully()).thenReturn(completed());
-        return service;
+        TesterService filter = mock(TesterService.class);
+        when(filter.closeAsync()).thenReturn(completed());
+        when(filter.closeAsyncGracefully()).thenReturn(completed());
+        return filter;
     }
 
     private static void setupServiceThrows(final TesterService service) {
@@ -307,19 +287,5 @@ class TrailersOnlyErrorTest {
         } catch (Throwable t) {
             errors.add(t);
         }
-    }
-
-    private static HttpServerBuilder applyCtx(HttpServerBuilder builder) {
-        return builder
-                .ioExecutor(SERVER_CTX.ioExecutor())
-                .executor(SERVER_CTX.executor())
-                .bufferAllocator(SERVER_CTX.bufferAllocator());
-    }
-
-    private static <U, R> SingleAddressHttpClientBuilder<U, R> applyCtx(SingleAddressHttpClientBuilder<U, R> builder) {
-        return builder
-                .ioExecutor(CLIENT_CTX.ioExecutor())
-                .executor(CLIENT_CTX.executor())
-                .bufferAllocator(CLIENT_CTX.bufferAllocator());
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BuilderUtils.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BuilderUtils.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
@@ -37,17 +38,18 @@ final class BuilderUtils {
         // No instances
     }
 
-    static HttpServerBuilder newServerBuilder(ExecutionContext<? extends ExecutionStrategy> ctx,
-                                              HttpProtocol... protocols) {
-        return newServerBuilderWithConfigs(ctx, toConfigs(protocols));
+    static HttpServerBuilder newLocalServer(ExecutionContext<? extends ExecutionStrategy> ctx,
+                                            HttpProtocol... protocols) {
+        return newLocalServerWithConfigs(ctx, toConfigs(protocols));
     }
 
-    static HttpServerBuilder newServerBuilderWithConfigs(ExecutionContext<? extends ExecutionStrategy> ctx,
-                                                         HttpProtocolConfig... protocols) {
+    static HttpServerBuilder newLocalServerWithConfigs(ExecutionContext<? extends ExecutionStrategy> ctx,
+                                                       HttpProtocolConfig... protocols) {
         HttpServerBuilder builder = HttpServers.forAddress(localAddress(0))
                 .ioExecutor(ctx.ioExecutor())
                 .executor(ctx.executor())
                 .bufferAllocator(ctx.bufferAllocator())
+                .executionStrategy(HttpExecutionStrategy.from(ctx.executionStrategy()))
                 .enableWireLogging("servicetalk-tests-wire-logger", TRACE, Boolean.TRUE::booleanValue)
                 .lifecycleObserver(logging("servicetalk-tests-lifecycle-observer-logger", TRACE));
         if (protocols.length > 0) {
@@ -56,14 +58,14 @@ final class BuilderUtils {
         return builder;
     }
 
-    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilder(
+    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClient(
             ServerContext serverContext,
             ExecutionContext<? extends ExecutionStrategy> ctx,
             HttpProtocol... protocols) {
-        return newClientBuilderWithConfigs(serverContext, ctx, toConfigs(protocols));
+        return newClientWithConfigs(serverContext, ctx, toConfigs(protocols));
     }
 
-    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilderWithConfigs(
+    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientWithConfigs(
             ServerContext serverContext,
             ExecutionContext<? extends ExecutionStrategy> ctx,
             HttpProtocolConfig... protocols) {
@@ -73,6 +75,7 @@ final class BuilderUtils {
                         .ioExecutor(ctx.ioExecutor())
                         .executor(ctx.executor())
                         .bufferAllocator(ctx.bufferAllocator())
+                        .executionStrategy(HttpExecutionStrategy.from(ctx.executionStrategy()))
                         .enableWireLogging("servicetalk-tests-wire-logger", TRACE, Boolean.TRUE::booleanValue)
                         .appendClientFilter(new HttpLifecycleObserverRequesterFilter(
                                 logging("servicetalk-tests-lifecycle-observer-logger", TRACE)));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
@@ -72,8 +72,8 @@ import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.UNPROCESSABLE_ENTITY;
-import static io.servicetalk.http.netty.BuilderUtils.newClientBuilderWithConfigs;
-import static io.servicetalk.http.netty.BuilderUtils.newServerBuilderWithConfigs;
+import static io.servicetalk.http.netty.BuilderUtils.newClientWithConfigs;
+import static io.servicetalk.http.netty.BuilderUtils.newLocalServerWithConfigs;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -573,7 +573,7 @@ class ExpectContinueTest {
     private static HttpServerContext startServer(HttpProtocol protocol,
                                                  boolean useOtherHeadersFactory,
                                                  BlockingStreamingHttpService service) throws Exception {
-        return newServerBuilderWithConfigs(SERVER_CTX,
+        return newLocalServerWithConfigs(SERVER_CTX,
                 useOtherHeadersFactory ? protocol.configOtherHeadersFactory : protocol.config)
                 .listenBlockingStreamingAndAwait(service);
     }
@@ -586,7 +586,7 @@ class ExpectContinueTest {
     private static StreamingHttpClient createClient(HttpServerContext serverContext,
                                                     HttpProtocol protocol, boolean useOtherHeadersFactory,
                                                     @Nullable StreamingHttpClientFilterFactory filterFactory) {
-        final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder = newClientBuilderWithConfigs(
+        final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder = newClientWithConfigs(
                 serverContext, CLIENT_CTX,
                 useOtherHeadersFactory ? protocol.configOtherHeadersFactory : protocol.config);
         if (filterFactory != null) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
@@ -32,7 +34,6 @@ import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpServerConfig;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -57,9 +58,11 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
 import static io.servicetalk.http.api.StreamingHttpRequests.newTransportRequest;
-import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.NettyHttpServer.initChannel;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -68,14 +71,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class FlushStrategyOnServerTest {
 
     @RegisterExtension
-    static final ExecutionContextExtension SERVER_CTX =
-            ExecutionContextExtension.cached("server-io", "server-executor")
-                    .setClassLevel(true);
-    @RegisterExtension
-    static final ExecutionContextExtension CLIENT_CTX =
-            ExecutionContextExtension.cached("client-io", "client-executor")
-                    .setClassLevel(true);
-
+    static final ExecutorExtension<Executor> EXECUTOR_RULE = ExecutorExtension.withCachedExecutor().setClassLevel(true);
     private static final String USE_AGGREGATED_RESP = "aggregated-resp";
     private static final String USE_EMPTY_RESP_BODY = "empty-resp-body";
 
@@ -110,8 +106,8 @@ class FlushStrategyOnServerTest {
             return succeeded(resp);
         };
 
-        final DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(
-                SERVER_CTX.bufferAllocator(), SERVER_CTX.ioExecutor(), SERVER_CTX.executor(), param.executionStrategy);
+        final DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR,
+                globalExecutionContext().ioExecutor(), EXECUTOR_RULE.executor(), param.executionStrategy);
 
         final ReadOnlyHttpServerConfig config = new HttpServerConfig().asReadOnly();
         final ReadOnlyTcpServerConfig tcpReadOnly = new TcpServerConfig().asReadOnly();
@@ -134,7 +130,9 @@ class FlushStrategyOnServerTest {
             fail(e);
         }
 
-        client = newClientBuilder(serverContext, CLIENT_CTX).buildBlocking();
+        client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                .protocols(h1Default())
+                .buildBlocking();
     }
 
     @AfterEach

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -176,7 +176,7 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
             verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
             verify(serverDataObserver, await()).onNewRead();
-            verify(serverReadObserver, await()).requestedToRead(anyLong());
+            verify(serverDataObserver, await()).onNewWrite();
         } else {
             verify(clientConnectionObserver).multiplexedConnectionEstablished(any(ConnectionInfo.class));
             verify(serverConnectionObserver, await()).multiplexedConnectionEstablished(any(ConnectionInfo.class));
@@ -186,12 +186,9 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
         assertConnectionClosed();
         verify(clientConnectionObserver).connectionClosed();
         verify(serverConnectionObserver, await()).connectionClosed();
-        if (protocol == HTTP_1) {
-            verify(serverReadObserver, await()).readFailed(any(ClosedChannelException.class));
-        }
 
         verifyNoMoreInteractions(clientTransportObserver, clientDataObserver, clientMultiplexedObserver,
-                serverTransportObserver, serverDataObserver, serverMultiplexedObserver, serverReadObserver);
+                serverTransportObserver, serverDataObserver, serverMultiplexedObserver);
         if (protocol != HTTP_2) {
             // HTTP/2 coded adds additional write/flush events related to connection preface. Also, it may emit more
             // flush events on the pipeline after the connection is closed.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InsufficientlySizedExecutorHttpTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InsufficientlySizedExecutorHttpTest.java
@@ -24,11 +24,9 @@ import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.transport.api.ServerContext;
-import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -43,9 +41,11 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpResponseStatus.SERVICE_UNAVAILABLE;
-import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
-import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
+import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
+import static io.servicetalk.http.netty.HttpServers.forAddress;
 import static io.servicetalk.transport.api.ConnectionAcceptorFactory.identity;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.instanceOf;
@@ -54,16 +54,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class InsufficientlySizedExecutorHttpTest {
-
-    @RegisterExtension
-    static final ExecutionContextExtension SERVER_CTX =
-            ExecutionContextExtension.cached("server-io", "server-executor")
-                    .setClassLevel(true);
-    @RegisterExtension
-    static final ExecutionContextExtension CLIENT_CTX =
-            ExecutionContextExtension.cached("client-io", "client-executor")
-                    .setClassLevel(true);
-
     @Nullable
     private Executor executor;
     @Nullable
@@ -116,9 +106,9 @@ class InsufficientlySizedExecutorHttpTest {
 
     private void initWhenClientUnderProvisioned(final int capacity) throws Exception {
         executor = getExecutorForCapacity(capacity);
-        server = newServerBuilder(SERVER_CTX)
+        server = forAddress(localAddress(0))
                 .listenStreamingAndAwait((ctx, request, responseFactory) -> succeeded(responseFactory.ok()));
-        client = newClientBuilder(server, CLIENT_CTX)
+        client = forSingleAddress(serverHostAndPort(server))
                 .executor(executor)
                 .executionStrategy(offloadAllStrategy())
                 .buildStreaming();
@@ -129,15 +119,13 @@ class InsufficientlySizedExecutorHttpTest {
         throws Exception {
         executor = getExecutorForCapacity(capacity);
         final HttpExecutionStrategy strategy = offloadAllStrategy();
-        HttpServerBuilder serverBuilder = newServerBuilder(SERVER_CTX);
+        HttpServerBuilder serverBuilder = forAddress(localAddress(0));
         if (addConnectionAcceptor) {
             serverBuilder.appendConnectionAcceptorFilter(identity());
         }
-        server = serverBuilder
-                .executor(executor)
-                .executionStrategy(strategy)
+        server = serverBuilder.executor(executor).executionStrategy(strategy)
                 .listenStreamingAndAwait((ctx, request, respFactory) -> succeeded(respFactory.ok()));
-        client = newClientBuilder(server, CLIENT_CTX).buildStreaming();
+        client = forSingleAddress(serverHostAndPort(server)).buildStreaming();
     }
 
     private HttpExecutionStrategy offloadAllStrategy() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
@@ -52,8 +52,8 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
-import static io.servicetalk.http.netty.BuilderUtils.newClientBuilderWithConfigs;
-import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
+import static io.servicetalk.http.netty.BuilderUtils.newClientWithConfigs;
+import static io.servicetalk.http.netty.BuilderUtils.newLocalServer;
 import static io.servicetalk.http.netty.GracefulConnectionClosureHandlingTest.RAW_STRING_SERIALIZER;
 import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
 import static java.lang.Long.MAX_VALUE;
@@ -208,10 +208,10 @@ class ServerPipelineControlFlowTest {
 
     private void test(HttpServerFactory serverFactory, boolean serverHasOffloading, boolean drainRequestPayloadBody,
                       boolean responseHasPayload) throws Exception {
-        try (HttpServerContext serverContext = serverFactory.create(newServerBuilder(SERVER_CTX)
+        try (HttpServerContext serverContext = serverFactory.create(newLocalServer(SERVER_CTX)
                 .executionStrategy(serverHasOffloading ? defaultStrategy() : offloadNone())
                 .drainRequestPayloadBody(drainRequestPayloadBody));
-             StreamingHttpClient client = newClientBuilderWithConfigs(serverContext, CLIENT_CTX,
+             StreamingHttpClient client = newClientWithConfigs(serverContext, CLIENT_CTX,
                      new H1ProtocolConfigBuilder().maxPipelinedRequests(3).build())
                      .buildStreaming();
              StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
@@ -24,7 +24,6 @@ import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.logging.slf4j.internal.FixedLevelLogger;
 import io.servicetalk.transport.api.ConnectionInfo;
 
-import java.util.Arrays;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.logging.slf4j.internal.Slf4jFixedLevelLoggers.newLogger;
@@ -108,23 +107,20 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
 
         @Override
         public void onRequestComplete() {
-            Object current = requestResult;
-            assert current == null : assertResultMsg(current, "requestResult");
-            assert requestMetaData != null : "Request meta-data is not expected to be null on completion";
+            assert requestResult == null;
+            assert requestMetaData != null;
             requestResult = Result.complete;
         }
 
         @Override
         public void onRequestError(final Throwable cause) {
-            Object current = requestResult;
-            assert current == null : assertResultMsg(current, "requestResult");
+            assert requestResult == null;
             requestResult = cause;
         }
 
         @Override
         public void onRequestCancel() {
-            Object current = requestResult;
-            assert current == null : assertResultMsg(current, "requestResult");
+            assert requestResult == null;
             requestResult = Result.cancelled;
         }
 
@@ -151,8 +147,7 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
 
         @Override
         public void onResponseComplete() {
-            Object current = responseResult;
-            assert current == null : assertResultMsg(current, "responseResult");
+            assert responseResult == null;
             assert responseMetaData != null;
             responseTimeMs = durationMs(startTime);
             responseResult = Result.complete;
@@ -160,16 +155,14 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
 
         @Override
         public void onResponseError(final Throwable cause) {
-            Object current = responseResult;
-            assert current == null : assertResultMsg(current, "responseResult");
+            assert responseResult == null;
             responseTimeMs = durationMs(startTime);
             responseResult = cause;
         }
 
         @Override
         public void onResponseCancel() {
-            Object current = responseResult;
-            assert current == null : assertResultMsg(current, "responseResult");
+            assert responseResult == null;
             responseTimeMs = durationMs(startTime);
             responseResult = Result.cancelled;
         }
@@ -220,12 +213,6 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
 
         private enum Result {
             complete, error, cancelled
-        }
-
-        private static String assertResultMsg(final Object current, final String name) {
-            return "Unexpected " + name + ": " + current + (current instanceof Throwable ?
-                    '\n' + String.join("\n", Arrays.stream(((Throwable) current).getStackTrace())
-                            .map(String::valueOf).toArray(CharSequence[]::new)) : "");
         }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandler.java
@@ -154,7 +154,9 @@ final class RequestResponseCloseHandler extends CloseHandler {
             protocolPayloadEndOutbound0(ctx);
             return;
         }
-        ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
+        if (isClient || (closeEvent != null && pending == 0)) {
+            ctx.pipeline().fireUserEventTriggered(OutboundDataEndEvent.INSTANCE);
+        }
         promise.addListener(f -> protocolPayloadEndOutbound0(ctx));
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SplittingFlushStrategy.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SplittingFlushStrategy.java
@@ -33,11 +33,8 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
 /**
  * A {@link FlushStrategy} that splits writes into logical write boundaries and manages flush state across those logical
  * write boundaries. Actual flush logic is delegated to an externally provided (and updatable) {@link FlushStrategy}.
- *
- * @deprecated This class will be removed in the future releases.
  */
-@Deprecated
-public final class SplittingFlushStrategy implements FlushStrategy {    // FIXME: 0.43 - remove deprecated class
+public final class SplittingFlushStrategy implements FlushStrategy {
     private static final AtomicReferenceFieldUpdater<SplittingFlushStrategy, SplittingWriteEventsListener>
             listenerUpdater = newUpdater(SplittingFlushStrategy.class, SplittingWriteEventsListener.class,
             "listener");
@@ -101,10 +98,7 @@ public final class SplittingFlushStrategy implements FlushStrategy {    // FIXME
 
     /**
      * A provider of {@link FlushBoundary} for each written item.
-     *
-     * @deprecated This interface will be removed in the future releases.
      */
-    @Deprecated
     @FunctionalInterface
     public interface FlushBoundaryProvider {
         /**

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/RequestResponseCloseHandlerTest.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,9 +62,7 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
@@ -114,7 +111,6 @@ import static java.util.Arrays.asList;
 import static java.util.Objects.hash;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -521,9 +517,8 @@ class RequestResponseCloseHandlerTest {
     @Nested
     class RequestResponseUserEventTest {
 
-        @ParameterizedTest(name = "{displayName} [{index}] isClient={0}")
-        @ValueSource(booleans = {false, true})
-        void outboundDataEndEventEmitsUserEventAlways(boolean isClient) throws Exception {
+        @Test
+        void clientOutboundDataEndEventEmitsUserEventAlways() throws Exception {
             AtomicBoolean ab = new AtomicBoolean(false);
             final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
                 @Override
@@ -534,50 +529,63 @@ class RequestResponseCloseHandlerTest {
                     ctx.fireUserEventTriggered(evt);
                 }
             });
-            final RequestResponseCloseHandler ch = new RequestResponseCloseHandler(isClient);
+            final RequestResponseCloseHandler ch = new RequestResponseCloseHandler(true);
             channel.eventLoop().execute(() -> ch.protocolPayloadEndOutbound(channel.pipeline().firstContext(),
                     channel.newPromise()));
-            channel.runPendingTasks();
-            assertThat("OutboundDataEndEvent not fired", ab.get(), is(true));
             channel.close().sync();
+            assertThat("OutboundDataEndEvent not fired", ab.get(), is(true));
         }
 
         @Test
-        void serverOutboundDataEndEventEmitsAfterEveryResponse() throws Exception {
-            BlockingQueue<OutboundDataEndEvent> events = new LinkedBlockingQueue<>();
+        void serverOutboundDataEndEventDoesntEmitUntilClosing() throws Exception {
+            AtomicBoolean ab = new AtomicBoolean(false);
             final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
                 @Override
                 public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
                     if (evt == OutboundDataEndEvent.INSTANCE) {
-                        events.add((OutboundDataEndEvent) evt);
+                        ab.set(true);
+                    }
+                    ctx.fireUserEventTriggered(evt);
+                }
+            });
+            final RequestResponseCloseHandler ch = new RequestResponseCloseHandler(false);
+            channel.eventLoop().execute(() ->
+                    ch.protocolPayloadEndOutbound(channel.pipeline().firstContext(), channel.newPromise()));
+            channel.close().sync();
+            assertThat("OutboundDataEndEvent should not fire", ab.get(), is(false));
+        }
+
+        @Test
+        void serverOutboundDataEndEventDoesntEmitUntilClosingAndIdle() throws Exception {
+            AtomicBoolean ab = new AtomicBoolean(false);
+            final EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
+                @Override
+                public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+                    if (evt == OutboundDataEndEvent.INSTANCE) {
+                        ab.set(true);
                     }
                     ctx.fireUserEventTriggered(evt);
                 }
             });
             final ChannelHandlerContext ctx = channel.pipeline().firstContext();
             final RequestResponseCloseHandler ch = new RequestResponseCloseHandler(false);
-            assertThat("Unexpected OutboundDataEndEvent", events, is(empty()));
             // Request #1
             channel.eventLoop().execute(() -> ch.protocolPayloadBeginInbound(ctx));
             channel.eventLoop().execute(() -> ch.protocolPayloadEndInbound(ctx));
-            assertThat("Unexpected OutboundDataEndEvent", events, is(empty()));
             // Request #2
             channel.eventLoop().execute(() -> ch.protocolPayloadBeginInbound(ctx));
             channel.eventLoop().execute(() -> ch.protocolPayloadEndInbound(ctx));
             channel.eventLoop().execute(() -> ch.gracefulUserClosing(channel));
-            assertThat("Unexpected OutboundDataEndEvent", events, is(empty()));
             // Response #1
             channel.eventLoop().execute(() -> ch.protocolPayloadBeginOutbound(ctx));
             channel.eventLoop().execute(() -> ch.protocolPayloadEndOutbound(ctx, ctx.newPromise()));
             channel.runPendingTasks();
-            assertThat("OutboundDataEndEvent not fired", events.poll(), is(OutboundDataEndEvent.INSTANCE));
-            assertThat("Unexpected OutboundDataEndEvent", events, is(empty()));
+            assertThat("OutboundDataEndEvent should not fire", ab.get(), is(false));
             // Response #2
             channel.eventLoop().execute(() -> ch.protocolPayloadBeginOutbound(ctx));
             channel.eventLoop().execute(() -> ch.protocolPayloadEndOutbound(ctx, ctx.newPromise()));
             channel.close().sync();
-            assertThat("OutboundDataEndEvent not fired", events.poll(), is(OutboundDataEndEvent.INSTANCE));
-            assertThat("Unexpected OutboundDataEndEvent", events, is(empty()));
+            assertThat("OutboundDataEndEvent not fired", ab.get(), is(true));
         }
 
         @Test

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/SslCloseNotifyAlertServerHandlingTest.java
@@ -17,6 +17,7 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.test.StepVerifiers;
+import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +25,10 @@ import java.nio.channels.ClosedChannelException;
 
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_INBOUND;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotifyAlertHandlingTest {
 
@@ -57,7 +62,11 @@ class SslCloseNotifyAlertServerHandlingTest extends AbstractSslCloseNotifyAlertH
                     closeNotifyAndVerifyClosing();
                     writeSource.onComplete();
                 })
-                .expectComplete()
+                .expectErrorConsumed(cause -> {
+                    assertThat("Unexpected write failure cause", cause, instanceOf(CloseEventObservedException.class));
+                    CloseEventObservedException ceoe = (CloseEventObservedException) cause;
+                    assertThat("Unexpected close event", ceoe.event(), is(CHANNEL_CLOSED_INBOUND));
+                })
                 .verify();
     }
 


### PR DESCRIPTION
This reverts commit a0e6540ffe77eac504e3a73181c5f428e98c2c63.

We will reapply this change after release.