### PR TITLE
Allow to open a new connection when reserving (HTTP).

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancer.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancer.java
@@ -73,6 +73,26 @@ public interface LoadBalancer<C extends LoadBalancedConnection> extends Listenab
     }
 
     /**
+     * Opens a new connection for a request instead of potentially reusing one.
+     * <p>
+     * If the returned connection is {@link LoadBalancedConnection#releaseAsync() released}, it is returned to the
+     * pool and made available for other connection requests sent via {@link #selectConnection(Predicate, ContextMap)}.
+     * If the connection should not be returned to the pool, it must be explicitly
+     * {@link LoadBalancedConnection#closeAsync() closed} by the caller.
+     *
+     * @param context A {@link ContextMap context} of the caller (e.g. request context) or {@code null} if no context
+     * provided.
+     * @return a {@link Single} that completes with a new connection to use. A
+     * {@link Single#failed(Throwable) failed Single} with {@link NoAvailableHostException} can be returned if no
+     * connection can be created at this time or with {@link ConnectionRejectedException} if a newly created connection
+     * was rejected by this load balancer.
+     */
+    default Single<C> newConnection(@Nullable ContextMap context) {
+        return failed(new UnsupportedOperationException(
+                "LoadBalancer#newConnection(ContextMap) is not supported by " + getClass()));
+    }
+
+    /**
      * A {@link Publisher} of events provided by this {@link LoadBalancer}. This maybe used to broadcast internal state
      * of this {@link LoadBalancer} to provide hints/visibility for external usage.
      * @return A {@link Publisher} of events provided by this {@link LoadBalancer}.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingHttpClient.java
@@ -21,12 +21,16 @@ package io.servicetalk.http.api;
 public interface BlockingHttpClient extends BlockingHttpRequester {
     /**
      * Reserve a {@link BlockingHttpConnection} based on provided {@link HttpRequestMetaData}.
+     * <p>
+     * If a new connection should be opened instead of potentially reusing an already established one, the
+     * {@link HttpContextKeys#HTTP_FORCE_NEW_CONNECTION} must be set.
      *
      * @param metaData Allows the underlying layers to know what {@link BlockingHttpConnection}s are valid to
      * reserve for future {@link HttpRequest requests} with the same {@link HttpRequestMetaData}.
      * For example this may provide some insight into shard or other info.
      * @return a {@link ReservedBlockingHttpConnection}.
      * @throws Exception if a exception occurs during the reservation process.
+     * @see HttpContextKeys#HTTP_FORCE_NEW_CONNECTION
      */
     ReservedBlockingHttpConnection reserveConnection(HttpRequestMetaData metaData) throws Exception;
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpClient.java
@@ -21,12 +21,16 @@ package io.servicetalk.http.api;
 public interface BlockingStreamingHttpClient extends BlockingStreamingHttpRequester {
     /**
      * Reserve a {@link BlockingStreamingHttpConnection} based on provided {@link HttpRequestMetaData}.
+     * <p>
+     * If a new connection should be opened instead of potentially reusing an already established one, the
+     * {@link HttpContextKeys#HTTP_FORCE_NEW_CONNECTION} must be set.
      *
      * @param metaData Allows the underlying layers to know what {@link BlockingStreamingHttpConnection}s are valid to
      * reserve for future {@link BlockingStreamingHttpRequest requests} with the same {@link HttpRequestMetaData}.
      * For example this may provide some insight into shard or other info.
      * @return a {@link ReservedBlockingStreamingHttpConnection}.
      * @throws Exception if a exception occurs during the reservation process.
+     * @see HttpContextKeys#HTTP_FORCE_NEW_CONNECTION
      */
     ReservedBlockingStreamingHttpConnection reserveConnection(HttpRequestMetaData metaData) throws Exception;
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
@@ -27,11 +27,15 @@ import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 public interface HttpClient extends HttpRequester, GracefulAutoCloseable {
     /**
      * Reserve an {@link HttpConnection} based on provided {@link HttpRequestMetaData}.
+     * <p>
+     * If a new connection should be opened instead of potentially reusing an already established one, the
+     * {@link HttpContextKeys#HTTP_FORCE_NEW_CONNECTION} must be set.
      *
      * @param metaData Allows the underlying layers to know what {@link HttpConnection}s are valid to
      * reserve for future {@link HttpRequest requests} with the same {@link HttpRequestMetaData}.
      * For example this may provide some insight into shard or other info.
      * @return a {@link Single} that provides the {@link ReservedHttpConnection} upon completion.
+     * @see HttpContextKeys#HTTP_FORCE_NEW_CONNECTION
      */
     Single<ReservedHttpConnection> reserveConnection(HttpRequestMetaData metaData);
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
@@ -48,7 +48,7 @@ public final class HttpContextKeys {
             newKey("HTTP_TARGET_ADDRESS_BEHIND_PROXY", Object.class);
 
     /**
-     * If set to true, forces creating a new connection versus potentially reusing an already established one.
+     * If set to true, forces creating a new connection versus potentially selecting an already established one.
      * <p>
      * This key is only available when reserving a connection and will be ignored when performing a regular
      * request on the client (for example through {@link HttpClient#request(HttpRequest)}).

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
@@ -47,6 +47,17 @@ public final class HttpContextKeys {
     public static final Key<Object> HTTP_TARGET_ADDRESS_BEHIND_PROXY =
             newKey("HTTP_TARGET_ADDRESS_BEHIND_PROXY", Object.class);
 
+    /**
+     * If set to true, forces creating a new connection versus potentially reusing an already established one.
+     * <p>
+     * This key is only available when reserving a connection and will be ignored when performing a regular
+     * request on the client (for example through {@link HttpClient#request(HttpRequest)}).
+     *
+     * @see HttpClient#reserveConnection(HttpRequestMetaData)
+     */
+    public static final Key<Boolean> HTTP_FORCE_NEW_CONNECTION =
+            newKey("HTTP_FORCE_NEW_CONNECTION", Boolean.class);
+
     private HttpContextKeys() {
         // No instances
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
@@ -27,11 +27,15 @@ import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 public interface StreamingHttpClient extends FilterableStreamingHttpClient, GracefulAutoCloseable {
     /**
      * Reserve a {@link StreamingHttpConnection} based on provided {@link HttpRequestMetaData}.
+     * <p>
+     * If a new connection should be opened instead of potentially reusing an already established one, the
+     * {@link HttpContextKeys#HTTP_FORCE_NEW_CONNECTION} must be set.
      *
      * @param metaData Allows the underlying layers to know what {@link StreamingHttpConnection}s are valid to
      * reserve for future {@link StreamingHttpRequest requests} with the same {@link HttpRequestMetaData}.
      * For example this may provide some insight into shard or other info.
      * @return a {@link Single} that provides the {@link ReservedStreamingHttpConnection} upon completion.
+     * @see HttpContextKeys#HTTP_FORCE_NEW_CONNECTION
      */
     @Override
     Single<ReservedStreamingHttpConnection> reserveConnection(HttpRequestMetaData metaData);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -52,7 +52,6 @@ import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.requestE
 import static io.servicetalk.http.netty.LoadBalancedStreamingHttpClient.OnStreamClosedRunnable.areStreamsSupported;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
-import static java.util.function.Function.identity;
 
 final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpClient {
 
@@ -158,9 +157,9 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
             final ContextMap context = metaData.context();
             final boolean forceNew = Boolean.TRUE.equals(context.get(HttpContextKeys.HTTP_FORCE_NEW_CONNECTION));
 
-            Single<ReservedStreamingHttpConnection> connection = forceNew ?
-                    loadBalancer.newConnection(context).map(identity()) :
-                    loadBalancer.selectConnection(SELECTOR_FOR_RESERVE, context).map(identity());
+            Single<FilterableStreamingHttpLoadBalancedConnection> connection = forceNew ?
+                    loadBalancer.newConnection(context) :
+                    loadBalancer.selectConnection(SELECTOR_FOR_RESERVE, context);
 
             final HttpExecutionStrategy strategy = requestExecutionStrategy(metaData,
                     executionContext().executionStrategy());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancedStreamingHttpClient.java
@@ -156,14 +156,11 @@ final class LoadBalancedStreamingHttpClient implements FilterableStreamingHttpCl
     public Single<ReservedStreamingHttpConnection> reserveConnection(final HttpRequestMetaData metaData) {
         return Single.defer(() -> {
             final ContextMap context = metaData.context();
-            final Boolean forceNew = context.get(HttpContextKeys.HTTP_FORCE_NEW_CONNECTION);
+            final boolean forceNew = Boolean.TRUE.equals(context.get(HttpContextKeys.HTTP_FORCE_NEW_CONNECTION));
 
-            Single<ReservedStreamingHttpConnection> connection;
-            if (forceNew != null && forceNew) {
-                connection = loadBalancer.newConnection(context).map(identity());
-            } else {
-                connection = loadBalancer.selectConnection(SELECTOR_FOR_RESERVE, context).map(identity());
-            }
+            Single<ReservedStreamingHttpConnection> connection = forceNew ?
+                    loadBalancer.newConnection(context).map(identity()) :
+                    loadBalancer.selectConnection(SELECTOR_FOR_RESERVE, context).map(identity());
 
             final HttpExecutionStrategy strategy = requestExecutionStrategy(metaData,
                     executionContext().executionStrategy());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ReserveConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ReserveConnectionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.DelegatingConnectionFactory;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpContextKeys;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.http.api.ReservedBlockingHttpConnection;
+import io.servicetalk.transport.api.TransportObserver;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReserveConnectionTest {
+
+    private HttpServerContext serverContext;
+    private BlockingHttpClient httpClient;
+    private AtomicInteger createdConnections;
+
+    @BeforeEach
+    void setup() throws Exception {
+        createdConnections = new AtomicInteger(0);
+
+        serverContext = HttpServers
+                .forAddress(localAddress(0))
+                .listenBlocking((ctx1, request, responseFactory) -> responseFactory.ok()).toFuture().get();
+
+        InetSocketAddress listenAddress = (InetSocketAddress) serverContext.listenAddress();
+        httpClient = HttpClients
+                .forSingleAddress(listenAddress.getHostName(), listenAddress.getPort())
+                .appendConnectionFactoryFilter(o ->
+                        new DelegatingConnectionFactory<InetSocketAddress, FilterableStreamingHttpConnection>(o) {
+                            @Override
+                            public Single<FilterableStreamingHttpConnection> newConnection(
+                                    final InetSocketAddress inetSocketAddress,
+                                    @Nullable final ContextMap context,
+                                    @Nullable final TransportObserver observer) {
+                                return delegate()
+                                        .newConnection(inetSocketAddress, context, observer)
+                                        .beforeOnSuccess(c -> createdConnections.incrementAndGet());
+                            }
+                        })
+                .buildBlocking();
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        httpClient.close();
+        serverContext.close();
+    }
+
+    @Test
+    void reusesConnectionOnReserve() throws Exception {
+        HttpRequest metaData = httpClient.get("/");
+
+        ReservedBlockingHttpConnection connection = httpClient.reserveConnection(metaData);
+        connection.release();
+        connection = httpClient.reserveConnection(metaData);
+        connection.release();
+        connection = httpClient.reserveConnection(metaData);
+        connection.release();
+
+        assertEquals(1, createdConnections.get());
+    }
+
+    @Test
+    void canForceNewConnection() throws Exception {
+        HttpRequest metaData = httpClient.get("/");
+        metaData.context().put(HttpContextKeys.HTTP_FORCE_NEW_CONNECTION, true);
+
+        ReservedBlockingHttpConnection connection = httpClient.reserveConnection(metaData);
+        connection.release();
+        connection = httpClient.reserveConnection(metaData);
+        connection.release();
+        connection = httpClient.reserveConnection(metaData);
+        connection.release();
+
+        assertEquals(3, createdConnections.get());
+    }
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -440,10 +440,10 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         return establishConnection
                 .flatMap(newCnx -> {
                     if (forceNewConnectionAndReserve && !newCnx.tryReserve()) {
-                        return failed(StacklessConnectionRejectedException.newInstance(
+                        return newCnx.closeAsync().concat(failed(StacklessConnectionRejectedException.newInstance(
                                 "Newly created connection " + newCnx + " for " + targetResource
                                         + " could not be reserved.",
-                                RoundRobinLoadBalancer.class, "selectConnection0(...)"));
+                                RoundRobinLoadBalancer.class, "selectConnection0(...)")));
                     }
 
                     // Invoke the selector before adding the connection to the pool, otherwise, connection can be

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -116,8 +116,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -776,8 +776,8 @@ abstract class RoundRobinLoadBalancerTest {
         TestLoadBalancedConnection conn2 = lb.newConnection(null).toFuture().get();
         assertEquals(2, connectionsCreated.size());
 
-        verify(conn1, atLeastOnce()).tryReserve();
-        verify(conn2, atLeastOnce()).tryReserve();
+        verify(conn1, times(1)).tryReserve();
+        verify(conn2, times(1)).tryReserve();
     }
 
     void sendServiceDiscoveryEvents(final ServiceDiscovererEvent... events) {


### PR DESCRIPTION
Motivation:

When a connection is being reserved on one of the HttpClient variants, at the moment the user has no control over the decision if an existing connection should be reused or a new one will be opened.

Use cases have been reported where being able to explicitly reserve a new connection instead of reusing one would be benefitial.

Modifications:

This changeset adds support for this feature by introducing two new APIs at different levels:

 - At the HttpClient level a HTTP_FORCE_NEW_CONNECTION context key has been added which signals the intention at the reserveConnection level by the user.
 - The LoadBalancer now features a newConnection method which by default throws an UnsupportedOperationException for backwards compatibility.

The RoundRobinLoadBalancer implements the newConnection API by reusing all of the existing internal functionality (only skipping the connection reuse part and having to explicitly reserve since no predicate is present).

Result:

The user can now explicitly ask for a new connection when reserving a connection instead of potentially receiving an already opened one.