### PR TITLE
RRLB: reduce number of state transitions when health-check passed

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -907,9 +907,9 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                 }
                 LOGGER.trace("{}: removed connection {} from {} after {} attempt(s).",
                         lbDescription, connection, this, removeAttempt);
-            // Use onErrorComplete instead of whenOnError to avoid double logging of an error inside subscribe():
-            // SimpleCompletableSubscriber.
             }).onErrorComplete(t -> {
+                // Use onErrorComplete instead of whenOnError to avoid double logging of an error inside subscribe():
+                // SimpleCompletableSubscriber.
                 LOGGER.error("{}: unexpected error while processing connection.onClose() for {}.",
                         lbDescription, connection, t);
                 return true;


### PR DESCRIPTION
Motivation:

When health-checking opens a new connection,
`host.addConnection(newCnx)` only adds a connection to the list, but keeps the state as `UNHEALTHY`. The following `markHealthy` will flip the state. This makes it possible for a racy state transitions in between. We can enhance `addConnection` to also change the state to keep everything atomic.

Modifications:

- `addConnection` transitions `ACTIVE` and `UNHEALTHY` states to `STATE_ACTIVE_NO_FAILURES`;
- Update comment to clarify why `markHealthy` can `cancelIfHealthCheck`;

Result:

Unhealthy host transitions to `ACTIVE` state at the same time when it adds a new connection to the list.