### PR TITLE
MultiAddressUrlClient: incorrect transformation of target without path

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -177,7 +177,11 @@ final class DefaultMultiAddressUrlHttpClientBuilder
                                                                   final String scheme, final String host) {
             final int fromIndex = scheme.length() + 3 + host.length();  // +3 because of "://" delimiter after scheme
             final int relativeReferenceIdx = requestTarget.indexOf('/', fromIndex);
-            return relativeReferenceIdx < 0 ? "/" : requestTarget.substring(relativeReferenceIdx);
+            if (relativeReferenceIdx >= 0) {
+                return requestTarget.substring(relativeReferenceIdx);
+            }
+            final int questionMarkIdx = requestTarget.indexOf('?', fromIndex);
+            return questionMarkIdx < 0 ? "/" : '/' + requestTarget.substring(questionMarkIdx);
         }
 
         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -209,6 +209,12 @@ class MultiAddressUrlHttpClientTest {
     }
 
     @Test
+    void requestWithAbsoluteFormRequestTargetWithoutPathWithParams() throws Exception {
+        StreamingHttpRequest request = client.get(format("http://%s?param=value", hostHeader));
+        requestAndValidate(request, BAD_REQUEST, "/?param=value");
+    }
+
+    @Test
     void requestWithAbsoluteFormRequestTargetWithInvalidHost() {
         // Verify it fails multiple times:
         requestWithInvalidHost();

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectSingle.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectSingle.java
@@ -204,7 +204,11 @@ final class RedirectSingle extends SubscribableSingle<StreamingHttpResponse> {
                                                                   final String scheme) {
             final int fromIndex = scheme.length() + 3;  // +3 because of "://" delimiter after scheme
             final int relativeReferenceIdx = requestTarget.indexOf('/', fromIndex);
-            return relativeReferenceIdx < 0 ? "/" : requestTarget.substring(relativeReferenceIdx);
+            if (relativeReferenceIdx >= 0) {
+                return requestTarget.substring(relativeReferenceIdx);
+            }
+            final int questionMarkIdx = requestTarget.indexOf('?', fromIndex);
+            return questionMarkIdx < 0 ? "/" : '/' + requestTarget.substring(questionMarkIdx);
         }
 
         @Override


### PR DESCRIPTION
Motivation:
`java.net.URI` considers `http://localhost?param=value` a correct absolute address. However, `MultiAddressUrlClient` sends `/` instead of `/?param=value` to the server after transforming absolute to relative request target.

Modifications:

- Enhance `DefaultMultiAddressUrlHttpClientBuilder.absoluteToRelativeFormRequestTarget` to account for this use-case;
- Sync `RedirectSingle.absoluteToRelativeFormRequestTarget`;

Result:

`MultiAddressUrlClient` and redirect logic correctly transform `http://localhost?param=value` to a relative `/?param=value` request target.