### PR TITLE
Always disable AUTO_READ for TcpServerBinder

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
@@ -68,9 +68,7 @@ final class DeferredServerChannelBinder {
                 (channel, connectionObserver) -> alpnInitChannel(listenAddress, channel, config, executionContext,
                         service, drainRequestPayloadBody, connectionObserver);
 
-        // We disable auto read by default so we can handle stuff in the ConnectionFilter before we accept any content.
-        // In case ALPN negotiates h2, h2 connection MUST enable auto read for its Channel.
-        return TcpServerBinder.bind(listenAddress, tcpConfig, false, executionContext, connectionAcceptor, channelInit,
+        return TcpServerBinder.bind(listenAddress, tcpConfig, executionContext, connectionAcceptor, channelInit,
                 serverConnection -> {
                     // Start processing requests on http/1.1 connection:
                     if (serverConnection instanceof NettyHttpServerConnection) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -96,8 +96,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
             return failed(newH2ConfigException());
         }
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();
-        // Auto read is required for h2
-        return TcpServerBinder.bind(listenAddress, tcpServerConfig, true, executionContext, connectionAcceptor,
+        return TcpServerBinder.bind(listenAddress, tcpServerConfig, executionContext, connectionAcceptor,
                 (channel, connectionObserver) -> initChannel(listenAddress, channel, executionContext, config,
                         new TcpServerChannelInitializer(tcpServerConfig, connectionObserver), service,
                         drainRequestPayloadBody, connectionObserver),

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -127,8 +127,7 @@ final class NettyHttpServer {
         }
         // This state is read only, so safe to keep a copy across Subscribers
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();
-        // We disable auto read so that we can handle stuff in the ConnectionFilter before we accept any content.
-        return TcpServerBinder.bind(address, tcpServerConfig, false, executionContext, connectionAcceptor,
+        return TcpServerBinder.bind(address, tcpServerConfig, executionContext, connectionAcceptor,
                 (channel, connectionObserver) -> initChannel(channel, executionContext, config,
                         new TcpServerChannelInitializer(tcpServerConfig, connectionObserver), service,
                         drainRequestPayloadBody, connectionObserver),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/EarlyAndLateConnectionAcceptorTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/EarlyAndLateConnectionAcceptorTest.java
@@ -64,7 +64,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class EarlyAndLateConnectionAcceptorTest {
 
@@ -163,8 +162,6 @@ class EarlyAndLateConnectionAcceptorTest {
     @ParameterizedTest(name = "{displayName} [{index}] protocol={0}")
     @EnumSource(Protocol.class)
     void testEarlyAcceptorWithOffloadingAndDifferentProtocols(Protocol protocol) throws Exception {
-        assumeFalse(protocol == Protocol.H2,
-                "Disabled due to a H2 plain AUTO_READ issue which will be addressed in a later commit");
         final AtomicInteger earlyOffloaded = new AtomicInteger();
 
         HttpServerBuilder builder = serverBuilder()
@@ -175,7 +172,6 @@ class EarlyAndLateConnectionAcceptorTest {
                     return info.executionContext().executor().timer(ofMillis(50));
                 });
         doSuccessRequestResponse(builder, protocol);
-
         assertEquals(1, earlyOffloaded.get());
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -30,7 +30,6 @@ import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
 import io.servicetalk.tcp.netty.internal.TcpServerBinder;
 import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpServerConfig;
-import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
@@ -117,15 +116,14 @@ class FlushStrategyOnServerTest {
         final ReadOnlyTcpServerConfig tcpReadOnly = new TcpServerConfig().asReadOnly();
 
         try {
-            serverContext = TcpServerBinder.bind(localAddress(0), tcpReadOnly, true,
+            serverContext = TcpServerBinder.bind(localAddress(0), tcpReadOnly,
                     httpExecutionContext, null,
                     (channel, observer) -> {
-                        final ConnectionObserver connectionObserver = config.tcpConfig().transportObserver()
-                                .onNewConnection(channel.localAddress(), channel.remoteAddress());
+                        channel.config().setAutoRead(true);
                         return initChannel(channel, httpExecutionContext, config,
-                                new TcpServerChannelInitializer(tcpReadOnly, connectionObserver)
+                                new TcpServerChannelInitializer(tcpReadOnly, observer)
                                         .andThen(channel1 -> channel1.pipeline().addLast(interceptor)), service,
-                                true, connectionObserver);
+                                true, observer);
                     },
                     connection -> connection.process(true), null, null)
                     .map(delegate -> new NettyHttpServerContext(delegate, service, httpExecutionContext))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -436,7 +436,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
 
             ReadOnlyTcpServerConfig sConfig = new TcpServerConfig().asReadOnly();
             ServerContext serverContext = resources.prepend(
-                    TcpServerBinder.bind(localAddress(0), sConfig, false,
+                    TcpServerBinder.bind(localAddress(0), sConfig,
                             SEC, null,
                             (channel, observer) -> DefaultNettyConnection.initChannel(channel, SEC.bufferAllocator(),
                                     SEC.executor(), SEC.ioExecutor(),

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -33,7 +33,7 @@ import static io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer.init
 /**
  * {@link ChannelInitializer} for TCP client.
  */
-public class TcpClientChannelInitializer implements ChannelInitializer {
+public class TcpClientChannelInitializer implements ChannelInitializer {    // FIXME: 0.43 - make this class final
 
     private final ChannelInitializer delegate;
 

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
 /**
  * {@link ChannelInitializer} for TCP.
  */
-public class TcpServerChannelInitializer implements ChannelInitializer {
+public class TcpServerChannelInitializer implements ChannelInitializer {    // FIXME: 0.43 - make this class final
 
     private final ChannelInitializer delegate;
 

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -82,7 +82,7 @@ public class TcpServer {
                               Function<NettyConnection<Buffer, Buffer>, Completable> service,
                               ExecutionStrategy executionStrategy)
             throws ExecutionException, InterruptedException {
-        return TcpServerBinder.bind(localAddress(port), config, false, executionContext, connectionAcceptor,
+        return TcpServerBinder.bind(localAddress(port), config, executionContext, connectionAcceptor,
                 (channel, connectionObserver) -> DefaultNettyConnection.<Buffer, Buffer>initChannel(channel,
                         executionContext.bufferAllocator(), executionContext.executor(), executionContext.ioExecutor(),
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),


### PR DESCRIPTION
Motivation:

AUTO_READ should be disabled by default to prevent reading any data before the decision to accept the connection is made and to allow managing back-pressure after that. Protocols that require AUTO_READ have to enable it at their handler (i.e. H2).

Modifications:

This changeset removes the autoRead option from the bind method of the TcpServerBinder and always sets it to false.

The code also re-enables the previously failing test in EarlyAndLateConnectionAcceptorTest.