### PR TITLE
Update tags for OpenTelemetry

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -36,7 +36,6 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
-import java.util.Optional;
 import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
@@ -134,6 +133,10 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryF
         if (componentName != null && !componentName.trim().isEmpty()) {
             return componentName;
         }
-        return Optional.ofNullable(request.host()).orElse(request.requestTarget());
+        String host = request.host();
+        if (host != null) {
+            return host;
+        }
+        return request.requestTarget();
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -27,6 +27,7 @@ import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.HostAndPort;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -128,12 +129,12 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryF
     }
 
     private String getSpanName(StreamingHttpRequest request) {
-        if (componentName != null && !componentName.isEmpty()) {
+        if (!componentName.isEmpty()) {
             return componentName;
         }
-        String host = request.host();
-        if (host != null) {
-            return host;
+        HostAndPort hostAndPort = request.effectiveHostAndPort();
+        if (hostAndPort != null) {
+            return hostAndPort.hostName();
         }
         return request.requestTarget();
     }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -37,7 +37,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
 import java.util.function.UnaryOperator;
-import javax.annotation.Nullable;
 
 /**
  * An HTTP filter that supports <a href="https://opentelemetry.io/docs/instrumentation/java/">open telemetry</a>.
@@ -54,7 +53,6 @@ import javax.annotation.Nullable;
 public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryFilter
     implements StreamingHttpClientFilterFactory, StreamingHttpConnectionFilterFactory {
 
-    @Nullable
     private final String componentName;
 
     /**
@@ -63,9 +61,9 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryF
      * @param openTelemetry the {@link OpenTelemetry}.
      * @param componentName The component name used during building new spans.
      */
-    public OpenTelemetryHttpRequestFilter(final OpenTelemetry openTelemetry, @Nullable String componentName) {
+    public OpenTelemetryHttpRequestFilter(final OpenTelemetry openTelemetry, String componentName) {
         super(openTelemetry);
-        this.componentName = componentName;
+        this.componentName = componentName.trim();
     }
 
     /**
@@ -73,7 +71,7 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryF
      *
      * @param componentName The component name used during building new spans.
      */
-    public OpenTelemetryHttpRequestFilter(@Nullable String componentName) {
+    public OpenTelemetryHttpRequestFilter(String componentName) {
         this(GlobalOpenTelemetry.get(), componentName);
     }
 
@@ -82,7 +80,7 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryF
      * using the hostname as the component name.
      */
     public OpenTelemetryHttpRequestFilter() {
-        this(GlobalOpenTelemetry.get(), null);
+        this(GlobalOpenTelemetry.get(), "");
     }
 
     @Override
@@ -130,7 +128,7 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryF
     }
 
     private String getSpanName(StreamingHttpRequest request) {
-        if (componentName != null && !componentName.trim().isEmpty()) {
+        if (componentName != null && !componentName.isEmpty()) {
             return componentName;
         }
         String host = request.host();

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
@@ -122,6 +122,6 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryFi
      * @return the operation name to build the span with.
      */
     private static String getOperationName(HttpRequestMetaData metaData) {
-        return metaData.method().name() + ' ' + metaData.requestTarget();
+        return metaData.method().name() + ' ' + metaData.path();
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestTagExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestTagExtractor.java
@@ -21,8 +21,6 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 
-import java.util.Optional;
-
 final class RequestTagExtractor {
 
     private RequestTagExtractor() {
@@ -45,10 +43,18 @@ final class RequestTagExtractor {
         span.setAttribute("http.route", httpRequestMetaData.rawPath());
         span.setAttribute("http.flavor", httpRequestMetaData.version().major() + "."
             + httpRequestMetaData.version().minor());
-        Optional.ofNullable(httpRequestMetaData.userInfo())
-            .map(userInfo -> span.setAttribute("http.user_agent", userInfo));
-        Optional.ofNullable(httpRequestMetaData.scheme()).map(scheme -> span.setAttribute("http.scheme", scheme));
-        Optional.ofNullable(httpRequestMetaData.host()).map(host -> span.setAttribute("net.host.name", host));
+        String userInfo = httpRequestMetaData.userInfo();
+        if (userInfo != null) {
+            span.setAttribute("http.user_agent", userInfo);
+        }
+        String scheme = httpRequestMetaData.scheme();
+        if (scheme != null) {
+            span.setAttribute("http.scheme", scheme);
+        }
+        String hostName = httpRequestMetaData.host();
+        if (hostName != null) {
+            span.setAttribute("net.host.name", hostName);
+        }
         span.setAttribute("net.host.port", httpRequestMetaData.port());
         return span.startSpan();
     }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestTagExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestTagExtractor.java
@@ -16,6 +16,7 @@
 
 package io.servicetalk.opentelemetry.http;
 
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.transport.api.HostAndPort;
 
@@ -36,7 +37,7 @@ final class RequestTagExtractor {
 
     private static String getHttpUrl(HttpRequestMetaData req) {
         return req.path()
-            + (req.rawQuery() == null ? "" : "?" + req.rawQuery());
+            + (req.rawQuery() == null ? "" : '?' + req.rawQuery());
     }
 
     static Span reportTagsAndStart(SpanBuilder span, HttpRequestMetaData httpRequestMetaData) {
@@ -44,8 +45,7 @@ final class RequestTagExtractor {
         span.setAttribute("http.method", getRequestMethod(httpRequestMetaData));
         span.setAttribute("http.target", getHttpUrl(httpRequestMetaData));
         span.setAttribute("http.route", httpRequestMetaData.rawPath());
-        span.setAttribute("http.flavor", httpRequestMetaData.version().major() + "."
-            + httpRequestMetaData.version().minor());
+        span.setAttribute("http.flavor", getFlavor(httpRequestMetaData.version()));
         CharSequence userAgent = httpRequestMetaData.headers().get(USER_AGENT);
         if (userAgent != null) {
             span.setAttribute("http.user_agent", userAgent.toString());
@@ -60,5 +60,19 @@ final class RequestTagExtractor {
             span.setAttribute("net.host.port", hostAndPort.port());
         }
         return span.startSpan();
+    }
+
+    public static String getFlavor(final HttpProtocolVersion version) {
+        if (version.major() == 1) {
+            if (version.minor() == 1) {
+                return "1.1";
+            }
+            if (version.minor() == 0) {
+                return "1.0";
+            }
+        } else if (version.major() == 2 && version.minor() == 0) {
+            return "2.0";
+        }
+        return version.major() + "." + version.minor();
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestTagExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestTagExtractor.java
@@ -17,9 +17,12 @@
 package io.servicetalk.opentelemetry.http;
 
 import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.transport.api.HostAndPort;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
+
+import static io.servicetalk.http.api.HttpHeaderNames.USER_AGENT;
 
 final class RequestTagExtractor {
 
@@ -43,19 +46,19 @@ final class RequestTagExtractor {
         span.setAttribute("http.route", httpRequestMetaData.rawPath());
         span.setAttribute("http.flavor", httpRequestMetaData.version().major() + "."
             + httpRequestMetaData.version().minor());
-        String userInfo = httpRequestMetaData.userInfo();
-        if (userInfo != null) {
-            span.setAttribute("http.user_agent", userInfo);
+        CharSequence userAgent = httpRequestMetaData.headers().get(USER_AGENT);
+        if (userAgent != null) {
+            span.setAttribute("http.user_agent", userAgent.toString());
         }
         String scheme = httpRequestMetaData.scheme();
         if (scheme != null) {
             span.setAttribute("http.scheme", scheme);
         }
-        String hostName = httpRequestMetaData.host();
-        if (hostName != null) {
-            span.setAttribute("net.host.name", hostName);
+        HostAndPort hostAndPort = httpRequestMetaData.effectiveHostAndPort();
+        if (hostAndPort != null) {
+            span.setAttribute("net.host.name", hostAndPort.hostName());
+            span.setAttribute("net.host.port", hostAndPort.port());
         }
-        span.setAttribute("net.host.port", httpRequestMetaData.port());
         return span.startSpan();
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestTagExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestTagExtractor.java
@@ -62,7 +62,7 @@ final class RequestTagExtractor {
         return span.startSpan();
     }
 
-    public static String getFlavor(final HttpProtocolVersion version) {
+    private static String getFlavor(final HttpProtocolVersion version) {
         if (version.major() == 1) {
             if (version.minor() == 1) {
                 return "1.1";

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilterTest.java
@@ -99,14 +99,14 @@ class OpenTelemetryHttpRequestFilterTest {
                 otelTesting.assertTraces()
                     .hasTracesSatisfyingExactly(ta ->
                         assertThat(ta.getSpan(0).getAttributes().get(SemanticAttributes.HTTP_URL))
-                            .startsWith("http://localhost:8080"));
+                            .isEqualTo("/"));
             }
         }
     }
 
     @Test
     void testInjectWithAParent() throws Exception {
-        final String requestUrl = "/";
+        final String requestUrl = "/path";
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         try (ServerContext context = buildServer(openTelemetry, true)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
@@ -130,14 +130,14 @@ class OpenTelemetryHttpRequestFilterTest {
                 otelTesting.assertTraces()
                     .hasTracesSatisfyingExactly(ta ->
                         assertThat(ta.getSpan(0).getAttributes().get(SemanticAttributes.HTTP_URL))
-                            .startsWith("http://localhost:8080"));
+                            .isEqualTo("/path"));
             }
         }
     }
 
     @Test
     void testInjectWithAParentCreated() throws Exception {
-        final String requestUrl = "/";
+        final String requestUrl = "/path/to/resource";
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         try (ServerContext context = buildServer(openTelemetry, true)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
@@ -172,7 +172,7 @@ class OpenTelemetryHttpRequestFilterTest {
                     otelTesting.assertTraces()
                         .hasTracesSatisfyingExactly(ta ->
                             assertThat(ta.getSpan(1).getAttributes().get(SemanticAttributes.HTTP_URL))
-                                .startsWith("http://localhost:8080"));
+                                .isEqualTo("/path/to/resource"));
                         otelTesting.assertTraces()
                         .hasTracesSatisfyingExactly(ta ->
                             assertThat(ta.getSpan(0).getAttributes().get(AttributeKey.stringKey("component")))


### PR DESCRIPTION
- http.url will not have localhost as it's not available all the time
- added http.target, http.route, http.flavor, http.user_agent, http.scheme, net.host.name, net.host.port
- allow http client filter to use host as default value, making component name optional