### PR TITLE
Consider request strategy when we schedule timeouts or retries

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpApiConversions.java
@@ -19,8 +19,6 @@ import io.servicetalk.http.api.StreamingHttpClientToBlockingHttpClient.ReservedS
 import io.servicetalk.http.api.StreamingHttpClientToBlockingStreamingHttpClient.ReservedStreamingHttpConnectionToBlockingStreaming;
 import io.servicetalk.http.api.StreamingHttpClientToHttpClient.ReservedStreamingHttpConnectionToReservedHttpConnection;
 
-import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
-
 /**
  * Conversion routines to {@link StreamingHttpService}.
  */
@@ -487,10 +485,5 @@ public final class HttpApiConversions {
      */
     public static BlockingStreamingHttpService toBlockingStreamingHttpService(StreamingHttpService service) {
         return new StreamingHttpServiceToBlockingStreamingHttpService(service);
-    }
-
-    static HttpExecutionStrategy requestStrategy(HttpRequestMetaData metaData, HttpExecutionStrategy fallback) {
-        final HttpExecutionStrategy strategy = metaData.context().get(HTTP_EXECUTION_STRATEGY_KEY);
-        return strategy != null ? strategy : fallback;
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterAutoRetryStrategiesTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterAutoRetryStrategiesTest.java
@@ -286,6 +286,6 @@ class RetryingHttpRequesterFilterAutoRetryStrategiesTest {
     @Nonnull
     private Completable applyRetry(final ContextAwareRetryingHttpClientFilter filter,
                                    final int count, final Throwable t) {
-        return filter.retryStrategy(immediate(), REQUEST_META_DATA).apply(count, t);
+        return filter.retryStrategy(REQUEST_META_DATA, filter.executionContext()).apply(count, t);
     }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
@@ -176,4 +176,9 @@ public final class TimeoutHttpRequesterFilter extends AbstractTimeoutHttpFilter
             }
         };
     }
+
+    @Override
+    boolean isService() {
+        return false;
+    }
 }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
@@ -163,4 +163,9 @@ public final class TimeoutHttpServiceFilter extends AbstractTimeoutHttpFilter
             }
         };
     }
+
+    @Override
+    boolean isService() {
+        return true;
+    }
 }

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
@@ -160,7 +160,8 @@ abstract class AbstractTimeoutHttpFilterTest {
                     .flatMapPublisher(StreamingHttpResponse::payloadBody))
                 .thenRequest(MAX_VALUE)
                 .expectErrorMatches(t -> TimeoutException.class.isInstance(t) &&
-                        (Thread.currentThread() instanceof IoThreadFactory.IoThread ^ strategy.hasOffloads()))
+                        (Thread.currentThread() instanceof IoThreadFactory.IoThread ^
+                                strategy.isRequestResponseOffloaded()))
                 .verify();
         assertThat("Response did not succeeded", responseSucceeded.get(), is(true));
         assertThat("No subscribe for payload body", payloadBody.isSubscribed(), is(true));

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilterTest.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.utils;
 
 import io.servicetalk.concurrent.TimeSource;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpConnectionContext;
@@ -31,6 +32,7 @@ import java.time.Duration;
 import java.util.function.BiFunction;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -72,6 +74,10 @@ public class TimeoutHttpRequesterFilterTest extends AbstractTimeoutHttpFilterTes
         when(connection.request(any())).thenReturn(responseSingle);
 
         StreamingHttpRequester requester = filterFactory.create(connection);
-        return requester.request(mock(StreamingHttpRequest.class));
+        StreamingHttpRequest request = mock(StreamingHttpRequest.class);
+        ContextMap requestContext = mock(ContextMap.class);
+        when(request.context()).thenReturn(requestContext);
+        when(requestContext.getOrDefault(HTTP_EXECUTION_STRATEGY_KEY, strategy)).thenReturn(strategy);
+        return requester.request(request);
     }
 }

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/TimeoutHttpServiceFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/TimeoutHttpServiceFilterTest.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.utils;
 
 import io.servicetalk.concurrent.TimeSource;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.DefaultHttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
@@ -32,6 +33,7 @@ import java.time.Duration;
 import java.util.function.BiFunction;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -71,7 +73,10 @@ public class TimeoutHttpServiceFilterTest extends AbstractTimeoutHttpFilterTest 
         when(service.handle(any(), any(), any())).thenReturn(responseSingle);
 
         StreamingHttpServiceFilter filter = filterFactory.create(service);
-        return filter.handle(serviceContext, mock(StreamingHttpRequest.class),
-                mock(StreamingHttpResponseFactory.class));
+        StreamingHttpRequest request = mock(StreamingHttpRequest.class);
+        ContextMap requestContext = mock(ContextMap.class);
+        when(request.context()).thenReturn(requestContext);
+        when(requestContext.getOrDefault(HTTP_EXECUTION_STRATEGY_KEY, strategy)).thenReturn(strategy);
+        return filter.handle(serviceContext, request, mock(StreamingHttpResponseFactory.class));
     }
 }


### PR DESCRIPTION
Motivation:

Currently, timeout and retrying filter uses an `HttpExecutionStrategy` from the `ExecutionContext`. However, on the requester side users can either use a different API that optimizes the pre-computed strategy or they can put a custom strategy per request.

Modifications:

- For `RetryingHttpRequesterFilter`, compute `alternativeTimerExecutor` based on `HTTP_EXECUTION_STRATEGY_KEY`;
- For `TimeoutHttpRequesterFilter`, compute `useForTimeout` based on `HTTP_EXECUTION_STRATEGY_KEY`;
- Adjust tests for new behavior;

Result:

1. On the client-side, the actual `HttpExecutionStrategy` associated with the request is considered.
2. Less use of offloading executor when there is no need to offload.