### PR TITLE
Use SslProvider.isOptionSupported to determine certificate compression support

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
@@ -32,6 +32,7 @@ import io.servicetalk.transport.api.SslProvider;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
+import io.netty.handler.ssl.OpenSsl;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -47,6 +48,7 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class SslCertificateCompressionTest {
 
@@ -56,6 +58,8 @@ class SslCertificateCompressionTest {
     @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
     @ValueSource(booleans = {true, false})
     void negotiatesCertificateCompression(boolean clientEnabled) throws Exception {
+        assumeTrue(OpenSsl.isAvailable());
+
         final HttpService service = (ctx, request, responseFactory) ->
             succeeded(responseFactory.ok().payloadBody("Hello World!", textSerializerUtf8()));
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
@@ -168,6 +168,20 @@ public final class SslContextFactory {
         }
     }
 
+    /**
+     * Configures TLS Certificate Compression if enabled and available.
+     * <p>
+     * Note that in addition to the application actually enabling and configuring TLS certificate compression on the
+     * {@link SslConfig}, it must also be available in the environment. Right now it is only supported through
+     * BoringSSL and as such the code checks if the {@link OpenSslContextOption} is available at runtime. If it is not,
+     * no error is raised but the feature is not enabled. This is by design, since certificate compression is a pure
+     * optimization instead of a security feature.
+     *
+     * @param config the ServiceTalk TLS config which enables and configures cert compression.
+     * @param builder netty's builder for the SSL context.
+     * @param nettySslProvider the (potentially null) SSL provider used with netty.
+     * @param forServer if this is for a server or client context.
+     */
     private static void configureCertificateCompression(SslConfig config, SslContextBuilder builder,
                                                         @Nullable io.netty.handler.ssl.SslProvider nettySslProvider,
                                                         boolean forServer) {
@@ -180,8 +194,7 @@ public final class SslContextFactory {
             nettySslProvider = forServer ? SslContext.defaultServerProvider() : SslContext.defaultClientProvider();
         }
 
-        // TODO: change once https://github.com/netty/netty/pull/13145 is merged and released
-        if (nettySslProvider != SslProvider.OPENSSL) {
+        if (!SslProvider.isOptionSupported(nettySslProvider, OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS)) {
             return;
         }
 


### PR DESCRIPTION
Motivation:

Netty recently added a getter to SslProvider which allows us to check if certain options are supported or not.

Modifications:

This changeset changes the SslContextFactory to use this new getter and explicitly check for
OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS before enabling certificate compression.

Result:

More reliable check if certificate compression is supported or not.