### PR TITLE
Streamlined the creation of GRPC Exceptions by adding convenience method

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatus.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatus.java
@@ -166,7 +166,6 @@ public final class GrpcStatus {
         return exception == null ? null : exception.status();
     }
 
-
     /**
      * Returns the current status wrapped in a {@link GrpcStatusException}.
      *

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatus.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatus.java
@@ -125,6 +125,20 @@ public final class GrpcStatus {
     }
 
     /**
+     * Obtains the status given an integer code value and a description String.
+     * @param codeValue integer code value.
+     * @param description description for the given status.
+     * @return status associated with the code value, or {@link GrpcStatusCode#UNKNOWN}.
+     */
+    public static GrpcStatus fromCodeValueAndDescription(int codeValue, String description) {
+        if (codeValue < 0 || codeValue >= INT_TO_GRPC_STATUS_MAP.length) {
+            return new GrpcStatus(UNKNOWN, "Unknown code: " + codeValue);
+        } else {
+            return new GrpcStatus(GrpcStatusCode.fromCodeValue(codeValue), description);
+        }
+    }
+
+    /**
      * Translates a throwable into a status.
      *
      * @param t the throwable.
@@ -152,14 +166,13 @@ public final class GrpcStatus {
         return exception == null ? null : exception.status();
     }
 
+
     /**
      * Returns the current status wrapped in a {@link GrpcStatusException}.
      *
      * @return the current status wrapped in a {@link GrpcStatusException}.
-     * @deprecated Use {@link GrpcStatusException#GrpcStatusException(GrpcStatus)}.
      */
-    @Deprecated
-    public GrpcStatusException asException() { // FIXME: 0.43 - remove deprecated method
+    public GrpcStatusException asException() {
         return new GrpcStatusException(this, () -> null);
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusCode.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusCode.java
@@ -164,4 +164,14 @@ public enum GrpcStatusCode {
         return h2ErrorCode < 0 || h2ErrorCode >= H2_ERROR_TO_STATUS_CODE_MAP.length ?
                 UNKNOWN : H2_ERROR_TO_STATUS_CODE_MAP[h2ErrorCode];
     }
+
+    /**
+     * Returns a standard {@link GrpcStatus} with description as part of a {@link GrpcStatusException} builder pattern.
+     * @param description the Description for pending {@link GrpcStatusException}.
+     * @return the GrpcStatus with set description
+     */
+    public GrpcStatus withDescription(String description) {
+        GrpcStatus grpcStatus = GrpcStatus.fromCodeValueAndDescription(this.value(), description);
+        return grpcStatus;
+    }
 }

--- a/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcStatusTest.java
+++ b/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcStatusTest.java
@@ -16,7 +16,6 @@
 package io.servicetalk.grpc.api;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestClassOrder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcStatusTest.java
+++ b/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcStatusTest.java
@@ -16,8 +16,11 @@
 package io.servicetalk.grpc.api;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GrpcStatusTest {
 
@@ -55,5 +58,17 @@ class GrpcStatusTest {
         final GrpcStatus grpcStatus = GrpcStatus.fromCodeValue(unknownCode);
         assertEquals(GrpcStatusCode.UNKNOWN, grpcStatus.code());
         assertEquals("Status code value not a number: " + unknownCode, grpcStatus.description());
+    }
+
+    @Test
+    void testGrpcStatusExceptionFromGrpcStatusCode() {
+        final String exceptionMessage = "denied!";
+        GrpcStatusException grpcStatusException = GrpcStatusCode.PERMISSION_DENIED.withDescription(exceptionMessage).asException();
+        Exception thrownGrpcStatusException = assertThrows(GrpcStatusException.class, () -> {
+            throw grpcStatusException;
+        });
+        final String expectedExceptionMessage = exceptionMessage;
+        final String actualMessage = thrownGrpcStatusException.getMessage();
+        assertTrue(actualMessage.contains(expectedExceptionMessage));
     }
 }


### PR DESCRIPTION
Motivation:

In reference to issue #2502, there should be a more convenient way to initialize GRPC Exceptions analogous to other GRPC implementations.

Modifications:

- Removed the deprecation from GrpcStatus.asException as it is required for this implementation of desired functionality.
- Added additional constructor for GrpcStatus to support initialization from codeValue and description.
- Added convenience method GrpcStatusCode.withDescription to support desired functionality.
- Added GrpcStatusTest.testGrpcStatusExceptionFromGrpcStatusCode for test-driven development and better test coverage.

Result:

GRPC Exceptions can now be initialized and thrown more conveniently.