### PR TITLE
`SequentialCancellable`: add `cancelCurrent()` method

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SequentialCancellable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SequentialCancellable.java
@@ -64,8 +64,17 @@ public class SequentialCancellable implements Cancellable {
     @Override
     public final void cancel() {
         Cancellable oldVal = currentUpdater.getAndSet(this, CANCELLED);
-            oldVal.cancel();
-        }
+        oldVal.cancel();
+    }
+
+    /**
+     * Cancels only the {@link Cancellable} that is currently hold without side effect for any
+     * {@link #nextCancellable(Cancellable)}.
+     */
+    public void cancelCurrent() {
+        Cancellable oldVal = currentUpdater.getAndUpdate(this, prev -> prev == CANCELLED ? CANCELLED : IGNORE_CANCEL);
+        oldVal.cancel();
+    }
 
     /**
      * Returns {@code true} if this {@link Cancellable} is cancelled.

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SequentialCancellable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/SequentialCancellable.java
@@ -68,7 +68,7 @@ public class SequentialCancellable implements Cancellable {
     }
 
     /**
-     * Cancels only the {@link Cancellable} that is currently hold without side effect for any
+     * Cancels only the {@link Cancellable} that is currently held without side effect for any
      * {@link #nextCancellable(Cancellable)}.
      */
     public void cancelCurrent() {


### PR DESCRIPTION
Motivation:

In scenarios when `SequentialCancellable` is used to manage global cancellation, there might be cases when we have to re-subscribe. Cancelling the current `Cancellable` will allow us to do this.

Modifications:

- Add `SequentialCancellable#cancelCurrent()` method;
- Test the new feature;

Result:

It's possible to cancel only the current `Cancellable` inside `SequentialCancellable` and then re-subscribe.