### PR TITLE
Don't allow to override ServiceDiscoverer for resolved address client

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -311,7 +311,9 @@ public final class HttpClients {
             final HostAndPort address) {
         final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> sd =
                 resolvedServiceDiscoverer();
-        return applyProviders(address, new DefaultSingleAddressHttpClientBuilder<>(address, sd))
+        return applyProviders(address,
+                withUnmodifiableServiceDiscoverer(new DefaultSingleAddressHttpClientBuilder<>(address, sd),
+                        sd, "resolved address " + address))
                 // Apply after providers to let them see these customizations.
                 .serviceDiscoverer(sd)
                 .retryServiceDiscoveryErrors(NoRetriesStrategy.INSTANCE);
@@ -333,7 +335,9 @@ public final class HttpClients {
     public static <R extends SocketAddress> SingleAddressHttpClientBuilder<R, R> forResolvedAddress(final R address) {
         final ServiceDiscoverer<R, R, ServiceDiscovererEvent<R>> sd =
                 mappingServiceDiscoverer(identity(), "identity for " + address.getClass().getSimpleName());
-        return applyProviders(address, new DefaultSingleAddressHttpClientBuilder<>(address, sd))
+        return applyProviders(address,
+                withUnmodifiableServiceDiscoverer(new DefaultSingleAddressHttpClientBuilder<>(address, sd),
+                        sd, "resolved address " + address))
                 // Apply after providers to let them see these customizations.
                 .serviceDiscoverer(sd)
                 .retryServiceDiscoveryErrors(NoRetriesStrategy.INSTANCE);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ForResolvedAddressTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ForResolvedAddressTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.transport.api.HostAndPort;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.net.InetSocketAddress;
+
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
+import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.mappingServiceDiscoverer;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.toResolvedInetSocketAddress;
+import static java.util.function.Function.identity;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class ForResolvedAddressTest {
+
+    @ParameterizedTest(name = "{displayName} [{index}]: protocol={0}")
+    @EnumSource(HttpProtocol.class)
+    void hostAndPort(HttpProtocol protocol) throws Exception {
+        try (HttpServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .protocols(protocol.config)
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             BlockingHttpClient client = HttpClients.forResolvedAddress(serverHostAndPort(serverContext))
+                     .protocols(protocol.config)
+                     .buildBlocking()) {
+            HttpResponse response = client.request(client.get("/"));
+            assertThat(response.status(), is(OK));
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: protocol={0}")
+    @EnumSource(HttpProtocol.class)
+    void inetSocketAddress(HttpProtocol protocol) throws Exception {
+        try (HttpServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .protocols(protocol.config)
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             BlockingHttpClient client = HttpClients.forResolvedAddress(
+                     (InetSocketAddress) serverContext.listenAddress())
+                     .protocols(protocol.config)
+                     .buildBlocking()) {
+            HttpResponse response = client.request(client.get("/"));
+            assertThat(response.status(), is(OK));
+        }
+    }
+
+    @Test
+    void hostAndPortThrowIfSdChanges() {
+        ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> otherSd =
+                globalDnsServiceDiscoverer();
+        HostAndPort address = HostAndPort.of("127.0.0.1", 8080);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> HttpClients.forResolvedAddress(address).serviceDiscoverer(otherSd));
+        assertThat(e.getMessage(), allOf(containsString(address.toString()), containsString(otherSd.toString())));
+    }
+
+    @Test
+    void inetSocketAddressThrowIfSdChanges() {
+        ServiceDiscoverer<InetSocketAddress, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> otherSd =
+                mappingServiceDiscoverer(identity(), ForResolvedAddressTest.class.getSimpleName());
+        InetSocketAddress address = toResolvedInetSocketAddress(HostAndPort.of("127.0.0.1", 8080));
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> HttpClients.forResolvedAddress(address).serviceDiscoverer(otherSd));
+        assertThat(e.getMessage(), allOf(containsString(address.toString()), containsString(otherSd.toString())));
+    }
+}


### PR DESCRIPTION
Motivation:

`HttpClients.forResolvedAddress(...)` uses a special `ServiceDiscoverer`
that users should not override. Otherwise, behavior will be
unpredictable.

Modifications:

- Use `withUnmodifiableServiceDiscoverer` to protect from overriding the
`ServiceDiscoverer`;
- Add `ForResolvedAddressTest` to validate this behavior;

Result:

Users can not change `ServiceDiscoverer` used by `HttpClients
.forResolvedAddress(...)`. In case they need a custom SD for this use
case, they can use `HttpClients.forSingleAddress(ServiceDiscoverer, U)`.

---

Depends on #2520, review only the latest commit: https://github.com/apple/servicetalk/pull/2524/commits/3713d8dc64cecdda0fb56e6f07d85db71eb41ebc