### PR TITLE
`LingeringRoundRobinLoadBalancerTest`: adjust assertions

### DIFF
--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringRoundRobinLoadBalancerTest.java
@@ -145,6 +145,7 @@ class LingeringRoundRobinLoadBalancerTest extends RoundRobinLoadBalancerTest {
                 // Either the host was already CLOSED and removed from the usedHosts collection:
                 assertThat(thrown.getCause(),
                         either(instanceOf(NoAvailableHostException.class))
+                                .or(instanceOf(NoActiveHostException.class))
                                 // Or we selected the host and in the meantime it entered the CLOSED state:
                                 .or(instanceOf(ConnectionRejectedException.class)));
                 assertAddresses(lb.usedAddresses(), EMPTY_ARRAY);


### PR DESCRIPTION
Motivation:

`LingeringRoundRobinLoadBalancerTest.expiringAHostDoesntRaceWithConnectionAdding()` can fail with `AssertionError`, see #1859.

Modifications:
- Add `NoActiveHostException` to the list of expected exceptions;

Result:

Fixes #1859