### PR TITLE
Allow to wrap Executor with custom TimeSource

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.concurrent.api;
 
+import io.servicetalk.concurrent.TimeSource;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -253,5 +255,24 @@ public final class Executors {
                                 ScheduledExecutorService scheduledExecutorService, boolean mayInterruptOnCancel) {
         return EXECUTOR_PLUGINS.wrapExecutor(
                 new DefaultExecutor(jdkExecutor, scheduledExecutorService, mayInterruptOnCancel));
+    }
+
+    /**
+     * Wraps the given {@link Executor} with the provided {@link TimeSource}.
+     * <p>
+     * The given {@link Executor} is wrapped into a {@link DelegatingExecutor} which delegates all calls but
+     * {@link Executor#currentTime(TimeUnit)} which will go to the provided {@link TimeSource}.
+     *
+     * @param delegate the {@link Executor} which should use the provided time source.
+     * @param timeSource the {@link TimeSource} that should be used when calling {@link Executor#currentTime(TimeUnit)}.
+     * @return The wrapped {@link Executor} with a custom {@link TimeSource}.
+     */
+    public static Executor withTimeSource(final Executor delegate, final TimeSource timeSource) {
+        return new DelegatingExecutor(delegate) {
+            @Override
+            public long currentTime(final TimeUnit unit) {
+                return timeSource.currentTime(unit);
+            }
+        };
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ExecutorsTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ExecutorsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.TimeSource;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ExecutorsTest {
+
+    @Test
+    void wrapsWithCustomTimeSource() {
+        TimeSource timeSource = unit -> 0xCAFEL;
+        Executor wrapped = Executors.withTimeSource(Executors.immediate(), timeSource);
+        assertThat("Custom TimeSource not called", wrapped.currentTime(TimeUnit.NANOSECONDS), is(0xCAFEL));
+    }
+}


### PR DESCRIPTION
Motivation:

When an Executor needs to wrapped with a custom TimeSource (i.e for testing) it is possible, but not very obvious or user friendly at the moment.

Modifications:

This changeset introduces a factory method to help delegate calles from a provided executor and also use a custom TimeSource.

Result:

It is now easier to use an executor with a custom TimeSource if needed.