### PR TITLE
Add `SslConfig.handshakeTimeout()`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslHandshakeTimeoutTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslHandshakeTimeoutTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.ReservedBlockingHttpConnection;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslProvider;
+import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
+
+import io.netty.handler.ssl.SslHandshakeTimeoutException;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
+
+import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
+import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
+import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.net.InetAddress.getLoopbackAddress;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SslHandshakeTimeoutTest {
+
+    static final long HANDSHAKE_TIMEOUT_MILLIS = CI ? 1000 : 200;
+
+    @RegisterExtension
+    static final ExecutionContextExtension SERVER_CTX =
+            ExecutionContextExtension.cached("server-io", "server-executor")
+                    .setClassLevel(true);
+    @RegisterExtension
+    static final ExecutionContextExtension CLIENT_CTX =
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
+
+    @ParameterizedTest(name = "{displayName} [{index}] sslProvider={0}")
+    @EnumSource(SslProvider.class)
+    void testServerSideTimeout(SslProvider sslProvider) throws Exception {
+        try (ServerContext serverContext = newServerBuilder(SERVER_CTX, HTTP_1)
+                .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem, DefaultTestCerts::loadServerKey)
+                        .handshakeTimeout(Duration.ofMillis(HANDSHAKE_TIMEOUT_MILLIS))
+                        .provider(sslProvider).build())
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             // Use a non-secure client to open a new connection without sending ClientHello or any data.
+             // We expect that remote server will close the connection after SslHandshake timeout.
+             BlockingHttpClient client = newClientBuilder(serverContext, CLIENT_CTX, HTTP_1).buildBlocking();
+             ReservedBlockingHttpConnection connection = client.reserveConnection(client.get("/"))) {
+            connection.connectionContext().onClose().toFuture().get(HANDSHAKE_TIMEOUT_MILLIS * 2, MILLISECONDS);
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] sslProvider={0}")
+    @EnumSource(SslProvider.class)
+    void testClientSideTimeout(SslProvider sslProvider) throws Exception {
+        // Use a non-secure server that accepts a new connection but never responds to ClientHello.
+        try (ServerSocket serverSocket = new ServerSocket(0, 50, getLoopbackAddress())) {
+            SERVER_CTX.executor().submit(() -> {
+                Socket socket = serverSocket.accept();
+                InputStream is = socket.getInputStream();
+                while (is.read() > 0) {
+                    // noop
+                }
+                return null;
+            });
+            try (BlockingHttpClient client = newClientBuilder(
+                    serverHostAndPort(serverSocket.getLocalSocketAddress()), CLIENT_CTX, HTTP_1)
+                    .sslConfig(new ClientSslConfigBuilder()
+                            .handshakeTimeout(Duration.ofMillis(HANDSHAKE_TIMEOUT_MILLIS))
+                            .provider(sslProvider).build())
+                    .buildBlocking()) {
+                assertThrows(SslHandshakeTimeoutException.class, () -> client.request(client.get("/")));
+            }
+        }
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.api;
 
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -45,9 +46,9 @@ abstract class AbstractSslConfig implements SslConfig {
     private final long sessionTimeout;
     @Nullable
     private final SslProvider provider;
-
     @Nullable
     private final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms;
+    private final Duration handshakeTimeout;
 
     AbstractSslConfig(@Nullable final TrustManagerFactory trustManagerFactory,
                       @Nullable final Supplier<InputStream> trustCertChainSupplier,
@@ -58,7 +59,8 @@ abstract class AbstractSslConfig implements SslConfig {
                       @Nullable final List<String> alpnProtocols,
                       @Nullable final List<String> ciphers, final long sessionCacheSize,
                       final long sessionTimeout, @Nullable final SslProvider provider,
-                      @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms) {
+                      @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms,
+                      final Duration handshakeTimeout) {
         this.trustManagerFactory = trustManagerFactory;
         this.trustCertChainSupplier = trustCertChainSupplier;
         this.keyManagerFactory = keyManagerFactory;
@@ -72,6 +74,7 @@ abstract class AbstractSslConfig implements SslConfig {
         this.sessionTimeout = sessionTimeout;
         this.provider = provider;
         this.certificateCompressionAlgorithms = certificateCompressionAlgorithms;
+        this.handshakeTimeout = handshakeTimeout;
     }
 
     @Nullable
@@ -129,7 +132,7 @@ abstract class AbstractSslConfig implements SslConfig {
     }
 
     @Override
-    public long sessionCacheSize() {
+    public final long sessionCacheSize() {
         return sessionCacheSize;
     }
 
@@ -146,7 +149,12 @@ abstract class AbstractSslConfig implements SslConfig {
 
     @Nullable
     @Override
-    public List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms() {
+    public final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms() {
         return certificateCompressionAlgorithms;
+    }
+
+    @Override
+    public final Duration handshakeTimeout() {
+        return handshakeTimeout;
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.api;
 
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -51,7 +52,9 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
 
     /**
      * Create a new instance using {@code tmf} to verify trusted servers.
+     *
      * @param tmf The {@link TrustManagerFactory} used to verify trusted servers.
+     * @see ClientSslConfig#trustManagerFactory()
      */
     public ClientSslConfigBuilder(TrustManagerFactory tmf) {
         trustManager(requireNonNull(tmf));
@@ -64,6 +67,8 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
      * <p>
      * Each invocation of the {@link Supplier} should provide an independent instance of {@link InputStream} and the
      * caller is responsible for invoking {@link InputStream#close()}.
+     *
+     * @see ClientSslConfig#trustCertChainSupplier()
      */
     public ClientSslConfigBuilder(Supplier<InputStream> trustCertChainSupplier) {
         trustManager(trustCertChainSupplier);
@@ -78,6 +83,7 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
      * Endpoint Identification Algorithm Name</a>.
      * An empty {@code String} ({@code ""}) disables hostname verification.
      * @return {@code this}.
+     * @see ClientSslConfig#hostnameVerificationAlgorithm()
      * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
      */
     public ClientSslConfigBuilder hostnameVerificationAlgorithm(String algorithm) {
@@ -87,8 +93,10 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
 
     /**
      * Set the non-authoritative name of the peer.
+     *
      * @param peerHost the non-authoritative name of the peer.
      * @return {@code this}.
+     * @see ClientSslConfig#peerHost()
      * @see SSLEngine#getPeerHost()
      */
     public ClientSslConfigBuilder peerHost(@Nullable String peerHost) {
@@ -98,9 +106,11 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
 
     /**
      * Set the non-authoritative port of the peer.
+     *
      * @param peerPort the non-authoritative port of the peer, or {@code -1} if unavailable (which may prevent
      * <a href="https://tools.ietf.org/html/rfc5077">session resumption</a>).
      * @return {@code this}.
+     * @see ClientSslConfig#peerPort()
      * @see SSLEngine#getPeerPort()
      */
     public ClientSslConfigBuilder peerPort(int peerPort) {
@@ -113,8 +123,10 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
 
     /**
      * Set the <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
+     *
      * @param sniHostname <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> host name.
      * @return {@code this}.
+     * @see ClientSslConfig#sniHostname()
      * @see SSLParameters#setServerNames(List)
      */
     public ClientSslConfigBuilder sniHostname(String sniHostname) {
@@ -133,7 +145,7 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
         return new DefaultClientSslConfig(hostnameVerificationAlgorithm, peerHost, peerPort, sniHostname,
                 trustManager(), trustCertChainSupplier(), keyManager(), keyCertChainSupplier(), keySupplier(),
                 keyPassword(), sslProtocols(), alpnProtocols(), ciphers(), sessionCacheSize(), sessionTimeout(),
-                provider(), certificateCompressionAlgorithms());
+                provider(), certificateCompressionAlgorithms(), handshakeTimeout());
     }
 
     @Override
@@ -162,10 +174,11 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
                                @Nullable final List<String> sslProtocols, @Nullable final List<String> alpnProtocols,
                                @Nullable final List<String> ciphers, final long sessionCacheSize,
                                final long sessionTimeout, @Nullable final SslProvider provider,
-                               @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms) {
+                               @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms,
+                               final Duration handshakeTimeout) {
             super(trustManagerFactory, trustCertChainSupplier, keyManagerFactory, keyCertChainSupplier, keySupplier,
                     keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout, provider,
-                    certificateCompressionAlgorithms);
+                    certificateCompressionAlgorithms, handshakeTimeout);
             this.hostnameVerificationAlgorithm = hostnameVerificationAlgorithm;
             this.peerHost = peerHost;
             this.peerPort = peerPort;

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingSslConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.api;
 
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -121,5 +122,10 @@ public abstract class DelegatingSslConfig<T extends SslConfig> implements SslCon
     @Override
     public List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms() {
         return delegate.certificateCompressionAlgorithms();
+    }
+
+    @Override
+    public Duration handshakeTimeout() {
+        return delegate.handshakeTimeout();
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSslConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.api;
 
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -36,6 +37,7 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
      * Create a new instance using the {@link KeyManagerFactory} for SSL/TLS handshakes.
      *
      * @param kmf the {@link KeyManagerFactory} to use for the SSL/TLS handshakes.
+     * @see ServerSslConfig#keyManagerFactory()
      */
     public ServerSslConfigBuilder(KeyManagerFactory kmf) {
         keyManager(kmf);
@@ -44,6 +46,7 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
     /**
      * Create a new instance from a {@link InputStream} which provides {@code X.509} certificate chain in {@code PEM}
      * format and a {@code PKCS#8} private key in {@code PEM} format.
+     *
      * @param keyCertChainSupplier the {@code X.509} certificate chain in {@code PEM} format.
      * <p>
      * Each invocation of the {@link Supplier} should provide an independent instance of {@link InputStream} and the
@@ -53,6 +56,8 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
      * <p>
      * Each invocation of the {@link Supplier} should provide an independent instance of {@link InputStream} and the
      * caller is responsible for invoking {@link InputStream#close()}.
+     * @see ServerSslConfig#keyCertChainSupplier()
+     * @see ServerSslConfig#keySupplier()
      */
     public ServerSslConfigBuilder(Supplier<InputStream> keyCertChainSupplier,
                                   Supplier<InputStream> keySupplier) {
@@ -62,6 +67,7 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
     /**
      * Create a new instance from a {@link InputStream} which provides {@code X.509} certificate chain in {@code PEM}
      * format and a {@code PKCS#8} private key in {@code PEM} format.
+     *
      * @param keyCertChainSupplier the {@code X.509} certificate chain in {@code PEM} format.
      * <p>
      * Each invocation of the {@link Supplier} should provide an independent instance of {@link InputStream} and the
@@ -72,6 +78,9 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
      * Each invocation of the {@link Supplier} should provide an independent instance of {@link InputStream} and the
      * caller is responsible for invoking {@link InputStream#close()}.
      * @param keyPassword the password required to access the key material from {@code keySupplier}.
+     * @see ServerSslConfig#keyCertChainSupplier()
+     * @see ServerSslConfig#keySupplier()
+     * @see ServerSslConfig#keyPassword()
      */
     public ServerSslConfigBuilder(Supplier<InputStream> keyCertChainSupplier, Supplier<InputStream> keySupplier,
                                   @Nullable String keyPassword) {
@@ -80,8 +89,10 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
 
     /**
      * Set the {@link SslClientAuthMode} which determines how client authentication should be done.
+     *
      * @param clientAuthMode the {@link SslClientAuthMode} which determines how client authentication should be done.
      * @return {@code this}.
+     * @see ServerSslConfig#clientAuthMode()
      * @see SSLParameters#getNeedClientAuth()
      * @see SSLParameters#getWantClientAuth()
      */
@@ -97,7 +108,8 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
     public ServerSslConfig build() {
         return new DefaultServerSslConfig(clientAuthMode, trustManager(), trustCertChainSupplier(), keyManager(),
                 keyCertChainSupplier(), keySupplier(), keyPassword(), sslProtocols(), alpnProtocols(), ciphers(),
-                sessionCacheSize(), sessionTimeout(), provider(), certificateCompressionAlgorithms());
+                sessionCacheSize(), sessionTimeout(), provider(), certificateCompressionAlgorithms(),
+                handshakeTimeout());
     }
 
     @Override
@@ -117,10 +129,11 @@ public final class ServerSslConfigBuilder extends AbstractSslConfigBuilder<Serve
                                @Nullable final List<String> sslProtocols, @Nullable final List<String> alpnProtocols,
                                @Nullable final List<String> ciphers, final long sessionCacheSize,
                                final long sessionTimeout, @Nullable final SslProvider provider,
-                               @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms) {
+                               @Nullable final List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms,
+                               final Duration handshakeTimeout) {
             super(trustManagerFactory, trustCertChainSupplier, keyManagerFactory, keyCertChainSupplier, keySupplier,
                     keyPassword, sslProtocols, alpnProtocols, ciphers, sessionCacheSize, sessionTimeout, provider,
-                    certificateCompressionAlgorithms);
+                    certificateCompressionAlgorithms, handshakeTimeout);
             this.clientAuthMode = clientAuthMode;
         }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/SslConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.api;
 
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -23,6 +24,8 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.TrustManagerFactory;
+
+import static io.servicetalk.transport.api.AbstractSslConfigBuilder.DEFAULT_HANDSHAKE_TIMEOUT;
 
 /**
  * Specifies the configuration for TLS/SSL.
@@ -155,9 +158,22 @@ public interface SslConfig {
      *
      * @return the list of certificate compression algorithms to advertise.
      * @see <a href="https://www.rfc-editor.org/rfc/rfc8879">RFC8879 - TLS Certificate Compression</a>
+     * @see CertificateCompressionAlgorithms
      */
     @Nullable // FIXME 0.43 - remove default implementation
     default List<CertificateCompressionAlgorithm> certificateCompressionAlgorithms() {
         return null;
+    }
+
+    /**
+     * Get the timeout for the handshake process.
+     * <p>
+     * Implementations can round the returned {@link Duration} to full time units, depending on their time granularity.
+     * {@link Duration#ZERO Zero duration} disables the timeout.
+     *
+     * @return the timeout for the handshake process or {@link Duration#ZERO} to disable it.
+     */
+    default Duration handshakeTimeout() {   // FIXME 0.43 - remove default implementation
+        return DEFAULT_HANDSHAKE_TIMEOUT;
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SniServerChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SniServerChannelInitializer.java
@@ -25,7 +25,7 @@ import io.netty.util.Mapping;
 
 import javax.net.ssl.SSLEngine;
 
-import static io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer.POOLED_ALLOCATOR;
+import static io.servicetalk.transport.netty.internal.SslUtils.newServerSslHandler;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -58,7 +58,7 @@ public final class SniServerChannelInitializer implements ChannelInitializer {
 
         @Override
         protected SslHandler newSslHandler(final SslContext context, final ByteBufAllocator ignore) {
-            return super.newSslHandler(context, POOLED_ALLOCATOR);
+            return newServerSslHandler(context);
         }
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 
-import static io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer.POOLED_ALLOCATOR;
-import static io.servicetalk.transport.netty.internal.SslUtils.newHandler;
+import static io.servicetalk.transport.netty.internal.SslUtils.newClientSslHandler;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -47,7 +46,7 @@ public class SslClientChannelInitializer implements ChannelInitializer {
 
     @Override
     public void init(Channel channel) {
-        final SslHandler sslHandler = newHandler(sslContext, POOLED_ALLOCATOR, sslConfig);
+        final SslHandler sslHandler = newClientSslHandler(sslContext, sslConfig);
         channel.pipeline().addLast(deferSslHandler ? new DeferSslHandler(channel, sslHandler) : sslHandler);
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslServerChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslServerChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,7 @@ package io.servicetalk.transport.netty.internal;
 import io.netty.channel.Channel;
 import io.netty.handler.ssl.SslContext;
 
-import static io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer.POOLED_ALLOCATOR;
-import static io.servicetalk.transport.netty.internal.SslUtils.newHandler;
+import static io.servicetalk.transport.netty.internal.SslUtils.newServerSslHandler;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -38,6 +37,6 @@ public final class SslServerChannelInitializer implements ChannelInitializer {
 
     @Override
     public void init(Channel channel) {
-        channel.pipeline().addLast(newHandler(sslContext, POOLED_ALLOCATOR));
+        channel.pipeline().addLast(newServerSslHandler(sslContext));
     }
 }

--- a/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/AddressUtils.java
+++ b/servicetalk-transport-netty-internal/src/testFixtures/java/io/servicetalk/transport/netty/internal/AddressUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2020, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 import static io.netty.util.NetUtil.isValidIpV6Address;
 import static java.net.InetAddress.getLoopbackAddress;
@@ -56,7 +57,17 @@ public final class AddressUtils {
      * @return a {@link HostAndPort} representation of server's listening address.
      */
     public static HostAndPort serverHostAndPort(final ServerContext ctx) {
-        return HostAndPort.of((InetSocketAddress) ctx.listenAddress());
+        return serverHostAndPort(ctx.listenAddress());
+    }
+
+    /**
+     * Returns a {@link HostAndPort} representation of server's listening address.
+     *
+     * @param address The {@link SocketAddress} of the server
+     * @return a {@link HostAndPort} representation of server's listening address.
+     */
+    public static HostAndPort serverHostAndPort(final SocketAddress address) {
+        return HostAndPort.of((InetSocketAddress) address);
     }
 
     /**


### PR DESCRIPTION
Motivation:

Users need control the timeout for SSL handshake.

Modifications:

- Add `SslConfig.handshakeTimeout()` and `AbstractSslConfigBuilder.handshakeTimeout(Duration)`;
- Refactor `SslContextFactory` to store timeout value in `SslContext` attributes and reuse code between `forClient` and `forServer` factories;
- Refactor `SslUtils` to apply handshake timeout when a new `SslHandler` is created;
- Add `SslHandshakeTimeoutTest`;
- Add javadoc references from `SslConfig` builders to `SslConfig`;

Result:

Users can control SSL handshake timeouts via `SslConfig` API.