### PR TITLE
Publisher[retry|repeat] change default exception handling mode

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -2213,7 +2213,7 @@ public abstract class Publisher<T> {
      * @see #retry(boolean, BiIntPredicate)
      */
     public final Publisher<T> retry(BiIntPredicate<Throwable> shouldRetry) {
-        return retry(false, shouldRetry);
+        return retry(true, shouldRetry);
     }
 
     /**
@@ -2315,7 +2315,7 @@ public abstract class Publisher<T> {
      * @see #retryWhen(boolean, BiIntFunction)
      */
     public final Publisher<T> retryWhen(BiIntFunction<Throwable, ? extends Completable> retryWhen) {
-        return retryWhen(false, retryWhen);
+        return retryWhen(true, retryWhen);
     }
 
     /**
@@ -2404,7 +2404,7 @@ public abstract class Publisher<T> {
      * @see #repeat(boolean, IntPredicate)
      */
     public final Publisher<T> repeat(IntPredicate shouldRepeat) {
-        return repeat(false, shouldRepeat);
+        return repeat(true, shouldRepeat);
     }
 
     /**
@@ -2477,7 +2477,7 @@ public abstract class Publisher<T> {
      * @see #repeatWhen(boolean, IntFunction)
      */
     public final Publisher<T> repeatWhen(IntFunction<? extends Completable> repeatWhen) {
-        return repeatWhen(false, repeatWhen);
+        return repeatWhen(true, repeatWhen);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatTest.java
@@ -142,7 +142,7 @@ class RepeatTest {
                 // First repeat function will catch the error from onNext and propagate downstream to the second
                 // retry function. After the second repeat operator completes, this operator will trigger another repeat
                 // so we expect to see values from signals array twice.
-                .repeat(true, i -> i == 1)
+                .repeat(i -> i == 1)
                 .validateOutstandingDemand()
                 .map(t -> {
                     if (onNextCount.getAndIncrement() == 0) {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/publisher/RepeatWhenTest.java
@@ -218,7 +218,7 @@ class RepeatWhenTest {
                 // First repeat function will catch the error from onNext and propagate downstream to the second
                 // retry function. After the second repeat operator completes, this operator will trigger another repeat
                 // so we expect to see values from signals array twice.
-                .repeatWhen(true, retryFunc)
+                .repeatWhen(retryFunc)
                 .validateOutstandingDemand()
                 .map(t -> {
                     if (onNextCount.getAndIncrement() == 0) {


### PR DESCRIPTION
Motivation:
The current default mode of Publisher retry/repeat operators allows exceptions to propagate from onNext. However this may result in incorrect demand management and lead to "hangs" due to off-by-one demand (downstream subscriber requested X, but may only see X-1 if an earlier downstream subscriber threw). ReactiveStreams spec specifies that Subscriber methods are generally not expected to throw [1]. For these reasons the current default maybe unsafe and isn't commonly expected. The alternative mode makes exception handling explicit and won't result in hangs.

[1] https://github.com/reactive-streams/reactive-streams-jvm#2.13

Modifications:
- Change default mode of operation to not allow downstream exceptions to propagate upstream.