### PR TITLE
Test HTTP/2 `KeepAliveManager` with `DuplexChannel`

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/CustomTransportTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/CustomTransportTest.java
@@ -78,8 +78,7 @@ class CustomTransportTest {
             assertThat(client.testBiDiStream(newReqStream("duplex")).toFuture().get(),
                     contains(newResp("hello duplexstream1"), newResp("hello duplexstream2")));
         } finally {
-            c.close();
-
+            c.close().sync();
             ioExecutor.closeAsync().toFuture().get();
         }
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -41,6 +41,7 @@ import io.netty.handler.codec.http2.Http2GoAwayFrame;
 import io.netty.handler.codec.http2.Http2PingFrame;
 import io.netty.handler.codec.http2.Http2SettingsAckFrame;
 import io.netty.handler.codec.http2.Http2SettingsFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
@@ -164,7 +165,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         notifyOnClosing();
     }
 
-    final void trackActiveStream(Channel streamChannel) {
+    final void trackActiveStream(Http2StreamChannel streamChannel) {
         keepAliveManager.trackActiveStream(streamChannel);
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAliveManager.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/KeepAliveManager.java
@@ -24,6 +24,7 @@ import io.netty.channel.socket.DuplexChannel;
 import io.netty.handler.codec.http2.DefaultHttp2GoAwayFrame;
 import io.netty.handler.codec.http2.DefaultHttp2PingFrame;
 import io.netty.handler.codec.http2.Http2PingFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
@@ -168,7 +169,7 @@ final class KeepAliveManager {
         }
     }
 
-    void trackActiveStream(final Channel streamChannel) {
+    void trackActiveStream(final Http2StreamChannel streamChannel) {
         activeChildChannelsUpdater.incrementAndGet(this);
         streamChannel.closeFuture().addListener(f -> {
             if (activeChildChannelsUpdater.decrementAndGet(this) == 0 &&

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/KeepAliveManagerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/KeepAliveManagerTest.java
@@ -16,24 +16,36 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.http.netty.H2ProtocolConfig.KeepAlivePolicy;
+import io.servicetalk.transport.netty.internal.EmbeddedDuplexChannel;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.socket.ChannelInputShutdownReadComplete;
+import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.handler.codec.http2.DefaultHttp2PingFrame;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2GoAwayFrame;
 import io.netty.handler.codec.http2.Http2PingFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.util.concurrent.Promise;
 import org.hamcrest.Matcher;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static io.netty.util.ReferenceCountUtil.release;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.DEFAULT_ACK_TIMEOUT;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.DEFAULT_IDLE_DURATION;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -47,41 +59,54 @@ import static org.mockito.Mockito.when;
 
 class KeepAliveManagerTest {
 
+    private final BlockingQueue<ScheduledTask> scheduledTasks = new LinkedBlockingQueue<>();
+    private EmbeddedChannel channel;
+    private KeepAliveManager manager;
 
-    private final BlockingQueue<ScheduledTask> scheduledTasks;
-    private final EmbeddedChannel channel;
-
-    KeepAliveManagerTest() {
-        scheduledTasks = new LinkedBlockingQueue<>();
-        channel = new EmbeddedChannel();
+    @AfterEach
+    void tearDown() {
+        channel.finishAndReleaseAll();
     }
 
-    @Test
-    void keepAliveDisallowedWithNoActiveStreams() {
-        KeepAliveManager manager = newManager(false);
+    private void setUp(boolean duplex, boolean allowPingWithoutActiveStreams) {
+        KeepAliveManagerHandler managerHandler = new KeepAliveManagerHandler();
+        channel = duplex ? new EmbeddedDuplexChannel(true, managerHandler) : new EmbeddedChannel(managerHandler);
+        manager = newManager(allowPingWithoutActiveStreams, channel);
+        managerHandler.keepAliveManager(manager);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void keepAliveDisallowedWithNoActiveStreams(boolean duplex) {
+        setUp(duplex, false);
         manager.channelIdle();
         verifyNoWrite();
         verifyNoScheduledTasks();
     }
 
-    @Test
-    void keepAliveAllowedWithNoActiveStreams() {
-        KeepAliveManager manager = newManager(true);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void keepAliveAllowedWithNoActiveStreams(boolean duplex) {
+        setUp(duplex, true);
         manager.channelIdle();
         verifyWrite(instanceOf(Http2PingFrame.class));
+        verifyPingAckTimeoutScheduled();
     }
 
-    @Test
-    void keepAliveWithActiveStreams() {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void keepAliveWithActiveStreams(boolean duplex) {
+        setUp(duplex, false);
         addActiveStream(manager);
         manager.channelIdle();
         verifyWrite(instanceOf(Http2PingFrame.class));
+        verifyPingAckTimeoutScheduled();
     }
 
-    @Test
-    void keepAlivePingAckReceived() {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void keepAlivePingAckReceived(boolean duplex) {
+        setUp(duplex, false);
         addActiveStream(manager);
         manager.channelIdle();
         Http2PingFrame ping = verifyWrite(instanceOf(Http2PingFrame.class));
@@ -96,9 +121,10 @@ class KeepAliveManagerTest {
         assertThat("Channel unexpectedly closed.", channel.isOpen(), is(true));
     }
 
-    @Test
-    void keepAlivePingAckWithUnknownContent() {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void keepAlivePingAckWithUnknownContent(boolean duplex) throws Exception {
+        setUp(duplex, false);
         addActiveStream(manager);
         manager.channelIdle();
         Http2PingFrame ping = verifyWrite(instanceOf(Http2PingFrame.class));
@@ -110,55 +136,60 @@ class KeepAliveManagerTest {
         verifyChannelCloseOnMissingPingAck(ackTimeoutTask);
     }
 
-    @Test
-    void keepAliveMissingPingAck() {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void keepAliveMissingPingAck(boolean duplex) throws Exception {
+        setUp(duplex, false);
         addActiveStream(manager);
         manager.channelIdle();
         verifyWrite(instanceOf(Http2PingFrame.class));
         verifyChannelCloseOnMissingPingAck(verifyPingAckTimeoutScheduled());
     }
 
-    @Test
-    void gracefulCloseNoActiveStreams() throws Exception {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void gracefulCloseNoActiveStreams(boolean duplex) throws Exception {
+        setUp(duplex, false);
         Http2PingFrame pingFrame = initiateGracefulCloseVerifyGoAwayAndPing(manager);
 
         sendGracefulClosePingAckAndVerifySecondGoAway(manager, pingFrame);
-
+        shutdownInputIfDuplexChannel();
         channel.closeFuture().sync().await();
     }
 
-    @Test
-    void gracefulCloseWithActiveStreams() throws Exception {
-        KeepAliveManager manager = newManager(false);
-        EmbeddedChannel activeStream = addActiveStream(manager);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void gracefulCloseWithActiveStreams(boolean duplex) throws Exception {
+        setUp(duplex, false);
+        Http2StreamChannel activeStream = addActiveStream(manager);
         Http2PingFrame pingFrame = initiateGracefulCloseVerifyGoAwayAndPing(manager);
 
         sendGracefulClosePingAckAndVerifySecondGoAway(manager, pingFrame);
 
         assertThat("Channel not closed.", channel.isOpen(), is(true));
         activeStream.close().sync().await();
-
+        shutdownInputIfDuplexChannel();
         channel.closeFuture().sync().await();
     }
 
-    @Test
-    void gracefulCloseNoActiveStreamsMissingPingAck() throws Exception {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void gracefulCloseNoActiveStreamsMissingPingAck(boolean duplex) throws Exception {
+        setUp(duplex, false);
         initiateGracefulCloseVerifyGoAwayAndPing(manager);
 
         ScheduledTask pingAckTimeoutTask = scheduledTasks.take();
         pingAckTimeoutTask.task.run();
         verifySecondGoAway();
-
+        shutdownInputIfDuplexChannel();
         channel.closeFuture().sync().await();
     }
 
-    @Test
-    void gracefulCloseActiveStreamsMissingPingAck() throws Exception {
-        KeepAliveManager manager = newManager(false);
-        EmbeddedChannel activeStream = addActiveStream(manager);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void gracefulCloseActiveStreamsMissingPingAck(boolean duplex) throws Exception {
+        setUp(duplex, false);
+        Http2StreamChannel activeStream = addActiveStream(manager);
         initiateGracefulCloseVerifyGoAwayAndPing(manager);
 
         ScheduledTask pingAckTimeoutTask = scheduledTasks.take();
@@ -166,15 +197,15 @@ class KeepAliveManagerTest {
         verifySecondGoAway();
 
         assertThat("Channel closed.", channel.isOpen(), is(true));
-
         activeStream.close().sync().await();
-
+        shutdownInputIfDuplexChannel();
         channel.closeFuture().sync().await();
     }
 
-    @Test
-    void gracefulClosePendingPingsCloseConnection() throws Exception {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void gracefulClosePendingPingsCloseConnection(boolean duplex) throws Exception {
+        setUp(duplex, false);
         addActiveStream(manager);
         Http2PingFrame pingFrame = initiateGracefulCloseVerifyGoAwayAndPing(manager);
 
@@ -186,19 +217,21 @@ class KeepAliveManagerTest {
         verifyChannelCloseOnMissingPingAck(verifyPingAckTimeoutScheduled());
     }
 
-    @Test
-    void pingsAreAcked() {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void pingsAreAcked(boolean duplex) {
+        setUp(duplex, false);
         long pingContent = ThreadLocalRandom.current().nextLong();
         manager.pingReceived(new DefaultHttp2PingFrame(pingContent, false));
         Http2PingFrame pingFrame = verifyWrite(instanceOf(Http2PingFrame.class));
         assertThat("Unexpected ping ack content.", pingFrame.content(), is(pingContent));
-        assertThat("Unexpected ping ack content.", pingFrame.ack(), is(true));
+        assertThat("Unexpected ping ack flag.", pingFrame.ack(), is(true));
     }
 
-    @Test
-    void channelClosedDuringGracefulClose() throws Exception {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void channelClosedDuringGracefulClose(boolean duplex) throws Exception {
+        setUp(duplex, false);
         addActiveStream(manager);
         initiateGracefulCloseVerifyGoAwayAndPing(manager);
         ScheduledTask pingAckTimeoutTask = scheduledTasks.take();
@@ -211,9 +244,10 @@ class KeepAliveManagerTest {
         verifyNoOtherActionPostClose(manager);
     }
 
-    @Test
-    void channelClosedDuringPing() {
-        KeepAliveManager manager = newManager(false);
+    @ParameterizedTest(name = "{displayName} [{index}] duplex={0}")
+    @ValueSource(booleans = {true, false})
+    void channelClosedDuringPing(boolean duplex) {
+        setUp(duplex, false);
         addActiveStream(manager);
         manager.channelIdle();
         verifyWrite(instanceOf(Http2PingFrame.class));
@@ -262,6 +296,8 @@ class KeepAliveManagerTest {
     private void verifySecondGoAway() {
         Http2GoAwayFrame secondGoAway = verifyWrite(instanceOf(Http2GoAwayFrame.class));
         assertThat("Unexpected error in go_away", secondGoAway.errorCode(), is(Http2Error.NO_ERROR.code()));
+        assertThat("Unexpected extra stream ids", secondGoAway.extraStreamIds(), is(0));
+        assertThat("Unexpected last stream id", secondGoAway.lastStreamId(), is(-1));
         verifyNoScheduledTasks();
     }
 
@@ -272,6 +308,8 @@ class KeepAliveManagerTest {
 
         Http2GoAwayFrame firstGoAway = verifyWrite(instanceOf(Http2GoAwayFrame.class));
         assertThat("Unexpected error in go_away", firstGoAway.errorCode(), is(Http2Error.NO_ERROR.code()));
+        assertThat("Unexpected extra stream ids", firstGoAway.extraStreamIds(), is(Integer.MAX_VALUE));
+        assertThat("Unexpected last stream id", firstGoAway.lastStreamId(), is(-1));
         Http2PingFrame pingFrame = verifyWrite(instanceOf(Http2PingFrame.class));
         verifyNoWrite();
         return pingFrame;
@@ -286,6 +324,11 @@ class KeepAliveManagerTest {
     }
 
     private void verifyNoWrite() {
+        if (channel instanceof EmbeddedDuplexChannel && ((EmbeddedDuplexChannel) channel).isOutputShutdown()) {
+            // EmbeddedDuplexChannel does not allow to poll messages after output shutdown.
+            // It's enough to verify only output shutdown state.
+            return;
+        }
         Object msg = channel.outboundMessages().poll();
         if (msg instanceof ByteBuf) {
             assertThat(((ByteBuf) msg).readableBytes(), is(0));
@@ -298,20 +341,27 @@ class KeepAliveManagerTest {
         assertThat("Unexpected tasks scheduled.", scheduledTasks.poll(), is(nullValue()));
     }
 
-    private static EmbeddedChannel addActiveStream(final KeepAliveManager manager) {
-        EmbeddedChannel stream = new EmbeddedChannel();
+    private Http2StreamChannel addActiveStream(final KeepAliveManager manager) {
+        Http2StreamChannel stream = mock(Http2StreamChannel.class);
+        ChannelPromise closeFuture = channel.newPromise();
+        when(stream.closeFuture()).thenReturn(closeFuture);
+        when(stream.close()).then(__ -> {
+            closeFuture.trySuccess();
+            return channel.newSucceededFuture();
+        });
         manager.trackActiveStream(stream);
         return stream;
     }
 
-    private void verifyChannelCloseOnMissingPingAck(final ScheduledTask ackTimeoutTask) {
+    private void verifyChannelCloseOnMissingPingAck(final ScheduledTask ackTimeoutTask) throws InterruptedException {
         ackTimeoutTask.task.run();
         verifyWrite(instanceOf(Http2GoAwayFrame.class));
         verifyNoScheduledTasks();
+        shutdownInputIfDuplexChannel();
         assertThat("Channel not closed.", channel.isOpen(), is(false));
     }
 
-    private KeepAliveManager newManager(final boolean allowPingWithoutActiveStreams) {
+    private KeepAliveManager newManager(final boolean allowPingWithoutActiveStreams, final Channel channel) {
         KeepAlivePolicy policy = mock(KeepAlivePolicy.class);
         when(policy.idleDuration()).thenReturn(DEFAULT_IDLE_DURATION);
         when(policy.ackTimeout()).thenReturn(DEFAULT_ACK_TIMEOUT);
@@ -327,6 +377,14 @@ class KeepAliveManagerTest {
                 (__, ___, ____) -> { });
     }
 
+    private void shutdownInputIfDuplexChannel() throws InterruptedException {
+        if (channel instanceof EmbeddedDuplexChannel) {
+            EmbeddedDuplexChannel duplexChannel = (EmbeddedDuplexChannel) channel;
+            duplexChannel.awaitOutputShutdown();
+            duplexChannel.shutdownInput().sync();   // Simulate FIN from the remote peer
+        }
+    }
+
     private static final class ScheduledTask {
         final Runnable task;
         final Promise<?> promise;
@@ -336,6 +394,35 @@ class KeepAliveManagerTest {
             this.task = task;
             this.promise = promise;
             this.delayMillis = delayMillis;
+        }
+    }
+
+    private static final class KeepAliveManagerHandler extends ChannelInboundHandlerAdapter {
+        private KeepAliveManager keepAliveManager;
+
+        void keepAliveManager(KeepAliveManager keepAliveManager) {
+            this.keepAliveManager = requireNonNull(keepAliveManager);
+        }
+
+        @Override
+        public void channelInactive(final ChannelHandlerContext ctx) {
+            keepAliveManager.channelClosed();
+        }
+
+        @Override
+        public void handlerRemoved(final ChannelHandlerContext ctx) {
+            keepAliveManager.channelClosed();
+        }
+
+        @Override
+        public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) throws Exception {
+            if (evt == ChannelInputShutdownReadComplete.INSTANCE || evt == SslCloseCompletionEvent.SUCCESS) {
+                keepAliveManager.channelInputShutdown();
+            } else if (evt == ChannelOutputShutdownEvent.INSTANCE) {
+                keepAliveManager.channelOutputShutdown();
+            } else {
+                release(evt);
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation:

`KeepAliveManagerTest` covers only non-duplex `Channel` use-case. However, `KeepAliveManager` state machine is a lot more complex for `DuplexChannel`. We need to enhance test coverage for the most used case.

Modifications:
- Parametrize `KeepAliveManagerTest` to test with duplex and non-duplex `Channel`, add more assertions;
- Modify `H2ParentConnectionContext` and `KeepAliveManager` to accept `Http2StreamChannel` instead of `Channel`;
- `KeepAliveTest`: fix `clientBuilder.initializeHttp` override issue (`CLIENT_CTX` is not set), do some other minor refactoring;

Result:

Enhanced test coverage for `KeepAliveManager`.