### PR TITLE
Jersey router: async endpoints don't propagate AsyncContext

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToOffloadedStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToOffloadedStreamingHttpService.java
@@ -73,7 +73,8 @@ public class StreamingHttpServiceToOffloadedStreamingHttpService implements Stre
                 final StreamingHttpRequest r = request;
                 resp = useExecutor.submit(
                                 () -> delegate.handle(wrappedCtx, r, responseFactory).shareContextOnSubscribe())
-                        // exec.submit() returns a Single<Single<response>>, so flatten nested Single.
+                        // exec.submit() returns a Single<Single<StreamingHttpResponse>>, so flatten nested Single.
+                        // No need to apply shareContextOnSubscribe() again because unwrapped Single already shares ctx.
                         .flatMap(identity());
             } else {
                 resp = delegate.handle(wrappedCtx, request, responseFactory);

--- a/servicetalk-http-netty/gradle/spotbugs/testFixtures-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/testFixtures-exclusions.xml
@@ -15,14 +15,15 @@
   ~ limitations under the License.
   -->
 <FindBugsFilter>
-  <Match>
-    <Class name="io.servicetalk.http.netty.AsyncContextHttpFilterVerifier"/>
-    <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
-  </Match>
   <!-- Not interested in returned values -->
   <Match>
     <Class name="io.servicetalk.http.netty.ProxyTunnel"/>
     <Method name="startProxy"/>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+  </Match>
+  <!-- Expected to pass the queue -->
+  <Match>
+    <Class name="io.servicetalk.http.netty.AsyncContextHttpFilterVerifier$AsyncContextAssertionFilter"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -25,7 +25,6 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Processors;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
-import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.DefaultHttpCookiePair;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
@@ -140,7 +139,6 @@ import static io.servicetalk.concurrent.api.Processors.newPublisherProcessor;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.context.api.ContextMap.Key.newKey;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
@@ -160,6 +158,10 @@ import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
 import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.MAX_CONCURRENCY_NO_OFFLOADING;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.K1;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.K2;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.K3;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.assertAsyncContext;
 import static io.servicetalk.http.netty.CloseUtils.onGracefulClosureStarted;
 import static io.servicetalk.http.netty.H2ToStH1Utils.COOKIE_STRICT_RFC_6265;
 import static io.servicetalk.http.netty.H2ToStH1Utils.PROXY_CONNECTION;
@@ -212,9 +214,6 @@ class H2PriorKnowledgeFeatureParityTest {
     private static final CharSequence[] CONNECTION_HEADERS = {CONNECTION_HEADER1, CONNECTION_HEADER2,
             CONNECTION_HEADER3, CONNECTION_HEADER4};
     private static final String EXPECT_FAIL_HEADER = "please_fail_expect";
-    private static final ContextMap.Key<String> K1 = newKey("k1", String.class);
-    private static final ContextMap.Key<String> K2 = newKey("k2", String.class);
-    private static final ContextMap.Key<String> K3 = newKey("k3", String.class);
     private EventLoopGroup serverEventLoopGroup;
     private HttpExecutionStrategy clientExecutionStrategy;
     private boolean h2PriorKnowledge;
@@ -2007,16 +2006,6 @@ class H2PriorKnowledgeFeatureParityTest {
                 });
             });
         });
-    }
-
-    private static <T> void assertAsyncContext(ContextMap.Key<T> key, T expectedValue,
-                                               Queue<Throwable> errorQueue) {
-        T actualValue = AsyncContext.get(key);
-        if (!expectedValue.equals(actualValue)) {
-            AssertionError e = new AssertionError("unexpected value for " + key + ": " +
-                    actualValue + " expected: " + expectedValue);
-            errorQueue.add(e);
-        }
     }
 
     private static final class TestConnectionFilter extends StreamingHttpConnectionFilter {

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
+  testFixturesImplementation testFixtures(project(":servicetalk-http-netty"))
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation project(":servicetalk-data-jackson")
   testFixturesImplementation project(":servicetalk-http-netty")

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AsyncContextTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AsyncContextTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.router.jersey;
+
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.AsyncContextAssertionFilter;
+import io.servicetalk.http.router.jersey.resources.AsyncContextResources;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import javax.ws.rs.core.Application;
+
+import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
+import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
+import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.router.jersey.AbstractJerseyStreamingHttpServiceTest.RouterApi.ASYNC_STREAMING;
+import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class AsyncContextTest extends AbstractJerseyStreamingHttpServiceTest {
+
+    private final BlockingQueue<Throwable> errors = new LinkedBlockingDeque<>();
+    private boolean lazyPayload;
+    private boolean hasK2;
+    private boolean hasK3;
+
+    void setUp(boolean lazyPayload, boolean hasK2, boolean hasK3) {
+        this.lazyPayload = lazyPayload;
+        this.hasK2 = hasK2;
+        this.hasK3 = hasK3;
+        assertDoesNotThrow(() -> super.setUp(ASYNC_STREAMING));
+    }
+
+    @AfterEach
+    void assertNoErrors() {
+        assertNoAsyncErrors(errors);
+    }
+
+    @Override
+    protected Application application() {
+        return new Application() {
+            @Override
+            public Set<Class<?>> getClasses() {
+                return Collections.singleton(AsyncContextResources.class);
+            }
+        };
+    }
+
+    @Override
+    void configureBuilders(HttpServerBuilder serverBuilder, HttpJerseyRouterBuilder jerseyRouterBuilder) {
+        super.configureBuilders(serverBuilder, jerseyRouterBuilder);
+        serverBuilder.appendServiceFilter(new AsyncContextAssertionFilter(errors, lazyPayload, hasK2, hasK3));
+    }
+
+    @Override
+    protected String testUri(final String path) {
+        return AsyncContextResources.PATH + path;
+    }
+
+    @Test
+    void noArgsNoReturn() {
+        setUp(false, false, false);
+        sendAndAssertResponse(get("/noArgsNoReturn"), NO_CONTENT, null, is(emptyString()), __ -> null);
+    }
+
+    @Test
+    void getBuffer() {
+        setUp(false, false, false);
+        sendAndAssertResponse(get("/getBuffer"), OK, TEXT_PLAIN, is(equalTo("foo")), 3);
+    }
+
+    @Test
+    void postBuffer() {
+        setUp(false, false, false);
+        sendAndAssertResponse(post("/postBuffer", "foo", TEXT_PLAIN), NO_CONTENT, null, is(emptyString()), __ -> null);
+    }
+
+    @Test
+    void syncEcho() {
+        setUp(false, false, false);
+        String payload = "foo";
+        sendAndAssertResponse(post("/syncEcho", payload, TEXT_PLAIN),
+                OK, TEXT_PLAIN, is(equalTo(payload)), payload.length());
+    }
+
+    @Test
+    void syncEchoResponse() {
+        setUp(false, false, false);
+        String payload = "foo";
+        sendAndAssertResponse(post("/syncEchoResponse", payload, TEXT_PLAIN),
+                OK, TEXT_PLAIN, is(equalTo(payload)), payload.length());
+    }
+
+    @Test
+    void postTextOioStreams() {
+        setUp(true, true, false);
+        String payload = "foo";
+        sendAndAssertResponse(post("/postTextOioStreams", payload, TEXT_PLAIN),
+                OK, TEXT_PLAIN, is(equalTo(payload)), payload.length());
+    }
+
+    @Test
+    void syncEchoJsonMap() {
+        setUp(false, false, false);
+        sendAndAssertResponse(post("/syncEchoJsonMap", "{\"key\":\"val1\"}", APPLICATION_JSON),
+                OK, APPLICATION_JSON, jsonEquals("{\"key\":\"val1\",\"foo\":\"bar1\"}"),
+                getJsonResponseContentLengthExtractor());
+    }
+
+    @Test
+    void completable() {
+        setUp(false, true, false);
+        sendAndAssertResponse(get("/completable"), NO_CONTENT, null, is(emptyString()), __ -> null);
+    }
+
+    @Test
+    void getSingleBuffer() {
+        setUp(false, true, false);
+        sendAndAssertResponse(get("/getSingleBuffer"), OK, TEXT_PLAIN, is(equalTo("foo")), 3);
+    }
+
+    @Test
+    void postSingleBuffer() {
+        setUp(true, true, false);
+        sendAndAssertResponse(post("/postSingleBuffer", "foo", TEXT_PLAIN),
+                NO_CONTENT, null, is(emptyString()), __ -> null);
+    }
+
+    @Test
+    void postSingleBufferSync() {
+        setUp(true, true, false);
+        sendAndAssertResponse(post("/postSingleBufferSync", "foo", TEXT_PLAIN),
+                NO_CONTENT, null, is(emptyString()), __ -> null);
+    }
+
+    @Test
+    void singleEcho() {
+        setUp(true, true, false);
+        String payload = "foo";
+        sendAndAssertResponse(post("/singleEcho", payload, TEXT_PLAIN),
+                OK, TEXT_PLAIN, is(equalTo(payload)), payload.length());
+    }
+
+    @Test
+    void getPublisherBuffer() {
+        setUp(false, true, true);
+        sendAndAssertResponse(get("/getPublisherBuffer"),
+                OK, TEXT_PLAIN, is(equalTo("foo")), __ -> null);
+    }
+
+    @Test
+    void postPublisherBuffer() {
+        setUp(true, true, false);
+        sendAndAssertResponse(post("/postPublisherBuffer", "foo", TEXT_PLAIN),
+                NO_CONTENT, null, is(emptyString()), __ -> null);
+    }
+
+    @Test
+    void publisherEcho() {
+        setUp(true, false, true);
+        String payload = "foo";
+        sendAndAssertResponse(post("/publisherEcho", payload, TEXT_PLAIN),
+                OK, TEXT_PLAIN, is(equalTo(payload)), __ -> null);
+    }
+
+    @Test
+    void publisherEchoSync() {
+        setUp(true, false, true);
+        String payload = "foo";
+        sendAndAssertResponse(post("/publisherEchoSync", payload, TEXT_PLAIN),
+                OK, TEXT_PLAIN, is(equalTo(payload)), __ -> null);
+    }
+
+    @Test
+    void getCompletionStage() {
+        setUp(false, true, false);
+        sendAndAssertResponse(get("/getCompletionStage"), OK, TEXT_PLAIN, is(equalTo("foo")), 3);
+    }
+
+    @Test
+    void getCompletionStageCompleteWithStExecutor() {
+        setUp(false, true, false);
+        sendAndAssertResponse(get("/getCompletionStageCompleteWithStExecutor"), OK, TEXT_PLAIN, is(equalTo("foo")), 3);
+    }
+}

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AsynchronousResourceTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/AsynchronousResourceTest.java
@@ -41,9 +41,9 @@ import static java.util.stream.IntStream.range;
 import static javax.ws.rs.core.MediaType.SERVER_SENT_EVENTS;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
@@ -59,7 +59,7 @@ class AsynchronousResourceTest extends AbstractResourceTest {
         setUp(serverNoOffloads, api);
         runTwiceToEnsureEndpointCache(() -> {
             StreamingHttpResponse res =
-                    sendAndAssertResponse(get("/completable"), NO_CONTENT, null, isEmptyString(), __ -> null);
+                    sendAndAssertResponse(get("/completable"), NO_CONTENT, null, is(emptyString()), __ -> null);
             assertThat(res.headers().get("X-Foo-Prop"), is(newAsciiString("barProp")));
 
             res = sendAndAssertResponse(get("/completable?fail=true"), INTERNAL_SERVER_ERROR, null, "");
@@ -85,7 +85,7 @@ class AsynchronousResourceTest extends AbstractResourceTest {
     void headStringSingle(final boolean serverNoOffloads, final RouterApi api) {
         setUp(serverNoOffloads, api);
         runTwiceToEnsureEndpointCache(() -> {
-            sendAndAssertResponse(head("/single-string"), OK, TEXT_PLAIN, isEmptyString(), 4);
+            sendAndAssertResponse(head("/single-string"), OK, TEXT_PLAIN, is(emptyString()), 4);
 
             sendAndAssertNoResponse(head("/single-string?fail=true"), INTERNAL_SERVER_ERROR);
         });
@@ -97,7 +97,7 @@ class AsynchronousResourceTest extends AbstractResourceTest {
         setUp(serverNoOffloads, api);
         runTwiceToEnsureEndpointCache(() -> {
             StreamingHttpResponse res =
-                    sendAndAssertResponse(head("/completable"), NO_CONTENT, null, isEmptyString(), __ -> null);
+                    sendAndAssertResponse(head("/completable"), NO_CONTENT, null, is(emptyString()), __ -> null);
             assertThat(res.headers().get("X-Foo-Prop"), is(newAsciiString("barProp")));
 
             res = sendAndAssertResponse(head("/completable?fail=true"), INTERNAL_SERVER_ERROR, null, "");
@@ -136,7 +136,7 @@ class AsynchronousResourceTest extends AbstractResourceTest {
     void headResponseSingle(final boolean serverNoOffloads, final RouterApi api) {
         setUp(serverNoOffloads, api);
         runTwiceToEnsureEndpointCache(() -> {
-            sendAndAssertResponse(head("/single-response"), ACCEPTED, TEXT_PLAIN, isEmptyString(), 4);
+            sendAndAssertResponse(head("/single-response"), ACCEPTED, TEXT_PLAIN, is(emptyString()), 4);
 
             sendAndAssertNoResponse(head("/single-response?fail=true"), INTERNAL_SERVER_ERROR);
         });
@@ -158,7 +158,7 @@ class AsynchronousResourceTest extends AbstractResourceTest {
         runTwiceToEnsureEndpointCache(
                 () -> sendAndAssertResponse(
                         head("/single-response-pub-entity?i=206"), PARTIAL_CONTENT, TEXT_PLAIN,
-                        isEmptyString(), 8));
+                        is(emptyString()), 8));
     }
 
     @ParameterizedTest(name = "{1} server-no-offloads = {0}")
@@ -178,7 +178,7 @@ class AsynchronousResourceTest extends AbstractResourceTest {
     void headMapSingle(final boolean serverNoOffloads, final RouterApi api) {
         setUp(serverNoOffloads, api);
         runTwiceToEnsureEndpointCache(() -> {
-            sendAndAssertResponse(head("/single-map"), OK, APPLICATION_JSON, isEmptyString(),
+            sendAndAssertResponse(head("/single-map"), OK, APPLICATION_JSON, is(emptyString()),
                     getJsonResponseContentLengthExtractor().andThen(i -> i != null ? 14 : null));
 
             sendAndAssertNoResponse(head("/single-map?fail=true"), INTERNAL_SERVER_ERROR);
@@ -202,7 +202,7 @@ class AsynchronousResourceTest extends AbstractResourceTest {
     void headPojoSingle(final boolean serverNoOffloads, final RouterApi api) {
         setUp(serverNoOffloads, api);
         runTwiceToEnsureEndpointCache(() -> {
-            sendAndAssertResponse(head("/single-pojo"), OK, APPLICATION_JSON, isEmptyString(),
+            sendAndAssertResponse(head("/single-pojo"), OK, APPLICATION_JSON, is(emptyString()),
                     getJsonResponseContentLengthExtractor().andThen(i -> i != null ? 29 : null));
 
             sendAndAssertNoResponse(head("/single-pojo?fail=true"), INTERNAL_SERVER_ERROR);
@@ -326,7 +326,7 @@ class AsynchronousResourceTest extends AbstractResourceTest {
         setUp(serverNoOffloads, api);
         assumeOffloads(AssumeOffloadsReason.COMPLETION_STAGE);
         runTwiceToEnsureEndpointCache(() -> {
-            sendAndAssertResponse(get("/void-completion"), NO_CONTENT, null, isEmptyString(), __ -> null);
+            sendAndAssertResponse(get("/void-completion"), NO_CONTENT, null, is(emptyString()), __ -> null);
             // Jersey is inconsistent: should be NO_CONTENT
             sendAndAssertNoResponse(get("/void-completion?defer=true"), OK);
 
@@ -521,7 +521,7 @@ class AsynchronousResourceTest extends AbstractResourceTest {
             // Jersey's OutboundEventWriter ignores the lack of a MessageBodyWriter for the event (an error is logged
             // but no feedback is provided to the client side)
             sendAndAssertResponse(get("/sse/unsupported"), OK, newAsciiString(SERVER_SENT_EVENTS),
-                    isEmptyString(), __ -> null);
+                    is(emptyString()), __ -> null);
         });
     }
 

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/BaseJerseyRouterTestSuite.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/BaseJerseyRouterTestSuite.java
@@ -40,7 +40,10 @@ import org.junit.platform.suite.api.SuiteDisplayName;
         // Execution strategy tests
         ExecutionStrategyConfigurationFailuresTest.class,
         ExecutionStrategyTest.class,
-        MixedModeResourceTest.class
+        MixedModeResourceTest.class,
+
+        // AsyncContext
+        AsyncContextTest.class
 })
 public abstract class BaseJerseyRouterTestSuite {
     // NOOP

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/ExecutionStrategyTest.java
@@ -80,7 +80,7 @@ final class ExecutionStrategyTest extends AbstractJerseyStreamingHttpServiceTest
     static final ExecutorExtension<Executor> ROUTE_EXEC =
             ExecutorExtension.withCachedExecutor("route").setClassLevel(true);
 
-    public static class TestApplication extends Application {
+    static class TestApplication extends Application {
         @Override
         public Set<Class<?>> getClasses() {
             // We load all test resources to ensure there's no unexpected interactions between different strategies

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/AsyncContextResources.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/AsyncContextResources.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.router.jersey.resources;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.transport.api.ConnectionContext;
+
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.K1;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.K2;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.K3;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.V1;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.V2;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.V3;
+import static io.servicetalk.http.router.jersey.resources.AsyncContextResources.PATH;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+/**
+ * Verifies {@link AsyncContext} visibility for different use-cases, because Jersey may have different logic to handling
+ * different endpoints.
+ */
+@Path(PATH)
+public class AsyncContextResources {
+    public static final String PATH = "/asyncContext";
+
+    @Context
+    private ConnectionContext ctx;
+
+    @GET
+    @Path("/noArgsNoReturn")
+    public void noArgsNoReturn() {
+        AsyncContext.put(K1, V1);
+    }
+
+    @GET
+    @Path("/getBuffer")
+    @Produces(TEXT_PLAIN)
+    public Buffer getBuffer() {
+        AsyncContext.put(K1, V1);
+        return ctx.executionContext().bufferAllocator().fromUtf8("foo");
+    }
+
+    @POST
+    @Path("/postBuffer")
+    @Consumes(TEXT_PLAIN)
+    public void postBuffer(Buffer buffer) {
+        AsyncContext.put(K1, V1);
+    }
+
+    @POST
+    @Path("/syncEcho")
+    @Consumes(TEXT_PLAIN)
+    @Produces(TEXT_PLAIN)
+    public Buffer syncEcho(Buffer buffer) {
+        AsyncContext.put(K1, V1);
+        return buffer;
+    }
+
+    @POST
+    @Path("/syncEchoResponse")
+    @Consumes(TEXT_PLAIN)
+    @Produces(TEXT_PLAIN)
+    public Response syncEchoResponse(Buffer buffer) {
+        AsyncContext.put(K1, V1);
+        return Response.ok(buffer).build();
+    }
+
+    @POST
+    @Path("/postTextOioStreams")
+    @Consumes(TEXT_PLAIN)
+    @Produces(TEXT_PLAIN)
+    public StreamingOutput postTextOioStreams(final InputStream requestContent) {
+        AsyncContext.put(K1, V1);
+        Scanner s = new Scanner(requestContent, UTF_8.name()).useDelimiter("\\A");
+        String result = s.hasNext() ? s.next() : "";
+        AsyncContext.put(K2, V2);
+        return output -> {
+            output.write(result.getBytes(UTF_8));
+            output.flush();
+        };
+    }
+
+    @POST
+    @Path("/syncEchoJsonMap")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public Map<String, String> syncEchoJsonMap(Map<String, String> requestContent) {
+        AsyncContext.put(K1, V1);
+        Map<String, String> responseContent = new HashMap<>(requestContent);
+        responseContent.put("foo", "bar1");
+        return responseContent;
+    }
+
+    @GET
+    @Path("/completable")
+    public Completable completable() {
+        AsyncContext.put(K1, V1);
+        return completed().beforeOnComplete(() -> AsyncContext.put(K2, V2));
+    }
+
+    @GET
+    @Path("/getSingleBuffer")
+    @Produces(TEXT_PLAIN)
+    public Single<Buffer> getSingleBuffer() {
+        AsyncContext.put(K1, V1);
+        return Single.fromSupplier(() -> ctx.executionContext().bufferAllocator().fromUtf8("foo"))
+                .beforeOnSuccess(__ -> AsyncContext.put(K2, V2));
+    }
+
+    @POST
+    @Path("/postSingleBuffer")
+    @Consumes(TEXT_PLAIN)
+    public Completable postSingleBuffer(Single<Buffer> in) {
+        AsyncContext.put(K1, V1);
+        return in.toCompletable().beforeOnComplete(() -> AsyncContext.put(K2, V2));
+    }
+
+    @POST
+    @Path("/postSingleBufferSync")
+    @Consumes(TEXT_PLAIN)
+    public void postSingleBufferSync(Single<Buffer> in) {
+        AsyncContext.put(K1, V1);
+        in.toCompletionStage().toCompletableFuture().join();
+        AsyncContext.put(K2, V2);
+    }
+
+    @POST
+    @Path("/singleEcho")
+    @Consumes(TEXT_PLAIN)
+    @Produces(TEXT_PLAIN)
+    public Single<Buffer> singleEcho(Single<Buffer> in) {
+        AsyncContext.put(K1, V1);
+        return in.beforeOnSuccess(__ -> AsyncContext.put(K2, V2));
+    }
+
+    @GET
+    @Path("/getPublisherBuffer")
+    @Produces(TEXT_PLAIN)
+    public Publisher<Buffer> getPublisherBuffer() {
+        AsyncContext.put(K1, V1);
+        AsyncContext.put(K2, V2);
+        return Publisher.from(ctx.executionContext().bufferAllocator().fromUtf8("foo"))
+                .beforeOnComplete(() -> AsyncContext.put(K3, V3));
+    }
+
+    @POST
+    @Path("/postPublisherBuffer")
+    @Consumes(TEXT_PLAIN)
+    public Completable postPublisherBuffer(Publisher<Buffer> in) {
+        AsyncContext.put(K1, V1);
+        return in.ignoreElements().beforeOnComplete(() -> AsyncContext.put(K2, V2));
+    }
+
+    @POST
+    @Path("/publisherEcho")
+    @Consumes(TEXT_PLAIN)
+    @Produces(TEXT_PLAIN)
+    public Publisher<Buffer> publisherEcho(Publisher<Buffer> in) {
+        AsyncContext.put(K1, V1);
+        return in.beforeOnComplete(() -> AsyncContext.put(K3, V3));
+    }
+
+    @POST
+    @Path("/publisherEchoSync")
+    @Consumes(TEXT_PLAIN)
+    @Produces(TEXT_PLAIN)
+    public Publisher<Buffer> publisherEchoSync(Publisher<Buffer> in) {
+        AsyncContext.put(K1, V1);
+        in.toCompletionStage().toCompletableFuture().join();
+        return Publisher.from(ctx.executionContext().bufferAllocator().fromUtf8("foo"))
+                .beforeOnComplete(() -> AsyncContext.put(K3, V3));
+    }
+
+    @GET
+    @Path("/getCompletionStage")
+    @Produces(TEXT_PLAIN)
+    public CompletionStage<String> getCompletionStage() {
+        AsyncContext.put(K1, V1);
+        return ctx.executionContext().executor().submit(() -> "foo")
+                .shareContextOnSubscribe()  // Users have to share the context manually
+                .toCompletionStage()
+                .thenApply(str -> {
+                    AsyncContext.put(K2, V2);
+                    return str;
+                });
+    }
+
+    @GET
+    @Path("/getCompletionStageCompleteWithStExecutor")
+    @Produces(TEXT_PLAIN)
+    public CompletionStage<String> getCompletionStageCompleteWithStExecutor() {
+        AsyncContext.put(K1, V1);
+        CompletableFuture<String> future = new CompletableFuture<>();
+        ctx.executionContext().executor().schedule(() -> future.complete("foo"), Duration.ofMillis(100));
+        return future.thenApply(str -> {
+            AsyncContext.put(K2, V2);
+            return str;
+        });
+    }
+}


### PR DESCRIPTION
Motivation:

When users use `AsyncContext` inside endpoints that operate with async primitives, the context is not propagated as expected on the response path.

Modifications:

- `EndpointEnhancingRequestFilter`: add `shareContextOnSubscribe()` when we subscribe to `Single<Response>` and when we use `flatMap` to `handleContainerResponse`;
- Add `AsyncContextTest` and `AsyncContextResources` to verify expected behavior for different endpoints;
- Make more `AsyncContextHttpFilterVerifier` utilities public to share code for `AsyncContext` verification;
- Avoid using deprecated `Matchers.isEmptyString()`;
- Remove outdated exclusion from `testFixtures-exclusions.xml`;

Result:

Jersey endpoints correctly propagate `AsyncContext`.