### PR TITLE
Deprecate unnecessary internal methods of `NettyIoExecutors`

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ClientTransportGrpcCallFactory.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/ClientTransportGrpcCallFactory.java
@@ -39,9 +39,9 @@ final class ClientTransportGrpcCallFactory implements GrpcClientCallFactory {
     private final GrpcExecutionContext ctx;
     private final ListenableAsyncCloseable closeable = emptyAsyncCloseable();
 
-    ClientTransportGrpcCallFactory(ClientTransport transport, EventLoopGroup group) {
+    ClientTransportGrpcCallFactory(ClientTransport transport, EventLoopGroup group, boolean isIoThreadSupported) {
         this.transport = transport;
-        ctx = new UtilGrpcExecutionContext(DEFAULT_ALLOCATOR, fromNettyEventLoopGroup(group),
+        ctx = new UtilGrpcExecutionContext(DEFAULT_ALLOCATOR, fromNettyEventLoopGroup(group, isIoThreadSupported),
                 globalExecutionContext().executor());
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/CustomTransportTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/CustomTransportTest.java
@@ -67,7 +67,7 @@ class CustomTransportTest {
             }.newClient(new ClientTransportGrpcCallFactory(
                     // Build the client transport, which just calls the server transport directly.
                     (method, requestMessages) -> serverTransport.handle(c, "clientId", method, requestMessages),
-                    ioExecutor.eventLoopGroup()));
+                    ioExecutor.eventLoopGroup(), ioExecutor.isIoThreadSupported()));
 
             // Test using the client.
             assertThat(client.test(newReq("scalar")).toFuture().get(), is(newResp("hello scalar")));

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/InMemoryServerTransport.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/InMemoryServerTransport.java
@@ -36,7 +36,6 @@ import io.servicetalk.grpc.customtransport.Utils.UtilGrpcExecutionContext;
 import io.servicetalk.serializer.api.StreamingDeserializer;
 import io.servicetalk.serializer.api.StreamingSerializer;
 import io.servicetalk.transport.netty.internal.GlobalExecutionContext;
-import io.servicetalk.transport.netty.internal.NettyIoExecutors;
 
 import com.google.rpc.Status;
 import io.netty.channel.Channel;
@@ -57,7 +56,8 @@ import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INTERNAL;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Math.ceil;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodType.methodType;
@@ -307,7 +307,7 @@ final class InMemoryServerTransport implements ServerTransport {
         // FastThreadLocal to store this info as well.
         GrpcExecutionContext executionContext =
                 EVENT_LOOP_GRPC_EXECUTION_CONTEXT_MAP.computeIfAbsent(channel.eventLoop(), el ->
-                        new UtilGrpcExecutionContext(allocator, NettyIoExecutors.fromNettyEventLoop(el),
+                        new UtilGrpcExecutionContext(allocator, fromNettyEventLoop(el, false),
                                 GlobalExecutionContext.globalExecutionContext().executor()));
 
         serviceContext = new ChannelGrpcServiceContext(channel, executionContext);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -73,7 +73,7 @@ class ServerRespondsOnClosingTest {
     ServerRespondsOnClosingTest() throws Exception {
         channel = new EmbeddedDuplexChannel(false);
         DefaultHttpExecutionContext httpExecutionContext = new DefaultHttpExecutionContext(DEFAULT_ALLOCATOR,
-                fromNettyEventLoop(channel.eventLoop()), immediate(), offloadNone());
+                fromNettyEventLoop(channel.eventLoop(), false), immediate(), offloadNone());
         final HttpServerConfig httpServerConfig = new HttpServerConfig();
         httpServerConfig.tcpConfig().enableWireLogging("servicetalk-tests-wire-logger", TRACE,
                 Boolean.TRUE::booleanValue);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/AbstractNettyIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/AbstractNettyIoExecutor.java
@@ -37,10 +37,6 @@ abstract class AbstractNettyIoExecutor<T extends EventLoopGroup> implements Nett
     protected final boolean interruptOnCancel;
     private final CompletableSource.Processor closingProcessor = newCompletableProcessor();
 
-    AbstractNettyIoExecutor(T eventLoop, boolean interruptOnCancel) {
-        this(eventLoop, interruptOnCancel, false);
-    }
-
     AbstractNettyIoExecutor(T eventLoop, boolean interruptOnCancel, boolean isIoThreadSupported) {
         this.eventLoop = eventLoop;
         this.interruptOnCancel = interruptOnCancel;

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/EventLoopGroupIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/EventLoopGroupIoExecutor.java
@@ -20,10 +20,6 @@ import io.netty.channel.EventLoopGroup;
 final class EventLoopGroupIoExecutor extends AbstractNettyIoExecutor<EventLoopGroup>
         implements EventLoopAwareNettyIoExecutor {
 
-    EventLoopGroupIoExecutor(EventLoopGroup eventLoopGroup, boolean interruptOnCancel) {
-        super(eventLoopGroup, interruptOnCancel);
-    }
-
     EventLoopGroupIoExecutor(EventLoopGroup eventLoopGroup, boolean interruptOnCancel, boolean isIoThreadSupported) {
         super(eventLoopGroup, interruptOnCancel, isIoThreadSupported);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/EventLoopIoExecutor.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/EventLoopIoExecutor.java
@@ -20,10 +20,6 @@ import io.netty.channel.EventLoopGroup;
 
 final class EventLoopIoExecutor extends AbstractNettyIoExecutor<EventLoop> implements EventLoopAwareNettyIoExecutor {
 
-    EventLoopIoExecutor(EventLoop eventLoop, boolean interruptOnCancel) {
-        super(eventLoop, interruptOnCancel);
-    }
-
     EventLoopIoExecutor(EventLoop eventLoop, boolean interruptOnCancel, boolean isIoThreadSupported) {
         super(eventLoop, interruptOnCancel, isIoThreadSupported);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
@@ -130,8 +130,10 @@ public final class NettyIoExecutors {
      * @param ioExecutor {@link IoExecutor} to convert.
      * @return {@link NettyIoExecutor} corresponding to the passed {@link IoExecutor}.
      * @throws IllegalArgumentException If {@link IoExecutor} is not of type {@link NettyIoExecutor}.
+     * @deprecated Use {@link EventLoopAwareNettyIoExecutors#toEventLoopAwareNettyIoExecutor(IoExecutor)}.
      */
-    public static NettyIoExecutor toNettyIoExecutor(IoExecutor ioExecutor) {
+    @Deprecated
+    public static NettyIoExecutor toNettyIoExecutor(IoExecutor ioExecutor) {  // FIXME: 0.43 - remove deprecated method
         requireNonNull(ioExecutor);
         if (ioExecutor instanceof NettyIoExecutor) {
             return (NettyIoExecutor) ioExecutor;
@@ -145,9 +147,11 @@ public final class NettyIoExecutors {
      *
      * @param eventLoop {@link EventLoop} to use to create a new {@link NettyIoExecutor}.
      * @return New {@link NettyIoExecutor} using the passed {@link EventLoop}.
+     * @deprecated Use {@link #fromNettyEventLoop(EventLoop, boolean)}.
      */
-    public static NettyIoExecutor fromNettyEventLoop(EventLoop eventLoop) {
-        return new EventLoopIoExecutor(eventLoop, true);
+    @Deprecated
+    public static NettyIoExecutor fromNettyEventLoop(EventLoop eventLoop) { // FIXME: 0.43 - remove deprecated method
+        return fromNettyEventLoop(eventLoop, false);
     }
 
     /**
@@ -168,9 +172,11 @@ public final class NettyIoExecutors {
      *
      * @param eventLoopGroup {@link EventLoopGroup} to use to create a new {@link NettyIoExecutor}.
      * @return New {@link NettyIoExecutor} using the passed {@link EventLoopGroup}.
+     * @deprecated Use {@link #fromNettyEventLoopGroup(EventLoopGroup, boolean)}.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     public static NettyIoExecutor fromNettyEventLoopGroup(EventLoopGroup eventLoopGroup) {
-        return new EventLoopGroupIoExecutor(eventLoopGroup, true);
+        return fromNettyEventLoopGroup(eventLoopGroup, false);
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/GlobalExecutionContextTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/GlobalExecutionContextTest.java
@@ -21,10 +21,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
+import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
 import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
-import static io.servicetalk.transport.netty.internal.NettyIoExecutors.toNettyIoExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 class GlobalExecutionContextTest {
 
@@ -33,8 +34,8 @@ class GlobalExecutionContextTest {
         ExecutionContext<?> gec = globalExecutionContext();
         CountDownLatch scheduleLatch = new CountDownLatch(2);
         gec.executor().schedule(scheduleLatch::countDown, 5, MILLISECONDS);
-        NettyIoExecutor ioExecutor = toNettyIoExecutor(gec.ioExecutor());
-        assertThat("global ioExecutor does not support IoThread", ioExecutor.isIoThreadSupported());
+        NettyIoExecutor ioExecutor = toEventLoopAwareNettyIoExecutor(gec.ioExecutor());
+        assertThat("Global IoExecutor does not support IoThread", ioExecutor.isIoThreadSupported(), is(true));
         ioExecutor.schedule(scheduleLatch::countDown, 5, MILLISECONDS);
         scheduleLatch.await();
     }


### PR DESCRIPTION
Motivation:

`io.servicetalk.transport.netty.internal.NettyIoExecutors` has a few public methods that are not necessary and can be removed in the future releases. All these methods already have alternative ways to achieve the same.

Modifications:

- Deprecate `NettyIoExecutors.toNettyIoExecutor(IoExecutor)`;
- Deprecate `NettyIoExecutors.fromNettyEventLoop(EventLoop)`;
- Deprecate `NettyIoExecutors.fromNettyEventLoopGroup(EventLoopGroup)`;
- Adjust tests to avoid using deprecated API;

Result:

Less publicly exposed internal methods.