### PR TITLE
Avoid int overflow when receive large `MAX_CONCURRENT_STREAMS` value

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -93,6 +93,7 @@ import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forNonPipelined;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
@@ -225,7 +226,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
             }
 
             maxConcurrencyProcessor.onNext(new MaxConcurrencyConsumableEvent(
-                    maxConcurrentStreams.intValue(), ctx.channel()));
+                    (int) min(maxConcurrentStreams, Integer.MAX_VALUE), ctx.channel()));
             return false;
         }
 
@@ -532,6 +533,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
         private final Channel channel;
 
         MaxConcurrencyConsumableEvent(final int maxConcurrentStreams, final Channel channel) {
+            assert maxConcurrentStreams >= 0;
             this.maxConcurrentStreams = maxConcurrentStreams;
             this.channel = channel;
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
@@ -178,6 +178,7 @@ final class ReservableRequestConcurrencyControllers {
                     assert event != null : "event can not be null in onNext.";
                     final int currentConcurrency = lastMaxConcurrency;
                     final int newConcurrency = event.event();
+                    assert newConcurrency >= 0;
                     if (currentConcurrency < newConcurrency) {
                         // When concurrency increases, consume event to notify Netty asap, then update the value to
                         // allow more requests to go through. Even if this event is offloaded, eventConsumed() will

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionHttpLoadBalanceFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionHttpLoadBalanceFactory.java
@@ -163,6 +163,7 @@ public final class CacheConnectionHttpLoadBalanceFactory<ResolvedAddress>
                         public void onNext(@Nullable final ConsumableEvent<Integer> integerConsumableEvent) {
                             if (integerConsumableEvent != null) {
                                 final int concurrency = integerConsumableEvent.event();
+                                assert concurrency >= 0;
                                 // Connections may set their max concurrency to 0 before shutting down.
                                 // Map cleanup is done in terminal method.
                                 if (concurrency > 0) {


### PR DESCRIPTION
Motivation:

RFC defines that settings values are represented as unsigned 32-bit numbers: https://datatracker.ietf.org/doc/html/rfc9113#section-6.5.1 Since it doesn't explicitly describe any additional restrictions for `SETTINGS_MAX_CONCURRENT_STREAMS` value, it can be as high as 4,294,967,295. When this happens, our concurrency controller receives `-1` and it forces the LB to create a new connection for every HTTP/2 request.

Modifications:

- `H2ClientParentConnectionContext` should adjust high `maxConcurrentStreams` values to `Integer.MAX_VALUE`. This is an equivalent of unbounded concurrency. Netty's
`DefaultHttp2ConnectionDecoder` and `DefaultHttp2ConnectionEncoder` do the same.
- Add a reproducer;

Result:

Large `SETTINGS_MAX_CONCURRENT_STREAMS` values are adjusted to `Integer.MAX_VALUE`.