### PR TITLE
Client should log observed errors from `ServiceDiscoverer`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -80,7 +80,6 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_2;
 import static io.servicetalk.http.netty.StrategyInfluencerAwareConversions.toConditionalClientFilterFactory;
 import static io.servicetalk.http.netty.StrategyInfluencerAwareConversions.toConditionalConnectionFilterFactory;
-import static io.servicetalk.utils.internal.ThrowableUtils.rootCause;
 import static java.lang.Integer.parseInt;
 import static java.time.Duration.ofMinutes;
 import static java.time.Duration.ofSeconds;
@@ -733,12 +732,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         public Publisher<Collection<E>> discover(final U u) {
             return delegate().discover(u)
                     .beforeOnError(t -> {
-                        if (LOGGER.isDebugEnabled()) {
-                            LOGGER.warn("Observed an error from {} while discovering '{}':", delegate(), u, t);
-                        } else {
-                            LOGGER.warn("Observed an error from {} while discovering '{}': {}",
-                                    delegate(), u, rootCause(t));
-                        }
+                        LOGGER.debug("Observed an error from {} while discovering '{}':", delegate(), u, t);
                         status.nextError(t);
                     })
                     .beforeOnNext(__ -> status.resetError());

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ThrowableUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ThrowableUtils.java
@@ -76,18 +76,4 @@ public final class ThrowableUtils {
         }
         return original;
     }
-
-    /**
-     * Returns the root cause of the passed {@link Throwable}.
-     *
-     * @param t {@link Throwable} to find the root cause
-     * @return the root cause of {@link Throwable}
-     */
-    public static Throwable rootCause(final Throwable t) {
-        Throwable root = t;
-        while (root.getCause() != null) {
-            root = root.getCause();
-        }
-        return root;
-    }
 }

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ThrowableUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ThrowableUtils.java
@@ -76,4 +76,18 @@ public final class ThrowableUtils {
         }
         return original;
     }
+
+    /**
+     * Returns the root cause of the passed {@link Throwable}.
+     *
+     * @param t {@link Throwable} to find the root cause
+     * @return the root cause of {@link Throwable}
+     */
+    public static Throwable rootCause(final Throwable t) {
+        Throwable root = t;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        return root;
+    }
 }


### PR DESCRIPTION
Motivation:

If `ServiceDiscoverer` fails for the first discovery call of a new client, the exception is propagated to the request caller. If it fails after the first collection of resolved addresses is returned, users never see errors from `ServiceDiscoverer` unless they opt-in for a `ServiceDiscoverer`-specific observer. This hides errors for users by default.

Modification:

- `DefaultSingleAddressHttpClientBuilder$StatusAwareServiceDiscoverer` logs all observed errors at `debug` level;

Result:

Users can see errors from `ServiceDiscoverer` and react when error rate increases.