### PR TITLE
Publisher#timeoutDemand avoid suprious timer error

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutDemandPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimeoutDemandPublisher.java
@@ -110,14 +110,21 @@ final class TimeoutDemandPublisher<T> extends AbstractNoHandleSubscribePublisher
 
         @Override
         void timerFires() {
-            final long prevDemand = demandUpdater.getAndSet(this, DEMAND_TIMER_FIRED);
-            if (prevDemand >= 0) {
-                try {
-                    stopTimer(true); // clear the reference and prevent future timers.
-                } finally {
-                    // Concurrent/multiple termination is protected by ConcurrentTerminalSubscriber.
-                    offloadTimeout(new TimeoutException("no demand timeout after " +
-                            NANOSECONDS.toMillis(parent.durationNs) + "ms"), parent.timeoutExecutor);
+            for (;;) {
+                final long currDemand = demand;
+                if (currDemand != 0) {
+                    // demand and timer state are set independent, so it is possible the timer may fire while there is
+                    // demand due to race conditions. If this is the case just bail as it isn't a "real" timeout.
+                    break;
+                } else if (demandUpdater.compareAndSet(this, currDemand, DEMAND_TIMER_FIRED)) {
+                    try {
+                        stopTimer(true); // clear the reference and prevent future timers.
+                    } finally {
+                        // Concurrent/multiple termination is protected by ConcurrentTerminalSubscriber.
+                        offloadTimeout(new TimeoutException("no demand timeout after " +
+                                NANOSECONDS.toMillis(parent.durationNs) + "ms"), parent.timeoutExecutor);
+                    }
+                    break;
                 }
             }
         }
@@ -131,6 +138,26 @@ final class TimeoutDemandPublisher<T> extends AbstractNoHandleSubscribePublisher
                 final Cancellable nextTimer = parent.timeoutExecutor.schedule(this::timerFires, parent.durationNs,
                         NANOSECONDS);
                 if (timerCancellableUpdater.compareAndSet(this, cancellable, nextTimer)) {
+                    assert cancellable == null;
+                    // We don't atomically manipulate the `demand` and set the timer so we can get the following race:
+                    // Thread1: `.onNext(..)` call decrements demand to 0 and enters the top of `startTimer()`, pauses.
+                    // Thread2: `.request(n > 0)`, increments demand from 0 -> n, enters `stopTimer(false)` and replaces
+                    // `null` with `null`.
+                    // Thread1: wakes and proceeds to successfully `startTimer()` despite demand being n > 0.
+                    // If we see demand > 0 here we know it is safe to stop the timer because this method is only called
+                    // on the Subscriber thread (no concurrency allowed), otherwise we let the timer stand.
+                    for (;;) {
+                        final long currDemand = demand;
+                        if (currDemand > 0) {
+                            nextTimer.cancel();
+                            // Try to reset the timerCancellableUpdater to the original state. If the CAS fails, no need
+                            // to loop because the only other state is LOCAL_IGNORE_CANCEL which is a terminal state.
+                            timerCancellableUpdater.compareAndSet(this, nextTimer, null);
+                            break;
+                        } else if (demandUpdater.compareAndSet(this, currDemand, currDemand)) {
+                            break;
+                        }
+                    }
                     break;
                 } else {
                     nextTimer.cancel();
@@ -142,16 +169,6 @@ final class TimeoutDemandPublisher<T> extends AbstractNoHandleSubscribePublisher
         void stopTimer(boolean terminal) {
             for (;;) {
                 final Cancellable cancellable = timerCancellable;
-                if (cancellable == null && !terminal) {
-                    // We don't atomically manipulate the `demand` and set the timer so we can get the following race:
-                    // Thread1: `.onNext(..)` call decrements demand to 0 and enters the top of `startTimer()`, pauses.
-                    // Thread2: `.request(n > 0)`, increments demand from 0 -> n, enters `stopTimer(false)` and replaces
-                    // `null` with `null`.
-                    // Thread1: wakes and proceeds to successfully `startTimer()` despite demand being n > 0.
-                    // Because we know that if demand is 0 there must either be a timer set or we must be racing with a
-                    // thread in `.onNext` which is about to set a timer, we must spin until we get a non-null value.
-                    continue;
-                }
                 if (cancellable == LOCAL_IGNORE_CANCEL) {
                     break;
                 } else if (timerCancellableUpdater.compareAndSet(this, cancellable,

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestExecutor.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestExecutor.java
@@ -286,7 +286,7 @@ public class TestExecutor implements Executor {
 
         // There maybe concurrent access to this Executor and other tasks schedule, so if in the mean time
         // someone inserts something into the queue we should attempt to add it back to the Map.
-        if (!removedQueue.isEmpty()) {
+        if (removedQueue != null && !removedQueue.isEmpty()) {
             final Queue<RunnableWrapper> existingQueue =
                     scheduledTasksByNano.putIfAbsent(scheduledNanos, removedQueue);
             if (existingQueue != null) {


### PR DESCRIPTION
Motivation:
Publisher#timeoutDemand had a race condition that was fixed between startTimer and stopTimer. However there is still a race condition where the timer may fire and propagate a timeout even though there is demand.

Modifications:
- timerFires should atomically check/set the demand to verify there is no demand before propagating a timeout.
- Move the race detection to the Subscriber thread which avoids busy-wait-loop between Subscription and Subscriber threads. This should reduce busy-wait due to thread visibility and may reduce the spurious timeout condition (where timer fires before it is cancelled) since the cancellation is done on the same thread that sets the timer.
- Fix TestExecutor NPE when removing a scheduled queue.