### PR TITLE
DefaultNettyConnection.initChannel() does not work on channels that already completed a SSL handshake.

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -142,7 +142,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                     initializer.init(channel);
                     pipeline = channel.pipeline();
                     parentChannelInitializer = new DefaultH2ClientParentConnection(connection, subscriber,
-                            delayedCancellable, NettyPipelineSslUtils.isSslEnabled(pipeline),
+                            delayedCancellable, NettyPipelineSslUtils.hasPendingSslHandshake(pipeline),
                             allowDropTrailersReadFromTransport, config.headersFactory(), reqRespFactory, observer);
                 } catch (Throwable cause) {
                     close(channel, cause);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -147,7 +147,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                     pipeline = channel.pipeline();
 
                     parentChannelInitializer = new DefaultH2ServerParentConnection(connection, subscriber,
-                            delayedCancellable, NettyPipelineSslUtils.isSslEnabled(pipeline), observer);
+                            delayedCancellable, NettyPipelineSslUtils.hasPendingSslHandshake(pipeline), observer);
 
                     new H2ServerParentChannelInitializer(h2ServerConfig,
                         new io.netty.channel.ChannelInitializer<Http2StreamChannel>() {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -493,9 +493,15 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 final DelayedCancellable delayedCancellable;
                 try {
                     delayedCancellable = new DelayedCancellable();
+
+                    SSLSession existingSSLSession = extractSslSessionAndReport(channel.pipeline(),
+                            SslHandshakeCompletionEvent.SUCCESS, $ -> { }, false);
+
                     DefaultNettyConnection<Read, Write> connection = new DefaultNettyConnection<>(channel, null,
-                            executionContext, closeHandler, flushStrategy, idleTimeoutMs, protocol, sslConfig, null,
-                            null, NoopDataObserver.INSTANCE, isClient, shouldWait, identity());
+                            executionContext, closeHandler, flushStrategy, idleTimeoutMs, protocol,
+                            sslConfig, existingSSLSession,
+                            null, NoopDataObserver.INSTANCE, isClient, shouldWait,
+                            identity());
                     channel.attr(CHANNEL_CLOSEABLE_KEY).set(connection);
                     // We need the NettyToStChannelInboundHandler to be last in the pipeline. We accomplish that by
                     // calling the ChannelInitializer before we do addLast for the NettyToStChannelInboundHandler.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -506,7 +506,7 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                     initializer.init(channel);
                     ChannelPipeline pipeline = connection.channel().pipeline();
                     nettyInboundHandler = new NettyToStChannelHandler<>(connection, subscriber,
-                            delayedCancellable, NettyPipelineSslUtils.isSslEnabled(pipeline), observer);
+                            delayedCancellable, NettyPipelineSslUtils.hasPendingSslHandshake(pipeline), observer);
                 } catch (Throwable cause) {
                     close(channel, cause);
                     deliverErrorFromSource(subscriber, cause);


### PR DESCRIPTION
###  Motivation
The value of `NettyToStChannelHandler.waitForSslHandshake` is coming from `NettyPipelineSslUtils.isSslEnabled()`. When it is true, `NettyToStChannelHandler` relies on the `SslHandshakeCompletionEvent` user event, which has been sent already, to notify the subscriber. This makes it impossible to use `DefaultNettyConnection.initChannel()` to “upgrade” channels that have a `SslHandler` but already completed the handshake.

### Modifications
- Add new `NettyPipelineSslUtils.hasPendingSslHandshake()` helper function.
- `DefaultNettyConnection.initChannel()` uses `NettyPipelineSslUtils.hasPendingSslHandshake()` instead of `NettyPipelineSslUtils.isSslEnabled()`.

### Result
`DefaultNettyConnection` works with `Channel`s that already completed a SSL handshake.
