### PR TITLE
Allow null values with FormUrlEncodedHttp[De]Serializer

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpSerializer.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/FormUrlEncodedHttpSerializer.java
@@ -57,7 +57,7 @@ final class FormUrlEncodedHttpSerializer implements HttpSerializer<Map<String, L
     FormUrlEncodedHttpSerializer(final Charset charset, final Consumer<HttpHeaders> addContentType) {
         this.charset = charset;
         this.addContentType = addContentType;
-        this.isOptimizedCharset = charset == UTF_8 || charset == StandardCharsets.US_ASCII;
+        this.isOptimizedCharset = UTF_8.equals(charset) || StandardCharsets.US_ASCII.equals(charset);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UriUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UriUtils.java
@@ -252,7 +252,9 @@ final class UriUtils {
         final String name;
         if (valueStart <= nameStart) {
             name = decoder.apply(s.substring(nameStart, valueEnd), charset);
-            value = "";
+            // If no value is present, it should be represented as null (and not an empty string) so we can distinguish
+            // the cases of "key1&..." and "key1=&..." (note the presence of the equals sign)
+            value = null;
         } else {
             name = decoder.apply(s.substring(nameStart, valueStart - 1), charset);
             value = decoder.apply(s.substring(valueStart, valueEnd), charset);

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Spliterator;
 import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpHeaderNames.AUTHORIZATION;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
@@ -654,17 +655,17 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         createFixture("/foo?bar");
         assertEquals("/foo?bar", fixture.requestTarget());
         assertEquals("bar", fixture.rawQuery());
-        assertEquals("", fixture.queryParameter("bar"));
+        assertNull(fixture.queryParameter("bar"));
         assertNull(fixture.queryParameter("nothing"));
 
         assertEquals(singletonList("bar"), iteratorAsList(fixture.queryParametersKeys().iterator()));
         Iterator<Entry<String, String>> itr = fixture.queryParameters().iterator();
-        assertNext(itr, "bar", "");
+        assertNext(itr, "bar", null);
         assertFalse(itr.hasNext());
 
         List<Entry<String, String>> entries = iteratorAsList(fixture.queryParameters().iterator());
         assertThat(entries, hasSize(1));
-        assertEntry(entries.get(0), "bar", "");
+        assertEntry(entries.get(0), "bar", null);
     }
 
     @Test
@@ -861,17 +862,17 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
                 .collect(toList());
     }
 
-    private static void assertNext(Iterator<Entry<String, String>> itr, String key, String value) {
+    private static void assertNext(Iterator<Entry<String, String>> itr, String key, @Nullable String value) {
         assertTrue(itr.hasNext());
         assertEntry(itr.next(), key, value);
     }
 
-    private static void assertEntry(Entry<String, String> next, String key, String value) {
+    private static void assertEntry(Entry<String, String> next, String key, @Nullable String value) {
         assertEquals(key, next.getKey());
         assertEquals(value, next.getValue());
     }
 
-    private static String queryValue(String v) {
-        return v.isEmpty() ? "" : "=" + v;
+    private static String queryValue(@Nullable String v) {
+        return v == null ? "" : "=" + v;
     }
 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/FormUrlEncodedHttpDeserializerTest.java
@@ -36,6 +36,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -152,15 +153,15 @@ class FormUrlEncodedHttpDeserializerTest {
         final Map<String, List<String>> deserialized = deserializer.deserialize(FE_HEADERS, toBuffer(formParameters));
         assertThat(deserialized.size(), is(2));
 
-        assertThat(deserialized.get("key1").size(), is(1));
-        assertThat(deserialized.get("key2").size(), is(2));
+        assertThat(deserialized.get("key1"), hasSize(1));
+        assertThat(deserialized.get("key2"), hasSize(2));
 
         assertThat(deserialized.get("key1").get(0), paramIsNull ? nullValue() : emptyString());
         assertThat(deserialized.get("key2").get(0), paramIsNull ? nullValue() : emptyString());
         assertThat(deserialized.get("key2").get(1), paramIsNull ? nullValue() : emptyString());
     }
 
-    private Buffer toBuffer(final String value) {
+    private static Buffer toBuffer(final String value) {
         return DEFAULT_ALLOCATOR.fromUtf8(value);
     }
 }


### PR DESCRIPTION
Motivation:

At the moment the behavior around null (and to an extent empty) values is a little bit unflexible. ServiceTalk makes the decision to ignore null values on encoding and converting them to the same value as an empty string on decoding.

Since there is no spec which says that null values are disallowed, it is better if ServiceTalk is flexible and lets the user decide if they want to ignore values (which they can do by checking and then just not encoding them in the first place).

Modifications:

This changeset modifies behavior as follows.

On the encoding side:
 - null values are now allowed and encoded as "just" the key, instead of not being encoded at all. (Distinguished without an "=" compared to an empty string)

On the decoding side:
 - Null values are now not turned into an empty string, but if just the key is present turned into "null" - and if the "=" is present, an empty string is decoded.

Note: this also implicitly changes the resulting HttpQuery behavior when calling lazyParseQueryString on HttpRequestMetaData, since it uses the same functionality underneath. Since the "get" method is marked as @Nullable already, there is no illegal behavior observed.