### PR TITLE
Implement TLS Certificate Compression Support

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpService;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.CertificateCompressionAlgorithms;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslProvider;
+import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class SslCertificateCompressionTest {
+
+    /**
+     * Compares the bytes written and read when certificate compression is enabled vs. when it is not.
+     */
+    @Test
+    void negotiatesServerCertCompression() throws Exception {
+        final HttpService service = (ctx, request, responseFactory) ->
+            succeeded(responseFactory.ok().payloadBody("Hello World!", textSerializerUtf8()));
+
+        long readWithoutCompression;
+        long readWithCompression;
+        long writtenWithoutCompression;
+        long writtenWithCompression;
+
+        try (ServerContext server = serverBuilder(false).listenAndAwait(service)) {
+            SslBytesReadTransportObserver observer = new SslBytesReadTransportObserver();
+            try (BlockingHttpClient client = clientBuilder(server, false, observer).buildBlocking()) {
+                client.request(client.get("/sayHello"));
+                readWithoutCompression = observer.handshakeBytesRead;
+                writtenWithoutCompression = observer.handshakeBytesWritten;
+            }
+        }
+
+        try (ServerContext server = serverBuilder(true).listenAndAwait(service)) {
+            SslBytesReadTransportObserver observer = new SslBytesReadTransportObserver();
+            try (BlockingHttpClient client = clientBuilder(server, true, observer).buildBlocking()) {
+                client.request(client.get("/sayHello"));
+                readWithCompression = observer.handshakeBytesRead;
+                writtenWithCompression = observer.handshakeBytesWritten;
+            }
+        }
+
+        // We cannot assert "smaller than" with compression since depending on the certificate and the compression
+        // algorithm chosen the result might not actually be smaller - but it is certainly different.
+        assertNotEquals(readWithCompression, readWithoutCompression);
+        assertNotEquals(writtenWithCompression, writtenWithoutCompression);
+    }
+
+    private static HttpServerBuilder serverBuilder(final boolean withCompression) {
+        ServerSslConfigBuilder sslConfig = new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
+                DefaultTestCerts::loadServerKey).provider(SslProvider.OPENSSL);
+        if (withCompression) {
+            sslConfig.certificateCompressionAlgorithms(
+                    Collections.singletonList(CertificateCompressionAlgorithms.zlibDefault()));
+        }
+        return HttpServers.forAddress(localAddress(0)).sslConfig(sslConfig.build());
+    }
+
+    private static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder(
+            ServerContext ctx, boolean withCompression, SslBytesReadTransportObserver observer) {
+        ClientSslConfigBuilder sslConfig = new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                .peerHost(serverPemHostname())
+                .provider(SslProvider.OPENSSL);
+        if (withCompression) {
+            sslConfig.certificateCompressionAlgorithms(
+                    Collections.singletonList(CertificateCompressionAlgorithms.zlibDefault()));
+        }
+        return HttpClients
+                .forSingleAddress(serverHostAndPort(ctx))
+                .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(observer))
+                .sslConfig(sslConfig.build());
+    }
+
+    static class SslBytesReadTransportObserver implements TransportObserver {
+        long handshakeBytesRead;
+        long handshakeBytesWritten;
+        boolean inHandshake;
+
+        @Override
+        public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
+            return new ConnectionObserver() {
+                @Override
+                public void onDataRead(final int size) {
+                    if (inHandshake) {
+                        handshakeBytesRead += size;
+                    }
+                }
+
+                @Override
+                public void onDataWrite(final int size) {
+                    if (inHandshake) {
+                        handshakeBytesWritten += size;
+                    }
+                }
+
+                @Override
+                public SecurityHandshakeObserver onSecurityHandshake() {
+                    inHandshake = true;
+                    return new SecurityHandshakeObserver() {
+                        @Override
+                        public void handshakeFailed(final Throwable cause) {
+                            inHandshake = false;
+                        }
+
+                        @Override
+                        public void handshakeComplete(final SSLSession sslSession) {
+                            inHandshake = false;
+                        }
+                    };
+                }
+
+                @Override
+                public void onFlush() {
+                }
+
+                @Override
+                public void onTransportHandshakeComplete() {
+                }
+
+                @Override
+                public DataObserver connectionEstablished(final ConnectionInfo info) {
+                    return NoopTransportObserver.NoopDataObserver.INSTANCE;
+                }
+
+                @Override
+                public MultiplexedObserver multiplexedConnectionEstablished(final ConnectionInfo info) {
+                    return NoopTransportObserver.NoopMultiplexedObserver.INSTANCE;
+                }
+
+                @Override
+                public void connectionClosed(final Throwable error) {
+                }
+
+                @Override
+                public void connectionClosed() {
+                }
+            };
+        }
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfig.java
@@ -46,6 +46,9 @@ abstract class AbstractSslConfig implements SslConfig {
     @Nullable
     private final SslProvider provider;
 
+    @Nullable
+    private final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms;
+
     AbstractSslConfig(@Nullable final TrustManagerFactory trustManagerFactory,
                       @Nullable final Supplier<InputStream> trustCertChainSupplier,
                       @Nullable final KeyManagerFactory keyManagerFactory,
@@ -54,7 +57,8 @@ abstract class AbstractSslConfig implements SslConfig {
                       @Nullable final String keyPassword, @Nullable final List<String> sslProtocols,
                       @Nullable final List<String> alpnProtocols,
                       @Nullable final List<String> ciphers, final long sessionCacheSize,
-                      final long sessionTimeout, @Nullable final SslProvider provider) {
+                      final long sessionTimeout, @Nullable final SslProvider provider,
+                      @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms) {
         this.trustManagerFactory = trustManagerFactory;
         this.trustCertChainSupplier = trustCertChainSupplier;
         this.keyManagerFactory = keyManagerFactory;
@@ -67,6 +71,7 @@ abstract class AbstractSslConfig implements SslConfig {
         this.sessionCacheSize = sessionCacheSize;
         this.sessionTimeout = sessionTimeout;
         this.provider = provider;
+        this.certificateCompressionAlgorithms = certificateCompressionAlgorithms;
     }
 
     @Nullable
@@ -137,5 +142,11 @@ abstract class AbstractSslConfig implements SslConfig {
     @Override
     public final SslProvider provider() {
         return provider;
+    }
+
+    @Nullable
+    @Override
+    public List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms() {
+        return certificateCompressionAlgorithms;
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.api;
 
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -54,6 +55,8 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
     private long sessionTimeout;
     @Nullable
     private SslProvider provider;
+    @Nullable
+    private List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms;
 
     /**
      * Set the {@link TrustManagerFactory} used for verifying the remote endpoint's certificate.
@@ -317,6 +320,37 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
     @Nullable
     final SslProvider provider() {
         return provider;
+    }
+
+    /**
+     * Sets the certificate compression algorithms to advertise if the feature is supported at runtime.
+     *
+     * @param algorithms the certificate compression algorithms to use.
+     * @return {@code this}.
+     * @see CertificateCompressionAlgorithms
+     */
+    public final T certificateCompressionAlgorithms(final List<CertificateCompressionAlgorithm> algorithms) {
+        if (algorithms.isEmpty()) {
+            throw new IllegalArgumentException("algorithms cannot be empty");
+        }
+        this.certificateCompressionAlgorithms = algorithms;
+        return thisT();
+    }
+
+    /**
+     * Sets the certificate compression algorithms to advertise if the feature is supported at runtime.
+     *
+     * @param algorithms the certificate compression algorithms to use.
+     * @return {@code this}.
+     * @see CertificateCompressionAlgorithms
+     */
+    public final T certificateCompressionAlgorithms(final CertificateCompressionAlgorithm... algorithms) {
+        return certificateCompressionAlgorithms(Arrays.asList(algorithms));
+    }
+
+    @Nullable
+    final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms() {
+        return certificateCompressionAlgorithms;
     }
 
     abstract T thisT();

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CertificateCompressionAlgorithm.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CertificateCompressionAlgorithm.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+/**
+ * Represents an algorithm that can compress and decompress SSL certificates.
+ * <p>
+ * This feature is defined in <a href="https://www.rfc-editor.org/rfc/rfc8879">RFC 8879</a> as an optional extension
+ * to TLS 1.3 and later.
+ */
+public interface CertificateCompressionAlgorithm {
+
+    /**
+     * Get the unique identifier for this algorithm.
+     * <p>
+     * RFC 8879 defines unique identifiers for each algorithm type and the returned value must reflect those defined
+     * in <a href="https://www.rfc-editor.org/rfc/rfc8879#section-7.3">the RFC</a>.
+     *
+     * @return the unique identifier for this algorithm.
+     */
+    int algorithmId();
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CertificateCompressionAlgorithms.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CertificateCompressionAlgorithms.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+/**
+ * A factory to create {@link CertificateCompressionAlgorithm Certificate Compression Algorithms}.
+ */
+public final class CertificateCompressionAlgorithms {
+
+    /**
+     * Unique ZLIB algorithm ID as defined in
+     * <a href="https://www.rfc-editor.org/rfc/rfc8879#name-compression-algorithms">RFC8879</a>.
+     */
+    public static final int ZLIB_ALGORITHM_ID = 0x01;
+
+    /**
+     * This just satisfies the marker interface which allows to extend the API in the future.
+     * <p>
+     * Currently, the actual ZLIB implementation can be found in transport-netty-internal.
+     */
+    private static final CertificateCompressionAlgorithm ZLIB = () -> ZLIB_ALGORITHM_ID;
+
+    private CertificateCompressionAlgorithms() {
+    }
+
+    /**
+     * Get the default ZLIB {@link CertificateCompressionAlgorithm}.
+     *
+     * @return the default ZLIB {@link CertificateCompressionAlgorithm}.
+     */
+    public static CertificateCompressionAlgorithm zlibDefault() {
+        return ZLIB;
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CertificateCompressionException.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CertificateCompressionException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+/**
+ * When thrown contains information about a failure during TLS certificate compression.
+ */
+public final class CertificateCompressionException extends RuntimeException {
+
+    /**
+     * Create a new {@link CertificateCompressionException} with just a message.
+     *
+     * @param message the message for the exception.
+     */
+    public CertificateCompressionException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Create a new {@link CertificateCompressionException} with message and cause.
+     *
+     * @param message the message for the exception.
+     * @param cause the cause of this exception.
+     */
+    public CertificateCompressionException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CertificateCompressionException.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CertificateCompressionException.java
@@ -15,10 +15,13 @@
  */
 package io.servicetalk.transport.api;
 
+import javax.net.ssl.SSLException;
+
 /**
  * When thrown contains information about a failure during TLS certificate compression.
  */
-public final class CertificateCompressionException extends RuntimeException {
+public final class CertificateCompressionException extends SSLException {
+    private static final long serialVersionUID = -8127714610191317316L;
 
     /**
      * Create a new {@link CertificateCompressionException} with just a message.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfigBuilder.java
@@ -133,7 +133,7 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
         return new DefaultClientSslConfig(hostnameVerificationAlgorithm, peerHost, peerPort, sniHostname,
                 trustManager(), trustCertChainSupplier(), keyManager(), keyCertChainSupplier(), keySupplier(),
                 keyPassword(), sslProtocols(), alpnProtocols(), ciphers(), sessionCacheSize(), sessionTimeout(),
-                provider());
+                provider(), certificateCompressionAlgorithms());
     }
 
     @Override
@@ -161,9 +161,11 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
                                @Nullable final Supplier<InputStream> keySupplier, @Nullable final String keyPassword,
                                @Nullable final List<String> sslProtocols, @Nullable final List<String> alpnProtocols,
                                @Nullable final List<String> ciphers, final long sessionCacheSize,
-                               final long sessionTimeout, @Nullable final SslProvider provider) {
+                               final long sessionTimeout, @Nullable final SslProvider provider,
+                               @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms) {
             super(trustManagerFactory, trustCertChainSupplier, keyManagerFactory, keyCertChainSupplier, keySupplier,
-                    keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout, provider);
+                    keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout, provider,
+                    certificateCompressionAlgorithms);
             this.hostnameVerificationAlgorithm = hostnameVerificationAlgorithm;
             this.peerHost = peerHost;
             this.peerPort = peerPort;

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingSslConfig.java
@@ -116,4 +116,10 @@ public abstract class DelegatingSslConfig<T extends SslConfig> implements SslCon
     public SslProvider provider() {
         return delegate.provider();
     }
+
+    @Nullable
+    @Override
+    public List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms() {
+        return delegate.certificateCompressionAlgorithms();
+    }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSslConfigBuilder.java
@@ -97,7 +97,7 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
     public ServerSslConfig build() {
         return new DefaultServerSslConfig(clientAuthMode, trustManager(), trustCertChainSupplier(), keyManager(),
                 keyCertChainSupplier(), keySupplier(), keyPassword(), sslProtocols(), alpnProtocols(), ciphers(),
-                sessionCacheSize(), sessionTimeout(), provider());
+                sessionCacheSize(), sessionTimeout(), provider(), certificateCompressionAlgorithms());
     }
 
     @Override
@@ -116,9 +116,11 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
                                @Nullable final Supplier<InputStream> keySupplier, @Nullable final String keyPassword,
                                @Nullable final List<String> sslProtocols, @Nullable final List<String> alpnProtocols,
                                @Nullable final List<String> ciphers, final long sessionCacheSize,
-                               final long sessionTimeout, @Nullable final SslProvider provider) {
+                               final long sessionTimeout, @Nullable final SslProvider provider,
+                               @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms) {
             super(trustManagerFactory, trustCertChainSupplier, keyManagerFactory, keyCertChainSupplier, keySupplier,
-                    keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout, provider);
+                    keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout, provider,
+                    certificateCompressionAlgorithms);
             this.clientAuthMode = clientAuthMode;
         }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SslConfig.java
@@ -145,10 +145,13 @@ public interface SslConfig {
      * are advertised, the other side is not required per RFC to compress so certificates might still be sent
      * uncompressed.
      * <p>
-     * Also note that this feature is only available with
-     * <a href="https://netty.io/wiki/forked-tomcat-native.html">BoringSSL</a> implementation of
-     * {@link SslProvider#OPENSSL}. Provided compression algorithms are ignored when the {@link SslProvider#JDK} is
-     * used.
+     * Also note that this feature is only available with:
+     * <ul>
+     *     <li><a href="https://netty.io/wiki/forked-tomcat-native.html">BoringSSL</a> implementation of
+     *     {@link SslProvider#OPENSSL}. Provided compression algorithms are ignored when the {@link SslProvider#JDK} is
+     *     used.</li>
+     *     <li>TLSv1.3 or above.</li>
+     * </ul>
      *
      * @return the list of certificate compression algorithms to advertise.
      * @see <a href="https://www.rfc-editor.org/rfc/rfc8879">RFC8879 - TLS Certificate Compression</a>

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SslConfig.java
@@ -136,4 +136,25 @@ public interface SslConfig {
      */
     @Nullable
     SslProvider provider();
+
+    /**
+     * Get the list of usable {@link CertificateCompressionAlgorithm CertificateCompressionAlgorithms} to advertise.
+     * <p>
+     * If this method returns null (by default) or an empty list, no certificate compression algorithms will be
+     * advertised during the TLS handshake which effectively disables this feature. Note that even though they
+     * are advertised, the other side is not required per RFC to compress so certificates might still be sent
+     * uncompressed.
+     * <p>
+     * Also note that this feature is only available with
+     * <a href="https://netty.io/wiki/forked-tomcat-native.html">BoringSSL</a> implementation of
+     * {@link SslProvider#OPENSSL}. Provided compression algorithms are ignored when the {@link SslProvider#JDK} is
+     * used.
+     *
+     * @return the list of certificate compression algorithms to advertise.
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc8879">RFC8879 - TLS Certificate Compression</a>
+     */
+    @Nullable // FIXME 0.43 - remove default implementation
+    default List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms() {
+        return null;
+    }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
@@ -192,7 +192,7 @@ public final class SslContextFactory {
             // the API is opened up this logic needs to change and take user-fed algorithms into account.
             if (algorithm.algorithmId() == CertificateCompressionAlgorithms.ZLIB_ALGORITHM_ID) {
                 configBuilder.addAlgorithm(
-                        new ZlibOpenSslCertificateCompressionAlgorithm(),
+                        ZlibOpenSslCertificateCompressionAlgorithm.INSTANCE,
                         OpenSslCertificateCompressionConfig.AlgorithmMode.Both
                 );
             } else {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
@@ -15,13 +15,18 @@
  */
 package io.servicetalk.transport.netty.internal;
 
+import io.servicetalk.transport.api.CertificateCompressionAlgorithm;
+import io.servicetalk.transport.api.CertificateCompressionAlgorithms;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.SslConfig;
 
 import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.OpenSslCertificateCompressionConfig;
+import io.netty.handler.ssl.OpenSslContextOption;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 
 import java.io.InputStream;
 import java.util.List;
@@ -72,11 +77,16 @@ public final class SslContextFactory {
             }
         }
         List<String> alpnProtocols = config.alpnProtocols();
-        builder.sslProvider(toNettySslProvider(config.provider(), alpnProtocols != null && !alpnProtocols.isEmpty()));
+        SslProvider nettySslProvider =
+                toNettySslProvider(config.provider(), alpnProtocols != null && !alpnProtocols.isEmpty());
+        builder.sslProvider(nettySslProvider);
 
         builder.protocols(config.sslProtocols());
         builder.ciphers(config.ciphers());
         builder.applicationProtocolConfig(nettyApplicationProtocol(alpnProtocols));
+
+        configureCertificateCompression(config, builder, nettySslProvider, false);
+
         try {
             return builder.build();
         } catch (SSLException e) {
@@ -132,7 +142,12 @@ public final class SslContextFactory {
         builder.protocols(config.sslProtocols());
         builder.ciphers(config.ciphers());
 
-        builder.sslProvider(toNettySslProvider(config.provider(), alpnProtocols != null && !alpnProtocols.isEmpty()));
+        io.netty.handler.ssl.SslProvider nettySslProvider =
+                toNettySslProvider(config.provider(), alpnProtocols != null && !alpnProtocols.isEmpty());
+        builder.sslProvider(nettySslProvider);
+
+        configureCertificateCompression(config, builder, nettySslProvider, true);
+
         try {
             return builder.build();
         } catch (SSLException e) {
@@ -151,6 +166,40 @@ public final class SslContextFactory {
                 closeAndRethrowUnchecked(trustManagerStream);
             }
         }
+    }
+
+    private static void configureCertificateCompression(SslConfig config, SslContextBuilder builder,
+                                                        @Nullable io.netty.handler.ssl.SslProvider nettySslProvider,
+                                                        boolean forServer) {
+        final List<CertificateCompressionAlgorithm> algorithms = config.certificateCompressionAlgorithms();
+        if (algorithms == null || algorithms.isEmpty()) {
+            return;
+        }
+
+        if (nettySslProvider == null) {
+            nettySslProvider = forServer ? SslContext.defaultServerProvider() : SslContext.defaultClientProvider();
+        }
+
+        // TODO: change once https://github.com/netty/netty/pull/13145 is merged and released
+        if (nettySslProvider != SslProvider.OPENSSL) {
+            return;
+        }
+
+        final OpenSslCertificateCompressionConfig.Builder configBuilder =
+                OpenSslCertificateCompressionConfig.newBuilder();
+        for (CertificateCompressionAlgorithm algorithm : algorithms) {
+            // Right now all we support is ZLIB - and it is not possible for the user to extend the list. Once
+            // the API is opened up this logic needs to change and take user-fed algorithms into account.
+            if (algorithm.algorithmId() == CertificateCompressionAlgorithms.ZLIB_ALGORITHM_ID) {
+                configBuilder.addAlgorithm(
+                        new ZlibOpenSslCertificateCompressionAlgorithm(),
+                        OpenSslCertificateCompressionConfig.AlgorithmMode.Both
+                );
+            } else {
+                throw new IllegalArgumentException("Unsupported: " + algorithm);
+            }
+        }
+        builder.option(OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS, configBuilder.build());
     }
 
     @Nullable

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithm.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithm.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.CertificateCompressionAlgorithms;
+import io.servicetalk.transport.api.CertificateCompressionException;
+
+import io.netty.handler.ssl.OpenSslCertificateCompressionAlgorithm;
+
+import java.io.ByteArrayOutputStream;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+import javax.net.ssl.SSLEngine;
+
+/**
+ * Implements ZLIB compression and decompression of OpenSSL certificates.
+ *
+ * @see <a href="https://www.zlib.net">ZLIB Website</a>
+ */
+final class ZlibOpenSslCertificateCompressionAlgorithm implements OpenSslCertificateCompressionAlgorithm {
+
+    @Override
+    public byte[] compress(final SSLEngine engine, final byte[] uncompressedCertificate) {
+        int uncompressedLength = uncompressedCertificate.length;
+        if (uncompressedLength == 0) {
+            return uncompressedCertificate;
+        }
+
+        final Deflater deflater = new Deflater();
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            deflater.setInput(uncompressedCertificate);
+            deflater.finish();
+
+            // This calculation (which is also used inside Netty) comes from the C library which describes it as:
+            // "...must be at least 0.1% larger than the uncompressed length plus 12 bytes..."
+            int bufferSizeEstimate = (int) Math.ceil(uncompressedLength * 1.001) + 12;
+
+            byte[] compressionBuffer = new byte[bufferSizeEstimate];
+            while (!deflater.finished()) {
+                int bytesCompressed = deflater.deflate(compressionBuffer);
+                outputStream.write(compressionBuffer, 0, bytesCompressed);
+            }
+            return outputStream.toByteArray();
+        } catch (Exception cause) {
+            throw new CertificateCompressionException("Failed to compress certificate with " + getClass(), cause);
+        } finally {
+            deflater.end();
+        }
+    }
+
+    @Override
+    public byte[] decompress(final SSLEngine engine, final int uncompressedLen, final byte[] compressedCertificate) {
+        if (compressedCertificate.length == 0) {
+            return compressedCertificate;
+        }
+
+        final Inflater inflater = new Inflater();
+        try {
+            inflater.setInput(compressedCertificate);
+
+            // We do not need to create a ByteArrayOutputStream like we do on compression, since we know the maximum
+            // size on decompress is provided as an argument and anything larger would be a violation of the RFC so
+            // it will be rejected with an Exception.
+            byte[] output = new byte[uncompressedLen];
+            int bytesWritten = 0;
+            while (!inflater.finished()) {
+                int decompressedBytes = inflater.inflate(output, bytesWritten, uncompressedLen - bytesWritten);
+                bytesWritten += decompressedBytes;
+                if (bytesWritten > uncompressedLen) {
+                    throw new CertificateCompressionException("Number of bytes written exceeds the " +
+                            "uncompressed certificate length");
+                }
+            }
+            return output;
+        } catch (Exception cause) {
+            throw new CertificateCompressionException("Failed to decompress certificate with " + getClass(), cause);
+        } finally {
+            inflater.end();
+        }
+    }
+
+    @Override
+    public int algorithmId() {
+        return CertificateCompressionAlgorithms.ZLIB_ALGORITHM_ID;
+    }
+}

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithmTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithmTest.java
@@ -34,7 +34,7 @@ class ZlibOpenSslCertificateCompressionAlgorithmTest {
     void compressAndDecompressCertificate() throws Exception {
         byte[] originalCert = inputStreamToArray(DefaultTestCerts.loadServerPem());
 
-        OpenSslCertificateCompressionAlgorithm algorithm = new ZlibOpenSslCertificateCompressionAlgorithm();
+        OpenSslCertificateCompressionAlgorithm algorithm = ZlibOpenSslCertificateCompressionAlgorithm.INSTANCE;
         byte[] compressedCert = algorithm.compress(null, originalCert);
         byte[] uncompressedCert = algorithm.decompress(null, originalCert.length, compressedCert);
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithmTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithmTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.test.resources.DefaultTestCerts;
+
+import io.netty.handler.ssl.OpenSslCertificateCompressionAlgorithm;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class ZlibOpenSslCertificateCompressionAlgorithmTest {
+
+    /**
+     * Simple round-trip test for the happy path as a sanity check.
+     */
+    @Test
+    void compressAndDecompressCertificate() throws Exception {
+        byte[] originalCert = inputStreamToArray(DefaultTestCerts.loadServerPem());
+
+        OpenSslCertificateCompressionAlgorithm algorithm = new ZlibOpenSslCertificateCompressionAlgorithm();
+        byte[] compressedCert = algorithm.compress(null, originalCert);
+        byte[] uncompressedCert = algorithm.decompress(null, originalCert.length, compressedCert);
+
+        assertArrayEquals(originalCert, uncompressedCert);
+    }
+
+    private static byte[] inputStreamToArray(final InputStream inputStream) throws Exception {
+        byte[] buffer = new byte[1000];
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        int temp;
+        while ((temp = inputStream.read(buffer)) != -1) {
+            outputStream.write(buffer, 0, temp);
+        }
+        return outputStream.toByteArray();
+    }
+}


### PR DESCRIPTION
Motivation:

RFC 8879 defines a TLS extension called "TLS Certificate Compression" which allows to compress certificates and possibly reduce the amount of data exchanged during a TLS handshake.

Since netty already added support for it when used together with BoringSSL (netty-tcnative), ServiceTalk can benefit from a higher-level integration.

Modifications:

This changeset implements ServiceTalk API for Certificate Compression and hooks it up with the Netty APIs internally.

The main entry point for the user is through the SslConfigBuilder where they can set the supported algorithms (for now only ZLIB) for both client and server use cases. We also support both the compression and decompression depending on the use case.

At the moment it is not possible to define custom algorithms, although the API has been design with this use-case in mind to open it up later if needed.

ZlibOpenSslCertificateCompressionAlgorithm performs the actual compression and decompression and is called from the netty layer when doing so.

NOTE: since certificate compression is a "best effort" optimization, there is no failure if the feature is not supported or not available at runtime. If needed, inspection through a TransportObserver can determine if the number of bytes exchanged during a handshake are decreased or not.

Result:

TLS certificate compression with ZLIB can now be enabled and lead to less network overhead when performing the TLS handshake.