### PR TITLE
Add `DnsServiceDiscovererBuilder.consolidateCacheSize(int)`

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -200,7 +200,7 @@ final class DefaultDnsClient implements DnsClient {
                                 // Use the same comparator as Netty uses by default.
                                 new NameServerComparator(preferredAddressType(resolvedAddressTypes).addressType())));
 
-        DnsNameResolverBuilderUtils.consolidateCacheSize(builder, consolidateCacheSize);
+        DnsNameResolverBuilderUtils.consolidateCacheSize(id, builder, consolidateCacheSize);
         if (queryTimeout != null) {
             builder.queryTimeoutMillis(queryTimeout.toMillis());
         }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021-2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,7 +139,7 @@ final class DefaultDnsClient implements DnsClient {
     private final String id;
     private boolean closed;
 
-    DefaultDnsClient(final String id, final IoExecutor ioExecutor,
+    DefaultDnsClient(final String id, final IoExecutor ioExecutor, final int consolidateCacheSize,
                      final int minTTL, final int maxTTL, final int minCacheTTL, final int maxCacheTTL,
                      final long ttlJitterNanos, final int srvConcurrency, final boolean inactiveEventsOnError,
                      final boolean completeOncePreferredResolved, final boolean srvFilterDuplicateEvents,
@@ -199,6 +199,8 @@ final class DefaultDnsClient implements DnsClient {
                         new DefaultAuthoritativeDnsServerCache(minCacheTTL, maxCacheTTL,
                                 // Use the same comparator as Netty uses by default.
                                 new NameServerComparator(preferredAddressType(resolvedAddressTypes).addressType())));
+
+        DnsNameResolverBuilderUtils.consolidateCacheSize(builder, consolidateCacheSize);
         if (queryTimeout != null) {
             builder.queryTimeoutMillis(queryTimeout.toMillis());
         }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -62,7 +62,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     private static final SocketAddress DEFAULT_LOCAL_ADDRESS =
             getBoolean(SKIP_BINDING_PROPERTY) ? null : new InetSocketAddress(0);
     private static final DnsResolverAddressTypes DEFAULT_DNS_RESOLVER_ADDRESS_TYPES = systemDefault();
-    private static final int DEFAULT_CONSOLIDATE_CACHE_SIZE = 1024;
+    static final int DEFAULT_CONSOLIDATE_CACHE_SIZE = 1024;
     private static final int DEFAULT_MIN_TTL_POLL_SECONDS = 10;
     private static final int DEFAULT_MAX_TTL_POLL_SECONDS = (int) TimeUnit.MINUTES.toSeconds(5);
     private static final int DEFAULT_MIN_TTL_CACHE_SECONDS = 0;

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021-2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     private static final SocketAddress DEFAULT_LOCAL_ADDRESS =
             getBoolean(SKIP_BINDING_PROPERTY) ? null : new InetSocketAddress(0);
     private static final DnsResolverAddressTypes DEFAULT_DNS_RESOLVER_ADDRESS_TYPES = systemDefault();
+    private static final int DEFAULT_CONSOLIDATE_CACHE_SIZE = 1024;
     private static final int DEFAULT_MIN_TTL_POLL_SECONDS = 10;
     private static final int DEFAULT_MAX_TTL_POLL_SECONDS = (int) TimeUnit.MINUTES.toSeconds(5);
     private static final int DEFAULT_MIN_TTL_CACHE_SECONDS = 0;
@@ -73,6 +74,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
             LOGGER.debug("-D{}: {}", SKIP_BINDING_PROPERTY, getBoolean(SKIP_BINDING_PROPERTY));
             LOGGER.debug("Default local address to bind to: {}", DEFAULT_LOCAL_ADDRESS);
             LOGGER.debug("Default DnsResolverAddressTypes: {}", DEFAULT_DNS_RESOLVER_ADDRESS_TYPES);
+            LOGGER.debug("Default consolidate cache size: {}", DEFAULT_CONSOLIDATE_CACHE_SIZE);
             LOGGER.debug("Default TTL poll boundaries in seconds: [{}, {}]",
                     DEFAULT_MIN_TTL_POLL_SECONDS, DEFAULT_MAX_TTL_POLL_SECONDS);
             LOGGER.debug("Default TTL cache boundaries in seconds: [{}, {}]",
@@ -97,6 +99,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     private IoExecutor ioExecutor;
     @Nullable
     private Duration queryTimeout;
+    private int consolidateCacheSize = DEFAULT_CONSOLIDATE_CACHE_SIZE;
     private int minTTLSeconds = DEFAULT_MIN_TTL_POLL_SECONDS;
     private int maxTTLSeconds = DEFAULT_MAX_TTL_POLL_SECONDS;
     private int minTTLCacheSeconds = DEFAULT_MIN_TTL_CACHE_SECONDS;
@@ -129,6 +132,15 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
             throw new IllegalArgumentException("id can not be empty");
         }
         this.id = id;
+    }
+
+    @Override
+    public DefaultDnsServiceDiscovererBuilder consolidateCacheSize(final int consolidateCacheSize) {
+        if (consolidateCacheSize < 0) {
+            throw new IllegalArgumentException("consolidateCacheSize: " + consolidateCacheSize + " (expected >= 0)");
+        }
+        this.consolidateCacheSize = consolidateCacheSize;
+        return this;
     }
 
     /**
@@ -334,7 +346,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
      */
     DnsClient build() {
         final DnsClient rawClient = new DefaultDnsClient(id,
-                ioExecutor == null ? globalExecutionContext().ioExecutor() : ioExecutor,
+                ioExecutor == null ? globalExecutionContext().ioExecutor() : ioExecutor, consolidateCacheSize,
                 minTTLSeconds, maxTTLSeconds, minTTLCacheSeconds, maxTTLCacheSeconds, ttlJitter.toNanos(),
                 srvConcurrency, inactiveEventsOnError, completeOncePreferredResolved, srvFilterDuplicateEvents,
                 srvHostNameRepeatInitialDelay, srvHostNameRepeatJitter, maxUdpPayloadSize, ndots, optResourceEnabled,

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
@@ -53,6 +53,12 @@ public class DelegatingDnsServiceDiscovererBuilder implements DnsServiceDiscover
     }
 
     @Override
+    public DnsServiceDiscovererBuilder consolidateCacheSize(final int consolidateCacheSize) {
+        delegate = delegate.consolidateCacheSize(consolidateCacheSize);
+        return this;
+    }
+
+    @Override
     public DnsServiceDiscovererBuilder ttl(final int minSeconds, final int maxSeconds) {
         delegate = delegate.ttl(minSeconds, maxSeconds);
         return this;

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsNameResolverBuilderUtils.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsNameResolverBuilderUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
+import static java.lang.invoke.MethodType.methodType;
+
+final class DnsNameResolverBuilderUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DnsNameResolverBuilderUtils.class);
+
+    @Nullable
+    private static final MethodHandle CONSOLIDATE_CACHE_SIZE;
+
+    static {
+        MethodHandle consolidateCacheSize;
+        try {
+            // Find a new method that exists only in Netty starting from 4.1.88.Final:
+            // https://github.com/netty/netty/commit/d010e63bf5bf744f2ab6d0fc4386611efe7954e6
+            consolidateCacheSize = MethodHandles.publicLookup()
+                    .findVirtual(DnsNameResolverBuilder.class, "consolidateCacheSize",
+                            methodType(DnsNameResolverBuilder.class, int.class));
+            // Verify the method is working as expected:
+            consolidateCacheSize(consolidateCacheSize, new DnsNameResolverBuilder(), 1);
+        } catch (Throwable cause) {
+            LOGGER.debug("DnsNameResolverBuilder#consolidateCacheSize(int) is available only starting from " +
+                            "Netty 4.1.88.Final. Detected Netty version: {}",
+                    DnsNameResolverBuilder.class.getPackage().getImplementationVersion(), cause);
+            consolidateCacheSize = null;
+        }
+        CONSOLIDATE_CACHE_SIZE = consolidateCacheSize;
+    }
+
+    private DnsNameResolverBuilderUtils() {
+        // No instances
+    }
+
+    private static DnsNameResolverBuilder consolidateCacheSize(final MethodHandle consolidateCacheSize,
+                                                               final DnsNameResolverBuilder builder,
+                                                               final int maxNumConsolidation) {
+        try {
+            // invokeExact requires return type cast to match the type signature
+            return (DnsNameResolverBuilder) consolidateCacheSize.invokeExact(builder, maxNumConsolidation);
+        } catch (Throwable t) {
+            throwException(t);
+            return builder;
+        }
+    }
+
+    static void consolidateCacheSize(final DnsNameResolverBuilder builder, final int maxNumConsolidation) {
+        if (CONSOLIDATE_CACHE_SIZE == null) {
+            return;
+        }
+        consolidateCacheSize(CONSOLIDATE_CACHE_SIZE, builder, maxNumConsolidation);
+    }
+}

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
@@ -31,6 +31,21 @@ import javax.annotation.Nullable;
  */
 public interface DnsServiceDiscovererBuilder {
     /**
+     * Set the maximum size of the cache that is used to consolidate concurrent lookups for different hostnames.
+     * <p>
+     * This means if multiple lookups are done for the same hostname and still in-flight, only one actual query will
+     * be made and the result will be cascaded to the others.
+     *
+     * @param consolidateCacheSize The maximum number of different hostnames for consolidation of concurrent lookups, or
+     * {@code 0} if no consolidation should be performed.
+     * @return {@code this}.
+     */
+    default DnsServiceDiscovererBuilder consolidateCacheSize(int consolidateCacheSize) {
+        throw new UnsupportedOperationException("DnsServiceDiscovererBuilder#consolidateCacheSize(int) is not " +
+                "supported by " + getClass());
+    }
+
+    /**
      * Controls min/max TTL values that will influence polling intervals.
      * <p>
      * The created {@link ServiceDiscoverer} polls DNS server based on TTL value of the resolved records. Min/max values


### PR DESCRIPTION
Motivation:

Starting from Netty 4.1.88, it added a new features to consolidate all concurrent lookups for the same hostname instead of sending independent requests.

Modifications:

- Add new `DnsServiceDiscovererBuilder.consolidateCacheSize(int)` API;
- Consolidate 1024 concurrent DNS hostnames by default, log default value;

Result:

By default, up to 1024 different hostnames will consolidate concurrent lookups. Users have API to change this value, if necessary.