### PR TITLE
Fix increased latency for gRPC after adding `ListenableAsyncCloseable.onClosing()`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ExecutionContextUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ExecutionContextUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.DelegatingHttpExecutionContext;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.transport.api.IoExecutor;
+
+import io.netty.channel.Channel;
+import io.netty.util.concurrent.FastThreadLocal;
+
+import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
+
+final class ExecutionContextUtils {
+
+    private static final FastThreadLocal<IoExecutor> CHANNEL_IO_EXECUTOR = new FastThreadLocal<>();
+
+    private ExecutionContextUtils() {
+        // No instances
+    }
+
+    static HttpExecutionContext channelExecutionContext(final Channel channel,
+                                                        final HttpExecutionContext builderExecutionContext) {
+        final IoExecutor channelIoExecutor = fromChannel(channel,
+                builderExecutionContext.ioExecutor().isIoThreadSupported());
+        return new DelegatingHttpExecutionContext(builderExecutionContext) {
+            @Override
+            public IoExecutor ioExecutor() {
+                return channelIoExecutor;
+            }
+        };
+    }
+
+    private static IoExecutor fromChannel(final Channel channel, boolean isIoThreadSupported) {
+        assert channel.eventLoop().inEventLoop();
+        IoExecutor ioExecutor = CHANNEL_IO_EXECUTOR.getIfExists();
+        if (ioExecutor != null) {
+            return ioExecutor;
+        }
+        ioExecutor = fromNettyEventLoop(channel.eventLoop(), isIoThreadSupported);
+        CHANNEL_IO_EXECUTOR.set(ioExecutor);
+        return ioExecutor;
+    }
+
+    // for tests only
+    static void clearThreadLocal() {
+        CHANNEL_IO_EXECUTOR.remove();
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ExecutionContextUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ExecutionContextUtils.java
@@ -15,11 +15,13 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.http.api.DelegatingHttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.transport.api.IoExecutor;
 
 import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.FastThreadLocal;
 
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
@@ -32,6 +34,16 @@ final class ExecutionContextUtils {
         // No instances
     }
 
+    /**
+     * Utility that maps {@link Channel#eventLoop()} into {@link IoExecutor} and caches the result for future mappings
+     * to reduce allocations. Because {@link IoExecutor} implements {@link ListenableAsyncCloseable} interface, its
+     * allocation cost is relatively high.
+     *
+     * @param channel {@link Channel} registered for a single {@link EventLoop} thread
+     * @param builderExecutionContext {@link HttpExecutionContext} pre-computed by the builder for new connections
+     * @return {@link HttpExecutionContext} which has {@link IoExecutor} backed by a single {@link EventLoop} thread
+     * associated with the passed {@link Channel}.
+     */
     static HttpExecutionContext channelExecutionContext(final Channel channel,
                                                         final HttpExecutionContext builderExecutionContext) {
         final IoExecutor channelIoExecutor = fromChannel(channel,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -19,7 +19,6 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
-import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpProtocolVersion;
@@ -54,9 +53,9 @@ import static io.netty.util.ReferenceCountUtil.release;
 import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.netty.ExecutionContextUtils.channelExecutionContext;
 import static io.servicetalk.http.netty.NettyHttp2ExceptionUtils.wrapIfNecessary;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.assignConnectionError;
-import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
 import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extractSslSessionAndReport;
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.getOption;
 
@@ -77,9 +76,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
                               @Nullable final SslConfig sslConfig,
                               final KeepAliveManager keepAliveManager) {
         super(channel, executionContext.executor());
-        this.executionContext = new DefaultHttpExecutionContext(executionContext.bufferAllocator(),
-                fromNettyEventLoop(channel.eventLoop(), executionContext.ioExecutor().isIoThreadSupported()),
-                executionContext.executor(), executionContext.executionStrategy());
+        this.executionContext = channelExecutionContext(channel, executionContext);
         this.flushStrategyHolder = new FlushStrategyHolder(flushStrategy);
         this.sslConfig = sslConfig;
         this.idleTimeoutMs = idleTimeoutMs;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -71,6 +71,7 @@ class ServerRespondsOnClosingTest {
     private final Queue<Exchange> requests = new ArrayDeque<>();
 
     ServerRespondsOnClosingTest() throws Exception {
+        ExecutionContextUtils.clearThreadLocal();
         channel = new EmbeddedDuplexChannel(false);
         DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR,
                 fromNettyEventLoop(channel.eventLoop()), immediate(), offloadNone());


### PR DESCRIPTION
Motivation:

#2430 adds `ListenableAsyncCloseable.onClosing()` method. Its implementations require allocation of a `CompletableProcessor`.
Because we wrap channel's `EventLoop` with `IoExecutor` on every new connection and every new HTTP/2 stream, it caused significant increase of allocations and pressure for GC. As the result, latency increased for all HTTP/2 and gRPC use-cases.

Modifications:

- Add `ExecutionContextUtils` that adapt `EventLoop` to `IoExecutor` API for `ExecutionContext` and cache its value in `FastThreadLocal` to reduce allocations;
- Make sure that HTTP/1.x and parent HTTP/2 connections use `ExecutionContextUtils`;
- For each new HTTP/2 stream (child channel) take execution context from the parent channel because child channel uses the same `EventLoop` as its parent channel;
- Add a new `DefaultNettyConnection.initChannel` overload that takes already constructed `ExecutionContext`;
- Adjust existing tests for new API;

Result:

Significantly reduced allocation rate and less GC pauses for HTTP/2 and gRPC.