### PR TITLE
Implement DnsServiceDiscovererBuilderProvider

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -125,6 +125,7 @@ final class DefaultDnsClient implements DnsClient {
     private final boolean inactiveEventsOnError;
     private final long ttlJitterNanos;
     private final DnsResolverAddressTypes addressTypes;
+    private final String id;
     private boolean closed;
 
     DefaultDnsClient(final IoExecutor ioExecutor, final int minTTL, final long ttlJitterNanos,
@@ -137,7 +138,7 @@ final class DefaultDnsClient implements DnsClient {
                      @Nullable final DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
                      @Nullable final DnsServiceDiscovererObserver observer,
                      final ServiceDiscovererEvent.Status missingRecordStatus,
-                     final int maxTTL) {
+                     final int maxTTL, final String id) {
         if (srvConcurrency <= 0) {
             throw new IllegalArgumentException("srvConcurrency: " + srvConcurrency + " (expected >0)");
         }
@@ -155,6 +156,7 @@ final class DefaultDnsClient implements DnsClient {
         this.ttlJitterNanos = ttlJitterNanos;
         this.observer = observer;
         this.missingRecordStatus = missingRecordStatus;
+        this.id = id;
         asyncCloseable = toAsyncCloseable(graceful -> {
             if (nettyIoExecutor.isCurrentThreadEventLoop()) {
                 closeAsync0();
@@ -198,8 +200,7 @@ final class DefaultDnsClient implements DnsClient {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + // FIXME: change to the name/id when builder requires it
-                '@' + toHexString(hashCode());
+        return id;
     }
 
     // visible for testing

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -200,7 +200,7 @@ final class DefaultDnsClient implements DnsClient {
 
     @Override
     public String toString() {
-        return id;
+        return id + " (instance @" + toHexString(hashCode()) + ')';
     }
 
     // visible for testing

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -22,8 +22,8 @@ import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -38,12 +38,14 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Builder for <a href="https://tools.ietf.org/html/rfc1035">DNS</a> {@link ServiceDiscoverer} which will attempt to
- * resolve {@code A}, {@code AAAA}, {@code CNAME}, and  {@code SRV} type queries.
+ * resolve {@code A}, {@code AAAA}, {@code CNAME}, and {@code SRV} type queries.
+ *
+ * @deprecated this class will be made package-private in the future, rely on the {@link DnsServiceDiscovererBuilder}
+ * instead.
  */
+@Deprecated // FIXME: 0.43 - make package private
 public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDiscovererBuilder {
-
     private final String id;
-
     @Nullable
     private DnsServerAddressStreamProvider dnsServerAddressStreamProvider;
     private DnsResolverAddressTypes dnsResolverAddressTypes = systemDefault();
@@ -77,7 +79,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
      *
      * @deprecated use {@link DnsServiceDiscoverers#builder(String)} instead.
      */
-    @Deprecated
+    @Deprecated // FIXME: 0.43 - remove deprecated constructor
     public DefaultDnsServiceDiscovererBuilder() {
         this(UUID.randomUUID().toString());
     }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -97,12 +97,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
         return this;
     }
 
-    /**
-     * The maximum allowed TTL. This will be the maximum poll interval as well as the maximum dns cache value.
-     *
-     * @param maxTTLSeconds the maximum amount of time a cache entry will be considered valid (in seconds).
-     * @return {@code this}.
-     */
+    @Override
     public DefaultDnsServiceDiscovererBuilder maxTTL(final int maxTTLSeconds) {
         if (minTTLSeconds <= 0) {
             throw new IllegalArgumentException("maxTTLSeconds: " + maxTTLSeconds + " (expected > 0)");
@@ -111,15 +106,6 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
         return this;
     }
 
-    /**
-     * The jitter to apply to schedule the next query after TTL.
-     * <p>
-     * The jitter value will be added on top of the TTL value returned from the DNS server to help spread out
-     * subsequent DNS queries.
-     *
-     * @param ttlJitter The jitter to apply to schedule the next query after TTL.
-     * @return {@code this}.
-     */
     @Override
     public DefaultDnsServiceDiscovererBuilder ttlJitter(final Duration ttlJitter) {
         ensurePositive(ttlJitter, "jitter");

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
@@ -26,12 +26,24 @@ import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * A {@link DnsServiceDiscovererBuilder} that delegates all methods to another {@link DnsServiceDiscovererBuilder}.
+ */
 public class DelegatingDnsServiceDiscovererBuilder implements DnsServiceDiscovererBuilder {
 
     private DnsServiceDiscovererBuilder delegate;
 
     public DelegatingDnsServiceDiscovererBuilder(final DnsServiceDiscovererBuilder delegate) {
         this.delegate = requireNonNull(delegate);
+    }
+
+    /**
+     * Returns the {@link DnsServiceDiscovererBuilder} delegate.
+     *
+     * @return Delegate {@link DnsServiceDiscovererBuilder}.
+     */
+    protected final DnsServiceDiscovererBuilder delegate() {
+        return delegate;
     }
 
     @Override

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.IoExecutor;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+public class DelegatingDnsServiceDiscovererBuilder implements DnsServiceDiscovererBuilder {
+
+    private DnsServiceDiscovererBuilder delegate;
+
+    public DelegatingDnsServiceDiscovererBuilder(final DnsServiceDiscovererBuilder delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder minTTL(final int minTTLSeconds) {
+        delegate = delegate.minTTL(minTTLSeconds);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder ttlJitter(final Duration ttlJitter) {
+        delegate = delegate.ttlJitter(ttlJitter);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder dnsServerAddressStreamProvider(
+            @Nullable final DnsServerAddressStreamProvider dnsServerAddressStreamProvider) {
+        delegate = delegate.dnsServerAddressStreamProvider(dnsServerAddressStreamProvider);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder optResourceEnabled(final boolean optResourceEnabled) {
+        delegate = delegate.optResourceEnabled(optResourceEnabled);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder maxUdpPayloadSize(final int maxUdpPayloadSize) {
+        delegate = delegate.maxUdpPayloadSize(maxUdpPayloadSize);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder ndots(final int ndots) {
+        delegate = delegate.ndots(ndots);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder queryTimeout(final Duration queryTimeout) {
+        delegate = delegate.queryTimeout(queryTimeout);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder dnsResolverAddressTypes(
+            @Nullable final DnsResolverAddressTypes dnsResolverAddressTypes) {
+        delegate = delegate.dnsResolverAddressTypes(dnsResolverAddressTypes);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder ioExecutor(final IoExecutor ioExecutor) {
+        delegate = delegate.ioExecutor(ioExecutor);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder observer(final DnsServiceDiscovererObserver observer) {
+        delegate = delegate.observer(observer);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder missingRecordStatus(final ServiceDiscovererEvent.Status status) {
+        delegate = delegate.missingRecordStatus(status);
+        return this;
+    }
+
+    @Override
+    public ServiceDiscoverer<String, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
+    buildSrvDiscoverer() {
+        return delegate.buildSrvDiscoverer();
+    }
+
+    @Override
+    public ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
+    buildARecordDiscoverer() {
+        return delegate.buildARecordDiscoverer();
+    }
+}

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
@@ -33,6 +33,11 @@ public class DelegatingDnsServiceDiscovererBuilder implements DnsServiceDiscover
 
     private DnsServiceDiscovererBuilder delegate;
 
+    /**
+     * Creates a new builder which delegates to the provided {@link DnsServiceDiscovererBuilder}.
+     *
+     * @param delegate the delegate builder.
+     */
     public DelegatingDnsServiceDiscovererBuilder(final DnsServiceDiscovererBuilder delegate) {
         this.delegate = requireNonNull(delegate);
     }
@@ -49,6 +54,12 @@ public class DelegatingDnsServiceDiscovererBuilder implements DnsServiceDiscover
     @Override
     public DnsServiceDiscovererBuilder minTTL(final int minTTLSeconds) {
         delegate = delegate.minTTL(minTTLSeconds);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder maxTTL(final int maxTTLSeconds) {
+        delegate = delegate.maxTTL(maxTTLSeconds);
         return this;
     }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
@@ -43,7 +43,7 @@ public interface DnsServiceDiscovererBuilder {
      * @param maxTTLSeconds the maximum amount of time a cache entry will be considered valid (in seconds).
      * @return {@code this}.
      */
-    DnsServiceDiscovererBuilder maxTTL(final int maxTTLSeconds);
+    DnsServiceDiscovererBuilder maxTTL(int maxTTLSeconds);
 
     /**
      * The jitter to apply to schedule the next query after TTL.

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
@@ -24,8 +24,11 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import javax.annotation.Nullable;
 
+/**
+ * Builder for <a href="https://tools.ietf.org/html/rfc1035">DNS</a> {@link ServiceDiscoverer} which will attempt to
+ * resolve {@code A}, {@code AAAA}, {@code CNAME}, and {@code SRV} type queries.
+ */
 public interface DnsServiceDiscovererBuilder {
-
     /**
      * The minimum allowed TTL. This will be the minimum poll interval.
      *

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
@@ -38,6 +38,14 @@ public interface DnsServiceDiscovererBuilder {
     DnsServiceDiscovererBuilder minTTL(int minTTLSeconds);
 
     /**
+     * The maximum allowed TTL. This will be the maximum poll interval as well as the maximum dns cache value.
+     *
+     * @param maxTTLSeconds the maximum amount of time a cache entry will be considered valid (in seconds).
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder maxTTL(final int maxTTLSeconds);
+
+    /**
      * The jitter to apply to schedule the next query after TTL.
      * <p>
      * The jitter value will be added on top of the TTL value returned from the DNS server to help spread out

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.IoExecutor;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import javax.annotation.Nullable;
+
+public interface DnsServiceDiscovererBuilder {
+
+    /**
+     * The minimum allowed TTL. This will be the minimum poll interval.
+     *
+     * @param minTTLSeconds The minimum amount of time a cache entry will be considered valid (in seconds).
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder minTTL(int minTTLSeconds);
+
+    /**
+     * The jitter to apply to schedule the next query after TTL.
+     * <p>
+     * The jitter value will be added on top of the TTL value returned from the DNS server to help spread out
+     * subsequent DNS queries.
+     *
+     * @param ttlJitter The jitter to apply to schedule the next query after TTL.
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder ttlJitter(Duration ttlJitter);
+
+    /**
+     * Set the {@link DnsServerAddressStreamProvider} which determines which DNS server should be used per query.
+     *
+     * @param dnsServerAddressStreamProvider the {@link DnsServerAddressStreamProvider} which determines which DNS
+     * server should be used per query.
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder dnsServerAddressStreamProvider(
+            @Nullable DnsServerAddressStreamProvider dnsServerAddressStreamProvider);
+
+    /**
+     * Enable the automatic inclusion of a optional records that tries to give the remote DNS server a hint about
+     * how much data the resolver can read per response. Some DNSServer may not support this and so fail to answer
+     * queries. If you find problems you may want to disable this.
+     *
+     * @param optResourceEnabled if optional records inclusion is enabled.
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder optResourceEnabled(boolean optResourceEnabled);
+
+    /**
+     * Set the maximum size of the receiving UDP datagram (in bytes).
+     * <p>
+     * If the DNS response exceeds this amount the request will be automatically retried via TCP.
+     *
+     * @param maxUdpPayloadSize the maximum size of the receiving UDP datagram (in bytes)
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder maxUdpPayloadSize(int maxUdpPayloadSize);
+
+    /**
+     * Set the number of dots which must appear in a name before an initial absolute query is made.
+     *
+     * @param ndots the ndots value.
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder ndots(int ndots);
+
+    /**
+     * Sets the timeout of each DNS query performed by this service discoverer.
+     *
+     * @param queryTimeout the query timeout value
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder queryTimeout(Duration queryTimeout);
+
+    /**
+     * Sets the list of the protocol families of the address resolved.
+     *
+     * @param dnsResolverAddressTypes the address types or {@code null} to use the default value, based on "java.net"
+     * system properties: {@code java.net.preferIPv4Stack} and {@code java.net.preferIPv6Stack}.
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder dnsResolverAddressTypes(
+            @Nullable DnsResolverAddressTypes dnsResolverAddressTypes);
+
+    /**
+     * Sets the {@link IoExecutor}.
+     *
+     * @param ioExecutor {@link IoExecutor} to use.
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder ioExecutor(IoExecutor ioExecutor);
+
+    /**
+     * Sets a {@link DnsServiceDiscovererObserver} that provides visibility into
+     * <a href="https://tools.ietf.org/html/rfc1034">DNS</a> {@link ServiceDiscoverer} built by this builder.
+     *
+     * @param observer a {@link DnsServiceDiscovererObserver} that provides visibility into
+     * <a href="https://tools.ietf.org/html/rfc1034">DNS</a> {@link ServiceDiscoverer} built by this builder
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder observer(DnsServiceDiscovererObserver observer);
+
+    /**
+     * Sets which {@link ServiceDiscovererEvent.Status} to use in {@link ServiceDiscovererEvent#status()} when a record
+     * for a previously seen address is missing in the response.
+     *
+     * @param status a {@link ServiceDiscovererEvent.Status} for missing records.
+     * @return {@code this}.
+     */
+    DnsServiceDiscovererBuilder missingRecordStatus(ServiceDiscovererEvent.Status status);
+
+    /**
+     * Build a new {@link ServiceDiscoverer} which queries
+     * <a href="https://tools.ietf.org/html/rfc2782">SRV Resource Records</a> corresponding to {@code serviceName}. For
+     * each SRV answer capture the <strong>Port</strong> and resolve the <strong>Target</strong>.
+     * @return a new {@link ServiceDiscoverer} which queries
+     * <a href="https://tools.ietf.org/html/rfc2782">SRV Resource Records</a> corresponding to {@code serviceName}. For
+     * each SRV answer capture the <strong>Port</strong> and resolve the <strong>Target</strong>.
+     */
+    ServiceDiscoverer<String, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> buildSrvDiscoverer();
+
+    /**
+     * Build a new {@link ServiceDiscoverer} which targets
+     * <a href="https://tools.ietf.org/html/rfc1035">host addresses</a> (e.g. A or AAAA records) and uses
+     * a fixed port derived from the {@link HostAndPort}.
+     * @return a new {@link ServiceDiscoverer} which targets
+     * <a href="https://tools.ietf.org/html/rfc1035">host addresses</a> (e.g. A or AAAA records) and uses
+     * a fixed port derived from the {@link HostAndPort}.
+     */
+    ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
+    buildARecordDiscoverer();
+}

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProvider.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+/**
+ * Provider for {@link DnsServiceDiscovererBuilder}.
+ */
+@FunctionalInterface
+public interface DnsServiceDiscovererBuilderProvider {
+
+    DnsServiceDiscovererBuilder newBuilder(String id, DnsServiceDiscovererBuilder builder);
+}

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProvider.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProvider.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.dns.discovery.netty;
 
+import io.servicetalk.client.api.ServiceDiscoverer;
+
 /**
  * Provider for {@link DnsServiceDiscovererBuilder}.
  */
@@ -28,7 +30,7 @@ public interface DnsServiceDiscovererBuilderProvider {
      * This method may return the pre-initialized {@code builder} as-is, or apply custom builder settings before
      * returning it, or wrap it ({@link DelegatingDnsServiceDiscovererBuilder} may be helpful).
      *
-     * @param id a (unique) identifier used to identify the underlying {@link DnsClient}.
+     * @param id a (unique) identifier used to identify the underlying {@link ServiceDiscoverer}.
      * @param builder pre-initialized {@link DnsServiceDiscovererBuilder}.
      * @return a {@link DnsServiceDiscovererBuilder} based on the unique ID and the
      * pre-initialized {@link DnsServiceDiscovererBuilder}.

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProvider.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProvider.java
@@ -21,5 +21,18 @@ package io.servicetalk.dns.discovery.netty;
 @FunctionalInterface
 public interface DnsServiceDiscovererBuilderProvider {
 
+    /**
+     * Returns a {@link DnsServiceDiscovererBuilder} based on the (unique) id and
+     * pre-initialized {@link DnsServiceDiscovererBuilder}.
+     * <p>
+     * This method may return the pre-initialized {@code builder} as-is, or apply custom builder settings before
+     * returning it, or wrap it ({@link DelegatingDnsServiceDiscovererBuilder} may be helpful).
+     *
+     * @param id a (unique) identifier used to identify the underlying {@link DnsClient}.
+     * @param builder pre-initialized {@link DnsServiceDiscovererBuilder}.
+     * @return a {@link DnsServiceDiscovererBuilder} based on the unique ID and the
+     * pre-initialized {@link DnsServiceDiscovererBuilder}.
+     * @see DelegatingDnsServiceDiscovererBuilder
+     */
     DnsServiceDiscovererBuilder newBuilder(String id, DnsServiceDiscovererBuilder builder);
 }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscoverers.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscoverers.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static io.servicetalk.utils.internal.ServiceLoaderUtils.loadProviders;
+
+public final class DnsServiceDiscoverers {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DnsServiceDiscoverers.class);
+
+    private static final List<DnsServiceDiscovererBuilderProvider> PROVIDERS;
+
+    static {
+        final ClassLoader classLoader = DnsServiceDiscoverers.class.getClassLoader();
+        PROVIDERS = loadProviders(DnsServiceDiscovererBuilderProvider.class, classLoader, LOGGER);
+    }
+
+    private DnsServiceDiscoverers() {
+        // No instances.
+    }
+
+    private static DnsServiceDiscovererBuilder applyProviders(final String id, DnsServiceDiscovererBuilder builder) {
+        for (DnsServiceDiscovererBuilderProvider provider : PROVIDERS) {
+            builder = provider.newBuilder(id, builder);
+        }
+        return builder;
+    }
+
+    public static DnsServiceDiscovererBuilder builder(final String id) {
+        return applyProviders(id, new DefaultDnsServiceDiscovererBuilder(id));
+    }
+}

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscoverers.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscoverers.java
@@ -22,6 +22,9 @@ import java.util.List;
 
 import static io.servicetalk.utils.internal.ServiceLoaderUtils.loadProviders;
 
+/**
+ * A factory to create DNS {@link io.servicetalk.client.api.ServiceDiscoverer ServiceDiscoverers}.
+ */
 public final class DnsServiceDiscoverers {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DnsServiceDiscoverers.class);
@@ -37,13 +40,22 @@ public final class DnsServiceDiscoverers {
         // No instances.
     }
 
-    private static DnsServiceDiscovererBuilder applyProviders(final String id, DnsServiceDiscovererBuilder builder) {
+    private static DnsServiceDiscovererBuilder applyProviders(String id, DnsServiceDiscovererBuilder builder) {
         for (DnsServiceDiscovererBuilderProvider provider : PROVIDERS) {
             builder = provider.newBuilder(id, builder);
         }
         return builder;
     }
 
+    /**
+     * A new {@link DnsServiceDiscovererBuilder} instance.
+     * <p>
+     * The returned builder can be customized using {@link DnsServiceDiscovererBuilderProvider}.
+     *
+     * @param id a (unique) ID to identify the created {@link DnsClient}.
+     * @return a new {@link DnsServiceDiscovererBuilder}.
+     */
+    @SuppressWarnings("deprecation")
     public static DnsServiceDiscovererBuilder builder(final String id) {
         return applyProviders(id, new DefaultDnsServiceDiscovererBuilder(id));
     }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscoverers.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscoverers.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.dns.discovery.netty;
 
+import io.servicetalk.client.api.ServiceDiscoverer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +54,7 @@ public final class DnsServiceDiscoverers {
      * <p>
      * The returned builder can be customized using {@link DnsServiceDiscovererBuilderProvider}.
      *
-     * @param id a (unique) ID to identify the created {@link DnsClient}.
+     * @param id a (unique) ID to identify the created {@link ServiceDiscoverer}.
      * @return a new {@link DnsServiceDiscovererBuilder}.
      */
     @SuppressWarnings("deprecation")

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
@@ -1085,7 +1085,7 @@ class DefaultDnsClientTest {
     }
 
     private DefaultDnsServiceDiscovererBuilder dnsClientBuilder() {
-        return new DefaultDnsServiceDiscovererBuilder()
+        return new DefaultDnsServiceDiscovererBuilder("test")
                 .ioExecutor(new NettyIoExecutorWithTestTimer(ioExecutor.executor(), timerExecutor.executor()))
                 .dnsResolverAddressTypes(IPV4_ONLY)
                 .optResourceEnabled(false)

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProviderTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProviderTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class DnsServiceDiscovererBuilderProviderTest {
+
+    private static final AtomicInteger buildCounter = new AtomicInteger();
+    private static final AtomicReference<String> buildId = new AtomicReference<>();
+
+    @Test
+    void appliesBuilderProvider() {
+        assertEquals(0, buildCounter.get());
+        assertNotNull(DnsServiceDiscoverers.builder("test"));
+        assertEquals(1, buildCounter.get());
+        assertEquals("test", buildId.get());
+    }
+
+    public static final class TestDnsServiceDiscovererBuilderProvider
+            implements DnsServiceDiscovererBuilderProvider {
+        @Override
+        public DnsServiceDiscovererBuilder newBuilder(final String id, final DnsServiceDiscovererBuilder builder) {
+            buildCounter.incrementAndGet();
+            buildId.set(id);
+            return new DelegatingDnsServiceDiscovererBuilder(builder);
+        }
+    }
+}

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProviderTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilderProviderTest.java
@@ -57,7 +57,8 @@ class DnsServiceDiscovererBuilderProviderTest {
                 @Override
                 public DnsServiceDiscovererBuilder ttlJitter(final Duration ttlJitter) {
                     ttlJitterIntercept.set(ttlJitter.toMillis());
-                    return super.ttlJitter(ttlJitter);
+                    delegate().ttlJitter(ttlJitter);
+                    return this;
                 }
             };
         }

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserverTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserverTest.java
@@ -84,7 +84,7 @@ class DnsServiceDiscovererObserverTest {
     }
 
     private DnsClient dnsClient(DnsServiceDiscovererObserver observer) {
-        return toClose.append(new DefaultDnsServiceDiscovererBuilder()
+        return toClose.append(new DefaultDnsServiceDiscovererBuilder("test")
                 .observer(observer)
                 .dnsResolverAddressTypes(DnsResolverAddressTypes.IPV4_PREFERRED)
                 .optResourceEnabled(false)

--- a/servicetalk-dns-discovery-netty/src/test/resources/META-INF/services/io.servicetalk.dns.discovery.netty.DnsServiceDiscovererBuilderProvider
+++ b/servicetalk-dns-discovery-netty/src/test/resources/META-INF/services/io.servicetalk.dns.discovery.netty.DnsServiceDiscovererBuilderProvider
@@ -1,0 +1,1 @@
+io.servicetalk.dns.discovery.netty.DnsServiceDiscovererBuilderProviderTest$TestDnsServiceDiscovererBuilderProvider

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/GlobalDnsServiceDiscoverer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/GlobalDnsServiceDiscoverer.java
@@ -21,7 +21,7 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.dns.discovery.netty.DefaultDnsServiceDiscovererBuilder;
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscoverers;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.HostAndPort;
 
@@ -86,7 +86,7 @@ final class GlobalDnsServiceDiscoverer {
 
     private static final class HostAndPortClientInitializer {
         static final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
-                HOST_PORT_SD = new DefaultDnsServiceDiscovererBuilder().buildARecordDiscoverer();
+                HOST_PORT_SD = DnsServiceDiscoverers.builder("global-host-port").buildARecordDiscoverer();
 
         static {
             LOGGER.debug("Initialized HostAndPortClientInitializer");
@@ -99,7 +99,7 @@ final class GlobalDnsServiceDiscoverer {
 
     private static final class SrvClientInitializer {
         static final ServiceDiscoverer<String, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> SRV_SD =
-                new DefaultDnsServiceDiscovererBuilder().buildSrvDiscoverer();
+                DnsServiceDiscoverers.builder("global-srv").buildSrvDiscoverer();
 
         static {
             LOGGER.debug("Initialized SrvClientInitializer");

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/GlobalDnsServiceDiscoverer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/GlobalDnsServiceDiscoverer.java
@@ -86,7 +86,7 @@ final class GlobalDnsServiceDiscoverer {
 
     private static final class HostAndPortClientInitializer {
         static final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
-                HOST_PORT_SD = DnsServiceDiscoverers.builder("global-host-port").buildARecordDiscoverer();
+                HOST_PORT_SD = DnsServiceDiscoverers.builder("global-a").buildARecordDiscoverer();
 
         static {
             LOGGER.debug("Initialized HostAndPortClientInitializer");


### PR DESCRIPTION
Motivation:

Similar to the related functionality in GRPC and HTTP servers, it can be useful to configure the DNS service discoverer also through a ServiceProvider.

Modifications:

This changeset introduces ServiceProvider functionality on top of the DefaultDnsServiceDiscovererBuilder. To do this, a new interface is introduced (to also provide a Delegate implementation) as well as a DnsServiceDiscoverers factory class to construct a builder with an ID.

Note that uniqueness on this ID is not enforced by ServiceTalk, but is something to recommend to the application developer when using this mechanism. The default construct is marked as deprecated and will use a UUID as the ID.

Result:

It is now possible to configure the DNS service discoverer through the ServiceProvider mechanism.