### PR TITLE
Possible race when `MAX_CONCURRENT_STREAMS` setting changes in HTTP/2

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConsumableEvent.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ConsumableEvent.java
@@ -30,6 +30,9 @@ public interface ConsumableEvent<T> {
 
     /**
      * Signify the {@link #event()} has been consumed and any side effects have taken place.
+     * <p>
+     * Implementations of this method are expected to be idempotent, meaning that if the event is already consumed then
+     * invoking this method has no effect.
      */
     void eventConsumed();
 }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/LatestValueSubscriber.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/LatestValueSubscriber.java
@@ -25,9 +25,13 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateS
 /**
  * A {@link Subscriber} which makes the latest value from {@link #onNext(Object)} available outside the context of the
  * {@link Subscriber}.
+ *
  * @param <T> The type of data.
+ * @deprecated This class is no longer used by ServiceTalk and will be removed in the future releases. If you depend on
+ * it, consider copying into your codebase.
  */
-public final class LatestValueSubscriber<T> implements Subscriber<T> {
+@Deprecated
+public final class LatestValueSubscriber<T> implements Subscriber<T> {  // FIXME: 0.43 - remove deprecated class
     @Nullable
     private volatile T latestValue;
     @Nullable

--- a/servicetalk-context-api/build.gradle
+++ b/servicetalk-context-api/build.gradle
@@ -18,7 +18,11 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api platform(project(":servicetalk-dependencies"))
-  implementation project(":servicetalk-annotations")
+  testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
+  implementation project(":servicetalk-annotations")
   implementation "com.google.code.findbugs:jsr305"
+
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/servicetalk-context-api/src/main/java/io/servicetalk/context/api/ContextMap.java
+++ b/servicetalk-context-api/src/main/java/io/servicetalk/context/api/ContextMap.java
@@ -72,7 +72,7 @@ public interface ContextMap {
          * @param type The type of the key. This <strong>WILL NOT</strong> be used in comparisons between {@link Key}
          * objects.
          * @param <T> The value type associated with the {@link Key}.
-         * @return a new {@link Key} which has a {@link String} used only in the {@link #toString()} method for
+         * @return A new {@link Key} which uses a passed name only in the {@link #toString()} method for
          * debugging visibility.
          */
         public static <T> Key<T> newKey(final String name, final Class<T> type) {

--- a/servicetalk-context-api/src/test/java/io/servicetalk/context/api/ContextMapTest.java
+++ b/servicetalk-context-api/src/test/java/io/servicetalk/context/api/ContextMapTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.context.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static io.servicetalk.context.api.ContextMap.Key.newKey;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+class ContextMapTest {
+
+    @Test
+    void testType() {
+        ContextMap.Key<CharSequence> key = newKey("key", CharSequence.class);
+        assertThat(key.type(), equalTo(CharSequence.class));
+        assertThat(key.type().isInstance("test"), is(true));
+        assertThat(key.type().isInstance(1), is(false));
+        assertThat(key.type().isAssignableFrom(String.class), is(true));
+        assertThat(key.type().isAssignableFrom(Integer.class), is(false));
+        CharSequence castCs = key.type().cast("test");
+        assertThat(castCs, equalTo("test"));
+    }
+
+    @Test
+    void testGenericType() {
+        @SuppressWarnings("unchecked")
+        ContextMap.Key<List<String>> key = newKey("key", (Class<List<String>>) (Class<?>) List.class);
+        assertThat(key.type(), equalTo(List.class));
+        assertThat(key.type().isInstance(Arrays.asList("test")), is(true));
+        assertThat(key.type().isInstance(Collections.singleton("test")), is(false));
+        assertThat(key.type().isAssignableFrom(ArrayList.class), is(true));
+        assertThat(key.type().isAssignableFrom(HashSet.class), is(false));
+        List<String> castList = key.type().cast(Arrays.asList("test"));
+        assertThat(castList, contains("test"));
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpEventKey.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpEventKey.java
@@ -21,6 +21,9 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A key which identifies a configuration setting for a connection. Setting values may change over time.
+ * <p>
+ * Comparison between {@link HttpEventKey} objects should be assumed to be on an instance basis.
+ * In general, {@code newKey(strA) != newKey(strA)}.
  *
  * @param <T> Type of the value of this setting.
  */
@@ -30,7 +33,7 @@ public final class HttpEventKey<T> {
      * Option to define max concurrent requests allowed on a connection.
      */
     public static final HttpEventKey<ConsumableEvent<Integer>> MAX_CONCURRENCY =
-            newKeyWithDebugToString("max-concurrency");
+            newKey("max-concurrency");
 
     private final String stringRepresentation;
 
@@ -45,22 +48,12 @@ public final class HttpEventKey<T> {
     /**
      * Creates a new {@link HttpEventKey} with the specific {@code name}.
      *
-     * @param stringRepresentation of the option. This is only used for debugging purpose and not for key equality.
-     * @param <T>                  Type of the value of the option.
-     * @return A new {@link HttpEventKey}.
-     */
-    static <T> HttpEventKey<T> newKeyWithDebugToString(String stringRepresentation) {
-        return new HttpEventKey<>(stringRepresentation);
-    }
-
-    /**
-     * Creates a new {@link HttpEventKey}.
-     *
+     * @param name of the option. This is only used for debugging purpose and not for key equality.
      * @param <T> Type of the value of the option.
      * @return A new {@link HttpEventKey}.
      */
-    static <T> HttpEventKey<T> newKey() {
-        return new HttpEventKey<>();
+    public static <T> HttpEventKey<T> newKey(String name) {
+        return new HttpEventKey<>(name);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpEventKey.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpEventKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.client.api.ConsumableEvent;
 
+import static java.lang.Integer.toHexString;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -33,31 +34,59 @@ public final class HttpEventKey<T> {
      * Option to define max concurrent requests allowed on a connection.
      */
     public static final HttpEventKey<ConsumableEvent<Integer>> MAX_CONCURRENCY =
-            newKey("max-concurrency");
+            newKey("max-concurrency", generify(ConsumableEvent.class));
 
-    private final String stringRepresentation;
+    private final String name;
+    private final Class<T> type;
 
-    private HttpEventKey(String stringRepresentation) {
-        this.stringRepresentation = requireNonNull(stringRepresentation);
-    }
-
-    private HttpEventKey() {
-        this.stringRepresentation = super.toString();
+    private HttpEventKey(final String name, final Class<T> type) {
+        this.name = requireNonNull(name);
+        this.type = requireNonNull(type);
     }
 
     /**
-     * Creates a new {@link HttpEventKey} with the specific {@code name}.
+     * Returns the name of the key.
      *
-     * @param name of the option. This is only used for debugging purpose and not for key equality.
-     * @param <T> Type of the value of the option.
-     * @return A new {@link HttpEventKey}.
+     * @return the name of the key.
      */
-    public static <T> HttpEventKey<T> newKey(String name) {
-        return new HttpEventKey<>(name);
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the type of the key.
+     *
+     * @return the type of the key.
+     */
+    public Class<T> type() {
+        return type;
+    }
+
+    /**
+     * Creates a new {@link HttpEventKey} with the specified name and type.
+     *
+     * @param name The name of the key. This <strong>WILL NOT</strong> be used in comparisons between
+     * {@link HttpEventKey} objects.
+     * @param type The type of the key. This <strong>WILL NOT</strong> be used in comparisons between
+     * {@link HttpEventKey} objects.
+     * @param <T> The value type associated with the {@link HttpEventKey}.
+     * @return A new {@link HttpEventKey} which uses a passed name only in the {@link #toString()} method for
+     * debugging visibility.
+     */
+    public static <T> HttpEventKey<T> newKey(String name, final Class<T> type) {
+        return new HttpEventKey<>(name, type);
     }
 
     @Override
     public String toString() {
-        return stringRepresentation;
+        return getClass().getSimpleName() +
+                "{name='" + name + '\'' +
+                ", type=" + type.getSimpleName() +
+                "}@" + toHexString(hashCode());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Class<T> generify(Class<?> clazz) {
+        return (Class<T>) clazz;
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpEventKeyTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/HttpEventKeyTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static io.servicetalk.http.api.HttpEventKey.newKey;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+class HttpEventKeyTest {
+
+    @Test
+    void testType() {
+        HttpEventKey<CharSequence> key = newKey("key", CharSequence.class);
+        assertThat(key.type(), equalTo(CharSequence.class));
+        assertThat(key.type().isInstance("test"), is(true));
+        assertThat(key.type().isInstance(1), is(false));
+        assertThat(key.type().isAssignableFrom(String.class), is(true));
+        assertThat(key.type().isAssignableFrom(Integer.class), is(false));
+        CharSequence castCs = key.type().cast("test");
+        assertThat(castCs, equalTo("test"));
+    }
+
+    @Test
+    void testGenericType() {
+        @SuppressWarnings("unchecked")
+        HttpEventKey<List<String>> key = newKey("key", (Class<List<String>>) (Class<?>) List.class);
+        assertThat(key.type(), equalTo(List.class));
+        assertThat(key.type().isInstance(Arrays.asList("test")), is(true));
+        assertThat(key.type().isInstance(Collections.singleton("test")), is(false));
+        assertThat(key.type().isAssignableFrom(ArrayList.class), is(true));
+        assertThat(key.type().isAssignableFrom(HashSet.class), is(false));
+        List<String> castList = key.type().cast(Arrays.asList("test"));
+        assertThat(castList, contains("test"));
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractLBHttpConnectionFactory.java
@@ -43,7 +43,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
-import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
+import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.MAX_CONCURRENCY_NO_OFFLOADING;
 import static io.servicetalk.transport.api.TransportObservers.asSafeObserver;
 import static java.util.Objects.requireNonNull;
 
@@ -121,11 +121,11 @@ abstract class AbstractLBHttpConnectionFactory<ResolvedAddress>
                     // Apply connection filters:
                     FilterableStreamingHttpConnection filteredConnection =
                             connectionFilterFunction != null ? connectionFilterFunction.create(conn) : conn;
-                    return protocolBinding.bind(filteredConnection,
-                            newConcurrencyController(filteredConnection.transportEventStream(MAX_CONCURRENCY)
-                                            .beforeOnNext(event -> LOGGER.debug("{} Received {} event: {}",
-                                                    conn, MAX_CONCURRENCY, event)),
-                                    filteredConnection.onClosing()), context);
+                    return protocolBinding.bind(filteredConnection, newConcurrencyController(
+                            filteredConnection.transportEventStream(MAX_CONCURRENCY_NO_OFFLOADING)
+                                    .beforeOnNext(event -> LOGGER.debug("{} Received {} event: {}",
+                                            conn, MAX_CONCURRENCY_NO_OFFLOADING, event)),
+                            filteredConnection.onClosing()), context);
                 });
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -67,7 +67,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
         implements FilterableStreamingHttpConnection {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractStreamingHttpConnection.class);
-    private static final IgnoreConsumedEvent<Integer> ZERO_MAX_CONCURRENCY_EVENT = new IgnoreConsumedEvent<>(0);
+    static final IgnoreConsumedEvent<Integer> ZERO_MAX_CONCURRENCY_EVENT = new IgnoreConsumedEvent<>(0);
 
     final CC connection;
     private final HttpConnectionContext connectionContext;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -71,7 +71,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractStreamingHttpConnection.class);
     static final IgnoreConsumedEvent<Integer> ZERO_MAX_CONCURRENCY_EVENT = new IgnoreConsumedEvent<>(0);
     static final HttpEventKey<ConsumableEvent<Integer>> MAX_CONCURRENCY_NO_OFFLOADING =
-            newKey("max-concurrency-no-offloading");
+            newKey("max-concurrency-no-offloading", generify(ConsumableEvent.class));
 
     final CC connection;
     private final HttpConnectionContext connectionContext;
@@ -284,5 +284,10 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     @Override
     public final String toString() {
         return getClass().getName() + '(' + connectionContext + ')';
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Class<T> generify(Class<?> clazz) {
+        return (Class<T>) clazz;
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -27,6 +27,7 @@ import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.netty.AlpnChannelSingle.NoopChannelInitializer;
+import io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.IgnoreConsumedEvent;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpConnector;
@@ -46,6 +47,8 @@ import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.
 import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 
 final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
+
+    private static final IgnoreConsumedEvent<Integer> ONE_MAX_CONCURRENCY_EVENT = new IgnoreConsumedEvent<>(1);
 
     AlpnLBHttpConnectionFactory(
             final ReadOnlyHttpClientConfig config, final HttpExecutionContext executionContext,
@@ -105,6 +108,6 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
         // We set initialMaxConcurrency to 1 here because we don't know what type of connection will be created when
         // ALPN completes. The actual maxConcurrency value will be updated by the MAX_CONCURRENCY stream,
         // when we create a connection.
-        return newController(maxConcurrency, onClosing, 1);
+        return newController(ONE_MAX_CONCURRENCY_EVENT, maxConcurrency, onClosing);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -27,7 +27,6 @@ import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.netty.AlpnChannelSingle.NoopChannelInitializer;
-import io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.IgnoreConsumedEvent;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpConnector;
@@ -47,8 +46,6 @@ import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.
 import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 
 final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
-
-    private static final IgnoreConsumedEvent<Integer> ONE_MAX_CONCURRENCY_EVENT = new IgnoreConsumedEvent<>(1);
 
     AlpnLBHttpConnectionFactory(
             final ReadOnlyHttpClientConfig config, final HttpExecutionContext executionContext,
@@ -108,6 +105,6 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
         // We set initialMaxConcurrency to 1 here because we don't know what type of connection will be created when
         // ALPN completes. The actual maxConcurrency value will be updated by the MAX_CONCURRENCY stream,
         // when we create a connection.
-        return newController(ONE_MAX_CONCURRENCY_EVENT, maxConcurrency, onClosing);
+        return newController(maxConcurrency, onClosing, 1);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -47,6 +47,7 @@ import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.InternalRetryingHttpClientFilter;
 import io.servicetalk.http.utils.HostHeaderHttpRequesterFilter;
 import io.servicetalk.http.utils.IdleTimeoutConnectionFilter;
 import io.servicetalk.logging.api.LogLevel;
@@ -313,6 +314,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 currClientFilterFactory = appendFilter(currClientFilterFactory,
                         ctx.builder.retryingHttpRequesterFilter);
             }
+            currClientFilterFactory = appendFilter(currClientFilterFactory, InternalRetryingHttpClientFilter.INSTANCE);
             FilterableStreamingHttpClient wrappedClient = currClientFilterFactory != null ?
                     currClientFilterFactory.create(lbClient, lb.eventStream(), ctx.sdStatus) :
                     lbClient;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -314,10 +314,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 currClientFilterFactory = appendFilter(currClientFilterFactory,
                         ctx.builder.retryingHttpRequesterFilter);
             }
+            // Internal retries must be the last filter in the chain, right before LoadBalancedStreamingHttpClient.
             currClientFilterFactory = appendFilter(currClientFilterFactory, InternalRetryingHttpClientFilter.INSTANCE);
-            FilterableStreamingHttpClient wrappedClient = currClientFilterFactory != null ?
-                    currClientFilterFactory.create(lbClient, lb.eventStream(), ctx.sdStatus) :
-                    lbClient;
+            FilterableStreamingHttpClient wrappedClient =
+                    currClientFilterFactory.create(lbClient, lb.eventStream(), ctx.sdStatus);
 
             if (builderStrategy != defaultStrategy() &&
                     builderStrategy.missing(computedStrategy) != offloadNone()) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -542,6 +542,14 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                 channel.writeAndFlush(Http2SettingsAckFrame.INSTANCE);
             }
         }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() +
+                    "{maxConcurrentStreams=" + maxConcurrentStreams +
+                    ", completed=" + completed +
+                    '}';
+        }
     }
 
     static final class StacklessCancellationException extends CancellationException {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -85,6 +85,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFro
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.ZERO_MAX_CONCURRENCY_EVENT;
 import static io.servicetalk.http.netty.HeaderUtils.OBJ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
@@ -94,6 +95,10 @@ import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
 final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
+
+    static final ConsumableEvent<Integer> DEFAULT_H2_MAX_CONCURRENCY_EVENT =
+            new IgnoreConsumedEvent<>(SMALLEST_MAX_CONCURRENT_STREAMS);
+
     private H2ClientParentConnectionContext(Channel channel, HttpExecutionContext executionContext,
                                             FlushStrategy flushStrategy, long idleTimeoutMs,
                                             @Nullable final SslConfig sslConfig,
@@ -154,10 +159,6 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                                                                                              H2ClientParentConnection {
 
         private static final Logger LOGGER = LoggerFactory.getLogger(DefaultH2ClientParentConnection.class);
-
-        private static final ConsumableEvent<Integer> DEFAULT_H2_MAX_CONCURRENCY_EVENT =
-                new IgnoreConsumedEvent<>(SMALLEST_MAX_CONCURRENT_STREAMS);
-        private static final ConsumableEvent<Integer> ZERO_MAX_CONCURRENCY_EVENT = new IgnoreConsumedEvent<>(0);
 
         private final Http2StreamChannelBootstrap bs;
         private final HttpHeadersFactory headersFactory;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -33,8 +33,8 @@ import io.servicetalk.transport.api.TransportObserver;
 
 import javax.annotation.Nullable;
 
-import static io.netty.handler.codec.http2.Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.netty.H2ClientParentConnectionContext.DEFAULT_H2_MAX_CONCURRENCY_EVENT;
 import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 
@@ -69,6 +69,6 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
     @Override
     ReservableRequestConcurrencyController newConcurrencyController(
             final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing) {
-        return newController(maxConcurrency, onClosing, SMALLEST_MAX_CONCURRENT_STREAMS);
+        return newController(DEFAULT_H2_MAX_CONCURRENCY_EVENT, maxConcurrency, onClosing);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -69,6 +69,6 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
     @Override
     ReservableRequestConcurrencyController newConcurrencyController(
             final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing) {
-        return newController(DEFAULT_H2_MAX_CONCURRENCY_EVENT, maxConcurrency, onClosing);
+        return newController(maxConcurrency, onClosing, DEFAULT_H2_MAX_CONCURRENCY_EVENT.event());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -53,6 +53,9 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
                 // We do not want close to trigger graceful closure (go away), instead when user triggers a graceful
                 // close, we do the appropriate go away handling.
                 .decoupleCloseAndGoAway(true)
+                // H2ServerParentConnectionContext.ackSettings(...) expects Netty to ack settings frame.
+                // While the default value is `true`, set this explicitly to avoid any unexpected changes.
+                .autoAckSettingsFrame(true)
                 // We ack PING frames in KeepAliveManager#pingReceived.
                 .autoAckPingFrame(false)
                 // We don't want to rely upon Netty to manage the graceful close timeout, because we expect

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttp2ExceptionUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttp2ExceptionUtils.java
@@ -82,25 +82,6 @@ final class NettyHttp2ExceptionUtils {
                 new H2StreamResetException(stream.id(), (int) resetFrame.errorCode());
     }
 
-    /**
-     * Checks if an {@link io.netty.handler.codec.http2.Http2Exception} is retryable on a different h2 parent
-     * connection.
-     *
-     * @param cause {@link io.netty.handler.codec.http2.Http2Exception} for inspection
-     * @return {@code true} if {@link io.netty.handler.codec.http2.Http2Exception} is retryable on a different h2
-     * parent connection.
-     */
-    private static boolean isRetryable(final io.netty.handler.codec.http2.Http2Exception cause) {
-        // The first check captures cases like:
-        //  - Cannot create stream %d greater than Last-Stream-ID %d from GOAWAY.
-        //  - Stream IDs are exhausted for this endpoint.
-        //  - Maximum active streams violated for this endpoint.
-        //  - Http2ChannelClosedException
-        return cause.error() == REFUSED_STREAM
-                // The  second check captures "No more streams can be created on this connection":
-                || cause instanceof io.netty.handler.codec.http2.Http2NoMoreStreamIdsException;
-    }
-
     private static boolean isRetryable(final io.netty.handler.codec.http2.Http2FrameStreamException cause) {
         return cause.error() == REFUSED_STREAM;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -25,6 +25,7 @@ import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.IgnoreConsumedEvent;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.TransportObserver;
 
@@ -59,6 +60,7 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
     ReservableRequestConcurrencyController newConcurrencyController(
             final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, Completable onClosing) {
         assert config.h1Config() != null;
-        return newController(maxConcurrency, onClosing, config.h1Config().maxPipelinedRequests());
+        return newController(new IgnoreConsumedEvent<>(config.h1Config().maxPipelinedRequests()),
+                maxConcurrency, onClosing);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -25,7 +25,6 @@ import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
-import io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.IgnoreConsumedEvent;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.TransportObserver;
 
@@ -60,7 +59,6 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
     ReservableRequestConcurrencyController newConcurrencyController(
             final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, Completable onClosing) {
         assert config.h1Config() != null;
-        return newController(new IgnoreConsumedEvent<>(config.h1Config().maxPipelinedRequests()),
-                maxConcurrency, onClosing);
+        return newController(maxConcurrency, onClosing, config.h1Config().maxPipelinedRequests());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
@@ -20,18 +20,24 @@ import io.servicetalk.client.api.RequestConcurrencyController;
 import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
-import io.servicetalk.concurrent.internal.LatestValueSubscriber;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.RequestConcurrencyController.Result.Accepted;
 import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedPermanently;
 import static io.servicetalk.client.api.RequestConcurrencyController.Result.RejectedTemporary;
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
@@ -40,6 +46,7 @@ import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
  * Factory for common {@link ReservableRequestConcurrencyController}s.
  */
 final class ReservableRequestConcurrencyControllers {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReservableRequestConcurrencyControllers.class);
 
     private ReservableRequestConcurrencyControllers() {
         // no instances
@@ -48,17 +55,15 @@ final class ReservableRequestConcurrencyControllers {
     /**
      * Create a new instance of {@link ReservableRequestConcurrencyController}.
      *
+     * @param initialEvent The initial event that defines default allowed concurrency.
      * @param maxConcurrency A {@link Publisher} that provides the maximum allowed concurrency updates.
      * @param onClosing A {@link Completable} that when terminated no more calls to
      * {@link RequestConcurrencyController#tryRequest()} are expected to succeed.
-     * @param initialMaxConcurrency The initial maximum value for concurrency, until {@code maxConcurrencySetting}
-     * provides data.
      * @return a new instance of {@link ReservableRequestConcurrencyController}.
      */
-    static ReservableRequestConcurrencyController newController(
-            final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing,
-            final int initialMaxConcurrency) {
-        return new ReservableRequestConcurrencyControllerMulti(maxConcurrency, onClosing, initialMaxConcurrency);
+    static ReservableRequestConcurrencyController newController(final ConsumableEvent<Integer> initialEvent,
+            final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing) {
+        return new ReservableRequestConcurrencyControllerMulti(initialEvent, maxConcurrency, onClosing);
     }
 
     /**
@@ -112,12 +117,13 @@ final class ReservableRequestConcurrencyControllers {
          */
         @SuppressWarnings("unused")
         private volatile int pendingRequests;
-        private final LatestValueSubscriber<Integer> maxConcurrencyHolder;
+        private volatile ConsumableEvent<Integer> latestEvent;
 
         AbstractReservableRequestConcurrencyController(
+                final ConsumableEvent<Integer> initialEvent,
                 final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency,
                 final Completable onClosing) {
-            maxConcurrencyHolder = new LatestValueSubscriber<>();
+            latestEvent = requireNonNull(initialEvent);
             // Subscribe to onClosing() before maxConcurrency, this order increases the chances of capturing the
             // STATE_QUIT before observing 0 from maxConcurrency which could lead to more ambiguous max concurrency
             // error messages for the users on connection tear-down.
@@ -139,24 +145,87 @@ final class ReservableRequestConcurrencyControllers {
                     pendingRequests = STATE_QUIT;
                 }
             });
-            toSource(maxConcurrency
-                    .afterOnNext(ConsumableEvent::eventConsumed)
-                    .map(ConsumableEvent::event)
-            ).subscribe(maxConcurrencyHolder);
+            toSource(maxConcurrency).subscribe(new Subscriber<ConsumableEvent<Integer>>() {
+
+                @Nullable
+                private Subscription subscription;
+
+                @Override
+                public void onSubscribe(final Subscription s) {
+                    if (checkDuplicateSubscription(subscription, s)) {
+                        subscription = s;
+                        s.request(1);
+                    }
+                }
+
+                @Override
+                public void onNext(@Nullable final ConsumableEvent<Integer> event) {
+                    assert subscription != null : "Subscription can not be null in onNext.";
+                    assert event != null : "event can not be null in onNext.";
+                    final ConsumableEvent<Integer> current = latestEvent;
+                    // Events have to be consumed in-order. Make sure the current one is consumed.
+                    current.eventConsumed();
+                    final int newConcurrency = event.event();
+                    if (current.event() < newConcurrency) {
+                        // When concurrency increases, consume event to notify Netty asap, then update latestEvent to
+                        // allow more requests to go through. Even if this event is offloaded, eventConsumed() will
+                        // queue a task on Netty's event loop before any new requests come in from different threads.
+                        // However, the race is still possible if only transportEventStream is offloaded, but requests
+                        // are executed on the event loop. In this case, we rely on InternalRetryingHttpClientFilter.
+                        event.eventConsumed();
+                        latestEvent = event;
+                    } else if (current.event() > newConcurrency) {
+                        // When concurrency decreases, update latestEvent and wait for pending requests to go
+                        // at or below the new limit before notifying Netty. This is the best effort to minimize
+                        // probability for a race condition between decreasing the concurrency limit and requests flow.
+                        // There is still a possibility for a race when:
+                        //   1. Caller thread remembers old value in tryRequest()
+                        //   2. IO-thread updates latestEvent
+                        //   3. Some requests complete and pendingRequests goes down exactly to the new limit
+                        //   4. IO-thread consumes event, which updates the limit inside Netty http2-handler
+                        //   5. Caller thread accepts a request based on the old concurrency limit value, then receives
+                        //      "Maximum active streams violated for this endpoint" exception.
+                        // In this case, we rely on InternalRetryingHttpClientFilter.
+                        latestEvent = event;
+                        if (pendingRequests <= newConcurrency) {
+                            event.eventConsumed();
+                        }
+                    } else {
+                        // No need to update latestEvent because the value is identical.
+                        event.eventConsumed();
+                    }
+                    subscription.request(1);
+                }
+
+                @Override
+                public void onError(final Throwable t) {
+                    LOGGER.info("Unexpected error from transportEventStream(MAX_CONCURRENCY).", t);
+                }
+
+                @Override
+                public void onComplete() {
+                    LOGGER.debug("transportEventStream(MAX_CONCURRENCY) stream completes.");
+                }
+            });
         }
 
         @Override
         public final void requestFinished() {
-            pendingRequestsUpdater.decrementAndGet(this);
+            final int outstandingRequests = pendingRequestsUpdater.decrementAndGet(this);
+            final ConsumableEvent<Integer> current = latestEvent;
+            if (outstandingRequests == current.event()) {
+                // This executes only if pendingRequests were above the new limit when latestEvent was received.
+                current.eventConsumed();
+            }
         }
 
         @Override
-        public boolean tryReserve() {
+        public final boolean tryReserve() {
             return pendingRequestsUpdater.compareAndSet(this, STATE_IDLE, STATE_RESERVED);
         }
 
         @Override
-        public Completable releaseAsync() {
+        public final Completable releaseAsync() {
             return new SubscribableCompletable() {
                 @Override
                 protected void handleSubscribe(Subscriber subscriber) {
@@ -178,8 +247,8 @@ final class ReservableRequestConcurrencyControllers {
             };
         }
 
-        final int lastSeenMaxValue(int defaultValue) {
-            return maxConcurrencyHolder.lastSeenValue(defaultValue);
+        final int lastSeenMaxValue() {
+            return latestEvent.event();
         }
 
         final int pendingRequests() {
@@ -191,25 +260,29 @@ final class ReservableRequestConcurrencyControllers {
         }
 
         @Override
-        public String toString() {
-            return "pendingRequests=" + pendingRequests + " maxRequests=" + maxConcurrencyHolder.lastSeenValue(-1);
+        public final String toString() {
+            return getClass().getSimpleName() +
+                    "{pendingRequests=" + pendingRequests +
+                    ", latestEvent=" + latestEvent +
+                    '}';
         }
     }
 
     private static final class ReservableRequestConcurrencyControllerMulti
             extends AbstractReservableRequestConcurrencyController {
-        private final int maxRequests;
-
-        ReservableRequestConcurrencyControllerMulti(final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency,
-                                                    final Completable onClosing,
-                                                    int maxRequests) {
-            super(maxConcurrency, onClosing);
-            this.maxRequests = maxRequests;
+        ReservableRequestConcurrencyControllerMulti(final ConsumableEvent<Integer> initialEvent,
+                                                    final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency,
+                                                    final Completable onClosing) {
+            super(initialEvent, maxConcurrency, onClosing);
         }
 
         @Override
         public Result tryRequest() {
-            final int maxConcurrency = lastSeenMaxValue(maxRequests);
+            // We assume that frequency of changing `maxConcurrency` is low, while frequency of requests is high and can
+            // cause CAS failure. We take `lastSeenMaxValue()` out of the loop to minimize number of volatile reads on
+            // the hot path. In case there is a race between changing `maxConcurrency` to a lower value and a new
+            // request, we rely on InternalRetryingHttpClientFilter to retry the request.
+            final int maxConcurrency = lastSeenMaxValue();
             for (;;) {
                 final int currentPending = pendingRequests();
                 if (currentPending < 0) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
@@ -86,6 +86,11 @@ final class ReservableRequestConcurrencyControllers {
         @Override
         public void eventConsumed() {
         }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "{event=" + event + '}';
+        }
     }
 
     private abstract static class AbstractReservableRequestConcurrencyController

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpConnectionTest.java
@@ -47,7 +47,6 @@ import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitelyN
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.http.api.DefaultHttpHeadersFactory.INSTANCE;
-import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
@@ -59,6 +58,7 @@ import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMet
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.StreamingHttpRequests.newRequest;
 import static io.servicetalk.http.api.StreamingHttpRequests.newTransportRequest;
+import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.MAX_CONCURRENCY_NO_OFFLOADING;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -111,7 +111,7 @@ final class AbstractHttpConnectionTest {
 
     @Test
     void shouldEmitMaxConcurrencyInEventStream() throws Exception {
-        Integer max = http.transportEventStream(MAX_CONCURRENCY)
+        Integer max = http.transportEventStream(MAX_CONCURRENCY_NO_OFFLOADING)
                 .afterOnNext(ConsumableEvent::eventConsumed).map(ConsumableEvent::event)
                 .firstOrElse(() -> null).toFuture().get();
         assertThat(max, equalTo(101));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BuilderUtils.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BuilderUtils.java
@@ -60,16 +60,30 @@ final class BuilderUtils {
             ServerContext serverContext,
             ExecutionContext<? extends ExecutionStrategy> ctx,
             HttpProtocol... protocols) {
-        return newClientBuilderWithConfigs(serverContext, ctx, toConfigs(protocols));
+        return newClientBuilder(serverHostAndPort(serverContext), ctx, protocols);
+    }
+
+    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilder(
+            HostAndPort serverHostAndPort,
+            ExecutionContext<? extends ExecutionStrategy> ctx,
+            HttpProtocol... protocols) {
+        return newClientBuilderWithConfigs(serverHostAndPort, ctx, toConfigs(protocols));
     }
 
     static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilderWithConfigs(
             ServerContext serverContext,
             ExecutionContext<? extends ExecutionStrategy> ctx,
             HttpProtocolConfig... protocols) {
+        return newClientBuilderWithConfigs(serverHostAndPort(serverContext), ctx, protocols);
+    }
+
+    static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> newClientBuilderWithConfigs(
+            HostAndPort serverHostAndPort,
+            ExecutionContext<? extends ExecutionStrategy> ctx,
+            HttpProtocolConfig... protocols) {
 
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
-                HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                HttpClients.forSingleAddress(serverHostAndPort)
                         .ioExecutor(ctx.ioExecutor())
                         .executor(ctx.executor())
                         .bufferAllocator(ctx.bufferAllocator())

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2022 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,19 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.client.api.ConnectionLimitReachedException;
+import io.servicetalk.client.api.LimitingConnectionFactoryFilter;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.ReservedHttpConnection;
 import io.servicetalk.http.api.StreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy;
 import io.servicetalk.http.netty.StreamObserverTest.MulticastTransportEventsStreamingHttpConnectionFilter;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
@@ -33,54 +37,74 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http2.DefaultHttp2SettingsFrame;
 import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.internal.BlockingUtils.blockingInvocation;
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
 import static io.servicetalk.http.netty.H2PriorKnowledgeFeatureParityTest.EchoHttp2Handler;
 import static io.servicetalk.http.netty.H2PriorKnowledgeFeatureParityTest.bindH2Server;
-import static io.servicetalk.http.netty.HttpClients.forResolvedAddress;
-import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
-import static io.servicetalk.http.netty.HttpsProxyTest.safeClose;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.disableAutoRetries;
 import static io.servicetalk.http.netty.StreamObserverTest.safeSync;
-import static io.servicetalk.logging.api.LogLevel.TRACE;
 import static io.servicetalk.transport.api.HostAndPort.of;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor;
 import static java.lang.Integer.parseInt;
 import static java.time.Duration.ofMillis;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Named.named;
 
 class H2ConcurrencyControllerTest {
 
-    private static final long MAX_CONCURRENT_STREAMS_VALUE = 1L;
+    private static final int SERVER_MAX_CONCURRENT_STREAMS_VALUE = 1;
     private static final int N_ITERATIONS = 3;
+    private static final int STEP = 4;
+    private static final int REPEATED_TEST_ITERATIONS = 16;
 
     @RegisterExtension
-    static final ExecutionContextExtension CTX =
+    static final ExecutionContextExtension CLIENT_CTX =
         ExecutionContextExtension.cached("client-io", "client-executor")
                 .setClassLevel(true);
 
+    private final CountDownLatch[] latches = new CountDownLatch[N_ITERATIONS];
+    private final AtomicReference<Channel> serverParentChannel = new AtomicReference<>();
+    private final AtomicBoolean alwaysEcho = new AtomicBoolean(false);
     private EventLoopGroup serverEventLoopGroup;
     private Channel serverAcceptorChannel;
-    private HttpClient client;
-    private final CountDownLatch[] latches = new CountDownLatch[N_ITERATIONS];
+    private HostAndPort serverAddress;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -93,7 +117,7 @@ class H2ConcurrencyControllerTest {
             @Override
             protected void initChannel(Http2StreamChannel ch) {
                 // Respond only for the first request which is used to propagate MAX_CONCURRENT_STREAMS_VALUE
-                if (secondAndMore.compareAndSet(false, true)) {
+                if (alwaysEcho.get() || secondAndMore.compareAndSet(false, true)) {
                     ch.pipeline().addLast(new EchoHttp2Handler());
                 } else {
                     // Do not respond to any subsequent requests, only release the associated latch to notify the client
@@ -109,84 +133,189 @@ class H2ConcurrencyControllerTest {
                 }
             }
         }, parentPipeline -> {
+            serverParentChannel.set(parentPipeline.channel());
         }, h2Builder -> {
-            h2Builder.initialSettings().maxConcurrentStreams(MAX_CONCURRENT_STREAMS_VALUE);
+            h2Builder.initialSettings().maxConcurrentStreams(SERVER_MAX_CONCURRENT_STREAMS_VALUE);
             return h2Builder;
         });
-        final HostAndPort serverAddress = of((InetSocketAddress) serverAcceptorChannel.localAddress());
-        client = forResolvedAddress(serverAddress)
-            .ioExecutor(CTX.ioExecutor())
-            .executor(CTX.executor())
-            .executionStrategy(defaultStrategy())
-            .appendClientFilter(disableAutoRetries())// All exceptions should be propagated
-            .appendConnectionFilter(MulticastTransportEventsStreamingHttpConnectionFilter::new)
-            .appendConnectionFilter(connection -> new StreamingHttpConnectionFilter(connection) {
-                @Override
-                public Single<StreamingHttpResponse> request(StreamingHttpRequest request) {
-                    return delegate().request(request)
-                        .liftSync(subscriber -> new SingleSource.Subscriber<StreamingHttpResponse>() {
-                            @Override
-                            public void onSubscribe(final Cancellable cancellable) {
-                                // Defer the cancel() signal to let the test thread start a new request
-                                subscriber.onSubscribe(() -> CTX.executor()
-                                    .schedule(cancellable::cancel, ofMillis(100)));
-                            }
 
-                            @Override
-                            public void onSuccess(@Nullable final StreamingHttpResponse result) {
-                                subscriber.onSuccess(result);
-                            }
-
-                            @Override
-                            public void onError(final Throwable t) {
-                                subscriber.onError(t);
-                            }
-                        });
-                }
-            })
-            .protocols(h2().enableFrameLogging("servicetalk-tests-h2-frame-logger", TRACE, () -> true).build())
-            .build();
+        serverAddress = of((InetSocketAddress) serverAcceptorChannel.localAddress());
     }
 
     @AfterEach
     void tearDown() throws Exception {
         safeSync(() -> serverAcceptorChannel.close().sync());
         safeSync(() -> serverEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).sync());
-        safeClose(client);
     }
 
-    @Test
-    void noMaxActiveStreamsViolatedError() throws Exception {
-        CountDownLatch maxConcurrencyUpdated = new CountDownLatch(1);
-        try (ReservedHttpConnection connection = client.reserveConnection(client.get("/")).map(conn -> {
-            conn.transportEventStream(MAX_CONCURRENCY).forEach(event -> {
-                if (event.event() == MAX_CONCURRENT_STREAMS_VALUE) {
-                    maxConcurrencyUpdated.countDown();
-                }
-            });
-            return conn;
-        }).toFuture().get()) {
-            awaitMaxConcurrentStreamsSettingsUpdate(connection, maxConcurrencyUpdated);
+    @RepeatedTest(REPEATED_TEST_ITERATIONS)
+    void noMaxActiveStreamsViolatedErrorAfterCancel() throws Exception {
+        try (HttpClient client = newClientBuilder(serverAddress, CLIENT_CTX, HTTP_2)
+                .appendClientFilter(disableAutoRetries())   // All exceptions should be propagated
+                .appendConnectionFilter(MulticastTransportEventsStreamingHttpConnectionFilter.INSTANCE)
+                .appendConnectionFilter(connection -> new StreamingHttpConnectionFilter(connection) {
+                    @Override
+                    public Single<StreamingHttpResponse> request(StreamingHttpRequest request) {
+                        return delegate().request(request)
+                                .liftSync(subscriber -> new SingleSource.Subscriber<StreamingHttpResponse>() {
+                                    @Override
+                                    public void onSubscribe(final Cancellable cancellable) {
+                                        // Defer the cancel() signal to let the test thread start a new request
+                                        subscriber.onSubscribe(() -> CLIENT_CTX.executor()
+                                                .schedule(cancellable::cancel, ofMillis(100)));
+                                    }
 
-            BlockingQueue<Throwable> exceptions = new LinkedBlockingDeque<>();
-            for (int i = 0; i < N_ITERATIONS; i++) {
-                final int idx = i;
-                Cancellable cancellable = client.request(client.get("/" + i))
-                    .whenOnError(exceptions::add)
-                    .afterFinally(() -> latches[idx].countDown())
-                    .subscribe(__ -> { /* response is not expected */ });
-                latches[i].await();
-                cancellable.cancel();
+                                    @Override
+                                    public void onSuccess(@Nullable final StreamingHttpResponse result) {
+                                        subscriber.onSuccess(result);
+                                    }
+
+                                    @Override
+                                    public void onError(final Throwable t) {
+                                        subscriber.onError(t);
+                                    }
+                                });
+                    }
+                })
+                .protocols(HTTP_2.config)
+                .build()) {
+
+            BlockingQueue<Integer> maxConcurrentStreams = new LinkedBlockingDeque<>();
+            try (ReservedHttpConnection connection = client.reserveConnection(client.get("/")).map(conn -> {
+                conn.transportEventStream(MAX_CONCURRENCY).forEach(event -> maxConcurrentStreams.add(event.event()));
+                return conn;
+            }).toFuture().get()) {
+                awaitMaxConcurrentStreamsSettingsUpdate(connection, maxConcurrentStreams,
+                        SERVER_MAX_CONCURRENT_STREAMS_VALUE);
+                connection.releaseAsync().toFuture().get();
+
+                BlockingQueue<Throwable> exceptions = new LinkedBlockingDeque<>();
+                for (int i = 0; i < N_ITERATIONS; i++) {
+                    final int idx = i;
+                    Cancellable cancellable = client.request(client.get("/" + i))
+                        .whenOnError(exceptions::add)
+                        .afterFinally(() -> latches[idx].countDown())
+                        .subscribe(__ -> { /* response is not expected */ });
+                    latches[i].await();
+                    cancellable.cancel();
+                }
+                assertThat(exceptions, is(empty()));
             }
-            assertThat(exceptions, is(empty()));
+        }
+    }
+
+    private static List<Arguments> params() {
+        List<Arguments> params = new ArrayList<>();
+        for (Named<HttpExecutionStrategy> strategy : asList(
+                named("defaultStrategy", defaultStrategy()),
+                named("offloadNone", offloadNone()),
+                named("offloadAll", offloadAll()),
+                named("offloadEvents", customStrategyBuilder().offloadEvent().build()))) {
+            // Use index to repeat the test. RepeatedTest can not be used simultaneously with ParameterizedTest.
+            for (int i = 1; i <= REPEATED_TEST_ITERATIONS; ++i) {
+                params.add(Arguments.of(strategy, i));
+            }
+        }
+        return params;
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] strategy={0}, repetition {1} of " + REPEATED_TEST_ITERATIONS)
+    @MethodSource("params")
+    void noMaxActiveStreamsViolatedErrorWhenLimitIncreases(HttpExecutionStrategy strategy,
+                @SuppressWarnings("unused") int repetition) throws Exception {
+        noMaxActiveStreamsViolatedErrorWhenLimitChanges(true, strategy);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] strategy={0}, repetition {1} of " + REPEATED_TEST_ITERATIONS)
+    @MethodSource("params")
+    void noMaxActiveStreamsViolatedErrorWhenLimitDecreases(HttpExecutionStrategy strategy,
+                @SuppressWarnings("unused") int repetition) throws Exception {
+        noMaxActiveStreamsViolatedErrorWhenLimitChanges(false, strategy);
+    }
+
+    private void noMaxActiveStreamsViolatedErrorWhenLimitChanges(boolean increase,
+                                                                 HttpExecutionStrategy strategy) throws Exception {
+        alwaysEcho.set(true);   // server should always respond
+        try (HttpClient client = newClientBuilder(serverAddress, CLIENT_CTX, HTTP_2)
+                .executionStrategy(strategy)
+                .appendConnectionFilter(MulticastTransportEventsStreamingHttpConnectionFilter.INSTANCE)
+                // Don't allow more than 1 connection:
+                .appendConnectionFactoryFilter(LimitingConnectionFactoryFilter.withMax(1))
+                // Retry all ConnectionLimitReachedException(s), don't retry RetryableException(s):
+                .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                        .maxTotalRetries(Integer.MAX_VALUE)
+                        .retryRetryableExceptions((metaData, e) -> {
+                            if (e instanceof ConnectionLimitReachedException) {
+                                // Use a limit of 128 to avoid StackOverflow
+                                return BackOffPolicy.ofImmediate(128);
+                            }
+                            return BackOffPolicy.ofNoRetries();
+                        })
+                        .build())
+                .protocols(HTTP_2.config)
+                .build()) {
+
+            BlockingQueue<Integer> maxConcurrentStreams = new LinkedBlockingDeque<>();
+            try (ReservedHttpConnection connection = client.reserveConnection(client.get("/")).map(conn -> {
+                conn.transportEventStream(MAX_CONCURRENCY).forEach(event -> maxConcurrentStreams.add(event.event()));
+                return conn;
+            }).toFuture().get()) {
+                awaitMaxConcurrentStreamsSettingsUpdate(connection, maxConcurrentStreams,
+                        SERVER_MAX_CONCURRENT_STREAMS_VALUE);
+                connection.releaseAsync().toFuture().get();
+
+                final Channel serverParentChannel = this.serverParentChannel.get();
+                assertThat(serverParentChannel, is(notNullValue()));
+
+                int newConcurrency = increase ? 0 : ((N_ITERATIONS + 1) * STEP);
+                if (!increase) {
+                    serverParentChannel.writeAndFlush(
+                            new DefaultHttp2SettingsFrame(new Http2Settings().maxConcurrentStreams(newConcurrency)));
+                    awaitMaxConcurrentStreamsSettingsUpdate(maxConcurrentStreams, newConcurrency);
+                }
+                final int nRequests = 16;
+                for (int i = 0; i < N_ITERATIONS; i++) {
+                    // Run multiple parallel requests every time the limit changes:
+                    List<Single<HttpResponse>> asyncResponses = new ArrayList<>(nRequests);
+                    for (int j = 0; j < nRequests; j++) {
+                        asyncResponses.add(client.request(client.get("/" + j)));
+                    }
+                    newConcurrency += increase ? STEP : -STEP;
+                    serverParentChannel.writeAndFlush(
+                            new DefaultHttp2SettingsFrame(new Http2Settings().maxConcurrentStreams(newConcurrency)));
+                    List<Object> responses = asyncResponses.parallelStream().map(s -> {
+                        try {
+                            return blockingInvocation(s);
+                        } catch (Exception e) {
+                            return e;
+                        }
+                    }).collect(Collectors.toList());
+                    for (Object maybeResponse : responses) {
+                        // We expect requests to either complete or fail with ConnectionLimitReachedException
+                        if (maybeResponse instanceof HttpResponse) {
+                            assertThat(((HttpResponse) maybeResponse).status(), is(OK));
+                        } else {
+                            assertThat(maybeResponse, is(instanceOf(ConnectionLimitReachedException.class)));
+                        }
+                    }
+                }
+            }
         }
     }
 
     private static void awaitMaxConcurrentStreamsSettingsUpdate(ReservedHttpConnection connection,
-                                                                CountDownLatch latch) throws Exception {
+                BlockingQueue<Integer> maxConcurrentStreams, int expectedValue) throws Exception {
+        // In some cases preface and initial settings won't be sent until after we make the first request.
         HttpResponse response = connection.request(connection.get("/")).toFuture().get();
         assertThat(response.status(), is(OK));
-        latch.await();
-        connection.releaseAsync().toFuture().get();
+        awaitMaxConcurrentStreamsSettingsUpdate(maxConcurrentStreams, expectedValue);
+    }
+
+    private static void awaitMaxConcurrentStreamsSettingsUpdate(BlockingQueue<Integer> maxConcurrentStreams,
+                                                                int expectedValue) throws Exception {
+        int value;
+        do {
+            value = maxConcurrentStreams.take();
+        } while (value != expectedValue);
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ConcurrencyControllerTest.java
@@ -62,12 +62,12 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.internal.BlockingUtils.blockingInvocation;
-import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.MAX_CONCURRENCY_NO_OFFLOADING;
 import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
 import static io.servicetalk.http.netty.H2PriorKnowledgeFeatureParityTest.EchoHttp2Handler;
 import static io.servicetalk.http.netty.H2PriorKnowledgeFeatureParityTest.bindH2Server;
@@ -182,7 +182,8 @@ class H2ConcurrencyControllerTest {
 
             BlockingQueue<Integer> maxConcurrentStreams = new LinkedBlockingDeque<>();
             try (ReservedHttpConnection connection = client.reserveConnection(client.get("/")).map(conn -> {
-                conn.transportEventStream(MAX_CONCURRENCY).forEach(event -> maxConcurrentStreams.add(event.event()));
+                conn.transportEventStream(MAX_CONCURRENCY_NO_OFFLOADING)
+                        .forEach(event -> maxConcurrentStreams.add(event.event()));
                 return conn;
             }).toFuture().get()) {
                 awaitMaxConcurrentStreamsSettingsUpdate(connection, maxConcurrentStreams,
@@ -257,7 +258,8 @@ class H2ConcurrencyControllerTest {
 
             BlockingQueue<Integer> maxConcurrentStreams = new LinkedBlockingDeque<>();
             try (ReservedHttpConnection connection = client.reserveConnection(client.get("/")).map(conn -> {
-                conn.transportEventStream(MAX_CONCURRENCY).forEach(event -> maxConcurrentStreams.add(event.event()));
+                conn.transportEventStream(MAX_CONCURRENCY_NO_OFFLOADING)
+                        .forEach(event -> maxConcurrentStreams.add(event.event()));
                 return conn;
             }).toFuture().get()) {
                 awaitMaxConcurrentStreamsSettingsUpdate(connection, maxConcurrentStreams,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -142,7 +142,6 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
-import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.COOKIE;
@@ -160,6 +159,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.MAX_CONCURRENCY_NO_OFFLOADING;
 import static io.servicetalk.http.netty.CloseUtils.onGracefulClosureStarted;
 import static io.servicetalk.http.netty.H2ToStH1Utils.COOKIE_STRICT_RFC_6265;
 import static io.servicetalk.http.netty.H2ToStH1Utils.PROXY_CONNECTION;
@@ -2026,7 +2026,7 @@ class H2PriorKnowledgeFeatureParityTest {
                              Queue<FilterableStreamingHttpConnection> connectionQueue,
                              Queue<Publisher<? extends ConsumableEvent<Integer>>> maxConcurrentPubQueue) {
             super(delegate);
-            maxConcurrent = delegate.transportEventStream(MAX_CONCURRENCY).multicast(2);
+            maxConcurrent = delegate.transportEventStream(MAX_CONCURRENCY_NO_OFFLOADING).multicast(2);
             connectionQueue.add(delegate);
             maxConcurrentPubQueue.add(maxConcurrent);
         }
@@ -2034,7 +2034,7 @@ class H2PriorKnowledgeFeatureParityTest {
         @SuppressWarnings("unchecked")
         @Override
         public <T> Publisher<? extends T> transportEventStream(final HttpEventKey<T> eventKey) {
-            return eventKey == MAX_CONCURRENCY ? (Publisher<? extends T>) maxConcurrent :
+            return eventKey == MAX_CONCURRENCY_NO_OFFLOADING ? (Publisher<? extends T>) maxConcurrent :
                     super.transportEventStream(eventKey);
         }
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -68,12 +68,12 @@ import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitelyN
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.MAX_CONCURRENCY_NO_OFFLOADING;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.http.netty.HttpServers.forAddress;
 import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
@@ -264,7 +264,7 @@ class HttpOffloadingTest {
     void clientSettingsStreamIsOffloaded() throws Exception {
         setup();
         subscribeTo(errors,
-                httpConnection.transportEventStream(MAX_CONCURRENCY).afterFinally(terminated::countDown),
+                httpConnection.transportEventStream(MAX_CONCURRENCY_NO_OFFLOADING).afterFinally(terminated::countDown),
                 "Client settings stream: ");
         httpConnection.closeAsyncGracefully().toFuture().get();
         terminated.await();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllersTest.java
@@ -44,7 +44,8 @@ class ReservableRequestConcurrencyControllersTest {
     void maxConcurrencyRequestAtTime() {
         final int maxRequestCount = 10;
         RequestConcurrencyController controller =
-                newController(from(new IgnoreConsumedEvent<>(maxRequestCount)), never(), maxRequestCount);
+                newController(new IgnoreConsumedEvent<>(maxRequestCount),
+                        from(new IgnoreConsumedEvent<>(maxRequestCount)), never());
         for (int i = 0; i < 100; ++i) {
             for (int j = 0; j < maxRequestCount; ++j) {
                 assertThat(controller.tryRequest(), is(Accepted));
@@ -58,7 +59,8 @@ class ReservableRequestConcurrencyControllersTest {
 
     @Test
     void limitIsAllowedToIncrease() {
-        RequestConcurrencyController controller = newController(limitPublisher, never(), 10);
+        RequestConcurrencyController controller = newController(new IgnoreConsumedEvent<>(10),
+                limitPublisher, never());
         for (int i = 1; i < 100; ++i) {
             limitPublisher.onNext(new IgnoreConsumedEvent<>(i));
             for (int j = 0; j < i; ++j) {
@@ -74,7 +76,7 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void limitIsAllowedToDecrease() {
         int maxRequestCount = 10;
-        RequestConcurrencyController controller = newController(limitPublisher, never(), 10);
+        RequestConcurrencyController controller = newController(new IgnoreConsumedEvent<>(10), limitPublisher, never());
 
         for (int j = 0; j < maxRequestCount; ++j) {
             assertThat(controller.tryRequest(), is(Accepted));
@@ -91,14 +93,15 @@ class ReservableRequestConcurrencyControllersTest {
 
     @Test
     void noMoreRequestsAfterClose() {
-        RequestConcurrencyController controller = newController(from(new IgnoreConsumedEvent<>(1)), completed(), 10);
+        RequestConcurrencyController controller = newController(new IgnoreConsumedEvent<>(10),
+                from(new IgnoreConsumedEvent<>(1)), completed());
         assertThat(controller.tryRequest(), is(RejectedPermanently));
     }
 
     @Test
     void defaultValueIsUsed() {
         final int maxRequestCount = 10;
-        RequestConcurrencyController controller = newController(limitPublisher, never(), 10);
+        RequestConcurrencyController controller = newController(new IgnoreConsumedEvent<>(10), limitPublisher, never());
         for (int j = 0; j < maxRequestCount; ++j) {
             assertThat(controller.tryRequest(), is(Accepted));
         }
@@ -111,7 +114,7 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void reserveWithNoRequests() throws Exception {
         ReservableRequestConcurrencyController controller =
-                newController(from(new IgnoreConsumedEvent<>(10)), never(), 10);
+                newController(new IgnoreConsumedEvent<>(10), from(new IgnoreConsumedEvent<>(10)), never());
         for (int i = 0; i < 10; ++i) {
             assertTrue(controller.tryReserve());
             assertFalse(controller.tryReserve());
@@ -128,7 +131,7 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void reserveFailsWhenPendingRequest() {
         ReservableRequestConcurrencyController controller =
-                newController(from(new IgnoreConsumedEvent<>(10)), never(), 10);
+                newController(new IgnoreConsumedEvent<>(10), from(new IgnoreConsumedEvent<>(10)), never());
         assertThat(controller.tryRequest(), is(Accepted));
         assertFalse(controller.tryReserve());
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllersTest.java
@@ -44,8 +44,7 @@ class ReservableRequestConcurrencyControllersTest {
     void maxConcurrencyRequestAtTime() {
         final int maxRequestCount = 10;
         RequestConcurrencyController controller =
-                newController(new IgnoreConsumedEvent<>(maxRequestCount),
-                        from(new IgnoreConsumedEvent<>(maxRequestCount)), never());
+                newController(from(new IgnoreConsumedEvent<>(maxRequestCount)), never(), maxRequestCount);
         for (int i = 0; i < 100; ++i) {
             for (int j = 0; j < maxRequestCount; ++j) {
                 assertThat(controller.tryRequest(), is(Accepted));
@@ -59,8 +58,7 @@ class ReservableRequestConcurrencyControllersTest {
 
     @Test
     void limitIsAllowedToIncrease() {
-        RequestConcurrencyController controller = newController(new IgnoreConsumedEvent<>(10),
-                limitPublisher, never());
+        RequestConcurrencyController controller = newController(limitPublisher, never(), 10);
         for (int i = 1; i < 100; ++i) {
             limitPublisher.onNext(new IgnoreConsumedEvent<>(i));
             for (int j = 0; j < i; ++j) {
@@ -76,7 +74,7 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void limitIsAllowedToDecrease() {
         int maxRequestCount = 10;
-        RequestConcurrencyController controller = newController(new IgnoreConsumedEvent<>(10), limitPublisher, never());
+        RequestConcurrencyController controller = newController(limitPublisher, never(), 10);
 
         for (int j = 0; j < maxRequestCount; ++j) {
             assertThat(controller.tryRequest(), is(Accepted));
@@ -93,15 +91,14 @@ class ReservableRequestConcurrencyControllersTest {
 
     @Test
     void noMoreRequestsAfterClose() {
-        RequestConcurrencyController controller = newController(new IgnoreConsumedEvent<>(10),
-                from(new IgnoreConsumedEvent<>(1)), completed());
+        RequestConcurrencyController controller = newController(from(new IgnoreConsumedEvent<>(1)), completed(), 10);
         assertThat(controller.tryRequest(), is(RejectedPermanently));
     }
 
     @Test
     void defaultValueIsUsed() {
         final int maxRequestCount = 10;
-        RequestConcurrencyController controller = newController(new IgnoreConsumedEvent<>(10), limitPublisher, never());
+        RequestConcurrencyController controller = newController(limitPublisher, never(), 10);
         for (int j = 0; j < maxRequestCount; ++j) {
             assertThat(controller.tryRequest(), is(Accepted));
         }
@@ -114,7 +111,7 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void reserveWithNoRequests() throws Exception {
         ReservableRequestConcurrencyController controller =
-                newController(new IgnoreConsumedEvent<>(10), from(new IgnoreConsumedEvent<>(10)), never());
+                newController(from(new IgnoreConsumedEvent<>(10)), never(), 10);
         for (int i = 0; i < 10; ++i) {
             assertTrue(controller.tryReserve());
             assertFalse(controller.tryReserve());
@@ -131,7 +128,7 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void reserveFailsWhenPendingRequest() {
         ReservableRequestConcurrencyController controller =
-                newController(new IgnoreConsumedEvent<>(10), from(new IgnoreConsumedEvent<>(10)), never());
+                newController(from(new IgnoreConsumedEvent<>(10)), never(), 10);
         assertThat(controller.tryRequest(), is(Accepted));
         assertFalse(controller.tryReserve());
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -23,7 +23,9 @@ import io.servicetalk.http.api.Http2Exception;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpConnection;
 import io.servicetalk.http.api.HttpEventKey;
+import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.DataObserver;
@@ -53,6 +55,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
 import static io.servicetalk.http.api.HttpEventKey.MAX_CONCURRENCY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.netty.H2PriorKnowledgeFeatureParityTest.bindH2Server;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
 import static io.servicetalk.http.netty.HttpTransportObserverTest.await;
@@ -118,7 +121,7 @@ class StreamObserverTest {
         });
         client = HttpClients.forSingleAddress(HostAndPort.of((InetSocketAddress) serverAcceptorChannel.localAddress()))
                 .protocols(h2().enableFrameLogging("servicetalk-tests-h2-frame-logger", TRACE, () -> true).build())
-                .appendConnectionFilter(MulticastTransportEventsStreamingHttpConnectionFilter::new)
+                .appendConnectionFilter(MulticastTransportEventsStreamingHttpConnectionFilter.INSTANCE)
                 .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(clientTransportObserver))
                 .build();
     }
@@ -182,24 +185,37 @@ class StreamObserverTest {
     }
 
     /**
-     * Filter that allows users to subscribe to
-     * {@link FilterableStreamingHttpConnection#transportEventStream(HttpEventKey)}.
+     * Filter that allows tests to subscribe to
+     * {@link FilterableStreamingHttpConnection#transportEventStream(HttpEventKey)} without loosing already delivered
+     * events.
      */
     static final class MulticastTransportEventsStreamingHttpConnectionFilter
-            extends StreamingHttpConnectionFilter {
+            implements StreamingHttpConnectionFilterFactory {
 
-        private final Publisher<? extends ConsumableEvent<Integer>> maxConcurrent;
+        static final StreamingHttpConnectionFilterFactory INSTANCE =
+                new MulticastTransportEventsStreamingHttpConnectionFilter();
 
-        MulticastTransportEventsStreamingHttpConnectionFilter(final FilterableStreamingHttpConnection delegate) {
-            super(delegate);
-            maxConcurrent = delegate.transportEventStream(MAX_CONCURRENCY).multicastToExactly(2);
+        private MulticastTransportEventsStreamingHttpConnectionFilter() {
+            // Singleton.
         }
 
-        @SuppressWarnings("unchecked")
         @Override
-        public <T> Publisher<? extends T> transportEventStream(final HttpEventKey<T> eventKey) {
-            return eventKey == MAX_CONCURRENCY ? (Publisher<? extends T>) maxConcurrent :
-                    delegate().transportEventStream(eventKey);
+        public StreamingHttpConnectionFilter create(FilterableStreamingHttpConnection connection) {
+            Publisher<? extends ConsumableEvent<Integer>> maxConcurrent = connection
+                    .transportEventStream(MAX_CONCURRENCY).multicast(2);
+            return new StreamingHttpConnectionFilter(connection) {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <T> Publisher<? extends T> transportEventStream(final HttpEventKey<T> eventKey) {
+                    return eventKey == MAX_CONCURRENCY ? (Publisher<? extends T>) maxConcurrent :
+                            delegate().transportEventStream(eventKey);
+                }
+            };
+        }
+
+        @Override
+        public HttpExecutionStrategy requiredOffloads() {
+            return offloadNone();
         }
     }
 }


### PR DESCRIPTION
Motivation:

A remote server can change `MAX_CONCURRENT_STREAMS` setting as part of establishing an HTTP/2 connection or at any time later. When this happens, there is a possibility that a request will fail with an exception caused by: io.netty.handler.codec.http2.Http2Exception$StreamException: Maximum active streams violated for this endpoint: 100
This happens in both cases: when the value increases or decreases bcz we need to coordinate between a state inside `ReservableRequestConcurrencyControllers` and inside Netty's http2-codec. Update of these states races with incoming requests when offloading is enabled.

Modifications:

- Enhance `H2ConcurrencyControllerTest` with reproducers for described scenarios;
- Refactor `ReservableRequestConcurrencyControllers` to handle events differently to minimize the risk for a race and clarify why we use this ordering;
- Introduce `MaxConcurrentStreamsViolatedStacklessHttp2Exception` as a replacement for the corresponding Netty exception;
- Add unconditional `InternalRetryingHttpClientFilter` that targets `MaxConcurrentStreamsViolatedStacklessHttp2Exception` and unconditionally retries it;
- Deprecate internal class `LatestValueSubscriber`;
- Clarify `ConsumableEvent#eventConsumed()` idempotency expectations;
- Log all `transportEventStream(MAX_CONCURRENCY)` events at `DEBUG` level in `AbstractLBHttpConnectionFactory`;
- Implement `toString()` for all `ConsumableEvent` implementations;
- Explicitly define that Netty should auto-ack settings frames on the server-side;
- Make `HttpEventKey.newKey(...)` public, add `type` to preserve the type information at runtime;
- Use internal (pkg-private) `MAX_CONCURRENCY_NO_OFFLOADING` key for concurrency controller to avoid offloading for events;

Result:

Users will not see "Maximum active streams violated for this endpoint" error from netty.