### PR TITLE
Remove `gradle-pitest-plugin`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -73,7 +73,6 @@ assertJCore=3.23.1
 hamcrestVersion=2.2
 mockitoCoreVersion=4.11.0
 spotbugsPluginVersion=5.0.13
-pitestPluginVersion=1.7.4
 opentelemetryInstrumentationVersion=1.9.2-alpha
 
 apacheDirectoryServerVersion=1.5.7

--- a/servicetalk-gradle-plugin-internal/plugin-config.gradle
+++ b/servicetalk-gradle-plugin-internal/plugin-config.gradle
@@ -22,7 +22,6 @@ dependencies {
   implementation gradleApi()
   implementation localGroovy()
   implementation "com.github.spotbugs.snom:spotbugs-gradle-plugin:$props.spotbugsPluginVersion"
-  implementation "info.solidsoft.gradle.pitest:gradle-pitest-plugin:$props.pitestPluginVersion"
 }
 
 gradlePlugin {

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -16,7 +16,6 @@
 package io.servicetalk.gradle.plugin.internal
 
 import com.github.spotbugs.snom.SpotBugsTask
-import info.solidsoft.gradle.pitest.PitestTask
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.Pmd
@@ -30,8 +29,6 @@ import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addQualityTask
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.createJavadocJarTask
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.createSourcesJarTask
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.locateBuildLevelConfigFile
-import static io.servicetalk.gradle.plugin.internal.Versions.PITEST_JUNIT5_PLUGIN_VERSION
-import static io.servicetalk.gradle.plugin.internal.Versions.PITEST_VERSION
 import static io.servicetalk.gradle.plugin.internal.Versions.PMD_VERSION
 import static io.servicetalk.gradle.plugin.internal.Versions.SPOTBUGS_VERSION
 import static io.servicetalk.gradle.plugin.internal.Versions.TARGET_VERSION
@@ -49,7 +46,6 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
     configureTestFixtures project
     configureTests project
     enforceCheckstyleRoot project
-    applyPitestPlugin project
     applyPmdPlugin project
     applySpotBugsPlugin project
     addQualityTask project
@@ -59,8 +55,10 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
     project.configure(project) {
       pluginManager.apply("java-library")
 
-      sourceCompatibility = TARGET_VERSION
-      targetCompatibility = TARGET_VERSION
+      java {
+        sourceCompatibility = TARGET_VERSION
+        targetCompatibility = TARGET_VERSION
+      }
 
       def javaRelease = Integer.parseInt(TARGET_VERSION.getMajorVersion())
 
@@ -242,33 +240,6 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
   private static void enforceCheckstyleRoot(Project project) {
     project.configure(project) {
       check.dependsOn checkstyleRoot
-    }
-  }
-
-  private static void applyPitestPlugin(Project project) {
-    project.configure(project) {
-      pluginManager.apply("info.solidsoft.pitest")
-
-      pitest {
-        pitestVersion = PITEST_VERSION
-        junit5PluginVersion = PITEST_JUNIT5_PLUGIN_VERSION
-      }
-
-      tasks.withType(PitestTask) {
-        timestampedReports = false
-
-        if (project.ext.isCiBuild) {
-          outputFormats = ['XML']
-        } else {
-          outputFormats = ['HTML']
-        }
-        failWhenNoMutations = false
-        verbose = false
-      }
-
-      tasks.withType(PitestTask).all {
-        group = "verification"
-      }
     }
   }
 

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
@@ -23,7 +23,5 @@ final class Versions {
   static final String CHECKSTYLE_VERSION = "9.2"
   static final String PMD_VERSION = "6.41.0"
   static final String SPOTBUGS_VERSION = "4.7.3"
-  static final String PITEST_VERSION = "1.7.4"
-  static final String PITEST_JUNIT5_PLUGIN_VERSION = "0.16"
   static final JavaVersion TARGET_VERSION = VERSION_1_8
 }


### PR DESCRIPTION
Motivation:

`gradle-pitest-plugin` is not an official plugin. Its latest version was released in Nov 2022. Gradle 8 complains that it uses deprecated API. Since we never actually used pitest, we should consider removing it.

Modifications:

- Remove `gradle-pitest-plugin` and its configuration;
- Wrap `sourceCompatibility/targetCompatibility` with `java` block, according to the guideline here:
https://docs.gradle.org/8.2.1/userguide/upgrading_version_8.html#java_convention_deprecation

Result:

No warnings from Gradle 8 about using deprecated API.