### PR TITLE
`KeepAliveManager`: add tests for #2611

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/KeepAliveTest.java
@@ -45,6 +45,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.netty.GrpcServers.forAddress;
@@ -57,7 +58,7 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.IDLE_TIMEOUT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static java.time.Duration.ofSeconds;
+import static java.time.Duration.ofMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -112,8 +113,8 @@ class KeepAliveTest {
 
     static Stream<Arguments> data() {
         return Stream.of(
-                Arguments.of(true, ofSeconds(1), ofSeconds(2)),
-                Arguments.of(false, ofSeconds(1), ofSeconds(2))
+                Arguments.of(true, ofMillis(CI ? 1000 : 200), ofMillis(CI ? 2000 : 400)),
+                Arguments.of(false, ofMillis(CI ? 1000 : 200), ofMillis(CI ? 2000 : 400))
         );
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -77,6 +77,7 @@ import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
@@ -101,7 +102,6 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAnd
 import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_INBOUND;
 import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.GRACEFUL_USER_CLOSING;
 import static io.servicetalk.utils.internal.PlatformDependent.throwException;
-import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -120,7 +120,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class GracefulConnectionClosureHandlingTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(GracefulConnectionClosureHandlingTest.class);
-    private static final long TIMEOUT_MILLIS = parseBoolean(System.getenv("CI")) ? 1000 : 200;
+    private static final long TIMEOUT_MILLIS = CI ? 1000 : 200;
     private static final Collection<Boolean> TRUE_FALSE = asList(true, false);
 
     static final HttpStreamingSerializer<String> RAW_STRING_SERIALIZER =


### PR DESCRIPTION
Motivation:

#2611 fixed behavior, but didn't add new tests to assert fixed scenarios.

Modifications:
- Test that the input will be shutdown after timeout;
- Test that channel is closes if any write operation inside `KeepAliveManager` fails;
- Reduce `KeepAliveTest` timeouts to speed up local tests;

Result:

Behavior fixed in #2611 is tested now.