### PR TITLE
Enhance debug logging for `ReservableRequestConcurrencyControllers`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -16,10 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.client.api.ReservableRequestConcurrencyController;
-import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -101,10 +98,10 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
 
     @Override
     ReservableRequestConcurrencyController newConcurrencyController(
-            final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing) {
+            final FilterableStreamingHttpConnection connection) {
         // We set initialMaxConcurrency to 1 here because we don't know what type of connection will be created when
         // ALPN completes. The actual maxConcurrency value will be updated by the MAX_CONCURRENCY stream,
         // when we create a connection.
-        return newController(maxConcurrency, onClosing, 1);
+        return newController(connection, 1);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -16,10 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.client.api.ReservableRequestConcurrencyController;
-import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -68,7 +65,7 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
 
     @Override
     ReservableRequestConcurrencyController newConcurrencyController(
-            final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, final Completable onClosing) {
-        return newController(maxConcurrency, onClosing, DEFAULT_H2_MAX_CONCURRENCY_EVENT.event());
+            final FilterableStreamingHttpConnection connection) {
+        return newController(connection, DEFAULT_H2_MAX_CONCURRENCY_EVENT.event());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -16,10 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.ConsumableEvent;
 import io.servicetalk.client.api.ReservableRequestConcurrencyController;
-import io.servicetalk.concurrent.api.Completable;
-import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -57,8 +54,8 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
 
     @Override
     ReservableRequestConcurrencyController newConcurrencyController(
-            final Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, Completable onClosing) {
+            final FilterableStreamingHttpConnection connection) {
         assert config.h1Config() != null;
-        return newController(maxConcurrency, onClosing, config.h1Config().maxPipelinedRequests());
+        return newController(connection, config.h1Config().maxPipelinedRequests());
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamObserverTest.java
@@ -210,6 +210,11 @@ class StreamObserverTest {
                     return eventKey == MAX_CONCURRENCY_NO_OFFLOADING ? (Publisher<? extends T>) maxConcurrency :
                             delegate().transportEventStream(eventKey);
                 }
+
+                @Override
+                public String toString() {
+                    return delegate().toString();
+                }
             };
         }
 


### PR DESCRIPTION
Motivation:

Provide more visibility for `ReservableRequestConcurrencyControllers` and how it changes internal state when new events received.

Modifications:

- Pass a connection to `ReservableRequestConcurrencyControllers` to always include connectionId when logging;
- Log when retrying MaxConcurrentStreamsViolatedStacklessHttp2Exception;
- Remove logging transport events from `AbstractLBHttpConnectionFactory` because we log it in `ReservableRequestConcurrencyControllers` now;

Results:

All `ReservableRequestConcurrencyControllers` logs contain connectionId.