### PR TITLE
Add the SkipWhile operator to Publisher

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FilterPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FilterPublisher.java
@@ -44,6 +44,19 @@ final class FilterPublisher<T> extends AbstractSynchronousPublisherOperator<T, T
         };
     }
 
+    static <T> Supplier<? extends Predicate<? super T>> skipWhileSupplier(final Predicate<? super T> predicate) {
+        return () -> new Predicate<T>() {
+            private boolean skipping = true;
+            @Override
+            public boolean test(T t) {
+                if (skipping) {
+                    skipping = predicate.test(t);
+                }
+                return !skipping;
+            }
+        };
+    }
+
     @Override
     public Subscriber<? super T> apply(final Subscriber<? super T> subscriber) {
         return new Subscriber<T>() {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2169,7 +2169,7 @@ public abstract class Publisher<T> {
      *
      * @param predicate for evaluating whether to continue skipping items.
      * @return A {@link Publisher} that skips items until the predicate returns false {@code predicate}.
-     * @see <a href="https://reactivex.io/documentation/operators/skipwhile.html">ReactiveX filter operator.</a>
+     * @see <a href="https://reactivex.io/documentation/operators/skipwhile.html">ReactiveX SkipWhile operator.</a>
      */
     public final Publisher<T> skipWhile(Predicate<? super T> predicate) {
         return filter(FilterPublisher.skipWhileSupplier(predicate));

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2150,6 +2150,32 @@ public abstract class Publisher<T> {
     }
 
     /**
+     * Skip items emitted by this {@link Publisher} until the first time the predicate is not satisfied.
+     * <p>
+     * This method provides a data transformation in sequential programming similar to:
+     * <pre>{@code
+     *     List<T> results = ...;
+     *     boolean skipping = true;
+     *     for (T t : resultOfThisPublisher()) {
+     *         if (skipping) {
+     *             skipping = predicate.test(t);
+     *         }
+     *         if (!skipping) {
+     *             results.add(t);
+     *         }
+     *     }
+     *     return results;
+     * }</pre>
+     *
+     * @param predicate for evaluating whether to continue skipping items.
+     * @return A {@link Publisher} that skips items until the predicate returns false {@code predicate}.
+     * @see <a href="https://reactivex.io/documentation/operators/skipwhile.html">ReactiveX filter operator.</a>
+     */
+    public final Publisher<T> skipWhile(Predicate<? super T> predicate) {
+        return filter(FilterPublisher.skipWhileSupplier(predicate));
+    }
+
+    /**
      * Takes at most {@code numElements} elements from {@code this} {@link Publisher}.
      * <p>
      * If no terminal event is received before receiving {@code numElements} elements, {@link Subscription} for the

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SkipWhileTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SkipWhileTest.java
@@ -20,12 +20,12 @@ import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,37 +35,23 @@ class SkipWhileTest {
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestSubscription subscription = new TestSubscription();
 
-    @Test
-    void skipWhile() {
-        Publisher<String> p = publisher.skipWhile(s -> !s.equals("Hello2"));
-        toSource(p).subscribe(subscriber);
-        publisher.onSubscribe(subscription);
-        subscriber.awaitSubscription().request(4);
-        publisher.onNext("Hello1", "Hello2", "Hello3");
-        assertThat(subscriber.takeOnNext(2), contains("Hello2", "Hello3"));
-        assertFalse(subscription.isCancelled());
-    }
-
-    @Test
-    void skipWhileComplete() {
-        Publisher<String> p = publisher.skipWhile(s -> !s.equals("Hello2"));
-        toSource(p).subscribe(subscriber);
-        publisher.onSubscribe(subscription);
-        subscriber.awaitSubscription().request(4);
-        publisher.onNext("Hello1", "Hello2");
-        publisher.onComplete();
-        assertEquals("Hello2", subscriber.takeOnNext());
-    }
-
-    @Test
-    void skipWhileCancelled() {
+    @ParameterizedTest(name = "doComplete={0} doCancel={1}")
+    @CsvSource(value = {"false,false", "false,true", "true,false"})
+    void skipWhile(boolean doComplete, boolean doCancel) {
         Publisher<String> p = publisher.skipWhile(s -> !s.equals("Hello2"));
         toSource(p).subscribe(subscriber);
         publisher.onSubscribe(subscription);
         subscriber.awaitSubscription().request(3);
-        publisher.onNext("Hello1", "Hello2");
-        assertEquals("Hello2", subscriber.takeOnNext());
-        subscriber.awaitSubscription().cancel();
-        assertTrue(subscription.isCancelled());
+        publisher.onNext("Hello1", "Hello2", "Hello3");
+        assertThat(subscriber.takeOnNext(2), contains("Hello2", "Hello3"));
+        if (doComplete) {
+            publisher.onComplete();
+            assertFalse(subscription.isCancelled());
+            subscriber.awaitOnComplete();
+        }
+        if (doCancel) {
+            subscriber.awaitSubscription().cancel();
+            assertTrue(subscription.isCancelled());
+        }
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SkipWhileTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SkipWhileTest.java
@@ -1,0 +1,56 @@
+package io.servicetalk.concurrent.api.publisher;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.concurrent.api.TestSubscription;
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+import org.junit.jupiter.api.Test;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SkipWhileTest {
+
+    private final TestPublisher<String> publisher = new TestPublisher<>();
+    private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
+    private final TestSubscription subscription = new TestSubscription();
+
+
+    @Test
+    void skipWhile() {
+        Publisher<String> p = publisher.skipWhile(s -> !s.equals("Hello2"));
+        toSource(p).subscribe(subscriber);
+        publisher.onSubscribe(subscription);
+        subscriber.awaitSubscription().request(4);
+        publisher.onNext("Hello1", "Hello2", "Hello3");
+        assertThat(subscriber.takeOnNext(2), contains("Hello2", "Hello3"));
+        assertFalse(subscription.isCancelled());
+    }
+
+    @Test
+    void skipWhileComplete() {
+        Publisher<String> p = publisher.skipWhile(s -> !s.equals("Hello2"));
+        toSource(p).subscribe(subscriber);
+        publisher.onSubscribe(subscription);
+        subscriber.awaitSubscription().request(4);
+        publisher.onNext("Hello1", "Hello2");
+        publisher.onComplete();
+        assertEquals("Hello2", subscriber.takeOnNext());
+    }
+
+    @Test
+    void skipWhileCancelled() {
+        Publisher<String> p = publisher.skipWhile(s -> !s.equals("Hello2"));
+        toSource(p).subscribe(subscriber);
+        publisher.onSubscribe(subscription);
+        subscriber.awaitSubscription().request(3);
+        publisher.onNext("Hello1", "Hello2");
+        assertEquals("Hello2", subscriber.takeOnNext());
+        subscriber.awaitSubscription().cancel();
+        assertTrue(subscription.isCancelled());
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SkipWhileTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/SkipWhileTest.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.servicetalk.concurrent.api.publisher;
 
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.concurrent.api.TestSubscription;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
 import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
@@ -13,12 +29,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SkipWhileTest {
+class SkipWhileTest {
 
     private final TestPublisher<String> publisher = new TestPublisher<>();
     private final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
     private final TestSubscription subscription = new TestSubscription();
-
 
     @Test
     void skipWhile() {

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherSkipWhileTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherSkipWhileTckTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+public class PublisherSkipWhileTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+    @Override
+    protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
+        return publisher.skipWhile(v -> v >= 0);
+    }
+}

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -297,7 +297,7 @@ If HTTP/1.x protocol is configured ServiceTalk always fallbacks to it if the pee
 IMPORTANT: Your runtime must support ALPN extension for TLS. The recommended way is to use OpenSSL provider and add
 link:https://netty.io/wiki/forked-tomcat-native.html#artifacts[netty-tcnative] artifact to the classpath. If OpenSSL is
 not available, make sure your JVM version supports ALPN or use
-link:https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html[another provider] that supports it.
+link:https://www.eclipse.org/jetty/documentation/current/#alpn-chapter[another provider] that supports it.
 
 NOTE: These examples use the link:#blocking-aggregated[blocking + aggregated] API for demonstration purposes, as the
 builder API is the same across all the HTTP APIs.


### PR DESCRIPTION
Motivation:

It's useful to be able to skip elements of a stream until a predicate fails but that isn't yet supported in Servicetalk.

Modifications:

Add the SkipWhile operator to the Servicetalk Publisher class.

Result:

SkipWhile is now supported.