### PR TITLE
Update Netty 4.1.89 -> 4.1.91

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ issueManagementUrl=https://github.com/apple/servicetalk/issues
 ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
-nettyVersion=4.1.89.Final
+nettyVersion=4.1.91.Final
 nettyIoUringVersion=0.0.19.Final
 
 jsr305Version=3.0.2

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -35,6 +35,8 @@ import org.mockito.verification.VerificationWithTimeout;
 import java.io.InputStream;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -90,17 +92,20 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         return clientTransportObserver;
     }
 
-    static ClientSslConfigBuilder defaultClientSslBuilder(SslProvider provider) {
+    static ClientSslConfigBuilder defaultClientSslBuilder(@Nullable SslProvider provider) {
         return defaultClientSslBuilder(provider, DefaultTestCerts::loadServerCAPem);
     }
 
-    static ClientSslConfigBuilder defaultClientSslBuilder(SslProvider provider,
+    static ClientSslConfigBuilder defaultClientSslBuilder(@Nullable SslProvider provider,
                                                           Supplier<InputStream> trustCertSupplier) {
-        return new ClientSslConfigBuilder(trustCertSupplier)
+        ClientSslConfigBuilder builder = new ClientSslConfigBuilder(trustCertSupplier)
                 .peerHost(serverPemHostname())
                 .peerPort(-1)
-                .provider(provider)
                 .sslProtocols("TLSv1.2");
+        if (provider != null) {
+            builder.provider(provider);
+        }
+        return builder;
     }
 
     static ClientSslConfig defaultClientSslConfig(SslProvider provider) {
@@ -114,10 +119,14 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         return config;
     }
 
-    static ServerSslConfigBuilder defaultServerSslBuilder(SslProvider provider) {
-        return new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
-                .provider(provider)
+    static ServerSslConfigBuilder defaultServerSslBuilder(@Nullable SslProvider provider) {
+        ServerSslConfigBuilder builder = new ServerSslConfigBuilder(
+                DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
                 .sslProtocols("TLSv1.2");
+        if (provider != null) {
+            builder.provider(provider);
+        }
+        return builder;
     }
 
     static ServerSslConfig defaultServerSslConfig(SslProvider provider) {

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -34,7 +34,6 @@ import org.mockito.verification.VerificationWithTimeout;
 
 import java.io.InputStream;
 import java.util.function.Supplier;
-
 import javax.annotation.Nullable;
 
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;


### PR DESCRIPTION
https://github.com/netty/netty/pull/13314 changes the exception type that netty throws when one of the sides is plaintext and another one is SSL. Instead of `SSLHandshakeException` it throws `NotSslRecordException`.
We need to adjust our tests to align with the new behavior.
Since this is a rare case that happens only due to programming mistake, the change has low risk.