### PR TITLE
Allow configuring "negative" DNS TTL for failed resolutions

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -141,7 +141,8 @@ final class DefaultDnsClient implements DnsClient {
 
     DefaultDnsClient(final String id, final IoExecutor ioExecutor,
                      final int minTTL, final int maxTTL, final int minCacheTTL, final int maxCacheTTL,
-                     final long ttlJitterNanos, final int srvConcurrency, final boolean inactiveEventsOnError,
+                     final int negativeTTLCacheSeconds, final long ttlJitterNanos,
+                     final int srvConcurrency, final boolean inactiveEventsOnError,
                      final boolean completeOncePreferredResolved, final boolean srvFilterDuplicateEvents,
                      Duration srvHostNameRepeatInitialDelay, Duration srvHostNameRepeatJitter,
                      @Nullable Integer maxUdpPayloadSize, @Nullable final Integer ndots,
@@ -160,7 +161,8 @@ final class DefaultDnsClient implements DnsClient {
         srvHostNameRepeater = repeatWithConstantBackoffDeltaJitter(
                 srvHostNameRepeatInitialDelay, srvHostNameRepeatJitter, nettyIoExecutor);
         this.ttlCache = new MinTtlCache(
-                maxCacheTTL == 0 ? NoopDnsCache.INSTANCE : new DefaultDnsCache(minCacheTTL, maxCacheTTL, 0),
+                maxCacheTTL == 0 && negativeTTLCacheSeconds == 0 ? NoopDnsCache.INSTANCE :
+                        new DefaultDnsCache(minCacheTTL, maxCacheTTL, negativeTTLCacheSeconds),
                 minTTL, nettyIoExecutor);
         this.maxTTLNanos = SECONDS.toNanos(maxTTL);
         this.ttlJitterNanos = ttlJitterNanos;

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -38,6 +38,7 @@ import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.glo
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static java.lang.Boolean.getBoolean;
 import static java.lang.Math.min;
+import static java.lang.System.getProperty;
 import static java.time.Duration.ofSeconds;
 import static java.util.Objects.requireNonNull;
 
@@ -68,9 +69,19 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     private static final int DEFAULT_MIN_TTL_CACHE_SECONDS = 0;
     private static final int DEFAULT_MAX_TTL_CACHE_SECONDS = 30;
     private static final int DEFAULT_TTL_POLL_JITTER_SECONDS = 4;
+    // System property recognized by JVM: https://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html
+    // We do not support "networkaddress.cache.ttl" because it's behavior in JDK is different. It overrides the original
+    // TTL from the server and caches exactly for the specified amount of time via the property.
+    private static final String NEGATIVE_TTL_CACHE_SECONDS_PROPERTY = "networkaddress.cache.negative.ttl";
+    private static final int DEFAULT_NEGATIVE_TTL_CACHE_SECONDS;
     private static final ServiceDiscovererEvent.Status DEFAULT_MISSING_RECOREDS_STATUS = EXPIRED;
 
     static {
+        final Integer negativeCacheTtlValue = parseProperty(NEGATIVE_TTL_CACHE_SECONDS_PROPERTY);
+        DEFAULT_NEGATIVE_TTL_CACHE_SECONDS = negativeCacheTtlValue == null ? 0 :
+                // A value of -1 indicates "cache forever".
+                (negativeCacheTtlValue < 0 ? Integer.MAX_VALUE : negativeCacheTtlValue);
+
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("-D{}: {}", SKIP_BINDING_PROPERTY, getBoolean(SKIP_BINDING_PROPERTY));
             LOGGER.debug("Default local address to bind to: {}", DEFAULT_LOCAL_ADDRESS);
@@ -80,8 +91,14 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
             LOGGER.debug("Default TTL poll jitter seconds: {}", DEFAULT_TTL_POLL_JITTER_SECONDS);
             LOGGER.debug("Default TTL cache boundaries in seconds: [{}, {}]",
                     DEFAULT_MIN_TTL_CACHE_SECONDS, DEFAULT_MAX_TTL_CACHE_SECONDS);
+            LOGGER.debug("-D{}={}", NEGATIVE_TTL_CACHE_SECONDS_PROPERTY, negativeCacheTtlValue);
+            LOGGER.debug("Default negative TTL cache in seconds: {}", DEFAULT_NEGATIVE_TTL_CACHE_SECONDS);
             LOGGER.debug("Default missing records status: {}", DEFAULT_MISSING_RECOREDS_STATUS);
         }
+
+        validateTtl(DEFAULT_MIN_TTL_POLL_SECONDS, DEFAULT_MAX_TTL_POLL_SECONDS,
+                DEFAULT_MIN_TTL_CACHE_SECONDS, DEFAULT_MAX_TTL_CACHE_SECONDS,
+                DEFAULT_NEGATIVE_TTL_CACHE_SECONDS);
     }
 
     private final String id;
@@ -104,6 +121,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     private int maxTTLSeconds = DEFAULT_MAX_TTL_POLL_SECONDS;
     private int minTTLCacheSeconds = DEFAULT_MIN_TTL_CACHE_SECONDS;
     private int maxTTLCacheSeconds = DEFAULT_MAX_TTL_CACHE_SECONDS;
+    private int negativeTTLCacheSeconds = DEFAULT_NEGATIVE_TTL_CACHE_SECONDS;
     private Duration ttlJitter = ofSeconds(DEFAULT_TTL_POLL_JITTER_SECONDS);
     private int srvConcurrency = 2048;
     private boolean inactiveEventsOnError;
@@ -160,6 +178,26 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     @Override
     public DefaultDnsServiceDiscovererBuilder ttl(final int minSeconds, final int maxSeconds,
                                                   final int minCacheSeconds, final int maxCacheSeconds) {
+        ttl(minSeconds, maxSeconds, minCacheSeconds, maxCacheSeconds, DEFAULT_NEGATIVE_TTL_CACHE_SECONDS);
+        return this;
+    }
+
+    @Override
+    public DefaultDnsServiceDiscovererBuilder ttl(final int minSeconds, final int maxSeconds,
+                                                  final int minCacheSeconds, final int maxCacheSeconds,
+                                                  final int negativeTTLCacheSeconds) {
+        validateTtl(minSeconds, maxSeconds, minCacheSeconds, maxCacheSeconds, negativeTTLCacheSeconds);
+        this.minTTLSeconds = minSeconds;
+        this.maxTTLSeconds = maxSeconds;
+        this.minTTLCacheSeconds = minCacheSeconds;
+        this.maxTTLCacheSeconds = maxCacheSeconds;
+        this.negativeTTLCacheSeconds = negativeTTLCacheSeconds;
+        return this;
+    }
+
+    private static void validateTtl(final int minSeconds, final int maxSeconds,
+                                    final int minCacheSeconds, final int maxCacheSeconds,
+                                    final int negativeTTLCacheSeconds) {
         if (minSeconds <= 0 || maxSeconds < minSeconds) {
             throw new IllegalArgumentException("minSeconds: " + minSeconds + ", maxSeconds: " + maxSeconds +
                     " (expected: 0 < minSeconds <= maxSeconds)");
@@ -174,11 +212,10 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
                     " (expected: 0 <= minCacheSeconds <= minSeconds(" + minSeconds +
                     ") <= maxCacheSeconds <= maxSeconds(" + maxSeconds + "))");
         }
-        this.minTTLSeconds = minSeconds;
-        this.maxTTLSeconds = maxSeconds;
-        this.minTTLCacheSeconds = minCacheSeconds;
-        this.maxTTLCacheSeconds = maxCacheSeconds;
-        return this;
+        if (negativeTTLCacheSeconds < 0) {
+            throw new IllegalArgumentException("negativeTTLCacheSeconds: " + negativeTTLCacheSeconds +
+                    " (expected >= 0)");
+        }
     }
 
     @Override
@@ -339,11 +376,26 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     DnsClient build() {
         final DnsClient rawClient = new DefaultDnsClient(id,
                 ioExecutor == null ? globalExecutionContext().ioExecutor() : ioExecutor,
-                minTTLSeconds, maxTTLSeconds, minTTLCacheSeconds, maxTTLCacheSeconds, ttlJitter.toNanos(),
+                minTTLSeconds, maxTTLSeconds, minTTLCacheSeconds, maxTTLCacheSeconds, negativeTTLCacheSeconds,
+                ttlJitter.toNanos(),
                 srvConcurrency, inactiveEventsOnError, completeOncePreferredResolved, srvFilterDuplicateEvents,
                 srvHostNameRepeatInitialDelay, srvHostNameRepeatJitter, maxUdpPayloadSize, ndots, optResourceEnabled,
                 queryTimeout, dnsResolverAddressTypes, localAddress, dnsServerAddressStreamProvider, observer,
                 missingRecordStatus);
         return filterFactory == null ? rawClient : filterFactory.create(rawClient);
+    }
+
+    @Nullable
+    private static Integer parseProperty(final String propertyName) {
+        final String propertyValue = getProperty(propertyName);
+        if (propertyValue == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(propertyValue);
+        } catch (NumberFormatException e) {
+            // Ignore
+            return null;
+        }
     }
 }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -69,9 +69,12 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     private static final int DEFAULT_MIN_TTL_CACHE_SECONDS = 0;
     private static final int DEFAULT_MAX_TTL_CACHE_SECONDS = 30;
     private static final int DEFAULT_TTL_POLL_JITTER_SECONDS = 4;
-    // System property recognized by JVM: https://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html
-    // We do not support "networkaddress.cache.ttl" because it's behavior in JDK is different. It overrides the original
-    // TTL from the server and caches exactly for the specified amount of time via the property.
+    /**
+     * This is one of the standard <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html">
+     * Java Network Properties</a>.
+     * We do not support {@code networkaddress.cache.ttl} because it's behavior in JDK is different. It overrides the
+     * original TTL from the server and caches exactly for the specified amount of time instead of just being a max cap.
+     */
     private static final String NEGATIVE_TTL_CACHE_SECONDS_PROPERTY = "networkaddress.cache.negative.ttl";
     private static final int DEFAULT_NEGATIVE_TTL_CACHE_SECONDS;
     private static final ServiceDiscovererEvent.Status DEFAULT_MISSING_RECOREDS_STATUS = EXPIRED;
@@ -95,10 +98,6 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
             LOGGER.debug("Default negative TTL cache in seconds: {}", DEFAULT_NEGATIVE_TTL_CACHE_SECONDS);
             LOGGER.debug("Default missing records status: {}", DEFAULT_MISSING_RECOREDS_STATUS);
         }
-
-        validateTtl(DEFAULT_MIN_TTL_POLL_SECONDS, DEFAULT_MAX_TTL_POLL_SECONDS,
-                DEFAULT_MIN_TTL_CACHE_SECONDS, DEFAULT_MAX_TTL_CACHE_SECONDS,
-                DEFAULT_NEGATIVE_TTL_CACHE_SECONDS);
     }
 
     private final String id;
@@ -186,18 +185,6 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     public DefaultDnsServiceDiscovererBuilder ttl(final int minSeconds, final int maxSeconds,
                                                   final int minCacheSeconds, final int maxCacheSeconds,
                                                   final int negativeTTLCacheSeconds) {
-        validateTtl(minSeconds, maxSeconds, minCacheSeconds, maxCacheSeconds, negativeTTLCacheSeconds);
-        this.minTTLSeconds = minSeconds;
-        this.maxTTLSeconds = maxSeconds;
-        this.minTTLCacheSeconds = minCacheSeconds;
-        this.maxTTLCacheSeconds = maxCacheSeconds;
-        this.negativeTTLCacheSeconds = negativeTTLCacheSeconds;
-        return this;
-    }
-
-    private static void validateTtl(final int minSeconds, final int maxSeconds,
-                                    final int minCacheSeconds, final int maxCacheSeconds,
-                                    final int negativeTTLCacheSeconds) {
         if (minSeconds <= 0 || maxSeconds < minSeconds) {
             throw new IllegalArgumentException("minSeconds: " + minSeconds + ", maxSeconds: " + maxSeconds +
                     " (expected: 0 < minSeconds <= maxSeconds)");
@@ -216,6 +203,12 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
             throw new IllegalArgumentException("negativeTTLCacheSeconds: " + negativeTTLCacheSeconds +
                     " (expected >= 0)");
         }
+        this.minTTLSeconds = minSeconds;
+        this.maxTTLSeconds = maxSeconds;
+        this.minTTLCacheSeconds = minCacheSeconds;
+        this.maxTTLCacheSeconds = maxCacheSeconds;
+        this.negativeTTLCacheSeconds = negativeTTLCacheSeconds;
+        return this;
     }
 
     @Override

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
@@ -66,6 +66,14 @@ public class DelegatingDnsServiceDiscovererBuilder implements DnsServiceDiscover
     }
 
     @Override
+    public DnsServiceDiscovererBuilder ttl(final int minSeconds, final int maxSeconds,
+                                           final int minCacheSeconds, final int maxCacheSeconds,
+                                           final int negativeCacheSeconds) {
+        delegate = delegate.ttl(minSeconds, maxSeconds, minCacheSeconds, maxCacheSeconds, negativeCacheSeconds);
+        return this;
+    }
+
+    @Override
     public DnsServiceDiscovererBuilder ttlJitter(final Duration ttlJitter) {
         delegate = delegate.ttlJitter(ttlJitter);
         return this;

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
@@ -46,6 +46,7 @@ public interface DnsServiceDiscovererBuilder {
      * than or equal to {@code minSeconds}.
      * @return {@code this}.
      * @see #ttl(int, int, int, int)
+     * @see #ttl(int, int, int, int, int)
      */
     DnsServiceDiscovererBuilder ttl(int minSeconds, int maxSeconds);
 
@@ -72,8 +73,44 @@ public interface DnsServiceDiscovererBuilder {
      * than or equal to {@code minCacheSeconds}, and less than or equal to {@code maxSeconds}.
      * @return {@code this}.
      * @see #ttl(int, int)
+     * @see #ttl(int, int, int, int, int)
      */
     DnsServiceDiscovererBuilder ttl(int minSeconds, int maxSeconds, int minCacheSeconds, int maxCacheSeconds);
+
+    /**
+     * Controls min/max TTL values that will affect polling intervals, local caching, and caching negative results.
+     * <p>
+     * The created {@link ServiceDiscoverer} polls DNS server based on TTL value of the resolved records. Min/max values
+     * help to make sure polling stays within reasonable boundaries. Too frequent DNS queries may generate too much load
+     * for the DNS server, too rare DNS queries may lead to incorrect state if the remote servers changed IPs before
+     * original TTL expired.
+     * <p>
+     * The second min/max pair controls for how long the resolved records should be cached locally. Cache is helpful in
+     * scenarios when multiple concurrent resolutions are possible for the same address: either an application runs
+     * multiple client instances for the same hostname or clients perform DNS resolutions per new connection instead of
+     * background polling.
+     *
+     * @param minSeconds The minimum about of time the result will be considered valid (in seconds), must be greater
+     * than {@code 0}.
+     * @param maxSeconds The maximum about of time the result will be considered valid (in seconds), must be greater
+     * than or equal to {@code minSeconds}.
+     * @param minCacheSeconds The minimum about of time the result will be cached locally (in seconds), must be greater
+     * than or equal to {@code 0}, and less than or equal to {@code minSeconds}.
+     * @param maxCacheSeconds The maximum about of time the result will be cached locally (in seconds), must be greater
+     * than or equal to {@code minCacheSeconds}, and less than or equal to {@code maxSeconds}.
+     * @param negativeCacheSeconds The amount of time an unsuccessful (failed) result will be cached locally (in
+     * seconds), must be greater than or equal to {@code 0}. If other overloads are used, the default value will
+     * recognize the standard Java system property {@code networkaddress.cache.negative.ttl},
+     * like {@link java.net.InetAddress} does.
+     * @return {@code this}.
+     * @see #ttl(int, int)
+     * @see #ttl(int, int, int, int)
+     */
+    default DnsServiceDiscovererBuilder ttl(int minSeconds, int maxSeconds, int minCacheSeconds, int maxCacheSeconds,
+                                            int negativeCacheSeconds) {
+        throw new UnsupportedOperationException("DnsServiceDiscovererBuilder#ttl(int, int, int, int, int) is not " +
+                "supported by " + getClass());
+    }
 
     /**
      * The jitter to apply for scheduling the next query after TTL to help spread out subsequent DNS queries.


### PR DESCRIPTION
Motivation:

Both JDK and Netty resolvers allow configuring "negative TTL" for
caching unsuccessful DNS resolutions. By default, it's configured to
0, but there is a Java system property to change it for
`java.net.InetAddress`.

Modifications:

- Add `DnsServiceDiscovererBuilder#ttl(int, int, int, int, int)`
overload that allows configuring negative TTL;
- Recognize `networkaddress.cache.negative.ttl` system property to
adjust the default value for Netty resolver;
- Log the default value at debug level;

Result:

Users can configure DNS caching for unsuccessful results.