### PR TITLE
Enhance `SniTest` to verify that SNI is present in `SSLSession`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
@@ -52,7 +52,7 @@ import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MutualSslTest {
-    private static final SslProvider[] SSL_PROVIDERS = {JDK, OPENSSL};
+    static final SslProvider[] SSL_PROVIDERS = {JDK, OPENSSL};
     @SuppressWarnings("rawtypes")
     private static final List<Map<SocketOption, Object>> SERVER_LISTEN_OPTIONS =
             asList(emptyMap(), serverTcpFastOpenOptions());


### PR DESCRIPTION
Motivation:

It may be necessary for users to read SNI used for the SSL handshake to apply different policies. Let's make sure the SNI is always present in `SSLSession`.

Modifications:

- Enhance `SniTest` to validate that `getRequestedServerNames()` contains value regardless of the used `SslProvider` and that `SNIHostName` matches the expected value;

Result:

Better test coverage for SNI use-case.