### PR TITLE
Publisher#timeout always propagate TimeoutException

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriber.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ConcurrentTerminalSubscriber.java
@@ -37,6 +37,7 @@ public final class ConcurrentTerminalSubscriber<T> implements Subscriber<T> {
     private static final int SUBSCRIBER_STATE_TERMINATING = 2;
     private static final int SUBSCRIBER_STATE_TERMINATED = 3;
 
+    @SuppressWarnings("rawtypes")
     private static final AtomicIntegerFieldUpdater<ConcurrentTerminalSubscriber> stateUpdater =
             AtomicIntegerFieldUpdater.newUpdater(ConcurrentTerminalSubscriber.class, "state");
 
@@ -209,5 +210,17 @@ public final class ConcurrentTerminalSubscriber<T> implements Subscriber<T> {
                 }
             }
         }
+    }
+
+    /**
+     * Used to terminate the delegate {@link Subscriber} managed by this class externally. This method will mark the
+     * internal state of this class as terminated so no more signals are propagated by this class.
+     * @return the delegate {@link Subscriber} managed by this class if not already terminated, otherwise {@code null}.
+     */
+    @Nullable
+    public Subscriber<T> unwrapMarkTerminated() {
+        final int localState = stateUpdater.getAndSet(this, SUBSCRIBER_STATE_TERMINATED);
+        return localState == SUBSCRIBER_STATE_TERMINATED || localState == SUBSCRIBER_STATE_TERMINATING ?
+                null : delegate;
     }
 }


### PR DESCRIPTION
Motivation:
Publisher#timeout operator is inconsistent with Single and Completable timeout operators in that when a timeout triggers it will not ensure the timeout exception is propagated. It is possible for upstream to propagate a different exception even though the source of the error is a timeout exception.

Modifications:
- Enhance ConcurrentTerminalSubscriber to allow for external termination and take advantage of that in Publisher#timeout.
- Add tests for Completable and Single timeout operators to ensure existing expected behavior doesn't regress.