### PR TITLE
Avoid implicit task dependencies for grpc generated tasks

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.gradle.plugin.internal
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -122,6 +123,23 @@ final class ProjectUtils {
         "Implementation-Vendor": "Apple Inc.",
         "Automatic-Module-Name": "io.${project.name.replace("-", ".")}"
     )
+  }
+
+  static void addGeneratedProtoDependsOn(Project project,
+                                         /*com.google.protobuf.gradle.GenerateProtoTask*/ DefaultTask task,
+                                         boolean projectTestGeneratedOnly) {
+    if (!projectTestGeneratedOnly) {
+      if (!task.isTest) {
+        project.sourcesJar.dependsOn task
+      }
+      // generateTestProto tasks also depends upon non-test proto tasks
+      project.pmdMain.dependsOn task
+      project.spotbugsMain.dependsOn task
+      project.checkstyleMain.dependsOn task
+    }
+    project.pmdTest.dependsOn task
+    project.spotbugsTest.dependsOn task
+    project.checkstyleTest.dependsOn task
   }
 
   private static <T extends Task> T createTask(Project project, String name, @DelegatesTo.Target Class<T> type,

--- a/servicetalk-grpc-health/build.gradle
+++ b/servicetalk-grpc-health/build.gradle
@@ -104,8 +104,9 @@ protobuf {
   }
   generateProtoTasks {
     all().each { task ->
-      task.dependsOn unzipGrpcProtos
       //// REMOVE if outside of ServiceTalk gradle project
+      io.servicetalk.gradle.plugin.internal.ProjectUtils.addGeneratedProtoDependsOn(project, task, false)
+      task.dependsOn unzipGrpcProtos
       task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
 
       // you may need to manually add the artifact name as an input

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -95,6 +95,7 @@ protobuf {
   }
   generateProtoTasks {
     all().each { task ->
+      io.servicetalk.gradle.plugin.internal.ProjectUtils.addGeneratedProtoDependsOn(project, task, true)
       if (task.isTest) {
         task.dependsOn(":servicetalk-grpc-protoc:buildExecutable") // use gradle project local grpc-protoc dependency
 

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -81,6 +81,7 @@ protobuf {
   }
   generateProtoTasks {
     all().each { task ->
+      io.servicetalk.gradle.plugin.internal.ProjectUtils.addGeneratedProtoDependsOn(project, task, true)
       task.generateDescriptorSet = true
       task.descriptorSetOptions.includeImports = true
       task.inputs


### PR DESCRIPTION
Motivation:
The protobuf gradle plugin will generate tasks dynamically, which have implicit relationships on our dynamically generated quality tasks (pmd, spotbugs, checkstyle). Gradle build generates warnings and deoptimizes some flows.

```
Execution optimizations have been disabled for task ':servicetalk-grpc-health:pmdMain' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/scottmitchell/git/servicetalk/servicetalk-grpc-health/src/generated'. Reason: Task ':servicetalk-grpc-health:pmdMain' uses this output of task ':servicetalk-grpc-health:generateTestProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6-rc-3/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```