### PR TITLE
Use an unbounded queue for fixed size Executors

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultExecutor.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.Cancellable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -27,7 +28,6 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
@@ -68,9 +68,9 @@ final class DefaultExecutor extends AbstractExecutor implements Consumer<Runnabl
         GLOBAL_SINGLE_THREADED_SCHEDULED_EXECUTOR.setRemoveOnCancelPolicy(true);
     }
 
-    DefaultExecutor(int coreSize, int maxSize, ThreadFactory threadFactory) {
+    DefaultExecutor(int coreSize, int maxSize, BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory) {
         this(new ThreadPoolExecutor(coreSize, maxSize, DEFAULT_KEEP_ALIVE_TIME_SECONDS, SECONDS,
-                new SynchronousQueue<>(), threadFactory, DEFAULT_REJECTION_HANDLER));
+                workQueue, threadFactory, DEFAULT_REJECTION_HANDLER));
     }
 
     DefaultExecutor(java.util.concurrent.Executor jdkExecutor) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
@@ -16,7 +16,9 @@
 package io.servicetalk.concurrent.api;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -78,7 +80,8 @@ public final class Executors {
      * @return A new {@link Executor} that will use the {@code size} number of threads.
      */
     public static Executor newFixedSizeExecutor(int size, ThreadFactory threadFactory) {
-        return EXECUTOR_PLUGINS.wrapExecutor(new DefaultExecutor(size, size, threadFactory));
+        return EXECUTOR_PLUGINS.wrapExecutor(
+                new DefaultExecutor(size, size, new LinkedBlockingQueue<>(), threadFactory));
     }
 
     /**
@@ -97,7 +100,8 @@ public final class Executors {
      * @return A new {@link Executor}.
      */
     public static Executor newCachedThreadExecutor(ThreadFactory threadFactory) {
-        return EXECUTOR_PLUGINS.wrapExecutor(new DefaultExecutor(1, Integer.MAX_VALUE, threadFactory));
+        return EXECUTOR_PLUGINS.wrapExecutor(
+                new DefaultExecutor(1, Integer.MAX_VALUE, new SynchronousQueue<>(), threadFactory));
     }
 
     /**


### PR DESCRIPTION
Motivation:

It's very difficult to properly use an Executor that has a fixed size thread pool because the current queue is a SynchronousQueue which will result in rejecting work if there isn't a free thread to service it. This also runs contrary to the patterns used in the JDK for fixed size thread pools which default to the unbounded LinkedBlockingQueue.

Modifications:

Use the unbounded LinkedBlockingQueue for Executors with fixed size.

Result:

Less surprising behavior of the fixed size Executors.