### PR TITLE
Provide default `fragment(String)` override for all request types

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingHttpRequest.java
@@ -294,7 +294,10 @@ public interface BlockingStreamingHttpRequest extends HttpRequestMetaData {
     BlockingStreamingHttpRequest version(HttpProtocolVersion version);
 
     @Override
-    BlockingStreamingHttpRequest fragment(@Nullable String fragment);
+    default BlockingStreamingHttpRequest fragment(@Nullable String fragment) {
+        throw new UnsupportedOperationException("BlockingStreamingHttpRequest#fragment(String) is not supported by " +
+                getClass());
+    }
 
     @Deprecated
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequest.java
@@ -137,7 +137,10 @@ public interface HttpRequest extends HttpRequestMetaData, TrailersHolder {
     HttpRequest setQueryParameters(String key, String... values);
 
     @Override
-    HttpRequest fragment(@Nullable String fragment);
+    default HttpRequest fragment(@Nullable String fragment) {
+        throw new UnsupportedOperationException("HttpRequest#fragment(String) is not supported by " +
+                getClass());
+    }
 
     @Override
     HttpRequest version(HttpProtocolVersion version);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequest.java
@@ -285,7 +285,10 @@ public interface StreamingHttpRequest extends HttpRequestMetaData {
     StreamingHttpRequest method(HttpRequestMethod method);
 
     @Override
-    StreamingHttpRequest fragment(@Nullable String fragment);
+    default StreamingHttpRequest fragment(@Nullable String fragment) {
+        throw new UnsupportedOperationException("StreamingHttpRequest#fragment(String) is not supported by " +
+                getClass());
+    }
 
     @Deprecated
     @Override


### PR DESCRIPTION
Motivation:

Even though `HttpRequestMetaData#fragment()` has default implementation, because all request types override it with different return type, we must provide default implementations for these overrides too. Otherwise, the code is not backward compatible.

Modifications:

- Add `default` implementation for `fragment(String)` in `HttpRequest`, `StreamingHttpRequest`, `BlockingStreamingHttpRequest`;

Result:

Request interfaces are backward compatible.