### PR TITLE
Add FlowControlUtils.addWithUnderOverflowProtection for int

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FlowControlUtils.java
@@ -124,4 +124,22 @@ public final class FlowControlUtils {
         // if overflow, sign extended right shift, then flip lower 63 bits (non-sign bits) to get 2s complement min/max.
         return ((x ^ sum) & (y ^ sum)) < 0 ? ((x >> 63) ^ Long.MAX_VALUE) : sum;
     }
+
+    /**
+     * Add two longs and prevent [under|over]flow which is defined as if both {@code x} and {@code y} have the same sign
+     * but the result of {@code x + y} has a different sign.
+     * @param x first value.
+     * @param y second value.
+     * @return
+     * <ul>
+     *     <li>{@code x + y} if no overflow</li>
+     *     <li>{@link Integer#MAX_VALUE} if overflow in the positive direction</li>
+     *     <li>{@link Integer#MIN_VALUE} if otherwise in the negative direction</li>
+     * </ul>
+     */
+    public static int addWithUnderOverflowProtection(final int x, final int y) {
+        final int sum = x + y;
+        // if overflow, sign extended right shift, then flip lower 63 bits (non-sign bits) to get 2s complement min/max.
+        return ((x ^ sum) & (y ^ sum)) < 0 ? ((x >> 31) ^ Integer.MAX_VALUE) : sum;
+    }
 }

--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/FlowControlUtilsTests.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/FlowControlUtilsTests.java
@@ -28,47 +28,92 @@ class FlowControlUtilsTests {
     }
 
     @Test
-    void addWithUnderOverflowProtectionPositiveNoOverflow() {
+    void addIntWithUnderOverflowProtectionPositiveNoOverflow() {
         assertEquals(3, addWithUnderOverflowProtection(1, 2));
     }
 
     @Test
-    void addWithUnderOverflowProtectionNegativeNoOverflow() {
+    void addLongWithUnderOverflowProtectionPositiveNoOverflow() {
+        assertEquals(3L, addWithUnderOverflowProtection(1L, 2L));
+    }
+
+    @Test
+    void addIntWithUnderOverflowProtectionNegativeNoOverflow() {
         assertEquals(-3, addWithUnderOverflowProtection(-1, -2));
     }
 
     @Test
-    void addWithUnderOverflowProtectionPositivePlusNegative() {
+    void addLongWithUnderOverflowProtectionNegativeNoOverflow() {
+        assertEquals(-3L, addWithUnderOverflowProtection(-1L, -2L));
+    }
+
+    @Test
+    void addIntWithUnderOverflowProtectionPositivePlusNegative() {
         assertEquals(1, addWithUnderOverflowProtection(-1, 2));
     }
 
     @Test
-    void addWithUnderOverflowProtectionZeroToMin() {
+    void addLongWithUnderOverflowProtectionPositivePlusNegative() {
+        assertEquals(1L, addWithUnderOverflowProtection(-1L, 2L));
+    }
+
+    @Test
+    void addIntWithUnderOverflowProtectionZeroToMin() {
+        assertEquals(Integer.MIN_VALUE, addWithUnderOverflowProtection(0, Integer.MIN_VALUE));
+    }
+
+    @Test
+    void addLongWithUnderOverflowProtectionZeroToMin() {
         assertEquals(Long.MIN_VALUE, addWithUnderOverflowProtection(0, Long.MIN_VALUE));
     }
 
     @Test
-    void addWithUnderOverflowProtectionNegativeOneToMin() {
+    void addIntWithUnderOverflowProtectionNegativeOneToMin() {
+        assertEquals(Integer.MIN_VALUE, addWithUnderOverflowProtection(-1, Integer.MIN_VALUE));
+    }
+
+    @Test
+    void addLongWithUnderOverflowProtectionNegativeOneToMin() {
         assertEquals(Long.MIN_VALUE, addWithUnderOverflowProtection(-1, Long.MIN_VALUE));
     }
 
     @Test
-    void addWithUnderOverflowProtectionMinToMin() {
+    void addIntWithUnderOverflowProtectionMinToMin() {
+        assertEquals(Integer.MIN_VALUE, addWithUnderOverflowProtection(Integer.MIN_VALUE, Integer.MIN_VALUE));
+    }
+
+    @Test
+    void addLongWithUnderOverflowProtectionMinToMin() {
         assertEquals(Long.MIN_VALUE, addWithUnderOverflowProtection(Long.MIN_VALUE, Long.MIN_VALUE));
     }
 
     @Test
-    void addWithUnderOverflowProtectionZeroToMax() {
+    void addIntWithUnderOverflowProtectionZeroToMax() {
+        assertEquals(Integer.MAX_VALUE, addWithUnderOverflowProtection(0, Integer.MAX_VALUE));
+    }
+
+    @Test
+    void addLongWithUnderOverflowProtectionZeroToMax() {
         assertEquals(Long.MAX_VALUE, addWithUnderOverflowProtection(0, Long.MAX_VALUE));
     }
 
     @Test
-    void addWithUnderOverflowProtectionOneToMax() {
+    void addIntWithUnderOverflowProtectionOneToMax() {
+        assertEquals(Integer.MAX_VALUE, addWithUnderOverflowProtection(1, Integer.MAX_VALUE));
+    }
+
+    @Test
+    void addLongWithUnderOverflowProtectionOneToMax() {
         assertEquals(Long.MAX_VALUE, addWithUnderOverflowProtection(1, Long.MAX_VALUE));
     }
 
     @Test
-    void addWithUnderOverflowProtectionMaxToMax() {
+    void addIntWithUnderOverflowProtectionMaxToMax() {
+        assertEquals(Integer.MAX_VALUE, addWithUnderOverflowProtection(Integer.MAX_VALUE, Integer.MAX_VALUE));
+    }
+
+    @Test
+    void addLongWithUnderOverflowProtectionMaxToMax() {
         assertEquals(Long.MAX_VALUE, addWithUnderOverflowProtection(Long.MAX_VALUE, Long.MAX_VALUE));
     }
 }


### PR DESCRIPTION
Motivation:
FlowControlUtils.addWithUnderOverflowProtection exists for long types but not int types.