### PR TITLE
H2PriorKnowledgeFeatureParityTest.serverGracefulClose ConnectionAcceptor disable offloading

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -1852,8 +1852,10 @@ class H2PriorKnowledgeFeatureParityTest {
                     return new DelegatingConnectionAcceptor(original) {
                         @Override
                         public Completable accept(final ConnectionContext context) {
-                            onGracefulClosureStarted(context, connectionOnClosingLatch);
-                            return completed();
+                            return Completable.defer(() -> {
+                                onGracefulClosureStarted(context, connectionOnClosingLatch);
+                                return completed().shareContextOnSubscribe();
+                            });
                         }
                     };
                 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
@@ -104,7 +104,7 @@ class NettyHttpServerConnectionTest {
                                 return Completable.defer(() -> {
                                     customCancellableRef.set(((NettyConnectionContext) context)
                                             .updateFlushStrategy((__, ___) -> customStrategy));
-                                    return completed();
+                                    return completed().shareContextOnSubscribe();
                                 });
                             }
                         };

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/NettyHttpServerConnectionTest.java
@@ -17,11 +17,17 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ConnectExecutionStrategy;
+import io.servicetalk.transport.api.ConnectionAcceptor;
+import io.servicetalk.transport.api.ConnectionAcceptorFactory;
+import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.DelegatingConnectionAcceptor;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
@@ -89,11 +95,26 @@ class NettyHttpServerConnectionTest {
 
         serverContext = HttpServers.forAddress(localAddress(0))
                 .ioExecutor(contextRule.ioExecutor())
-                .appendConnectionAcceptorFilter(original -> original.append(ctx -> {
-                            customCancellableRef.set(
-                                    ((NettyConnectionContext) ctx).updateFlushStrategy((__, ___) -> customStrategy));
-                            return completed();
-                        }))
+                .appendConnectionAcceptorFilter(new ConnectionAcceptorFactory() {
+                    @Override
+                    public ConnectionAcceptor create(ConnectionAcceptor original) {
+                        return new DelegatingConnectionAcceptor(original) {
+                            @Override
+                            public Completable accept(final ConnectionContext context) {
+                                return Completable.defer(() -> {
+                                    customCancellableRef.set(((NettyConnectionContext) context)
+                                            .updateFlushStrategy((__, ___) -> customStrategy));
+                                    return completed();
+                                });
+                            }
+                        };
+                    }
+
+                    @Override
+                    public ConnectExecutionStrategy requiredOffloads() {
+                        return ConnectExecutionStrategy.offloadNone();
+                    }
+                })
                 .executionStrategy(serverExecutionStrategy)
                 .listenStreaming((ctx, request, responseFactory) -> {
                     if (handledFirstRequest.compareAndSet(false, true)) {


### PR DESCRIPTION
Motivation:
H2PriorKnowledgeFeatureParityTest.serverGracefulClose installs a ConnectionAcceptor which intercepts messages through the netty pipeline. However the filter is offloaded by default and may miss events.

Modifications:
- Override `requiredOffloads` when creating the `ConnectionAcceptorFactory` to disable offloading.

Fixes:
https://github.com/apple/servicetalk/issues/2378