### PR TITLE
New filter: `JavaNetSoTimeoutHttpConnectionFilter`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/JavaNetSoTimeoutHttpConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/JavaNetSoTimeoutHttpConnectionFilterTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.CharSequences;
+import io.servicetalk.buffer.api.CompositeBuffer;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap.Key;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.BlockingStreamingHttpClient;
+import io.servicetalk.http.api.BlockingStreamingHttpRequest;
+import io.servicetalk.http.api.BlockingStreamingHttpResponse;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.utils.JavaNetSoTimeoutHttpConnectionFilter;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.context.api.ContextMap.Key.newKey;
+import static io.servicetalk.http.api.HttpHeaderNames.EXPECT;
+import static io.servicetalk.http.api.HttpHeaderValues.CONTINUE;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
+import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JavaNetSoTimeoutHttpConnectionFilterTest {
+
+    @RegisterExtension
+    static final ExecutionContextExtension SERVER_CTX =
+            ExecutionContextExtension.cached("server-io", "server-executor")
+                    .setClassLevel(true);
+    @RegisterExtension
+    static final ExecutionContextExtension CLIENT_CTX =
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
+
+    private static final String READ_REQUEST_DELAY_MS = "READ_REQUEST_DELAY_MS";
+    private static final String RETURN_RESPONSE_DELAY_MS = "RETURN_RESPONSE_DELAY_MS";
+    private static final String RESPONSE_PAYLOAD_DELAY_MS = "RESPONSE_PAYLOAD_DELAY_MS";
+
+    private static final Duration READ_TIMEOUT_VALUE = Duration.ofMillis(100);
+    private static final String SERVER_DELAY_VALUE = "200";
+
+    private static final Key<Duration> READ_TIMEOUT_KEY = newKey("READ_TIMEOUT_KEY", Duration.class);
+
+    @Nullable
+    private static ServerContext server;
+    @Nullable
+    private static BlockingHttpClient client;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        server = newServerBuilder(SERVER_CTX).listenStreamingAndAwait((ctx, request, responseFactory) -> {
+            Buffer hello = ctx.executionContext().bufferAllocator().fromAscii("Hello");
+
+            Executor executor = ctx.executionContext().executor();
+            Duration readRequestDelay = delay(request.headers().get(READ_REQUEST_DELAY_MS));
+            Duration returnResponseDelay = delay(request.headers().get(RETURN_RESPONSE_DELAY_MS));
+            Duration responsePayloadDelay = delay(request.headers().get(RESPONSE_PAYLOAD_DELAY_MS));
+
+            Single<Buffer> requestBody = request.payloadBody()
+                    .collect(() -> ctx.executionContext().bufferAllocator().newCompositeBuffer(),
+                            CompositeBuffer::addBuffer).map(Function.identity());
+            if (readRequestDelay != null) {
+                requestBody = executor.timer(readRequestDelay).concat(requestBody);
+            }
+
+            return requestBody.flatMap(buffer -> {
+                Publisher<Buffer> payload = responsePayloadDelay == null ? from(hello, buffer) :
+                        from(hello).concat(executor.timer(responsePayloadDelay).concat(from(buffer)));
+
+                Single<StreamingHttpResponse> responseSingle = Single.succeeded(responseFactory.ok()
+                        .payloadBody(payload));
+                if (returnResponseDelay != null) {
+                    responseSingle = executor.timer(returnResponseDelay).concat(responseSingle);
+                }
+                return responseSingle;
+            });
+        });
+        client = newClientBuilder(server, CLIENT_CTX)
+                .appendConnectionFilter(new JavaNetSoTimeoutHttpConnectionFilter(
+                        (metaData, timeSource) -> metaData.context().get(READ_TIMEOUT_KEY)))
+                .buildBlocking();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        try {
+            if (client != null) {
+                client.close();
+            }
+        } finally {
+            if (server != null) {
+                server.close();
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: expectContinue={0} withServerDelays={1}")
+    @CsvSource({"false,false", "false,true", "true,false", "true,true"})
+    void noTimeout(boolean expectContinue, boolean withServerDelays) throws Exception {
+        HttpRequest request = newRequest();
+        if (expectContinue) {
+            request.addHeader(EXPECT, CONTINUE);
+        }
+        if (withServerDelays) {
+            request.addHeader(READ_REQUEST_DELAY_MS, "20")
+                    .addHeader(RETURN_RESPONSE_DELAY_MS, "20")
+                    .addHeader(RESPONSE_PAYLOAD_DELAY_MS, "20");
+        }
+        HttpResponse response = client().request(request);
+        assertThat(response.status(), is(OK));
+        assertThat(response.payloadBody().toString(US_ASCII), is(equalTo("HelloWorld")));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: expectContinue={0} withServerDelays={1}")
+    @CsvSource({"false,false", "false,true", "true,false", "true,true"})
+    void noTimeoutStreaming(boolean expectContinue, boolean withServerDelays) throws Exception {
+        BlockingStreamingHttpClient client = client().asBlockingStreamingClient();
+        BlockingStreamingHttpRequest request = newStreamingRequest();
+        if (expectContinue) {
+            request.addHeader(EXPECT, CONTINUE);
+        }
+        if (withServerDelays) {
+            request.addHeader(READ_REQUEST_DELAY_MS, "20")
+                    .addHeader(RETURN_RESPONSE_DELAY_MS, "20")
+                    .addHeader(RESPONSE_PAYLOAD_DELAY_MS, "20");
+        }
+        StringBuilder sb = new StringBuilder();
+        BlockingStreamingHttpResponse response = client.request(request);
+        assertThat(response.status(), is(OK));
+        for (Buffer chunk : response.payloadBody()) {
+            sb.append(chunk.toString(US_ASCII));
+        }
+        assertThat(sb.toString(), is(equalTo("HelloWorld")));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: expectContinue={0}")
+    @ValueSource(booleans = {false, true})
+    void metaDataTimeout(boolean expectContinue) {
+        SocketTimeoutException e = assertThrows(SocketTimeoutException.class, () -> {
+            HttpRequest request = newRequest()
+                    .addHeader(RETURN_RESPONSE_DELAY_MS, SERVER_DELAY_VALUE);
+            if (expectContinue) {
+                request.addHeader(EXPECT, CONTINUE);
+            }
+            request.context().put(READ_TIMEOUT_KEY, READ_TIMEOUT_VALUE);
+            client().request(request);
+        });
+        assertThat(e.getMessage(), endsWith("response meta-data"));
+        assertThat(e.getCause(), instanceOf(TimeoutException.class));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: expectContinue={0}")
+    @ValueSource(booleans = {false, true})
+    void metaDataTimeoutStreaming(boolean expectContinue) {
+        SocketTimeoutException e = assertThrows(SocketTimeoutException.class, () -> {
+            BlockingStreamingHttpClient client = client().asBlockingStreamingClient();
+            BlockingStreamingHttpRequest request = newStreamingRequest()
+                    .addHeader(RETURN_RESPONSE_DELAY_MS, SERVER_DELAY_VALUE);
+            if (expectContinue) {
+                request.addHeader(EXPECT, CONTINUE);
+            }
+            request.context().put(READ_TIMEOUT_KEY, READ_TIMEOUT_VALUE);
+            client.request(request);
+        });
+        assertThat(e.getMessage(), endsWith("response meta-data"));
+        assertThat(e.getCause(), instanceOf(TimeoutException.class));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: expectContinue={0}")
+    @ValueSource(booleans = {false, true})
+    void responsePayloadTimeout(boolean expectContinue) {
+        SocketTimeoutException e = assertThrows(SocketTimeoutException.class, () -> {
+            HttpRequest request = newRequest()
+                    .addHeader(RESPONSE_PAYLOAD_DELAY_MS, SERVER_DELAY_VALUE);
+            if (expectContinue) {
+                request.addHeader(EXPECT, CONTINUE);
+            }
+            request.context().put(READ_TIMEOUT_KEY, READ_TIMEOUT_VALUE);
+            client().request(request);
+        });
+        assertThat(e.getMessage(), endsWith("next response payload body chunk"));
+        assertThat(e.getCause(), instanceOf(TimeoutException.class));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: expectContinue={0}")
+    @ValueSource(booleans = {false, true})
+    void responsePayloadTimeoutStreaming(boolean expectContinue) {
+        SocketTimeoutException e = assertThrows(SocketTimeoutException.class, () -> {
+            BlockingStreamingHttpClient client = client().asBlockingStreamingClient();
+            BlockingStreamingHttpRequest request = newStreamingRequest()
+                    .addHeader(RESPONSE_PAYLOAD_DELAY_MS, SERVER_DELAY_VALUE);
+            if (expectContinue) {
+                request.addHeader(EXPECT, CONTINUE);
+            }
+            request.context().put(READ_TIMEOUT_KEY, READ_TIMEOUT_VALUE);
+            Iterator<Buffer> payload = client.request(request).payloadBody().iterator();
+            assertThat(payload.hasNext(), is(true));
+            assertThat(payload.next().toString(US_ASCII), is(equalTo("Hello")));
+            payload.next();
+        });
+        assertThat(e.getMessage(), endsWith("next response payload body chunk"));
+        assertThat(e.getCause(), instanceOf(TimeoutException.class));
+    }
+
+    @Test
+    void continueTimeout() {
+        SocketTimeoutException e = assertThrows(SocketTimeoutException.class, () -> {
+            // Request payload body awaits 100 (Continue) only when streaming client is used.
+            BlockingStreamingHttpClient client = client().asBlockingStreamingClient();
+            BlockingStreamingHttpRequest request = newStreamingRequest()
+                    .addHeader(EXPECT, CONTINUE)
+                    .addHeader(READ_REQUEST_DELAY_MS, SERVER_DELAY_VALUE);
+            request.context().put(READ_TIMEOUT_KEY, READ_TIMEOUT_VALUE);
+            client.request(request);
+        });
+        assertThat(e.getMessage(), endsWith("100 (Continue) response"));
+        assertThat(e.getCause(), is(nullValue()));
+    }
+
+    private static BlockingHttpClient client() {
+        assert client != null;
+        return client;
+    }
+
+    private static HttpRequest newRequest() {
+        return client().post("/")
+                .payloadBody(client().executionContext().bufferAllocator().fromAscii("World"));
+    }
+
+    private static BlockingStreamingHttpRequest newStreamingRequest() {
+        final BlockingStreamingHttpClient client = client().asBlockingStreamingClient();
+        return client.post("/")
+                .payloadBody(Collections.singleton(client.executionContext().bufferAllocator().fromAscii("World")));
+    }
+
+    @Nullable
+    private static Duration delay(@Nullable CharSequence value) {
+        if (value == null) {
+            return null;
+        }
+        return Duration.ofMillis(CharSequences.parseLong(value));
+    }
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/JavaNetSoTimeoutHttpConnectionFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/JavaNetSoTimeoutHttpConnectionFilter.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.TimeSource;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Processors;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.SourceAdapters;
+import io.servicetalk.concurrent.internal.ThrowableUtils;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpContextKeys;
+import io.servicetalk.http.api.HttpExecutionStrategies;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpHeaderNames;
+import io.servicetalk.http.api.HttpHeaderValues;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.utils.AbstractTimeoutHttpFilter.FixedDuration;
+import io.servicetalk.transport.api.ExecutionContext;
+
+import java.net.SocketOptions;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A filter to mimics {@link SocketOptions#SO_TIMEOUT} behavior on the client-side.
+ * <p>
+ * While {@link TimeoutHttpRequesterFilter} apples a timeout for the overall duration to receive either the response
+ * metadata (headers) or the complete reception of the response (including headers, payload body, optional trailers, as
+ * well as time to send the request), this filter applies timeout only to read operations. It means that time to send
+ * the request is not accounted. Also, if the remote server is sending a large payload body, the timeout will be applied
+ * on every chunk read, which may result in unpredictable time to read the full response if the remote slowly sends
+ * 1 byte withing the timeout boundaries. Use this filter only for compatibility with classic blocking Java libraries.
+ * To protect from the described use-cases, consider also using {@link TimeoutHttpRequesterFilter} before applying this
+ * filter.
+ * <p>
+ * This filter implements only {@link StreamingHttpConnectionFilterFactory} and therefore can be applied only at the
+ * connection level. This restriction ensures that the timeout is applied only for the response read operations
+ * (similar to {@link SocketOptions#SO_TIMEOUT} used by Java blocking API), without waiting for selecting or
+ * establishing a connection.
+ * <p>
+ * {@link SocketTimeoutException} (or its subtype) will be propagated when the timeout is reached.
+ *
+ * @see TimeoutHttpRequesterFilter
+ */
+public final class JavaNetSoTimeoutHttpConnectionFilter implements StreamingHttpConnectionFilterFactory {
+
+    private final BiFunction<HttpRequestMetaData, TimeSource, Duration> timeoutForRequest;
+    @Nullable
+    private final Executor timeoutExecutor;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param duration the timeout {@link Duration}
+     */
+    public JavaNetSoTimeoutHttpConnectionFilter(final Duration duration) {
+        this(new FixedDuration(duration));
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param duration the timeout {@link Duration}
+     * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
+     */
+    public JavaNetSoTimeoutHttpConnectionFilter(final Duration duration, final Executor timeoutExecutor) {
+        this(new FixedDuration(duration), timeoutExecutor);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param timeoutForRequest function for extracting timeout from request which may also determine the timeout using
+     * other sources. If no timeout is to be applied then the function should return {@code null}
+     */
+    public JavaNetSoTimeoutHttpConnectionFilter(
+            final BiFunction<HttpRequestMetaData, TimeSource, Duration> timeoutForRequest) {
+        this.timeoutForRequest = requireNonNull(timeoutForRequest);
+        this.timeoutExecutor = null;
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param timeoutForRequest function for extracting timeout from request which may also determine the timeout using
+     * other sources. If no timeout is to be applied then the function should return {@code null}
+     * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
+     */
+    public JavaNetSoTimeoutHttpConnectionFilter(
+            final BiFunction<HttpRequestMetaData, TimeSource, Duration> timeoutForRequest,
+            final Executor timeoutExecutor) {
+        this.timeoutForRequest = requireNonNull(timeoutForRequest);
+        this.timeoutExecutor = requireNonNull(timeoutExecutor);
+    }
+
+    @Override
+    public StreamingHttpConnectionFilter create(final FilterableStreamingHttpConnection connection) {
+        return new StreamingHttpConnectionFilter(connection) {
+            @Override
+            public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                return Single.defer(() -> {
+                    final Executor timeoutExecutor = contextExecutor(request, executionContext());
+                    @Nullable
+                    final Duration timeout = timeoutForRequest.apply(request, timeoutExecutor);
+                    if (timeout == null) {
+                        return delegate().request(request).shareContextOnSubscribe();
+                    }
+
+                    final CompletableSource.Processor requestProcessor = Processors.newCompletableProcessor();
+                    final Cancellable continueTimeout;
+                    final boolean expectContinue = request.headers()
+                            .contains(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE);
+                    if (expectContinue) {
+                        continueTimeout = timeoutExecutor.schedule(() ->
+                                requestProcessor.onError(newStacklessSocketTimeoutException("Read timed out after " +
+                                        timeout.toMillis() + "ms waiting for 100 (Continue) response")), timeout);
+                    } else {
+                        continueTimeout = null;
+                    }
+                    return delegate().request(request.transformMessageBody(p -> {
+                                Publisher<?> body = p.beforeFinally(requestProcessor::onComplete);
+                                if (continueTimeout != null) {
+                                    // Subscribe to the request payload body indicates we received 100 (Continue)
+                                    return body.beforeOnSubscribe(__ -> continueTimeout.cancel());
+                                }
+                                return body;
+                            }))
+                            // Defer timeout counter until after the request payload body is complete
+                            .ambWith(SourceAdapters.fromSource(requestProcessor)
+                                    // Start timeout counter after requestProcessor completes
+                                    .concat(Single.<StreamingHttpResponse>never().timeout(timeout, timeoutExecutor)
+                                            .onErrorMap(TimeoutException.class, t -> newStacklessSocketTimeoutException(
+                                                    "Read timed out after " + timeout.toMillis() +
+                                                            "ms waiting for response meta-data")
+                                                    .initCause(t))))
+                            .map(response -> response.transformMessageBody(p -> p.timeout(timeout, timeoutExecutor)
+                                    .onErrorMap(TimeoutException.class, t -> newStacklessSocketTimeoutException(
+                                            "Read timed out after " + timeout.toMillis() +
+                                                    "ms waiting for the next response payload body chunk")
+                                            .initCause(t))))
+                            .shareContextOnSubscribe();
+                });
+            }
+        };
+    }
+
+    private Executor contextExecutor(final HttpRequestMetaData requestMetaData,
+            final ExecutionContext<HttpExecutionStrategy> context) {
+        if (timeoutExecutor != null) {
+            return timeoutExecutor;
+        }
+        // We have to consider the execution strategy associated with the request.
+        final HttpExecutionStrategy strategy = requestMetaData.context()
+                .getOrDefault(HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY, context.executionStrategy());
+        assert strategy != null;
+        return strategy.isMetadataReceiveOffloaded() || strategy.isDataReceiveOffloaded() ?
+               context.executor() : context.ioExecutor();
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return HttpExecutionStrategies.offloadNone();
+    }
+
+    private StacklessSocketTimeoutException newStacklessSocketTimeoutException(final String message) {
+        return StacklessSocketTimeoutException.newInstance(message, this.getClass(), "request");
+    }
+
+    private static final class StacklessSocketTimeoutException extends SocketTimeoutException {
+        private static final long serialVersionUID = -6407427631101487627L;
+
+        private StacklessSocketTimeoutException(String message) {
+            super(message);
+        }
+
+        @Override
+        public Throwable fillInStackTrace() {
+            // Don't fill in the stacktrace to reduce performance overhead
+            return this;
+        }
+
+        static StacklessSocketTimeoutException newInstance(final String message, final Class<?> clazz,
+                                                           final String method) {
+            return ThrowableUtils.unknownStackTrace(new StacklessSocketTimeoutException(message), clazz, method);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

For backward compatibility with blocking Java libraries, it's helpful to have a filter that mimics behavior of `SO_TIMEOUT` socket option.