### PR TITLE
`TransportObserver` doesn't propagate early connect failures

### DIFF
--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
@@ -56,6 +56,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.socketChannel;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.toNettyAddress;
+import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.assignConnectionError;
 import static io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer.POOLED_ALLOCATOR;
 import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
 import static java.util.Objects.requireNonNull;
@@ -113,6 +114,9 @@ public final class TcpConnector {
                                 cause = new io.servicetalk.client.api.ConnectTimeoutException(msg, cause);
                             } else if (cause instanceof ConnectException) {
                                 cause = new RetryableConnectException((ConnectException) cause);
+                            }
+                            if (f instanceof ChannelFuture) {
+                                assignConnectionError(((ChannelFuture) f).channel(), cause);
                             }
                             connectHandler.connectFailed(cause);
                         }


### PR DESCRIPTION
Motivation:

If a connection attempt fails before it was established, the observer invokes `connectionClosed()` callback instead of
`connectionClosed(Throwable)`. As the result, observer doesn't see an error.

Modifications:

- `TcpConnector` intercepts the failed `ChannelFuture` and assigns the exception before Netty invokes `CLOSE_ON_FAILURE` listener that `Bootstrap` attached by default;
- Enhance `TcpTransportObserverErrorsTest` to validate this use-case;

Result:

Users see exception via observer if connect attempt fails.