### PR TITLE
Bind DNS channels to a local wildcard address

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -63,6 +63,7 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -146,6 +147,7 @@ final class DefaultDnsClient implements DnsClient {
                      @Nullable Integer maxUdpPayloadSize, @Nullable final Integer ndots,
                      @Nullable final Boolean optResourceEnabled, @Nullable final Duration queryTimeout,
                      final DnsResolverAddressTypes dnsResolverAddressTypes,
+                     @Nullable final SocketAddress localAddress,
                      @Nullable final DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
                      @Nullable final DnsServiceDiscovererObserver observer,
                      final ServiceDiscovererEvent.Status missingRecordStatus) {
@@ -179,6 +181,7 @@ final class DefaultDnsClient implements DnsClient {
                 (Class<? extends SocketChannel>) socketChannel(eventLoop, InetSocketAddress.class);
         final ResolvedAddressTypes resolvedAddressTypes = DnsResolverAddressTypes.toNettyType(addressTypes);
         final DnsNameResolverBuilder builder = new DnsNameResolverBuilder(eventLoop)
+                .localAddress(localAddress)
                 .channelType(datagramChannel(eventLoop))
                 .resolvedAddressTypes(resolvedAddressTypes)
                 // Enable TCP fallback to be able to handle truncated responses.

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -58,9 +58,9 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
      */
     @Deprecated // FIXME: 0.43 - consider removing this system property
     private static final String SKIP_BINDING_PROPERTY = "io.servicetalk.dns.discovery.netty.skipBinding";
-    private static final boolean SKIP_BINDING = getBoolean(SKIP_BINDING_PROPERTY);
     @Nullable
-    private static final SocketAddress DEFAULT_LOCAL_ADDRESS = SKIP_BINDING ? null : new InetSocketAddress(0);
+    private static final SocketAddress DEFAULT_LOCAL_ADDRESS =
+            getBoolean(SKIP_BINDING_PROPERTY) ? null : new InetSocketAddress(0);
     private static final DnsResolverAddressTypes DEFAULT_DNS_RESOLVER_ADDRESS_TYPES = systemDefault();
     private static final int DEFAULT_MIN_TTL_POLL_SECONDS = 10;
     private static final int DEFAULT_MAX_TTL_POLL_SECONDS = (int) TimeUnit.MINUTES.toSeconds(5);
@@ -70,7 +70,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
 
     static {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("-D{}: {}", SKIP_BINDING_PROPERTY, SKIP_BINDING);
+            LOGGER.debug("-D{}: {}", SKIP_BINDING_PROPERTY, getBoolean(SKIP_BINDING_PROPERTY));
             LOGGER.debug("Default local address to bind to: {}", DEFAULT_LOCAL_ADDRESS);
             LOGGER.debug("Default DnsResolverAddressTypes: {}", DEFAULT_DNS_RESOLVER_ADDRESS_TYPES);
             LOGGER.debug("Default TTL poll boundaries in seconds: [{}, {}]",

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -59,7 +59,8 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     @Deprecated // FIXME: 0.43 - consider removing this system property
     private static final String SKIP_BINDING_PROPERTY = "io.servicetalk.dns.discovery.netty.skipBinding";
     private static final boolean SKIP_BINDING = getBoolean(SKIP_BINDING_PROPERTY);
-    private static final SocketAddress DEFAULT_LOCAL_ADDRESS = new InetSocketAddress(0);
+    @Nullable
+    private static final SocketAddress DEFAULT_LOCAL_ADDRESS = SKIP_BINDING ? null : new InetSocketAddress(0);
     private static final DnsResolverAddressTypes DEFAULT_DNS_RESOLVER_ADDRESS_TYPES = systemDefault();
     private static final int DEFAULT_MIN_TTL_POLL_SECONDS = 10;
     private static final int DEFAULT_MAX_TTL_POLL_SECONDS = (int) TimeUnit.MINUTES.toSeconds(5);

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
@@ -21,6 +21,7 @@ import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.time.Duration;
 import javax.annotation.Nullable;
 
@@ -67,6 +68,12 @@ public class DelegatingDnsServiceDiscovererBuilder implements DnsServiceDiscover
     @Override
     public DnsServiceDiscovererBuilder ttlJitter(final Duration ttlJitter) {
         delegate = delegate.ttlJitter(ttlJitter);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder localAddress(@Nullable final SocketAddress localAddress) {
+        delegate = delegate.localAddress(localAddress);
         return this;
     }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
@@ -21,6 +21,7 @@ import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.time.Duration;
 import javax.annotation.Nullable;
 
@@ -83,6 +84,19 @@ public interface DnsServiceDiscovererBuilder {
      * @return {@code this}.
      */
     DnsServiceDiscovererBuilder ttlJitter(Duration ttlJitter);
+
+    /**
+     * Set the local {@link SocketAddress} to bind to.
+     *
+     * @param localAddress the local {@link SocketAddress} to bind to or {@code null} to skip binding. When specified,
+     * all DNS queries will be sent from the specified address. When skipped, OS will automatically bind before sending
+     * frames but address won't be available in logs.
+     * @return {@code this}.
+     */
+    default DnsServiceDiscovererBuilder localAddress(@Nullable SocketAddress localAddress) {
+        throw new UnsupportedOperationException("DnsServiceDiscovererBuilder#localAddress(SocketAddress) is not " +
+                "supported by " + getClass());
+    }
 
     /**
      * Set the {@link DnsServerAddressStreamProvider} which determines which DNS server should be used per query.

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
@@ -74,6 +74,7 @@ import static io.servicetalk.dns.discovery.netty.DnsTestUtils.nextIp;
 import static io.servicetalk.dns.discovery.netty.DnsTestUtils.nextIp6;
 import static io.servicetalk.dns.discovery.netty.TestRecordStore.createCnameRecord;
 import static io.servicetalk.dns.discovery.netty.TestRecordStore.createSrvRecord;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.createIoExecutor;
 import static java.net.InetAddress.getByName;
 import static java.time.Duration.ofMillis;
@@ -1164,6 +1165,7 @@ class DefaultDnsClientTest {
 
     private DefaultDnsServiceDiscovererBuilder dnsClientBuilder() {
         return new DefaultDnsServiceDiscovererBuilder("test")
+                .localAddress(localAddress(0))
                 .ioExecutor(new NettyIoExecutorWithTestTimer(ioExecutor.executor(), timerExecutor.executor()))
                 .dnsResolverAddressTypes(IPV4_ONLY)
                 .optResourceEnabled(false)

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserverTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserverTest.java
@@ -44,6 +44,7 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseabl
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.dns.discovery.netty.DnsTestUtils.nextIp;
 import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static java.lang.Math.min;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
@@ -102,6 +103,7 @@ class DnsServiceDiscovererObserverTest {
                 .dnsServerAddressStreamProvider(new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()))
                 .ndots(1)
                 .ttl(DEFAULT_TTL, MAX_TTL)
+                .localAddress(localAddress(0))
                 .build());
     }
 


### PR DESCRIPTION
Motivation:

Currently, Netty's DNS resolver is configured to bind automatically after we write a packet. As the result, logs show only channel id but not local address:port pair. As the result, it's hard to correlate the packets we send with server-side DNS logs.

Modifications:
- Introduce `DnsServiceDiscovererBuilder` API for users to specify a local `SocketAddress`;
- Use `new InetSocketAddress(0)` by default for binding;
- Temporarily add a system property that allows users to quickly revert pre-existing default behavior:
`-Dio.servicetalk.dns.discovery.netty.skipBinding=boolean`;
- Log pre-initialized default values of `DefaultDnsServiceDiscovererBuilder` at debug level;

Result:

Users can see `[id: 0x1d761bfc, L:/0.0.0.0:63085]` instead of just `[id: 0x1d761bfc]` in Netty logs when DEBUG level is enabled for `io.netty.resolver.dns`.