### PR TITLE
Add gRPC Request Response Context Example

### DIFF
--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -28,3 +28,4 @@
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#execution-strategy[Execution Strategy]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#route-guide[Route Guide]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#protoc-options[Protoc Options]
+** xref:{page-version}@servicetalk-examples::grpc/index.adoc#request-response-context[Request Response Context]

--- a/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/grpc/index.adoc
@@ -178,3 +178,22 @@ The example demonstrates the impact of different route execution strategy config
 
 This example demonstrates how options for the servicetalk-grpc-protoc plugin can be used. See
 link:{source-root}/servicetalk-examples/grpc/protoc-options[protoc-options] for more details.
+
+[#request-response-context]
+== Request Response Context
+
+This example demonstrates how request and response context can be used to access HTTP meta-data.
+
+=== Asynchronous
+
+This example demonstrates context with asynchronous request processing using the
+link:{source-root}/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/async/RequestResponseContextClient.java[RequestResponseContextClient]
+and a
+link:{source-root}/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/async/RequestResponseContextServer.java[RequestResponseContextServer].
+
+=== Blocking
+
+This example demonstrates context with blocking request processing using the
+link:{source-root}/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/blocking/BlockingRequestResponseContextClient.java[BlockingRequestResponseContextClient]
+and a
+link:{source-root}/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/blocking/BlockingRequestResponseContextServer.java[BlockingRequestResponseContextServer].

--- a/servicetalk-examples/grpc/request-response-context/README.adoc
+++ b/servicetalk-examples/grpc/request-response-context/README.adoc
@@ -1,0 +1,4 @@
+== ServiceTalk gRPC Request Response Context Example
+
+Extends "Hello World" ServiceTalk gRPC example to demonstrate how request and response context can be used to access
+HTTP meta-data.

--- a/servicetalk-examples/grpc/request-response-context/build.gradle
+++ b/servicetalk-examples/grpc/request-response-context/build.gradle
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+  dependencies {
+    classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufGradlePluginVersion"
+  }
+}
+
+apply plugin: "java"
+apply plugin: "com.google.protobuf"
+apply from: "../../gradle/idea.gradle"
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-grpc-netty")
+  implementation project(":servicetalk-grpc-protoc")
+  implementation project(":servicetalk-grpc-protobuf")
+
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+
+  //// REMOVE if outside of ServiceTalk gradle project
+  def pluginJar = file("${project.rootProject.rootDir}/servicetalk-grpc-protoc/build" +
+      "/buildExecutable/servicetalk-grpc-protoc-${project.version}-all.jar")
+  //// REMOVE if outside of ServiceTalk gradle project
+
+  plugins {
+    servicetalk_grpc {
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+      //// "path" is used only because we want to use the gradle project local version of the plugin.
+      path = pluginJar.path
+      //// REMOVE if outside of ServiceTalk gradle project - use "artifact" as demonstrated below
+
+      // artifact = "io.servicetalk:servicetalk-grpc-protoc:$serviceTalkVersion:all@jar"
+    }
+  }
+  generateProtoTasks {
+    all().each { task ->
+      //// REMOVE if outside of ServiceTalk gradle project
+      task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
+
+      // you may need to manually add the artifact name as an input
+      task.inputs
+          .file(pluginJar)
+          .withNormalizer(ClasspathNormalizer)
+          .withPropertyName("servicetalkPluginJar")
+          .withPathSensitivity(PathSensitivity.RELATIVE)
+      //// REMOVE if outside of ServiceTalk gradle project
+
+      task.plugins {
+        servicetalk_grpc {
+          // Need to tell protobuf-gradle-plugin to output in the correct directory if all generated
+          // code for a single proto goes to a single file (e.g. "java_multiple_files = false" in the .proto).
+          outputSubDir = "java"
+        }
+      }
+    }
+  }
+  generatedFilesBaseDir = "$buildDir/generated/sources/proto"
+}

--- a/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/HttpContextFilters.java
+++ b/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/HttpContextFilters.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.context;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap.Key;
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.context.api.ContextMap.Key.newKey;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+
+/**
+ * HTTP filters that translate information between request/response context and request/response HTTP headers.
+ */
+public final class HttpContextFilters {
+
+    public static final Key<CharSequence> USER_ID_KEY = newKey("user-id-key", CharSequence.class);
+    private static final CharSequence USER_ID_HEADER = newAsciiString("user-id-header");
+
+    private HttpContextFilters() {
+        // No instances
+    }
+
+    public static StreamingHttpClientFilterFactory clientFilter() {
+        return ClientFilter.INSTANCE;
+    }
+
+    public static StreamingHttpServiceFilterFactory serviceFilter() {
+        return ServiceFilter.INSTANCE;
+    }
+
+    private static final class ClientFilter implements StreamingHttpClientFilterFactory {
+
+        static final StreamingHttpClientFilterFactory INSTANCE = new ClientFilter();
+
+        private ClientFilter() {
+            // Singleton
+        }
+
+        @Override
+        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
+            return new StreamingHttpClientFilter(client) {
+                @Override
+                protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                                final StreamingHttpRequest request) {
+                    // Single.defer(...) helps to make sure the header is set on every retry
+                    return Single.defer(() -> {
+                        // gRPC request context can be accessed via HTTP request context:
+                        CharSequence userId = request.context().get(USER_ID_KEY);
+                        if (userId != null) {
+                            request.setHeader(USER_ID_HEADER, userId);
+                        }
+                        return delegate.request(request).whenOnSuccess(response -> {
+                            CharSequence responseUserId = response.headers().get(USER_ID_HEADER);
+                            if (responseUserId != null) {
+                                // HTTP response context will be translated to gRPC response context.
+                                // If necessary, the entire HttpHeaders object can be put into the context.
+                                response.context().put(USER_ID_KEY, responseUserId);
+                            }
+                        }).shareContextOnSubscribe();
+                    });
+                }
+            };
+        }
+
+        @Override
+        public HttpExecutionStrategy requiredOffloads() {
+            return offloadNone();   // This filter doesn't block
+        }
+    }
+
+    private static final class ServiceFilter implements StreamingHttpServiceFilterFactory {
+
+        static final StreamingHttpServiceFilterFactory INSTANCE = new ServiceFilter();
+
+        private ServiceFilter() {
+            // Singleton
+        }
+
+        @Override
+        public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+            return new StreamingHttpServiceFilter(service) {
+                @Override
+                public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                            final StreamingHttpRequest request,
+                                                            final StreamingHttpResponseFactory responseFactory) {
+                    CharSequence userId = request.headers().get(USER_ID_HEADER);
+                    if (userId != null) {
+                        // HTTP request context will be translated to gRPC request context.
+                        // If necessary, the entire HttpHeaders object can be put into the context.
+                        request.context().put(USER_ID_KEY, userId);
+                    }
+                    return delegate().handle(ctx, request, responseFactory).whenOnSuccess(response -> {
+                        // gRPC response context can be accessed via HTTP response context:
+                        CharSequence responseUserId = response.context().get(USER_ID_KEY);
+                        if (responseUserId != null) {
+                            response.setHeader(USER_ID_HEADER, responseUserId);
+                        }
+                    });
+                }
+            };
+        }
+
+        @Override
+        public HttpExecutionStrategy requiredOffloads() {
+            return offloadNone();   // This filter doesn't block
+        }
+    }
+}

--- a/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/async/RequestResponseContextClient.java
+++ b/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/async/RequestResponseContextClient.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.context.async;
+
+import io.servicetalk.examples.grpc.context.HttpContextFilters;
+import io.servicetalk.grpc.api.DefaultGrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcClientMetadata;
+import io.servicetalk.grpc.netty.GrpcClients;
+import io.servicetalk.http.api.HttpMetaData;
+
+import io.grpc.examples.helloworld.Greeter.ClientFactory;
+import io.grpc.examples.helloworld.Greeter.GreeterClient;
+import io.grpc.examples.helloworld.HelloRequest;
+
+/**
+ * This example demonstrates how {@link GrpcClientMetadata#requestContext() request} and
+ * {@link GrpcClientMetadata#responseContext() response} context can be used to access {@link HttpMetaData}.
+ * <p>
+ * Start the {@link RequestResponseContextServer} first.
+ */
+public final class RequestResponseContextClient {
+    public static void main(String... args) throws Exception {
+        try (GreeterClient client = GrpcClients.forAddress("localhost", 8080)
+                .initializeHttp(httpBuilder -> httpBuilder.appendClientFilter(HttpContextFilters.clientFilter()))
+                .build(new ClientFactory())) {
+
+            // GrpcClientMetadata opens access to request and response context:
+            GrpcClientMetadata metadata = new DefaultGrpcClientMetadata();
+            metadata.requestContext().put(HttpContextFilters.USER_ID_KEY, "xyz");
+            client.sayHello(metadata, HelloRequest.newBuilder().setName("World").build())
+                    .whenOnSuccess(reply -> {
+                        System.out.print(reply);
+                        System.out.println("Response user-id: " +
+                                metadata.responseContext().get(HttpContextFilters.USER_ID_KEY));
+                    })
+            // This example is demonstrating asynchronous execution, but needs to prevent the main thread from exiting
+            // before the response has been processed. This isn't typical usage for an asynchronous API but is useful
+            // for demonstration purposes.
+                    .toFuture().get();
+        }
+    }
+}

--- a/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/async/RequestResponseContextServer.java
+++ b/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/async/RequestResponseContextServer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.context.async;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.examples.grpc.context.HttpContextFilters;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.netty.GrpcServers;
+import io.servicetalk.http.api.HttpMetaData;
+
+import io.grpc.examples.helloworld.Greeter.GreeterService;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+
+/**
+ * This example demonstrates how {@link GrpcServiceContext#requestContext() request} and
+ * {@link GrpcServiceContext#responseContext() response} context can be used to access {@link HttpMetaData}.
+ * <p>
+ * Start this server first and then run the {@link RequestResponseContextClient}.
+ */
+public final class RequestResponseContextServer {
+    public static void main(String... args) throws Exception {
+        GrpcServers.forPort(8080)
+                .initializeHttp(httpBuilder -> httpBuilder.appendServiceFilter(HttpContextFilters.serviceFilter()))
+                .listenAndAwait(new GreeterService() {
+                    @Override
+                    public Single<HelloReply> sayHello(final GrpcServiceContext ctx, final HelloRequest request) {
+                        return Single.defer(() -> {
+                            CharSequence userId = ctx.requestContext().get(HttpContextFilters.USER_ID_KEY);
+                            ctx.responseContext().put(HttpContextFilters.USER_ID_KEY, userId + "-processed");
+                            return succeeded(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
+                        });
+                    }
+                })
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/async/package-info.java
+++ b/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/async/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.grpc.context.async;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/blocking/BlockingRequestResponseContextClient.java
+++ b/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/blocking/BlockingRequestResponseContextClient.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.context.blocking;
+
+import io.servicetalk.examples.grpc.context.HttpContextFilters;
+import io.servicetalk.grpc.api.DefaultGrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcClientMetadata;
+import io.servicetalk.grpc.netty.GrpcClients;
+import io.servicetalk.http.api.HttpMetaData;
+
+import io.grpc.examples.helloworld.Greeter.BlockingGreeterClient;
+import io.grpc.examples.helloworld.Greeter.ClientFactory;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+
+/**
+ * This example demonstrates how {@link GrpcClientMetadata#requestContext() request} and
+ * {@link GrpcClientMetadata#responseContext() response} context can be used to access {@link HttpMetaData}.
+ * <p>
+ * Start the {@link BlockingRequestResponseContextServer} first.
+ */
+public final class BlockingRequestResponseContextClient {
+    public static void main(String[] args) throws Exception {
+        try (BlockingGreeterClient client = GrpcClients.forAddress("localhost", 8080)
+                .initializeHttp(httpBuilder -> httpBuilder.appendClientFilter(HttpContextFilters.clientFilter()))
+                .buildBlocking(new ClientFactory())) {
+            // GrpcClientMetadata opens access to request and response context:
+            GrpcClientMetadata metadata = new DefaultGrpcClientMetadata();
+            metadata.requestContext().put(HttpContextFilters.USER_ID_KEY, "xyz");
+            HelloReply reply = client.sayHello(metadata, HelloRequest.newBuilder().setName("World").build());
+            System.out.print(reply);
+            System.out.println("Response user-id: " + metadata.responseContext().get(HttpContextFilters.USER_ID_KEY));
+        }
+    }
+}

--- a/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/blocking/BlockingRequestResponseContextServer.java
+++ b/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/blocking/BlockingRequestResponseContextServer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.grpc.context.blocking;
+
+import io.servicetalk.examples.grpc.context.HttpContextFilters;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.netty.GrpcServers;
+import io.servicetalk.http.api.HttpMetaData;
+
+import io.grpc.examples.helloworld.Greeter.BlockingGreeterService;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+
+/**
+ * This example demonstrates how {@link GrpcServiceContext#requestContext() request} and
+ * {@link GrpcServiceContext#responseContext() response} context can be used to access {@link HttpMetaData}.
+ * <p>
+ * Start this server first and then run the {@link BlockingRequestResponseContextClient}.
+ */
+public final class BlockingRequestResponseContextServer {
+    public static void main(String[] args) throws Exception {
+        GrpcServers.forPort(8080)
+                .initializeHttp(httpBuilder -> httpBuilder.appendServiceFilter(HttpContextFilters.serviceFilter()))
+                .listenAndAwait(new BlockingGreeterService() {
+                    @Override
+                    public HelloReply sayHello(final GrpcServiceContext ctx, final HelloRequest request) {
+                        CharSequence userId = ctx.requestContext().get(HttpContextFilters.USER_ID_KEY);
+                        ctx.responseContext().put(HttpContextFilters.USER_ID_KEY, userId + "-processed");
+                        return HelloReply.newBuilder().setMessage("Hello " + request.getName()).build();
+                    }
+                })
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/blocking/package-info.java
+++ b/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/blocking/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.grpc.context.blocking;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/package-info.java
+++ b/servicetalk-examples/grpc/request-response-context/src/main/java/io/servicetalk/examples/grpc/context/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.grpc.context;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/grpc/request-response-context/src/main/proto/greeter.proto
+++ b/servicetalk-examples/grpc/request-response-context/src/main/proto/greeter.proto
@@ -1,0 +1,37 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/servicetalk-examples/grpc/request-response-context/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/grpc/request-response-context/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.H2ServerParentConnectionContext" level="DEBUG"/>
+
+    <!-- Prints default subscriber errors-->
+    <Logger name="io.servicetalk.concurrent.api" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,6 +44,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:grpc:helloworld",
         "servicetalk-examples:grpc:routeguide",
         "servicetalk-examples:grpc:protoc-options",
+        "servicetalk-examples:grpc:request-response-context",
         "servicetalk-examples:grpc:compression",
         "servicetalk-examples:grpc:errors",
         "servicetalk-examples:grpc:deadline",
@@ -115,6 +116,8 @@ include "servicetalk-annotations",
 project(":servicetalk-examples:grpc:helloworld").name = "servicetalk-examples-grpc-helloworld"
 project(":servicetalk-examples:grpc:routeguide").name = "servicetalk-examples-grpc-routeguide"
 project(":servicetalk-examples:grpc:protoc-options").name = "servicetalk-examples-grpc-protoc-options"
+project(":servicetalk-examples:grpc:request-response-context").name =
+    "servicetalk-examples-grpc-request-response-context"
 project(":servicetalk-examples:grpc:compression").name = "servicetalk-examples-grpc-compression"
 project(":servicetalk-examples:grpc:deadline").name = "servicetalk-examples-grpc-deadline"
 project(":servicetalk-examples:grpc:debugging").name = "servicetalk-examples-grpc-debugging"


### PR DESCRIPTION
Motivation:

Demonstrate how users can use gRPC request/response context to access HTTP headers.

Modifications:

- Add `servicetalk-examples-grpc-request-response-context` module;

Result:

Users can see how to use gRPC request/response context.