### PR TITLE
`DefaultDnsClient` log when resolution fails with an exception

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -778,6 +778,9 @@ final class DefaultDnsClient implements DnsClient {
             }
 
             private void cancelAndTerminate0(Throwable cause) {
+                assertInEventloop();
+                LOGGER.debug("{} subscription for {} will be cancelled and terminated with an error.",
+                        DefaultDnsClient.this, AbstractDnsPublisher.this, cause);
                 try {
                     cancel0();
                 } finally {


### PR DESCRIPTION
Motivation:

If DNS resolution fails with an exception, currently we log only the fact of cancelling the subscription, but we don't log what was the root cause.

Modifications:

- Log `cause` inside `cancelAndTerminate0`;

Result:

Debug logs show DNS errors.