### PR TITLE
Only depend on OpenTelemetry api and not the overall BOM

### DIFF
--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   api platform("com.google.protobuf:protobuf-bom:${protobufVersion}")
   api platform("org.apache.logging.log4j:log4j-bom:${log4jVersion}")
   api platform("org.glassfish.jersey:jersey-bom:${jerseyVersion}")
-  api platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion")
 
   constraints {
     api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"

--- a/servicetalk-opentelemetry-asynccontext/build.gradle
+++ b/servicetalk-opentelemetry-asynccontext/build.gradle
@@ -21,7 +21,7 @@ dependencies {
   testImplementation enforcedPlatform(project(":servicetalk-dependencies"))
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
 
-  api "io.opentelemetry:opentelemetry-api"
+  api "io.opentelemetry:opentelemetry-api:$opentelemetryVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")

--- a/servicetalk-opentelemetry-http/build.gradle
+++ b/servicetalk-opentelemetry-http/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   testRuntimeOnly enforcedPlatform(project(":servicetalk-dependencies"))
 
   api project(":servicetalk-http-api")
-  api "io.opentelemetry:opentelemetry-api"
+  api "io.opentelemetry:opentelemetry-api:$opentelemetryVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-http-utils")
@@ -35,7 +35,7 @@ dependencies {
   testImplementation project(":servicetalk-data-jackson")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "io.opentelemetry:opentelemetry-sdk-testing"
+  testImplementation "io.opentelemetry:opentelemetry-sdk-testing:$opentelemetryVersion"
   testImplementation "io.opentelemetry.instrumentation:opentelemetry-log4j-2.13.2:$opentelemetryInstrumentationVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.assertj:assertj-core:$assertJCore"


### PR DESCRIPTION
Motivation:

Depending on the BOM instead of just the minimal -api package causes downstream issues in terms of how these dependency versions are managed.

Modifications:

In order to more tighly control what we are depending on, this changeset only depends on the-api package.