### PR TITLE
Remove ServiceAdapterHolder from DefaultHttpServerBuilder

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractServiceAdapterHolder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractServiceAdapterHolder.java
@@ -34,4 +34,9 @@ abstract class AbstractServiceAdapterHolder implements StreamingHttpService, Ser
     public HttpExecutionStrategy serviceInvocationStrategy() {
         return serviceInvocationStrategy;
     }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return serviceInvocationStrategy;
+    }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
@@ -288,7 +288,7 @@ public final class HttpApiConversions {
      * @param influencer {@link HttpExecutionStrategyInfluencer} to influence the strategy for invoking the resulting
      * {@link StreamingHttpService}.
      * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
-     * @deprecated Use overload with {@link HttpExecutionStrategy} rather than {@link HttpExecutionStrategyInfluencer}
+     * @deprecated Use {@link #toStreamingHttpService(HttpExecutionStrategy, HttpService)} instead.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     public static ServiceAdapterHolder toStreamingHttpService(HttpService service,
@@ -297,7 +297,7 @@ public final class HttpApiConversions {
     }
 
     /**
-     * Convert from a {@link HttpService} to a {@link ServiceAdapterHolder}.
+     * Convert from a {@link HttpService} to a {@link StreamingHttpService}.
      *
      * @param service The {@link HttpService} to convert.
      * @param strategy required strategy for the service when invoking the resulting {@link ServiceAdapterHolder}.
@@ -314,7 +314,7 @@ public final class HttpApiConversions {
      *
      * @param service The {@link HttpService} to convert.
      * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
-     * @return {@link StreamingHttpService} containing the service adapted to the streaming programming model.
+     * @return the converted {@link StreamingHttpService} to be used for the streaming programming model.
      */
     public static StreamingHttpService toStreamingHttpService(HttpExecutionStrategy strategy, HttpService service) {
         return new ServiceToStreamingService(service, strategy);
@@ -327,7 +327,7 @@ public final class HttpApiConversions {
      * @param influencer {@link HttpExecutionStrategyInfluencer} to influence the strategy for invoking the resulting
      * {@link StreamingHttpService}.
      * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
-     * @deprecated Use overload with {@link HttpExecutionStrategy} rather than {@link HttpExecutionStrategyInfluencer}
+     * @deprecated Use {@link #toStreamingHttpService(HttpExecutionStrategy, BlockingStreamingHttpService)} instead.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     public static ServiceAdapterHolder toStreamingHttpService(BlockingStreamingHttpService service,
@@ -336,7 +336,7 @@ public final class HttpApiConversions {
     }
 
     /**
-     * Convert from a {@link BlockingStreamingHttpService} to a {@link ServiceAdapterHolder}.
+     * Convert from a {@link BlockingStreamingHttpService} to a {@link StreamingHttpService}.
      *
      * @param service The {@link BlockingStreamingHttpService} to convert.
      * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
@@ -354,7 +354,7 @@ public final class HttpApiConversions {
      *
      * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
      * @param service The {@link BlockingStreamingHttpService} to convert.
-     * @return {@link StreamingHttpService} containing the service adapted to the streaming programming model.
+     * @return the converted {@link StreamingHttpService} to be used for the streaming programming model.
      */
     public static StreamingHttpService toStreamingHttpService(HttpExecutionStrategy strategy,
                                                               BlockingStreamingHttpService service) {
@@ -362,13 +362,13 @@ public final class HttpApiConversions {
     }
 
     /**
-     * Convert from a {@link BlockingStreamingHttpService} to a {@link StreamingHttpService}.
+     * Convert from a {@link BlockingHttpService} to a {@link StreamingHttpService}.
      *
-     * @param service The {@link BlockingStreamingHttpService} to convert.
+     * @param service The {@link BlockingHttpService} to convert.
      * @param influencer {@link HttpExecutionStrategyInfluencer} to influence the strategy for invoking the resulting
      * {@link StreamingHttpService}.
      * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
-     * @deprecated Use overload with {@link HttpExecutionStrategy} rather than {@link HttpExecutionStrategyInfluencer}
+     * @deprecated Use {@link #toStreamingHttpService(HttpExecutionStrategy, BlockingHttpService)} instead.
      */
     // FIXME: 0.43 - remove deprecated method
     @Deprecated
@@ -378,12 +378,12 @@ public final class HttpApiConversions {
     }
 
     /**
-     * Convert from a {@link BlockingStreamingHttpService} to a {@link ServiceAdapterHolder}.
+     * Convert from a {@link BlockingHttpService} to a {@link StreamingHttpService}.
      *
-     * @param service The {@link BlockingStreamingHttpService} to convert.
+     * @param service The {@link BlockingHttpService} to convert.
      * @param strategy required strategy for the service when invoking the resulting {@link ServiceAdapterHolder}.
      * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
-     * @deprecated use {@link #toStreamingHttpService(HttpExecutionStrategy, BlockingHttpService)} instead.
+     * @deprecated Use {@link #toStreamingHttpService(HttpExecutionStrategy, BlockingHttpService)} instead.
      */
     @Deprecated // FIXME: 0.43 - Remove deprecation
     public static ServiceAdapterHolder toStreamingHttpService(BlockingHttpService service,
@@ -392,11 +392,11 @@ public final class HttpApiConversions {
     }
 
     /**
-     * Convert from a {@link BlockingStreamingHttpService} to a {@link StreamingHttpService}.
+     * Convert from a {@link BlockingHttpService} to a {@link StreamingHttpService}.
      *
      * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
-     * @param service The {@link BlockingStreamingHttpService} to convert.
-     * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
+     * @param service The {@link BlockingHttpService} to convert.
+     * @return the converted {@link StreamingHttpService} to be used for the streaming programming model.
      */
     public static StreamingHttpService toStreamingHttpService(HttpExecutionStrategy strategy,
                                                               BlockingHttpService service) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
@@ -302,9 +302,10 @@ public final class HttpApiConversions {
      *
      * @param service The {@link HttpService} to convert.
      * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
-     * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
+     * @return {@link ServiceToStreamingService} containing the service adapted to the streaming programming model.
      */
-    public static ServiceAdapterHolder toStreamingHttpService(HttpService service, HttpExecutionStrategy strategy) {
+    public static ServiceToStreamingService toStreamingHttpService(HttpService service,
+                                                                   HttpExecutionStrategy strategy) {
         return new ServiceToStreamingService(service, strategy);
     }
 
@@ -329,10 +330,11 @@ public final class HttpApiConversions {
      *
      * @param service The {@link BlockingStreamingHttpService} to convert.
      * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
-     * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
+     * @return {@link BlockingStreamingToStreamingService} containing the service adapted to the streaming
+     * programming model.
      */
-    public static ServiceAdapterHolder toStreamingHttpService(BlockingStreamingHttpService service,
-                                                              HttpExecutionStrategy strategy) {
+    public static BlockingStreamingToStreamingService toStreamingHttpService(BlockingStreamingHttpService service,
+                                                                             HttpExecutionStrategy strategy) {
         return new BlockingStreamingToStreamingService(service, strategy);
     }
 
@@ -357,10 +359,10 @@ public final class HttpApiConversions {
      *
      * @param service The {@link BlockingStreamingHttpService} to convert.
      * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
-     * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
+     * @return {@link BlockingToStreamingService} containing the service adapted to the streaming programming model.
      */
-    public static ServiceAdapterHolder toStreamingHttpService(BlockingHttpService service,
-                                                              HttpExecutionStrategy strategy) {
+    public static BlockingToStreamingService toStreamingHttpService(BlockingHttpService service,
+                                                                    HttpExecutionStrategy strategy) {
         return new BlockingToStreamingService(service, strategy);
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
@@ -290,11 +290,23 @@ public final class HttpApiConversions {
      * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
      * @deprecated Use overload with {@link HttpExecutionStrategy} rather than {@link HttpExecutionStrategyInfluencer}
      */
-    // FIXME: 0.43 - remove deprecated method
-    @Deprecated
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     public static ServiceAdapterHolder toStreamingHttpService(HttpService service,
                                                               HttpExecutionStrategyInfluencer influencer) {
         return toStreamingHttpService(service, influencer.requiredOffloads());
+    }
+
+    /**
+     * Convert from a {@link HttpService} to a {@link ServiceAdapterHolder}.
+     *
+     * @param service The {@link HttpService} to convert.
+     * @param strategy required strategy for the service when invoking the resulting {@link ServiceAdapterHolder}.
+     * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
+     * @deprecated use {@link #toStreamingHttpService(HttpExecutionStrategy, HttpService)} instead.
+     */
+    @Deprecated // FIXME: 0.43 - remove deprecated method
+    public static ServiceAdapterHolder toStreamingHttpService(HttpService service, HttpExecutionStrategy strategy) {
+        return new ServiceToStreamingService(service, strategy);
     }
 
     /**
@@ -302,10 +314,9 @@ public final class HttpApiConversions {
      *
      * @param service The {@link HttpService} to convert.
      * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
-     * @return {@link ServiceToStreamingService} containing the service adapted to the streaming programming model.
+     * @return {@link StreamingHttpService} containing the service adapted to the streaming programming model.
      */
-    public static ServiceToStreamingService toStreamingHttpService(HttpService service,
-                                                                   HttpExecutionStrategy strategy) {
+    public static StreamingHttpService toStreamingHttpService(HttpExecutionStrategy strategy, HttpService service) {
         return new ServiceToStreamingService(service, strategy);
     }
 
@@ -318,23 +329,35 @@ public final class HttpApiConversions {
      * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
      * @deprecated Use overload with {@link HttpExecutionStrategy} rather than {@link HttpExecutionStrategyInfluencer}
      */
-    // FIXME: 0.43 - remove deprecated method
-    @Deprecated
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     public static ServiceAdapterHolder toStreamingHttpService(BlockingStreamingHttpService service,
                                                               HttpExecutionStrategyInfluencer influencer) {
         return toStreamingHttpService(service, influencer.requiredOffloads());
     }
 
     /**
-     * Convert from a {@link BlockingStreamingHttpService} to a {@link StreamingHttpService}.
+     * Convert from a {@link BlockingStreamingHttpService} to a {@link ServiceAdapterHolder}.
      *
      * @param service The {@link BlockingStreamingHttpService} to convert.
      * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
-     * @return {@link BlockingStreamingToStreamingService} containing the service adapted to the streaming
-     * programming model.
+     * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
+     * @deprecated use {@link #toStreamingHttpService(HttpExecutionStrategy, BlockingStreamingHttpService)} instead.
      */
-    public static BlockingStreamingToStreamingService toStreamingHttpService(BlockingStreamingHttpService service,
-                                                                             HttpExecutionStrategy strategy) {
+    @Deprecated // FIXME: 0.43 - remove deprecated method
+    public static ServiceAdapterHolder toStreamingHttpService(BlockingStreamingHttpService service,
+                                                              HttpExecutionStrategy strategy) {
+        return new BlockingStreamingToStreamingService(service, strategy);
+    }
+
+    /**
+     * Convert from a {@link BlockingStreamingHttpService} to a {@link StreamingHttpService}.
+     *
+     * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
+     * @param service The {@link BlockingStreamingHttpService} to convert.
+     * @return {@link StreamingHttpService} containing the service adapted to the streaming programming model.
+     */
+    public static StreamingHttpService toStreamingHttpService(HttpExecutionStrategy strategy,
+                                                              BlockingStreamingHttpService service) {
         return new BlockingStreamingToStreamingService(service, strategy);
     }
 
@@ -355,14 +378,28 @@ public final class HttpApiConversions {
     }
 
     /**
-     * Convert from a {@link BlockingStreamingHttpService} to a {@link StreamingHttpService}.
+     * Convert from a {@link BlockingStreamingHttpService} to a {@link ServiceAdapterHolder}.
      *
      * @param service The {@link BlockingStreamingHttpService} to convert.
-     * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
-     * @return {@link BlockingToStreamingService} containing the service adapted to the streaming programming model.
+     * @param strategy required strategy for the service when invoking the resulting {@link ServiceAdapterHolder}.
+     * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
+     * @deprecated use {@link #toStreamingHttpService(HttpExecutionStrategy, BlockingHttpService)} instead.
      */
-    public static BlockingToStreamingService toStreamingHttpService(BlockingHttpService service,
-                                                                    HttpExecutionStrategy strategy) {
+    @Deprecated // FIXME: 0.43 - Remove deprecation
+    public static ServiceAdapterHolder toStreamingHttpService(BlockingHttpService service,
+                                                              HttpExecutionStrategy strategy) {
+        return new BlockingToStreamingService(service, strategy);
+    }
+
+    /**
+     * Convert from a {@link BlockingStreamingHttpService} to a {@link StreamingHttpService}.
+     *
+     * @param strategy required strategy for the service when invoking the resulting {@link StreamingHttpService}.
+     * @param service The {@link BlockingStreamingHttpService} to convert.
+     * @return {@link ServiceAdapterHolder} containing the service adapted to the streaming programming model.
+     */
+    public static StreamingHttpService toStreamingHttpService(HttpExecutionStrategy strategy,
+                                                              BlockingHttpService service) {
         return new BlockingToStreamingService(service, strategy);
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
@@ -436,8 +436,11 @@ public final class HttpApiConversions {
 
     /**
      * A holder for {@link StreamingHttpService} that adapts another {@code service} to the streaming programming model.
+     *
+     * @deprecated this interface is not needed anymore and will be removed in a future version with no replacement.
      */
-    public interface ServiceAdapterHolder {
+    @Deprecated
+    public interface ServiceAdapterHolder { // FIXME: 0.43 - remove deprecated interface
 
         /**
          * {@link StreamingHttpService} that adapts another {@code service} to the streaming programming model. This

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -257,7 +257,7 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
     @Override
     public Single<HttpServerContext> listen(final HttpService service) {
         HttpExecutionStrategy executionStrategy = computeServiceStrategy(HttpService.class, service);
-        return listenForService(toStreamingHttpService(service, executionStrategy), executionStrategy);
+        return listenForService(toStreamingHttpService(executionStrategy, service), executionStrategy);
     }
 
     @Override
@@ -268,13 +268,13 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
     @Override
     public Single<HttpServerContext> listenBlocking(final BlockingHttpService service) {
         HttpExecutionStrategy executionStrategy = computeServiceStrategy(BlockingHttpService.class, service);
-        return listenForService(toStreamingHttpService(service, executionStrategy), executionStrategy);
+        return listenForService(toStreamingHttpService(executionStrategy, service), executionStrategy);
     }
 
     @Override
     public Single<HttpServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
         HttpExecutionStrategy executionStrategy = computeServiceStrategy(BlockingStreamingHttpService.class, service);
-        return listenForService(toStreamingHttpService(service, executionStrategy), executionStrategy);
+        return listenForService(toStreamingHttpService(executionStrategy, service), executionStrategy);
     }
 
     private HttpExecutionContext buildExecutionContext(final HttpExecutionStrategy strategy) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -256,8 +256,8 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
 
     @Override
     public Single<HttpServerContext> listen(final HttpService service) {
-        HttpExecutionStrategy executionStrategy = computeServiceStrategy(HttpService.class, service);
-        StreamingHttpService streamingService = toStreamingHttpService(executionStrategy, service);
+        StreamingHttpService streamingService = toStreamingHttpService(
+                computeServiceStrategy(HttpService.class, service), service);
         return listenForService(streamingService, streamingService.requiredOffloads());
     }
 
@@ -268,15 +268,15 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
 
     @Override
     public Single<HttpServerContext> listenBlocking(final BlockingHttpService service) {
-        HttpExecutionStrategy executionStrategy = computeServiceStrategy(BlockingHttpService.class, service);
-        StreamingHttpService streamingService = toStreamingHttpService(executionStrategy, service);
+        StreamingHttpService streamingService = toStreamingHttpService(
+                computeServiceStrategy(BlockingHttpService.class, service), service);
         return listenForService(streamingService, streamingService.requiredOffloads());
     }
 
     @Override
     public Single<HttpServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
-        HttpExecutionStrategy executionStrategy = computeServiceStrategy(BlockingStreamingHttpService.class, service);
-        StreamingHttpService streamingService = toStreamingHttpService(executionStrategy, service);
+        StreamingHttpService streamingService = toStreamingHttpService(
+                computeServiceStrategy(BlockingStreamingHttpService.class, service), service);
         return listenForService(streamingService, streamingService.requiredOffloads());
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -257,7 +257,8 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
     @Override
     public Single<HttpServerContext> listen(final HttpService service) {
         HttpExecutionStrategy executionStrategy = computeServiceStrategy(HttpService.class, service);
-        return listenForService(toStreamingHttpService(executionStrategy, service), executionStrategy);
+        StreamingHttpService streamingService = toStreamingHttpService(executionStrategy, service);
+        return listenForService(streamingService, streamingService.requiredOffloads());
     }
 
     @Override
@@ -268,13 +269,15 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
     @Override
     public Single<HttpServerContext> listenBlocking(final BlockingHttpService service) {
         HttpExecutionStrategy executionStrategy = computeServiceStrategy(BlockingHttpService.class, service);
-        return listenForService(toStreamingHttpService(executionStrategy, service), executionStrategy);
+        StreamingHttpService streamingService = toStreamingHttpService(executionStrategy, service);
+        return listenForService(streamingService, streamingService.requiredOffloads());
     }
 
     @Override
     public Single<HttpServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
         HttpExecutionStrategy executionStrategy = computeServiceStrategy(BlockingStreamingHttpService.class, service);
-        return listenForService(toStreamingHttpService(executionStrategy, service), executionStrategy);
+        StreamingHttpService streamingService = toStreamingHttpService(executionStrategy, service);
+        return listenForService(streamingService, streamingService.requiredOffloads());
     }
 
     private HttpExecutionContext buildExecutionContext(final HttpExecutionStrategy strategy) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.BlockingHttpService;
 import io.servicetalk.http.api.BlockingStreamingHttpService;
-import io.servicetalk.http.api.HttpApiConversions;
 import io.servicetalk.http.api.HttpExceptionMapperServiceFilter;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategies;
@@ -257,7 +256,8 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
 
     @Override
     public Single<HttpServerContext> listen(final HttpService service) {
-        return listenForAdapter(toStreamingHttpService(service, computeServiceStrategy(HttpService.class, service)));
+        HttpExecutionStrategy executionStrategy = computeServiceStrategy(HttpService.class, service);
+        return listenForService(toStreamingHttpService(service, executionStrategy), executionStrategy);
     }
 
     @Override
@@ -267,23 +267,19 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
 
     @Override
     public Single<HttpServerContext> listenBlocking(final BlockingHttpService service) {
-        return listenForAdapter(toStreamingHttpService(service,
-                computeServiceStrategy(BlockingHttpService.class, service)));
+        HttpExecutionStrategy executionStrategy = computeServiceStrategy(BlockingHttpService.class, service);
+        return listenForService(toStreamingHttpService(service, executionStrategy), executionStrategy);
     }
 
     @Override
     public Single<HttpServerContext> listenBlockingStreaming(final BlockingStreamingHttpService service) {
-        return listenForAdapter(toStreamingHttpService(service,
-                computeServiceStrategy(BlockingStreamingHttpService.class, service)));
+        HttpExecutionStrategy executionStrategy = computeServiceStrategy(BlockingStreamingHttpService.class, service);
+        return listenForService(toStreamingHttpService(service, executionStrategy), executionStrategy);
     }
 
     private HttpExecutionContext buildExecutionContext(final HttpExecutionStrategy strategy) {
         executionContextBuilder.executionStrategy(strategy);
         return executionContextBuilder.build();
-    }
-
-    private Single<HttpServerContext> listenForAdapter(HttpApiConversions.ServiceAdapterHolder adapterHolder) {
-        return listenForService(adapterHolder.adaptor(), adapterHolder.serviceInvocationStrategy());
     }
 
     /**

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
@@ -45,7 +45,7 @@ class ConnectionContextToStringTest extends AbstractNettyHttpServerTest {
     void service(final StreamingHttpService service) {
         super.service((toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) ->
                         responseFactory.ok().payloadBody(ctx.toString(), textSerializerUtf8()),
-                HttpExecutionStrategies.offloadNone())));
+                HttpExecutionStrategies.offloadNone())).adaptor());
     }
 
     @ParameterizedTest(name = "protocol={0}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
@@ -43,9 +43,9 @@ class ConnectionContextToStringTest extends AbstractNettyHttpServerTest {
 
     @Override
     void service(final StreamingHttpService service) {
-        super.service((toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) ->
-                        responseFactory.ok().payloadBody(ctx.toString(), textSerializerUtf8()),
-                HttpExecutionStrategies.offloadNone())).adaptor());
+        super.service((toStreamingHttpService(HttpExecutionStrategies.offloadNone(),
+                (BlockingHttpService) (ctx, request, responseFactory) ->
+                        responseFactory.ok().payloadBody(ctx.toString(), textSerializerUtf8()))));
     }
 
     @ParameterizedTest(name = "protocol={0}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionContextToStringTest.java
@@ -45,7 +45,7 @@ class ConnectionContextToStringTest extends AbstractNettyHttpServerTest {
     void service(final StreamingHttpService service) {
         super.service((toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) ->
                         responseFactory.ok().payloadBody(ctx.toString(), textSerializerUtf8()),
-                HttpExecutionStrategies.offloadNone())).adaptor());
+                HttpExecutionStrategies.offloadNone())));
     }
 
     @ParameterizedTest(name = "protocol={0}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestResponseContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestResponseContextTest.java
@@ -137,7 +137,7 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                     HttpResponse response = responseFactory.ok().payloadBody(request.payloadBody());
                     transferContext(request, response);
                     return succeeded(response);
-                }, offloadNone());
+                }, offloadNone()).adaptor();
                 break;
             case AsyncStreaming:
                 newService = (ctx, request, responseFactory) -> {
@@ -151,7 +151,7 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                     HttpResponse response = responseFactory.ok().payloadBody(request.payloadBody());
                     transferContext(request, response);
                     return response;
-                }, offloadNone());
+                }, offloadNone()).adaptor();
                 break;
             case BlockingStreaming:
                 newService = toStreamingHttpService((ctx, request, response) -> {
@@ -161,7 +161,7 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                             writer.write(chunk);
                         }
                     }
-                }, offloadNone());
+                }, offloadNone()).adaptor();
                 break;
             default:
                 throw new IllegalStateException("Unknown api: " + api);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestResponseContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestResponseContextTest.java
@@ -137,7 +137,7 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                     HttpResponse response = responseFactory.ok().payloadBody(request.payloadBody());
                     transferContext(request, response);
                     return succeeded(response);
-                }, offloadNone()).adaptor();
+                }, offloadNone());
                 break;
             case AsyncStreaming:
                 newService = (ctx, request, responseFactory) -> {
@@ -151,7 +151,7 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                     HttpResponse response = responseFactory.ok().payloadBody(request.payloadBody());
                     transferContext(request, response);
                     return response;
-                }, offloadNone()).adaptor();
+                }, offloadNone());
                 break;
             case BlockingStreaming:
                 newService = toStreamingHttpService((ctx, request, response) -> {
@@ -161,7 +161,7 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                             writer.write(chunk);
                         }
                     }
-                }, offloadNone()).adaptor();
+                }, offloadNone());
                 break;
             default:
                 throw new IllegalStateException("Unknown api: " + api);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestResponseContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RequestResponseContextTest.java
@@ -133,11 +133,11 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
         assert api != null;
         switch (api) {
             case AsyncAggregated:
-                newService = toStreamingHttpService((HttpService) (ctx, request, responseFactory) -> {
+                newService = toStreamingHttpService(offloadNone(), (HttpService) (ctx, request, responseFactory) -> {
                     HttpResponse response = responseFactory.ok().payloadBody(request.payloadBody());
                     transferContext(request, response);
                     return succeeded(response);
-                }, offloadNone()).adaptor();
+                });
                 break;
             case AsyncStreaming:
                 newService = (ctx, request, responseFactory) -> {
@@ -147,21 +147,22 @@ class RequestResponseContextTest extends AbstractNettyHttpServerTest {
                 };
                 break;
             case BlockingAggregated:
-                newService = toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) -> {
+                newService = toStreamingHttpService(offloadNone(),
+                        (BlockingHttpService) (ctx, request, responseFactory) -> {
                     HttpResponse response = responseFactory.ok().payloadBody(request.payloadBody());
                     transferContext(request, response);
                     return response;
-                }, offloadNone()).adaptor();
+                });
                 break;
             case BlockingStreaming:
-                newService = toStreamingHttpService((ctx, request, response) -> {
+                newService = toStreamingHttpService(offloadNone(), (ctx, request, response) -> {
                     transferContext(request, response);
                     try (HttpPayloadWriter<Buffer> writer = response.sendMetaData()) {
                         for (Buffer chunk : request.payloadBody()) {
                             writer.write(chunk);
                         }
                     }
-                }, offloadNone()).adaptor();
+                });
                 break;
             default:
                 throw new IllegalStateException("Unknown api: " + api);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -86,7 +86,7 @@ class ServerRespondsOnClosingTest {
         };
         serverConnection = initChannel(channel, httpExecutionContext, config, new TcpServerChannelInitializer(
                 config.tcpConfig(), connectionObserver),
-                toStreamingHttpService(service, offloadNone()).adaptor(), true,
+                toStreamingHttpService(offloadNone(), service), true,
                 connectionObserver).toFuture().get();
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -86,7 +86,7 @@ class ServerRespondsOnClosingTest {
         };
         serverConnection = initChannel(channel, httpExecutionContext, config, new TcpServerChannelInitializer(
                 config.tcpConfig(), connectionObserver),
-                toStreamingHttpService(service, offloadNone()), true,
+                toStreamingHttpService(service, offloadNone()).adaptor(), true,
                 connectionObserver).toFuture().get();
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -86,7 +86,7 @@ class ServerRespondsOnClosingTest {
         };
         serverConnection = initChannel(channel, httpExecutionContext, config, new TcpServerChannelInitializer(
                 config.tcpConfig(), connectionObserver),
-                toStreamingHttpService(service, offloadNone()).adaptor(), true,
+                toStreamingHttpService(service, offloadNone()), true,
                 connectionObserver).toFuture().get();
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SupportedBufferAllocatorsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SupportedBufferAllocatorsTest.java
@@ -68,7 +68,7 @@ class SupportedBufferAllocatorsTest extends AbstractNettyHttpServerTest {
     void service(final StreamingHttpService service) {
         super.service((toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) ->
                         responseFactory.ok().payloadBody(allocator.fromAscii(request.payloadBody().toString(US_ASCII))),
-                offloadNone())).adaptor());
+                offloadNone())));
     }
 
     @ParameterizedTest(name = "{index}: protocol={0}, allocator={1}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SupportedBufferAllocatorsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SupportedBufferAllocatorsTest.java
@@ -68,7 +68,7 @@ class SupportedBufferAllocatorsTest extends AbstractNettyHttpServerTest {
     void service(final StreamingHttpService service) {
         super.service((toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) ->
                         responseFactory.ok().payloadBody(allocator.fromAscii(request.payloadBody().toString(US_ASCII))),
-                offloadNone())));
+                offloadNone())).adaptor());
     }
 
     @ParameterizedTest(name = "{index}: protocol={0}, allocator={1}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SupportedBufferAllocatorsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SupportedBufferAllocatorsTest.java
@@ -66,9 +66,9 @@ class SupportedBufferAllocatorsTest extends AbstractNettyHttpServerTest {
 
     @Override
     void service(final StreamingHttpService service) {
-        super.service((toStreamingHttpService((BlockingHttpService) (ctx, request, responseFactory) ->
-                        responseFactory.ok().payloadBody(allocator.fromAscii(request.payloadBody().toString(US_ASCII))),
-                offloadNone())).adaptor());
+        super.service((toStreamingHttpService(offloadNone(), (BlockingHttpService) (ctx, request, responseFactory) ->
+                        responseFactory.ok().payloadBody(allocator.fromAscii(request.payloadBody().toString(US_ASCII)))
+        )));
     }
 
     @ParameterizedTest(name = "{index}: protocol={0}, allocator={1}")

--- a/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilder.java
+++ b/servicetalk-http-router-predicate/src/main/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilder.java
@@ -17,7 +17,6 @@ package io.servicetalk.http.router.predicate;
 
 import io.servicetalk.http.api.BlockingHttpService;
 import io.servicetalk.http.api.BlockingStreamingHttpService;
-import io.servicetalk.http.api.HttpApiConversions.ServiceAdapterHolder;
 import io.servicetalk.http.api.HttpCookiePair;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
@@ -259,20 +258,20 @@ public final class HttpPredicateRouterBuilder implements RouteStarter {
 
         @Override
         public RouteStarter thenRouteTo(final HttpService service) {
-            final ServiceAdapterHolder adapterHolder = toStreamingHttpService(service, serviceOffloads(service));
-            return thenRouteTo0(adapterHolder.adaptor(), adapterHolder.serviceInvocationStrategy());
+            final StreamingHttpService streamingService = toStreamingHttpService(serviceOffloads(service), service);
+            return thenRouteTo0(streamingService, streamingService.requiredOffloads());
         }
 
         @Override
         public RouteStarter thenRouteTo(final BlockingHttpService service) {
-            final ServiceAdapterHolder adapterHolder = toStreamingHttpService(service, serviceOffloads(service));
-            return thenRouteTo0(adapterHolder.adaptor(), adapterHolder.serviceInvocationStrategy());
+            final StreamingHttpService streamingService = toStreamingHttpService(serviceOffloads(service), service);
+            return thenRouteTo0(streamingService, streamingService.requiredOffloads());
         }
 
         @Override
         public RouteStarter thenRouteTo(final BlockingStreamingHttpService service) {
-            final ServiceAdapterHolder adapterHolder = toStreamingHttpService(service, serviceOffloads(service));
-            return thenRouteTo0(adapterHolder.adaptor(), adapterHolder.serviceInvocationStrategy());
+            final StreamingHttpService streamingService = toStreamingHttpService(serviceOffloads(service), service);
+            return thenRouteTo0(streamingService, streamingService.requiredOffloads());
         }
 
         private HttpExecutionStrategy serviceOffloads(final HttpExecutionStrategyInfluencer service) {


### PR DESCRIPTION
Motivation:

The ServiceAdapterHolder is not needed anymore conceptually since the Service now carries its offloading properties (HttpExecutionStrategy) as part of the class itself.

Modifications:

This changeset is the first step to remove the ServiceAdapterHolder by removing it from the DefaultHttpServerBuilder. The HttpExecutionStrategy is still computed but instead of going through the ServiceAdapterHolder indirection the codepath now consistently uses the StreamingHttpService codepath.

Result:

Simplified DefaultHttpServerBuilder as well as removing most of the current ServiceAdapterHolder usage (there is still some left which can be cleaned up in follow-up changesets).