### PR TITLE
Add `ClientHello` configuration options for SNI

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServerBuilder.java
@@ -27,6 +27,7 @@ import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
+import java.time.Duration;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -78,6 +79,13 @@ public class DelegatingHttpServerBuilder implements HttpServerBuilder {
     @Override
     public HttpServerBuilder sslConfig(final ServerSslConfig defaultConfig, final Map<String, ServerSslConfig> sniMap) {
         delegate = delegate.sslConfig(defaultConfig, sniMap);
+        return this;
+    }
+
+    @Override
+    public HttpServerBuilder sslConfig(final ServerSslConfig defaultConfig, final Map<String, ServerSslConfig> sniMap,
+                                       final int maxClientHelloLength, final Duration clientHelloTimeout) {
+        delegate = delegate.sslConfig(defaultConfig, sniMap, maxClientHelloLength, clientHelloTimeout);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -87,8 +87,7 @@ public interface HttpServerBuilder {
      * to provide the corresponding {@link ServerSslConfig}.
      * @param maxClientHelloLength The maximum length of a
      * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message in bytes, up to
-     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1">2^14</a> bytes.
-     * Zero ({@code 0}) disables validation.
+     * {@code 2^24 - 1} bytes. Zero ({@code 0}) disables validation.
      * @param clientHelloTimeout The timeout for waiting until
      * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message is received.
      * Implementations can round the specified {@link Duration} to full time units, depending on their time granularity.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
+import java.time.Duration;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -60,6 +61,7 @@ public interface HttpServerBuilder {
 
     /**
      * Set the SSL/TLS configuration.
+     *
      * @param config The configuration to use.
      * @return {@code this}.
      */
@@ -67,6 +69,7 @@ public interface HttpServerBuilder {
 
     /**
      * Set the SSL/TLS and <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> configuration.
+     *
      * @param defaultConfig The configuration to use is the client certificate's SNI extension isn't present or the
      * SNI hostname doesn't match any values in {@code sniMap}.
      * @param sniMap A map where the keys are matched against the client certificate's SNI extension value in order
@@ -74,6 +77,29 @@ public interface HttpServerBuilder {
      * @return {@code this}.
      */
     HttpServerBuilder sslConfig(ServerSslConfig defaultConfig, Map<String, ServerSslConfig> sniMap);
+
+    /**
+     * Set the SSL/TLS and <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> configuration.
+     *
+     * @param defaultConfig The configuration to use is the client certificate's SNI extension isn't present or the
+     * SNI hostname doesn't match any values in {@code sniMap}.
+     * @param sniMap A map where the keys are matched against the client certificate's SNI extension value in order
+     * to provide the corresponding {@link ServerSslConfig}.
+     * @param maxClientHelloLength The maximum length of a
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message in bytes, up to
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1">2^14</a> bytes.
+     * Zero ({@code 0}) disables validation.
+     * @param clientHelloTimeout The timeout for waiting until
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message is received.
+     * Implementations can round the specified {@link Duration} to full time units, depending on their time granularity.
+     * {@link Duration#ZERO Zero (0)} disables timeout.
+     * @return {@code this}.
+     */
+    default HttpServerBuilder sslConfig(ServerSslConfig defaultConfig, Map<String, ServerSslConfig> sniMap,
+                                        int maxClientHelloLength, Duration clientHelloTimeout) {
+        throw new UnsupportedOperationException(
+                "sslConfig(ServerSslConfig, Map, int, Durations) is not supported by " + getClass());
+    }
 
     /**
      * Adds a {@link SocketOption} that is applied to connected/accepted socket channels.
@@ -220,8 +246,7 @@ public interface HttpServerBuilder {
      * @see #appendLateConnectionAcceptor(LateConnectionAcceptor)
      */
     default HttpServerBuilder appendEarlyConnectionAcceptor(EarlyConnectionAcceptor acceptor) {
-        throw new UnsupportedOperationException("appendEarlyConnectionAcceptor is not supported " +
-                "by " + getClass());
+        throw new UnsupportedOperationException("appendEarlyConnectionAcceptor is not supported by " + getClass());
     }
 
     /**
@@ -252,8 +277,7 @@ public interface HttpServerBuilder {
      * @see #appendEarlyConnectionAcceptor(EarlyConnectionAcceptor)
      */
     default HttpServerBuilder appendLateConnectionAcceptor(LateConnectionAcceptor acceptor) {
-        throw new UnsupportedOperationException("appendLateConnectionAcceptor is not supported " +
-                "by " + getClass());
+        throw new UnsupportedOperationException("appendLateConnectionAcceptor is not supported by " + getClass());
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -70,7 +70,7 @@ public interface HttpServerBuilder {
     /**
      * Set the SSL/TLS and <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> configuration.
      *
-     * @param defaultConfig The configuration to use is the client certificate's SNI extension isn't present or the
+     * @param defaultConfig The configuration to use if the client certificate's SNI extension isn't present or the
      * SNI hostname doesn't match any values in {@code sniMap}.
      * @param sniMap A map where the keys are matched against the client certificate's SNI extension value in order
      * to provide the corresponding {@link ServerSslConfig}.
@@ -81,7 +81,7 @@ public interface HttpServerBuilder {
     /**
      * Set the SSL/TLS and <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> configuration.
      *
-     * @param defaultConfig The configuration to use is the client certificate's SNI extension isn't present or the
+     * @param defaultConfig The configuration to use if the client certificate's SNI extension isn't present or the
      * SNI hostname doesn't match any values in {@code sniMap}.
      * @param sniMap A map where the keys are matched against the client certificate's SNI extension value in order
      * to provide the corresponding {@link ServerSslConfig}.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -210,6 +211,13 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
     @Override
     public HttpServerBuilder sslConfig(final ServerSslConfig defaultConfig, final Map<String, ServerSslConfig> sniMap) {
         this.config.tcpConfig().sslConfig(defaultConfig, sniMap);
+        return this;
+    }
+
+    @Override
+    public HttpServerBuilder sslConfig(final ServerSslConfig defaultConfig, final Map<String, ServerSslConfig> sniMap,
+                                       final int maxClientHelloLength, final Duration clientHelloTimeout) {
+        this.config.tcpConfig().sslConfig(defaultConfig, sniMap, maxClientHelloLength, clientHelloTimeout);
         return this;
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MutualSslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,8 +43,6 @@ import static io.servicetalk.http.netty.TcpFastOpenTest.clientTcpFastOpenOptions
 import static io.servicetalk.http.netty.TcpFastOpenTest.serverTcpFastOpenOptions;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static io.servicetalk.transport.api.SslClientAuthMode.REQUIRE;
-import static io.servicetalk.transport.api.SslProvider.JDK;
-import static io.servicetalk.transport.api.SslProvider.OPENSSL;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.util.Arrays.asList;
@@ -52,7 +50,6 @@ import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MutualSslTest {
-    static final SslProvider[] SSL_PROVIDERS = {JDK, OPENSSL};
     @SuppressWarnings("rawtypes")
     private static final List<Map<SocketOption, Object>> SERVER_LISTEN_OPTIONS =
             asList(emptyMap(), serverTcpFastOpenOptions());
@@ -63,8 +60,8 @@ class MutualSslTest {
     @SuppressWarnings({"rawtypes", "unused"})
     private static Collection<Arguments> params() {
         List<Arguments> params = new ArrayList<>();
-        for (SslProvider serverSslProvider : SSL_PROVIDERS) {
-            for (SslProvider clientSslProvider : SSL_PROVIDERS) {
+        for (SslProvider serverSslProvider : SslProvider.values()) {
+            for (SslProvider clientSslProvider : SslProvider.values()) {
                 for (Map<SocketOption, Object> serverListenOptions : SERVER_LISTEN_OPTIONS) {
                     for (Map<SocketOption, Object> clientOptions : CLIENT_OPTIONS) {
                         params.add(Arguments.of(serverSslProvider, clientSslProvider,

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-transport-netty")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305"
   implementation "org.slf4j:slf4j-api"
 

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -56,7 +56,8 @@ public class TcpServerChannelInitializer implements ChannelInitializer {    // F
         }
 
         if (config.sniMapping() != null) {
-            delegate = delegate.andThen(new SniServerChannelInitializer(config.sniMapping()));
+            delegate = delegate.andThen(new SniServerChannelInitializer(config.sniMapping(),
+                    config.sniMaxClientHelloLength(), config.sniClientHelloTimeout().toMillis()));
         } else if (config.sslContext() != null) {
             delegate = delegate.andThen(new SslServerChannelInitializer(config.sslContext()));
         }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -39,8 +39,9 @@ import static java.util.Objects.requireNonNull;
  */
 public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
     /**
-     * The maximum length of client hello message as defined by
-     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1">RFC5246</a>.
+     * The maximum length of ClientHello message as defined by
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">RFC5246</a> and
+     * <a href="https://datatracker.ietf.org/doc/html/rfc6347#section-3.2.3">RFC6347</a> as {@code 2^24 - 1}.
      */
     private static final int MAX_CLIENT_HELLO_LENGTH = 0xFFFFFF;
     private static final Duration DEFAULT_CLIENT_HELLO_TIMEOUT = ofSeconds(10); // same as default in Netty SslHandler
@@ -108,8 +109,7 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
      * found the corresponding {@link ServerSslConfig} is used.
      * @param maxClientHelloLength the maximum length of a
      * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message in bytes, up to
-     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1">2^14</a> bytes.
-     * Zero ({@code 0}) disables validation.
+     * {@code 2^24 - 1} bytes. Zero ({@code 0}) disables validation.
      * @param clientHelloTimeout The timeout for waiting until
      * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message is received.
      * Implementations can round the specified {@link Duration} to full time units, depending on their time granularity.

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,17 +24,26 @@ import io.netty.channel.ChannelOption;
 
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.addOption;
+import static io.servicetalk.utils.internal.DurationUtils.ensureNonNegative;
+import static java.time.Duration.ofSeconds;
 import static java.util.Objects.requireNonNull;
 
 /**
  * Configuration for TCP based servers.
  */
 public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
+    /**
+     * The maximum length of client hello message as defined by
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1">RFC5246</a>.
+     */
+    private static final int MAX_CLIENT_HELLO_LENGTH = 0xFFFFFF;
+    private static final Duration DEFAULT_CLIENT_HELLO_TIMEOUT = ofSeconds(10); // same as default in Netty SslHandler
 
     @Nullable
     @SuppressWarnings("rawtypes")
@@ -42,6 +51,14 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
     private TransportObserver transportObserver = NoopTransportObserver.INSTANCE;
     @Nullable
     private Map<String, ServerSslConfig> sniConfig;
+    private int sniMaxClientHelloLength = MAX_CLIENT_HELLO_LENGTH;
+    private Duration sniClientHelloTimeout = DEFAULT_CLIENT_HELLO_TIMEOUT;
+
+    @Nullable
+    @SuppressWarnings("rawtypes")
+    Map<ChannelOption, Object> listenOptions() {
+        return listenOptions;
+    }
 
     TransportObserver transportObserver() {
         return transportObserver;
@@ -52,10 +69,12 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
         return sniConfig;
     }
 
-    @Nullable
-    @SuppressWarnings("rawtypes")
-    Map<ChannelOption, Object> listenOptions() {
-        return listenOptions;
+    int sniMaxClientHelloLength() {
+        return sniMaxClientHelloLength;
+    }
+
+    Duration sniClientHelloTimeout() {
+        return sniClientHelloTimeout;
     }
 
     /**
@@ -78,6 +97,34 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
     public TcpServerConfig sslConfig(ServerSslConfig defaultSslConfig, Map<String, ServerSslConfig> sniConfig) {
         sslConfig(defaultSslConfig);
         this.sniConfig = requireNonNull(sniConfig);
+        return this;
+    }
+
+    /**
+     * Add SSL/TLS and SNI related config.
+     *
+     * @param defaultSslConfig the default {@link ServerSslConfig} used when no SNI match is found.
+     * @param sniConfig client SNI hostname values are matched against keys in this {@link Map} and if a match is
+     * found the corresponding {@link ServerSslConfig} is used.
+     * @param maxClientHelloLength the maximum length of a
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message in bytes, up to
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1">2^14</a> bytes.
+     * Zero ({@code 0}) disables validation.
+     * @param clientHelloTimeout The timeout for waiting until
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message is received.
+     * Implementations can round the specified {@link Duration} to full time units, depending on their time granularity.
+     * {@link Duration#ZERO Zero (0)} disables timeout.
+     * @return {@code this}
+     */
+    public TcpServerConfig sslConfig(ServerSslConfig defaultSslConfig, Map<String, ServerSslConfig> sniConfig,
+                                     int maxClientHelloLength, Duration clientHelloTimeout) {
+        sslConfig(defaultSslConfig, sniConfig);
+        if (maxClientHelloLength < 0 || maxClientHelloLength > MAX_CLIENT_HELLO_LENGTH) {
+            throw new IllegalArgumentException("maxClientHelloLength: " + maxClientHelloLength +
+                    "(expected [0, " + MAX_CLIENT_HELLO_LENGTH + ']');
+        }
+        this.sniMaxClientHelloLength = maxClientHelloLength;
+        this.sniClientHelloTimeout = ensureNonNegative(clientHelloTimeout, "clientHelloTimeout");
         return this;
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SniServerChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SniServerChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,29 +22,87 @@ import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Mapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import javax.net.ssl.SSLEngine;
 
 import static io.servicetalk.transport.netty.internal.SslUtils.newServerSslHandler;
+import static java.lang.invoke.MethodType.methodType;
 import static java.util.Objects.requireNonNull;
 
 /**
  * SNI {@link ChannelInitializer} for servers.
  */
 public final class SniServerChannelInitializer implements ChannelInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SniServerChannelInitializer.class);
+
+    private static final Mapping<String, SslContext> NULL_MAPPING = input -> null;
+    private static final boolean CAN_SET_ALL_SETTINGS;
+
+    static {
+        MethodHandle newCtor;
+        try {
+            // Find a new constructor that exists only in Netty starting from 4.1.94.Final:
+            newCtor = MethodHandles.publicLookup().findConstructor(SniHandler.class,
+                    methodType(void.class, Mapping.class, int.class, long.class));
+            // Verify the new constructor is working as expected:
+            if (!(newCtor.invoke(NULL_MAPPING, 0, 0L) instanceof SniHandler)) {
+                throw new IllegalStateException("MethodHandle did not return an instance of SniHandler");
+            }
+        } catch (Throwable cause) {
+            LOGGER.debug("SniHandler(Mapping, int, long) constructor is available only starting from " +
+                            "Netty 4.1.94.Final. Detected Netty version: {}",
+                    SniHandler.class.getPackage().getImplementationVersion(), cause);
+            newCtor = null;
+        }
+        CAN_SET_ALL_SETTINGS = newCtor != null;
+    }
+
     private final Mapping<String, SslContext> sniMapping;
+    private final int maxClientHelloLength;
+    private final long clientHelloTimeoutMillis;
 
     /**
      * Create a new instance.
+     *
      * @param sniMapping to use for SNI configuration.
+     * @deprecated Use {@link #SniServerChannelInitializer(Mapping, int, long)}.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated constructor
     public SniServerChannelInitializer(final Mapping<String, SslContext> sniMapping) {
+        this(sniMapping, 0, 0L);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param sniMapping to use for SNI configuration.
+     * @param maxClientHelloLength The maximum length of a
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message in bytes, up to
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1">2^14</a> bytes.
+     * Zero ({@code 0}) disables validation.
+     * @param clientHelloTimeoutMillis The timeout in milliseconds for waiting until
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message is received.
+     * Zero ({@code 0}) disables timeout.
+     *
+     */
+    public SniServerChannelInitializer(final Mapping<String, SslContext> sniMapping,
+                                       final int maxClientHelloLength,
+                                       final long clientHelloTimeoutMillis) {
         this.sniMapping = requireNonNull(sniMapping);
+        this.maxClientHelloLength = maxClientHelloLength;
+        this.clientHelloTimeoutMillis = clientHelloTimeoutMillis;
     }
 
     @Override
     public void init(final Channel channel) {
-        channel.pipeline().addLast(new SniHandlerWithPooledAllocator(sniMapping));
+        channel.pipeline().addLast(CAN_SET_ALL_SETTINGS ?
+                new SniHandlerWithAllSettings(sniMapping, maxClientHelloLength, clientHelloTimeoutMillis) :
+                new SniHandlerWithPooledAllocator(sniMapping));
     }
 
     /**
@@ -54,6 +112,19 @@ public final class SniServerChannelInitializer implements ChannelInitializer {
     private static final class SniHandlerWithPooledAllocator extends SniHandler {
         SniHandlerWithPooledAllocator(final Mapping<String, SslContext> mapping) {
             super(mapping);
+        }
+
+        @Override
+        protected SslHandler newSslHandler(final SslContext context, final ByteBufAllocator ignore) {
+            return newServerSslHandler(context);
+        }
+    }
+
+    private static final class SniHandlerWithAllSettings extends SniHandler {
+        SniHandlerWithAllSettings(final Mapping<String, SslContext> mapping,
+                                  final int maxClientHelloLength,
+                                  final long clientHelloTimeoutMillis) {
+            super(mapping, maxClientHelloLength, clientHelloTimeoutMillis);
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SniServerChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SniServerChannelInitializer.java
@@ -83,8 +83,7 @@ public final class SniServerChannelInitializer implements ChannelInitializer {
      * @param sniMapping to use for SNI configuration.
      * @param maxClientHelloLength The maximum length of a
      * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message in bytes, up to
-     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-6.2.1">2^14</a> bytes.
-     * Zero ({@code 0}) disables validation.
+     * {@code 2^24 - 1} bytes. Zero ({@code 0}) disables validation.
      * @param clientHelloTimeoutMillis The timeout in milliseconds for waiting until
      * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message is received.
      * Zero ({@code 0}) disables timeout.


### PR DESCRIPTION
Motivation:

Netty 4.1.94 exposed a new option to configure maximum length of a
`ClientHello` message. `SniHandler` also allows configuring a timeout
for parsing SNI info before starting the handshake.
See https://github.com/netty/netty/commit/535da17e45201ae4278c0479e6162bb4127d4c32

Modifications:

- Add `HttpServerBuilder.sslConfig(ServerSslConfig, Map, int, long)`
overload to give users a way for `SniHandler` configuration;
- Propagate new options via `TcpServerConfig`;
- Enhance `SniServerChannelInitializer` to apply new options when the
min required Netty version is detected;
- Set reasonable default values;
- Add `SniTest.sniTimeout(...)`;

Result:

Users can control the maximum `ClientHello` length and timeout for parsing
SNI information.