### PR TITLE
`ConnectionLimitReachedException` should not trigger RRLB health-checking

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionLimitReachedException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConnectionLimitReachedException.java
@@ -15,15 +15,19 @@
  */
 package io.servicetalk.client.api;
 
+import io.servicetalk.client.api.LimitingConnectionFactoryFilter.ConnectionLimiter;
+import io.servicetalk.transport.api.RetryableException;
+
 import java.net.ConnectException;
 
 /**
  * Thrown when the number of connections reached their limit for a given resource (i.e. a host)
  * depending on the context.
  *
- * @see LimitingConnectionFactoryFilter
+ * @see ConnectionLimiter#newConnectionRefusedException(Object)
+ * @see LimitingConnectionFactoryFilter#withMax(int)
  */
-public class ConnectionLimitReachedException extends ConnectException {
+public class ConnectionLimitReachedException extends ConnectException implements RetryableException {
 
     private static final long serialVersionUID = 645105614301638032L;
 

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LimitingConnectionFactoryFilter.java
@@ -57,6 +57,8 @@ public final class LimitingConnectionFactoryFilter<ResolvedAddress, C extends Li
 
     /**
      * Create a new {@link ConnectionFactory} that only creates a maximum of {@code maxConnections} active connections.
+     * <p>
+     * When the limit is reached, {@link ConnectionLimitReachedException} will be thrown.
      *
      * @param maxConnections Maximum number of active connections to create.
      * @param <A> The type of a resolved address that can be used for connecting.
@@ -126,8 +128,10 @@ public final class LimitingConnectionFactoryFilter<ResolvedAddress, C extends Li
         void onConnectionClose(ResolvedAddress target);
 
         /**
-         * Create a {@link ConnectionLimitReachedException} representing a connection attempt refused, typically
+         * Create a {@link Throwable} representing a connection attempt refused, typically
          * as a result of returning {@code false} from {@link #isConnectAllowed(Object)}.
+         * <p>
+         * The default and recommended exception type is {@link ConnectionLimitReachedException}.
          *
          * @param target {@link ResolvedAddress} for which connection was refused.
          * @return {@link Throwable} representing a connection attempt was refused.
@@ -196,6 +200,12 @@ public final class LimitingConnectionFactoryFilter<ResolvedAddress, C extends Li
         @Override
         public void onConnectionClose(final ResolvedAddress target) {
             countUpdater.decrementAndGet(this);
+        }
+
+        @Override
+        public Throwable newConnectionRefusedException(final ResolvedAddress target) {
+            return new ConnectionLimitReachedException("No more connections allowed for the host: " + target +
+                    ". Reached the maximum limit of " + maxAllowed + " connection(s).");
         }
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -16,6 +16,7 @@
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionLimitReachedException;
 import io.servicetalk.client.api.ConnectionRejectedException;
 import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.client.api.LoadBalancer;
@@ -614,7 +615,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             for (;;) {
                 ConnState previous = connStateUpdater.get(this);
 
-                if (!ActiveState.class.equals(previous.state.getClass()) || previous.connections.length > 0) {
+                if (!ActiveState.class.equals(previous.state.getClass()) || previous.connections.length > 0
+                        || cause instanceof ConnectionLimitReachedException) {
                     LOGGER.debug("Load balancer for {}: failed to open a new connection to the host on address {}. {}",
                             targetResource, address, previous, cause);
                     break;


### PR DESCRIPTION
Motivation:

`ConnectionLimitReachedException` should implement a `RetryableException` contract and should not mark the remote host unhealthy bcz it's a local limit that does not affect the host's actual healthiness. Hosts are not marked as "unhealthy" if there are open connections to them, but there is currently a risk to changes host's state to "unhealthy" from the cold start, if we wait for allowed connections to open.

Modifications:

- Enhance `markUnhealthy` logic inside `RoundRobinLoadBalancer` to ignore `ConnectionLimitReachedException` for counting towards the threshold;
- Test that `ConnectionLimitReachedException` doesn't move a host to "unhealthy" state;
- Add `RetryableException` marker for `ConnectionLimitReachedException`;
- Clarify `LimitingConnectionFactoryFilter`'s javadoc about recommended exception;
- Implement `newConnectionRefusedException` inside `MaxConnectionsLimiter` to include the current limit at the end of exception message;

Results:

1. `ConnectionLimitReachedException` doesn't change the state of the host.
2. `ConnectionLimitReachedException` is marked as `RetryableException`.
3. `LimitingConnectionFactoryFilter.withMax(int)` includes its limit in the exception message.

Follow-up for #2454.