### PR TITLE
`RetryingHttpRequesterFilter`: don't wait for LB if it's already ready

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancerReadySubscriber.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/LoadBalancerReadySubscriber.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerReadyEvent;
 import io.servicetalk.concurrent.CompletableSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
@@ -24,7 +25,6 @@ import io.servicetalk.concurrent.internal.DelayedCancellable;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 
@@ -38,13 +38,18 @@ final class LoadBalancerReadySubscriber extends DelayedCancellable implements Su
 
     /**
      * Get {@link Completable} that will complete when a {@link LoadBalancerReadyEvent} returns {@code true}
-     * from {@link LoadBalancerReadyEvent#isReady()}.
+     * from {@link LoadBalancerReadyEvent#isReady()} or {@code null} if the {@link LoadBalancer} is already ready.
+     * <p>
+     * This can happen if the {@link LoadBalancer} already signaled its {@link LoadBalancerReadyEvent ready event}, but
+     * all hosts become unhealthy later.
+     *
      * @return A {@link Completable} that will complete when a {@link LoadBalancerReadyEvent} returns {@code true}
-     * from {@link LoadBalancerReadyEvent#isReady()}.
+     * from {@link LoadBalancerReadyEvent#isReady()} or {@code null} if the {@link LoadBalancer} is already ready.
      */
-    public Completable onHostsAvailable() {
+    @Nullable
+    Completable onHostsAvailable() {
         Processor onHostsAvailable = this.onHostsAvailable;
-        return onHostsAvailable == null ? completed() : fromSource(onHostsAvailable);
+        return onHostsAvailable == null ? null : fromSource(onHostsAvailable);
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -187,6 +187,10 @@ public final class RetryingHttpRequesterFilter
                 if (loadBalancerReadySubscriber != null && t instanceof NoAvailableHostException) {
                     ++lbNotReadyCount;
                     final Completable onHostsAvailable = loadBalancerReadySubscriber.onHostsAvailable();
+                    if (onHostsAvailable == null) {
+                        // Exit from the retrying loop if the LB is ready, but we keep getting NoAvailableHostException.
+                        return failed(t);
+                    }
                     return sdStatus == null ? onHostsAvailable : onHostsAvailable.ambWith(sdStatus);
                 }
 


### PR DESCRIPTION
Motivation:

`NoAvailableHostException` can be thrown when either LB is not ready yet or when it's already ready, but all hosts turned into unhealthy state. In this case, there is no need to wait for "ready" event, because the `onHostsAvailable` completable is already completed.

Modifications:
- `LoadBalancerReadySubscriber` returns `null` if it's already "ready";
- `RetryingHttpRequesterFilter.OuterRetryStrategy` fails fast when LB is ready but we received `NoAvailableHostException`;
- Test this behavior;

Result:

We do not keep retrying when LB is already ready.