### PR TITLE
CloseHandler force RST on close if still reading to avoid half close hang

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLifecycleObserverHttpFilter.java
@@ -139,7 +139,7 @@ abstract class AbstractLifecycleObserverHttpFilter implements HttpExecutionStrat
             try {
                 responseSingle = responseFunction.apply(transformed);
             } catch (Throwable t) {
-                onExchange.onResponseError(t);
+                exchangeContext.onError(t); // Go through exchange context so finally methods are invoked.
                 return Single.<StreamingHttpResponse>failed(t).shareContextOnSubscribe();
             }
             return responseSingle
@@ -249,6 +249,11 @@ abstract class AbstractLifecycleObserverHttpFilter implements HttpExecutionStrat
                 safeReport(onExchange::onExchangeFinally, onExchange, "onExchangeFinally");
                 clearContext.run();
             }
+        }
+
+        @Override
+        public String toString() {
+            return "remaining=" + remaining;
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
@@ -286,8 +286,11 @@ class ServerPipelineControlFlowTest {
             });
             switch (protocol) {
                 case HTTP_1:
-                    assertThat(e, instanceOf(CloseEventObservedException.class));
-                    assertThat(((CloseEventObservedException) e).event(), is(CHANNEL_CLOSED_INBOUND));
+                    if (e instanceof CloseEventObservedException) {
+                        assertThat(((CloseEventObservedException) e).event(), is(CHANNEL_CLOSED_INBOUND));
+                    } else {
+                        assertThat(e, instanceOf(IOException.class));
+                    }
                     break;
                 case HTTP_2:
                     assertThat(e, instanceOf(Http2Exception.class));

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -164,7 +164,7 @@ public abstract class CloseHandler {
     abstract void channelCloseNotify(ChannelHandlerContext ctx);
 
     /**
-     * Signal that {@link Channel#close()} is above to be called.
+     * Signal that {@link Channel#close()} is about to be called.
      * @param channel The channel.
      */
     void channelClose(Channel channel) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -164,6 +164,14 @@ public abstract class CloseHandler {
     abstract void channelCloseNotify(ChannelHandlerContext ctx);
 
     /**
+     * Signal that {@link Channel#close()} is above to be called.
+     * @param channel The channel.
+     */
+    void channelClose(Channel channel) {
+        // FIXME: 0.43 make method abstract
+    }
+
+    /**
      * Request {@link Channel} inbound close, to be emitted from the {@link EventLoop} for the channel.
      * <p>
      * This method will not ensure graceful closure of the channel inbound and may abort reads.
@@ -304,6 +312,10 @@ public abstract class CloseHandler {
         }
 
         @Override
+        void channelClose(final Channel channel) {
+        }
+
+        @Override
         public void protocolPayloadBeginInbound(final ChannelHandlerContext ctx) {
         }
 
@@ -327,6 +339,15 @@ public abstract class CloseHandler {
 
         @Override
         public void protocolClosingOutbound(final ChannelHandlerContext ctx) {
+        }
+    }
+
+    static void setSocketResetOnClose(SocketChannel channel) {
+        try {
+            channel.config().setSoLinger(0);
+        } catch (Exception e) {
+            LOGGER.trace("{} set SO_LINGER=0 failed (expected when IN+OUT or IN+RST closed channel): {}", channel,
+                    e.getMessage());
         }
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/LoggingCloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/LoggingCloseHandler.java
@@ -115,6 +115,12 @@ final class LoggingCloseHandler extends CloseHandler {
     }
 
     @Override
+    void channelClose(final Channel channel) {
+        logger.log("{} closeChannel {}", channel, delegate);
+        delegate.channelClose(channel);
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + '(' + delegate + ")";
     }


### PR DESCRIPTION
Motivation:
HttpLifecycleObserverTest#testClientCancelsRequestAfterResponse tests half close
behavior but is subject to the OS's TCP implementation sending a RST before
the test writes, and therefore the write returning an error. However some
scenarios the client would just send a FIN and the server write would succeed.

Modifications:
- Server should wait to write until it has recieved the RST
- CloseHandler should force a RST before full close is done. This can
  be achieved by setting SO_LINGER to 0.

Result:
Fixes `HttpLifecycleObserverTest#testClientCancelsRequestAfterResponse(HttpProtocol) [1] protocol=HTTP_1`
prevents hangs when read is complete and write is still open.