### PR TITLE
Revert "PublisherAsBlockingIterable LinkedBlockingQueue -> LinkedTransferQueue (#2386)"

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
@@ -39,7 +39,7 @@ import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUncheck
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
-import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
+import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static java.lang.Math.min;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
@@ -101,7 +101,7 @@ final class PublisherAsBlockingIterable<T> implements BlockingIterable<T> {
 
         SubscriberAndIterator(int queueCapacity) {
             requestN = queueCapacity;
-            data = new LinkedTransferQueue<>();
+            data = new LinkedBlockingQueue<>();
         }
 
         @Override


### PR DESCRIPTION
This reverts commit 1c463da9974575711b032d57988c62724facb395 (https://github.com/apple/servicetalk/pull/2386).

We didn't observe visible improvements for `ServiceTalkGrpcBlockingClientStrAgg`, but saw negative impact on HTTP/1.1 blocking-streaming cases:
1. On the client-side for `GET` : -10k RPS, +5-10ms p99
2. On the server-side for `POST` : -10k RPS, +5ms p99