### PR TITLE
Revert `NettyConnectionContext.onClosing()` back

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyConnectionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyConnectionContext.java
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ConnectionContext;
 
@@ -56,6 +57,9 @@ public interface NettyConnectionContext extends ConnectionContext {
      * the transport.
      */
     Single<Throwable> transportError();
+
+    @Override
+    Completable onClosing();    // FIXME: 0.43 - remove override from this interface
 
     /**
      * Return the Netty {@link Channel} backing this connection.


### PR DESCRIPTION
Motivation:

#2430 moved `onClosing()` method from internal `NettyConnectionContext` to public `ListenableAsyncCloseable` interface. While moving a method upward in the class hierarchy should be a binary compatible change, let's preserve it for 0.42.x for extra cautious.