### PR TITLE
`RoundRobinLoadBalancer`: re-subscribe when all hosts become unhealthy

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialPublisherSubscriberFunction.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialPublisherSubscriberFunction.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -32,6 +33,7 @@ public final class SequentialPublisherSubscriberFunction<T>
         implements Function<Subscriber<? super T>, Subscriber<? super T>> {
 
     private final AtomicBoolean subscribed = new AtomicBoolean();
+    private final AtomicInteger numberOfSubscribers = new AtomicInteger();
     @Nullable
     private volatile Subscriber<? super T> subscriber;
 
@@ -41,6 +43,7 @@ public final class SequentialPublisherSubscriberFunction<T>
             throw new IllegalStateException("Duplicate subscriber: " + subscriber);
         }
         this.subscriber = subscriber;
+        numberOfSubscribers.incrementAndGet();
         return new DelegatingPublisherSubscriber<T>(subscriber) {
             @Override
             public void onSubscribe(final Subscription s) {
@@ -98,5 +101,14 @@ public final class SequentialPublisherSubscriberFunction<T>
      */
     public boolean isSubscribed() {
         return subscribed.get();
+    }
+
+    /**
+     * Returns total number of observed {@link Subscriber}s.
+     *
+     * @return total number of observed {@link Subscriber}s.
+     */
+    public int numberOfSubscribers() {
+        return numberOfSubscribers.get();
     }
 }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialPublisherSubscriberFunction.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialPublisherSubscriberFunction.java
@@ -33,7 +33,7 @@ public final class SequentialPublisherSubscriberFunction<T>
         implements Function<Subscriber<? super T>, Subscriber<? super T>> {
 
     private final AtomicBoolean subscribed = new AtomicBoolean();
-    private final AtomicInteger numberOfSubscribers = new AtomicInteger();
+    private final AtomicInteger numberOfSubscribersSeen = new AtomicInteger();
     @Nullable
     private volatile Subscriber<? super T> subscriber;
 
@@ -43,7 +43,7 @@ public final class SequentialPublisherSubscriberFunction<T>
             throw new IllegalStateException("Duplicate subscriber: " + subscriber);
         }
         this.subscriber = subscriber;
-        numberOfSubscribers.incrementAndGet();
+        numberOfSubscribersSeen.incrementAndGet();
         return new DelegatingPublisherSubscriber<T>(subscriber) {
             @Override
             public void onSubscribe(final Subscription s) {
@@ -108,7 +108,7 @@ public final class SequentialPublisherSubscriberFunction<T>
      *
      * @return total number of observed {@link Subscriber}s.
      */
-    public int numberOfSubscribers() {
-        return numberOfSubscribers.get();
+    public int numberOfSubscribersSeen() {
+        return numberOfSubscribersSeen.get();
     }
 }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestExecutor.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestExecutor.java
@@ -59,7 +59,12 @@ public class TestExecutor implements Executor {
         this(ThreadLocalRandom.current().nextLong());
     }
 
-    TestExecutor(final long epochNanos) {
+    /**
+     * Create a new instance.
+     *
+     * @param epochNanos initial value for {@link #currentTime(TimeUnit)} in nanoseconds
+     */
+    public TestExecutor(final long epochNanos) {
         currentNanos = epochNanos;
         nanoOffset = epochNanos - Long.MIN_VALUE;
     }

--- a/servicetalk-loadbalancer/build.gradle
+++ b/servicetalk-loadbalancer/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305"
   implementation "org.slf4j:slf4j-api"
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutor.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.concurrent.api.DelegatingExecutor;
+import io.servicetalk.concurrent.api.Executor;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * An {@link Executor} that always starts counting {@link #currentTime(TimeUnit)} from {@code 0}.
+ */
+final class NormalizedTimeSourceExecutor extends DelegatingExecutor {
+
+    private final long offset;
+
+    NormalizedTimeSourceExecutor(final Executor delegate) {
+        super(delegate);
+        offset = delegate.currentTime(NANOSECONDS);
+    }
+
+    @Override
+    public long currentTime(final TimeUnit unit) {
+        return delegate().currentTime(unit) - offset;
+    }
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -196,6 +196,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
     }
 
     private void subscribeToEvents(boolean resubscribe) {
+        // This method is invoked only when we are in RESUBSCRIBING state. Only one thread can own this state.
+        assert nextResubscribeTime == RESUBSCRIBING;
         if (resubscribe) {
             discoveryCancellable.cancelCurrent();
         }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -54,6 +54,7 @@ import java.util.Map.Entry;
 import java.util.Spliterator;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -84,7 +85,7 @@ import static java.lang.Math.min;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 import static java.util.stream.Collectors.toList;
 
@@ -102,10 +103,15 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
 
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<RoundRobinLoadBalancer, List> usedHostsUpdater =
-            newUpdater(RoundRobinLoadBalancer.class, List.class, "usedHosts");
+            AtomicReferenceFieldUpdater.newUpdater(RoundRobinLoadBalancer.class, List.class, "usedHosts");
     @SuppressWarnings("rawtypes")
     private static final AtomicIntegerFieldUpdater<RoundRobinLoadBalancer> indexUpdater =
-            newUpdater(RoundRobinLoadBalancer.class, "index");
+            AtomicIntegerFieldUpdater.newUpdater(RoundRobinLoadBalancer.class, "index");
+    @SuppressWarnings("rawtypes")
+    private static final AtomicLongFieldUpdater<RoundRobinLoadBalancer> nextResubscribeTimeUpdater =
+            AtomicLongFieldUpdater.newUpdater(RoundRobinLoadBalancer.class, "nextResubscribeTime");
+
+    private static final long RESUBSCRIBING = -1L;
 
     /**
      * With a relatively small number of connections we can minimize connection creation under moderate concurrency by
@@ -124,15 +130,20 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
      */
     private static final float RANDOM_SEARCH_FACTOR = 0.75f;
 
+    private volatile long nextResubscribeTime = RESUBSCRIBING;
     @SuppressWarnings("unused")
     private volatile int index;
     private volatile List<Host<ResolvedAddress, C>> usedHosts = emptyList();
 
     private final String targetResource;
+    private final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher;
+    private final Processor<Object, Object> eventStreamProcessor = newPublisherProcessorDropHeadOnOverflow(32);
     private final Publisher<Object> eventStream;
     private final SequentialCancellable discoveryCancellable = new SequentialCancellable();
     private final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory;
     private final int linearSearchSpace;
+    @Nullable
+    private final HealthCheckConfig healthCheckConfig;
     private final ListenableAsyncCloseable asyncCloseable;
 
     /**
@@ -154,169 +165,12 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             final int linearSearchSpace,
             @Nullable final HealthCheckConfig healthCheckConfig) {
         this.targetResource = requireNonNull(targetResourceName) + " (instance @" + toHexString(hashCode()) + ')';
-        Processor<Object, Object> eventStreamProcessor = newPublisherProcessorDropHeadOnOverflow(32);
+        this.eventPublisher = requireNonNull(eventPublisher);
         this.eventStream = fromSource(eventStreamProcessor);
         this.connectionFactory = requireNonNull(connectionFactory);
         this.linearSearchSpace = linearSearchSpace;
-
-        toSource(eventPublisher).subscribe(
-                new Subscriber<Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>>() {
-
-            @Override
-            public void onSubscribe(final Subscription s) {
-                // We request max value here to make sure we do not access Subscription concurrently
-                // (requestN here and cancel from discoveryCancellable). If we request-1 in onNext we would have to wrap
-                // the Subscription in a ConcurrentSubscription which is costly.
-                // Since, we synchronously process onNexts we do not really care about flow control.
-                s.request(Long.MAX_VALUE);
-                discoveryCancellable.nextCancellable(s);
-            }
-
-            @Override
-            public void onNext(final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
-                for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
-                    final ServiceDiscovererEvent.Status eventStatus = event.status();
-                    LOGGER.debug("Load balancer for {}: received new ServiceDiscoverer event {}. Inferred status: {}.",
-                            targetResource, event, eventStatus);
-
-                    @SuppressWarnings("unchecked")
-                    final List<Host<ResolvedAddress, C>> usedAddresses =
-                            usedHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, oldHosts -> {
-                                if (isClosedList(oldHosts)) {
-                                    return oldHosts;
-                                }
-                                final ResolvedAddress addr = requireNonNull(event.address());
-                                @SuppressWarnings("unchecked")
-                                final List<Host<ResolvedAddress, C>> oldHostsTyped =
-                                        (List<Host<ResolvedAddress, C>>) oldHosts;
-
-                                if (AVAILABLE.equals(eventStatus)) {
-                                    return addHostToList(oldHostsTyped, addr);
-                                } else if (EXPIRED.equals(eventStatus)) {
-                                    if (oldHostsTyped.isEmpty()) {
-                                        return emptyList();
-                                    } else {
-                                        return markHostAsExpired(oldHostsTyped, addr);
-                                    }
-                                } else if (UNAVAILABLE.equals(eventStatus)) {
-                                    return listWithHostRemoved(oldHostsTyped, host -> {
-                                        boolean match = host.address.equals(addr);
-                                        if (match) {
-                                            host.markClosed();
-                                        }
-                                        return match;
-                                    });
-                                } else {
-                                    LOGGER.error("Load balancer for {}: Unexpected Status in event:" +
-                                            " {} (mapped to {}). Leaving usedHosts unchanged: {}",
-                                            targetResource, event, eventStatus, oldHosts);
-                                    return oldHosts;
-                                }
-                            });
-
-                    LOGGER.debug("Load balancer for {}: now using {} addresses: {}.",
-                            targetResource, usedAddresses.size(), usedAddresses);
-
-                    if (AVAILABLE.equals(eventStatus)) {
-                        if (usedAddresses.size() == 1) {
-                            eventStreamProcessor.onNext(LOAD_BALANCER_READY_EVENT);
-                        }
-                    } else if (usedAddresses.isEmpty()) {
-                        eventStreamProcessor.onNext(LOAD_BALANCER_NOT_READY_EVENT);
-                    }
-                }
-            }
-
-            private List<Host<ResolvedAddress, C>> markHostAsExpired(
-                    final List<Host<ResolvedAddress, C>> oldHostsTyped, final ResolvedAddress addr) {
-                for (Host<ResolvedAddress, C> host : oldHostsTyped) {
-                    if (host.address.equals(addr)) {
-                        // Host removal will be handled by the Host's onClose::afterFinally callback
-                        host.markExpired();
-                        break;  // because duplicates are not allowed, we can stop iteration
-                    }
-                }
-                return oldHostsTyped;
-            }
-
-            private Host<ResolvedAddress, C> createHost(ResolvedAddress addr) {
-                Host<ResolvedAddress, C> host = new Host<>(targetResource, addr, healthCheckConfig);
-                host.onClose().afterFinally(() ->
-                        usedHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, previousHosts -> {
-                                    @SuppressWarnings("unchecked")
-                                    List<Host<ResolvedAddress, C>> previousHostsTyped =
-                                            (List<Host<ResolvedAddress, C>>) previousHosts;
-                                    return listWithHostRemoved(previousHostsTyped, current -> current == host);
-                                }
-                        )).subscribe();
-                return host;
-            }
-
-            private List<Host<ResolvedAddress, C>> addHostToList(
-                    List<Host<ResolvedAddress, C>> oldHostsTyped, ResolvedAddress addr) {
-                if (oldHostsTyped.isEmpty()) {
-                    return singletonList(createHost(addr));
-                }
-
-                // duplicates are not allowed
-                for (Host<ResolvedAddress, C> host : oldHostsTyped) {
-                    if (host.address.equals(addr)) {
-                        if (!host.markActiveIfNotClosed()) {
-                            // If the host is already in CLOSED state, we should create a new entry.
-                            // For duplicate ACTIVE events or for repeated activation due to failed CAS
-                            // of replacing the usedHosts array the marking succeeds so we will not add a new entry.
-                            break;
-                        }
-                        return oldHostsTyped;
-                    }
-                }
-
-                final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHostsTyped.size() + 1);
-                newHosts.addAll(oldHostsTyped);
-                newHosts.add(createHost(addr));
-                return newHosts;
-            }
-
-            private List<Host<ResolvedAddress, C>> listWithHostRemoved(
-                    List<Host<ResolvedAddress, C>> oldHostsTyped, Predicate<Host<ResolvedAddress, C>> hostPredicate) {
-                if (oldHostsTyped.isEmpty()) {
-                    // this can happen when an expired host is removed during closing of the RoundRobinLoadBalancer,
-                    // but all of its connections have already been closed
-                    return oldHostsTyped;
-                }
-                final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHostsTyped.size() - 1);
-                for (int i = 0; i < oldHostsTyped.size(); ++i) {
-                    final Host<ResolvedAddress, C> current = oldHostsTyped.get(i);
-                    if (hostPredicate.test(current)) {
-                        for (int x = i + 1; x < oldHostsTyped.size(); ++x) {
-                            newHosts.add(oldHostsTyped.get(x));
-                        }
-                        return newHosts.isEmpty() ? emptyList() : newHosts;
-                    } else {
-                        newHosts.add(current);
-                    }
-                }
-                return newHosts;
-            }
-
-            @Override
-            public void onError(final Throwable t) {
-                List<Host<ResolvedAddress, C>> hosts = usedHosts;
-                eventStreamProcessor.onError(t);
-                LOGGER.error(
-                    "Load balancer for {}: service discoverer {} emitted an error. Last seen addresses (size {}): {}",
-                    targetResource, eventPublisher, hosts.size(), hosts, t);
-            }
-
-            @Override
-            public void onComplete() {
-                List<Host<ResolvedAddress, C>> hosts = usedHosts;
-                eventStreamProcessor.onComplete();
-                LOGGER.error("Load balancer for {}: service discoverer {} completed. Last seen addresses (size {}): {}",
-                        targetResource, eventPublisher, hosts.size(), hosts);
-            }
-        });
-        asyncCloseable = toAsyncCloseable(graceful -> {
+        this.healthCheckConfig = healthCheckConfig;
+        this.asyncCloseable = toAsyncCloseable(graceful -> {
             discoveryCancellable.cancel();
             eventStreamProcessor.onComplete();
             final CompositeCloseable compositeCloseable;
@@ -325,6 +179,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                 if (isClosedList(currentList) ||
                         usedHostsUpdater.compareAndSet(this, currentList, new ClosedList<>(currentList))) {
                     compositeCloseable = newCompositeCloseable().appendAll(currentList).appendAll(connectionFactory);
+                    LOGGER.debug("Load balancer for {} is closing {}gracefully. Last seen addresses (size={}): {}.",
+                            targetResource, graceful ? "" : "non", currentList.size(), currentList);
                     break;
                 }
             }
@@ -336,6 +192,261 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                     })
                     .beforeOnComplete(() -> usedHosts = new ClosedList<>(emptyList()));
         });
+        subscribeToEvents(false);
+    }
+
+    private void subscribeToEvents(boolean resubscribe) {
+        if (resubscribe) {
+            discoveryCancellable.cancelCurrent();
+        }
+        toSource(eventPublisher).subscribe(new EventSubscriber(resubscribe));
+        if (healthCheckConfig != null) {
+            assert healthCheckConfig.executor instanceof NormalizedTimeSourceExecutor;
+            nextResubscribeTime = nextResubscribeTime(healthCheckConfig);
+        }
+    }
+
+    private static long nextResubscribeTime(final HealthCheckConfig config) {
+        final long lower = config.healthCheckResubscribeLowerBound;
+        final long upper = config.healthCheckResubscribeUpperBound;
+        return config.executor.currentTime(NANOSECONDS) +
+                (lower == upper ? lower : ThreadLocalRandom.current().nextLong(lower, upper));
+    }
+
+    private static <ResolvedAddress, C extends LoadBalancedConnection> boolean allUnhealthy(
+            final List<Host<ResolvedAddress, C>> usedHosts) {
+        boolean allUnhealthy = !usedHosts.isEmpty();
+        for (Host<ResolvedAddress, C> host : usedHosts) {
+            if (!Host.isUnhealthy(host.connState)) {
+                allUnhealthy = false;
+                break;
+            }
+        }
+        return allUnhealthy;
+    }
+
+    private static <ResolvedAddress> boolean onlyAvailable(
+            final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
+        boolean onlyAvailable = !events.isEmpty();
+        for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
+            if (!AVAILABLE.equals(event.status())) {
+                onlyAvailable = false;
+                break;
+            }
+        }
+        return onlyAvailable;
+    }
+
+    private static <ResolvedAddress, C extends LoadBalancedConnection> boolean notAvailable(
+            final Host<ResolvedAddress, C> host,
+            final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
+        boolean available = false;
+        for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
+            if (host.address.equals(event.address())) {
+                available = true;
+                break;
+            }
+        }
+        return !available;
+    }
+
+    private final class EventSubscriber
+            implements Subscriber<Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> {
+
+        private boolean firstEventsAfterResubscribe;
+
+        EventSubscriber(boolean resubscribe) {
+            this.firstEventsAfterResubscribe = resubscribe;
+        }
+
+        @Override
+        public void onSubscribe(final Subscription s) {
+            // We request max value here to make sure we do not access Subscription concurrently
+            // (requestN here and cancel from discoveryCancellable). If we request-1 in onNext we would have to wrap
+            // the Subscription in a ConcurrentSubscription which is costly.
+            // Since, we synchronously process onNexts we do not really care about flow control.
+            s.request(Long.MAX_VALUE);
+            discoveryCancellable.nextCancellable(s);
+        }
+
+        @Override
+        public void onNext(@Nullable final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
+            if (events == null) {
+                LOGGER.debug("Load balancer for {}: unexpectedly received null instead of events.", targetResource);
+                return;
+            }
+            for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
+                final ServiceDiscovererEvent.Status eventStatus = event.status();
+                LOGGER.debug("Load balancer for {}: received new ServiceDiscoverer event {}. Inferred status: {}.",
+                        targetResource, event, eventStatus);
+
+                @SuppressWarnings("unchecked")
+                final List<Host<ResolvedAddress, C>> usedAddresses =
+                        usedHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, oldHosts -> {
+                            if (isClosedList(oldHosts)) {
+                                return oldHosts;
+                            }
+                            final ResolvedAddress addr = requireNonNull(event.address());
+                            @SuppressWarnings("unchecked")
+                            final List<Host<ResolvedAddress, C>> oldHostsTyped =
+                                    (List<Host<ResolvedAddress, C>>) oldHosts;
+
+                            if (AVAILABLE.equals(eventStatus)) {
+                                return addHostToList(oldHostsTyped, addr);
+                            } else if (EXPIRED.equals(eventStatus)) {
+                                if (oldHostsTyped.isEmpty()) {
+                                    return emptyList();
+                                } else {
+                                    return markHostAsExpired(oldHostsTyped, addr);
+                                }
+                            } else if (UNAVAILABLE.equals(eventStatus)) {
+                                return listWithHostRemoved(oldHostsTyped, host -> {
+                                    boolean match = host.address.equals(addr);
+                                    if (match) {
+                                        host.markClosed();
+                                    }
+                                    return match;
+                                });
+                            } else {
+                                LOGGER.error("Load balancer for {}: Unexpected Status in event:" +
+                                        " {} (mapped to {}). Leaving usedHosts unchanged: {}",
+                                        targetResource, event, eventStatus, oldHosts);
+                                return oldHosts;
+                            }
+                        });
+
+                LOGGER.debug("Load balancer for {}: now using addresses (size={}): {}.",
+                        targetResource, usedAddresses.size(), usedAddresses);
+
+                if (AVAILABLE.equals(eventStatus)) {
+                    if (usedAddresses.size() == 1) {
+                        eventStreamProcessor.onNext(LOAD_BALANCER_READY_EVENT);
+                    }
+                } else if (usedAddresses.isEmpty()) {
+                    eventStreamProcessor.onNext(LOAD_BALANCER_NOT_READY_EVENT);
+                }
+            }
+
+            if (firstEventsAfterResubscribe) {
+                // We can enter this path only if we re-subscribed because all previous hosts were UNHEALTHY.
+                if (events.isEmpty()) {
+                    return; // Wait for the next collection of events.
+                }
+                firstEventsAfterResubscribe = false;
+
+                if (!onlyAvailable(events)) {
+                    // Looks like the current ServiceDiscoverer maintains a state between re-subscribes. It already
+                    // assigned correct states to all hosts. Even if some of them were left UNHEALTHY, we should keep
+                    // running health-checks.
+                    return;
+                }
+                // Looks like the current ServiceDiscoverer doesn't maintain a state between re-subscribes and always
+                // starts from an empty state propagating only AVAILABLE events. To be in sync with the
+                // ServiceDiscoverer we should clean up and close gracefully all hosts that are not present in the
+                // initial collection of events, regardless of their current state.
+                final List<Host<ResolvedAddress, C>> currentHosts = usedHosts;
+                for (Host<ResolvedAddress, C> host : currentHosts) {
+                    if (notAvailable(host, events)) {
+                        host.closeAsyncGracefully().subscribe();
+                    }
+                }
+            }
+        }
+
+        private List<Host<ResolvedAddress, C>> markHostAsExpired(
+                final List<Host<ResolvedAddress, C>> oldHostsTyped, final ResolvedAddress addr) {
+            for (Host<ResolvedAddress, C> host : oldHostsTyped) {
+                if (host.address.equals(addr)) {
+                    // Host removal will be handled by the Host's onClose::afterFinally callback
+                    host.markExpired();
+                    break;  // because duplicates are not allowed, we can stop iteration
+                }
+            }
+            return oldHostsTyped;
+        }
+
+        private Host<ResolvedAddress, C> createHost(ResolvedAddress addr) {
+            Host<ResolvedAddress, C> host = new Host<>(targetResource, addr, healthCheckConfig);
+            host.onClose().afterFinally(() ->
+                    usedHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, previousHosts -> {
+                                @SuppressWarnings("unchecked")
+                                List<Host<ResolvedAddress, C>> previousHostsTyped =
+                                        (List<Host<ResolvedAddress, C>>) previousHosts;
+                                return listWithHostRemoved(previousHostsTyped, current -> current == host);
+                            }
+                    )).subscribe();
+            return host;
+        }
+
+        private List<Host<ResolvedAddress, C>> addHostToList(
+                List<Host<ResolvedAddress, C>> oldHostsTyped, ResolvedAddress addr) {
+            if (oldHostsTyped.isEmpty()) {
+                return singletonList(createHost(addr));
+            }
+
+            // duplicates are not allowed
+            for (Host<ResolvedAddress, C> host : oldHostsTyped) {
+                if (host.address.equals(addr)) {
+                    if (!host.markActiveIfNotClosed()) {
+                        // If the host is already in CLOSED state, we should create a new entry.
+                        // For duplicate ACTIVE events or for repeated activation due to failed CAS
+                        // of replacing the usedHosts array the marking succeeds so we will not add a new entry.
+                        break;
+                    }
+                    return oldHostsTyped;
+                }
+            }
+
+            final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHostsTyped.size() + 1);
+            newHosts.addAll(oldHostsTyped);
+            newHosts.add(createHost(addr));
+            return newHosts;
+        }
+
+        private List<Host<ResolvedAddress, C>> listWithHostRemoved(
+                List<Host<ResolvedAddress, C>> oldHostsTyped, Predicate<Host<ResolvedAddress, C>> hostPredicate) {
+            if (oldHostsTyped.isEmpty()) {
+                // this can happen when an expired host is removed during closing of the RoundRobinLoadBalancer,
+                // but all of its connections have already been closed
+                return oldHostsTyped;
+            }
+            final List<Host<ResolvedAddress, C>> newHosts = new ArrayList<>(oldHostsTyped.size() - 1);
+            for (int i = 0; i < oldHostsTyped.size(); ++i) {
+                final Host<ResolvedAddress, C> current = oldHostsTyped.get(i);
+                if (hostPredicate.test(current)) {
+                    for (int x = i + 1; x < oldHostsTyped.size(); ++x) {
+                        newHosts.add(oldHostsTyped.get(x));
+                    }
+                    return newHosts.isEmpty() ? emptyList() : newHosts;
+                } else {
+                    newHosts.add(current);
+                }
+            }
+            return newHosts;
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            List<Host<ResolvedAddress, C>> hosts = usedHosts;
+            if (healthCheckConfig == null) {
+                // Terminate processor only if we will never re-subscribe
+                eventStreamProcessor.onError(t);
+            }
+            LOGGER.error(
+                "Load balancer for {}: service discoverer {} emitted an error. Last seen addresses (size={}): {}.",
+                targetResource, eventPublisher, hosts.size(), hosts, t);
+        }
+
+        @Override
+        public void onComplete() {
+            List<Host<ResolvedAddress, C>> hosts = usedHosts;
+            if (healthCheckConfig == null) {
+                // Terminate processor only if we will never re-subscribe
+                eventStreamProcessor.onComplete();
+            }
+            LOGGER.error("Load balancer for {}: service discoverer completed. Last seen addresses (size={}): {}.",
+                    targetResource, hosts.size(), hosts);
+        }
     }
 
     private static <T> Single<T> failedLBClosed(String targetResource) {
@@ -423,6 +534,14 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             }
         }
         if (pickedHost == null) {
+            if (healthCheckConfig != null && allUnhealthy(usedHosts)) {
+                final long currNextResubscribeTime = nextResubscribeTime;
+                if (currNextResubscribeTime >= 0 &&
+                        healthCheckConfig.executor.currentTime(NANOSECONDS) >= currNextResubscribeTime &&
+                        nextResubscribeTimeUpdater.compareAndSet(this, currNextResubscribeTime, RESUBSCRIBING)) {
+                    subscribeToEvents(true);
+                }
+            }
             return failed(StacklessNoAvailableHostException.newInstance("Failed to pick an active host for " +
                             targetResource + ". Either all are busy, expired, or unhealthy: " + usedHosts,
                     RoundRobinLoadBalancer.class, "selectConnection0(...)"));
@@ -503,13 +622,18 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         private final Duration healthCheckInterval;
         private final Duration jitter;
         private final int failedThreshold;
+        private final long healthCheckResubscribeLowerBound;
+        private final long healthCheckResubscribeUpperBound;
 
         HealthCheckConfig(final Executor executor, final Duration healthCheckInterval, final Duration healthCheckJitter,
-                          final int failedThreshold) {
+                          final int failedThreshold, final long healthCheckResubscribeLowerBound,
+                          final long healthCheckResubscribeUpperBound) {
             this.executor = executor;
             this.healthCheckInterval = healthCheckInterval;
             this.failedThreshold = failedThreshold;
             this.jitter = healthCheckJitter;
+            this.healthCheckResubscribeLowerBound = healthCheckResubscribeLowerBound;
+            this.healthCheckResubscribeUpperBound = healthCheckResubscribeUpperBound;
         }
     }
 
@@ -530,7 +654,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
 
         @SuppressWarnings("rawtypes")
         private static final AtomicReferenceFieldUpdater<Host, ConnState> connStateUpdater =
-                AtomicReferenceFieldUpdater.newUpdater(Host.class, ConnState.class, "connState");
+                newUpdater(Host.class, ConnState.class, "connState");
 
         private final String targetResource;
         final Addr address;
@@ -540,7 +664,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         private volatile ConnState connState = ACTIVE_EMPTY_CONN_STATE;
 
         Host(String targetResource, Addr address, @Nullable HealthCheckConfig healthCheckConfig) {
-            this.targetResource = requireNonNull(targetResource);
+            this.targetResource = targetResource;
             this.address = requireNonNull(address);
             this.healthCheckConfig = healthCheckConfig;
             this.closeable = toAsyncCloseable(graceful ->
@@ -563,7 +687,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         void markClosed() {
             final ConnState oldState = closeConnState();
             final Object[] toRemove = oldState.connections;
-            cancelIfHealthCheck(oldState.state);
+            cancelIfHealthCheck(oldState);
             LOGGER.debug("Load balancer for {}: closing {} connection(s) gracefully to the closed address: {}.",
                     targetResource, toRemove.length, address);
             for (Object conn : toRemove) {
@@ -596,7 +720,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
 
                 if (connStateUpdater.compareAndSet(this, oldState,
                         new ConnState(oldState.connections, nextState))) {
-                    cancelIfHealthCheck(oldState.state);
+                    cancelIfHealthCheck(oldState);
                     if (nextState == State.CLOSED) {
                         // Trigger the callback to remove the host from usedHosts array.
                         this.closeAsync().subscribe();
@@ -614,13 +738,13 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             // In an unlikely scenario that the following connection attempts fail indefinitely, a health check task
             // would leak and would not be cancelled. Therefore, we cancel it here and allow failures to trigger a new
             // health check.
-            Object oldState = connStateUpdater.getAndUpdate(this, previous -> {
-                if (HealthCheck.class.equals(previous.state.getClass())) {
+            ConnState oldState = connStateUpdater.getAndUpdate(this, previous -> {
+                if (Host.isUnhealthy(previous)) {
                     return new ConnState(previous.connections, STATE_ACTIVE_NO_FAILURES);
                 }
                 return previous;
-            }).state;
-            if (oldState != originalHealthCheckState) {
+            });
+            if (oldState.state != originalHealthCheckState) {
                 cancelIfHealthCheck(oldState);
             }
         }
@@ -632,7 +756,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
 
                 if (!ActiveState.class.equals(previous.state.getClass()) || previous.connections.length > 0
                         || cause instanceof ConnectionLimitReachedException) {
-                    LOGGER.debug("Load balancer for {}: failed to open a new connection to the host on address {}. {}",
+                    LOGGER.debug("Load balancer for {}: failed to open a new connection to the host on address {}. {}.",
                             targetResource, address, previous, cause);
                     break;
                 }
@@ -667,6 +791,10 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
 
         boolean isActiveAndHealthy() {
             return ActiveState.class.equals(connState.state.getClass());
+        }
+
+        static boolean isUnhealthy(final ConnState connState) {
+            return HealthCheck.class.equals(connState.state.getClass());
         }
 
         boolean addConnection(C connection) {
@@ -783,7 +911,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         private Completable doClose(final Function<? super C, Completable> closeFunction) {
             return Completable.defer(() -> {
                 final ConnState oldState = closeConnState();
-                cancelIfHealthCheck(oldState.state);
+                cancelIfHealthCheck(oldState);
                 final Object[] connections = oldState.connections;
                 return (connections.length == 0 ? completed() :
                         from(connections).flatMapCompletableDelayError(conn -> closeFunction.apply((C) conn)))
@@ -791,10 +919,10 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             });
         }
 
-        private void cancelIfHealthCheck(Object o) {
-            if (HealthCheck.class.equals(o.getClass())) {
+        private void cancelIfHealthCheck(ConnState connState) {
+            if (Host.isUnhealthy(connState)) {
                 @SuppressWarnings("unchecked")
-                HealthCheck<Addr, C> healthCheck = (HealthCheck<Addr, C>) o;
+                HealthCheck<Addr, C> healthCheck = (HealthCheck<Addr, C>) connState.state;
                 LOGGER.debug("Load balancer for {}: health check cancelled for {}.", targetResource, healthCheck.host);
                 healthCheck.cancel();
             }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutorTest.java
@@ -36,6 +36,7 @@ class NormalizedTimeSourceExecutorTest {
 
     @AfterEach
     void tearDown() throws Exception {
+        testExecutor.closeAsync().toFuture().get();
         executor.closeAsync().toFuture().get();
     }
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.TestExecutor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("NumericOverflow")
+class NormalizedTimeSourceExecutorTest {
+
+    private TestExecutor testExecutor;
+    private Executor executor;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        executor.closeAsync().toFuture().get();
+    }
+
+    void setUp(long initialValue) {
+        testExecutor = new TestExecutor(initialValue);
+        executor = new NormalizedTimeSourceExecutor(testExecutor);
+        assertThat("Unexpected initial value", executor.currentTime(NANOSECONDS), is(0L));
+    }
+
+    void advanceAndVerify(long advanceByNanos, long expected) {
+        testExecutor.advanceTimeByNoExecuteTasks(advanceByNanos, NANOSECONDS);
+        assertThat(executor.currentTime(NANOSECONDS), is(expected));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: initialValue={0}")
+    @ValueSource(longs = {MIN_VALUE, -100, 0, 100, MAX_VALUE})
+    void minValue(long initialValue) {
+        setUp(initialValue);
+        advanceAndVerify(10, 10);
+        advanceAndVerify(MAX_VALUE - 10, MAX_VALUE);
+        advanceAndVerify(10, MAX_VALUE + 10);
+        advanceAndVerify(MAX_VALUE - 8, 0);
+    }
+}

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -710,7 +710,7 @@ abstract class RoundRobinLoadBalancerTest {
     void resubscribeToEventsWhenAllHostsAreUnhealthy(boolean sdReturnsDelta) throws Exception {
         serviceDiscoveryPublisher.onComplete();
         assertThat(sequentialPublisherSubscriberFunction.isSubscribed(), is(false));
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(1));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(1));
 
         DelegatingConnectionFactory alwaysFail12ConnectionFactory = new DelegatingConnectionFactory(address -> {
             switch (address) {
@@ -724,7 +724,7 @@ abstract class RoundRobinLoadBalancerTest {
         lb = defaultLb(alwaysFail12ConnectionFactory);
 
         assertThat(sequentialPublisherSubscriberFunction.isSubscribed(), is(true));
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(2));
 
         assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
         sendServiceDiscoveryEvents(upEvent("address-1"));
@@ -735,12 +735,12 @@ abstract class RoundRobinLoadBalancerTest {
         for (int i = 0; i < DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD * lb.usedAddresses().size(); ++i) {
             assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
         }
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(2));
         // Assert the next select attempt after resubscribe internal triggers re-subscribe
         testExecutor.advanceTimeBy(DEFAULT_HEALTH_CHECK_RESUBSCRIBE_INTERVAL.toMillis() * 2, MILLISECONDS);
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(2));
         assertSelectThrows(instanceOf(NoAvailableHostException.class));
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(3));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(3));
 
         // Verify state after re-subscribe
         assertAddresses(lb.usedAddresses(), "address-1", "address-2");
@@ -768,7 +768,7 @@ abstract class RoundRobinLoadBalancerTest {
     void resubscribeToEventsNotTriggeredWhenDisabled() throws Exception {
         serviceDiscoveryPublisher.onComplete();
         assertThat(sequentialPublisherSubscriberFunction.isSubscribed(), is(false));
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(1));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(1));
 
         DelegatingConnectionFactory alwaysFailConnectionFactory =
                 new DelegatingConnectionFactory(address -> Single.failed(UNHEALTHY_HOST_EXCEPTION));
@@ -782,7 +782,7 @@ abstract class RoundRobinLoadBalancerTest {
                         .newLoadBalancer(serviceDiscoveryPublisher, alwaysFailConnectionFactory, "test-service");
 
         assertThat(sequentialPublisherSubscriberFunction.isSubscribed(), is(true));
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(2));
 
         assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
         sendServiceDiscoveryEvents(upEvent("address-1"));
@@ -793,11 +793,11 @@ abstract class RoundRobinLoadBalancerTest {
         for (int i = 0; i < DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD * lb.usedAddresses().size(); ++i) {
             assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
         }
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(2));
         testExecutor.advanceTimeBy(DEFAULT_HEALTH_CHECK_RESUBSCRIBE_INTERVAL.toMillis() * 2, MILLISECONDS);
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(2));
         assertSelectThrows(instanceOf(NoAvailableHostException.class));
-        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribersSeen(), is(2));
     }
 
     @Test

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -32,6 +32,7 @@ import io.servicetalk.concurrent.api.ExecutorExtension;
 import io.servicetalk.concurrent.api.LegacyTestSingle;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.SequentialPublisherSubscriberFunction;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestExecutor;
 import io.servicetalk.concurrent.api.TestPublisher;
@@ -52,6 +53,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -93,12 +95,17 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.DEFAULT_TIMEOUT_SECONDS;
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
+import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory.DEFAULT_HEALTH_CHECK_RESUBSCRIBE_INTERVAL;
 import static io.servicetalk.loadbalancer.RoundRobinLoadBalancerTest.UnhealthyHostConnectionFactory.UNHEALTHY_HOST_EXCEPTION;
+import static java.lang.Long.MAX_VALUE;
+import static java.time.Duration.ZERO;
 import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofNanos;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -132,8 +139,12 @@ abstract class RoundRobinLoadBalancerTest {
             new TestSingleSubscriber<>();
     private final List<TestLoadBalancedConnection> connectionsCreated = new CopyOnWriteArrayList<>();
     private final Queue<Runnable> connectionRealizers = new ConcurrentLinkedQueue<>();
-
-    final TestPublisher<Collection<ServiceDiscovererEvent<String>>> serviceDiscoveryPublisher = new TestPublisher<>();
+    private final SequentialPublisherSubscriberFunction<Collection<ServiceDiscovererEvent<String>>>
+            sequentialPublisherSubscriberFunction = new SequentialPublisherSubscriberFunction<>();
+    final TestPublisher<Collection<ServiceDiscovererEvent<String>>> serviceDiscoveryPublisher =
+            new TestPublisher.Builder<Collection<ServiceDiscovererEvent<String>>>()
+                    .sequentialSubscribers(sequentialPublisherSubscriberFunction)
+                    .build();
     private DelegatingConnectionFactory connectionFactory =
             new DelegatingConnectionFactory(this::newRealizedConnectionSingle);
 
@@ -394,7 +405,7 @@ abstract class RoundRobinLoadBalancerTest {
         assertTrue(connectionFactory.isClosed(), "ConnectionFactory not closed.");
     }
 
-    @ParameterizedTest(name = "closeFromLb={0}")
+    @ParameterizedTest(name = "{displayName} [{index}]: closeFromLb={0}")
     @ValueSource(booleans = {true, false})
     void closeGracefulThenClose(boolean closeFromLb)
             throws ExecutionException, InterruptedException {
@@ -504,18 +515,14 @@ abstract class RoundRobinLoadBalancerTest {
         sendServiceDiscoveryEvents(upEvent("address-1"));
 
         for (int i = 0; i < DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD; ++i) {
-            Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null)
-                    .toFuture().get());
-            assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
+            assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
         }
 
         assertThat(testExecutor.scheduledTasksPending(), equalTo(0));
 
         for (int i = 0; i < timeAdvancementsTillHealthy - 1; ++i) {
             unhealthyHostConnectionFactory.advanceTime(testExecutor);
-            Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null)
-                    .toFuture().get());
-            assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
+            assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
         }
 
         unhealthyHostConnectionFactory.advanceTime(testExecutor);
@@ -541,17 +548,13 @@ abstract class RoundRobinLoadBalancerTest {
         sendServiceDiscoveryEvents(upEvent("address-1"));
 
         for (int i = 0; i < DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD; ++i) {
-            Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null)
-                    .toFuture().get());
-            assertThat(e.getCause(), is(exception));
+            assertSelectThrows(is(exception));
         }
         assertThat(testExecutor.scheduledTasksPending(), equalTo(0));
 
         for (int i = 0; i < timeAdvancementsTillHealthy - 1; ++i) {
             unhealthyHostConnectionFactory.advanceTime(testExecutor);
-            Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null)
-                    .toFuture().get());
-            assertThat(e.getCause(), is(exception));
+            assertSelectThrows(is(exception));
         }
 
         unhealthyHostConnectionFactory.advanceTime(testExecutor);
@@ -575,9 +578,7 @@ abstract class RoundRobinLoadBalancerTest {
         sendServiceDiscoveryEvents(upEvent("address-1"));
 
         for (int i = 0; i < DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD; ++i) {
-            Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null)
-                    .toFuture().get());
-            assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
+            assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
         }
 
         for (int i = 0; i < timeAdvancementsTillHealthy; ++i) {
@@ -622,8 +623,7 @@ abstract class RoundRobinLoadBalancerTest {
         sendServiceDiscoveryEvents(upEvent("address-1"));
 
         // Trigger first health check:
-        Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null).toFuture().get());
-        assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
+        assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
         // Execute two health checks: first will fail due to connectionFactory,
         // second - due to an unexpected error from executor:
         for (int i = 0; i < 2; ++i) {
@@ -631,8 +631,7 @@ abstract class RoundRobinLoadBalancerTest {
         }
 
         // Trigger yet another health check:
-        e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null).toFuture().get());
-        assertThat(e.getCause(), is(UNHEALTHY_HOST_EXCEPTION));
+        assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
         // Execute two health checks: first will fail due to connectionFactory, second succeeds:
         for (int i = 0; i < 2; ++i) {
             unhealthyHostConnectionFactory.advanceTime(testExecutor);
@@ -662,9 +661,7 @@ abstract class RoundRobinLoadBalancerTest {
         // Imitate concurrency by running multiple threads attempting to establish connections.
         ExecutorService executor = Executors.newFixedThreadPool(3);
         try {
-            final Runnable runnable = () ->
-                    assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null).toFuture().get());
-
+            final Runnable runnable = () -> assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
             for (int i = 0; i < 1000; i++) {
                 executor.submit(runnable);
             }
@@ -694,9 +691,7 @@ abstract class RoundRobinLoadBalancerTest {
                 unhealthyHostConnectionFactory.advanceTime(testExecutor);
 
                 // Assert still unhealthy
-                Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null)
-                        .toFuture().get());
-                assertThat(e.getCause(), instanceOf(NoAvailableHostException.class));
+                assertSelectThrows(instanceOf(NoAvailableHostException.class));
             }
         } finally {
             // Shutdown the concurrent validation of unhealthiness.
@@ -708,6 +703,101 @@ abstract class RoundRobinLoadBalancerTest {
 
         final TestLoadBalancedConnection selectedConnection = lb.selectConnection(any(), null).toFuture().get();
         assertThat(selectedConnection, equalTo(properConnection.toFuture().get()));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: sdReturnsDelta={0}")
+    @ValueSource(booleans = {false, true})
+    void resubscribeToEventsWhenAllHostsAreUnhealthy(boolean sdReturnsDelta) throws Exception {
+        serviceDiscoveryPublisher.onComplete();
+        assertThat(sequentialPublisherSubscriberFunction.isSubscribed(), is(false));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(1));
+
+        DelegatingConnectionFactory alwaysFail12ConnectionFactory = new DelegatingConnectionFactory(address -> {
+            switch (address) {
+                case "address-1":
+                case "address-2":
+                    return Single.failed(UNHEALTHY_HOST_EXCEPTION);
+                default:
+                    return Single.succeeded(newConnection(address));
+            }
+        });
+        lb = defaultLb(alwaysFail12ConnectionFactory);
+
+        assertThat(sequentialPublisherSubscriberFunction.isSubscribed(), is(true));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+
+        assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+        sendServiceDiscoveryEvents(upEvent("address-2"));
+        assertAddresses(lb.usedAddresses(), "address-1", "address-2");
+
+        // Force all usedAddresses into UNHEALTHY state
+        for (int i = 0; i < DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD * lb.usedAddresses().size(); ++i) {
+            assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
+        }
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        // Assert the next select attempt after resubscribe internal triggers re-subscribe
+        testExecutor.advanceTimeBy(DEFAULT_HEALTH_CHECK_RESUBSCRIBE_INTERVAL.toMillis() * 2, MILLISECONDS);
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        assertSelectThrows(instanceOf(NoAvailableHostException.class));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(3));
+
+        // Verify state after re-subscribe
+        assertAddresses(lb.usedAddresses(), "address-1", "address-2");
+        if (sdReturnsDelta) {
+            sendServiceDiscoveryEvents(upEvent("address-3"), upEvent("address-4"), downEvent("address-1"));
+            assertAddresses(lb.usedAddresses(), "address-2", "address-3", "address-4");
+            sendServiceDiscoveryEvents(downEvent("address-2"));
+        } else {
+            sendServiceDiscoveryEvents(upEvent("address-3"), upEvent("address-4"));
+        }
+        assertAddresses(lb.usedAddresses(), "address-3", "address-4");
+
+        // Verify the LB is recovered
+        Map<String, Matcher<? super String>> expected = new HashMap<>();
+        expected.put("address-3", is("address-3"));
+        expected.put("address-4", is("address-4"));
+        String selected1 = lb.selectConnection(any(), null).toFuture().get().address();
+        assertThat(selected1, is(anyOf(expected.values())));
+        expected.remove(selected1);
+        assertThat(lb.selectConnection(any(), null).toFuture().get().address(), is(anyOf(expected.values())));
+        assertConnectionCount(lb.usedAddresses(), connectionsCount("address-3", 1), connectionsCount("address-4", 1));
+    }
+
+    @Test
+    void resubscribeToEventsNotTriggeredWhenDisabled() throws Exception {
+        serviceDiscoveryPublisher.onComplete();
+        assertThat(sequentialPublisherSubscriberFunction.isSubscribed(), is(false));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(1));
+
+        DelegatingConnectionFactory alwaysFailConnectionFactory =
+                new DelegatingConnectionFactory(address -> Single.failed(UNHEALTHY_HOST_EXCEPTION));
+        lb = (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>)
+                new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                        .healthCheckInterval(ofMillis(50), ofMillis(10))
+                        // Set resubscribe interval to very large number
+                        .healthCheckResubscribeInterval(ofNanos(MAX_VALUE), ZERO)
+                        .backgroundExecutor(testExecutor)
+                        .build()
+                        .newLoadBalancer(serviceDiscoveryPublisher, alwaysFailConnectionFactory, "test-service");
+
+        assertThat(sequentialPublisherSubscriberFunction.isSubscribed(), is(true));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+
+        assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+        sendServiceDiscoveryEvents(upEvent("address-2"));
+        assertAddresses(lb.usedAddresses(), "address-1", "address-2");
+
+        // Force all usedAddresses into UNHEALTHY state
+        for (int i = 0; i < DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD * lb.usedAddresses().size(); ++i) {
+            assertSelectThrows(is(UNHEALTHY_HOST_EXCEPTION));
+        }
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        testExecutor.advanceTimeBy(DEFAULT_HEALTH_CHECK_RESUBSCRIBE_INTERVAL.toMillis() * 2, MILLISECONDS);
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
+        assertSelectThrows(instanceOf(NoAvailableHostException.class));
+        assertThat(sequentialPublisherSubscriberFunction.numberOfSubscribers(), is(2));
     }
 
     @Test
@@ -830,6 +920,11 @@ abstract class RoundRobinLoadBalancerTest {
         final Matcher<Iterable<? extends T>> iterableMatcher =
                 addressAndConnCount.length == 0 ? emptyIterable() : contains(args);
         assertThat(addresses, iterableMatcher);
+    }
+
+    private void assertSelectThrows(Matcher<Throwable> matcher) {
+        Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null).toFuture().get());
+        assertThat(e.getCause(), matcher);
     }
 
     Map.Entry<String, Integer> connectionsCount(String addr, int count) {

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/DurationUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/DurationUtils.java
@@ -77,7 +77,7 @@ public final class DurationUtils {
      * @throws IllegalArgumentException if the passed duration is not greater or equal to {@link Duration#ZERO}
      */
     public static Duration ensureNonNegative(final Duration duration, final String name) {
-        if (duration.isNegative()) {
+        if (requireNonNull(duration, name).isNegative()) {
             throw new IllegalArgumentException(name + ": " + duration + " (expected >= 0)");
         }
         return duration;

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/DurationUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/DurationUtils.java
@@ -68,6 +68,22 @@ public final class DurationUtils {
     }
 
     /**
+     * Ensures the duration is non-negative.
+     *
+     * @param duration the {@link Duration} to validate
+     * @param name name of the {@link Duration} variable
+     * @return the passed duration if all checks pass
+     * @throws NullPointerException if the passed duration is {@code null}
+     * @throws IllegalArgumentException if the passed duration is not greater or equal to {@link Duration#ZERO}
+     */
+    public static Duration ensureNonNegative(final Duration duration, final String name) {
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException(name + ": " + duration + " (expected >= 0)");
+        }
+        return duration;
+    }
+
+    /**
      * Checks if the duration is considered "infinite".
      *
      * @param duration the {@link Duration} to validate

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/DurationUtilsTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/DurationUtilsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
+import static io.servicetalk.utils.internal.DurationUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static io.servicetalk.utils.internal.DurationUtils.isInfinite;
 import static io.servicetalk.utils.internal.DurationUtils.isPositive;
@@ -26,6 +27,7 @@ import static java.time.Duration.ofNanos;
 import static java.time.Duration.ofSeconds;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DurationUtilsTest {
@@ -49,9 +51,21 @@ class DurationUtilsTest {
     @Test
     void testEnsurePositive() {
         assertThrows(NullPointerException.class, () -> ensurePositive(null, "duration"));
-        assertThrows(IllegalArgumentException.class, () -> ensurePositive(Duration.ZERO, "duration"));
-        assertThrows(IllegalArgumentException.class, () -> ensurePositive(ofNanos(1L).negated(), "duration"));
         assertThrows(IllegalArgumentException.class, () -> ensurePositive(ofSeconds(1L).negated(), "duration"));
+        assertThrows(IllegalArgumentException.class, () -> ensurePositive(ofNanos(1L).negated(), "duration"));
+        assertThrows(IllegalArgumentException.class, () -> ensurePositive(Duration.ZERO, "duration"));
+        assertDoesNotThrow(() -> ensureNonNegative(ofNanos(1L), "duration"));
+        assertDoesNotThrow(() -> ensureNonNegative(ofSeconds(1L), "duration"));
+    }
+
+    @Test
+    void testEnsureNonNegative() {
+        assertThrows(NullPointerException.class, () -> ensureNonNegative(null, "duration"));
+        assertThrows(IllegalArgumentException.class, () -> ensureNonNegative(ofSeconds(1L).negated(), "duration"));
+        assertThrows(IllegalArgumentException.class, () -> ensureNonNegative(ofNanos(1L).negated(), "duration"));
+        assertDoesNotThrow(() -> ensureNonNegative(Duration.ZERO, "duration"));
+        assertDoesNotThrow(() -> ensureNonNegative(ofNanos(1L), "duration"));
+        assertDoesNotThrow(() -> ensureNonNegative(ofSeconds(1L), "duration"));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

It’s possible for the RRLB to turn into a state when all available
hosts become unhealthy. Possible scenarios:
- DNS returned incorrect results;
- All hosts were restarted and got different addresses.
RRL will be in a dead state until TTL expires, which may take some time.

Modifications:
- When RRLB detects that all hosts are unhealthy, it re-subscribes to the
SD events publisher to trigger a new resolution;
- Add `RoundRobinLoadBalancerFactory.Builder#healthCheckResubscribeInterval`
option to configure the new feature;
- Wrap `backgroundExecutor` with `NormalizedTimeSourceExecutor` to make
sure `currentTime` is always positive;
- Test behavior when the new feature is enabled/disabled;
- Add `DurationUtils.ensureNonNegative(...)` utility for validation;
- Make `TestExecutor(long)` constructor public to test
`NormalizedTimeSourceExecutor`;
- Add `SequentialPublisherSubscriberFunction.numberOfSubscribers()` to
verify how many subscribers the `TestPublisher` already saw;

Result:

RRLB forces SD to re-resolve addresses by cancelling the current subscription
and re-subscribing to the publisher when it detects that all hosts become
unhealthy.

---
~This PR depends on #2513 and #2516, review only the last commit.~

TODO:
- [x] Add tests for RRLB;
- [x] #2518;