### PR TITLE
Add SslConfig#maxCertificateListBytes()

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateMaxSizeTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateMaxSizeTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.ServerSslConfigBuilder;
+
+import io.netty.handler.ssl.OpenSsl;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import javax.net.ssl.SSLHandshakeException;
+
+import static io.netty.handler.ssl.OpenSslContextOption.MAX_CERTIFICATE_LIST_BYTES;
+import static io.netty.handler.ssl.SslProvider.isOptionSupported;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
+import static io.servicetalk.transport.api.SslClientAuthMode.REQUIRE;
+import static io.servicetalk.transport.api.SslProvider.OPENSSL;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+final class SslCertificateMaxSizeTest {
+    /**
+     * <a href="
+     * https://source.chromium.org/chromium/chromium/src/+/main:third_party/boringssl/src/ssl/handshake.cc;l=233">limit
+     * </a>
+     */
+    private static final int BORINGSSL_LOWER_LIMIT = 16384;
+    private static boolean certMaxSizeAvailable() {
+        return OpenSsl.isAvailable() &&
+                isOptionSupported(io.netty.handler.ssl.SslProvider.OPENSSL, MAX_CERTIFICATE_LIST_BYTES);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {arguments}")
+    @CsvSource({"true,false", "false,true", "false,false"})
+    @EnabledIf(
+            value = "certMaxSizeAvailable",
+            disabledReason = "OpenSSL not available or max certificate size is not supported")
+    void respectsCertificateMaxSize(boolean serverLowerLimit, boolean clientLowerLimit) throws Exception {
+        final byte[] serverCertChain = readAllBytes(DefaultTestCerts.loadServerPem());
+        final byte[] clientCertChain = readAllBytes(DefaultTestCerts.loadClientPem());
+        // FIXME: To test the lower bound the cert length must be larger than BoringSSL's lower limit.
+        if (serverLowerLimit) {
+            assumeTrue(clientCertChain.length > BORINGSSL_LOWER_LIMIT);
+        }
+        if (clientLowerLimit) {
+            assumeTrue(serverCertChain.length > BORINGSSL_LOWER_LIMIT);
+        }
+        try (ServerContext server = serverBuilder(serverLowerLimit ? 1 : clientCertChain.length)
+                .listenBlockingAndAwait((ctx, request, responseFactory) ->
+                        responseFactory.ok().payloadBody("Hello World!", textSerializerUtf8()))) {
+            try (BlockingHttpClient client = clientBuilder(server, clientLowerLimit ? 1 : serverCertChain.length)
+                    .buildBlocking()) {
+                if (serverLowerLimit || clientLowerLimit) {
+                    assertThrows(SSLHandshakeException.class, () -> client.request(client.get("/sayHello")));
+                } else {
+                    assertThat(client.request(client.get("/sayHello")).status(), equalTo(OK));
+                }
+            }
+        }
+    }
+
+    private static HttpServerBuilder serverBuilder(int maxCertBytes) {
+        ServerSslConfigBuilder sslConfig = new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
+                DefaultTestCerts::loadServerKey)
+                .trustManager(DefaultTestCerts::loadClientCAPem)
+                .clientAuthMode(REQUIRE)
+                .maxCertificateListBytes(maxCertBytes)
+                .provider(OPENSSL);
+        return HttpServers.forAddress(localAddress(0)).sslConfig(sslConfig.build());
+    }
+
+    private static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder(
+            ServerContext ctx, int maxCertBytes) {
+        ClientSslConfigBuilder sslConfig = new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                .keyManager(DefaultTestCerts::loadClientPem, DefaultTestCerts::loadClientKey)
+                .peerHost(serverPemHostname())
+                .maxCertificateListBytes(maxCertBytes)
+                .provider(OPENSSL);
+        return HttpClients
+                .forSingleAddress(serverHostAndPort(ctx))
+                .sslConfig(sslConfig.build());
+    }
+
+    // JDK9+ can use InputStream.readAllBytes()
+    private static byte[] readAllBytes(InputStream is) throws IOException {
+        try {
+            final int readSize = 2048;
+            ByteArrayOutputStream buf = new ByteArrayOutputStream(readSize);
+            byte[] bytes = new byte[readSize];
+            while (is.read(bytes) > 0) {
+                buf.write(bytes);
+            }
+            return buf.toByteArray();
+        } finally {
+            is.close();
+        }
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfig.java
@@ -44,6 +44,7 @@ abstract class AbstractSslConfig implements SslConfig {
     private final List<String> ciphers;
     private final long sessionCacheSize;
     private final long sessionTimeout;
+    private final int maxCertificateListBytes;
     @Nullable
     private final SslProvider provider;
     @Nullable
@@ -57,8 +58,8 @@ abstract class AbstractSslConfig implements SslConfig {
                       @Nullable final Supplier<InputStream> keySupplier,
                       @Nullable final String keyPassword, @Nullable final List<String> sslProtocols,
                       @Nullable final List<String> alpnProtocols,
-                      @Nullable final List<String> ciphers, final long sessionCacheSize,
-                      final long sessionTimeout, @Nullable final SslProvider provider,
+                      @Nullable final List<String> ciphers, final long sessionCacheSize, final long sessionTimeout,
+                      final int maxCertificateListBytes, @Nullable final SslProvider provider,
                       @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms,
                       final Duration handshakeTimeout) {
         this.trustManagerFactory = trustManagerFactory;
@@ -72,6 +73,7 @@ abstract class AbstractSslConfig implements SslConfig {
         this.ciphers = ciphers;
         this.sessionCacheSize = sessionCacheSize;
         this.sessionTimeout = sessionTimeout;
+        this.maxCertificateListBytes = maxCertificateListBytes;
         this.provider = provider;
         this.certificateCompressionAlgorithms = certificateCompressionAlgorithms;
         this.handshakeTimeout = handshakeTimeout;
@@ -156,5 +158,10 @@ abstract class AbstractSslConfig implements SslConfig {
     @Override
     public final Duration handshakeTimeout() {
         return handshakeTimeout;
+    }
+
+    @Override
+    public int maxCertificateListBytes() {
+        return maxCertificateListBytes;
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
@@ -60,6 +60,7 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
     private List<String> ciphers;
     private long sessionCacheSize;
     private long sessionTimeout;
+    private int maxCertificateListBytes;
     @Nullable
     private SslProvider provider;
     @Nullable
@@ -387,6 +388,7 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
     }
 
     /**
+<<<<<<< HEAD
      * Sets the timeout for the handshake process.
      * <p>
      * Implementations can round the returned {@link Duration} to full time units, depending on their time granularity.
@@ -403,6 +405,24 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
 
     final Duration handshakeTimeout() {
         return handshakeTimeout;
+    }
+
+    /**
+     * Set the preferred maximum allowed size of the certificate chain in bytes. This may not be respected
+     * and depends on if the {@link SSLEngine} supports this feature.
+     * @param maxBytes Number of bytes for the certificate chain.
+     * @return {@code this}.
+     */
+    public final T maxCertificateListBytes(int maxBytes) {
+        if (maxBytes < 0) {
+            throw new IllegalArgumentException("maxBytes: " + maxBytes + " (expected >=0)");
+        }
+        this.maxCertificateListBytes = maxBytes;
+        return thisT();
+    }
+
+    final int maxCertificateListBytes() {
+        return maxCertificateListBytes;
     }
 
     abstract T thisT();

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
@@ -388,7 +388,6 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
     }
 
     /**
-<<<<<<< HEAD
      * Sets the timeout for the handshake process.
      * <p>
      * Implementations can round the returned {@link Duration} to full time units, depending on their time granularity.
@@ -410,7 +409,7 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
     /**
      * Set the preferred maximum allowed size of the certificate chain in bytes. This may not be respected
      * and depends on if the {@link SSLEngine} supports this feature.
-     * @param maxBytes Number of bytes for the certificate chain.
+     * @param maxBytes Number of bytes for the certificate chain. {@code 0} may mean "use the default limit".
      * @return {@code this}.
      */
     public final T maxCertificateListBytes(int maxBytes) {

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfigBuilder.java
@@ -145,7 +145,7 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
         return new DefaultClientSslConfig(hostnameVerificationAlgorithm, peerHost, peerPort, sniHostname,
                 trustManager(), trustCertChainSupplier(), keyManager(), keyCertChainSupplier(), keySupplier(),
                 keyPassword(), sslProtocols(), alpnProtocols(), ciphers(), sessionCacheSize(), sessionTimeout(),
-                provider(), certificateCompressionAlgorithms(), handshakeTimeout());
+                maxCertificateListBytes(), provider(), certificateCompressionAlgorithms(), handshakeTimeout());
     }
 
     @Override
@@ -173,12 +173,13 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
                                @Nullable final Supplier<InputStream> keySupplier, @Nullable final String keyPassword,
                                @Nullable final List<String> sslProtocols, @Nullable final List<String> alpnProtocols,
                                @Nullable final List<String> ciphers, final long sessionCacheSize,
-                               final long sessionTimeout, @Nullable final SslProvider provider,
+                               final long sessionTimeout, final int maxCertificateListBytes,
+                               @Nullable final SslProvider provider,
                                @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms,
                                final Duration handshakeTimeout) {
             super(trustManagerFactory, trustCertChainSupplier, keyManagerFactory, keyCertChainSupplier, keySupplier,
-                    keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout, provider,
-                    certificateCompressionAlgorithms, handshakeTimeout);
+                    keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout,
+                    maxCertificateListBytes, provider, certificateCompressionAlgorithms, handshakeTimeout);
             this.hostnameVerificationAlgorithm = hostnameVerificationAlgorithm;
             this.peerHost = peerHost;
             this.peerPort = peerPort;

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingSslConfig.java
@@ -128,4 +128,9 @@ public abstract class DelegatingSslConfig<T extends SslConfig> implements SslCon
     public Duration handshakeTimeout() {
         return delegate.handshakeTimeout();
     }
+
+    @Override
+    public int maxCertificateListBytes() {
+        return delegate.maxCertificateListBytes();
+    }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSslConfigBuilder.java
@@ -108,8 +108,8 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
     public ServerSslConfig build() {
         return new DefaultServerSslConfig(clientAuthMode, trustManager(), trustCertChainSupplier(), keyManager(),
                 keyCertChainSupplier(), keySupplier(), keyPassword(), sslProtocols(), alpnProtocols(), ciphers(),
-                sessionCacheSize(), sessionTimeout(), provider(), certificateCompressionAlgorithms(),
-                handshakeTimeout());
+                sessionCacheSize(), sessionTimeout(), maxCertificateListBytes(), provider(),
+                certificateCompressionAlgorithms(), handshakeTimeout());
     }
 
     @Override
@@ -128,12 +128,13 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
                                @Nullable final Supplier<InputStream> keySupplier, @Nullable final String keyPassword,
                                @Nullable final List<String> sslProtocols, @Nullable final List<String> alpnProtocols,
                                @Nullable final List<String> ciphers, final long sessionCacheSize,
-                               final long sessionTimeout, @Nullable final SslProvider provider,
+                               final long sessionTimeout, final int maxCertificateListBytes,
+                               @Nullable final SslProvider provider,
                                @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms,
                                final Duration handshakeTimeout) {
             super(trustManagerFactory, trustCertChainSupplier, keyManagerFactory, keyCertChainSupplier, keySupplier,
-                    keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout, provider,
-                    certificateCompressionAlgorithms, handshakeTimeout);
+                    keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout,
+                    maxCertificateListBytes, provider, certificateCompressionAlgorithms, handshakeTimeout);
             this.clientAuthMode = clientAuthMode;
         }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SslConfig.java
@@ -176,4 +176,14 @@ public interface SslConfig {
     default Duration handshakeTimeout() {   // FIXME 0.43 - remove default implementation
         return DEFAULT_HANDSHAKE_TIMEOUT;
     }
+
+    /**
+     * Get the preferred maximum allowed size of the certificate chain in bytes. This may not be respected
+     * and depends on if the {@link SSLEngine} supports this feature.
+     * @return Maximum number of bytes for the certificate chain, or {@code <=0} to use the default limit.
+     */
+    // FIXME 0.43 - remove default implementation
+    default int maxCertificateListBytes() {
+        return 0;
+    }
 }


### PR DESCRIPTION
Motivation:
Some use cases have certificate chains larger than the BoringSSL default limit. This may result in handshake failures and there is no way to configure the maximum value.

Modifications:
- Add SslConfig#maxCertificateListBytes() and corresponding builder methods to allow configuring the limit (if supported by SSLEngine).