### PR TITLE
Implement explicit, customizable DNS maxTTL

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -730,9 +730,9 @@ final class DefaultDnsClient implements DnsClient {
 
                     ttlNanos = dnsAnswer.ttlNanos();
                     if (ttlNanos > maxTTLNanos) {
-                        LOGGER.info("{} DNS Record {} has a high TTL of {}ms which is larger than maxTTL of {}ms, " +
-                                        "capping to maxTTL.", DefaultDnsClient.this, addresses,
-                                NANOSECONDS.toMillis(ttlNanos), NANOSECONDS.toMillis(maxTTLNanos));
+                        LOGGER.info("{} result for {} has a high TTL={}s which is larger than configured maxTTL={}s.",
+                                DefaultDnsClient.this, AbstractDnsPublisher.this,
+                                NANOSECONDS.toSeconds(ttlNanos), NANOSECONDS.toSeconds(maxTTLNanos));
                         ttlNanos = maxTTLNanos;
                     }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -40,14 +40,6 @@ import static java.util.Objects.requireNonNull;
  * resolve {@code A}, {@code AAAA}, {@code CNAME}, and  {@code SRV} type queries.
  */
 public final class DefaultDnsServiceDiscovererBuilder {
-
-    // Specifies the maximum TTL time in seconds that a DNS entry is allowed to have. If the server
-    // returns a larger one, it will be capped at this value.
-    //
-    // Note: this value is set to 1 hour by default because CoreDNS also uses 3600 seconds as its
-    // maximum value.
-    private static final int DEFAULT_MAX_TTL_SECS = (int) TimeUnit.HOURS.toSeconds(1);
-
     @Nullable
     private DnsServerAddressStreamProvider dnsServerAddressStreamProvider;
     private DnsResolverAddressTypes dnsResolverAddressTypes = systemDefault();
@@ -62,7 +54,7 @@ public final class DefaultDnsServiceDiscovererBuilder {
     @Nullable
     private Duration queryTimeout;
     private int minTTLSeconds = 10;
-    private int maxTTLSeconds = DEFAULT_MAX_TTL_SECS;
+    private int maxTTLSeconds = (int) TimeUnit.MINUTES.toSeconds(5);
     private Duration ttlJitter = ofSeconds(4);
     private int srvConcurrency = 2048;
     private boolean inactiveEventsOnError;

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
@@ -984,6 +984,25 @@ class DefaultDnsClientTest {
         latchOnError.await();
     }
 
+    @Test
+    void capsMaxTTL() throws Exception {
+        setup(builder -> builder.maxTTL(3));
+        final String domain = "servicetalk.io";
+        String ip = nextIp();
+        recordStore.addIPv4Address(domain, 5, ip);
+
+        TestPublisherSubscriber<ServiceDiscovererEvent<InetAddress>> subscriber = dnsQuery(domain);
+        Subscription subscription = subscriber.awaitSubscription();
+        subscription.request(Long.MAX_VALUE);
+
+        System.err.println(subscriber.takeOnNext());
+        recordStore.removeIPv4Address(domain, 1, ip);
+        advanceTime(3);
+        System.err.println(subscriber.takeOnNext());
+
+        //assertEvent(subscriber.takeOnNext(), ipv6, AVAILABLE);
+    }
+
     private static <T> Subscriber<ServiceDiscovererEvent<T>> mockThrowSubscriber(
             CountDownLatch latchOnError, Queue<ServiceDiscovererEvent<T>> queue) {
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
Motivation:

At the moment it is possible to configure a minTTL for DNS resolution, but maxTTL is not configured (the cache uses Integer.MAX_INT) and the actual maxTTL for resolution is applied to whatever the DNS entry returns from the server.

To provide more customizations as well as being able to explicitly "cap" a TTL at a maximum value, it makes sense to allow setting an explicit maximum TTL.

Modifications:

This changeset introduces a configurable maxTTL option on the DefaultDnsServiceDiscovererBuilder with a sensible default setting. This value then:

 - Propagates to netty's DefaultDnsCache as the maximum value

as well as

 - Caps the returned TTL from the server to this value and logs a INFO level message if it has been capped (since reaching the MAX is really not expected in a well configured environment and can point to issues the actual deployed system).

Result:

Configurable DNS maxTTL as well as TTL capping for the DNS records to provide better safety at runtime.