### PR TITLE
CacheConnectionHttpLoadBalanceFactoryTest allow more tolerance

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
@@ -118,7 +118,7 @@ final class CacheConnectionHttpLoadBalanceFactoryTest {
             assertThat(connectionObserver.count.get(),
                     // Initial number of streams is unbound, so we may create more streams on connections before the
                     // client acknowledges the servers max_concurrent_streams setting update.
-                    lessThanOrEqualTo((int) ceil((double) (numRequests + numRetries.get()) / maxConcurrency)));
+                    lessThanOrEqualTo((int) ceil((double) (numRequests + numRetries.get()) / maxConcurrency) + 1));
         }
     }
 


### PR DESCRIPTION
Motivation:
CacheConnectionHttpLoadBalanceFactoryTest may fail by creating one more connection than the test currently allows.

Modifications:
- allow 1 more connection than currently is allowed.