### PR TITLE
Publisher scanWith enhancements

### DIFF
--- a/servicetalk-concurrent-api/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-concurrent-api/gradle/checkstyle/suppressions.xml
@@ -23,4 +23,5 @@
     files="docs[\\/]modules[\\/]ROOT[\\/]assets[\\/]images[\\/].+\.svg"/>
   <!-- mapOnError supports re-throwing a Throwable from onError(Throwable) -->
   <suppress checks="IllegalThrowsCheck" files="io[\\/]servicetalk[\\/]concurrent[\\/]api[\\/]ScanWithMapper.java"/>
+  <suppress checks="IllegalThrowsCheck" files="io[\\/]servicetalk[\\/]concurrent[\\/]api[\\/]ScanMapper.java"/>
 </suppressions>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanLifetimeMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanLifetimeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,23 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
 
 import java.util.function.Supplier;
 
 /**
  * Provides the ability to transform (aka map) signals emitted via
- * the {@link Publisher#scanWithLifetime(Supplier)} operator, as well as the ability to cleanup state
+ * the {@link Publisher#scanWithLifetimeMapper(Supplier)} operator, as well as the ability to cleanup state
  * via {@link #afterFinally}.
  * @param <T> Type of items emitted by the {@link Publisher} this operator is applied.
  * @param <R> Type of items emitted by this operator.
- * @deprecated Use {@link ScanLifetimeMapper}.
  */
-@Deprecated
-public interface ScanWithLifetimeMapper<T, R> extends ScanWithMapper<T, R> {
+public interface ScanLifetimeMapper<T, R> extends ScanMapper<T, R> {
     /**
-     * Invoked after a terminal signal {@link PublisherSource.Subscriber#onError(Throwable)} or
-     * {@link PublisherSource.Subscriber#onComplete()} or {@link PublisherSource.Subscription#cancel()}.
-     * No further interaction will occur with the {@link ScanWithLifetimeMapper} to prevent use-after-free
+     * Invoked after a terminal signal {@link Subscriber#onError(Throwable)} or
+     * {@link Subscriber#onComplete()} or {@link Subscription#cancel()}.
+     * No further interaction will occur with the {@link ScanLifetimeMapper} to prevent use-after-free
      * on internal state.
      */
     void afterFinally();

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanMapper.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+/**
+ * Provides the ability to transform (aka map) signals emitted via the {@link Publisher#scanWithMapper(Supplier)}
+ * operator.
+ * @param <T> Type of items emitted by the {@link Publisher} this operator is applied.
+ * @param <R> Type of items emitted by this operator.
+ */
+public interface ScanMapper<T, R> {
+    /**
+     * Invoked on each {@link Subscriber#onNext(Object)} signal and maps from type {@link T} to type {@link R}.
+     * @param next The next element emitted from {@link Subscriber#onNext(Object)}.
+     * @return The result of mapping {@code next}.
+     */
+    @Nullable
+    R mapOnNext(@Nullable T next);
+
+    /**
+     * Invoked when a {@link Subscriber#onError(Throwable)} signal is received and can map the current state into an
+     * object of type {@link R} which will be emitted downstream as {@link Subscriber#onNext(Object)}, followed by
+     * a terminal signal.
+     * <p>
+     * If this method throws the exception will be propagated downstream via {@link Subscriber#onError(Throwable)}.
+     * @param cause The cause from upstream {@link Subscriber#onError(Throwable)}.
+     * @return
+     * <ul>
+     *     <li>{@code null} if no mapping is required and {@code cause} is propagated to
+     *     {@link Subscriber#onError(Throwable)}</li>
+     *     <li>non-{@code null} will propagate {@link MappedTerminal#onNext()} to {@link Subscriber#onNext(Object)}
+     *     then will terminate with {@link MappedTerminal#terminal()}</li>
+     * </ul>
+     * @throws Throwable If an exception occurs, which will be propagated downstream via
+     * {@link Subscriber#onError(Throwable)}.
+     */
+    @Nullable
+    MappedTerminal<R> mapOnError(Throwable cause) throws Throwable;
+
+    /**
+     * Invoked when a {@link Subscriber#onComplete()} signal is received and can map the current state into an
+     * object of type {@link R} which will be emitted downstream as {@link Subscriber#onNext(Object)}, followed by
+     * a terminal signal.
+     * <p>
+     * If this method throws the exception will be propagated downstream via {@link Subscriber#onError(Throwable)}.
+     * @return
+     * <ul>
+     *     <li>{@code null} if no mapping is required and {@code cause} is propagated to
+     *     {@link Subscriber#onError(Throwable)}</li>
+     *     <li>non-{@code null} will propagate {@link MappedTerminal#onNext()} to {@link Subscriber#onNext(Object)}
+     *     then will terminate with {@link MappedTerminal#terminal()}</li>
+     * </ul>
+     * @throws Throwable If an exception occurs, which will be propagated downstream via
+     * {@link Subscriber#onError(Throwable)}.
+     */
+    @Nullable
+    MappedTerminal<R> mapOnComplete() throws Throwable;
+
+    /**
+     * Result of a mapping operation of a terminal signal.
+     * @param <R> The mapped result type.
+     */
+    interface MappedTerminal<R> {
+        /**
+         * Get the signal to be delivered to {@link Subscriber#onNext(Object)} if {@link #onNextValid()}.
+         * @return the signal to be delivered to {@link Subscriber#onNext(Object)} if {@link #onNextValid()}.
+         */
+        @Nullable
+        R onNext();
+
+        /**
+         * Determine if {@link #onNext()} is valid and should be propagated downstream.
+         * @return {@code true} to propagate {@link #onNext()}, {@code false} will only propagate {@link #terminal()}.
+         */
+        boolean onNextValid();
+
+        /**
+         * The terminal event to propagate.
+         * @return
+         * <ul>
+         *     <li>{@code null} means {@link Subscriber#onComplete()}</li>
+         *     <li>non-{@code null} will propagate as {@link Subscriber#onError(Throwable)}</li>
+         * </ul>
+         */
+        @Nullable
+        Throwable terminal();
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithMapper.java
@@ -24,7 +24,9 @@ import javax.annotation.Nullable;
  * Provides the ability to transform (aka map) signals emitted via the {@link Publisher#scanWith(Supplier)} operator.
  * @param <T> Type of items emitted by the {@link Publisher} this operator is applied.
  * @param <R> Type of items emitted by this operator.
+ * @deprecated Use {@link ScanMapper}.
  */
+@Deprecated
 public interface ScanWithMapper<T, R> {
     /**
      * Invoked on each {@link Subscriber#onNext(Object)} signal and maps from type {@link T} to type {@link R}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ScanWithPublisher.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
+import io.servicetalk.concurrent.api.ScanMapper.MappedTerminal;
 import io.servicetalk.concurrent.internal.FlowControlUtils;
 import io.servicetalk.context.api.ContextMap;
 
@@ -31,14 +32,20 @@ import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R> {
     private final Publisher<T> original;
-    private final Supplier<? extends ScanWithMapper<? super T, ? extends R>> mapperSupplier;
+    private final Supplier<? extends ScanMapper<? super T, ? extends R>> mapperSupplier;
 
     ScanWithPublisher(Publisher<T> original, Supplier<R> initial, BiFunction<R, ? super T, R> accumulator) {
-        this(original, new SupplierScanWithMapper<>(initial, accumulator));
+        this(new SupplierScanWithMapper<>(initial, accumulator), original);
     }
 
     ScanWithPublisher(Publisher<T> original,
+                      @SuppressWarnings("deprecation")
                       Supplier<? extends ScanWithMapper<? super T, ? extends R>> mapperSupplier) {
+        this(new SupplierScanMapper<>(mapperSupplier), original);
+    }
+
+    ScanWithPublisher(Supplier<? extends ScanMapper<? super T, ? extends R>> mapperSupplier,
+                      Publisher<T> original) {
         this.mapperSupplier = requireNonNull(mapperSupplier);
         this.original = original;
     }
@@ -63,7 +70,7 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
         private static final long TERMINATED = Long.MIN_VALUE;
         private static final long TERMINAL_PENDING = TERMINATED + 1;
         /**
-         * We don't want to invoke {@link ScanWithMapper#mapOnError(Throwable)} for invalid demand because we may never
+         * We don't want to invoke {@link ScanMapper#mapOnError(Throwable)} for invalid demand because we may never
          * get enough demand to deliver an {@link #onNext(Object)} to the downstream subscriber. {@code -1} to avoid
          * {@link #demand} underflow in onNext (in case the source doesn't deliver a timely error).
          */
@@ -72,16 +79,17 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
         private final Subscriber<? super R> subscriber;
         private final ContextMap contextMap;
         private final AsyncContextProvider contextProvider;
-        private final ScanWithMapper<? super T, ? extends R> mapper;
+        private final ScanMapper<? super T, ? extends R> mapper;
         private volatile long demand;
         /**
-         * Retains the {@link #onError(Throwable)} cause for use in the {@link Subscription}.
+         * Retains the {@link MappedTerminal} cause for use in the {@link Subscription}.
          * Happens-before relationship with {@link #demand} means no volatile or other synchronization required.
          */
         @Nullable
-        private Throwable errorCause;
+        private MappedTerminal<? extends R> mappedTerminal;
 
-        ScanWithSubscriber(final Subscriber<? super R> subscriber, final ScanWithMapper<? super T, ? extends R> mapper,
+        ScanWithSubscriber(final Subscriber<? super R> subscriber,
+                           final ScanMapper<? super T, ? extends R> mapper,
                            final AsyncContextProvider contextProvider, final ContextMap contextMap) {
             this.subscriber = subscriber;
             this.contextProvider = contextProvider;
@@ -103,11 +111,8 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
                     } else if (demandUpdater.getAndAccumulate(ScanWithSubscriber.this, n,
                             FlowControlUtils::addWithOverflowProtectionIfNotNegative) == TERMINAL_PENDING) {
                         demand = TERMINATED;
-                        if (errorCause != null) {
-                            deliverOnErrorFromSubscription(errorCause, newOffloadedSubscriber());
-                        } else {
-                            deliverOnCompleteFromSubscription(newOffloadedSubscriber());
-                        }
+                        assert mappedTerminal != null;
+                        deliverAllTerminalFromSubscription(mappedTerminal, newOffloadedSubscriber());
                     } else {
                         subscription.request(n);
                     }
@@ -157,79 +162,47 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
 
         /**
          * Executes the on-error signal and returns {@code true} if demand was sufficient to deliver the result of the
-         * mapped {@code Throwable} with {@link ScanWithMapper#mapOnError(Throwable)}.
+         * mapped {@code Throwable} and terminal signal.
          *
          * @param t The throwable to propagate
          * @return {@code true} if the demand was sufficient to deliver the result of the mapped {@code Throwable} with
-         * {@link ScanWithMapper#mapOnError(Throwable)}.
+         * terminal signal.
          */
         protected boolean onError0(final Throwable t) {
-            errorCause = t;
-            final boolean doMap;
             try {
-                doMap = mapper.mapTerminal();
+                mappedTerminal = mapper.mapOnError(t);
             } catch (Throwable cause) {
                 subscriber.onError(cause);
                 return true;
             }
-            if (doMap) {
-                for (;;) {
-                    final long currDemand = demand;
-                    if (currDemand > 0 && demandUpdater.compareAndSet(this, currDemand, TERMINATED)) {
-                        deliverOnError(t, subscriber);
-                        break;
-                    } else if (currDemand == 0 && demandUpdater.compareAndSet(this, currDemand, TERMINAL_PENDING)) {
-                        return false;
-                    } else if (currDemand < 0) {
-                        // Either we previously saw invalid request n, or upstream has sent a duplicate terminal event.
-                        // In either circumstance we propagate the error downstream and bail.
-                        subscriber.onError(t);
-                        break;
-                    }
-                }
-            } else {
-                demand = TERMINATED;
-                subscriber.onError(t);
-            }
 
+            if (mappedTerminal != null) {
+                return deliverAllTerminal(mappedTerminal, subscriber, t);
+            }
+            demand = TERMINATED;
+            subscriber.onError(t);
             return true;
         }
 
         /**
          * Executes the on-completed signal and returns {@code true} if demand was sufficient to deliver the concat item
-         * from {@link ScanWithMapper#mapOnComplete()} downstream.
+         * from {@link ScanMapper#mapOnComplete()} downstream.
          *
          * @return {@code true} if demand was sufficient to deliver the concat item from
-         * {@link ScanWithMapper#mapOnComplete()} downstream.
+         * {@link ScanMapper#mapOnComplete()} downstream.
          */
         protected boolean onComplete0() {
-            final boolean doMap;
             try {
-                doMap = mapper.mapTerminal();
+                mappedTerminal = mapper.mapOnComplete();
             } catch (Throwable cause) {
                 subscriber.onError(cause);
                 return true;
             }
-            if (doMap) {
-                for (;;) {
-                    final long currDemand = demand;
-                    if (currDemand > 0 && demandUpdater.compareAndSet(this, currDemand, TERMINATED)) {
-                        deliverOnComplete(subscriber);
-                        break;
-                    } else if (currDemand == 0 && demandUpdater.compareAndSet(this, currDemand, TERMINAL_PENDING)) {
-                        return false;
-                    } else if (currDemand < 0) {
-                        // Either we previously saw invalid request n, or upstream has sent a duplicate terminal event.
-                        // In either circumstance we propagate the error downstream and bail.
-                        subscriber.onError(new IllegalStateException("onComplete with invalid demand: " + currDemand));
-                        break;
-                    }
-                }
-            } else {
-                demand = TERMINATED;
-                subscriber.onComplete();
+            if (mappedTerminal != null) {
+                return deliverAllTerminal(mappedTerminal, subscriber, null);
             }
-
+            demand = TERMINATED;
+            subscriber.onComplete();
             return true;
         }
 
@@ -237,36 +210,75 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
             //NOOP
         }
 
-        protected void deliverOnErrorFromSubscription(Throwable t, Subscriber<? super R> subscriber) {
-            deliverOnError(t, subscriber);
+        protected void deliverAllTerminalFromSubscription(final MappedTerminal<? extends R> mappedTerminal,
+                                                          final Subscriber<? super R> subscriber) {
+            deliverOnNextAndTerminal(mappedTerminal, subscriber);
         }
 
-        protected void deliverOnCompleteFromSubscription(Subscriber<? super R> subscriber) {
-            deliverOnComplete(subscriber);
+        private boolean deliverAllTerminal(final MappedTerminal<? extends R> mappedTerminal,
+                                           final Subscriber<? super R> subscriber,
+                                           @Nullable final Throwable originalCause) {
+            if (mappedTerminal.onNextValid()) {
+                for (;;) {
+                    final long currDemand = demand;
+                    if (currDemand > 0 && demandUpdater.compareAndSet(this, currDemand, TERMINATED)) {
+                        deliverOnNextAndTerminal(mappedTerminal, subscriber);
+                        break;
+                    } else if (currDemand == 0 && demandUpdater.compareAndSet(this, currDemand, TERMINAL_PENDING)) {
+                        return false;
+                    } else if (currDemand < 0) {
+                        // Either we previously saw invalid request n, or upstream has sent a duplicate terminal
+                        // event. In either circumstance we propagate the error downstream and bail.
+                        subscriber.onError(originalCause != null ? originalCause :
+                                new IllegalStateException("onComplete with invalid demand: " + currDemand));
+                        break;
+                    }
+                }
+            } else {
+                demand = TERMINATED;
+                deliverTerminal(mappedTerminal, subscriber);
+            }
+            return true;
         }
 
-        private void deliverOnError(Throwable t, Subscriber<? super R> subscriber) {
+        private void deliverTerminal(final MappedTerminal<? extends R> mappedTerminal,
+                                     final Subscriber<? super R> subscriber) {
+            final Throwable cause = mappedTerminal.terminal();
+            if (cause == null) {
+                subscriber.onComplete();
+            } else {
+                subscriber.onError(cause);
+            }
+        }
+
+        private void deliverOnNextAndTerminal(final MappedTerminal<? extends R> mappedTerminal,
+                                              final Subscriber<? super R> subscriber) {
+            assert mappedTerminal.onNextValid();
             try {
-                subscriber.onNext(mapper.mapOnError(t));
+                subscriber.onNext(mappedTerminal.onNext());
             } catch (Throwable cause) {
                 subscriber.onError(cause);
                 return;
             }
-            subscriber.onComplete();
-        }
-
-        private void deliverOnComplete(Subscriber<? super R> subscriber) {
-            try {
-                subscriber.onNext(mapper.mapOnComplete());
-            } catch (Throwable cause) {
-                subscriber.onError(cause);
-                return;
-            }
-            subscriber.onComplete();
+            deliverTerminal(mappedTerminal, subscriber);
         }
     }
 
-    private static final class SupplierScanWithMapper<T, R> implements Supplier<ScanWithMapper<T, R>> {
+    @SuppressWarnings("deprecation")
+    private static final class SupplierScanMapper<T, R> implements Supplier<ScanMapper<T, R>> {
+        private final Supplier<? extends ScanWithMapper<? super T, ? extends R>> mapperSupplier;
+
+        SupplierScanMapper(Supplier<? extends ScanWithMapper<? super T, ? extends R>> mapperSupplier) {
+            this.mapperSupplier = requireNonNull(mapperSupplier);
+        }
+
+        @Override
+        public ScanMapper<T, R> get() {
+            return new ScanMapperAdapter<>(mapperSupplier.get());
+        }
+    }
+
+    private static final class SupplierScanWithMapper<T, R> implements Supplier<ScanMapper<T, R>> {
         private final BiFunction<R, ? super T, R> accumulator;
         private final Supplier<R> initial;
 
@@ -276,8 +288,8 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
         }
 
         @Override
-        public ScanWithMapper<T, R> get() {
-            return new ScanWithMapper<T, R>() {
+        public ScanMapper<T, R> get() {
+            return new ScanMapper<T, R>() {
                 @Nullable
                 private R state = initial.get();
 
@@ -287,25 +299,72 @@ final class ScanWithPublisher<T, R> extends AbstractNoHandleSubscribePublisher<R
                     return state;
                 }
 
+                @Nullable
                 @Override
-                public R mapOnError(final Throwable cause) {
-                    throw newMapTerminalUnsupported();
+                public MappedTerminal<R> mapOnError(final Throwable cause) {
+                    return null;
                 }
 
+                @Nullable
                 @Override
-                public R mapOnComplete() {
-                    throw newMapTerminalUnsupported();
-                }
-
-                @Override
-                public boolean mapTerminal() {
-                    return false;
+                public MappedTerminal<R> mapOnComplete() {
+                    return null;
                 }
             };
         }
+    }
 
-        private static IllegalStateException newMapTerminalUnsupported() {
-            throw new IllegalStateException("mapTerminal returns false, this method should never be invoked!");
+    @SuppressWarnings("deprecation")
+    static class ScanMapperAdapter<T, R, X extends ScanWithMapper<? super T, ? extends R>>
+            implements ScanMapper<T, R> {
+        final X mapper;
+
+        ScanMapperAdapter(final X mapper) {
+            this.mapper = requireNonNull(mapper);
+        }
+
+        @Nullable
+        @Override
+        public R mapOnNext(@Nullable final T next) {
+            return mapper.mapOnNext(next);
+        }
+
+        @Nullable
+        @Override
+        public MappedTerminal<R> mapOnError(final Throwable cause) throws Throwable {
+            return mapper.mapTerminal() ? new FixedMappedTerminal<>(mapper.mapOnError(cause)) : null;
+        }
+
+        @Nullable
+        @Override
+        public MappedTerminal<R> mapOnComplete() {
+            return mapper.mapTerminal() ? new FixedMappedTerminal<>(mapper.mapOnComplete()) : null;
+        }
+    }
+
+    private static final class FixedMappedTerminal<R> implements MappedTerminal<R> {
+        @Nullable
+        private final R onNext;
+
+        private FixedMappedTerminal(@Nullable final R onNext) {
+            this.onNext = onNext;
+        }
+
+        @Nullable
+        @Override
+        public R onNext() {
+            return onNext;
+        }
+
+        @Override
+        public boolean onNextValid() {
+            return true;
+        }
+
+        @Nullable
+        @Override
+        public Throwable terminal() {
+            return null;
         }
     }
 }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithLifetimeTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithLifetimeTckTest.java
@@ -16,7 +16,7 @@
 package io.servicetalk.concurrent.reactivestreams.tck;
 
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.ScanWithLifetimeMapper;
+import io.servicetalk.concurrent.api.ScanLifetimeMapper;
 
 import org.testng.annotations.Test;
 
@@ -28,11 +28,7 @@ import static java.lang.String.valueOf;
 public class PublisherScanWithLifetimeTckTest extends AbstractPublisherOperatorTckTest<String> {
     @Override
     protected Publisher<String> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.scanWithLifetime(() -> new ScanWithLifetimeMapper<Integer, String>() {
-            @Override
-            public void afterFinally() {
-            }
-
+        return publisher.scanWithLifetimeMapper(() -> new ScanLifetimeMapper<Integer, String>() {
             @Nullable
             @Override
             public String mapOnNext(@Nullable final Integer next) {
@@ -41,19 +37,18 @@ public class PublisherScanWithLifetimeTckTest extends AbstractPublisherOperatorT
 
             @Nullable
             @Override
-            public String mapOnError(final Throwable cause) throws Throwable {
+            public MappedTerminal<String> mapOnError(final Throwable cause) {
                 return null;
             }
 
             @Nullable
             @Override
-            public String mapOnComplete() {
+            public MappedTerminal<String> mapOnComplete() {
                 return null;
             }
 
             @Override
-            public boolean mapTerminal() {
-                return false;
+            public void afterFinally() {
             }
         });
     }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithMapperTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherScanWithMapperTckTest.java
@@ -16,7 +16,7 @@
 package io.servicetalk.concurrent.reactivestreams.tck;
 
 import io.servicetalk.concurrent.api.Publisher;
-import io.servicetalk.concurrent.api.ScanWithMapper;
+import io.servicetalk.concurrent.api.ScanMapper;
 
 import org.testng.annotations.Test;
 
@@ -28,7 +28,7 @@ import static java.lang.String.valueOf;
 public class PublisherScanWithMapperTckTest extends AbstractPublisherOperatorTckTest<String> {
     @Override
     protected Publisher<String> composePublisher(Publisher<Integer> publisher, int elements) {
-        return publisher.scanWith(() -> new ScanWithMapper<Integer, String>() {
+        return publisher.scanWithMapper(() -> new ScanMapper<Integer, String>() {
             @Nullable
             @Override
             public String mapOnNext(@Nullable final Integer next) {
@@ -37,19 +37,14 @@ public class PublisherScanWithMapperTckTest extends AbstractPublisherOperatorTck
 
             @Nullable
             @Override
-            public String mapOnError(final Throwable cause) {
+            public MappedTerminal<String> mapOnError(final Throwable cause) {
                 return null;
             }
 
             @Nullable
             @Override
-            public String mapOnComplete() {
+            public MappedTerminal<String> mapOnComplete() {
                 return null;
-            }
-
-            @Override
-            public boolean mapTerminal() {
-                return false;
             }
         });
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -188,7 +188,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
                     // requests with non-replayable messageBody
                     flatRequest = Single.<Object>succeeded(request).concatDeferSubscribe(messageBody);
                     if (shouldAppendTrailers(connectionContext().protocol(), request)) {
-                        flatRequest = flatRequest.scanWith(HeaderUtils::appendTrailersMapper);
+                        flatRequest = flatRequest.scanWithMapper(HeaderUtils::appendTrailersMapper);
                     }
                 }
                 addRequestTransferEncodingIfNecessary(request);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -429,7 +429,7 @@ final class NettyHttpServer {
                 } else {
                     flatResponse = Single.<Object>succeeded(response).concatPropagateCancel(messageBody);
                     if (shouldAppendTrailers(protocolVersion, response)) {
-                        flatResponse = flatResponse.scanWith(HeaderUtils::appendTrailersMapper);
+                        flatResponse = flatResponse.scanWithMapper(HeaderUtils::appendTrailersMapper);
                     }
                 }
                 addResponseTransferEncodingIfNecessary(response, requestMethod);


### PR DESCRIPTION
Motivation:
Publisher scanWith operators only allow a limited set of
mapped terminal transformations. Use cases like mapping
state and preserving the onError Throwable aren't possible.

Modifications:
- Introduce ScanMapper and ScanLifetimeMapper which
support MappedTerminal that allows all the terminal combinations
to be mapped.
- Deprecate ScanWithMapper and ScanWithLifetimeMapper in favor of
these new APIs.
- Deprecate Publisher.scanWith and Publisher.scanWithLiftime in
favor of the new extension operators.