### PR TITLE
`JavaNetSoTimeoutHttpConnectionFilter`: handle zero and negative values

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
@@ -57,6 +57,7 @@ abstract class AbstractTimeoutHttpFilter implements HttpExecutionStrategyInfluen
     @Nullable
     private final Executor timeoutExecutor;
 
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     AbstractTimeoutHttpFilter(final TimeoutFromRequest timeoutForRequest, final boolean fullRequestResponse) {
         requireNonNull(timeoutForRequest, "timeoutForRequest");
         this.timeoutForRequest = (request, timeSource) -> timeoutForRequest.apply(request);
@@ -71,6 +72,7 @@ abstract class AbstractTimeoutHttpFilter implements HttpExecutionStrategyInfluen
         this.timeoutExecutor = null;
     }
 
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     AbstractTimeoutHttpFilter(final TimeoutFromRequest timeoutForRequest, final boolean fullRequestResponse,
                               final Executor timeoutExecutor) {
         requireNonNull(timeoutForRequest, "timeoutForRequest");

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpRequesterFilter.java
@@ -55,7 +55,7 @@ public final class TimeoutHttpRequesterFilter extends AbstractTimeoutHttpFilter
     /**
      * Creates a new instance which requires only that the response metadata be received before the timeout.
      *
-     * @param duration the timeout {@link Duration}
+     * @param duration the timeout {@link Duration}, must be {@code > 0}
      */
     public TimeoutHttpRequesterFilter(final Duration duration) {
         this(new FixedDuration(duration), false);
@@ -64,7 +64,7 @@ public final class TimeoutHttpRequesterFilter extends AbstractTimeoutHttpFilter
     /**
      * Creates a new instance which requires only that the response metadata be received before the timeout.
      *
-     * @param duration the timeout {@link Duration}
+     * @param duration the timeout {@link Duration}, must be {@code > 0}
      * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
      */
     public TimeoutHttpRequesterFilter(final Duration duration, final Executor timeoutExecutor) {
@@ -74,7 +74,7 @@ public final class TimeoutHttpRequesterFilter extends AbstractTimeoutHttpFilter
     /**
      * Creates a new instance.
      *
-     * @param duration the timeout {@link Duration}
+     * @param duration the timeout {@link Duration}, must be {@code > 0}
      * @param fullRequestResponse if {@code true} then timeout is for full request/response transaction otherwise only
      * the response metadata must arrive before the timeout
      */
@@ -85,7 +85,7 @@ public final class TimeoutHttpRequesterFilter extends AbstractTimeoutHttpFilter
     /**
      * Creates a new instance.
      *
-     * @param duration the timeout {@link Duration}
+     * @param duration the timeout {@link Duration}, must be {@code > 0}
      * @param fullRequestResponse if {@code true} then timeout is for full request/response transaction otherwise only
      * the response metadata must arrive before the timeout
      * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
@@ -105,7 +105,7 @@ public final class TimeoutHttpRequesterFilter extends AbstractTimeoutHttpFilter
      * the response metadata must arrive before the timeout
      * @deprecated Use {@link TimeoutHttpRequesterFilter#TimeoutHttpRequesterFilter(BiFunction, boolean)}.
      */
-    @Deprecated
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     public TimeoutHttpRequesterFilter(final TimeoutFromRequest timeoutForRequest, final boolean fullRequestResponse) {
         super(timeoutForRequest, fullRequestResponse);
     }
@@ -133,7 +133,7 @@ public final class TimeoutHttpRequesterFilter extends AbstractTimeoutHttpFilter
      * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
      * @deprecated Use {@link TimeoutHttpRequesterFilter#TimeoutHttpRequesterFilter(BiFunction, boolean, Executor)}.
      */
-    @Deprecated
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     public TimeoutHttpRequesterFilter(final TimeoutFromRequest timeoutForRequest,
                                       final boolean fullRequestResponse,
                                       final Executor timeoutExecutor) {

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/TimeoutHttpServiceFilter.java
@@ -53,7 +53,7 @@ public final class TimeoutHttpServiceFilter extends AbstractTimeoutHttpFilter
     /**
      * Creates a new instance which requires only that the response metadata be received before the timeout.
      *
-     * @param duration the timeout {@link Duration}
+     * @param duration the timeout {@link Duration}, must be {@code > 0}
      */
     public TimeoutHttpServiceFilter(Duration duration) {
         super(new FixedDuration(duration), false);
@@ -62,7 +62,7 @@ public final class TimeoutHttpServiceFilter extends AbstractTimeoutHttpFilter
     /**
      * Creates a new instance which requires only that the response metadata be received before the timeout.
      *
-     * @param duration the timeout {@link Duration}
+     * @param duration the timeout {@link Duration}, must be {@code > 0}
      * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
      */
     public TimeoutHttpServiceFilter(Duration duration, Executor timeoutExecutor) {
@@ -72,7 +72,7 @@ public final class TimeoutHttpServiceFilter extends AbstractTimeoutHttpFilter
     /**
      * Creates a new instance.
      *
-     * @param duration the timeout {@link Duration}
+     * @param duration the timeout {@link Duration}, must be {@code > 0}
      * @param fullRequestResponse if {@code true} then timeout is for full request/response transaction otherwise only
      * the response metadata must arrive before the timeout
      */
@@ -83,7 +83,7 @@ public final class TimeoutHttpServiceFilter extends AbstractTimeoutHttpFilter
     /**
      * Creates a new instance.
      *
-     * @param duration the timeout {@link Duration}
+     * @param duration the timeout {@link Duration}, must be {@code > 0}
      * @param fullRequestResponse if {@code true} then timeout is for full request/response transaction otherwise only
      * the response metadata must arrive before the timeout
      * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
@@ -101,7 +101,7 @@ public final class TimeoutHttpServiceFilter extends AbstractTimeoutHttpFilter
      * the response metadata must arrive before the timeout
      * @deprecated Use {@link TimeoutHttpServiceFilter#TimeoutHttpServiceFilter(BiFunction, boolean)}.
      */
-    @Deprecated
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     public TimeoutHttpServiceFilter(TimeoutFromRequest timeoutForRequest, boolean fullRequestResponse) {
         super(timeoutForRequest, fullRequestResponse);
     }
@@ -129,7 +129,7 @@ public final class TimeoutHttpServiceFilter extends AbstractTimeoutHttpFilter
      * @param timeoutExecutor the {@link Executor} to use for managing the timer notifications
      * @deprecated Use {@link TimeoutHttpServiceFilter#TimeoutHttpServiceFilter(BiFunction, boolean, Executor)}.
      */
-    @Deprecated
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     public TimeoutHttpServiceFilter(TimeoutFromRequest timeoutForRequest,
                                     boolean fullRequestResponse,
                                     Executor timeoutExecutor) {


### PR DESCRIPTION
Motivation:

`java.net.Socket#setSoTimeout(int)` javadoc describes that zero value results in infinite timeout and all other values must be positive. Otherwise, `IllegalArgumentException` is thrown. We should align with this contract.

Modifications:

- Clarify javadoc for `JavaNetSoTimeoutHttpConnectionFilter`;
- Handle zero and negative timeout values;
- Enhance tests;

Result:

`JavaNetSoTimeoutHttpConnectionFilter` handles values similar to `java.net.Socket`.