### PR TITLE
Publisher#validateOutstandingDemand operator

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LongBinaryConsumer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LongBinaryConsumer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+/**
+ * A special consumer that takes two {@code long} arguments.
+ */
+@FunctionalInterface
+public interface LongBinaryConsumer {
+    /**
+     * Evaluates this consumer on the given arguments.
+     *
+     * @param first The first argument.
+     * @param second The second argument.
+     */
+    void accept(long first, long second);
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ValidateDemandPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ValidateDemandPublisher.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.internal.FlowControlUtils;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.function.ObjLongConsumer;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static java.util.Objects.requireNonNull;
+
+final class ValidateDemandPublisher<T> extends AbstractSynchronousPublisherOperator<T, T> {
+    private final ObjLongConsumer<T> onNextConsumer;
+    private final LongBinaryConsumer requestConsumer;
+
+    ValidateDemandPublisher(final Publisher<T> original,
+                            final ObjLongConsumer<T> onNextConsumer,
+                            final LongBinaryConsumer requestConsumer) {
+        super(original);
+        this.onNextConsumer = requireNonNull(onNextConsumer);
+        this.requestConsumer = requireNonNull(requestConsumer);
+    }
+
+    @Override
+    public Subscriber<? super T> apply(final Subscriber<? super T> subscriber) {
+        return new ValidateDemandSubscriber<>(this, subscriber);
+    }
+
+    private static final class ValidateDemandSubscriber<T> implements Subscriber<T> {
+        @SuppressWarnings("rawtypes")
+        private static final AtomicLongFieldUpdater<ValidateDemandSubscriber> demandUpdater =
+                AtomicLongFieldUpdater.newUpdater(ValidateDemandSubscriber.class, "demand");
+        private final Subscriber<? super T> subscriber;
+        private final ValidateDemandPublisher<T> parent;
+        private volatile long demand;
+
+        private ValidateDemandSubscriber(ValidateDemandPublisher<T> parent,
+                                         final Subscriber<? super T> subscriber) {
+            this.parent = parent;
+            this.subscriber = requireNonNull(subscriber);
+        }
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            subscriber.onSubscribe(new Subscription() {
+                @Override
+                public void request(final long n) {
+                    try {
+                        if (isRequestNValid(n)) {
+                            final long currDemand = demandUpdater.accumulateAndGet(ValidateDemandSubscriber.this, n,
+                                    FlowControlUtils::addWithOverflowProtection);
+                            parent.requestConsumer.accept(n, currDemand);
+                        }
+                    } finally {
+                        subscription.request(n);
+                    }
+                }
+
+                @Override
+                public void cancel() {
+                    subscription.cancel();
+                }
+            });
+        }
+
+        @Override
+        public void onNext(@Nullable final T t) {
+            final long currDemand = demandUpdater.decrementAndGet(this);
+            parent.onNextConsumer.accept(t, currDemand);
+            if (currDemand < 0) {
+                throw new IllegalStateException("Received onNext signal='" + t + "' with no demand");
+            }
+            subscriber.onNext(t);
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            subscriber.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            subscriber.onComplete();
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ValidateDemandPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/ValidateDemandPublisherTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+class ValidateDemandPublisherTest {
+    private final TestPublisher<Integer> source = new TestPublisher.Builder<Integer>().build();
+    private final TestPublisherSubscriber<Integer> subscriber = new TestPublisherSubscriber<>();
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void validDemandNoop(boolean onError) {
+        toSource(source.validateOutstandingDemand()).subscribe(subscriber);
+        subscriber.awaitSubscription().request(2);
+        source.onNext(1, 2);
+        assertThat(subscriber.takeOnNext(2), contains(1, 2));
+
+        if (onError) {
+            subscriber.onError(DELIBERATE_EXCEPTION);
+            assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            subscriber.onComplete();
+            subscriber.awaitOnComplete();
+        }
+    }
+
+    @Test
+    void invalidDemandGenerateError() {
+        toSource(source.validateOutstandingDemand()).subscribe(subscriber);
+        source.onNext(1);
+        assertThat(subscriber.awaitOnError(), instanceOf(IllegalStateException.class));
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherValidateDemandTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherValidateDemandTckTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+@Test
+public class PublisherValidateDemandTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+    @Override
+    protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
+        return publisher.validateOutstandingDemand();
+    }
+}


### PR DESCRIPTION
Motivation:
Some use cases use custom operators and sources that may invalidate demand
which can invalidate state in other operators and leave the system in
an undefined state. There is no easy way to validate this and get visibility.

Modifications:
- Add Publisher#validateOutstandingDemand operator