### PR TITLE
Improve how we copy payload body in case of redirect

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultPayloadInfo.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultPayloadInfo.java
@@ -31,6 +31,10 @@ final class DefaultPayloadInfo implements PayloadInfo {
     }
 
     DefaultPayloadInfo(PayloadInfo from) {
+        setAll(from);
+    }
+
+    DefaultPayloadInfo setAll(PayloadInfo from) {
         if (from instanceof DefaultPayloadInfo) {
             this.flags = ((DefaultPayloadInfo) from).flags;
         } else {
@@ -39,6 +43,7 @@ final class DefaultPayloadInfo implements PayloadInfo {
             setMayHaveTrailers(from.mayHaveTrailers());
             setGenericTypeBuffer(from.isGenericTypeBuffer());
         }
+        return this;
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpPayloadHolder.java
@@ -201,6 +201,10 @@ final class StreamingHttpPayloadHolder implements PayloadInfo {
         return payloadInfo.isGenericTypeBuffer();
     }
 
+    DefaultPayloadInfo payloadInfo() {
+        return payloadInfo;
+    }
+
     BufferAllocator allocator() {
         return allocator;
     }


### PR DESCRIPTION
Motivation:

- No need to always use `concat` when we carry message body from original to redirect request;
- We can access `DefaultPayloadInfo` to copy original request flags;

Modifications:

- Discard an empty publisher instead of using concatenation;
- Give pkg-private access to `DefaultPayloadInfo`;
- Copy original flags when available instead of using pessimistic approach that always sets "mayHaveTrailers";

Result:

More optimal copying of the message body, preserving original PayloadInfo flags.