### PR TITLE
Add warning in example that DefaultTestCerts should not be used

### DIFF
--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -197,6 +197,8 @@ public final class DebuggingExampleClient {
                 /*
                  * For ALPN, make sure to supply both HTTP/2 and HTTP/1.X HttpProtocolConfigs and SslConfig.
                  */
+                // Note: DefaultTestCerts contains self-signed certificates that may be used only for local testing
+                // or demonstration purposes. Never use those for real use-cases.
                 // .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build())
                 // .protocols(HttpProtocolConfigs.h2()
                 //         .enableFrameLogging("servicetalk-examples-h2-frame-logger", TRACE, LOG_USER_DATA)

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -192,6 +192,8 @@ public final class DebuggingExampleServer {
                 /*
                  * For ALPN, make sure to supply both HTTP/2 and HTTP/1.X HttpProtocolConfigs and SslConfig.
                  */
+                // Note: DefaultTestCerts contains self-signed certificates that may be used only for local testing
+                // or demonstration purposes. Never use those for real use-cases.
                 // .sslConfig(new ServerSslConfigBuilder(
                 //         DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey).build())
                 // .protocols(HttpProtocolConfigs.h2()

--- a/servicetalk-examples/http/http2/src/main/java/io/servicetalk/examples/http/http2/alpn/HttpClientWithAlpn.java
+++ b/servicetalk-examples/http/http2/src/main/java/io/servicetalk/examples/http/http2/alpn/HttpClientWithAlpn.java
@@ -37,6 +37,8 @@ public final class HttpClientWithAlpn {
         // streaming API see helloworld examples.
         try (BlockingHttpClient client = HttpClients.forSingleAddress("localhost", 8080)
                 .protocols(h2Default(), h1Default()) // Configure support for HTTP/2 and HTTP/1.1 protocols
+                // Note: DefaultTestCerts contains self-signed certificates that may be used only for local testing.
+                // or demonstration purposes. Never use those for real use-cases.
                 .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build())
                 .buildBlocking()) {
             HttpResponse response = client.request(client.get("/"));

--- a/servicetalk-examples/http/http2/src/main/java/io/servicetalk/examples/http/http2/alpn/HttpServerWithAlpn.java
+++ b/servicetalk-examples/http/http2/src/main/java/io/servicetalk/examples/http/http2/alpn/HttpServerWithAlpn.java
@@ -33,6 +33,8 @@ public final class HttpServerWithAlpn {
     public static void main(String[] args) throws Exception {
         HttpServers.forPort(8080)
                 .protocols(h2Default(), h1Default()) // Configure support for HTTP/2 and HTTP/1.1 protocols
+                // Note: DefaultTestCerts contains self-signed certificates that may be used only for local testing.
+                // or demonstration purposes. Never use those for real use-cases.
                 .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
                         .build())
                 // Note: this example demonstrates only blocking-aggregated programming paradigm, for asynchronous and

--- a/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpClientMutualTLS.java
+++ b/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpClientMutualTLS.java
@@ -32,6 +32,8 @@ public final class HttpClientMutualTLS {
         // Note: this example demonstrates only blocking-aggregated programming paradigm, for asynchronous and
         // streaming API see helloworld examples.
         try (BlockingHttpClient client = HttpClients.forSingleAddress("localhost", 8080)
+                // Note: DefaultTestCerts contains self-signed certificates that may be used only for local testing.
+                // or demonstration purposes. Never use those for real use-cases.
                 .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                         // Specify the client's certificate/key pair to use to authenticate to the server.
                         .keyManager(DefaultTestCerts::loadClientPem, DefaultTestCerts::loadClientKey).build())

--- a/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpServerMutualTLS.java
+++ b/servicetalk-examples/http/mutual-tls/src/main/java/io/servicetalk/examples/http/mutualtls/HttpServerMutualTLS.java
@@ -29,6 +29,8 @@ public final class HttpServerMutualTLS {
 
     public static void main(String[] args) throws Exception {
         HttpServers.forPort(8080)
+                // Note: DefaultTestCerts contains self-signed certificates that may be used only for local testing.
+                // or demonstration purposes. Never use those for real use-cases.
                 .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
                         // Require clients to authenticate, otherwise a handshake may succeed without authentication.
                         .clientAuthMode(SslClientAuthMode.REQUIRE)

--- a/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/RedirectingServer.java
+++ b/servicetalk-examples/http/redirects/src/main/java/io/servicetalk/examples/http/redirects/RedirectingServer.java
@@ -45,6 +45,8 @@ public final class RedirectingServer {
 
     public static void main(String... args) throws Exception {
         ServerContext finalServer = HttpServers.forPort(SECURE_SERVER_PORT)
+                // Note: DefaultTestCerts contains self-signed certificates that may be used only for local testing.
+                // or demonstration purposes. Never use those for real use-cases.
                 .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
                         .build())
                 // Wire-logging helps to demonstrate requests and responses that have been sent


### PR DESCRIPTION
Motivation:

`DefaultTestCerts` contains self-signed certificates that we use only to demonstrate SSL configuration API.

Modifications:

- Add a note in all examples to notify users they should not copy paste this certificates in their projects;

Result:

Users have a warning about DefaultTestCerts.