### PR TITLE
Publisher#buffer retry with sequential subscription

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherBuffer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherBuffer.java
@@ -55,9 +55,12 @@ final class PublisherBuffer<T, B> extends AbstractAsynchronousPublisherOperator<
             return new Subscriber<T>() {
                 @Override
                 public void onSubscribe(final Subscription subscription) {
-                    subscription.cancel();
-                    deliverErrorFromSource(subscriber,
-                            new IllegalArgumentException("bufferSizeHint: " + bufferSizeHint + " (expected > 0)"));
+                    try {
+                        subscription.cancel();
+                    } finally {
+                        deliverErrorFromSource(subscriber,
+                                new IllegalArgumentException("bufferSizeHint: " + bufferSizeHint + " (expected > 0)"));
+                    }
                 }
 
                 @Override
@@ -211,19 +214,19 @@ final class PublisherBuffer<T, B> extends AbstractAsynchronousPublisherOperator<
         @Override
         public void onError(final Throwable t) {
             try {
-                state.boundariesTerminated(t, target);
-            } finally {
                 tSubscription.cancel();
+            } finally {
+                state.boundariesTerminated(t, target);
             }
         }
 
         @Override
         public void onComplete() {
             try {
+                tSubscription.cancel();
+            } finally {
                 state.boundariesTerminated(new IllegalStateException("Boundaries source completed unexpectedly."),
                         target);
-            } finally {
-                tSubscription.cancel();
             }
         }
     }


### PR DESCRIPTION
Motivation:
If the BufferStrategy terminates and the operator is applied to a Publisher that only supports sequential subscription model any retry operations will fail with duplicate Subscriber exception.

Modifications:
- Cancel before propagating error, so any retry operator will have state reset on the publisher.