### PR TITLE
`NettyIoExecutors`: allow passing 0 for N of IoThreads to infer default

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyIoExecutors.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import static io.servicetalk.transport.netty.internal.NativeTransportUtils.isEpollAvailable;
 import static io.servicetalk.transport.netty.internal.NativeTransportUtils.isIoUringAvailable;
 import static io.servicetalk.transport.netty.internal.NativeTransportUtils.isKQueueAvailable;
-import static java.lang.Runtime.getRuntime;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -67,7 +66,7 @@ public final class NettyIoExecutors {
     /**
      * Create a new {@link NettyIoExecutor}.
      *
-     * @param ioThreads number of threads.
+     * @param ioThreads number of threads or {@code 0} (zero) to use the default value.
      * @return The created {@link IoExecutor}
      */
     public static EventLoopAwareNettyIoExecutor createIoExecutor(int ioThreads) {
@@ -77,7 +76,7 @@ public final class NettyIoExecutors {
     /**
      * Create a new {@link NettyIoExecutor}.
      *
-     * @param ioThreads number of threads.
+     * @param ioThreads number of threads or {@code 0} (zero) to use the default value.
      * @param threadNamePrefix the name prefix used for the created {@link Thread}s.
      * @return The created {@link IoExecutor}
      */
@@ -95,21 +94,20 @@ public final class NettyIoExecutors {
      */
     public static <T extends Thread & IoThread> EventLoopAwareNettyIoExecutor createIoExecutor(
             IoThreadFactory<T> threadFactory) {
-        return createIoExecutor(getRuntime().availableProcessors() * 2, threadFactory);
+        return createIoExecutor(0, threadFactory);
     }
 
     /**
      * Create a new {@link NettyIoExecutor}.
      *
      * @param <T> Type of the IO thread instances created by factory.
-     * @param ioThreads number of threads.
+     * @param ioThreads number of threads or {@code 0} (zero) to use the default value.
      * @param threadFactory the {@link IoThreadFactory} to use. If possible you should use an instance of
      * {@link NettyIoThreadFactory} as it allows internal optimizations.
      * @return The created {@link IoExecutor}
      */
     public static <T extends Thread & IoThread> EventLoopAwareNettyIoExecutor createIoExecutor(
             int ioThreads, IoThreadFactory<T> threadFactory) {
-        validateIoThreads(ioThreads);
         return new EventLoopGroupIoExecutor(createEventLoopGroup(ioThreads, threadFactory), true, true);
     }
 
@@ -193,7 +191,7 @@ public final class NettyIoExecutors {
     }
 
     private static void validateIoThreads(final int ioThreads) {
-        if (ioThreads <= 0) {
+        if (ioThreads < 0) {
             throw new IllegalArgumentException("ioThreads: " + ioThreads + " (expected >0)");
         }
     }

--- a/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
+++ b/servicetalk-transport-netty/src/main/java/io/servicetalk/transport/netty/NettyIoExecutors.java
@@ -32,7 +32,7 @@ public final class NettyIoExecutors {
      * Creates a new {@link IoExecutor} with the specified number of {@code ioThreads}.
      *
      * @param <T> Type of the IO thread instances created by factory.
-     * @param ioThreads number of threads.
+     * @param ioThreads number of threads or {@code 0} (zero) to use the default value.
      * @param threadFactory the {@link IoThreadFactory} to use.
      * @return The created {@link IoExecutor}
      */
@@ -44,7 +44,7 @@ public final class NettyIoExecutors {
     /**
      * Creates a new {@link IoExecutor} with the specified number of {@code ioThreads}.
      *
-     * @param ioThreads number of threads.
+     * @param ioThreads number of threads or {@code 0} (zero) to use the default value.
      * @return The created {@link IoExecutor}
      */
     public static IoExecutor createIoExecutor(int ioThreads) {
@@ -75,7 +75,7 @@ public final class NettyIoExecutors {
     /**
      * Creates a new {@link IoExecutor} with the specified number of {@code ioThreads}.
      *
-     * @param ioThreads number of threads.
+     * @param ioThreads number of threads or {@code 0} (zero) to use the default value.
      * @param threadNamePrefix the name prefix used for the created {@link Thread}s.
      * @return The created {@link IoExecutor}
      */


### PR DESCRIPTION
Motivation:

Netty's `MultithreadEventLoopGroup` already has a logic to identify the default number of EventLoop threads and exposes system properties to influence these numbers. Users of Netty based frameworks expect these properties to be taken into account:
- `io.netty.eventLoopThreads`
- `io.netty.availableProcessors`

Modifications:

- Allow users to pass `0` (zero) to `NettyIoExecutors.createIoExecutor`, which is recognized by Netty as a special value that considers system properties;

Result:

Users can use Netty's system properties to influence default Netty behavior for number of EvenLoop threads.