### PR TITLE
Pin specific JDK11 version to avoid javadoc bug

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,14 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11.0.16+8'
+          distribution: 'zulu'
+          cache: 'gradle'
+      - name: Print JDK Version
+        run: java -version
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:


### PR DESCRIPTION
Motivation:

CodeQL job started to fail with javadoc bug:
https://github.com/apple/servicetalk/actions/runs/3567715145/jobs/5995737033
Looks like they updated JDK11 version.

Modifications:

- Force CodeQL task to use a specific JDK11 version;

Result:

CodeQL task continues to work.