### PR TITLE
Extend DnsServiceDiscovererObserver functionality

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
@@ -20,7 +20,7 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 
 /**
  * An observer that provides visibility into <a href="https://tools.ietf.org/html/rfc1034">DNS</a>
- * {@link ServiceDiscoverer} built by {@link DefaultDnsServiceDiscovererBuilder}.
+ * {@link ServiceDiscoverer} built by {@link DnsServiceDiscovererBuilder}.
  */
 public interface DnsServiceDiscovererObserver {
 
@@ -30,8 +30,22 @@ public interface DnsServiceDiscovererObserver {
      * @param name the name of DNS record to be discovered
      * @return {@link DnsDiscoveryObserver} that provides visibility into individual DNS resolutions behind the
      * associated discovery
+     * @deprecated use {@link #onNewDiscovery(String, String)} instead.
      */
+    @Deprecated // FIXME 0.43: remove deprecated method
     DnsDiscoveryObserver onNewDiscovery(String name);
+
+    /**
+     * Notifies that a new {@link ServiceDiscoverer#discover(Object) discovery} started.
+     *
+     * @param serviceDiscovererId the ID of the {@link ServiceDiscoverer}.
+     * @param name the name of DNS record to be discovered
+     * @return {@link DnsDiscoveryObserver} that provides visibility into individual DNS resolutions behind the
+     * associated discovery
+     */
+    default DnsDiscoveryObserver onNewDiscovery(String serviceDiscovererId, String name) { // FIXME: 0.43 remove default
+        return onNewDiscovery(name);
+    }
 
     /**
      * An observer that provides visibility into individual DNS resolutions.
@@ -46,6 +60,23 @@ public interface DnsServiceDiscovererObserver {
          * @return {@link DnsResolutionObserver} that provides visibility into results of the current DNS resolution
          */
         DnsResolutionObserver onNewResolution(String name);
+
+        /**
+         * Notifies that the current DNS discovery got canceled (did not complete successfully).
+         */
+        default void discoveryCanceled() { } // FIXME: 0.43 remove default
+
+        /**
+         * Notifies that the current DNS discovery completed successfully.
+         */
+        default void discoveryCompleted() { } // FIXME: 0.43 remove default
+
+        /**
+         * Notifies that the current DNS discovery failed.
+         *
+         * @param cause {@link Throwable} as a cause for the failure
+         */
+        default void discoveryFailed(Throwable cause) { } // FIXME: 0.43 remove default
     }
 
     /**

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
@@ -67,11 +67,6 @@ public interface DnsServiceDiscovererObserver {
         default void discoveryCanceled() { } // FIXME: 0.43 remove default
 
         /**
-         * Notifies that the current DNS discovery completed successfully.
-         */
-        default void discoveryCompleted() { } // FIXME: 0.43 remove default
-
-        /**
          * Notifies that the current DNS discovery failed.
          *
          * @param cause {@link Throwable} as a cause for the failure

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
@@ -30,9 +30,12 @@ public interface DnsServiceDiscovererObserver {
      * @param name the name of DNS record to be discovered
      * @return {@link DnsDiscoveryObserver} that provides visibility into individual DNS resolutions behind the
      * associated discovery
-     * @deprecated use {@link #onNewDiscovery(String, String)} instead.
+     * @deprecated use {@link #onNewDiscovery(String, String)} instead. To avoid breaking changes, all
+     * current implementations must implement both methods. In the next version the default implementation will
+     * swap. Then users will be able to keep implementation only for the new method. In the release after, the
+     * deprecated method will be removed.
      */
-    @Deprecated // FIXME 0.43: remove deprecated method
+    @Deprecated // FIXME 0.4 - swap default impl
     DnsDiscoveryObserver onNewDiscovery(String name);
 
     /**
@@ -48,7 +51,14 @@ public interface DnsServiceDiscovererObserver {
     }
 
     /**
-     * An observer that provides visibility into individual DNS resolutions.
+     * An observer that provides visibility into individual DNS discoveries.
+     * <p>
+     * The discovery is considered complete when one of the terminal events is invoked. It's guaranteed only one
+     * terminal event will be invoked per request (either {@link #discoveryCancelled()} or
+     * {@link #discoveryFailed(Throwable)}).
+     * <p>
+     * In case of an SRV lookup, there might be multiple {@link DnsResolutionObserver DNS resolutions} observed for one
+     * discovery.
      */
     interface DnsDiscoveryObserver {
 
@@ -62,12 +72,16 @@ public interface DnsServiceDiscovererObserver {
         DnsResolutionObserver onNewResolution(String name);
 
         /**
-         * Notifies that the current DNS discovery got canceled (did not complete successfully).
+         * Notifies that the current DNS discovery got cancelled.
+         * <p>
+         * This is one of the possible terminal events.
          */
-        default void discoveryCanceled() { } // FIXME: 0.43 remove default
+        default void discoveryCancelled() { } // FIXME: 0.43 remove default
 
         /**
          * Notifies that the current DNS discovery failed.
+         * <p>
+         * This is one of the possible terminal events.
          *
          * @param cause {@link Throwable} as a cause for the failure
          */
@@ -76,11 +90,17 @@ public interface DnsServiceDiscovererObserver {
 
     /**
      * An observer that provides visibility into DNS resolution results.
+     * <p>
+     * The resolution is considered complete when one of the terminal events is invoked. It's guaranteed only one
+     * terminal event will be invoked per request (either {@link #resolutionFailed(Throwable)} or
+     * {@link #resolutionCompleted(ResolutionResult)}).
      */
     interface DnsResolutionObserver {
 
         /**
          * Notifies that the current DNS resolution failed.
+         * <p>
+         * This is one of the possible terminal events.
          *
          * @param cause {@link Throwable} as a cause for the failure
          */
@@ -88,6 +108,8 @@ public interface DnsServiceDiscovererObserver {
 
         /**
          * Notifies that the current DNS resolution completed successfully.
+         * <p>
+         * This is one of the possible terminal events.
          *
          * @param result the {@link ResolutionResult}
          */

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserver.java
@@ -54,8 +54,7 @@ public interface DnsServiceDiscovererObserver {
      * An observer that provides visibility into individual DNS discoveries.
      * <p>
      * The discovery is considered complete when one of the terminal events is invoked. It's guaranteed only one
-     * terminal event will be invoked per request (either {@link #discoveryCancelled()} or
-     * {@link #discoveryFailed(Throwable)}).
+     * terminal event will be invoked per request.
      * <p>
      * In case of an SRV lookup, there might be multiple {@link DnsResolutionObserver DNS resolutions} observed for one
      * discovery.
@@ -92,8 +91,7 @@ public interface DnsServiceDiscovererObserver {
      * An observer that provides visibility into DNS resolution results.
      * <p>
      * The resolution is considered complete when one of the terminal events is invoked. It's guaranteed only one
-     * terminal event will be invoked per request (either {@link #resolutionFailed(Throwable)} or
-     * {@link #resolutionCompleted(ResolutionResult)}).
+     * terminal event will be invoked per request.
      */
     interface DnsResolutionObserver {
 

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserverTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserverTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 
@@ -48,9 +49,13 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -62,6 +67,7 @@ class DnsServiceDiscovererObserverTest {
     private static final String SERVICE_NAME = "servicetalk";
     private static final String INVALID = "invalid.";
     private static final int DEFAULT_TTL = 1;
+    private static final String DISCOVERER_ID = "test";
 
     private final TestRecordStore recordStore = new TestRecordStore();
     private final TestDnsServer dnsServer = new TestDnsServer(recordStore);
@@ -84,7 +90,7 @@ class DnsServiceDiscovererObserverTest {
     }
 
     private DnsClient dnsClient(DnsServiceDiscovererObserver observer) {
-        return toClose.append(new DefaultDnsServiceDiscovererBuilder("test")
+        return toClose.append(new DefaultDnsServiceDiscovererBuilder(DISCOVERER_ID)
                 .observer(observer)
                 .dnsResolverAddressTypes(DnsResolverAddressTypes.IPV4_PREFERRED)
                 .optResourceEnabled(false)
@@ -107,9 +113,37 @@ class DnsServiceDiscovererObserverTest {
     private void testNewDiscoveryObserver(BiFunction<DnsClient, String, Publisher<?>> publisherFactory,
                                           String expectedName) throws Exception {
         BlockingQueue<String> newDiscoveryCalls = new LinkedBlockingDeque<>();
-        DnsClient client = dnsClient(name -> {
-            newDiscoveryCalls.add(name);
-            return NoopDnsDiscoveryObserver.INSTANCE;
+        final AtomicBoolean discoveryCanceledCalled = new AtomicBoolean();
+        DnsClient client = dnsClient(new DnsServiceDiscovererObserver() {
+            @Override
+            public DnsDiscoveryObserver onNewDiscovery(final String name) {
+                fail("This method must not be called anymore when overridden");
+                return null;
+            }
+
+            @Override
+            public DnsDiscoveryObserver onNewDiscovery(final String serviceDiscovererId, final String name) {
+                newDiscoveryCalls.add(name);
+                assertEquals(DISCOVERER_ID, serviceDiscovererId);
+                return new DnsDiscoveryObserver() {
+                    @Override
+                    public DnsResolutionObserver onNewResolution(final String name) {
+                        return NoopDnsResolutionObserver.INSTANCE;
+                    }
+
+                    @Override
+                    public void discoveryCanceled() {
+                        // the takeAtMost operator below will trigger a cancellation, not a completion event
+                        discoveryCanceledCalled.set(true);
+                    }
+
+                    @Override
+                    public void discoveryCompleted() { }
+
+                    @Override
+                    public void discoveryFailed(final Throwable cause) { }
+                };
+            }
         });
 
         Publisher<?> publisher = publisherFactory.apply(client, expectedName);
@@ -118,6 +152,7 @@ class DnsServiceDiscovererObserverTest {
         publisher.takeAtMost(1).ignoreElements().toFuture().get();
         assertThat("Unexpected number of calls to newDiscovery(name)", newDiscoveryCalls, hasSize(1));
         assertThat("Unexpected name for newDiscovery(name)", newDiscoveryCalls, hasItem(equalTo(expectedName)));
+        assertTrue(discoveryCanceledCalled.get());
     }
 
     @Test
@@ -153,6 +188,47 @@ class DnsServiceDiscovererObserverTest {
         assertThat("Unexpected name for newResolution(name)", newResolution, hasItem(equalTo(SERVICE_NAME)));
         assertThat("Unexpected name for newResolution(name)", newResolution,
                 hasItem(anyOf(equalTo(HOST_NAME), equalTo(HOST_NAME + '.'))));
+    }
+
+    @Test
+    void aQueryFailedDiscovery() {
+        testFailedDiscovery(DnsClient::dnsQuery);
+    }
+
+    @Test
+    void srvQueryFailedDiscovery() {
+        testFailedDiscovery(DnsClient::dnsSrvQuery);
+    }
+
+    private void testFailedDiscovery(BiFunction<DnsClient, String, Publisher<?>> publisherFactory) {
+        BlockingQueue<Throwable> discoveryFailures = new LinkedBlockingDeque<>();
+        DnsClient client = dnsClient(name -> new DnsDiscoveryObserver() {
+            @Override
+            public DnsResolutionObserver onNewResolution(final String name) {
+                return NoopDnsResolutionObserver.INSTANCE;
+            }
+
+            @Override
+            public void discoveryCanceled() { }
+
+            @Override
+            public void discoveryCompleted() { }
+
+            @Override
+            public void discoveryFailed(final Throwable cause) {
+                discoveryFailures.add(cause);
+            }
+        });
+
+        Publisher<?> publisher = publisherFactory.apply(client, INVALID);
+        assertThat("Unexpected calls to discoveryFailed(t)", discoveryFailures, hasSize(0));
+        // Wait until SD returns at least one address:
+        ExecutionException ee = assertThrows(ExecutionException.class,
+                () -> publisher.takeAtMost(1).ignoreElements().toFuture().get());
+        Throwable cause = ee.getCause();
+        assertThat(cause, instanceOf(UnknownHostException.class));
+        assertThat("Unexpected number of calls to discoveryFailed(t)", discoveryFailures, hasSize(1));
+        assertThat("Unexpected name for discoveryFailed(t)", discoveryFailures, hasItem(sameInstance(cause)));
     }
 
     @Test
@@ -289,34 +365,34 @@ class DnsServiceDiscovererObserverTest {
     @Test
     void aQueryOnNewDiscoveryThrows() throws Exception {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
-        when(observer.onNewDiscovery(anyString())).thenThrow(DELIBERATE_EXCEPTION);
+        when(observer.onNewDiscovery(eq(DISCOVERER_ID), anyString())).thenThrow(DELIBERATE_EXCEPTION);
 
         DnsClient client = dnsClient(observer);
         Publisher<?> publisher = client.dnsQuery(HOST_NAME);
         verifyNoInteractions(observer);
         // Wait until SD returns at least one address:
         publisher.takeAtMost(1).ignoreElements().toFuture().get();
-        verify(observer).onNewDiscovery(HOST_NAME);
+        verify(observer).onNewDiscovery(DISCOVERER_ID, HOST_NAME);
     }
 
     @Test
     void srvQueryOnNewDiscoveryThrows() throws Exception {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
-        when(observer.onNewDiscovery(anyString())).thenThrow(DELIBERATE_EXCEPTION);
+        when(observer.onNewDiscovery(eq(DISCOVERER_ID), anyString())).thenThrow(DELIBERATE_EXCEPTION);
 
         DnsClient client = dnsClient(observer);
         Publisher<?> publisher = client.dnsSrvQuery(SERVICE_NAME);
         verifyNoInteractions(observer);
         // Wait until SD returns at least one address:
         publisher.takeAtMost(1).ignoreElements().toFuture().get();
-        verify(observer).onNewDiscovery(SERVICE_NAME);
+        verify(observer).onNewDiscovery(DISCOVERER_ID, SERVICE_NAME);
     }
 
     @Test
     void onNewResolutionThrows() throws Exception {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
         DnsDiscoveryObserver discoveryObserver = mock(DnsDiscoveryObserver.class);
-        when(observer.onNewDiscovery(anyString())).thenReturn(discoveryObserver);
+        when(observer.onNewDiscovery(eq(DISCOVERER_ID), anyString())).thenReturn(discoveryObserver);
         when(discoveryObserver.onNewResolution(anyString())).thenThrow(DELIBERATE_EXCEPTION);
 
         DnsClient client = dnsClient(observer);
@@ -324,16 +400,16 @@ class DnsServiceDiscovererObserverTest {
         verifyNoInteractions(observer, discoveryObserver);
         // Wait until SD returns at least one address:
         publisher.takeAtMost(1).ignoreElements().toFuture().get();
-        verify(observer).onNewDiscovery(HOST_NAME);
+        verify(observer).onNewDiscovery(DISCOVERER_ID, HOST_NAME);
         verify(discoveryObserver).onNewResolution(HOST_NAME);
     }
 
     @Test
-    void resolutionFailedThrows() throws Exception {
+    void resolutionFailedThrows() {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
         DnsDiscoveryObserver discoveryObserver = mock(DnsDiscoveryObserver.class);
         DnsResolutionObserver resolutionObserver = mock(DnsResolutionObserver.class);
-        when(observer.onNewDiscovery(anyString())).thenReturn(discoveryObserver);
+        when(observer.onNewDiscovery(eq(DISCOVERER_ID), anyString())).thenReturn(discoveryObserver);
         when(discoveryObserver.onNewResolution(anyString())).thenReturn(resolutionObserver);
         doThrow(DELIBERATE_EXCEPTION).when(resolutionObserver).resolutionFailed(any());
 
@@ -343,7 +419,7 @@ class DnsServiceDiscovererObserverTest {
         // Wait until SD returns at least one address:
         ExecutionException ee = assertThrows(ExecutionException.class,
                 () -> publisher.takeAtMost(1).ignoreElements().toFuture().get());
-        verify(observer).onNewDiscovery(INVALID);
+        verify(observer).onNewDiscovery(DISCOVERER_ID, INVALID);
         verify(discoveryObserver).onNewResolution(INVALID);
         verify(resolutionObserver).resolutionFailed(ee.getCause());
     }
@@ -353,7 +429,7 @@ class DnsServiceDiscovererObserverTest {
         DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
         DnsDiscoveryObserver discoveryObserver = mock(DnsDiscoveryObserver.class);
         DnsResolutionObserver resolutionObserver = mock(DnsResolutionObserver.class);
-        when(observer.onNewDiscovery(anyString())).thenReturn(discoveryObserver);
+        when(observer.onNewDiscovery(eq(DISCOVERER_ID), anyString())).thenReturn(discoveryObserver);
         when(discoveryObserver.onNewResolution(anyString())).thenReturn(resolutionObserver);
         doThrow(DELIBERATE_EXCEPTION).when(resolutionObserver).resolutionCompleted(any());
 
@@ -362,22 +438,9 @@ class DnsServiceDiscovererObserverTest {
         verifyNoInteractions(observer, discoveryObserver, resolutionObserver);
         // Wait until SD returns at least one address:
         publisher.takeAtMost(1).ignoreElements().toFuture().get();
-        verify(observer).onNewDiscovery(HOST_NAME);
+        verify(observer).onNewDiscovery(DISCOVERER_ID, HOST_NAME);
         verify(discoveryObserver).onNewResolution(HOST_NAME);
         verify(resolutionObserver).resolutionCompleted(any());
-    }
-
-    private static final class NoopDnsDiscoveryObserver implements DnsDiscoveryObserver {
-        static final DnsDiscoveryObserver INSTANCE = new NoopDnsDiscoveryObserver();
-
-        private NoopDnsDiscoveryObserver() {
-            // Singleton
-        }
-
-        @Override
-        public DnsResolutionObserver onNewResolution(final String name) {
-            return NoopDnsResolutionObserver.INSTANCE;
-        }
     }
 
     private static class NoopDnsResolutionObserver implements DnsResolutionObserver {


### PR DESCRIPTION
Motivation:

To enhance the utility of the DnsServiceDiscovererObserver a couple additional APIs can be provided:

 - The newly introduced ServiceDiscoverer ID is brought in scope
 - Further lifecycle callbacks are added to the DnsDiscoveryObserver

Modifications:

This changeset adds the two enhancements mentioned in the motivation in a backwards-compatible way. In the next minor released the interface can be cleaned up.

Tests have been enhanced to test the newly added functionality.

Result:

More functionality around the DnsServiceDiscovererObserver.