### PR TITLE
Javadoc: fix broken RFC link.

### DIFF
--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfig.java
@@ -27,7 +27,7 @@ import javax.net.ssl.SSLParameters;
 public interface ClientSslConfig extends SslConfig {
     /**
      * Get the algorithm to use for hostname verification to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * <a href="https://tools.ietf.org/html/rfc2818#section-3.1">server identity</a>.
      *
      * @return The algorithm to use when verifying the host name.
      * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfigBuilder.java
@@ -76,7 +76,7 @@ public final class ClientSslConfigBuilder extends AbstractSslConfigBuilder<Clien
 
     /**
      * Set the algorithm to use for hostname verification to verify the
-     * <a href="https://tools.ietf.org/search/rfc2818#section-3.1">server identity</a>.
+     * <a href="https://tools.ietf.org/html/rfc2818#section-3.1">server identity</a>.
      *
      * @param algorithm The algorithm to use when verifying the host name.
      * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">


### PR DESCRIPTION
`https://tools.ietf.org/search/` prefix is broken. All other Javadoc links has `https://tools.ietf.org/html/` prefix and works just fine.