### PR TITLE
Change default SD retry strategy to exponential backoff with full jitter

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -60,12 +60,12 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
-import static io.servicetalk.concurrent.api.RetryStrategies.retryWithConstantBackoffDeltaJitter;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffFullJitter;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_INIT_DURATION;
-import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_JITTER;
+import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.SD_RETRY_STRATEGY_MAX_DELAY;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.setExecutionContext;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -104,8 +104,8 @@ final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttp
         final HttpExecutionContext executionContext = executionContextBuilder.build();
         BiIntFunction<Throwable, ? extends Completable> sdRetryStrategy = serviceDiscovererRetryStrategy;
         if (sdRetryStrategy == null) {
-            sdRetryStrategy = retryWithConstantBackoffDeltaJitter(__ -> true, SD_RETRY_STRATEGY_INIT_DURATION,
-                    SD_RETRY_STRATEGY_JITTER, executionContext.executor());
+            sdRetryStrategy = retryWithExponentialBackoffFullJitter(__ -> true, SD_RETRY_STRATEGY_INIT_DURATION,
+                    SD_RETRY_STRATEGY_MAX_DELAY, executionContext.executor());
         }
         final ServiceDiscoverer<U, R, PartitionedServiceDiscovererEvent<R>> psd =
                 new DefaultSingleAddressHttpClientBuilder.RetryingServiceDiscoverer<>(serviceDiscoverer,


### PR DESCRIPTION
Motivation:

Currently, clients fallback to `retryWithConstantBackoffDeltaJitter` retry strategy for `ServiceDiscovery` if users didn't provide one. Retrying with a constant backoff could add more pressure on DNS servers if they start failing consistently. Exponential backoff will help us to slow down for permanent errors.

Modifications:
- `retryWithConstantBackoffDeltaJitter(10, 5)` -> `retryWithExponentialBackoffFullJitter(8, 256)` - changes retries from every 5-15 seconds to exponentially increasing delay from 0-8 to 0-256 seconds;

Result:

Less pressure on DNS servers for permanent failures.