### PR TITLE
RoundRobinLoadBalancer fix connection leak during graceful closure

### DIFF
--- a/servicetalk-loadbalancer/build.gradle
+++ b/servicetalk-loadbalancer/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.apache.logging.log4j:log4j-core"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -560,12 +560,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         private ConnState closeConnState() {
             for (;;) {
                 final ConnState oldState = connState;
-                if (oldState.state != State.CLOSED) {
-                    if (connStateUpdater.compareAndSet(this, oldState,
-                            new ConnState(oldState.connections, State.CLOSED))) {
-                        return oldState;
-                    }
-                } else {
+                if (oldState.state == State.CLOSED || connStateUpdater.compareAndSet(this, oldState,
+                        new ConnState(oldState.connections, State.CLOSED))) {
                     return oldState;
                 }
             }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -315,9 +315,9 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         asyncCloseable = toAsyncCloseable(graceful -> {
             discoveryCancellable.cancel();
             eventStreamProcessor.onComplete();
-            // We lock because items are removed from the collection via onClosing (on the leading edge). If
-            // closeAsyncGracefully is called all the items will be removed from the collection, however that
-            // operation may timeout and then a subsequent closeAsync is expected to close the original items.
+            // We lock because the collection of hosts is dereferenced and if closeAsyncGracefully is called all the
+            // items will be removed from the collection, however that operation may timeout and then a subsequent
+            // closeAsync is expected to close the original items.
             synchronized (discoveryCancellable) {
                 if (compositeCloseable == null) {
                     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Motivation:
RoundRobinLoadBalancer clears state of all hosts and each host clears all connections when closing. However a common pattern is to initiate gracefulClosure with a timeout, and then force a full close after a timeout interval. In this scenario RRLB has discarded the reference to connections and will not full close the connections.

Modifications:
- asyncCloseable needs to keep state about what hosts are being closed and each host can't dereference connections until they are fully closed.
- switch back to using onClose to cleanup the connection list as otherwise we may leak connections that have started graceful closure and never finished.