### PR TITLE
`SpecialHttpExecutionStrategy` should implement all interface methods

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SpecialHttpExecutionStrategy.java
@@ -41,6 +41,11 @@ enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
         }
 
         @Override
+        public boolean isRequestResponseOffloaded() {
+            return false;
+        }
+
+        @Override
         public boolean isMetadataReceiveOffloaded() {
             return false;
         }
@@ -90,6 +95,11 @@ enum SpecialHttpExecutionStrategy implements HttpExecutionStrategy {
 
         @Override
         public boolean hasOffloads() {
+            return true;
+        }
+
+        @Override
+        public boolean isRequestResponseOffloaded() {
             return true;
         }
 


### PR DESCRIPTION
Motivation:

`SpecialHttpExecutionStrategy` impls miss override for `isRequestResponseOffloaded()` flag. While it still computes the same result, it's better to be explicit for these implementations.