### PR TITLE
Implement RoundRobinLoadBalancerBuilderProvider

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/RoundRobinLoadBalancerSDEventsBenchmark.java
@@ -23,7 +23,7 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.context.api.ContextMap;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
+import io.servicetalk.loadbalancer.RoundRobinLoadBalancers;
 import io.servicetalk.transport.api.TransportObserver;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -80,15 +80,15 @@ public class RoundRobinLoadBalancerSDEventsBenchmark {
     @Benchmark
     public LoadBalancer<LoadBalancedConnection> mixed() {
         // RR load balancer synchronously subscribes and will consume all events during construction.
-        return new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, LoadBalancedConnection>().build()
+        return RoundRobinLoadBalancers.<InetSocketAddress, LoadBalancedConnection>builder("mixed").build()
                 .newLoadBalancer(from(mixedEvents), ConnFactory.INSTANCE, "benchmark");
     }
 
     @Benchmark
     public LoadBalancer<LoadBalancedConnection> available() {
         // RR load balancer synchronously subscribes and will consume all events during construction.
-        return new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, LoadBalancedConnection>().build()
-                        .newLoadBalancer(from(availableEvents), ConnFactory.INSTANCE, "benchmark");
+        return RoundRobinLoadBalancers.<InetSocketAddress, LoadBalancedConnection>builder("available").build()
+                .newLoadBalancer(from(availableEvents), ConnFactory.INSTANCE, "benchmark");
     }
 
     private static final class ConnFactory implements ConnectionFactory<InetSocketAddress, LoadBalancedConnection> {

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -95,6 +95,7 @@ import static io.servicetalk.transport.netty.internal.BuilderUtils.socketChannel
 import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.lang.Integer.toHexString;
+import static java.lang.System.identityHashCode;
 import static java.nio.ByteBuffer.wrap;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -199,7 +200,7 @@ final class DefaultDnsClient implements DnsClient {
 
     @Override
     public String toString() {
-        return id + " (instance @" + toHexString(hashCode()) + ')';
+        return id + '@' + toHexString(identityHashCode(this));
     }
 
     // visible for testing

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -157,7 +157,7 @@ final class DefaultDnsClient implements DnsClient {
         this.ttlJitterNanos = ttlJitterNanos;
         this.observer = observer;
         this.missingRecordStatus = missingRecordStatus;
-        this.id = id + " (instance @" + toHexString(identityHashCode(this)) + ')';
+        this.id = id + '@' + toHexString(identityHashCode(this));
         asyncCloseable = toAsyncCloseable(graceful -> {
             if (nettyIoExecutor.isCurrentThreadEventLoop()) {
                 closeAsync0();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -34,7 +34,7 @@ import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
+import io.servicetalk.loadbalancer.RoundRobinLoadBalancers;
 
 import java.util.Collection;
 
@@ -119,8 +119,9 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
          * @return A new {@link Builder}.
          */
         public static <ResolvedAddress> Builder<ResolvedAddress> fromDefaults() {
-            return from(new RoundRobinLoadBalancerFactory
-                    .Builder<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection>().build());
+            return from(RoundRobinLoadBalancers
+                    .<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection>builder(
+                            DefaultHttpLoadBalancerFactory.class.getSimpleName()).build());
         }
 
         /**

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
@@ -24,7 +24,7 @@ import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.utils.CacheConnectionHttpLoadBalanceFactory;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
+import io.servicetalk.loadbalancer.RoundRobinLoadBalancers;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
@@ -90,9 +90,9 @@ final class CacheConnectionHttpLoadBalanceFactoryTest {
                      .enableWireLogging("servicetalk-tests-h2-frame-logger", LogLevel.TRACE, () -> false)
                      .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(connectionObserver))
                      .loadBalancerFactory(new CacheConnectionHttpLoadBalanceFactory<>(
-                             DefaultHttpLoadBalancerFactory.Builder.from(
-                                     new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress,
-                                             FilterableStreamingHttpLoadBalancedConnection>().build()).build(),
+                             DefaultHttpLoadBalancerFactory.Builder.from(RoundRobinLoadBalancers.<InetSocketAddress,
+                                     FilterableStreamingHttpLoadBalancedConnection>builder(getClass().getSimpleName())
+                                     .build()).build(),
                              a -> maxConcurrency))
                      // The accounting for connection caching and the ConcurrencyController are done at different layers
                      // so it is possible the connection caching will give a connection to the load balancer that fails

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -577,7 +577,7 @@ class ClientEffectiveStrategyTest {
                         eventPublisher,
                 final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
             return RoundRobinLoadBalancers.<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>builder(
-                    getClass().getSimpleName()).build()
+                    ClientEffectiveStrategyTest.class.getSimpleName()).build()
                     .newLoadBalancer(targetResource, eventPublisher, connectionFactory);
         }
 
@@ -589,7 +589,7 @@ class ClientEffectiveStrategyTest {
                         connectionFactory,
                 final String targetResource) {
             return RoundRobinLoadBalancers.<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>builder(
-                    getClass().getSimpleName()).build()
+                    ClientEffectiveStrategyTest.class.getSimpleName()).build()
                     .newLoadBalancer(eventPublisher, connectionFactory, targetResource);
         }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -45,7 +45,7 @@ import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
+import io.servicetalk.loadbalancer.RoundRobinLoadBalancers;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoThreadFactory;
@@ -576,8 +576,8 @@ class ClientEffectiveStrategyTest {
                 final Publisher<? extends Collection<? extends ServiceDiscovererEvent<InetSocketAddress>>>
                         eventPublisher,
                 final ConnectionFactory<InetSocketAddress, T> connectionFactory) {
-            return new RoundRobinLoadBalancerFactory
-                    .Builder<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>().build()
+            return RoundRobinLoadBalancers.<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>builder(
+                    getClass().getSimpleName()).build()
                     .newLoadBalancer(targetResource, eventPublisher, connectionFactory);
         }
 
@@ -588,8 +588,8 @@ class ClientEffectiveStrategyTest {
                 final ConnectionFactory<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>
                         connectionFactory,
                 final String targetResource) {
-            return new RoundRobinLoadBalancerFactory
-                    .Builder<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>().build()
+            return RoundRobinLoadBalancers.<InetSocketAddress, FilterableStreamingHttpLoadBalancedConnection>builder(
+                    getClass().getSimpleName()).build()
                     .newLoadBalancer(eventPublisher, connectionFactory, targetResource);
         }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -33,7 +33,7 @@ import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory;
+import io.servicetalk.loadbalancer.RoundRobinLoadBalancers;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.RetryableException;
@@ -221,7 +221,7 @@ class RetryingHttpRequesterFilterTest {
             implements LoadBalancerFactory<InetSocketAddress, C> {
 
         private final LoadBalancerFactory<InetSocketAddress, C> rr =
-                new RoundRobinLoadBalancerFactory.Builder<InetSocketAddress, C>().build();
+                RoundRobinLoadBalancers.<InetSocketAddress, C>builder(getClass().getSimpleName()).build();
 
         @SuppressWarnings("deprecation")
         @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DelegatingRoundRobinLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DelegatingRoundRobinLoadBalancerBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.concurrent.api.Executor;
+
+import java.time.Duration;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link RoundRobinLoadBalancerBuilder} that delegates all methods to another {@link RoundRobinLoadBalancerBuilder}.
+ *
+ * @param <ResolvedAddress> The resolved address type.
+ * @param <C> The type of connection.
+ */
+public class DelegatingRoundRobinLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection>
+        implements RoundRobinLoadBalancerBuilder<ResolvedAddress, C> {
+
+    private RoundRobinLoadBalancerBuilder<ResolvedAddress, C> delegate;
+
+    /**
+     * Creates a new builder which delegates to the provided {@link RoundRobinLoadBalancerBuilder}.
+     *
+     * @param delegate the delegate builder.
+     */
+    public DelegatingRoundRobinLoadBalancerBuilder(final RoundRobinLoadBalancerBuilder<ResolvedAddress, C> delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    /**
+     * Returns the {@link DelegatingRoundRobinLoadBalancerBuilder} delegate.
+     *
+     * @return Delegate {@link DelegatingRoundRobinLoadBalancerBuilder}.
+     */
+    protected final RoundRobinLoadBalancerBuilder<ResolvedAddress, C> delegate() {
+        return delegate;
+    }
+
+    @Override
+    public RoundRobinLoadBalancerBuilder<ResolvedAddress, C> linearSearchSpace(final int linearSearchSpace) {
+        delegate = delegate.linearSearchSpace(linearSearchSpace);
+        return this;
+    }
+
+    @Override
+    public RoundRobinLoadBalancerBuilder<ResolvedAddress, C> backgroundExecutor(final Executor backgroundExecutor) {
+        delegate = delegate.backgroundExecutor(backgroundExecutor);
+        return this;
+    }
+
+    @Override
+    public RoundRobinLoadBalancerBuilder<ResolvedAddress, C> healthCheckInterval(final Duration interval,
+                                                                                 final Duration jitter) {
+        delegate = delegate.healthCheckInterval(interval, jitter);
+        return this;
+    }
+
+    @Override
+    public RoundRobinLoadBalancerBuilder<ResolvedAddress, C> healthCheckResubscribeInterval(final Duration interval,
+                                                                                            final Duration jitter) {
+        delegate = delegate.healthCheckResubscribeInterval(interval, jitter);
+        return this;
+    }
+
+    @Override
+    public RoundRobinLoadBalancerBuilder<ResolvedAddress, C> healthCheckFailedConnectionsThreshold(
+            final int threshold) {
+        delegate = delegate.healthCheckFailedConnectionsThreshold(threshold);
+        return this;
+    }
+
+    @Override
+    public RoundRobinLoadBalancerFactory<ResolvedAddress, C> build() {
+        return delegate.build();
+    }
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DelegatingRoundRobinLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DelegatingRoundRobinLoadBalancerBuilder.java
@@ -16,6 +16,7 @@
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.concurrent.api.Executor;
 
 import java.time.Duration;
@@ -85,7 +86,7 @@ public class DelegatingRoundRobinLoadBalancerBuilder<ResolvedAddress, C extends 
     }
 
     @Override
-    public RoundRobinLoadBalancerFactory<ResolvedAddress, C> build() {
+    public LoadBalancerFactory<ResolvedAddress, C> build() {
         return delegate.build();
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -151,6 +151,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
     /**
      * Creates a new instance.
      *
+     * @param id a (unique) ID to identify the created {@link RoundRobinLoadBalancer}.
      * @param targetResourceName {@link String} representation of the target resource for which this instance
      * is performing load balancing.
      * @param eventPublisher provides a stream of addresses to connect to.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -82,6 +82,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static java.lang.Integer.toHexString;
 import static java.lang.Math.min;
+import static java.lang.System.identityHashCode;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -135,6 +136,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
     private volatile int index;
     private volatile List<Host<ResolvedAddress, C>> usedHosts = emptyList();
 
+    private final String id;
     private final String targetResource;
     private final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher;
     private final Processor<Object, Object> eventStreamProcessor = newPublisherProcessorDropHeadOnOverflow(32);
@@ -156,15 +158,17 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
      * @param healthCheckConfig configuration for the health checking mechanism, which monitors hosts that
      * are unable to have a connection established. Providing {@code null} disables this mechanism (meaning the host
      * continues being eligible for connecting on the request path).
-     * @see io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory
+     * @see RoundRobinLoadBalancerFactory
      */
     RoundRobinLoadBalancer(
+            final String id,
             final String targetResourceName,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
             final int linearSearchSpace,
             @Nullable final HealthCheckConfig healthCheckConfig) {
-        this.targetResource = requireNonNull(targetResourceName) + " (instance @" + toHexString(hashCode()) + ')';
+        this.id = id + '@' + toHexString(identityHashCode(this));
+        this.targetResource = requireNonNull(targetResourceName);
         this.eventPublisher = requireNonNull(eventPublisher);
         this.eventStream = fromSource(eventStreamProcessor);
         this.connectionFactory = requireNonNull(connectionFactory);
@@ -179,8 +183,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                 if (isClosedList(currentList) ||
                         usedHostsUpdater.compareAndSet(this, currentList, new ClosedList<>(currentList))) {
                     compositeCloseable = newCompositeCloseable().appendAll(currentList).appendAll(connectionFactory);
-                    LOGGER.debug("Load balancer for {} is closing {}gracefully. Last seen addresses (size={}): {}.",
-                            targetResource, graceful ? "" : "non", currentList.size(), currentList);
+                    LOGGER.debug("{} is closing {}gracefully. Last seen addresses (size={}): {}.",
+                            this, graceful ? "" : "non", currentList.size(), currentList);
                     break;
                 }
             }
@@ -274,13 +278,13 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         @Override
         public void onNext(@Nullable final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
             if (events == null) {
-                LOGGER.debug("Load balancer for {}: unexpectedly received null instead of events.", targetResource);
+                LOGGER.debug("{}: unexpectedly received null instead of events.", RoundRobinLoadBalancer.this);
                 return;
             }
             for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
                 final ServiceDiscovererEvent.Status eventStatus = event.status();
-                LOGGER.debug("Load balancer for {}: received new ServiceDiscoverer event {}. Inferred status: {}.",
-                        targetResource, event, eventStatus);
+                LOGGER.debug("{}: received new ServiceDiscoverer event {}. Inferred status: {}.",
+                        RoundRobinLoadBalancer.this, event, eventStatus);
 
                 @SuppressWarnings("unchecked")
                 final List<Host<ResolvedAddress, C>> usedAddresses =
@@ -310,15 +314,15 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                                     return match;
                                 });
                             } else {
-                                LOGGER.error("Load balancer for {}: Unexpected Status in event:" +
+                                LOGGER.error("{}: Unexpected Status in event:" +
                                         " {} (mapped to {}). Leaving usedHosts unchanged: {}",
-                                        targetResource, event, eventStatus, oldHosts);
+                                        RoundRobinLoadBalancer.this, event, eventStatus, oldHosts);
                                 return oldHosts;
                             }
                         });
 
-                LOGGER.debug("Load balancer for {}: now using addresses (size={}): {}.",
-                        targetResource, usedAddresses.size(), usedAddresses);
+                LOGGER.debug("{}: now using addresses (size={}): {}.",
+                        RoundRobinLoadBalancer.this, usedAddresses.size(), usedAddresses);
 
                 if (AVAILABLE.equals(eventStatus)) {
                     if (usedAddresses.size() == 1) {
@@ -368,7 +372,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         }
 
         private Host<ResolvedAddress, C> createHost(ResolvedAddress addr) {
-            Host<ResolvedAddress, C> host = new Host<>(targetResource, addr, healthCheckConfig);
+            Host<ResolvedAddress, C> host = new Host<>(RoundRobinLoadBalancer.this.toString(), addr, healthCheckConfig);
             host.onClose().afterFinally(() ->
                     usedHostsUpdater.updateAndGet(RoundRobinLoadBalancer.this, previousHosts -> {
                                 @SuppressWarnings("unchecked")
@@ -435,8 +439,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                 eventStreamProcessor.onError(t);
             }
             LOGGER.error(
-                "Load balancer for {}: service discoverer {} emitted an error. Last seen addresses (size={}): {}.",
-                targetResource, eventPublisher, hosts.size(), hosts, t);
+                "{}: service discoverer {} emitted an error. Last seen addresses (size={}): {}.",
+                    RoundRobinLoadBalancer.this, eventPublisher, hosts.size(), hosts, t);
         }
 
         @Override
@@ -446,8 +450,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                 // Terminate processor only if we will never re-subscribe
                 eventStreamProcessor.onComplete();
             }
-            LOGGER.error("Load balancer for {}: service discoverer completed. Last seen addresses (size={}): {}.",
-                    targetResource, hosts.size(), hosts);
+            LOGGER.error("{}: service discoverer completed. Last seen addresses (size={}): {}.",
+                    RoundRobinLoadBalancer.this, hosts.size(), hosts);
         }
     }
 
@@ -473,8 +477,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
     @Override
     public String toString() {
         return "RoundRobinLoadBalancer{" +
-                "targetResource='" + targetResource + '\'' +
-                ", usedHosts=" + usedHosts +
+                "id=" + id +
+                ", targetResource=" + targetResource +
                 '}';
     }
 
@@ -658,15 +662,15 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         private static final AtomicReferenceFieldUpdater<Host, ConnState> connStateUpdater =
                 newUpdater(Host.class, ConnState.class, "connState");
 
-        private final String targetResource;
+        private final String lbDescription;
         final Addr address;
         @Nullable
         private final HealthCheckConfig healthCheckConfig;
         private final ListenableAsyncCloseable closeable;
         private volatile ConnState connState = ACTIVE_EMPTY_CONN_STATE;
 
-        Host(String targetResource, Addr address, @Nullable HealthCheckConfig healthCheckConfig) {
-            this.targetResource = targetResource;
+        Host(String lbDescription, Addr address, @Nullable HealthCheckConfig healthCheckConfig) {
+            this.lbDescription = lbDescription;
             this.address = requireNonNull(address);
             this.healthCheckConfig = healthCheckConfig;
             this.closeable = toAsyncCloseable(graceful ->
@@ -690,8 +694,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             final ConnState oldState = closeConnState();
             final Object[] toRemove = oldState.connections;
             cancelIfHealthCheck(oldState);
-            LOGGER.debug("Load balancer for {}: closing {} connection(s) gracefully to the closed address: {}.",
-                    targetResource, toRemove.length, address);
+            LOGGER.debug("{}: closing {} connection(s) gracefully to the closed address: {}.",
+                    lbDescription, toRemove.length, address);
             for (Object conn : toRemove) {
                 @SuppressWarnings("unchecked")
                 final C cConn = (C) conn;
@@ -758,8 +762,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
 
                 if (!ActiveState.class.equals(previous.state.getClass()) || previous.connections.length > 0
                         || cause instanceof ConnectionLimitReachedException) {
-                    LOGGER.debug("Load balancer for {}: failed to open a new connection to the host on address {}. {}.",
-                            targetResource, address, previous, cause);
+                    LOGGER.debug("{}: failed to open a new connection to the host on address {}. {}.",
+                            lbDescription, address, previous, cause);
                     break;
                 }
 
@@ -768,9 +772,9 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                     final ActiveState nextState = previousState.forNextFailedConnection();
                     if (connStateUpdater.compareAndSet(this, previous,
                             new ConnState(previous.connections, nextState))) {
-                        LOGGER.debug("Load balancer for {}: failed to open a new connection to the host on address {}" +
+                        LOGGER.debug("{}: failed to open a new connection to the host on address {}" +
                                         " {} time(s) ({} consecutive failures will trigger health-checking).",
-                                targetResource, address, nextState.failedConnections,
+                                lbDescription, address, nextState.failedConnections,
                                 healthCheckConfig.failedThreshold, cause);
                         break;
                     }
@@ -781,10 +785,10 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                 final HealthCheck<Addr, C> healthCheck = new HealthCheck<>(connectionFactory, this, cause);
                 final ConnState nextState = new ConnState(previous.connections, healthCheck);
                 if (connStateUpdater.compareAndSet(this, previous, nextState)) {
-                    LOGGER.info("Load balancer for {}: failed to open a new connection to the host on address {} " +
+                    LOGGER.info("{}: failed to open a new connection to the host on address {} " +
                                     "{} time(s) in a row. Error counting threshold reached, marking this host as " +
                                     "UNHEALTHY for the selection algorithm and triggering background health-checking.",
-                            targetResource, address, healthCheckConfig.failedThreshold, cause);
+                            lbDescription, address, healthCheckConfig.failedThreshold, cause);
                     healthCheck.schedule(cause);
                     break;
                 }
@@ -828,8 +832,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                 }
             }
 
-            LOGGER.trace("Load balancer for {}: added a new connection {} to {} after {} attempt(s).",
-                    targetResource, connection, this, addAttempt);
+            LOGGER.trace("{}: added a new connection {} to {} after {} attempt(s).",
+                    lbDescription, connection, this, addAttempt);
             // Instrument the new connection so we prune it on close
             connection.onClose().beforeFinally(() -> {
                 int removeAttempt = 0;
@@ -876,8 +880,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                         }
                     }
                 }
-                LOGGER.trace("Load balancer for {}: removed connection {} from {} after {} attempt(s).",
-                        targetResource, connection, this, removeAttempt);
+                LOGGER.trace("{}: removed connection {} from {} after {} attempt(s).",
+                        lbDescription, connection, this, removeAttempt);
             }).subscribe();
             return true;
         }
@@ -925,7 +929,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             if (Host.isUnhealthy(connState)) {
                 @SuppressWarnings("unchecked")
                 HealthCheck<Addr, C> healthCheck = (HealthCheck<Addr, C>) connState.state;
-                LOGGER.debug("Load balancer for {}: health check cancelled for {}.", targetResource, healthCheck.host);
+                LOGGER.debug("{}: health check cancelled for {}.", lbDescription, healthCheck.host);
                 healthCheck.cancel();
             }
         }
@@ -934,7 +938,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         public String toString() {
             final ConnState connState = this.connState;
             return "Host{" +
-                    "address=" + address +
+                    "lbDescription=" + lbDescription +
+                    ", address=" + address +
                     ", state=" + connState.state +
                     ", #connections=" + connState.connections.length +
                     '}';
@@ -990,8 +995,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                                         // attempt will be invoked on IoExecutor as a new task.
                                         .retryWhen(retryWithConstantBackoffDeltaJitter(
                                                 cause -> {
-                                                    LOGGER.debug("Load balancer for {}: health check failed for {}.",
-                                                            host.targetResource, host, cause);
+                                                    LOGGER.debug("{}: health check failed for {}.",
+                                                            host.lbDescription, host, cause);
                                                     return true;
                                                 },
                                                 host.healthCheckConfig.healthCheckInterval,
@@ -1000,24 +1005,24 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                                 .flatMapCompletable(newCnx -> {
                                     if (host.addConnection(newCnx)) {
                                         host.markHealthy(this);
-                                        LOGGER.info("Load balancer for {}: health check passed for {}, marking this " +
+                                        LOGGER.info("{}: health check passed for {}, marking this " +
                                                         "host as ACTIVE for the selection algorithm.",
-                                                host.targetResource, host);
+                                                host.lbDescription, host);
                                         return completed();
                                     } else {
                                         // This happens only if the host is closed, no need to mark as healthy.
-                                        LOGGER.debug("Load balancer for {}: health check passed for {}, but the " +
+                                        LOGGER.debug("{}: health check passed for {}, but the " +
                                                         "host rejected a new connection {}. Closing it now.",
-                                                host.targetResource, host, newCnx);
+                                                host.lbDescription, host, newCnx);
                                         return newCnx.closeAsync();
                                     }
                                 })
                                 // Use onErrorComplete instead of whenOnError to avoid double logging of an error inside
                                 // subscribe(): SimpleCompletableSubscriber.
                                 .onErrorComplete(t -> {
-                                    LOGGER.error("Load balancer for {}: health check terminated with " +
+                                    LOGGER.error("{}: health check terminated with " +
                                             "an unexpected error for {}. Marking this host as ACTIVE as a fallback " +
-                                            "to allow connection attempts.", host.targetResource, host, t);
+                                            "to allow connection attempts.", host.lbDescription, host, t);
                                     host.markHealthy(this);
                                     return true;
                                 })

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilder.java
@@ -19,15 +19,50 @@ import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.context.api.ContextMap;
 
 import java.time.Duration;
+import java.util.function.Predicate;
 
 /**
- * Builder for {@link RoundRobinLoadBalancerFactory}.
+ * Builder for {@link LoadBalancerFactory} that creates {@link LoadBalancer} instances which use a round-robin strategy
+ * for selecting connections from a pool of addresses.
+ * <p>
+ * The addresses are provided via the {@link Publisher published}
+ * {@link ServiceDiscovererEvent events} that signal the host's {@link ServiceDiscovererEvent.Status status}.
+ * Instances returned handle {@link ServiceDiscovererEvent.Status#AVAILABLE},
+ * {@link ServiceDiscovererEvent.Status#EXPIRED}, and {@link ServiceDiscovererEvent.Status#UNAVAILABLE} event statuses.
+ * <p>The created instances have the following behaviour:
+ * <ul>
+ *     <li>Round robining is done at address level.</li>
+ *     <li>Connections are created lazily, without any concurrency control on their creation. This can lead to
+ *     over-provisioning connections when dealing with a requests surge.</li>
+ *     <li>Existing connections are reused unless a selector passed to
+ *     {@link LoadBalancer#selectConnection(Predicate, ContextMap)} suggests otherwise. This can lead to situations
+ *     where connections will be used to their maximum capacity (for example in the context of pipelining) before new
+ *     connections are created.</li>
+ *     <li>Closed connections are automatically pruned.</li>
+ *     <li>When {@link Publisher}&lt;{@link ServiceDiscovererEvent}&gt; delivers events with
+ *     {@link ServiceDiscovererEvent#status()} of value {@link ServiceDiscovererEvent.Status#UNAVAILABLE}, connections
+ *     are immediately closed for the associated {@link ServiceDiscovererEvent#address()}. In case of
+ *     {@link ServiceDiscovererEvent.Status#EXPIRED}, already established connections to
+ *     {@link ServiceDiscovererEvent#address()} are used for requests, but no new connections are created. In case the
+ *     address' connections are busy, another host is tried. If all hosts are busy, selection fails with a
+ *     {@link io.servicetalk.client.api.ConnectionRejectedException}.</li>
+ *     <li>For hosts to which consecutive connection attempts fail, a background health checking task is created and the
+ *     host is not considered for opening new connections until the background check succeeds to create a connection.
+ *     Upon such event, the connection can immediately be reused and future attempts will again consider this host. This
+ *     behaviour can be disabled using a negative argument for
+ *     {@link RoundRobinLoadBalancerBuilder#healthCheckFailedConnectionsThreshold(int)} and the failing host will take
+ *     part in the regular round robin cycle for trying to establish a connection on the request path.</li>
+ * </ul>
  *
  * @param <ResolvedAddress> The resolved address type.
  * @param <C> The type of connection.
+ * @see RoundRobinLoadBalancers
  */
 public interface RoundRobinLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection> {
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilder.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.client.api.LoadBalancer;
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.concurrent.api.Executor;
+
+import java.time.Duration;
+
+/**
+ * Builder for {@link RoundRobinLoadBalancerFactory}.
+ *
+ * @param <ResolvedAddress> The resolved address type.
+ * @param <C> The type of connection.
+ */
+public interface RoundRobinLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection> {
+
+    /**
+     * Sets the linear search space to find an available connection for the next host.
+     * <p>
+     * When the next host has already opened connections, this {@link LoadBalancer} will perform a linear search for
+     * a connection that can serve the next request up to a specified number of attempts. If there are more open
+     * connections, selection of remaining connections will be attempted randomly.
+     * <p>
+     * Higher linear search space may help to better identify excess connections in highly concurrent environments,
+     * but may result in slightly increased selection time.
+     *
+     * @param linearSearchSpace the number of attempts for a linear search space, {@code 0} enforces random
+     * selection all the time.
+     * @return {@code this}.
+     */
+    RoundRobinLoadBalancerBuilder<ResolvedAddress, C> linearSearchSpace(int linearSearchSpace);
+
+    /**
+     * This {@link LoadBalancer} may monitor hosts to which connection establishment has failed
+     * using health checks that run in the background. The health check tries to establish a new connection
+     * and if it succeeds, the host is returned to the load balancing pool. As long as the connection
+     * establishment fails, the host is not considered for opening new connections for processed requests.
+     * If an {@link Executor} is not provided using this method, a default shared instance is used
+     * for all {@link LoadBalancer LoadBalancers} created by this factory.
+     * <p>
+     * {@link #healthCheckFailedConnectionsThreshold(int)} can be used to disable this mechanism and always
+     * consider all hosts for establishing new connections.
+     *
+     * @param backgroundExecutor {@link Executor} on which to schedule health checking.
+     * @return {@code this}.
+     * @see #healthCheckFailedConnectionsThreshold(int)
+     */
+    RoundRobinLoadBalancerBuilder<ResolvedAddress, C> backgroundExecutor(Executor backgroundExecutor);
+
+    /**
+     * Configure an interval for health checking a host that failed to open connections. If no interval is provided
+     * using this method, a default value will be used.
+     * <p>
+     * {@link #healthCheckFailedConnectionsThreshold(int)} can be used to disable the health checking mechanism
+     * and always consider all hosts for establishing new connections.
+     *
+     * @param interval interval at which a background health check will be scheduled.
+     * @param jitter the amount of jitter to apply to each retry {@code interval}.
+     * @return {@code this}.
+     * @see #healthCheckFailedConnectionsThreshold(int)
+     */
+    RoundRobinLoadBalancerBuilder<ResolvedAddress, C> healthCheckInterval(Duration interval, Duration jitter);
+
+    /**
+     * Configure an interval for re-subscribing to the original events stream in case all existing hosts become
+     * unhealthy.
+     * <p>
+     * In situations when there is a latency between {@link ServiceDiscoverer} propagating the updated state and all
+     * known hosts become unhealthy, which could happen due to intermediate caching layers, re-subscribe to the
+     * events stream can help to exit from a dead state.
+     * <p>
+     * {@link #healthCheckFailedConnectionsThreshold(int)} can be used to disable the health checking mechanism
+     * and always consider all hosts for establishing new connections.
+     *
+     * @param interval interval at which re-subscribes will be scheduled.
+     * @param jitter the amount of jitter to apply to each re-subscribe {@code interval}.
+     * @return {@code this}.
+     * @see #healthCheckFailedConnectionsThreshold(int)
+     */
+    RoundRobinLoadBalancerBuilder<ResolvedAddress, C> healthCheckResubscribeInterval(Duration interval,
+                                                                                     Duration jitter);
+
+    /**
+     * Configure a threshold for consecutive connection failures to a host. When the {@link LoadBalancer}
+     * consecutively fails to open connections in the amount greater or equal to the specified value,
+     * the host will be marked as unhealthy and connection establishment will take place in the background
+     * repeatedly until a connection is established. During that time, the host will not take part in
+     * load balancing selection.
+     * <p>
+     * Use a negative value of the argument to disable health checking.
+     *
+     * @param threshold number of consecutive connection failures to consider a host unhealthy and eligible for
+     * background health checking. Use negative value to disable the health checking mechanism.
+     * @return {@code this}.
+     * @see #backgroundExecutor(Executor)
+     */
+    RoundRobinLoadBalancerBuilder<ResolvedAddress, C> healthCheckFailedConnectionsThreshold(int threshold);
+
+    /**
+     * Builds the {@link RoundRobinLoadBalancerFactory} configured by this builder.
+     *
+     * @return a new instance of {@link RoundRobinLoadBalancerFactory} with settings from this builder.
+     */
+    RoundRobinLoadBalancerFactory<ResolvedAddress, C> build();
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilder.java
@@ -17,6 +17,7 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.client.api.LoadBalancer;
+import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.concurrent.api.Executor;
 
@@ -113,9 +114,9 @@ public interface RoundRobinLoadBalancerBuilder<ResolvedAddress, C extends LoadBa
     RoundRobinLoadBalancerBuilder<ResolvedAddress, C> healthCheckFailedConnectionsThreshold(int threshold);
 
     /**
-     * Builds the {@link RoundRobinLoadBalancerFactory} configured by this builder.
+     * Builds the {@link LoadBalancerFactory} configured by this builder.
      *
-     * @return a new instance of {@link RoundRobinLoadBalancerFactory} with settings from this builder.
+     * @return a new instance of {@link LoadBalancerFactory} with settings from this builder.
      */
-    RoundRobinLoadBalancerFactory<ResolvedAddress, C> build();
+    LoadBalancerFactory<ResolvedAddress, C> build();
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProvider.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProvider.java
@@ -29,6 +29,7 @@ public interface RoundRobinLoadBalancerBuilderProvider {
      * This method may return the pre-initialized {@code builder} as-is, or apply custom builder settings before
      * returning it, or wrap it ({@link DelegatingRoundRobinLoadBalancerBuilder} may be helpful).
      *
+     * @param id a (unique) identifier used to identify the underlying {@link RoundRobinLoadBalancer}.
      * @param builder pre-initialized {@link RoundRobinLoadBalancerBuilder}.
      * @return a {@link RoundRobinLoadBalancerBuilder} based on the pre-initialized
      * {@link RoundRobinLoadBalancerBuilder}.
@@ -36,5 +37,5 @@ public interface RoundRobinLoadBalancerBuilderProvider {
      * @param <C> The type of connection.
      */
     <ResolvedAddress, C extends LoadBalancedConnection> RoundRobinLoadBalancerBuilder<ResolvedAddress, C>
-    newBuilder(RoundRobinLoadBalancerBuilder<ResolvedAddress, C> builder);
+    newBuilder(String id, RoundRobinLoadBalancerBuilder<ResolvedAddress, C> builder);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProvider.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+
+/**
+ * Provider for {@link RoundRobinLoadBalancerBuilder}.
+ */
+public interface RoundRobinLoadBalancerBuilderProvider {
+
+    /**
+     * Returns a {@link RoundRobinLoadBalancerBuilder} based on the pre-initialized
+     * {@link RoundRobinLoadBalancerBuilder}.
+     * <p>
+     * This method may return the pre-initialized {@code builder} as-is, or apply custom builder settings before
+     * returning it, or wrap it ({@link DelegatingRoundRobinLoadBalancerBuilder} may be helpful).
+     *
+     * @param builder pre-initialized {@link RoundRobinLoadBalancerBuilder}.
+     * @return a {@link RoundRobinLoadBalancerBuilder} based on the pre-initialized
+     * {@link RoundRobinLoadBalancerBuilder}.
+     * @param <ResolvedAddress> The resolved address type.
+     * @param <C> The type of connection.
+     */
+    <ResolvedAddress, C extends LoadBalancedConnection> RoundRobinLoadBalancerBuilder<ResolvedAddress, C>
+    newBuilder(RoundRobinLoadBalancerBuilder<ResolvedAddress, C> builder);
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -40,6 +40,7 @@ import static io.servicetalk.utils.internal.DurationUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static io.servicetalk.utils.internal.DurationUtils.isPositive;
 import static java.time.Duration.ofSeconds;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -75,7 +76,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  *
  * @param <ResolvedAddress> The resolved address type.
  * @param <C> The type of connection.
+ * @deprecated this class will be made package-private in the future, rely on {@link RoundRobinLoadBalancers} instead.
  */
+@Deprecated // FIXME: 0.43 - make package private
 public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConnection>
         implements LoadBalancerFactory<ResolvedAddress, C> {
 
@@ -153,7 +156,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
         }
 
         Builder(final String id) {
-            this.id = id;
+            this.id = requireNonNull(id);
         }
 
         @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -125,7 +125,8 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
      * @param <ResolvedAddress> The resolved address type.
      * @param <C> The type of connection.
      */
-    public static final class Builder<ResolvedAddress, C extends LoadBalancedConnection> {
+    public static final class Builder<ResolvedAddress, C extends LoadBalancedConnection>
+            implements RoundRobinLoadBalancerBuilder<ResolvedAddress, C> {
         private int linearSearchSpace = 16;
         @Nullable
         private Executor backgroundExecutor;
@@ -157,6 +158,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
          * selection all the time.
          * @return {@code this}.
          */
+        @Override
         public RoundRobinLoadBalancerFactory.Builder<ResolvedAddress, C> linearSearchSpace(int linearSearchSpace) {
             if (linearSearchSpace < 0) {
                 throw new IllegalArgumentException("linearSearchSpace: " + linearSearchSpace + " (expected >=0)");
@@ -180,6 +182,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
          * @return {@code this}.
          * @see #healthCheckFailedConnectionsThreshold(int)
          */
+        @Override
         public RoundRobinLoadBalancerFactory.Builder<ResolvedAddress, C> backgroundExecutor(
                 Executor backgroundExecutor) {
             this.backgroundExecutor = new NormalizedTimeSourceExecutor(backgroundExecutor);
@@ -217,6 +220,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
          * @return {@code this}.
          * @see #healthCheckFailedConnectionsThreshold(int)
          */
+        @Override
         public RoundRobinLoadBalancerFactory.Builder<ResolvedAddress, C> healthCheckInterval(Duration interval,
                                                                                              Duration jitter) {
             validate(interval, jitter);
@@ -241,6 +245,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
          * @return {@code this}.
          * @see #healthCheckFailedConnectionsThreshold(int)
          */
+        @Override
         public RoundRobinLoadBalancerFactory.Builder<ResolvedAddress, C> healthCheckResubscribeInterval(
                 Duration interval, Duration jitter) {
             validate(interval, jitter);
@@ -279,6 +284,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
          * @see #backgroundExecutor(Executor)
          * @see #healthCheckInterval(Duration)
          */
+        @Override
         public RoundRobinLoadBalancerFactory.Builder<ResolvedAddress, C> healthCheckFailedConnectionsThreshold(
                 int threshold) {
             if (threshold == 0) {
@@ -293,6 +299,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
          *
          * @return a new instance of {@link RoundRobinLoadBalancerFactory} with settings from this builder.
          */
+        @Override
         public RoundRobinLoadBalancerFactory<ResolvedAddress, C> build() {
             if (this.healthCheckFailedConnectionsThreshold < 0) {
                 return new RoundRobinLoadBalancerFactory<>(linearSearchSpace, null);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancers.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancers.java
@@ -43,9 +43,9 @@ public final class RoundRobinLoadBalancers {
 
     private static <ResolvedAddress, C extends LoadBalancedConnection>
     RoundRobinLoadBalancerBuilder<ResolvedAddress, C> applyProviders(
-            RoundRobinLoadBalancerBuilder<ResolvedAddress, C> builder) {
+            String id, RoundRobinLoadBalancerBuilder<ResolvedAddress, C> builder) {
         for (RoundRobinLoadBalancerBuilderProvider provider : PROVIDERS) {
-            builder = provider.newBuilder(builder);
+            builder = provider.newBuilder(id, builder);
         }
         return builder;
     }
@@ -55,12 +55,14 @@ public final class RoundRobinLoadBalancers {
      * <p>
      * The returned builder can be customized using {@link RoundRobinLoadBalancerBuilderProvider}.
      *
+     * @param id a (unique) ID to identify the created {@link RoundRobinLoadBalancer}.
      * @param <ResolvedAddress> The resolved address type.
      * @param <C> The type of connection.
      * @return a new {@link RoundRobinLoadBalancerBuilder}.
      */
+    @SuppressWarnings("deprecation")
     public static <ResolvedAddress, C extends LoadBalancedConnection> RoundRobinLoadBalancerBuilder<ResolvedAddress, C>
-    builder() {
-        return applyProviders(new RoundRobinLoadBalancerFactory.Builder<>());
+    builder(final String id) {
+        return applyProviders(id, new RoundRobinLoadBalancerFactory.Builder<>(id));
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancers.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancers.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static io.servicetalk.utils.internal.ServiceLoaderUtils.loadProviders;
+
+/**
+ * A factory to create {@link RoundRobinLoadBalancer RoundRobinLoadBalancers}.
+ */
+public final class RoundRobinLoadBalancers {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoundRobinLoadBalancers.class);
+
+    private static final List<RoundRobinLoadBalancerBuilderProvider> PROVIDERS;
+
+    static {
+        final ClassLoader classLoader = RoundRobinLoadBalancers.class.getClassLoader();
+        PROVIDERS = loadProviders(RoundRobinLoadBalancerBuilderProvider.class, classLoader, LOGGER);
+    }
+
+    private RoundRobinLoadBalancers() {
+        // No instances.
+    }
+
+    private static <ResolvedAddress, C extends LoadBalancedConnection>
+    RoundRobinLoadBalancerBuilder<ResolvedAddress, C> applyProviders(
+            RoundRobinLoadBalancerBuilder<ResolvedAddress, C> builder) {
+        for (RoundRobinLoadBalancerBuilderProvider provider : PROVIDERS) {
+            builder = provider.newBuilder(builder);
+        }
+        return builder;
+    }
+
+    /**
+     * A new {@link RoundRobinLoadBalancerBuilder} instance.
+     * <p>
+     * The returned builder can be customized using {@link RoundRobinLoadBalancerBuilderProvider}.
+     *
+     * @param <ResolvedAddress> The resolved address type.
+     * @param <C> The type of connection.
+     * @return a new {@link RoundRobinLoadBalancerBuilder}.
+     */
+    public static <ResolvedAddress, C extends LoadBalancedConnection> RoundRobinLoadBalancerBuilder<ResolvedAddress, C>
+    builder() {
+        return applyProviders(new RoundRobinLoadBalancerFactory.Builder<>());
+    }
+}

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProviderTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProviderTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,13 +43,13 @@ class RoundRobinLoadBalancerBuilderProviderTest {
 
     @Test
     void appliesBuilderProvider() {
-        RoundRobinLoadBalancers.builder("test").linearSearchSpace(1234).build();
+        RoundRobinLoadBalancers.builder(getClass().getSimpleName()).linearSearchSpace(1234).build();
         assertThat("TestRoundRobinLoadBalancerBuilderProvider not called",
                 TestRoundRobinLoadBalancerBuilderProvider.buildCounter.get(), is(1));
         assertThat("Builder method not intercepted",
-                TestRoundRobinLoadBalancerBuilderProvider.linearSearchSpaceIntercept.get(), is(1234L));
+                TestRoundRobinLoadBalancerBuilderProvider.linearSearchSpaceIntercept.get(), is(1234));
         assertThat("Unexpected builder ID", TestRoundRobinLoadBalancerBuilderProvider.buildId.get(),
-                is("test"));
+                is(getClass().getSimpleName()));
     }
 
     public static final class TestRoundRobinLoadBalancerBuilderProvider
@@ -59,7 +58,7 @@ class RoundRobinLoadBalancerBuilderProviderTest {
         // Used to prevent applying this provider for other test classes:
         static final AtomicBoolean activated = new AtomicBoolean();
         static final AtomicInteger buildCounter = new AtomicInteger();
-        static final AtomicLong linearSearchSpaceIntercept = new AtomicLong();
+        static final AtomicInteger linearSearchSpaceIntercept = new AtomicInteger();
         static final AtomicReference<String> buildId = new AtomicReference<>();
 
         static void reset() {

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProviderTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProviderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class RoundRobinLoadBalancerBuilderProviderTest {
+
+    private static final AtomicInteger buildCounter = new AtomicInteger();
+    private static final AtomicLong linearSearchSpaceIntercept = new AtomicLong();
+
+    @Test
+    void appliesBuilderProvider() {
+        final RoundRobinLoadBalancerFactory<Object, LoadBalancedConnection> loadBalancerFactory =
+                RoundRobinLoadBalancers.builder().linearSearchSpace(1234).build();
+        assertThat("TestRoundRobinLoadBalancerBuilderProvider not called", buildCounter.get(), is(1));
+        assertThat("Builder method not intercepted", linearSearchSpaceIntercept.get(), is(1234L));
+    }
+
+    public static final class TestRoundRobinLoadBalancerBuilderProvider
+            implements RoundRobinLoadBalancerBuilderProvider {
+        @Override
+        public <ResolvedAddress, C extends LoadBalancedConnection> RoundRobinLoadBalancerBuilder<ResolvedAddress, C>
+        newBuilder(final RoundRobinLoadBalancerBuilder<ResolvedAddress, C> builder) {
+            buildCounter.incrementAndGet();
+            return new DelegatingRoundRobinLoadBalancerBuilder<ResolvedAddress, C>(builder) {
+                @Override
+                public RoundRobinLoadBalancerBuilder<ResolvedAddress, C> linearSearchSpace(
+                        final int linearSearchSpace) {
+                    linearSearchSpaceIntercept.set(linearSearchSpace);
+                    delegate().linearSearchSpace(linearSearchSpace);
+                    return this;
+                }
+            };
+        }
+    }
+}

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerTest.java
@@ -507,7 +507,7 @@ abstract class RoundRobinLoadBalancerTest {
         final DelegatingConnectionFactory connectionFactory = unhealthyHostConnectionFactory.createFactory();
 
         lb = (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>)
-                new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                RoundRobinLoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
                         .healthCheckFailedConnectionsThreshold(-1)
                         .build()
                         .newLoadBalancer(serviceDiscoveryPublisher, connectionFactory, "test-service");
@@ -604,7 +604,7 @@ abstract class RoundRobinLoadBalancerTest {
 
         final AtomicInteger scheduleCnt = new AtomicInteger();
         lb = (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>)
-                new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                RoundRobinLoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
                         .healthCheckInterval(ofMillis(50), ofMillis(10))
                         .healthCheckFailedConnectionsThreshold(1)
                         .backgroundExecutor(new DelegatingExecutor(testExecutor) {
@@ -773,7 +773,7 @@ abstract class RoundRobinLoadBalancerTest {
         DelegatingConnectionFactory alwaysFailConnectionFactory =
                 new DelegatingConnectionFactory(address -> Single.failed(UNHEALTHY_HOST_EXCEPTION));
         lb = (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>)
-                new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                RoundRobinLoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
                         .healthCheckInterval(ofMillis(50), ofMillis(10))
                         // Set resubscribe interval to very large number
                         .healthCheckResubscribeInterval(ofNanos(MAX_VALUE), ZERO)
@@ -805,7 +805,7 @@ abstract class RoundRobinLoadBalancerTest {
         serviceDiscoveryPublisher.onComplete();
 
         lb = (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>)
-                new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                RoundRobinLoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
                         .healthCheckInterval(ofMillis(50), ofMillis(10))
                         .backgroundExecutor(testExecutor)
                         .build()
@@ -901,7 +901,7 @@ abstract class RoundRobinLoadBalancerTest {
         final TestPublisher<Collection<ServiceDiscovererEvent<String>>> serviceDiscoveryPublisher,
         final DelegatingConnectionFactory connectionFactory) {
         return (RoundRobinLoadBalancer<String, TestLoadBalancedConnection>)
-                new RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>()
+                RoundRobinLoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
                         .healthCheckInterval(ofMillis(50), ofMillis(10))
                         .backgroundExecutor(testExecutor)
                         .build()

--- a/servicetalk-loadbalancer/src/test/resources/META-INF/services/io.servicetalk.loadbalancer.RoundRobinLoadBalancerBuilderProvider
+++ b/servicetalk-loadbalancer/src/test/resources/META-INF/services/io.servicetalk.loadbalancer.RoundRobinLoadBalancerBuilderProvider
@@ -1,0 +1,16 @@
+#
+# Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+io.servicetalk.loadbalancer.RoundRobinLoadBalancerBuilderProviderTest$TestRoundRobinLoadBalancerBuilderProvider


### PR DESCRIPTION
Motivation:

It can be useful to configure the RoundRobinLoadBalancer through a ServiceProvider, similar to other components already present in ServiceTalk.

Modifications:

This changeset introduces ServiceProvider functionality on top of the RoundRobinLoadBalancerBuilder. To do this, the builder has been refactored into an interface and a delegate implementation is also introduced.

Result:

It is now possible to configure the RoundRobinLoadBalancer through the ServiceProvider mechanism.