### PR TITLE
HttpObjectDecoder chunk size long -> int

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -81,6 +81,7 @@ import static io.servicetalk.http.netty.HeaderUtils.removeTransferEncodingChunke
 import static io.servicetalk.http.netty.HttpKeepAlive.shouldClose;
 import static java.lang.Character.isISOControl;
 import static java.lang.Character.isWhitespace;
+import static java.lang.Integer.parseUnsignedInt;
 import static java.lang.Long.parseUnsignedLong;
 import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -418,7 +419,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 }
                 onDataSeen();
                 final int lfIndex = crlfIndex(longLFIndex);
-                long chunkSize = getChunkSize(buffer, lfIndex);
+                int chunkSize = getChunkSize(buffer, lfIndex);
                 consumeCRLF(buffer, lfIndex);
                 this.chunkSize = chunkSize;
                 if (chunkSize == 0) {
@@ -799,7 +800,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         }
     }
 
-    private static long getChunkSize(final ByteBuf buffer, final int lfIndex) {
+    private static int getChunkSize(final ByteBuf buffer, final int lfIndex) {
         if (lfIndex - 2 < buffer.readerIndex()) {
             throw new DecoderException("Chunked encoding specified but chunk-size not found");
         }
@@ -807,7 +808,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 lfIndex - 1 - buffer.readerIndex(), US_ASCII));
     }
 
-    private static long getChunkSize(String hex) {
+    private static int getChunkSize(String hex) {
         hex = hex.trim();
         for (int i = 0; i < hex.length(); ++i) {
             char c = hex.charAt(i);
@@ -818,7 +819,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         }
 
         try {
-            return parseUnsignedLong(hex, 16);
+            return parseUnsignedInt(hex, 16);
         } catch (NumberFormatException cause) {
             throw invalidChunkSize(hex, cause);
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -82,7 +82,6 @@ import static io.servicetalk.http.netty.HttpKeepAlive.shouldClose;
 import static java.lang.Character.isISOControl;
 import static java.lang.Character.isWhitespace;
 import static java.lang.Integer.parseUnsignedInt;
-import static java.lang.Long.parseUnsignedLong;
 import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;


### PR DESCRIPTION
Motivation:
HttpObjectDecoder parses chunk size as a long but in practice we truncate the value to an integer internally. We should parse the value as a int and raise an error early rather than discarding data.