### PR TITLE
Logging LifeCycleObservers quote connection

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExceptionMapperServiceFilter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExceptionMapperServiceFilter.java
@@ -86,7 +86,7 @@ public final class GrpcExceptionMapperServiceFilter implements StreamingHttpServ
         if (serverCatchAllShouldLog(cause)) {
             final CharSequence codeValue = response.headers().get(GRPC_STATUS);
             assert codeValue != null;
-            LOGGER.error("Unexpected exception during a {} processing for connection={}, request='{} {} {}' was " +
+            LOGGER.error("Unexpected exception during a {} processing for connection='{}', request='{} {} {}' was " +
                             "mapped to grpc-status: {} ({})", what, ctx, request.method(), request.requestTarget(),
                     request.version(), codeValue, fromCodeValue(codeValue), cause);
         }

--- a/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserver.java
+++ b/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserver.java
@@ -189,7 +189,7 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
                 requestResult = Result.cancelled;
             }
             if (responseMetaData != null) {
-                logger.log("connection={} " +
+                logger.log("connection='{}' " +
                 "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} requestResult={} " +
                 "responseCode={} responseHeadersCount={} responseSize={} responseTrailersCount={} grpcStatus={} " +
                 "responseResult={} responseTime={}ms totalTime={}ms",
@@ -200,7 +200,7 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
                 responseTrailersCount, grpcStatus, unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
                 combine(responseResult, requestResult));
             } else {
-                logger.log("connection={} " +
+                logger.log("connection='{}' " +
                 "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} requestResult={} " +
                 "responseResult={} responseTime={}ms totalTime={}ms",
                 connInfo == null ? "unknown" : connInfo,

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
@@ -118,7 +118,7 @@ public final class ContentCodingHttpServiceFilter implements StreamingHttpServic
                             return response;
                         }).shareContextOnSubscribe();
                     } catch (UnsupportedContentEncodingException cause) {
-                        LOGGER.error("Request failed for service={}, connection={}", service, this, cause);
+                        LOGGER.error("Request failed for service={}, connection='{}'", service, this, cause);
                         // see https://tools.ietf.org/html/rfc7231#section-3.1.2.2
                         return succeeded(responseFactory.unsupportedMediaType()).shareContextOnSubscribe();
                     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExceptionMapperServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpExceptionMapperServiceFilter.java
@@ -76,18 +76,18 @@ public final class HttpExceptionMapperServiceFilter implements StreamingHttpServ
         final HttpResponseStatus status;
         if (cause instanceof RejectedExecutionException) {
             status = SERVICE_UNAVAILABLE;
-            LOGGER.error("Task rejected by service processing for connection={}, request='{} {} {}'. Returning: {}",
+            LOGGER.error("Task rejected by service processing for connection='{}', request='{} {} {}'. Returning: {}",
                     ctx, request.method(), request.requestTarget(), request.version(), status, cause);
         } else if (cause instanceof SerializationException) {
             // It is assumed that a failure occurred when attempting to deserialize the request.
             status = UNSUPPORTED_MEDIA_TYPE;
-            LOGGER.error("Failed to deserialize or serialize for connection={}, request='{} {} {}'. Returning: {}",
+            LOGGER.error("Failed to deserialize or serialize for connection='{}', request='{} {} {}'. Returning: {}",
                     ctx, request.method(), request.requestTarget(), request.version(), status, cause);
         } else if (cause instanceof PayloadTooLargeException) {
             status = PAYLOAD_TOO_LARGE;
         } else {
             status = INTERNAL_SERVER_ERROR;
-            LOGGER.error("Unexpected exception during service processing for connection={}, request='{} {} {}'. " +
+            LOGGER.error("Unexpected exception during service processing for connection='{}', request='{} {} {}'. " +
                             "Trying to return: {}", ctx, request.method(), request.requestTarget(), request.version(),
                     status, cause);
         }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
@@ -94,7 +94,7 @@ final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
                                         }
                                     } catch (Throwable cause) {
                                         if (result1 != null) {
-                                            LOGGER.debug("Unexpected error, closing connection={}", result1, cause);
+                                            LOGGER.debug("Unexpected error, closing connection='{}'", result1, cause);
                                             result1.closeAsync().subscribe();
                                         }
                                         subscriber.onError(cause);

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
@@ -187,7 +187,7 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
             }
             assert responseResult != null;
             if (responseMetaData != null) {
-                logger.log("connection={} " +
+                logger.log("connection='{}' " +
                 "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} requestResult={} " +
                 "responseCode={} responseHeadersCount={} responseSize={} responseTrailersCount={} responseResult={} " +
                 "responseTime={}ms totalTime={}ms",
@@ -198,7 +198,7 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
                 responseTrailersCount, unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
                 combine(responseResult, requestResult));
             } else {
-                logger.log("connection={} " +
+                logger.log("connection='{}' " +
                 "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} requestResult={} " +
                 "responseResult={} responseTime={}ms totalTime={}ms",
                 connInfo == null ? "unknown" : connInfo,


### PR DESCRIPTION
Motivation:
LoggingGrpcLifecycleObserver and LoggingGrpcLifecycleObserver log the connection context, but the connection context string has spaces and special characters that may impact log indexers.

Modifications:
- quote places that log connection strings