### PR TITLE
Split release tag regex into 2 separate patterns

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -2,7 +2,8 @@ name: Release Publisher
 on:
   push:
     tags:
-      - "^[0-9]+.[0-9]+.[0-9]+(.[0-9]+)?$"
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+.[0-9]+"
 jobs:
   build:
     name: Release JDK ${{ matrix.java }}
@@ -58,7 +59,7 @@ jobs:
           sudo -E env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel -PreleaseBuild=true$FIRST_GRADLE_TARGETS && ./gradlew --no-daemon -PreleaseBuild=true$SECOND_GRADLE_TARGETS"
       - name: Publish Test Results
         if: always()
-        uses: scacap/action-surefire-report@be8172cc301d1805659f46260815db3e9ad574b2
+        uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -4,6 +4,7 @@ on:
     branches: [ main, '0.41', '0.42' ]
     tags-ignore:
       - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+.[0-9]+"
 jobs:
   build:
     name: Snapshot JDK ${{ matrix.java }}


### PR DESCRIPTION
Motivation:

GitHub Actions pattern matching does not support full regex features: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

Modifications:

- Split one regex into 2 different patterns;
- Do the same for ci-snapshot.yml to ignore these releases;

Result:

Release pipeline should be triggered for a.b.c and a.b.c.d releases.