### PR TITLE
gradlew 8 extension -> classifier

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -153,7 +153,7 @@ final class ProjectUtils {
       description = "Assembles a Jar archive containing the $sourceSet.name sources."
       group = JavaBasePlugin.DOCUMENTATION_GROUP
       archiveAppendix = sourceSet.name == "main" ? null : sourceSet.name
-      archiveExtension = "sources"
+      archiveClassifier = "sources"
       addManifestAttributes(project, manifest)
       from sourceSet.allSource
     }
@@ -184,7 +184,7 @@ final class ProjectUtils {
       description = "Assembles a Jar archive containing the $sourceSet.name Javadoc."
       group = JavaBasePlugin.DOCUMENTATION_GROUP
       archiveAppendix = sourceSet.name == "main" ? null : sourceSet.name
-      archiveExtension = "javadoc"
+      archiveClassifier = "javadoc"
       addManifestAttributes(project, manifest)
       from javadocTask
     }

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -52,7 +52,7 @@ shadowJar {
   // includes javaPoet and Google protobufs
   configurations = [project.configurations.compileClasspath]
   archiveBaseName = project.name
-  archiveExtension = 'all'
+  archiveClassifier = 'all'
 }
 
 def grpcPluginUberJarName = project.name + "-" + project.version + "-all.jar"


### PR DESCRIPTION
Motivation:
Gradle 8 deprecated the classifier member in its API which was replaced with archiveClassifier. However when upgrading the archiveExtension member was used by mistake.