### PR TITLE
Adjust DNS default max TTL cache boundary to 30 seconds

### DIFF
--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
@@ -1006,7 +1006,9 @@ class DefaultDnsClientTest {
         final int cappedMaxTTL = 3;
         final int dnsServerMaxTTL = cappedMaxTTL * 2;
 
-        setup(builder -> builder.ttl(1, cappedMaxTTL));
+        setup(builder -> cache ?
+                builder.ttl(1, cappedMaxTTL, 1, cappedMaxTTL) :
+                builder.ttl(1, cappedMaxTTL, 0, 0));
         final String domain = "servicetalk.io";
         String ip1 = nextIp();
         String ip2 = nextIp();
@@ -1035,7 +1037,9 @@ class DefaultDnsClientTest {
         final int cappedMaxTTL = 3;
         final int dnsServerMaxTTL = cappedMaxTTL * 2;
 
-        setup(builder -> builder.ttl(1, cappedMaxTTL));
+        setup(builder -> cache ?
+                builder.ttl(1, cappedMaxTTL, 1, cappedMaxTTL) :
+                builder.ttl(1, cappedMaxTTL, 0, 0));
         final String domain = "servicetalk.io";
         String ip1 = nextIp();
         String ip2 = nextIp();
@@ -1172,7 +1176,7 @@ class DefaultDnsClientTest {
                 .srvConcurrency(512)
                 .dnsServerAddressStreamProvider(new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()))
                 .ndots(1)
-                .ttl(1, 5)
+                .ttl(1, 5, 0, 0)
                 .ttlJitter(Duration.ofNanos(1));
     }
 


### PR DESCRIPTION
Motivation:

Having no cache works well for happy path and for poisoned cache use-case described in #2518. Unfortunately, users may leak new client instances and add excess load on DNS. Having a short-lived cache, similar to OpenJDK default, will help to reduce number of outgoing DNS queries.

Modifications:

- Increase `DEFAULT_MAX_TTL_CACHE_SECONDS` from 0 to 30 seconds;
- Use `Math.min(pollTtl, cacheTtl)` inside `ttl(int, int)` overload to avoid `minCacheSeconds > minSeconds` and `maxCacheSeconds > maxSeconds`;
- Log `DEFAULT_TTL_POLL_JITTER_SECONDS` at debug level;
- Stop using `DEFAULT_MIN_TTL_POLL_SECONDS` for `srvHostNameRepeatInitialDelay` because they are not related;
- Adjust tests to disable default cache because we manage time manually;

Result:

`DnsServiceDiscoverer` caches results by default for up to 30 seconds, still respecting the original TTL from a DNS server if it's lower than 30 seconds.