### PR TITLE
Fix `RetryingHttpRequesterFilterTest.disableAutoRetry()`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -120,7 +120,7 @@ class RetryingHttpRequesterFilterTest {
                 .buildBlocking();
         Exception e = assertThrows(Exception.class, () -> failingClient.request(failingClient.get("/")));
         assertThat(e, instanceOf(RetryableException.class));
-        assertThat("Unexpected calls to select.", lbSelectInvoked.get(), is(1));
+        assertThat("Unexpected calls to select.", lbSelectInvoked.get(), is(lessThanOrEqualTo(2)));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

#2458 changed `disableAutoRetries()` to still wait for the LB for the first time. As the result, the test can select a connection up to 2 times.

Modifications:

- Change the matcher to `lessThanOrEqualTo(2)`;

Result:

`RetryingHttpRequesterFilterTest.disableAutoRetry()` is not flaky.