### PR TITLE
DefaultDnsClient reduce log level for TTL > max

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -814,7 +814,7 @@ final class DefaultDnsClient implements DnsClient {
                     ttlNanos = dnsAnswer.ttlNanos();
                     if (ttlNanos > maxTTLNanos) {
                         if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("{} result for {} has TTL={}s > maxTTL={}s",
+                            LOGGER.debug("{} result for {} has TTL={} > maxTTL={}",
                                     DefaultDnsClient.this, AbstractDnsPublisher.this, NANOSECONDS.toSeconds(ttlNanos),
                                     NANOSECONDS.toSeconds(maxTTLNanos));
                         }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -813,9 +813,11 @@ final class DefaultDnsClient implements DnsClient {
                     final List<T> addresses = dnsAnswer.answer();
                     ttlNanos = dnsAnswer.ttlNanos();
                     if (ttlNanos > maxTTLNanos) {
-                        LOGGER.info("{} result for {} has a high TTL={}s which is larger than configured maxTTL={}s.",
-                                DefaultDnsClient.this, AbstractDnsPublisher.this,
-                                NANOSECONDS.toSeconds(ttlNanos), NANOSECONDS.toSeconds(maxTTLNanos));
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug("{} result for {} has a high TTL={}s which is larger than configured maxTTL={}s.",
+                                    DefaultDnsClient.this, AbstractDnsPublisher.this,
+                                    NANOSECONDS.toSeconds(ttlNanos), NANOSECONDS.toSeconds(maxTTLNanos));
+                        }
                         ttlNanos = maxTTLNanos;
                     }
                     final List<ServiceDiscovererEvent<T>> events = calculateDifference(activeAddresses, addresses,

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -814,9 +814,9 @@ final class DefaultDnsClient implements DnsClient {
                     ttlNanos = dnsAnswer.ttlNanos();
                     if (ttlNanos > maxTTLNanos) {
                         if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("{} result for {} has a high TTL={}s which is larger than configured maxTTL={}s.",
-                                    DefaultDnsClient.this, AbstractDnsPublisher.this,
-                                    NANOSECONDS.toSeconds(ttlNanos), NANOSECONDS.toSeconds(maxTTLNanos));
+                            LOGGER.debug("{} result for {} has TTL={}s > maxTTL={}s",
+                                    DefaultDnsClient.this, AbstractDnsPublisher.this, NANOSECONDS.toSeconds(ttlNanos),
+                                    NANOSECONDS.toSeconds(maxTTLNanos));
                         }
                         ttlNanos = maxTTLNanos;
                     }


### PR DESCRIPTION
Motivation:
DefaultDnsClient logs at info level if the TTL from DNS is larger than the maximum configured TTL value. This level of logging can be noisy in production and not necessarily be within the client's control.