### PR TITLE
`Publisher.fromInputStream`: clarify `InputStream` ownership in javadoc

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -4062,6 +4062,13 @@ public abstract class Publisher<T> {
      * Create a new {@link Publisher} that when subscribed will emit all data from the {@link InputStream} to the
      * {@link Subscriber} and then {@link Subscriber#onComplete()}.
      * <p>
+     * The resulting publisher is not replayable and supports only a single {@link Subscriber}.
+     * <p>
+     * After a returned {@link Publisher} is subscribed, it owns the passed {@link InputStream}, meaning that the
+     * {@link InputStream} will be automatically closed when the {@link Publisher} is cancelled or terminated. Not
+     * necessary to close the {@link InputStream} after subscribe, but it should be closed when control flow never
+     * subscribes to the returned {@link Publisher}.
+     * <p>
      * The Reactive Streams specification provides two criteria (
      * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#3.4">3.4</a>, and
      * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#3.5">3.5</a>) stating
@@ -4082,6 +4089,13 @@ public abstract class Publisher<T> {
     /**
      * Create a new {@link Publisher} that when subscribed will emit all data from the {@link InputStream} to the
      * {@link Subscriber} and then {@link Subscriber#onComplete()}.
+     * <p>
+     * The resulting publisher is not replayable and supports only a single {@link Subscriber}.
+     * <p>
+     * After a returned {@link Publisher} is subscribed, it owns the passed {@link InputStream}, meaning that the
+     * {@link InputStream} will be automatically closed when the {@link Publisher} is cancelled or terminated. Not
+     * necessary to close the {@link InputStream} after subscribe, but it should be closed when control flow never
+     * subscribes to the returned {@link Publisher}.
      * <p>
      * The Reactive Streams specification provides two criteria (
      * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#3.4">3.4</a>, and

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -99,6 +99,9 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     /**
      * Returns a {@link BlockingStreamingHttpRequest} with its underlying payload set to {@code payloadBody}.
      * <p>
+     * After the request is sent, it owns the passed {@link InputStream}, meaning that the {@link InputStream} will be
+     * automatically closed when the request is finished.
+     * <p>
      * A best effort will be made to apply back pressure to the existing payload body which is being replaced. If this
      * default policy is not sufficient you can use {@link #transformPayloadBody(UnaryOperator)} for more fine grain
      * control.


### PR DESCRIPTION
Motivation:

Users are not sure if they have to close the `InputStream` or not after converting it into a `Publisher` or after passing into a request object.

Modifications:

- Clarify `InputStream` ownership for `Publisher.fromInputStream`;
- Enhance `FromInputStreamPublisherTest`;

Result:

Users have better understanding if they should close `InputStream` or not.