### PR TITLE
Introduce GrpcExecutionStrategies#offloadNone

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -68,7 +68,7 @@ public final class GrpcExecutionStrategies {
      *
      * @return {@link GrpcExecutionStrategy} that disables all request-response path offloads.
      * @see #offloadNone()
-     * @deprecated Use a custom strategy with no offloads instead; (for example {@link #offloadNone()})
+     * @deprecated Use {@link #offloadNone()} instead.
      */
     // FIXME: 0.43 - remove deprecated method
     @Deprecated

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategies.java
@@ -24,6 +24,9 @@ import io.servicetalk.http.api.HttpExecutionStrategyInfluencer;
  */
 public final class GrpcExecutionStrategies {
 
+    private static final GrpcExecutionStrategy OFFLOAD_NONE_STRATEGY =
+            new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.offloadNone());
+
     @Deprecated
     private static final GrpcExecutionStrategy NEVER_OFFLOAD_STRATEGY = // FIXME: 0.43 - remove deprecated constant
             new DefaultGrpcExecutionStrategy(HttpExecutionStrategies.offloadNever()) {
@@ -64,13 +67,26 @@ public final class GrpcExecutionStrategies {
      * When merged with another execution strategy the result is always this strategy.
      *
      * @return {@link GrpcExecutionStrategy} that disables all request-response path offloads.
-     * @deprecated Use a custom strategy with no offloads instead;
-     * {@code GrpcExecutionStrategies.customStrategyBuilder().offloadNone().build()}
+     * @see #offloadNone()
+     * @deprecated Use a custom strategy with no offloads instead; (for example {@link #offloadNone()})
      */
     // FIXME: 0.43 - remove deprecated method
     @Deprecated
     public static GrpcExecutionStrategy offloadNever() {
         return NEVER_OFFLOAD_STRATEGY;
+    }
+
+    /**
+     * An {@link GrpcExecutionStrategy} that requires no offloads on the request-response path or transport event path.
+     * <p>
+     * For {@link HttpExecutionStrategyInfluencer}s that do not block, the
+     * {@link HttpExecutionStrategyInfluencer#requiredOffloads()} method should return this value. Unlike
+     * {@link #offloadNever()}, this strategy merges normally with other execution strategy instances.
+     * @return {@link GrpcExecutionStrategy} that requires no request-response path offloads.
+     * @see #offloadNever()
+     */
+    public static GrpcExecutionStrategy offloadNone() {
+        return OFFLOAD_NONE_STRATEGY;
     }
 
     /**

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategy.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExecutionStrategy.java
@@ -30,7 +30,7 @@ public interface GrpcExecutionStrategy extends HttpExecutionStrategy {
      *
      * @return New {@link GrpcExecutionStrategy} using the passed {@link HttpExecutionStrategy}.
      */
-    static GrpcExecutionStrategy from(HttpExecutionStrategy httpExecutionStrategy) {
+    static GrpcExecutionStrategy from(final HttpExecutionStrategy httpExecutionStrategy) {
         GrpcExecutionStrategy result;
         if (httpExecutionStrategy instanceof GrpcExecutionStrategy) {
             result = (GrpcExecutionStrategy) httpExecutionStrategy;
@@ -38,6 +38,8 @@ public interface GrpcExecutionStrategy extends HttpExecutionStrategy {
             result = GrpcExecutionStrategies.offloadNever();
         } else if (HttpExecutionStrategies.defaultStrategy() == httpExecutionStrategy) {
             result = GrpcExecutionStrategies.defaultStrategy();
+        } else if (HttpExecutionStrategies.offloadNone() == httpExecutionStrategy) {
+            result = GrpcExecutionStrategies.offloadNone();
         } else {
             result = new DefaultGrpcExecutionStrategy(httpExecutionStrategy);
         }


### PR DESCRIPTION
Motivation:

To ensure partiy with HttpExecutionStrategies it makes sense to introduce "offloadNone" as a static utility method instead of only making it accessible through a builder.

Modifications:

This changeset adds the static "offloadNone" utility method in GrpcExecutionStrategies and clarifies the javadoc of "offloadNever" (which is deprecated) on alternative usage.

Result:

Feature parity between GRPC and HTTP on the "offloadNone" execution strategy creation.