### PR TITLE
Add fragment methods to HttpRequestMetaData

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
@@ -182,6 +182,12 @@ abstract class AbstractDelegatingHttpRequest implements PayloadInfo, HttpRequest
         return original.query();
     }
 
+    @Nullable
+    @Override
+    public String fragment() {
+        return original.fragment();
+    }
+
     @Override
     public boolean hasQueryParameter(final String key) {
         return original.hasQueryParameter(key);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -293,6 +293,9 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     @Override
     BlockingStreamingHttpRequest version(HttpProtocolVersion version);
 
+    @Override
+    BlockingStreamingHttpRequest fragment(@Nullable String fragment);
+
     @Deprecated
     @Override
     default BlockingStreamingHttpRequest encoding(ContentCodec encoding) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -154,6 +154,18 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
         return this;
     }
 
+    @Nullable
+    @Override
+    public String fragment() {
+        return original.fragment();
+    }
+
+    @Override
+    public HttpRequestMetaData fragment(@Nullable String fragment) {
+        original.fragment(fragment);
+        return this;
+    }
+
     @Override
     public BlockingIterable<Buffer> payloadBody() {
         return original.payloadBody().toIterable();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -154,14 +154,8 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
         return this;
     }
 
-    @Nullable
     @Override
-    public String fragment() {
-        return original.fragment();
-    }
-
-    @Override
-    public HttpRequestMetaData fragment(@Nullable String fragment) {
+    public BlockingStreamingHttpRequest fragment(@Nullable String fragment) {
         original.fragment(fragment);
         return this;
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -145,6 +145,18 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
         return this;
     }
 
+    @Nullable
+    @Override
+    public String fragment() {
+        return original.fragment();
+    }
+
+    @Override
+    public HttpRequest fragment(@Nullable String fragment) {
+        original.fragment(fragment);
+        return this;
+    }
+
     @Override
     public HttpRequest addHeader(final CharSequence name, final CharSequence value) {
         original.addHeader(name, value);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -145,12 +145,6 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
         return this;
     }
 
-    @Nullable
-    @Override
-    public String fragment() {
-        return original.fragment();
-    }
-
     @Override
     public HttpRequest fragment(@Nullable String fragment) {
         original.fragment(fragment);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -442,19 +443,21 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
     @Override
     public HttpRequestMetaData fragment(@Nullable String fragment) {
 
-      if (fragment == null && fragment() == null) {
+      String origFragment = fragment();
+
+      if ((fragment == null && origFragment == null) || Objects.equals(origFragment, fragment)) {
         return this;
       }
 
       String originalRequestTarget = requestTarget();
 
-      if (lazyParseRequestTarget().fragment() != null) {
-        int fragmentLength = lazyParseRequestTarget().fragment().length() + 1;
+      if (origFragment != null) {
+        int fragmentLength = origFragment.length() + 1;
         // remove the existing fragment
         originalRequestTarget = originalRequestTarget.substring(0, originalRequestTarget.length() - fragmentLength);
       }
 
-      return requestTarget(fragment == null || fragment.isEmpty()
+      return requestTarget(fragment == null
               ? originalRequestTarget
               : originalRequestTarget + "#" + fragment
       );

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
@@ -457,10 +457,7 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
         originalRequestTarget = originalRequestTarget.substring(0, originalRequestTarget.length() - fragmentLength);
       }
 
-      return requestTarget(fragment == null
-              ? originalRequestTarget
-              : originalRequestTarget + "#" + fragment
-      );
+      return requestTarget(fragment == null ? originalRequestTarget : (originalRequestTarget + "#" + fragment));
     }
 
     private void invalidateParsedUri() {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
@@ -433,6 +433,33 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
         requestTarget(sb.toString());
     }
 
+    @Nullable
+    @Override
+    public String fragment() {
+      return lazyParseRequestTarget().fragment();
+    }
+
+    @Override
+    public HttpRequestMetaData fragment(@Nullable String fragment) {
+
+      if (fragment == null && fragment() == null) {
+        return this;
+      }
+
+      String originalRequestTarget = requestTarget();
+
+      if (lazyParseRequestTarget().fragment() != null) {
+        int fragmentLength = lazyParseRequestTarget().fragment().length() + 1;
+        // remove the existing fragment
+        originalRequestTarget = originalRequestTarget.substring(0, originalRequestTarget.length() - fragmentLength);
+      }
+
+      return requestTarget(fragment == null || fragment.isEmpty()
+              ? originalRequestTarget
+              : originalRequestTarget + "#" + fragment
+      );
+    }
+
     private void invalidateParsedUri() {
         requestTargetUri = null;
         httpQuery = null;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultStreamingHttpRequest.java
@@ -156,6 +156,11 @@ final class DefaultStreamingHttpRequest extends DefaultHttpRequestMetaData
         return this;
     }
 
+    public StreamingHttpRequest fragment(@Nullable String fragment) {
+        super.fragment(fragment);
+        return this;
+    }
+
     @Override
     public Publisher<Buffer> payloadBody() {
         return payloadHolder.payloadBody();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
@@ -137,6 +137,9 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
     HttpRequest setQueryParameters(String key, String... values);
 
     @Override
+    HttpRequest fragment(@Nullable String fragment);
+
+    @Override
     HttpRequest version(HttpProtocolVersion version);
 
     @Deprecated

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
@@ -407,6 +407,27 @@ public interface HttpRequestMetaData extends HttpMetaData {
     boolean removeQueryParameters(String key, String value);
 
     /**
+     * Returns the <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.5">fragment</a> part of the request target.
+     *
+     * @return the fragment part of the request target.
+     */
+    @Nullable
+    default String fragment() {
+        throw new UnsupportedOperationException("HttpRequestMetaData#fragment() is not supported by " +
+                                                getClass());
+    }
+
+    /**
+     * Sets the <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.5">fragment</a> part of the request target.
+     * @param fragment the fragment to set.
+     * @return {@code this}.
+     */
+    default HttpRequestMetaData fragment(@Nullable String fragment) {
+        throw new UnsupportedOperationException("HttpRequestMetaData#fragment(String) is not supported by " +
+                                                getClass());
+    }
+
+    /**
      * Get the <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">host</a> and
      * <a href="https://tools.ietf.org/html/rfc3986#section-3.2.3">port</a> components
      * of the <a href="https://tools.ietf.org/html/rfc7230#section-5.5">effective request URI</a>.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
@@ -407,7 +407,8 @@ public interface HttpRequestMetaData extends HttpMetaData {
     boolean removeQueryParameters(String key, String value);
 
     /**
-     * Returns the <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.5">fragment</a> part of the request target.
+     * Returns the <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.5">fragment</a> part of the request
+     * target.
      *
      * @return the fragment part of the request target.
      */
@@ -419,7 +420,9 @@ public interface HttpRequestMetaData extends HttpMetaData {
     }
 
     /**
-     * Sets the <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.5">fragment</a> part of the request target.
+     * Sets the <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.5">fragment</a> part of the request
+     * target.
+     *
      * @param fragment the fragment to set.
      * @return {@code this}.
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
@@ -411,6 +411,7 @@ public interface HttpRequestMetaData extends HttpMetaData {
      *
      * @return the fragment part of the request target.
      */
+    // FIXME: 0.43 - consider removing default implementations
     @Nullable
     default String fragment() {
         throw new UnsupportedOperationException("HttpRequestMetaData#fragment() is not supported by " +
@@ -422,6 +423,7 @@ public interface HttpRequestMetaData extends HttpMetaData {
      * @param fragment the fragment to set.
      * @return {@code this}.
      */
+    // FIXME: 0.43 - consider removing default implementations
     default HttpRequestMetaData fragment(@Nullable String fragment) {
         throw new UnsupportedOperationException("HttpRequestMetaData#fragment(String) is not supported by " +
                                                 getClass());

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
@@ -284,6 +284,9 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     @Override
     StreamingHttpRequest method(HttpRequestMethod method);
 
+    @Override
+    StreamingHttpRequest fragment(@Nullable String fragment);
+
     @Deprecated
     @Override
     default StreamingHttpRequest encoding(ContentCodec encoding) {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -848,6 +848,28 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     }
 
     @Test
+    void testEmptyFragment() {
+        createFixture("/some/path?query=value#");
+        assertEquals("", fixture.fragment());
+    }
+
+    @Test
+    void testSetEmptyFragment() {
+        createFixture("/some/path?query=value");
+        fixture.fragment("");
+        assertEquals("/some/path?query=value#", fixture.requestTarget());
+        assertEquals("", fixture.fragment());
+    }
+
+    @Test
+    void testSetIdenticalFragment() {
+        createFixture("/some/path?query=value#fragment");
+        fixture.fragment("fragment");
+        assertEquals("/some/path?query=value#fragment", fixture.requestTarget());
+        assertEquals("fragment", fixture.fragment());
+    }
+
+    @Test
     void testToString() {
         createFixture("/some/path?a=query");
         fixture.headers().set(HOST, "some.site.com");

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -802,6 +802,52 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
     }
 
     @Test
+    void testGetFragment() {
+        createFixture("/some/path#fragment");
+        assertEquals("fragment", fixture.fragment());
+    }
+
+    @Test
+    void testSetFragment() {
+        createFixture("/some/path");
+        fixture.fragment("fragment");
+        assertEquals("fragment", fixture.fragment());
+        assertEquals("/some/path#fragment", fixture.requestTarget());
+    }
+
+    @Test
+    void testSetFragmentWithQuery() {
+        createFixture("/some/path?query=value");
+        fixture.fragment("fragment");
+        assertEquals("fragment", fixture.fragment());
+        assertEquals("/some/path?query=value#fragment", fixture.requestTarget());
+    }
+
+    @Test
+    void testSetFragmentAbsoluteForm() {
+        createFixture("http://my.site.com/some/path?foo=bar&abc=def&foo=baz");
+        fixture.fragment("fragment");
+        assertEquals("fragment", fixture.fragment());
+        assertEquals("http://my.site.com/some/path?foo=bar&abc=def&foo=baz#fragment", fixture.requestTarget());
+    }
+
+    @Test
+    void testOverwriteFragment() {
+        createFixture("/some/path?query=value#fragment");
+        fixture.fragment("overwrite");
+        assertEquals("overwrite", fixture.fragment());
+        assertEquals("/some/path?query=value#overwrite", fixture.requestTarget());
+    }
+
+    @Test
+    void testClearFragment() {
+        createFixture("/some/path?query=value#fragment");
+        fixture.fragment(null);
+        assertNull(fixture.fragment());
+        assertEquals("/some/path?query=value", fixture.requestTarget());
+    }
+
+    @Test
     void testToString() {
         createFixture("/some/path?a=query");
         fixture.headers().set(HOST, "some.site.com");


### PR DESCRIPTION
Motivation:

Without fragment support users are not able to build a full request target using only builder methods

Modifications:

- Adds setter and getter for fragment in HttpRequestMetaData implementations
- Adds tests to AbstractHttpRequestMetaDataTest

Result:

Users are now able to set a fragment for request targets