### PR TITLE
Provide common HTTP Service interface for all API variants.

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
@@ -24,7 +24,7 @@ import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEI
  * The equivalent of {@link HttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
  */
 @FunctionalInterface
-public interface BlockingHttpService extends Service, GracefulAutoCloseable {
+public interface BlockingHttpService extends HttpServiceBase, GracefulAutoCloseable {
     /**
      * Handles a single HTTP request.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpService.java
@@ -24,7 +24,7 @@ import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEI
  * The equivalent of {@link HttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
  */
 @FunctionalInterface
-public interface BlockingHttpService extends HttpExecutionStrategyInfluencer, GracefulAutoCloseable {
+public interface BlockingHttpService extends Service, GracefulAutoCloseable {
     /**
      * Handles a single HTTP request.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
@@ -23,7 +23,7 @@ import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEI
  * The equivalent of {@link StreamingHttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
  */
 @FunctionalInterface
-public interface BlockingStreamingHttpService extends Service, GracefulAutoCloseable {
+public interface BlockingStreamingHttpService extends HttpServiceBase, GracefulAutoCloseable {
     /**
      * Handles a single HTTP request.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpService.java
@@ -23,7 +23,7 @@ import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEI
  * The equivalent of {@link StreamingHttpService} but with synchronous/blocking APIs instead of asynchronous APIs.
  */
 @FunctionalInterface
-public interface BlockingStreamingHttpService extends HttpExecutionStrategyInfluencer, GracefulAutoCloseable {
+public interface BlockingStreamingHttpService extends Service, GracefulAutoCloseable {
     /**
      * Handles a single HTTP request.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -32,6 +32,7 @@ import io.servicetalk.transport.api.TransportObserver;
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
@@ -318,6 +319,27 @@ public interface HttpServerBuilder {
      * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
      * <p>
      * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * <p>
+     * Note that this method is generic in the sense that it accepts all HTTP {@link Service} implementations to be
+     * passed in, namely {@link StreamingHttpService}, {@link HttpService}, {@link BlockingStreamingHttpService} and
+     * {@link BlockingHttpService}. It is especially useful when Dependency Injection is used and the type of service
+     * is not known at compile time.
+     *
+     * @param service Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
+     * @return A {@link HttpServerContext} by blocking the calling thread until the server is successfully started or
+     * throws an {@link Exception} if the server could not be started.
+     * @throws IllegalArgumentException if an unknown/unsupported {@link Service} is being provided.
+     * @throws Exception if the server could not be started.
+     */
+    default HttpServerContext listenServiceAndAwait(Service service) throws Exception {
+        return blockingInvocation(listenService(service));
+    }
+
+    /**
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
+     * <p>
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
      *
      * @param service Service invoked for every request received by this server. The returned {@link HttpServerContext}
      * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
@@ -372,6 +394,38 @@ public interface HttpServerBuilder {
      */
     default HttpServerContext listenBlockingStreamingAndAwait(BlockingStreamingHttpService service) throws Exception {
         return blockingInvocation(listenBlockingStreaming(service));
+    }
+
+    /**
+     * Starts this server and returns the {@link HttpServerContext} after the server has been successfully started.
+     * <p>
+     * If the underlying protocol (e.g. TCP) supports it this will result in a socket bind/listen on {@code address}.
+     * <p>
+     * Note that this method is generic in the sense that it accepts all HTTP {@link Service} implementations to be
+     * passed in, namely {@link StreamingHttpService}, {@link HttpService}, {@link BlockingStreamingHttpService} and
+     * {@link BlockingHttpService}. It is especially useful when Dependency Injection is used and the type of service
+     * is not known at compile time.
+     *
+     * @param service Service invoked for every request received by this server. The returned {@link HttpServerContext}
+     * manages the lifecycle of the {@code service}, ensuring it is closed when the {@link HttpServerContext} is closed.
+     * @return A {@link Single} that completes when the server is successfully started or terminates with an error if
+     * the server could not be started.
+     * @throws IllegalArgumentException if an unknown/unsupported {@link Service} is being provided.
+     */
+    default Single<HttpServerContext> listenService(final Service service) {
+        Objects.requireNonNull(service);
+
+        if (service instanceof HttpService) {
+            return listen((HttpService) service);
+        } else if (service instanceof StreamingHttpService) {
+            return listenStreaming((StreamingHttpService) service);
+        } else if (service instanceof BlockingHttpService) {
+            return listenBlocking((BlockingHttpService) service);
+        } else if (service instanceof BlockingStreamingHttpService) {
+            return listenBlockingStreaming((BlockingStreamingHttpService) service);
+        } else {
+            throw new IllegalArgumentException("Unknown/Unsupported service type: " + service);
+        }
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
@@ -25,7 +25,7 @@ import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEI
  * Same as {@link StreamingHttpService} but that accepts {@link HttpRequest} and returns {@link HttpResponse}.
  */
 @FunctionalInterface
-public interface HttpService extends AsyncCloseable, Service {
+public interface HttpService extends AsyncCloseable, HttpServiceBase {
     /**
      * Handles a single HTTP request.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpService.java
@@ -25,7 +25,7 @@ import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEI
  * Same as {@link StreamingHttpService} but that accepts {@link HttpRequest} and returns {@link HttpResponse}.
  */
 @FunctionalInterface
-public interface HttpService extends AsyncCloseable, HttpExecutionStrategyInfluencer {
+public interface HttpService extends AsyncCloseable, Service {
     /**
      * Handles a single HTTP request.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServiceBase.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServiceBase.java
@@ -23,5 +23,5 @@ package io.servicetalk.http.api;
  * @see BlockingHttpService
  * @see BlockingStreamingHttpService
  */
-public interface Service extends HttpExecutionStrategyInfluencer {
+public interface HttpServiceBase extends HttpExecutionStrategyInfluencer {
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Service.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Service.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+/**
+ * Parent interface for all available HTTP services.
+ *
+ * @see HttpService
+ * @see StreamingHttpService
+ * @see BlockingHttpService
+ * @see BlockingStreamingHttpService
+ */
+public interface Service extends HttpExecutionStrategyInfluencer {
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
@@ -25,7 +25,7 @@ import static io.servicetalk.concurrent.api.Completable.completed;
  * A service contract for the HTTP protocol.
  */
 @FunctionalInterface
-public interface StreamingHttpService extends AsyncCloseable, HttpExecutionStrategyInfluencer {
+public interface StreamingHttpService extends AsyncCloseable, Service {
     /**
      * Handles a single HTTP request.
      *

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpService.java
@@ -25,7 +25,7 @@ import static io.servicetalk.concurrent.api.Completable.completed;
  * A service contract for the HTTP protocol.
  */
 @FunctionalInterface
-public interface StreamingHttpService extends AsyncCloseable, Service {
+public interface StreamingHttpService extends AsyncCloseable, HttpServiceBase {
     /**
      * Handles a single HTTP request.
      *

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.BlockingHttpService;
+import io.servicetalk.http.api.BlockingStreamingHttpService;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.http.api.HttpService;
+import io.servicetalk.http.api.Service;
+import io.servicetalk.http.api.StreamingHttpService;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class HttpServiceTest {
+
+    @ParameterizedTest
+    @MethodSource("serviceProvider")
+    void supportsHttpServiceVariantAtRuntime(Service service) throws Exception {
+        assertNotNull(HttpServers.forAddress(localAddress(0)).listenServiceAndAwait(service));
+    }
+
+    @Test
+    void failsOnUnknownService() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Service service = new Service() {
+                @Override
+                public HttpExecutionStrategy requiredOffloads() {
+                    return Service.super.requiredOffloads();
+                }
+            };
+
+            try (HttpServerContext ctx = HttpServers.forAddress(localAddress(0)).listenServiceAndAwait(service)) {
+                ctx.closeGracefully();
+            }
+        });
+    }
+
+    static Stream<Arguments> serviceProvider() {
+        return Stream.of(
+                arguments(named("BlockingHttpService",
+                        (BlockingHttpService) (ctx, request, responseFactory) -> responseFactory.ok())),
+                arguments(named("BlockingStreamingHttpService",
+                        (BlockingStreamingHttpService) (ctx, request, response) -> { })),
+                arguments(named("HttpService",
+                        (HttpService) (ctx, request, responseFactory) ->
+                                Single.succeeded(responseFactory.ok()))),
+                arguments(named("StreamingHttpService",
+                        (StreamingHttpService) (ctx, request, responseFactory) ->
+                                Single.succeeded(responseFactory.ok())))
+                );
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-public class HttpServiceTest {
+class HttpServiceTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] {0}")
     @MethodSource("serviceProvider")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceTest.java
@@ -21,7 +21,7 @@ import io.servicetalk.http.api.BlockingStreamingHttpService;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpService;
-import io.servicetalk.http.api.Service;
+import io.servicetalk.http.api.HttpServiceBase;
 import io.servicetalk.http.api.StreamingHttpService;
 
 import org.junit.jupiter.api.Test;
@@ -39,19 +39,19 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class HttpServiceTest {
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] {0}")
     @MethodSource("serviceProvider")
-    void supportsHttpServiceVariantAtRuntime(Service service) throws Exception {
+    void supportsHttpServiceVariantAtRuntime(HttpServiceBase service) throws Exception {
         assertNotNull(HttpServers.forAddress(localAddress(0)).listenServiceAndAwait(service));
     }
 
     @Test
     void failsOnUnknownService() {
         assertThrows(IllegalArgumentException.class, () -> {
-            Service service = new Service() {
+            HttpServiceBase service = new HttpServiceBase() {
                 @Override
                 public HttpExecutionStrategy requiredOffloads() {
-                    return Service.super.requiredOffloads();
+                    return HttpServiceBase.super.requiredOffloads();
                 }
             };
 


### PR DESCRIPTION
  **Motivation**

  Right now four different Service API variants are provided, all
  with their async and sync listen* overloads. If the service
  type is known at compile time those overloads suffice, but in
  situations where the type is only determined at runtime (for
  example when DI is used) the user needs to write verbose code
  that can be provided by ServiceTalk and improve the developer
  experience.

  **Modifications**

  This changeset introduces a new "Service" interface in the
  http package and it now acts as a parent for the four different
  service implementations. The HttpServerBuilder gets two more
  overloads (blocking and non-blocking) to accept the Service
  type and then internally performs the runtime type checking
  and delegates to the appropriate methods.