### PR TITLE
Use unpadded jctools queues by default

### DIFF
--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent.java
@@ -278,7 +278,7 @@ public final class PlatformDependent {
         static {
             // Internal property, subject to removal after validation completed.
             final String useUnpaddedQueuesName = "io.servicetalk.internal.queues.useUnpadded";
-            boolean useUnpaddedQueues = parseBoolean(getProperty(useUnpaddedQueuesName, "false"));
+            boolean useUnpaddedQueues = parseBoolean(getProperty(useUnpaddedQueuesName, "true"));
             if (useUnpaddedQueues) {
                 Queue<Integer> queue = null;
                 try {


### PR DESCRIPTION
Modifications:
- `io.servicetalk.internal.queues.useUnpadded` value defaults to "true" to use unpadded queues by default. This property will be removed in future releases, but exists in case there are any regressions detected.