### PR TITLE
`Publisher.takeUntil(Completable)`: preserve original terminal signal

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TakeUntilPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TakeUntilPublisher.java
@@ -77,19 +77,23 @@ final class TakeUntilPublisher<T> extends AbstractSynchronousPublisherOperator<T
 
                 @Override
                 public void onComplete() {
-                    try {
-                        cancelDownstreamSubscription();
-                    } finally {
-                        subscriber.processOnComplete();
+                    if (subscriber.deferredOnComplete()) {
+                        try {
+                            cancelDownstreamSubscription();
+                        } finally {
+                            subscriber.deliverDeferredTerminal();
+                        }
                     }
                 }
 
                 @Override
                 public void onError(Throwable t) {
-                    try {
-                        cancelDownstreamSubscription();
-                    } finally {
-                        subscriber.processOnError(t);
+                    if (subscriber.deferredOnError(t)) {
+                        try {
+                            cancelDownstreamSubscription();
+                        } finally {
+                            subscriber.deliverDeferredTerminal();
+                        }
                     }
                 }
 
@@ -108,19 +112,23 @@ final class TakeUntilPublisher<T> extends AbstractSynchronousPublisherOperator<T
 
         @Override
         public void onError(Throwable t) {
-            try {
-                cancelUntil();
-            } finally {
-                subscriber.processOnError(t);
+            if (subscriber.deferredOnError(t)) {
+                try {
+                    cancelUntil();
+                } finally {
+                    subscriber.deliverDeferredTerminal();
+                }
             }
         }
 
         @Override
         public void onComplete() {
-            try {
-                cancelUntil();
-            } finally {
-                subscriber.processOnComplete();
+            if (subscriber.deferredOnComplete()) {
+                try {
+                    cancelUntil();
+                } finally {
+                    subscriber.deliverDeferredTerminal();
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:

For `takeUntil` operator, when either `Publisher` or `Completable` terminates, downstream `Subscriber` should see the original terminal signal, even if the other source terminates concurrently.

Modifications:

- Use recently added "deferred" methods of `ConcurrentTerminalSubscriber`;
- Add test to reproduce the original issue;
- Refactor existing tests to use `ParameterizedTest`;

Result:

`takeUntil` operators propagates the initial terminal signal.