### PR TITLE
Add mark/reset functionality to `BufferInputStream`

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferInputStream.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferInputStream.java
@@ -23,8 +23,11 @@ import static java.util.Objects.requireNonNull;
 final class BufferInputStream extends InputStream {
     private final Buffer buffer;
 
+    private int mark;
+
     BufferInputStream(Buffer buffer) {
         this.buffer = requireNonNull(buffer);
+        this.mark = buffer.readerIndex();
     }
 
     @Override
@@ -60,5 +63,20 @@ final class BufferInputStream extends InputStream {
     @Override
     public int available() {
         return buffer.readableBytes();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public void mark(final int readlimit) {
+        mark = buffer.readerIndex();
+    }
+
+    @Override
+    public void reset() {
+        buffer.readerIndex(mark);
     }
 }


### PR DESCRIPTION
Motivation:
BufferInputStream can support the mark/reset functionality, as noted in #1562, like ByteArrayInputStream and ByteBufInputStream (from netty).

Modifications:
- Implemented the mark, reset and markSupported methods of BufferInputStream
- Added test cases

Result:
Resolves #1562.