### PR TITLE
Deprecate `H2KeepAlivePolicies.disabled()`

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
@@ -52,7 +52,6 @@ import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
 import static io.servicetalk.grpc.netty.GrpcServers.forAddress;
 import static io.servicetalk.grpc.netty.TesterProto.TestRequest.newBuilder;
 import static io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
-import static io.servicetalk.http.netty.H2KeepAlivePolicies.disabled;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.whenIdleFor;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
@@ -124,7 +123,7 @@ class KeepAliveTest {
     private static H2ProtocolConfig h2Config(@Nullable final Duration keepAliveIdleFor) {
         return h2()
             .enableFrameLogging("servicetalk-tests-h2-frame-logger", TRACE, () -> true)
-            .keepAlivePolicy(keepAliveIdleFor == null ? disabled() : whenIdleFor(keepAliveIdleFor))
+            .keepAlivePolicy(keepAliveIdleFor == null ? null : whenIdleFor(keepAliveIdleFor))
             .build();
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2KeepAlivePolicies.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2KeepAlivePolicies.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
  * A factory to create {@link KeepAlivePolicy} instances.
  */
 public final class H2KeepAlivePolicies {
-    static final KeepAlivePolicy DISABLE_KEEP_ALIVE =
+    private static final KeepAlivePolicy DISABLE_KEEP_ALIVE =
             new DefaultKeepAlivePolicy(ofDays(365), ofDays(365), false);
     static final Duration DEFAULT_IDLE_DURATION = ofSeconds(30);
     static final Duration DEFAULT_ACK_TIMEOUT = ofSeconds(30);
@@ -40,8 +40,10 @@ public final class H2KeepAlivePolicies {
      * Returns a {@link KeepAlivePolicy} that disables all keep alive behaviors.
      *
      * @return A {@link KeepAlivePolicy} that disables all keep alive behaviors.
+     * @deprecated Use {@code null} for {@link H2ProtocolConfigBuilder#keepAlivePolicy(KeepAlivePolicy)} instead.
      */
-    public static KeepAlivePolicy disabled() {
+    @Deprecated
+    public static KeepAlivePolicy disabled() {  // FIXME: 0.43 - remove deprecated method
         return DISABLE_KEEP_ALIVE;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -29,7 +29,7 @@ import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_HEADER_LIST_SIZE;
-import static io.servicetalk.http.netty.H2KeepAlivePolicies.DISABLE_KEEP_ALIVE;
+import static io.servicetalk.http.netty.H2KeepAlivePolicies.disabled;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -114,12 +114,13 @@ public final class H2ProtocolConfigBuilder {
     /**
      * Sets the {@link KeepAlivePolicy} to use.
      *
-     * @param policy {@link KeepAlivePolicy} to use.
+     * @param policy {@link KeepAlivePolicy} to use or {@link null} to disable it.
      * @return {@code this}
      * @see H2KeepAlivePolicies
      */
-    public H2ProtocolConfigBuilder keepAlivePolicy(final KeepAlivePolicy policy) {
-        this.keepAlivePolicy = policy == DISABLE_KEEP_ALIVE ? null : requireNonNull(policy);
+    @SuppressWarnings("deprecation")
+    public H2ProtocolConfigBuilder keepAlivePolicy(@Nullable final KeepAlivePolicy policy) {
+        this.keepAlivePolicy = policy == disabled() ? null : policy;
         return this;
     }
 


### PR DESCRIPTION
Motivation:

A special static constant to disable keep-alive is hard to discover. The internal state of `H2ProtocolConfigBuilder` converts `disabled()` to `null`. The `H2ProtocolConfig.keepAlivePolicy()` is nullable. Using `null` is expected.

Modifications:

- Deprecate `H2KeepAlivePolicies.disabled()`;
- Make `H2ProtocolConfigBuilder.keepAlivePolicy(...)` argument nullable;

Result:

Users can use `null` instead of `H2KeepAlivePolicies.disabled()`.