### PR TITLE
Do not fail IoUring test on older CI systems

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/IoUringTest.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.concurrent.internal.TestTimeoutConstants;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpResponse;
@@ -70,7 +69,7 @@ class IoUringTest {
         EventLoopAwareNettyIoExecutor ioUringExecutor = null;
         try {
             IoUringUtils.tryIoUring(true);
-            assumeTrue(TestTimeoutConstants.CI || IoUringUtils.isAvailable(), "io_uring is unavailable on " +
+            assumeTrue(IoUringUtils.isAvailable(), "io_uring is unavailable on " +
                     System.getProperty("os.name") + ' ' + System.getProperty("os.version"));
             IOUring.ensureAvailability();
 


### PR DESCRIPTION
Motivation:

Currently, the ioUringIsAvailableOnLinux test assumes that if when run under CI, the kernel version is always up to par with what netty needs to get IoUring enabled. This assumption might not always hold true, so allow to skip the test gracefully when CI has an older kernel version instead of failing the test suite.