### PR TITLE
Rename `LoadBalancerFactory#newLoadBalancerTyped` -> `newLoadBalancer`

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
@@ -81,14 +81,14 @@ public class RoundRobinLoadBalancerSDEventsBenchmark {
     public LoadBalancer<LoadBalancedConnection> mixed() {
         // RR load balancer synchronously subscribes and will consume all events during construction.
         return new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, LoadBalancedConnection>().build()
-                .newLoadBalancerTyped("benchmark", from(mixedEvents), ConnFactory.INSTANCE);
+                .newLoadBalancer(from(mixedEvents), ConnFactory.INSTANCE, "benchmark");
     }
 
     @Benchmark
     public LoadBalancer<LoadBalancedConnection> available() {
         // RR load balancer synchronously subscribes and will consume all events during construction.
         return new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, LoadBalancedConnection>().build()
-                        .newLoadBalancerTyped("benchmark", from(availableEvents), ConnFactory.INSTANCE);
+                        .newLoadBalancer(from(availableEvents), ConnFactory.INSTANCE, "benchmark");
     }
 
     private static final class ConnFactory implements ConnectionFactory<InetSocketAddress, LoadBalancedConnection> {

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
@@ -43,7 +43,7 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
      * @param <T> Type of connections created by the passed {@link ConnectionFactory}.
      * @return a new {@link LoadBalancer}.
-     * @deprecated Use {@link #newLoadBalancerTyped(String, Publisher, ConnectionFactory)}.
+     * @deprecated Use {@link #newLoadBalancer(Publisher, ConnectionFactory, String)}.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     default <T extends C> LoadBalancer<T> newLoadBalancer(
@@ -68,7 +68,7 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
      * @param <T> Type of connections created by the passed {@link ConnectionFactory}.
      * @return a new {@link LoadBalancer}.
-     * @deprecated Use {@link #newLoadBalancerTyped(String, Publisher, ConnectionFactory)}.
+     * @deprecated Use {@link #newLoadBalancer(Publisher, ConnectionFactory, String)}.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated method
     <T extends C> LoadBalancer<T> newLoadBalancer(
@@ -79,22 +79,22 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
     /**
      * Create a new {@link LoadBalancer}.
      *
-     * @param targetResource A {@link String} representation of the target resource for which the created instance
-     * will perform load balancing. Bear in mind, load balancing is performed over the a collection of hosts provided
-     * via the {@code eventPublisher} which may not correspond directly to a single unresolved address, but potentially
-     * a merged collection.
      * @param eventPublisher A stream of {@link Collection}&lt;{@link ServiceDiscovererEvent}&gt;
      * which the {@link LoadBalancer} can use to connect to physical hosts. Typically generated
      * from {@link ServiceDiscoverer#discover(Object) ServiceDiscoverer}.
      * @param connectionFactory {@link ConnectionFactory} that the returned {@link LoadBalancer} will use to generate
      * new connections. Returned {@link LoadBalancer} will own the responsibility for this {@link ConnectionFactory}
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
+     * @param targetResource A {@link String} representation of the target resource for which the created instance
+     * will perform load balancing. Bear in mind, load balancing is performed over the a collection of hosts provided
+     * via the {@code eventPublisher} which may not correspond directly to a single unresolved address, but potentially
+     * a merged collection.
      * @return a new {@link LoadBalancer}.
      */
-    default LoadBalancer<C> newLoadBalancerTyped(
-            String targetResource,
+    default LoadBalancer<C> newLoadBalancer(
             Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
-            ConnectionFactory<ResolvedAddress, C> connectionFactory) {
+            ConnectionFactory<ResolvedAddress, C> connectionFactory,
+            String targetResource) {
         return newLoadBalancer(targetResource, eventPublisher, connectionFactory);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -67,11 +67,11 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
     }
 
     @Override
-    public LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> newLoadBalancerTyped(
-            final String targetResource,
+    public LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> newLoadBalancer(
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
-            final ConnectionFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> connectionFactory) {
-        return rawFactory.newLoadBalancerTyped(targetResource, eventPublisher, connectionFactory);
+            final ConnectionFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> connectionFactory,
+            final String targetResource) {
+        return rawFactory.newLoadBalancer(eventPublisher, connectionFactory, targetResource);
     }
 
     @Override   // FIXME: 0.43 - remove deprecated method

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -290,10 +290,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
             }
 
             final LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> lb =
-                    closeOnException.prepend(ctx.builder.loadBalancerFactory.newLoadBalancerTyped(
-                            targetAddress(ctx),
+                    closeOnException.prepend(ctx.builder.loadBalancerFactory.newLoadBalancer(
                             sdEvents,
-                            connectionFactory));
+                            connectionFactory,
+                            targetAddress(ctx)));
 
             ContextAwareStreamingHttpClientFilterFactory currClientFilterFactory = ctx.builder.clientFilterFactory;
             if (roConfig.hasProxy() && sslContext == null) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -582,15 +582,15 @@ class ClientEffectiveStrategyTest {
         }
 
         @Override
-        public LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> newLoadBalancerTyped(
-                final String targetResource,
+        public LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> newLoadBalancer(
                 final Publisher<? extends Collection<? extends ServiceDiscovererEvent<InetSocketAddress>>>
                         eventPublisher,
                 final ConnectionFactory<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>
-                        connectionFactory) {
+                        connectionFactory,
+                final String targetResource) {
             return new RoundRobinLoadBalancerFactory
                     .Builder<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>().build()
-                    .newLoadBalancerTyped(targetResource, eventPublisher, connectionFactory);
+                    .newLoadBalancer(eventPublisher, connectionFactory, targetResource);
         }
 
         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -233,13 +233,13 @@ class RetryingHttpRequesterFilterTest {
         }
 
         @Override
-        public LoadBalancer<C> newLoadBalancerTyped(
-                final String targetResource,
+        public LoadBalancer<C> newLoadBalancer(
                 final Publisher<? extends Collection<? extends ServiceDiscovererEvent<InetSocketAddress>>>
                         eventPublisher,
-                final ConnectionFactory<InetSocketAddress, C> connectionFactory) {
+                final ConnectionFactory<InetSocketAddress, C> connectionFactory,
+                final String targetResource) {
             return new InspectingLoadBalancer<>(
-                    rr.newLoadBalancerTyped(targetResource, eventPublisher, connectionFactory));
+                    rr.newLoadBalancer(eventPublisher, connectionFactory, targetResource));
         }
 
         @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionHttpLoadBalanceFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionHttpLoadBalanceFactory.java
@@ -76,17 +76,18 @@ public final class CacheConnectionHttpLoadBalanceFactory<ResolvedAddress>
     }
 
     @Override
-    public LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> newLoadBalancerTyped(
-        final String targetResource,
+    public LoadBalancer<FilterableStreamingHttpLoadBalancedConnection> newLoadBalancer(
         final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
-        final ConnectionFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> connectionFactory) {
+        final ConnectionFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> connectionFactory,
+        final String targetResource) {
+
         final HttpCacheConnectionFactory<ResolvedAddress> cacheFactory =
                 new HttpCacheConnectionFactory<>(connectionFactory, maxConcurrencyFunc);
-        return delegate.newLoadBalancerTyped(targetResource, eventPublisher,
+        return delegate.newLoadBalancer(eventPublisher,
                 new CacheConnectionFactory<>(cacheFactory, r -> {
                     ConcurrencyRefCnt v = cacheFactory.maxConcurrentMap.get(r);
                     return v == null ? maxConcurrencyFunc.applyAsInt(r) : v.concurrency;
-                }));
+                }), targetResource);
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -101,10 +101,10 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
     }
 
     @Override
-    public LoadBalancer<C> newLoadBalancerTyped(
-            final String targetResource,
+    public LoadBalancer<C> newLoadBalancer(
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
-            final ConnectionFactory<ResolvedAddress, C> connectionFactory) {
+            final ConnectionFactory<ResolvedAddress, C> connectionFactory,
+            final String targetResource) {
         return new RoundRobinLoadBalancer<>(requireNonNull(targetResource), eventPublisher, connectionFactory,
                 linearSearchSpace, healthCheckConfig);
     }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -496,7 +496,7 @@ abstract class RoundRobinLoadBalancerTest {
                 new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
                         .healthCheckFailedConnectionsThreshold(-1)
                         .build()
-                        .newLoadBalancerTyped("test-service", serviceDiscoveryPublisher, connectionFactory);
+                        .newLoadBalancer(serviceDiscoveryPublisher, connectionFactory, "test-service");
 
         sendServiceDiscoveryEvents(upEvent("address-1"));
 
@@ -614,7 +614,7 @@ abstract class RoundRobinLoadBalancerTest {
                             }
                         })
                         .build()
-                        .newLoadBalancerTyped("test-service", serviceDiscoveryPublisher, connectionFactory);
+                        .newLoadBalancer(serviceDiscoveryPublisher, connectionFactory, "test-service");
 
         sendServiceDiscoveryEvents(upEvent("address-1"));
 
@@ -716,7 +716,7 @@ abstract class RoundRobinLoadBalancerTest {
                         .healthCheckInterval(ofMillis(50), ofMillis(10))
                         .backgroundExecutor(testExecutor)
                         .build()
-                        .newLoadBalancerTyped("test-service", serviceDiscoveryPublisher, connectionFactory);
+                        .newLoadBalancer(serviceDiscoveryPublisher, connectionFactory, "test-service");
 
         assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
 
@@ -788,7 +788,7 @@ abstract class RoundRobinLoadBalancerTest {
                         .healthCheckInterval(ofMillis(50), ofMillis(10))
                         .backgroundExecutor(testExecutor)
                         .build()
-                        .newLoadBalancerTyped("test-service", serviceDiscoveryPublisher, connectionFactory);
+                        .newLoadBalancer(serviceDiscoveryPublisher, connectionFactory, "test-service");
     }
 
     @SafeVarargs


### PR DESCRIPTION
Motivation:

Preserve the original name of the method. Instead, swap arguments to avoid method name collision.