### PR TITLE
Sequential `Subscriber` is not reset after cancel for all test sources

### DIFF
--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ConcurrentCompletableSubscriberFunction.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ConcurrentCompletableSubscriberFunction.java
@@ -26,6 +26,11 @@ import java.util.function.Function;
 /**
  * Allows multiple {@link Subscriber}s to be concurrently subscribed to a {@link TestCompletable}, and multicasts
  * signals to them all.
+ * <p>
+ * This function should be used only when auto on-subscribe is disabled and {@link Subscriber#onSubscribe(Cancellable)}
+ * have to be invoked with a new {@link Cancellable} for each {@link Subscriber} in {@link #subscribers()} list.
+ *
+ * @see TestCompletable.Builder#disableAutoOnSubscribe()
  */
 public final class ConcurrentCompletableSubscriberFunction
         implements Function<Subscriber, Subscriber> {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ConcurrentPublisherSubscriberFunction.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ConcurrentPublisherSubscriberFunction.java
@@ -26,8 +26,12 @@ import java.util.function.Function;
 /**
  * Allows multiple {@link Subscriber}s to be concurrently subscribed to a {@link TestPublisher}, and multicasts signals
  * to them all.
+ * <p>
+ * This function should be used only when auto on-subscribe is disabled and {@link Subscriber#onSubscribe(Subscription)}
+ * have to be invoked with a new {@link Subscription} for each {@link Subscriber} in {@link #subscribers()} list.
  *
  * @param <T> Type of items received by the {@code Subscriber}.
+ * @see TestPublisher.Builder#disableAutoOnSubscribe()
  */
 public final class ConcurrentPublisherSubscriberFunction<T>
         implements Function<Subscriber<? super T>, Subscriber<? super T>> {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ConcurrentSingleSubscriberFunction.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/ConcurrentSingleSubscriberFunction.java
@@ -26,8 +26,12 @@ import java.util.function.Function;
 /**
  * Allows multiple {@link Subscriber}s to be concurrently subscribed to a {@link TestSingle}, and multicasts signals
  * to them all.
+ * <p>
+ * This function should be used only when auto on-subscribe is disabled and {@link Subscriber#onSubscribe(Cancellable)}
+ * have to be invoked with a new {@link Cancellable} for each {@link Subscriber} in {@link #subscribers()} list.
  *
  * @param <T> Type of items received by the {@code Subscriber}.
+ * @see TestSingle.Builder#disableAutoOnSubscribe()
  */
 public final class ConcurrentSingleSubscriberFunction<T>
         implements Function<Subscriber<? super T>, Subscriber<? super T>> {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialCompletableSubscriberFunction.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialCompletableSubscriberFunction.java
@@ -62,6 +62,7 @@ public final class SequentialCompletableSubscriberFunction
 
             private void reset(final Subscriber subscriber) {
                 if (SequentialCompletableSubscriberFunction.this.subscriber == subscriber) {
+                    SequentialCompletableSubscriberFunction.this.subscriber = null;
                     subscribed.set(false);
                 }
             }
@@ -69,9 +70,9 @@ public final class SequentialCompletableSubscriberFunction
     }
 
     /**
-     * Returns the most recently subscribed {@link Subscriber}.
+     * Returns the currently subscribed {@link Subscriber}.
      *
-     * @return the most recently subscribed {@link Subscriber}.
+     * @return the currently subscribed {@link Subscriber}.
      */
     @Nullable
     public Subscriber subscriber() {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialPublisherSubscriberFunction.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialPublisherSubscriberFunction.java
@@ -72,6 +72,7 @@ public final class SequentialPublisherSubscriberFunction<T>
 
             private void reset(final Subscriber<? super T> subscriber) {
                 if (SequentialPublisherSubscriberFunction.this.subscriber == subscriber) {
+                    SequentialPublisherSubscriberFunction.this.subscriber = null;
                     subscribed.set(false);
                 }
             }
@@ -79,9 +80,9 @@ public final class SequentialPublisherSubscriberFunction<T>
     }
 
     /**
-     * Returns the most recently subscribed {@link Subscriber}.
+     * Returns the currently subscribed {@link Subscriber}.
      *
-     * @return the most recently subscribed {@link Subscriber}.
+     * @return the currently subscribed {@link Subscriber}.
      */
     @Nullable
     public Subscriber<? super T> subscriber() {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialSingleSubscriberFunction.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/SequentialSingleSubscriberFunction.java
@@ -64,6 +64,7 @@ public final class SequentialSingleSubscriberFunction<T>
 
             private void reset(final Subscriber<? super T> subscriber) {
                 if (SequentialSingleSubscriberFunction.this.subscriber == subscriber) {
+                    SequentialSingleSubscriberFunction.this.subscriber = null;
                     subscribed.set(false);
                 }
             }
@@ -71,9 +72,9 @@ public final class SequentialSingleSubscriberFunction<T>
     }
 
     /**
-     * Returns the most recently subscribed {@link Subscriber}.
+     * Returns the currently subscribed {@link Subscriber}.
      *
-     * @return the most recently subscribed {@link Subscriber}.
+     * @return the currently subscribed {@link Subscriber}.
      */
     @Nullable
     public Subscriber<? super T> subscriber() {

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
@@ -179,24 +179,32 @@ public final class TestCompletable extends Completable implements CompletableSou
 
         /**
          * Allow concurrent subscribers. Default is to allow only sequential subscribers.
+         * <p>
+         * This mode automatically {@link #disableAutoOnSubscribe() disables auto on-subscribe}.
          *
          * @return this.
          * @see ConcurrentCompletableSubscriberFunction
+         * @see #disableAutoOnSubscribe()
          */
         public Builder concurrentSubscribers() {
             subscriberCardinalityFunction = new ConcurrentCompletableSubscriberFunction();
+            disableAutoOnSubscribe();
             return this;
         }
 
         /**
          * Allow concurrent subscribers, with the specified {@link ConcurrentCompletableSubscriberFunction}.
          * Default is to allow only sequential subscribers.
+         * <p>
+         * This mode automatically {@link #disableAutoOnSubscribe() disables auto on-subscribe}.
          *
          * @param function the {@link ConcurrentCompletableSubscriberFunction} to use.
          * @return this.
+         * @see #disableAutoOnSubscribe()
          */
         public Builder concurrentSubscribers(final ConcurrentCompletableSubscriberFunction function) {
             subscriberCardinalityFunction = requireNonNull(function);
+            disableAutoOnSubscribe();
             return this;
         }
 
@@ -294,9 +302,8 @@ public final class TestCompletable extends Completable implements CompletableSou
         }
 
         private Function<Subscriber, Subscriber> buildSubscriberFunction() {
-            Function<Subscriber, Subscriber> subscriberFunction =
-                    autoOnSubscribeFunction;
-            subscriberFunction = andThen(subscriberFunction, subscriberCardinalityFunction);
+            Function<Subscriber, Subscriber> subscriberFunction = subscriberCardinalityFunction;
+            subscriberFunction = andThen(subscriberFunction, autoOnSubscribeFunction);
             assert subscriberFunction != null;
             return subscriberFunction;
         }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
@@ -209,24 +209,32 @@ public final class TestPublisher<T> extends Publisher<T> implements PublisherSou
 
         /**
          * Allow concurrent subscribers. Default is to allow only sequential subscribers.
+         * <p>
+         * This mode automatically {@link #disableAutoOnSubscribe() disables auto on-subscribe}.
          *
          * @return this.
          * @see ConcurrentPublisherSubscriberFunction
+         * @see #disableAutoOnSubscribe()
          */
         public Builder<T> concurrentSubscribers() {
             subscriberCardinalityFunction = new ConcurrentPublisherSubscriberFunction<>();
+            disableAutoOnSubscribe();
             return this;
         }
 
         /**
          * Allow concurrent subscribers, with the specified {@link ConcurrentPublisherSubscriberFunction}.
          * Default is to allow only sequential subscribers.
+         * <p>
+         * This mode automatically {@link #disableAutoOnSubscribe() disables auto on-subscribe}.
          *
          * @param function the {@link ConcurrentPublisherSubscriberFunction} to use.
          * @return this.
+         * @see #disableAutoOnSubscribe()
          */
         public Builder<T> concurrentSubscribers(final ConcurrentPublisherSubscriberFunction<T> function) {
             subscriberCardinalityFunction = requireNonNull(function);
+            disableAutoOnSubscribe();
             return this;
         }
 
@@ -359,8 +367,8 @@ public final class TestPublisher<T> extends Publisher<T> implements PublisherSou
         private Function<Subscriber<? super T>, Subscriber<? super T>> buildSubscriberFunction() {
             Function<Subscriber<? super T>, Subscriber<? super T>> subscriberFunction =
                     demandCheckingSubscriberFunction;
-            subscriberFunction = andThen(subscriberFunction, autoOnSubscribeSubscriberFunction);
             subscriberFunction = andThen(subscriberFunction, subscriberCardinalityFunction);
+            subscriberFunction = andThen(subscriberFunction, autoOnSubscribeSubscriberFunction);
             assert subscriberFunction != null;
             return subscriberFunction;
         }

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
@@ -184,24 +184,32 @@ public final class TestSingle<T> extends Single<T> implements SingleSource<T> {
 
         /**
          * Allow concurrent subscribers. Default is to allow only sequential subscribers.
+         * <p>
+         * This mode automatically {@link #disableAutoOnSubscribe() disables auto on-subscribe}.
          *
          * @return this.
          * @see ConcurrentSingleSubscriberFunction
+         * @see #disableAutoOnSubscribe()
          */
         public Builder<T> concurrentSubscribers() {
             subscriberCardinalityFunction = new ConcurrentSingleSubscriberFunction<>();
+            disableAutoOnSubscribe();
             return this;
         }
 
         /**
          * Allow concurrent subscribers, with the specified {@link ConcurrentSingleSubscriberFunction}.
          * Default is to allow only sequential subscribers.
+         * <p>
+         * This mode automatically {@link #disableAutoOnSubscribe() disables auto on-subscribe}.
          *
          * @param function the {@link ConcurrentSingleSubscriberFunction} to use.
          * @return this.
+         * @see #disableAutoOnSubscribe()
          */
         public Builder<T> concurrentSubscribers(final ConcurrentSingleSubscriberFunction<T> function) {
             subscriberCardinalityFunction = requireNonNull(function);
+            disableAutoOnSubscribe();
             return this;
         }
 
@@ -299,9 +307,8 @@ public final class TestSingle<T> extends Single<T> implements SingleSource<T> {
         }
 
         private Function<Subscriber<? super T>, Subscriber<? super T>> buildSubscriberFunction() {
-            Function<Subscriber<? super T>, Subscriber<? super T>> subscriberFunction =
-                    autoOnSubscribeFunction;
-            subscriberFunction = andThen(subscriberFunction, subscriberCardinalityFunction);
+            Function<Subscriber<? super T>, Subscriber<? super T>> subscriberFunction = subscriberCardinalityFunction;
+            subscriberFunction = andThen(subscriberFunction, autoOnSubscribeFunction);
             assert subscriberFunction != null;
             return subscriberFunction;
         }


### PR DESCRIPTION
Motivation:

When `Sequential*SubscriberFunction` (this is a default mode for all test sources) is used, `cancel()` doesn't reset the current `Subscriber`. Therefore, following re-subscribes fail with "Duplicate subscriber" exception. This happens because `AutoOnSubscribe*SubscriberFunction` is applied before `subscriberCardinalityFunction`. As the result, `onSubscribe` is invoked before `Sequential*SubscriberFunction` wraps the `Subscriber`.

Modifications:

- Always apply `autoOnSubscribeSubscriberFunction` last, after `subscriberCardinalityFunction`;
- Add tests to verify the described scenario;
- Always reset the current `Subscriber` when `Sequential*SubscriberFunction` resets;
- Clarify that `Concurrent*SubscriberFunction` always requires manyual `onSubscribe` management;
- Disable auto on-subscribe when `concurrentSubscribers` mode is used;

Result:

It's possible to re-subscribe to the test source after the previous subscription is cancelled when `sequentialSubscribers` mode is used.