### PR TITLE
Deprecate BufferHandler and BufferHolder

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferHolder.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferHolder.java
@@ -18,7 +18,7 @@ package io.servicetalk.buffer.api;
 /**
  * An object which contains a {@link Buffer}.
  *
- * @deprecated This API is going to be removed in the next minor version with no planned replacement. If it cannot be
+ * @deprecated This API is going to be removed in future releases with no planned replacement. If it cannot be
  *             removed from your application, consider copying it into your codebase.
  */
 @Deprecated // FIXME: 0.43 - Remove deprecation

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferHolder.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferHolder.java
@@ -17,7 +17,11 @@ package io.servicetalk.buffer.api;
 
 /**
  * An object which contains a {@link Buffer}.
+ *
+ * @deprecated This API is going to be removed in the next minor version with no planned replacement. If it cannot be
+ *             removed from your application, consider copying it into your codebase.
  */
+@Deprecated // FIXME: 0.43 - Remove deprecation
 public interface BufferHolder {
     /**
      * The buffer contained by this object.

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -89,6 +89,7 @@ final class TcpClient {
      * @param address to connect.
      * @return New {@link NettyConnection}.
      */
+    @SuppressWarnings("deprecation") // legitimate use of BufferHandler
     public Single<NettyConnection<Buffer, Buffer>> connect(ExecutionContext<?> executionContext,
                                                            SocketAddress address) {
         return TcpConnector.connect(null, address, config, false, executionContext,

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -100,6 +100,7 @@ public class TcpServer {
     }
 
     // Visible to allow tests to override.
+    @SuppressWarnings("deprecation") // legitimate use of BufferHandler
     ChannelInitializer getChannelInitializer(final Function<NettyConnection<Buffer, Buffer>, Completable> service,
                                              final ExecutionContext<?> executionContext) {
         return channel -> channel.pipeline().addLast(BufferHandler.INSTANCE);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BufferHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BufferHandler.java
@@ -40,8 +40,12 @@ import static io.servicetalk.buffer.netty.BufferUtils.newBufferFrom;
  * </ul>
  *
  * This also releases any {@link ByteBuf} once converted to {@link Buffer}.
+ *
+ * @deprecated This API is going to be removed in the next minor version with no planned replacement. If it cannot be
+ *             removed from your application, consider copying it into your codebase.
  */
 @Sharable
+@Deprecated // FIXME: 0.43 - Remove deprecation and copy into tests
 public final class BufferHandler extends ChannelDuplexHandler {
     public static final ChannelDuplexHandler INSTANCE = new BufferHandler();
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BufferHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BufferHandler.java
@@ -41,7 +41,7 @@ import static io.servicetalk.buffer.netty.BufferUtils.newBufferFrom;
  *
  * This also releases any {@link ByteBuf} once converted to {@link Buffer}.
  *
- * @deprecated This API is going to be removed in the next minor version with no planned replacement. If it cannot be
+ * @deprecated This API is going to be removed in future releases with no planned replacement. If it cannot be
  *             removed from your application, consider copying it into your codebase.
  */
 @Sharable


### PR DESCRIPTION
Motivation:

Both the BufferHandler and the BufferHolder did see very limited use and are scheduled for removal in the next minor release.

Modifications:

To preserve backwards compatibility and to notify potential users, both APIs are marked as deprecated now in preparation for removal.