### PR TITLE
Provide better exception when connection limit reached in LimitingCon…

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionLimitReachedException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionLimitReachedException.java
@@ -20,6 +20,8 @@ import java.net.ConnectException;
 /**
  * Thrown when the number of connections reached their limit for a given resource (i.e. a host)
  * depending on the context.
+ *
+ * @see LimitingConnectionFactoryFilter
  */
 public class ConnectionLimitReachedException extends ConnectException {
 

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionLimitReachedException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionLimitReachedException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api;
+
+import java.net.ConnectException;
+
+/**
+ * Thrown when the number of connections reached their limit for a given resource (i.e. a host)
+ * depending on the context.
+ */
+public class ConnectionLimitReachedException extends ConnectException {
+
+    private static final long serialVersionUID = 645105614301638032L;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message.
+     */
+    public ConnectionLimitReachedException(final String message) {
+        super(message);
+    }
+}

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
@@ -133,7 +133,7 @@ public final class LimitingConnectionFactoryFilter<ResolvedAddress, C extends Li
          * @return {@link Throwable} representing a connection attempt was refused.
          */
         default Throwable newConnectionRefusedException(ResolvedAddress target) {
-            return new ConnectException("No more connections allowed for the host: " + target);
+            return new ConnectionLimitReachedException("No more connections allowed for the host: " + target);
         }
     }
 

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
@@ -126,8 +126,8 @@ public final class LimitingConnectionFactoryFilter<ResolvedAddress, C extends Li
         void onConnectionClose(ResolvedAddress target);
 
         /**
-         * Create a {@link Throwable} representing a connection attempt refused, typically  as a result of returning
-         * {@code false} from {@link #isConnectAllowed(Object)}.
+         * Create a {@link ConnectionLimitReachedException} representing a connection attempt refused, typically
+         * as a result of returning {@code false} from {@link #isConnectAllowed(Object)}.
          *
          * @param target {@link ResolvedAddress} for which connection was refused.
          * @return {@link Throwable} representing a connection attempt was refused.


### PR DESCRIPTION
…nectionFactoryFilter

Motivation:

Before this change, when the LimitingConnectionFactoryFilter does not allow more connections for a given host, a generic ConnectException is returned. Developer productivity can be improved since at the moment the user needs to inspect the text message for further information and to distinguish different failure cases.

Modifications:

This changeset subclasses the ConnectException for backwards compatibility and returns a ConnectionLimitReachedException instead. The actual message is also preserved for compatibility reasons.

Result:

Better user experience when matching on the exception instance while still being backwards compatible.