### PR TITLE
Update release tag regex to allow optional 4th version section

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -2,7 +2,7 @@ name: Release Publisher
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "^[0-9]+.[0-9]+.[0-9]+(.[0-9]+)?$"
 jobs:
   build:
     name: Release JDK ${{ matrix.java }}


### PR DESCRIPTION
Motivation:

To allow us releasing versions like a.b.c and a.b.c.d, we need to improve the regex to account for the optional 4th section.

Modifications:

- Update ci-release.yml

Result:

Release job will be triggered for both a.b.c and a.b.c.d versions.