### PR TITLE
`ProxyConnectConnectionFactoryFilter`: report when the channel is closed

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -125,7 +125,8 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
             final DeferSslHandler deferSslHandler = channel.pipeline().get(DeferSslHandler.class);
             if (deferSslHandler == null) {
                 if (!channel.isActive()) {
-                    LOGGER.info("{} is unexpectedly closed after receiving response: {}",
+                    LOGGER.info("{} is unexpectedly closed after receiving response: {}. " +
+                                    "Investigate logs on a proxy side to identify the cause.",
                             connection, response.toString((name, value) -> value));
                     return failed(StacklessClosedChannelException.newInstance(
                             ProxyConnectConnectionFactoryFilter.class, "handleConnectResponse: " +


### PR DESCRIPTION
Motivation:

When proxy returns 2xx status code with `Connection: closed` header, users see an awkward error saying:
Failed to find a handler of type DeferSslHandler in channel pipeline. It confuses users. We can handle this case with a better exception message.

Modifications:
- Check if the channel is still active before generating `IllegalStateException`;

Result:

More clear exception message when proxy closes the connection.