### PR TITLE
Extend `RedirectConfig`: custom allowed statuses and location mapper

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfig.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfig.java
@@ -15,7 +15,10 @@
  */
 package io.servicetalk.http.api;
 
+import io.servicetalk.http.api.HttpResponseStatus.StatusClass;
+
 import java.util.Set;
+import java.util.function.BiFunction;
 
 /**
  * Configuration options for <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4">redirection</a>.
@@ -77,6 +80,15 @@ public interface RedirectConfig {
     int maxRedirects();
 
     /**
+     * {@link HttpResponseStatus}es that are allowed to follow redirects.
+     * <p>
+     * All statuses in this set must belong to {@link StatusClass#REDIRECTION_3XX REDIRECTION_3XX} status class.
+     *
+     * @return {@link HttpResponseStatus}es that are allowed to follow redirects.
+     */
+    Set<HttpResponseStatus> allowedStatuses();
+
+    /**
      * {@link HttpRequestMethod}s that are allowed to follow redirects.
      *
      * @return {@link HttpRequestMethod}s that are allowed to follow redirects.
@@ -103,6 +115,15 @@ public interface RedirectConfig {
      * @see MultiAddressHttpClientBuilder#followRedirects(RedirectConfig)
      */
     boolean allowNonRelativeRedirects();
+
+    /**
+     * A function to extract redirect location information from the redirect {@link HttpResponseMetaData response},
+     * optionally considering the previous {@link HttpRequestMetaData request} as well.
+     *
+     * @return A function to extract redirect location information. If the function returns {@code null}, redirection
+     * response won't be followed.
+     */
+    BiFunction<HttpRequestMetaData, HttpResponseMetaData, String> locationMapper();
 
     /**
      * {@link RedirectPredicate} to make the final decision if redirect should be performed or not based on the

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectingHttpRequesterFilter.java
@@ -121,6 +121,9 @@ public final class RedirectingHttpRequesterFilter implements StreamingHttpClient
     private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                   final StreamingHttpRequest request,
                                                   final boolean allowNonRelativeRedirects) {
+        if (config.maxRedirects() <= 0) {
+            return delegate.request(request);
+        }
         final Single<StreamingHttpResponse> response = delegate.request(
                 // Duplicate each payload buffer chunk to allow safely replaying it without worry that indexes can move
                 request.transformMessageBody(p -> p.map(item -> {
@@ -129,9 +132,6 @@ public final class RedirectingHttpRequesterFilter implements StreamingHttpClient
                     }
                     return item;
                 })));
-        if (config.maxRedirects() <= 0) {
-            return response;
-        }
         return new RedirectSingle(delegate, request, response, allowNonRelativeRedirects, config);
     }
 


### PR DESCRIPTION
Motivation:

Existing implementation of `RedirectSingle` strictly follows only redirect responses defined by RFC7231 and extract the target resource from `Location` header. This is too restrictive behavior that does not allow users to redirect custom status codes with custom location headers.

Modifications:

- Add `RedirectConfig.allowedStatuses()` to customize which status codes can follow redirect;
- Add `RedirectConfig.locationMapper()` to customize the target resource identification;
- Enhance `RedirectConfigBuilder` and `RedirectSingle` to support new config options;
- Enhance tests;

Result:

Users can configure redirects for custom status codes and location mapper.