### PR TITLE
Publisher[retry|repeat] operators demand management if onNext throws

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2253,15 +2253,10 @@ public abstract class Publisher<T> {
      * <ul>
      *     <li>{@code true} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will be
      *     caught, cancel the {@link Subscription}, propagate a {@link Subscriber#onError(Throwable)} downstream, and
-     *     no retry will be attempted. <b>Unless you are sure all downstream operators consume the
-     *     {@link Subscriber#onNext(Object)} this option SHOULD be used</b>. Otherwise, the outstanding demand counting
-     *     in this operator will be incorrect and may lead to a "hang" (e.g. this operator thinks demand has been
-     *     consumed downstream so won't request it upstream after the retry, but if not all downstream operators see the
-     *     signal because one before threw, they may wait for a signal they requested but will never be delivered).</li>
+     *     no retry will be attempted.</li>
      *     <li>{@code false} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will NOT
-     *     be caught and will propagate upstream. Use with caution as this may lead to incorrect demand accounting and
-     *     "hang" (see above). Example use case where this option makes sense is if the last {@link Subscriber} is
-     *     the only one expected to throw and demand is correctly accounted.</li>
+     *     be caught and will propagate upstream. May lead to incorrect demand accounting and "hangs" if this operator
+     *     isn't the last in the chain.</li>
      * </ul>
      * @param shouldRetry {@link BiIntPredicate} that given the retry count and the most recent {@link Throwable}
      * emitted from this {@link Publisher} determines if the operation should be retried.
@@ -2365,15 +2360,10 @@ public abstract class Publisher<T> {
      * <ul>
      *     <li>{@code true} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will be
      *     caught, cancel the {@link Subscription}, propagate a {@link Subscriber#onError(Throwable)} downstream, and
-     *     no retry will be attempted. <b>Unless you are sure all downstream operators consume the
-     *     {@link Subscriber#onNext(Object)} this option SHOULD be used</b>. Otherwise, the outstanding demand counting
-     *     in this operator will be incorrect and may lead to a "hang" (e.g. this operator thinks demand has been
-     *     consumed downstream so won't request it upstream after the retry, but if not all downstream operators see the
-     *     signal because one before threw, they may wait for a signal they requested but will never be delivered).</li>
+     *     no retry will be attempted.</li>
      *     <li>{@code false} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will NOT
-     *     be caught and will propagate upstream. Use with caution as this may lead to incorrect demand accounting and
-     *     "hang" (see above). Example use case where this option makes sense is if the last {@link Subscriber} is
-     *     the only one expected to throw and demand is correctly accounted.</li>
+     *     be caught and will propagate upstream. May lead to incorrect demand accounting and "hangs" if this operator
+     *     isn't the last in the chain.</li>
      * </ul>
      * @param retryWhen {@link BiIntFunction} that given the retry count and the most recent {@link Throwable} emitted
      * from this {@link Publisher} returns a {@link Completable}. If this {@link Completable} emits an error, that error
@@ -2438,15 +2428,10 @@ public abstract class Publisher<T> {
      * <ul>
      *     <li>{@code true} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will be
      *     caught, cancel the {@link Subscription}, propagate a {@link Subscriber#onError(Throwable)} downstream, and
-     *     no retry will be attempted. <b>Unless you are sure all downstream operators consume the
-     *     {@link Subscriber#onNext(Object)} this option SHOULD be used</b>. Otherwise, the outstanding demand counting
-     *     in this operator will be incorrect and may lead to a "hang" (e.g. this operator thinks demand has been
-     *     consumed downstream so won't request it upstream after the retry, but if not all downstream operators see the
-     *     signal because one before threw, they may wait for a signal they requested but will never be delivered).</li>
+     *     no retry will be attempted.</li>
      *     <li>{@code false} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will NOT
-     *     be caught and will propagate upstream. Use with caution as this may lead to incorrect demand accounting and
-     *     "hang" (see above). Example use case where this option makes sense is if the last {@link Subscriber} is
-     *     the only one expected to throw and demand is correctly accounted.</li>
+     *     be caught and will propagate upstream. May lead to incorrect demand accounting and "hangs" if this operator
+     *     isn't the last in the chain.</li>
      * </ul>
      * @param shouldRepeat {@link IntPredicate} that given the repeat count determines if the operation should be
      * repeated.
@@ -2523,15 +2508,10 @@ public abstract class Publisher<T> {
      * <ul>
      *     <li>{@code true} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will be
      *     caught, cancel the {@link Subscription}, propagate a {@link Subscriber#onError(Throwable)} downstream, and
-     *     no retry will be attempted. <b>Unless you are sure all downstream operators consume the
-     *     {@link Subscriber#onNext(Object)} this option SHOULD be used</b>. Otherwise, the outstanding demand counting
-     *     in this operator will be incorrect and may lead to a "hang" (e.g. this operator thinks demand has been
-     *     consumed downstream so won't request it upstream after the retry, but if not all downstream operators see the
-     *     signal because one before threw, they may wait for a signal they requested but will never be delivered).</li>
+     *     no retry will be attempted.</li>
      *     <li>{@code false} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will NOT
-     *     be caught and will propagate upstream. Use with caution as this may lead to incorrect demand accounting and
-     *     "hang" (see above). Example use case where this option makes sense is if the last {@link Subscriber} is
-     *     the only one expected to throw and demand is correctly accounted.</li>
+     *     be caught and will propagate upstream. May lead to incorrect demand accounting and "hangs" if this operator
+     *     isn't the last in the chain.</li>
      * </ul>
      * @param repeatWhen {@link IntFunction} that given the repeat count returns a {@link Completable}.
      * If this {@link Completable} emits an error repeat is terminated, otherwise, original {@link Publisher} is

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2205,20 +2205,74 @@ public abstract class Publisher<T> {
      *         }
      *     }
      * }</pre>
-     *
      * @param shouldRetry {@link BiIntPredicate} that given the retry count and the most recent {@link Throwable}
-     * emitted from this
-     * {@link Publisher} determines if the operation should be retried.
+     * emitted from this {@link Publisher} determines if the operation should be retried.
      * @return A {@link Publisher} that emits all items from this {@link Publisher} and re-subscribes if an error is
      * emitted if the passed {@link BiIntPredicate} returned {@code true}.
-     *
      * @see <a href="https://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
+     * @see #retry(boolean, BiIntPredicate)
      */
     public final Publisher<T> retry(BiIntPredicate<Throwable> shouldRetry) {
-        return new RedoPublisher<>(this,
+        return retry(false, shouldRetry);
+    }
+
+    /**
+     * Re-subscribes to this {@link Publisher} if an error is emitted and the passed {@link BiIntPredicate} returns
+     * {@code true}.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
+     *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
+     * This method provides a means to retry an operation under certain failure conditions and in sequential programming
+     * is similar to:
+     * <pre>{@code
+     *     public List<T> execute() {
+     *         List<T> results = ...;
+     *         return execute(0, results);
+     *     }
+     *
+     *     private List<T> execute(int attempts, List<T> results) {
+     *         try {
+     *             Iterator<T> itr = resultOfThisPublisher();
+     *             while (itr.hasNext()) {
+     *                 T t = itr.next(); // Any iteration with the Iterator may throw
+     *                 results.add(t);
+     *             }
+     *             return results;
+     *         } catch (Throwable cause) {
+     *             if (!terminateOnNextException && shouldRetry.apply(attempts + 1, cause)) {
+     *                 return execute(attempts + 1, results);
+     *             } else {
+     *                 throw cause;
+     *             }
+     *         }
+     *     }
+     * }</pre>
+     * @param terminateOnNextException
+     * <ul>
+     *     <li>{@code true} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will be
+     *     caught, cancel the {@link Subscription}, propagate a {@link Subscriber#onError(Throwable)} downstream, and
+     *     no retry will be attempted. <b>Unless you are sure all downstream operators consume the
+     *     {@link Subscriber#onNext(Object)} this option SHOULD be used</b>. Otherwise, the outstanding demand counting
+     *     in this operator will be incorrect and may lead to a "hang" (e.g. this operator thinks demand has been
+     *     consumed downstream so won't request it upstream after the retry, but if not all downstream operators see the
+     *     signal because one before threw, they may wait for a signal they requested but will never be delivered).</li>
+     *     <li>{@code false} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will NOT
+     *     be caught and will propagate upstream. Use with caution as this may lead to incorrect demand accounting and
+     *     "hang" (see above). Example use case where this option makes sense is if the last {@link Subscriber} is
+     *     the only one expected to throw and demand is correctly accounted.</li>
+     * </ul>
+     * @param shouldRetry {@link BiIntPredicate} that given the retry count and the most recent {@link Throwable}
+     * emitted from this {@link Publisher} determines if the operation should be retried.
+     * @return A {@link Publisher} that emits all items from this {@link Publisher} and re-subscribes if an error is
+     * emitted if the passed {@link BiIntPredicate} returned {@code true}.
+     * @see <a href="https://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
+     */
+    public final Publisher<T> retry(boolean terminateOnNextException, BiIntPredicate<Throwable> shouldRetry) {
+        return new RedoPublisher<>(this, terminateOnNextException,
                 (retryCount, terminalNotification) -> terminalNotification.cause() != null &&
-                        shouldRetry.test(retryCount, terminalNotification.cause())
-        );
+                        shouldRetry.test(retryCount, terminalNotification.cause()));
     }
 
     /**
@@ -2256,23 +2310,83 @@ public abstract class Publisher<T> {
      *         }
      *     }
      * }</pre>
-     *
      * @param retryWhen {@link BiIntFunction} that given the retry count and the most recent {@link Throwable} emitted
      * from this {@link Publisher} returns a {@link Completable}. If this {@link Completable} emits an error, that error
      * is emitted from the returned {@link Publisher}, otherwise, original {@link Publisher} is re-subscribed when this
      * {@link Completable} completes.
      * @return A {@link Publisher} that emits all items from this {@link Publisher} and re-subscribes if an error is
      * emitted and {@link Completable} returned by {@link BiIntFunction} completes successfully.
-     *
      * @see <a href="https://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
+     * @see #retryWhen(boolean, BiIntFunction)
      */
     public final Publisher<T> retryWhen(BiIntFunction<Throwable, ? extends Completable> retryWhen) {
-        return new RedoWhenPublisher<>(this, (retryCount, notification) -> {
-            if (notification.cause() == null) {
-                return completed();
-            }
-            return retryWhen.apply(retryCount, notification.cause());
-        }, true);
+        return retryWhen(false, retryWhen);
+    }
+
+    /**
+     * Re-subscribes to this {@link Publisher} if an error is emitted and the {@link Completable} returned by the
+     * supplied {@link BiIntFunction} completes successfully. If the returned {@link Completable} emits an error, the
+     * returned {@link Publisher} terminates with that error.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
+     *   {@code retryWhen((i, cause) -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
+     * This method provides a means to retry an operation under certain failure conditions in an asynchronous fashion
+     * and in sequential programming is similar to:
+     * <pre>{@code
+     *     public List<T> execute() {
+     *         List<T> results = ...;
+     *         return execute(0, results);
+     *     }
+     *
+     *     private List<T> execute(int attempts, List<T> results) {
+     *         try {
+     *             Iterator<T> itr = resultOfThisPublisher();
+     *             while (itr.hasNext()) {
+     *                 T t = itr.next(); // Any iteration with the Iterator may throw
+     *                 results.add(t);
+     *             }
+     *             return results;
+     *         } catch (Throwable cause) {
+     *             if (terminateOnNextException) {
+     *               throw cause;
+     *             }
+     *             try {
+     *                 shouldRetry.apply(attempts + 1, cause); // Either throws or completes normally
+     *                 execute(attempts + 1, results);
+     *             } catch (Throwable ignored) {
+     *                 throw cause;
+     *             }
+     *         }
+     *     }
+     * }</pre>
+     * @param terminateOnNextException
+     * <ul>
+     *     <li>{@code true} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will be
+     *     caught, cancel the {@link Subscription}, propagate a {@link Subscriber#onError(Throwable)} downstream, and
+     *     no retry will be attempted. <b>Unless you are sure all downstream operators consume the
+     *     {@link Subscriber#onNext(Object)} this option SHOULD be used</b>. Otherwise, the outstanding demand counting
+     *     in this operator will be incorrect and may lead to a "hang" (e.g. this operator thinks demand has been
+     *     consumed downstream so won't request it upstream after the retry, but if not all downstream operators see the
+     *     signal because one before threw, they may wait for a signal they requested but will never be delivered).</li>
+     *     <li>{@code false} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will NOT
+     *     be caught and will propagate upstream. Use with caution as this may lead to incorrect demand accounting and
+     *     "hang" (see above). Example use case where this option makes sense is if the last {@link Subscriber} is
+     *     the only one expected to throw and demand is correctly accounted.</li>
+     * </ul>
+     * @param retryWhen {@link BiIntFunction} that given the retry count and the most recent {@link Throwable} emitted
+     * from this {@link Publisher} returns a {@link Completable}. If this {@link Completable} emits an error, that error
+     * is emitted from the returned {@link Publisher}, otherwise, original {@link Publisher} is re-subscribed when this
+     * {@link Completable} completes.
+     * @return A {@link Publisher} that emits all items from this {@link Publisher} and re-subscribes if an error is
+     * emitted and {@link Completable} returned by {@link BiIntFunction} completes successfully.
+     * @see <a href="https://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
+     */
+    public final Publisher<T> retryWhen(boolean terminateOnNextException,
+                                        BiIntFunction<Throwable, ? extends Completable> retryWhen) {
+        return new RedoWhenPublisher<>(this, true, terminateOnNextException, (retryCount, notification) ->
+                notification.cause() == null ? completed() : retryWhen.apply(retryCount, notification.cause()));
     }
 
     /**
@@ -2292,19 +2406,57 @@ public abstract class Publisher<T> {
      *     } while (shouldRepeat.test(++i));
      *     return results;
      * }</pre>
-     *
      * @param shouldRepeat {@link IntPredicate} that given the repeat count determines if the operation should be
      * repeated.
      * @return A {@link Publisher} that emits all items from this {@link Publisher} and re-subscribes when it completes
      * if the passed {@link IntPredicate} returns {@code true}.
-     *
      * @see <a href="https://reactivex.io/documentation/operators/repeat.html">ReactiveX repeat operator.</a>
+     * @see #repeat(boolean, IntPredicate)
      */
     public final Publisher<T> repeat(IntPredicate shouldRepeat) {
-        return new RedoPublisher<>(this,
-                (repeatCount, terminalNotification) -> terminalNotification.cause() == null &&
-                        shouldRepeat.test(repeatCount)
-        );
+        return repeat(false, shouldRepeat);
+    }
+
+    /**
+     * Re-subscribes to this {@link Publisher} when it completes and the passed {@link IntPredicate} returns
+     * {@code true}.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
+     * This method provides a means to repeat an operation multiple times and in sequential programming is similar to:
+     * <pre>{@code
+     *     List<T> results = new ...;
+     *     int i = 0;
+     *     do {
+     *         results.addAll(resultOfThisPublisher());
+     *     } while (shouldRepeat.test(++i));
+     *     return results;
+     * }</pre>
+     * @param terminateOnNextException
+     * <ul>
+     *     <li>{@code true} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will be
+     *     caught, cancel the {@link Subscription}, propagate a {@link Subscriber#onError(Throwable)} downstream, and
+     *     no retry will be attempted. <b>Unless you are sure all downstream operators consume the
+     *     {@link Subscriber#onNext(Object)} this option SHOULD be used</b>. Otherwise, the outstanding demand counting
+     *     in this operator will be incorrect and may lead to a "hang" (e.g. this operator thinks demand has been
+     *     consumed downstream so won't request it upstream after the retry, but if not all downstream operators see the
+     *     signal because one before threw, they may wait for a signal they requested but will never be delivered).</li>
+     *     <li>{@code false} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will NOT
+     *     be caught and will propagate upstream. Use with caution as this may lead to incorrect demand accounting and
+     *     "hang" (see above). Example use case where this option makes sense is if the last {@link Subscriber} is
+     *     the only one expected to throw and demand is correctly accounted.</li>
+     * </ul>
+     * @param shouldRepeat {@link IntPredicate} that given the repeat count determines if the operation should be
+     * repeated.
+     * @return A {@link Publisher} that emits all items from this {@link Publisher} and re-subscribes when it completes
+     * if the passed {@link IntPredicate} returns {@code true}.
+     * @see <a href="https://reactivex.io/documentation/operators/repeat.html">ReactiveX repeat operator.</a>
+     */
+    public final Publisher<T> repeat(boolean terminateOnNextException, IntPredicate shouldRepeat) {
+        return new RedoPublisher<>(this, terminateOnNextException, (repeatCount, terminalNotification) ->
+                terminalNotification.cause() == null && shouldRepeat.test(repeatCount));
     }
 
     /**
@@ -2331,22 +2483,67 @@ public abstract class Publisher<T> {
      *     }
      *     return results;
      * }</pre>
-     *
      * @param repeatWhen {@link IntFunction} that given the repeat count returns a {@link Completable}.
      * If this {@link Completable} emits an error repeat is terminated, otherwise, original {@link Publisher} is
      * re-subscribed when this {@link Completable} completes.
      * @return A {@link Publisher} that emits all items from this {@link Publisher} and re-subscribes if an error is
      * emitted and {@link Completable} returned by {@link IntFunction} completes successfully.
-     *
      * @see <a href="https://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
+     * @see #repeatWhen(boolean, IntFunction)
      */
     public final Publisher<T> repeatWhen(IntFunction<? extends Completable> repeatWhen) {
-        return new RedoWhenPublisher<>(this, (retryCount, notification) -> {
-            if (notification.cause() != null) {
-                return completed();
-            }
-            return repeatWhen.apply(retryCount);
-        }, false);
+        return repeatWhen(false, repeatWhen);
+    }
+
+    /**
+     * Re-subscribes to this {@link Publisher} when it completes and the {@link Completable} returned by the supplied
+     * {@link IntFunction} completes successfully. If the returned {@link Completable} emits an error, the returned
+     * {@link Publisher} is completed.
+     * <pre>
+     * This method may result in a {@link StackOverflowError} if too many consecutive calls are made. This can be
+     * avoided by trampolining the call stack onto an {@link Executor}. For example:
+     *   {@code repeatWhen(i -> i % 10 == 0 ? executor.submit(() -> { }) : Completable.completed())}
+     * </pre>
+     * This method provides a means to repeat an operation multiple times when in an asynchronous fashion and in
+     * sequential programming is similar to:
+     * <pre>{@code
+     *     List<T> results = new ...;
+     *     int i = 0;
+     *     while (true) {
+     *         results.addAll(resultOfThisPublisher());
+     *         try {
+     *             repeatWhen.apply(++i); // Either throws or completes normally
+     *         } catch (Throwable cause) {
+     *             break;
+     *         }
+     *     }
+     *     return results;
+     * }</pre>
+     * @param terminateOnNextException
+     * <ul>
+     *     <li>{@code true} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will be
+     *     caught, cancel the {@link Subscription}, propagate a {@link Subscriber#onError(Throwable)} downstream, and
+     *     no retry will be attempted. <b>Unless you are sure all downstream operators consume the
+     *     {@link Subscriber#onNext(Object)} this option SHOULD be used</b>. Otherwise, the outstanding demand counting
+     *     in this operator will be incorrect and may lead to a "hang" (e.g. this operator thinks demand has been
+     *     consumed downstream so won't request it upstream after the retry, but if not all downstream operators see the
+     *     signal because one before threw, they may wait for a signal they requested but will never be delivered).</li>
+     *     <li>{@code false} means that exceptions thrown from downstream {@link Subscriber#onNext(Object)} will NOT
+     *     be caught and will propagate upstream. Use with caution as this may lead to incorrect demand accounting and
+     *     "hang" (see above). Example use case where this option makes sense is if the last {@link Subscriber} is
+     *     the only one expected to throw and demand is correctly accounted.</li>
+     * </ul>
+     * @param repeatWhen {@link IntFunction} that given the repeat count returns a {@link Completable}.
+     * If this {@link Completable} emits an error repeat is terminated, otherwise, original {@link Publisher} is
+     * re-subscribed when this {@link Completable} completes.
+     * @return A {@link Publisher} that emits all items from this {@link Publisher} and re-subscribes if an error is
+     * emitted and {@link Completable} returned by {@link IntFunction} completes successfully.
+     * @see <a href="https://reactivex.io/documentation/operators/retry.html">ReactiveX retry operator.</a>
+     */
+    public final Publisher<T> repeatWhen(boolean terminateOnNextException,
+                                         IntFunction<? extends Completable> repeatWhen) {
+        return new RedoWhenPublisher<>(this, false, terminateOnNextException, (retryCount, notification) ->
+                notification.cause() != null ? completed() : repeatWhen.apply(retryCount));
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
@@ -54,6 +54,13 @@ final class RedoPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
     }
 
     abstract static class AbstractRedoSubscriber<T> implements Subscriber<T> {
+        /**
+         * Unless you are sure all downstream operators consume the {@link Subscriber#onNext(Object)} this option
+         * SHOULD be {@code true}. Otherwise, the outstanding demand counting in this operator will be incorrect and may
+         * lead to a "hang" (e.g. this operator thinks demand has been consumed downstream so won't request it upstream
+         * after the retry, but if not all downstream operators see the signal because one before threw, they may wait
+         * for a signal they requested but will never be delivered).
+         */
         private final boolean terminateOnNextException;
         private final SequentialSubscription subscription;
         private boolean terminated;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RedoPublisher.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
+import io.servicetalk.concurrent.internal.ConcurrentSubscription;
 import io.servicetalk.concurrent.internal.TerminalNotification;
 import io.servicetalk.context.api.ContextMap;
 
@@ -23,6 +24,7 @@ import java.util.function.IntPredicate;
 
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 
 /**
  * {@link Publisher} to do {@link Publisher#repeat(IntPredicate)} and {@link Publisher#retry(BiIntPredicate)}
@@ -31,12 +33,14 @@ import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
  * @param <T> Type of items emitted from this {@link Publisher}.
  */
 final class RedoPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
-
+    private final boolean terminateOnNextException;
     private final Publisher<T> original;
     private final BiPredicate<Integer, TerminalNotification> shouldRedo;
 
-    RedoPublisher(Publisher<T> original, BiPredicate<Integer, TerminalNotification> shouldRedo) {
+    RedoPublisher(Publisher<T> original, boolean terminateOnNextException,
+                  BiPredicate<Integer, TerminalNotification> shouldRedo) {
         this.original = original;
+        this.terminateOnNextException = terminateOnNextException;
         this.shouldRedo = shouldRedo;
     }
 
@@ -45,16 +49,20 @@ final class RedoPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
                          AsyncContextProvider contextProvider) {
         // For the current subscribe operation we want to use contextMap directly, but in the event a re-subscribe
         // operation occurs we want to restore the original state of the AsyncContext map, so we save a copy upfront.
-        original.delegateSubscribe(new RedoSubscriber<>(new SequentialSubscription(), 0, subscriber, contextMap.copy(),
-                contextProvider, this), contextMap, contextProvider);
+        original.delegateSubscribe(new RedoSubscriber<>(terminateOnNextException, new SequentialSubscription(), 0,
+                subscriber, contextMap.copy(), contextProvider, this), contextMap, contextProvider);
     }
 
     abstract static class AbstractRedoSubscriber<T> implements Subscriber<T> {
-        final SequentialSubscription subscription;
+        private final boolean terminateOnNextException;
+        private final SequentialSubscription subscription;
+        private boolean terminated;
         final Subscriber<? super T> subscriber;
         int redoCount;
 
-        AbstractRedoSubscriber(SequentialSubscription subscription, int redoCount, Subscriber<? super T> subscriber) {
+        AbstractRedoSubscriber(boolean terminateOnNextException, SequentialSubscription subscription, int redoCount,
+                               Subscriber<? super T> subscriber) {
+            this.terminateOnNextException = terminateOnNextException;
             this.subscription = subscription;
             this.redoCount = redoCount;
             this.subscriber = subscriber;
@@ -63,6 +71,11 @@ final class RedoPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
         @Override
         public final void onSubscribe(Subscription s) {
             s = decorate(s);
+            if (terminateOnNextException) {
+                // ConcurrentSubscription because if exception is thrown from downstream onNext we invoke cancel which
+                // may introduce concurrency on the subscription.
+                s = ConcurrentSubscription.wrap(s);
+            }
             // Downstream Subscriber only gets one Subscription but every time we re-subscribe we switch the current
             // Subscription in SequentialSubscription to the new Subscription. This will make sure that we always
             // request from the "current" Subscription.
@@ -75,8 +88,55 @@ final class RedoPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
             }
         }
 
+        @Override
+        public final void onNext(T t) {
+            if (terminated) {
+                return;
+            }
+            subscription.itemReceived();
+            try {
+                subscriber.onNext(t);
+            } catch (Throwable cause) {
+                handleOnNextException(cause);
+            }
+        }
+
+        @Override
+        public final void onError(Throwable cause) {
+            if (terminated) {
+                return;
+            }
+            onError0(cause);
+        }
+
+        @Override
+        public final void onComplete() {
+            if (terminated) {
+                return;
+            }
+            onComplete0();
+        }
+
+        abstract void onComplete0();
+
+        abstract void onError0(Throwable cause);
+
         Subscription decorate(Subscription s) {
             return s;
+        }
+
+        private void handleOnNextException(Throwable cause) {
+            if (!terminateOnNextException) {
+                throwException(cause);
+            } else if (terminated) { // just in case on-next delivered a terminal in re-entry fashion
+                return;
+            }
+            terminated = true;
+            try {
+                subscription.cancel();
+            } finally {
+                subscriber.onError(cause);
+            }
         }
     }
 
@@ -85,28 +145,22 @@ final class RedoPublisher<T> extends AbstractNoHandleSubscribePublisher<T> {
         private final ContextMap contextMap;
         private final AsyncContextProvider contextProvider;
 
-        RedoSubscriber(SequentialSubscription subscription, int redoCount, Subscriber<? super T> subscriber,
-                       ContextMap contextMap, AsyncContextProvider contextProvider,
+        RedoSubscriber(boolean terminateOnNextException, SequentialSubscription subscription, int redoCount,
+                       Subscriber<? super T> subscriber, ContextMap contextMap, AsyncContextProvider contextProvider,
                        RedoPublisher<T> redoPublisher) {
-            super(subscription, redoCount, subscriber);
+            super(terminateOnNextException, subscription, redoCount, subscriber);
             this.redoPublisher = redoPublisher;
             this.contextMap = contextMap;
             this.contextProvider = contextProvider;
         }
 
         @Override
-        public void onNext(T t) {
-            subscription.itemReceived();
-            subscriber.onNext(t);
-        }
-
-        @Override
-        public void onError(Throwable t) {
+        void onError0(Throwable t) {
             tryRedo(TerminalNotification.error(t));
         }
 
         @Override
-        public void onComplete() {
+        void onComplete0() {
             tryRedo(complete());
         }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferTest.java
@@ -656,7 +656,7 @@ class PublisherBufferTest {
         AtomicInteger counter = new AtomicInteger();
         toSource(defer(() -> from(counter.incrementAndGet()))
                 .whenOnNext(items::add)
-                .retry((i, t) -> i < 3 && t == DELIBERATE_EXCEPTION)
+                .retry(false, (i, t) -> i < 3 && t == DELIBERATE_EXCEPTION)
                 .buffer(new TestBufferStrategy(bPublisher, 1)))
                 .subscribe(new Subscriber<Integer>() {
                     @Override

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -317,7 +317,7 @@ final class DefaultDnsClient implements DnsClient {
                                 srvFilterDups(returnPub, availableAddresses, srvEvent.address().port()) :
                                 returnPub.map(ev -> mapEventList(ev, inetAddress ->
                                         new InetSocketAddress(inetAddress, srvEvent.address().port())));
-                    }).retryWhen((i, cause) -> {
+                    }).retryWhen(false, (i, cause) -> {
                         assertInEventloop();
                         // If this error is because the SRV entry was detected as inactive, then propagate the error and
                         // don't retry. Otherwise this is a resolution exception (e.g. UnknownHostException), and retry.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -752,7 +752,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
         @Override
         public Publisher<Collection<E>> discover(final U u) {
-            return delegate().discover(u).retryWhen(retryStrategy);
+            // terminateOnNextException false -> LB is after this operator, if LB throws do best effort retry.
+            return delegate().discover(u).retryWhen(false, retryStrategy);
         }
     }
 


### PR DESCRIPTION
Motivation:
Publisher `retry*` and `repeat*` operators need to persist outstanding demand between "re-do" operations. Otherwise the downstream Subscriber will have requested signals, but they won't be requested from the new async source after switching. If a downstream operator (or Subscriber) throws from onNext the retry/repeat operator has to decrement demand to avoid violating the Reactive Streams specification (no more than request(n) amount of onNext(..)), but downstream Subscribers that didn't see the onNext (because an earlier operator threw) will be hung waiting for request(n) that will never be delivered.

Modifications:
- Publisher[retry|repeat] introduce a flag to determine if downstream onNext throwing should be terminal. This mode should be used unless it is known the onNext signal always makes it to the last Subscriber and its request(n) accounting can tolerate the exception it throws.