### PR TITLE
Add ListenableAsyncCloseable#onClosing()

### DIFF
--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/DefaultPartitionedClientGroup.java
@@ -132,6 +132,11 @@ public final class DefaultPartitionedClientGroup<U, R, Client extends Listenable
     }
 
     @Override
+    public Completable onClosing() {
+        return partitionMap.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         // Cancel doesn't provide any status and is assumed to complete immediately so we just cancel when subscribe
         // is called.
@@ -210,8 +215,18 @@ public final class DefaultPartitionedClientGroup<U, R, Client extends Listenable
         }
 
         @Override
+        public Completable onClosing() {
+            return close.onClosing();
+        }
+
+        @Override
         public Completable closeAsync() {
             return close.closeAsync();
+        }
+
+        @Override
+        public Completable closeAsyncGracefully() {
+            return close.closeAsyncGracefully();
         }
 
         static final class MutableInt {

--- a/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMap.java
+++ b/servicetalk-client-api-internal/src/main/java/io/servicetalk/client/api/internal/partition/PowerSetPartitionMap.java
@@ -207,6 +207,11 @@ public final class PowerSetPartitionMap<T extends AsyncCloseable> implements Par
     }
 
     @Override
+    public Completable onClosing() {
+        return asyncCloseable.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return asyncCloseable.closeAsync();
     }

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultClientGroup.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultClientGroup.java
@@ -176,6 +176,11 @@ final class DefaultClientGroup<Key, Client extends ListenableAsyncCloseable> imp
     }
 
     @Override
+    public Completable onClosing() {
+        return asyncCloseable.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return asyncCloseable.closeAsync();
     }

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingConnectionFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingConnectionFactory.java
@@ -69,6 +69,11 @@ public class DelegatingConnectionFactory<ResolvedAddress, C extends ListenableAs
     }
 
     @Override
+    public Completable onClosing() {
+        return delegate.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return delegate.closeAsync();
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingStExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ContextPreservingStExecutor.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
@@ -44,6 +45,11 @@ final class ContextPreservingStExecutor implements Executor {
     }
 
     @Override
+    public Cancellable schedule(final Runnable task, final Duration delay) {
+        return delegate.schedule(new ContextPreservingRunnable(task), delay);
+    }
+
+    @Override
     public long currentTime(TimeUnit unit) {
         return delegate.currentTime(unit);
     }
@@ -54,12 +60,24 @@ final class ContextPreservingStExecutor implements Executor {
     }
 
     @Override
+    public Completable onClosing() {
+        return delegate.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return delegate.closeAsync();
+    }
+
+    @Override
+    public Completable closeAsyncGracefully() {
+        return delegate.closeAsyncGracefully();
     }
 
     static Executor of(Executor delegate) {
         return delegate instanceof ContextPreservingStExecutor ? delegate :
                 new ContextPreservingStExecutor(delegate);
     }
+
+    // Don't override methods that return an async source. Context will be captured at subscribe by the async source.
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
@@ -112,6 +112,11 @@ public abstract class DelegatingExecutor implements Executor {
     }
 
     @Override
+    public Completable onClosing() {
+        return delegate.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return delegate.closeAsync();
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ListenableAsyncCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ListenableAsyncCloseable.java
@@ -25,4 +25,21 @@ public interface ListenableAsyncCloseable extends AsyncCloseable {
      * @return the {@code Completable} that is notified on close.
      */
     Completable onClose();
+
+    /**
+     * Returns a {@link Completable} that is notified when closing begins.
+     * <p>
+     * Closing begin might be when a close operation is initiated locally (e.g. subscribing to {@link #closeAsync()}) or
+     * it could also be a transport event received from a remote peer (e.g. read a {@code connection: close} header).
+     * <p>
+     * For backwards compatibility this method maybe functionally equivalent to {@link #onClose()}. Therefore, provides
+     * a best-effort leading edge notification of closing, but may fall back to notification on trailing edge.
+     * <p>
+     * The goal of this method is often to notify asap when closing so this method may not be offloaded and care must
+     * be taken to avoid blocking if subscribing to the return {@link Completable}.
+     * @return a {@link Completable} that is notified when closing begins.
+     */
+    default Completable onClosing() {
+        return onClose();
+    }
 }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -273,6 +273,11 @@ final class DefaultDnsClient implements DnsClient {
     }
 
     @Override
+    public Completable onClosing() {
+        return asyncCloseable.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return asyncCloseable.closeAsync();
     }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsClientFilter.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsClientFilter.java
@@ -56,6 +56,11 @@ class DnsClientFilter implements DnsClient {
     }
 
     @Override
+    public Completable onClosing() {
+        return client.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return client.closeAsync();
     }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsClients.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsClients.java
@@ -65,6 +65,11 @@ final class DnsClients {
             }
 
             @Override
+            public Completable onClosing() {
+                return dns.onClosing();
+            }
+
+            @Override
             public Publisher<Collection<ServiceDiscovererEvent<InetSocketAddress>>> discover(final String s) {
                 return dns.dnsSrvQuery(s);
             }
@@ -101,6 +106,11 @@ final class DnsClients {
             @Override
             public Completable onClose() {
                 return dns.onClose();
+            }
+
+            @Override
+            public Completable onClosing() {
+                return dns.onClosing();
             }
 
             @Override

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -374,6 +374,11 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
         return streamingHttpClient.onClose();
     }
 
+    @Override
+    public Completable onClosing() {
+        return streamingHttpClient.onClosing();
+    }
+
     /**
      * Determines the timeout for a new request using three potential sources; the deadline in the async context, the
      * request timeout, and the client default. The timeout will be the lesser of the context and request timeouts or if

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcServiceContext.java
@@ -103,6 +103,11 @@ final class DefaultGrpcServiceContext extends DefaultGrpcMetadata implements Grp
     }
 
     @Override
+    public Completable onClosing() {
+        return connectionContext.onClosing();
+    }
+
+    @Override
     public Completable onClose() {
         return connectionContext.onClose();
     }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -234,6 +234,11 @@ final class GrpcRouter {
         }
 
         @Override
+        public Completable onClosing() {
+            return delegate.onClosing();
+        }
+
+        @Override
         public SocketAddress listenAddress() {
             return delegate.listenAddress();
         }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ClientTransportGrpcCallFactory.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ClientTransportGrpcCallFactory.java
@@ -136,6 +136,11 @@ final class ClientTransportGrpcCallFactory implements GrpcClientCallFactory {
     }
 
     @Override
+    public Completable onClosing() {
+        return closeable.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return closeable.closeAsync();
     }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
@@ -154,6 +154,11 @@ final class Utils {
             return closeAsync.onClose();
         }
 
+        @Override
+        public Completable onClosing() {
+            return closeAsync.onClosing();
+        }
+
         @Deprecated
         @Override
         public String path() {

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Generator.java
@@ -153,6 +153,7 @@ import static io.servicetalk.grpc.protoc.Words.metadata;
 import static io.servicetalk.grpc.protoc.Words.methodDescriptor;
 import static io.servicetalk.grpc.protoc.Words.methodDescriptors;
 import static io.servicetalk.grpc.protoc.Words.onClose;
+import static io.servicetalk.grpc.protoc.Words.onClosing;
 import static io.servicetalk.grpc.protoc.Words.registerRoutes;
 import static io.servicetalk.grpc.protoc.Words.request;
 import static io.servicetalk.grpc.protoc.Words.requestEncoding;
@@ -1274,6 +1275,7 @@ final class Generator {
                         .build())
                 .addMethod(newDelegatingMethodSpec(executionContext, factory, GrpcExecutionContext, null))
                 .addMethod(newDelegatingCompletableMethodSpec(onClose, factory))
+                .addMethod(newDelegatingCompletableMethodSpec(onClosing, factory))
                 .addMethod(newDelegatingCompletableMethodSpec(closeAsync, factory))
                 .addMethod(newDelegatingCompletableMethodSpec(closeAsyncGracefully, factory))
                 .addMethod(newDelegatingCompletableToBlockingMethodSpec(close, closeAsync, factory))

--- a/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
+++ b/servicetalk-grpc-protoc/src/main/java/io/servicetalk/grpc/protoc/Words.java
@@ -30,6 +30,7 @@ final class Words {
     static final String ctx = "ctx";
     static final String factory = "factory";
     static final String onClose = "onClose";
+    static final String onClosing = "onClosing";
     static final String metadata = "metadata";
     static final String request = "request";
     static final String response = "response";

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
@@ -106,6 +106,11 @@ public class DelegatingHttpServiceContext extends HttpServiceContext {
     }
 
     @Override
+    public Completable onClosing() {
+        return delegate.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return delegate.closeAsync();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLoadBalancerFactory.java
@@ -179,6 +179,11 @@ public interface HttpLoadBalancerFactory<ResolvedAddress>
         }
 
         @Override
+        public Completable onClosing() {
+            return delegate.onClosing();
+        }
+
+        @Override
         public Completable closeAsync() {
             return delegate.closeAsync();
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientFilter.java
@@ -64,6 +64,11 @@ public class StreamingHttpClientFilter implements FilterableStreamingHttpClient 
     }
 
     @Override
+    public Completable onClosing() {
+        return delegate.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return delegate.closeAsync();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClientToHttpClient.java
@@ -90,6 +90,11 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
     }
 
     @Override
+    public Completable onClosing() {
+        return client.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return client.closeAsync();
     }
@@ -182,6 +187,11 @@ final class StreamingHttpClientToHttpClient implements HttpClient {
         @Override
         public Completable onClose() {
             return connection.onClose();
+        }
+
+        @Override
+        public Completable onClosing() {
+            return connection.onClosing();
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionFilter.java
@@ -69,6 +69,11 @@ public class StreamingHttpConnectionFilter implements FilterableStreamingHttpCon
     }
 
     @Override
+    public Completable onClosing() {
+        return delegate.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return delegate.closeAsync();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnectionToHttpConnection.java
@@ -102,6 +102,11 @@ final class StreamingHttpConnectionToHttpConnection implements HttpConnection {
     }
 
     @Override
+    public Completable onClosing() {
+        return connection.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return connection.closeAsync();
     }

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/AbstractHttpRequesterFilterTest.java
@@ -293,6 +293,11 @@ public abstract class AbstractHttpRequesterFilterTest {
             }
 
             @Override
+            public Completable onClosing() {
+                return connection.onClosing();
+            }
+
+            @Override
             public HttpExecutionContext executionContext() {
                 return connection.executionContext();
             }

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestHttpServiceContext.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestHttpServiceContext.java
@@ -108,6 +108,11 @@ public class TestHttpServiceContext extends HttpServiceContext {
     }
 
     @Override
+    public Completable onClosing() {
+        return completed();
+    }
+
+    @Override
     public Completable onClose() {
         return completed();
     }

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpClient.java
@@ -80,6 +80,11 @@ public final class TestStreamingHttpClient {
                     }
 
                     @Override
+                    public Completable onClosing() {
+                        return closeable.onClosing();
+                    }
+
+                    @Override
                     public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
                         return reqRespFactory.newRequest(method, requestTarget);
                     }
@@ -145,6 +150,11 @@ public final class TestStreamingHttpClient {
                             }
 
                             @Override
+                            public Completable onClosing() {
+                                return rc.onClosing();
+                            }
+
+                            @Override
                             public Completable closeAsync() {
                                 return rc.closeAsync();
                             }
@@ -180,6 +190,11 @@ public final class TestStreamingHttpClient {
             @Override
             public Completable onClose() {
                 return filterChain.onClose();
+            }
+
+            @Override
+            public Completable onClosing() {
+                return filterChain.onClosing();
             }
 
             @Override

--- a/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpConnection.java
+++ b/servicetalk-http-api/src/testFixtures/java/io/servicetalk/http/api/TestStreamingHttpConnection.java
@@ -57,6 +57,11 @@ public final class TestStreamingHttpConnection {
                     }
 
                     @Override
+                    public Completable onClosing() {
+                        return closeable.onClosing();
+                    }
+
+                    @Override
                     public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
                         return failed(new UnsupportedOperationException());
                     }
@@ -109,6 +114,11 @@ public final class TestStreamingHttpConnection {
             @Override
             public Completable onClose() {
                 return filterChain.onClose();
+            }
+
+            @Override
+            public Completable onClosing() {
+                return filterChain.onClosing();
             }
 
             @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -257,6 +257,11 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     }
 
     @Override
+    public final Completable onClosing() {
+        return connectionContext.onClosing();
+    }
+
+    @Override
     public final Completable closeAsync() {
         return connectionContext.closeAsync();
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConditionalHttpClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConditionalHttpClientFilter.java
@@ -79,4 +79,9 @@ final class ConditionalHttpClientFilter extends StreamingHttpClientFilter {
     public Completable onClose() {
         return closeable.onClose();
     }
+
+    @Override
+    public Completable onClosing() {
+        return closeable.onClosing();
+    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConditionalHttpConnectionFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ConditionalHttpConnectionFilter.java
@@ -77,4 +77,9 @@ final class ConditionalHttpConnectionFilter extends StreamingHttpConnectionFilte
     public Completable onClose() {
         return closeable.onClose();
     }
+
+    @Override
+    public Completable onClosing() {
+        return closeable.onClosing();
+    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -180,6 +180,11 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
         }
 
         @Override
+        public Completable onClosing() {
+            return delegate.onClosing();
+        }
+
+        @Override
         public Completable closeAsync() {
             return delegate.closeAsync();
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -383,6 +383,11 @@ final class DefaultMultiAddressUrlHttpClientBuilder
         }
 
         @Override
+        public Completable onClosing() {
+            return closeable.onClosing();
+        }
+
+        @Override
         public Completable closeAsync() {
             return closeable.closeAsync();
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.Cancellable;
-import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -74,11 +73,6 @@ final class DefaultNettyHttpConnectionContext extends DelegatingConnectionContex
     @Override
     public Single<Throwable> transportError() {
         return nettyConnectionContext.transportError();
-    }
-
-    @Override
-    public Completable onClosing() {
-        return nettyConnectionContext.onClosing();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -196,6 +196,11 @@ final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttp
         }
 
         @Override
+        public Completable onClosing() {
+            return group.onClosing();
+        }
+
+        @Override
         public Completable closeAsync() {
             return group.closeAsync();
         }
@@ -237,6 +242,11 @@ final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttp
         @Override
         public Completable onClose() {
             return close.onClose();
+        }
+
+        @Override
+        public Completable onClosing() {
+            return close.onClosing();
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -757,6 +757,11 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         }
 
         @Override
+        public Completable onClosing() {
+            return delegate.onClosing();
+        }
+
+        @Override
         public Completable closeAsync() {
             return delegate.closeAsync();
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
@@ -140,6 +140,11 @@ final class FilterableClientToClient implements StreamingHttpClient {
                 }
 
                 @Override
+                public Completable onClosing() {
+                    return rc.onClosing();
+                }
+
+                @Override
                 public Completable closeAsync() {
                     return rc.closeAsync();
                 }
@@ -170,6 +175,11 @@ final class FilterableClientToClient implements StreamingHttpClient {
     @Override
     public Completable onClose() {
         return client.onClose();
+    }
+
+    @Override
+    public Completable onClosing() {
+        return client.onClosing();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/GlobalDnsServiceDiscoverer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/GlobalDnsServiceDiscoverer.java
@@ -136,6 +136,11 @@ final class GlobalDnsServiceDiscoverer {
         }
 
         @Override
+        public Completable onClosing() {
+            return closeable.onClosing();
+        }
+
+        @Override
         public Completable closeAsync() {
             return closeable.closeAsync();
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -463,17 +463,26 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
         }
 
         @Override
+        public Completable onClosing() {
+            return parentContext.onClosing();
+        }
+
+        @Override
         public Completable closeAsync() {
-            maxConcurrencyProcessor.onNext(ZERO_MAX_CONCURRENCY_EVENT);
-            maxConcurrencyProcessor.onComplete();
-            return parentContext.closeAsync();
+            return Completable.defer(() -> {
+                maxConcurrencyProcessor.onNext(ZERO_MAX_CONCURRENCY_EVENT);
+                maxConcurrencyProcessor.onComplete();
+                return parentContext.closeAsync().shareContextOnSubscribe();
+            });
         }
 
         @Override
         public Completable closeAsyncGracefully() {
-            maxConcurrencyProcessor.onNext(ZERO_MAX_CONCURRENCY_EVENT);
-            maxConcurrencyProcessor.onComplete();
-            return parentContext.closeAsyncGracefully();
+            return Completable.defer(() -> {
+                maxConcurrencyProcessor.onNext(ZERO_MAX_CONCURRENCY_EVENT);
+                maxConcurrencyProcessor.onComplete();
+                return parentContext.closeAsyncGracefully().shareContextOnSubscribe();
+            });
         }
 
         @Override
@@ -504,11 +513,6 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
         @Override
         public Single<Throwable> transportError() {
             return parentContext.transportError();
-        }
-
-        @Override
-        public Completable onClosing() {
-            return parentContext.onClosing();
         }
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -320,6 +320,11 @@ public final class HttpClients {
                             }
 
                             @Override
+                            public Completable onClosing() {
+                                return closeable.onClosing();
+                            }
+
+                            @Override
                             public Completable closeAsync() {
                                 return closeable.closeAsync();
                             }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -179,6 +179,11 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
     }
 
     @Override
+    public Completable onClosing() {
+        return loadBalancer.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return loadBalancer.closeAsync();
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -237,6 +237,11 @@ final class NettyHttpServer {
         }
 
         @Override
+        public Completable onClosing() {
+            return asyncCloseable.onClosing();
+        }
+
+        @Override
         public String toString() {
             return delegate.toString();
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -82,7 +82,7 @@ import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Thread.NORM_PRIORITY;
 import static java.nio.charset.StandardCharsets.US_ASCII;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CloseUtils.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CloseUtils.java
@@ -44,6 +44,9 @@ final class CloseUtils {
      * @param closingStarted a {@link CountDownLatch} to notify
      */
     static void onGracefulClosureStarted(ConnectionContext cc, CountDownLatch closingStarted) {
+        // cc.onClosing() will trigger on the leading edge of closure, which maybe when the user calls closeAsync().
+        // The tests that depend upon this method need to wait until protocol events occur to ensure no more data will
+        // be processed, which isn't the same as cc.onClosing().
         NettyConnectionContext nettyCtx = (NettyConnectionContext) cc;
         if (cc.protocol() == HTTP_1_1) {
             nettyCtx.transportError().subscribe(t -> {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryOffloadingTest.java
@@ -94,6 +94,11 @@ class ConnectionFactoryOffloadingTest {
                                 }
 
                                 @Override
+                                public Completable onClosing() {
+                                    return close.onClosing();
+                                }
+
+                                @Override
                                 public Completable closeAsync() {
                                     return close.closeAsync();
                                 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientsCompileTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientsCompileTest.java
@@ -61,6 +61,11 @@ class HttpClientsCompileTest {
         }
 
         @Override
+        public Completable onClosing() {
+            return Completable.completed();
+        }
+
+        @Override
         public Completable closeAsync() {
             return Completable.completed();
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionDrainTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionDrainTest.java
@@ -180,8 +180,18 @@ class NettyHttpServerConnectionDrainTest {
             }
 
             @Override
+            public Completable onClosing() {
+                return serverContext.onClosing();
+            }
+
+            @Override
             public Completable closeAsync() {
                 return serverContext.closeAsync();
+            }
+
+            @Override
+            public Completable closeAsyncGracefully() {
+                return serverContext.closeAsyncGracefully();
             }
 
             @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -254,6 +254,11 @@ class RetryingHttpRequesterFilterTest {
         }
 
         @Override
+        public Completable onClosing() {
+            return delegate.onClosing();
+        }
+
+        @Override
         public Completable closeAsync() {
             return delegate.closeAsync();
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerGracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerGracefulConnectionClosureHandlingTest.java
@@ -78,8 +78,6 @@ class ServerGracefulConnectionClosureHandlingTest {
                 @Override
                 public Completable accept(final ConnectionContext context) {
                     CloseUtils.onGracefulClosureStarted(context, serverConnectionClosing);
-                    // ((NettyHttpServerConnection) context).onClosing()
-                    //     .whenFinally(serverConnectionClosing::countDown).subscribe();
                     context.onClose().whenFinally(serverConnectionClosed::countDown).subscribe();
                     return completed();
                 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TimeoutHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TimeoutHttpRequesterFilterTest.java
@@ -25,7 +25,6 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.utils.BeforeFinallyHttpOperator;
 import io.servicetalk.http.utils.TimeoutHttpRequesterFilter;
-import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +52,7 @@ class TimeoutHttpRequesterFilterTest extends AbstractNettyHttpServerTest {
     @Test
     void onClosingWinsOnError() throws Exception {
         connectionFilterFactory(appendConnectionFilter(c -> {
-                    ((NettyConnectionContext) c.connectionContext()).onClosing()
+                    c.connectionContext().onClosing()
                             .subscribe(() -> firstEventRef.compareAndSet(null, Event.ON_CLOSING));
                     return new StreamingHttpConnectionFilter(c) {
                         @Override

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilterTest.java
@@ -112,6 +112,11 @@ class PayloadSizeLimitingHttpRequesterFilterTest {
             }
 
             @Override
+            public Completable onClosing() {
+                return closeable.onClosing();
+            }
+
+            @Override
             public Completable closeAsync() {
                 return closeable.closeAsync();
             }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -760,6 +760,7 @@ abstract class RoundRobinLoadBalancerTest {
         when(cnx.closeAsync()).thenReturn(closeable.closeAsync());
         when(cnx.closeAsyncGracefully()).thenReturn(closeable.closeAsyncGracefully());
         when(cnx.onClose()).thenReturn(closeable.onClose());
+        when(cnx.onClosing()).thenReturn(closeable.onClosing());
         when(cnx.address()).thenReturn(address);
         when(cnx.toString()).thenReturn(address + '@' + cnx.hashCode());
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
@@ -99,6 +99,11 @@ public class DelegatingConnectionContext implements ConnectionContext {
     }
 
     @Override
+    public Completable onClosing() {
+        return delegate.onClosing();
+    }
+
+    @Override
     public Completable closeAsync() {
         return delegate.closeAsync();
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/AbstractNettyIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/AbstractNettyIoExecutor.java
@@ -32,7 +32,6 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 abstract class AbstractNettyIoExecutor<T extends EventLoopGroup> implements NettyIoExecutor, Executor {
-
     protected final boolean isIoThreadSupported;
     protected final T eventLoop;
     protected final boolean interruptOnCancel;
@@ -46,8 +45,12 @@ abstract class AbstractNettyIoExecutor<T extends EventLoopGroup> implements Nett
         this.eventLoop = eventLoop;
         this.interruptOnCancel = interruptOnCancel;
         this.isIoThreadSupported = isIoThreadSupported;
-        // Best effort completion of closingProcessor if the EventLoop is closed outside the scope of this Object
-        eventLoop.terminationFuture().addListener(f -> closingProcessor.onComplete());
+        try {
+            // Best effort completion of closingProcessor if the EventLoop is closed outside the scope of this Object
+            eventLoop.terminationFuture().addListener(f -> closingProcessor.onComplete());
+        } catch (Throwable ignored) {
+            // EmbeddedEventLoop doesn't support this method.
+        }
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/GlobalExecutionContext.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Executors;
+import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.DefaultExecutionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.ExecutionStrategy;
@@ -28,8 +29,12 @@ import io.netty.channel.EventLoopGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.transport.api.ExecutionStrategy.offloadAll;
@@ -104,6 +109,11 @@ public final class GlobalExecutionContext {
         }
 
         @Override
+        public Completable onClosing() {
+            return delegate.onClosing();
+        }
+
+        @Override
         public boolean isUnixDomainSocketSupported() {
             return delegate.isUnixDomainSocketSupported();
         }
@@ -116,6 +126,11 @@ public final class GlobalExecutionContext {
         @Override
         public boolean isIoThreadSupported() {
             return delegate.isIoThreadSupported();
+        }
+
+        @Override
+        public BooleanSupplier shouldOffloadSupplier() {
+            return delegate.shouldOffloadSupplier();
         }
 
         @Override
@@ -140,6 +155,11 @@ public final class GlobalExecutionContext {
         }
 
         @Override
+        public long currentTime(final TimeUnit unit) {
+            return delegate.currentTime(unit);
+        }
+
+        @Override
         public Cancellable execute(final Runnable task) throws RejectedExecutionException {
             return delegate.execute(task);
         }
@@ -148,6 +168,41 @@ public final class GlobalExecutionContext {
         public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit)
                 throws RejectedExecutionException {
             return delegate.schedule(task, delay, unit);
+        }
+
+        @Override
+        public Cancellable schedule(final Runnable task, final Duration delay) throws RejectedExecutionException {
+            return delegate.schedule(task, delay);
+        }
+
+        @Override
+        public Completable timer(final long delay, final TimeUnit unit) {
+            return delegate.timer(delay, unit);
+        }
+
+        @Override
+        public Completable timer(final Duration delay) {
+            return delegate.timer(delay);
+        }
+
+        @Override
+        public Completable submit(final Runnable runnable) {
+            return delegate.submit(runnable);
+        }
+
+        @Override
+        public Completable submitRunnable(final Supplier<Runnable> runnableSupplier) {
+            return delegate.submitRunnable(runnableSupplier);
+        }
+
+        @Override
+        public <T> Single<T> submit(final Callable<? extends T> callable) {
+            return delegate.submit(callable);
+        }
+
+        @Override
+        public <T> Single<T> submitCallable(final Supplier<? extends Callable<? extends T>> callableSupplier) {
+            return delegate.submitCallable(callableSupplier);
         }
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelListenableAsyncCloseable.java
@@ -101,6 +101,7 @@ public class NettyChannelListenableAsyncCloseable implements PrivilegedListenabl
      *
      * @return a {@link Completable} that notifies when the connection has begun its closing sequence.
      */
+    @Override
     public final Completable onClosing() {
         return fromSource(onClosing);
     }
@@ -117,12 +118,12 @@ public class NettyChannelListenableAsyncCloseable implements PrivilegedListenabl
 
     @Override
     public final Completable closeAsyncNoOffload() {
-        return closeAsync(onCloseNoOffload());
+        return closeAsync(onCloseNoOffload);
     }
 
     @Override
     public final Completable closeAsyncGracefullyNoOffload() {
-        return closeAsyncGracefully(onCloseNoOffload());
+        return closeAsyncGracefully(onCloseNoOffload);
     }
 
     private Completable closeAsync(Completable source) {
@@ -160,10 +161,6 @@ public class NettyChannelListenableAsyncCloseable implements PrivilegedListenabl
     @Override
     public final Completable onClose() {
         return onClose;
-    }
-
-    final Completable onCloseNoOffload() {
-        return onCloseNoOffload;
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyConnectionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyConnectionContext.java
@@ -16,7 +16,6 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.Cancellable;
-import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ConnectionContext;
 
@@ -57,18 +56,6 @@ public interface NettyConnectionContext extends ConnectionContext {
      * the transport.
      */
     Single<Throwable> transportError();
-
-    /**
-     * Returns a {@link Completable} that notifies when the connection has begun its closing sequence.
-     * <p>
-     * <b>Note:</b>The {@code Completable} is not required to be blocking-safe and should be offloaded if the
-     * {@link io.servicetalk.concurrent.CompletableSource.Subscriber} may block.
-     *
-     * @return a {@link Completable} that notifies when the connection has begun its closing sequence. A configured
-     * {@link CloseHandler} will determine whether more reads or writes will be allowed on this
-     * {@link NettyConnectionContext}.
-     */
-    Completable onClosing();
 
     /**
      * Return the Netty {@link Channel} backing this connection.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyServerContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyServerContext.java
@@ -110,4 +110,9 @@ public final class NettyServerContext implements ServerContext {
     public Completable onClose() {
         return closeable.onClose();
     }
+
+    @Override
+    public Completable onClosing() {
+        return closeable.onClosing();
+    }
 }


### PR DESCRIPTION
Motivation:
It is useful to get a notified on the leading edge when closing beings. This may drive decisions like stopping to use a connection or resources that is being closed and not suitable for reuse.

Modifications:
- Use existing transport mechansims to drive onClosing for connections.
- Remove NettyConnectionContext override of onClosing and defer to the base class.