### PR TITLE
RetryingHttpRequesterFilter use original Publisher avoid SOOE

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1641,7 +1641,7 @@ public abstract class Completable {
      * @param context The {@link ContextMap} to use for {@link AsyncContext} when subscribed.
      * @return A {@link Completable} that will use the {@link ContextMap} for {@link AsyncContext} when subscribed.
      */
-    public final Completable shareContextOnSubscribe(ContextMap context) {
+    public final Completable setContextOnSubscribe(ContextMap context) {
         return new CompletableSetContextOnSubscribe(this, context);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1633,6 +1633,19 @@ public abstract class Completable {
     }
 
     /**
+     * Specify the {@link ContextMap} to use for {@link AsyncContext} when the returned {@link Completable} is
+     * subscribed to.
+     * <p>
+     * This operator only impacts behavior if the returned {@link Completable} is subscribed directly after this
+     * operator, that means this must be the "last operator" in the chain for this to have an impact.
+     * @param context The {@link ContextMap} to use for {@link AsyncContext} when subscribed.
+     * @return A {@link Completable} that will use the {@link ContextMap} for {@link AsyncContext} when subscribed.
+     */
+    public final Completable shareContextOnSubscribe(ContextMap context) {
+        return new CompletableSetContextOnSubscribe(this, context);
+    }
+
+    /**
      * Creates a new {@link Completable} that terminates with the result (either success or error) of either this
      * {@link Completable} or the passed {@code other} {@link Completable}, whichever terminates first. Therefore the
      * result is said to be <strong>ambiguous</strong> relative to which source it originated from. After the first

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableSetContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableSetContextOnSubscribe.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.context.api.ContextMap;
+
+import static java.util.Objects.requireNonNull;
+
+final class CompletableSetContextOnSubscribe extends AbstractNoHandleSubscribeCompletable {
+    private final Completable original;
+    private final ContextMap context;
+
+    CompletableSetContextOnSubscribe(final Completable original, ContextMap context) {
+        this.original = original;
+        this.context = requireNonNull(context);
+    }
+
+    @Override
+    ContextMap contextForSubscribe(AsyncContextProvider provider) {
+        return context;
+    }
+
+    @Override
+    void handleSubscribe(final Subscriber subscriber,
+                         final ContextMap contextMap, final AsyncContextProvider contextProvider) {
+        // This operator currently only targets the subscribe method. Given this limitation if we try to change the
+        // ContextMap now it is possible that operators downstream in the subscribe call stack may have modified
+        // the ContextMap and we don't want to discard those changes by using a different ContextMap.
+        original.handleSubscribe(subscriber, contextMap, contextProvider);
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -3775,7 +3775,7 @@ public abstract class Publisher<T> {
      * @param context The {@link ContextMap} to use for {@link AsyncContext} when subscribed.
      * @return A {@link Completable} that will use the {@link ContextMap} for {@link AsyncContext} when subscribed.
      */
-    public final Publisher<T> shareContextOnSubscribe(ContextMap context) {
+    public final Publisher<T> setContextOnSubscribe(ContextMap context) {
         return new PublisherSetContextOnSubscribe<>(this, context);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -3767,6 +3767,19 @@ public abstract class Publisher<T> {
     }
 
     /**
+     * Specify the {@link ContextMap} to use for {@link AsyncContext} when the returned {@link Publisher} is
+     * subscribed to.
+     * <p>
+     * This operator only impacts behavior if the returned {@link Publisher} is subscribed directly after this
+     * operator, that means this must be the "last operator" in the chain for this to have an impact.
+     * @param context The {@link ContextMap} to use for {@link AsyncContext} when subscribed.
+     * @return A {@link Completable} that will use the {@link ContextMap} for {@link AsyncContext} when subscribed.
+     */
+    public final Publisher<T> shareContextOnSubscribe(ContextMap context) {
+        return new PublisherSetContextOnSubscribe<>(this, context);
+    }
+
+    /**
      * <strong>This method requires advanced knowledge of building operators. Before using this method please attempt
      * to compose existing operator(s) to satisfy your use case.</strong>
      * <p>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSetContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSetContextOnSubscribe.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.context.api.ContextMap;
+
+import static java.util.Objects.requireNonNull;
+
+final class PublisherSetContextOnSubscribe<T> extends AbstractNoHandleSubscribePublisher<T> {
+    private final Publisher<T> original;
+    private final ContextMap context;
+
+    PublisherSetContextOnSubscribe(final Publisher<T> original, ContextMap context) {
+        this.original = original;
+        this.context = requireNonNull(context);
+    }
+
+    @Override
+    ContextMap contextForSubscribe(AsyncContextProvider provider) {
+        return context;
+    }
+
+    @Override
+    void handleSubscribe(final Subscriber<? super T> singleSubscriber,
+                         final ContextMap contextMap, final AsyncContextProvider contextProvider) {
+        // This operator currently only targets the subscribe method. Given this limitation if we try to change the
+        // ContextMap now it is possible that operators downstream in the subscribe call stack may have modified
+        // the ContextMap and we don't want to discard those changes by using a different ContextMap.
+        original.handleSubscribe(singleSubscriber, contextMap, contextProvider);
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1717,7 +1717,7 @@ public abstract class Single<T> {
      * @param context The {@link ContextMap} to use for {@link AsyncContext} when subscribed.
      * @return A {@link Single} that will use the {@link ContextMap} for {@link AsyncContext} when subscribed.
      */
-    public final Single<T> shareContextOnSubscribe(ContextMap context) {
+    public final Single<T> setContextOnSubscribe(ContextMap context) {
         return new SingleSetContextOnSubscribe<>(this, context);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1710,6 +1710,18 @@ public abstract class Single<T> {
     }
 
     /**
+     * Specify the {@link ContextMap} to use for {@link AsyncContext} when the returned {@link Single} is subscribed to.
+     * <p>
+     * This operator only impacts behavior if the returned {@link Single} is subscribed directly after this operator,
+     * that means this must be the "last operator" in the chain for this to have an impact.
+     * @param context The {@link ContextMap} to use for {@link AsyncContext} when subscribed.
+     * @return A {@link Single} that will use the {@link ContextMap} for {@link AsyncContext} when subscribed.
+     */
+    public final Single<T> shareContextOnSubscribe(ContextMap context) {
+        return new SingleSetContextOnSubscribe<>(this, context);
+    }
+
+    /**
      * <strong>This method requires advanced knowledge of building operators. Before using this method please attempt
      * to compose existing operator(s) to satisfy your use case.</strong>
      * <p>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleSetContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleSetContextOnSubscribe.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.context.api.ContextMap;
+
+import static java.util.Objects.requireNonNull;
+
+final class SingleSetContextOnSubscribe<T> extends AbstractNoHandleSubscribeSingle<T> {
+    private final Single<T> original;
+    private final ContextMap context;
+
+    SingleSetContextOnSubscribe(Single<T> original, ContextMap context) {
+        this.original = original;
+        this.context = requireNonNull(context);
+    }
+
+    @Override
+    ContextMap contextForSubscribe(AsyncContextProvider provider) {
+        return context;
+    }
+
+    @Override
+    void handleSubscribe(final Subscriber<? super T> singleSubscriber,
+                         final ContextMap contextMap, final AsyncContextProvider contextProvider) {
+        // This operator currently only targets the subscribe method. Given this limitation if we try to change the
+        // ContextMap now it is possible that operators downstream in the subscribe call stack may have modified
+        // the ContextMap and we don't want to discard those changes by using a different ContextMap.
+        original.handleSubscribe(singleSubscriber, contextMap, contextProvider);
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
@@ -37,7 +37,7 @@ final class BlockingToStreamingService extends AbstractServiceAdapterHolder {
                                                 final StreamingHttpRequest request,
                                                 final StreamingHttpResponseFactory responseFactory) {
         return request.toRequest().flatMap(req -> fromCallable(() -> original.handle(
-                ctx, req, ctx.responseFactory())).map(HttpResponse::toStreamingResponse));
+                ctx, req, ctx.responseFactory())).map(HttpResponse::toStreamingResponse).shareContextOnSubscribe());
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToHttpService.java
@@ -31,9 +31,8 @@ final class StreamingHttpServiceToHttpService implements HttpService {
     public Single<HttpResponse> handle(final HttpServiceContext ctx,
                                        final HttpRequest request,
                                        final HttpResponseFactory responseFactory) {
-
         return original.handle(ctx, request.toStreamingRequest(), ctx.streamingResponseFactory())
-                .flatMap(StreamingHttpResponse::toResponse);
+                .flatMap(resp -> resp.toResponse().shareContextOnSubscribe());
     }
 
     @Override


### PR DESCRIPTION
Motivation:
RetryingHttpRequesterFilter uses the request across retry operations. The request's Publisher state is shared across retries and operators applied via transformMessageBody will therefore be reapplied on each retry. This typically isn't desirable from a semantics perspective but may also lead to StackOverflowException if enough retries are attempted.

Modifications:
- RetryingHttpRequesterFilter should reuse the original Publisher for request payload body on each retry attempt.