### PR TITLE
Guard against trying to complete a cancelled Future

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -323,7 +323,7 @@ final class DefaultDnsClient implements DnsClient {
                             .addListener((Future<? super List<DnsRecord>> completedFuture) -> {
                                 Throwable cause = completedFuture.cause();
                                 if (cause != null) {
-                                    promise.setFailure(cause);
+                                    promise.tryFailure(cause);
                                 } else {
                                     final DnsAnswer<HostAndPort> dnsAnswer;
                                     long minTTLSeconds = Long.MAX_VALUE;
@@ -395,7 +395,7 @@ final class DefaultDnsClient implements DnsClient {
                     resolver.resolveAll(name).addListener(completedFuture -> {
                         Throwable cause = completedFuture.cause();
                         if (cause != null) {
-                            dnsAnswerPromise.setFailure(cause);
+                            dnsAnswerPromise.tryFailure(cause);
                         } else {
                             final DnsAnswer<InetAddress> dnsAnswer;
                             try {

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -359,7 +359,7 @@ final class DefaultDnsClient implements DnsClient {
                                             }
                                         }
                                     }
-                                    promise.setSuccess(dnsAnswer);
+                                    promise.trySuccess(dnsAnswer);
                                 }
                             });
                     return promise;
@@ -409,7 +409,7 @@ final class DefaultDnsClient implements DnsClient {
                                 dnsAnswerPromise.setFailure(cause2);
                                 return;
                             }
-                            dnsAnswerPromise.setSuccess(dnsAnswer);
+                            dnsAnswerPromise.trySuccess(dnsAnswer);
                         }
                     });
                     return dnsAnswerPromise;

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -350,7 +350,7 @@ final class DefaultDnsClient implements DnsClient {
                                         }
                                         dnsAnswer = new DnsAnswer<>(hostAndPorts, SECONDS.toNanos(minTTLSeconds));
                                     } catch (Throwable cause2) {
-                                        promise.setFailure(cause2);
+                                        promise.tryFailure(cause2);
                                         return;
                                     } finally {
                                         if (toRelease != null) {
@@ -406,7 +406,7 @@ final class DefaultDnsClient implements DnsClient {
                                                 (List<InetAddress>) completedFuture.getNow());
                                 dnsAnswer = new DnsAnswer<>(addresses, SECONDS.toNanos(ttlCache.minTtl(name)));
                             } catch (Throwable cause2) {
-                                dnsAnswerPromise.setFailure(cause2);
+                                dnsAnswerPromise.tryFailure(cause2);
                                 return;
                             }
                             dnsAnswerPromise.trySuccess(dnsAnswer);


### PR DESCRIPTION
Problem/Solution/Result

The DNS client can attempt to complete its result promise even after the Promise
itself has been cancelled upstream, ie the subscriber is no longer interested in
the DNS query results; this will result in an unhandled exception in what should
be a normal use case. We should instead replace calls to setSuccess with
trySuccess on the DNS Promise to guard against this situation.