### PR TITLE
`Http2SettingsBuilder.initialWindowSize` should accept `int`, not `long`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2SettingsBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2SettingsBuilder.java
@@ -98,10 +98,24 @@ public final class Http2SettingsBuilder {
      *
      * @param value The value.
      * @return {@code this}.
+     * @deprecated Use {@link #initialWindowSize(int)}.
      */
+    @Deprecated
     public Http2SettingsBuilder initialWindowSize(long value) {
         validate31Unsigned(value);
-        settings.put(INITIAL_WINDOW_SIZE, value);
+        return initialWindowSize((int) value);
+    }
+
+    /**
+     * Set the value for
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_INITIAL_WINDOW_SIZE</a>.
+     *
+     * @param value The value.
+     * @return {@code this}.
+     */
+    public Http2SettingsBuilder initialWindowSize(int value) {
+        validate31Unsigned(value);
+        settings.put(INITIAL_WINDOW_SIZE, (long) value);
         return this;
     }
 
@@ -145,13 +159,19 @@ public final class Http2SettingsBuilder {
     }
 
     private static void validate32Unsigned(long value) {
-        if (value < 0 || value >= MAX_UNSIGNED_INT) {
+        if (value < 0 || value > MAX_UNSIGNED_INT) {
             throw new IllegalArgumentException("value: " + value + "(expected [0, " + MAX_UNSIGNED_INT + "]");
         }
     }
 
     private static void validate31Unsigned(long value) {
-        if (value < 0 || value >= Integer.MAX_VALUE) {
+        if (value < 0 || value > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("value: " + value + "(expected [0, " + Integer.MAX_VALUE + "]");
+        }
+    }
+
+    private static void validate31Unsigned(int value) {
+        if (value < 0) {
             throw new IllegalArgumentException("value: " + value + "(expected [0, " + Integer.MAX_VALUE + "]");
         }
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -54,7 +54,7 @@ public final class H2ProtocolConfigBuilder {
     private static final int DEFAULT_FLOW_CONTROL_QUANTUM = 1024 * 16;
     private Http2Settings h2Settings = new Http2SettingsBuilder()
             .initialWindowSize(INITIAL_FLOW_CONTROL_WINDOW)
-            .maxHeaderListSize((int) DEFAULT_HEADER_LIST_SIZE)
+            .maxHeaderListSize(DEFAULT_HEADER_LIST_SIZE)
             .build();
     private HttpHeadersFactory headersFactory = H2HeadersFactory.INSTANCE;
     private BiPredicate<CharSequence, CharSequence> headersSensitivityDetector = DEFAULT_SENSITIVITY_DETECTOR;


### PR DESCRIPTION
Motivation:

RFC says: Values above the maximum flow-control window size of 2^31-1 MUST be treated as a connection error of type `FLOW_CONTROL_ERROR`. To prevent users from accidentally setting incorrect values, we should accept only `int`. Also, `Http2Settings.initialWindowSize()` return type is `Integer`. Builder should be consistent.

Modifications:

- Deprecate `Http2SettingsBuilder.initialWindowSize(long)`;
- Add `Http2SettingsBuilder.initialWindowSize(int)`;
- Change `validate32Unsigned` and `validate31Unsigned` to throw an exception only when the passed value is greater than the max value;
- Remove unnecessary type cast for `maxHeaderListSize` in `H2ProtocolConfigBuilder`;

Result:

1. Users can not accidentally configure too large `initialWindowSize` value.
2. `Integer.MAX_VALUE` and `MAX_UNSIGNED_INT` are accepted values for settings.