### PR TITLE
Don't wait for handshake if it's already done when adding last handlers

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -170,6 +170,11 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         keepAliveManager.trackActiveStream(streamChannel);
     }
 
+    static boolean shouldWaitForSslHandshake(@Nullable final SSLSession sslSession,
+                                             @Nullable final SslConfig sslConfig) {
+        return sslConfig != null && sslSession == null;
+    }
+
     abstract static class AbstractH2ParentConnection extends ChannelInboundHandlerAdapter {
         final H2ParentConnectionContext parentContext;
         final boolean waitForSslHandshake;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -74,12 +74,13 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
 
     H2ParentConnectionContext(final Channel channel, final HttpExecutionContext executionContext,
                               final FlushStrategy flushStrategy, final long idleTimeoutMs,
-                              @Nullable final SslConfig sslConfig,
+                              @Nullable final SslConfig sslConfig, @Nullable final SSLSession sslSession,
                               final KeepAliveManager keepAliveManager) {
         super(channel, executionContext.executor());
         this.executionContext = channelExecutionContext(channel, executionContext);
         this.flushStrategyHolder = new FlushStrategyHolder(flushStrategy);
         this.sslConfig = sslConfig;
+        this.sslSession = sslSession;
         this.idleTimeoutMs = idleTimeoutMs;
         this.keepAliveManager = keepAliveManager;
     }
@@ -253,7 +254,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
                 if (evt instanceof SslHandshakeCompletionEvent) {
                     parentContext.sslSession = extractSslSessionAndReport(ctx.pipeline(),
                             (SslHandshakeCompletionEvent) evt, this::tryFailSubscriber,
-                            observer != NoopConnectionObserver.INSTANCE);
+                            waitForSslHandshake && observer != NoopConnectionObserver.INSTANCE);
                     tryCompleteSubscriber();
                 } else if (evt == ChannelInputShutdownReadComplete.INSTANCE || evt == SslCloseCompletionEvent.SUCCESS) {
                     parentContext.keepAliveManager.channelInputShutdown();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
@@ -69,13 +69,14 @@ public final class NettyPipelineSslUtils {
      * @param pipeline {@link ChannelPipeline} which contains a handler containing the {@link SSLSession}
      * @param connectionObserver {@link ConnectionObserver} in case the handshake status should be reported
      * @return The {@link SSLSession} or {@code null} if none can be found
+     * @throws IllegalStateException if {@link SslHandler} can not be found in the {@link ChannelPipeline}
      */
     @Nullable
     public static SSLSession extractSslSessionAndReport(@Nullable final SslConfig sslConfig,
                                                         final ChannelPipeline pipeline,
                                                         final ConnectionObserver connectionObserver) {
         if (sslConfig == null) {
-            assert noSslHandlers(pipeline);
+            assert noSslHandlers(pipeline) : "No SslConfig configured but SSL-related handler found in the pipeline";
             return null;
         }
         final SslHandler sslHandler = pipeline.get(SslHandler.class);


### PR DESCRIPTION
Motivation:

Currently, `waitForSslHandshake` flag is defined by presence of `SslHandler` in the pipeline.
However, there could be a use-case when `DefaultNettyConnection` is added after handshake
is already complete and there is no need to wait for it anymore.

Modifications:
- Deprecate `NettyPipelineSslUtils.isSslEnabled(...)`, instead introduce
`NettyPipelineSslUtils.extractSslSessionAndReport(...)` overload that can extract `SSLSession`
if the handshake is already complete and avoid `waitForSslHandshake`;
- Use the new utility in `DefaultNettyConnection`, `H2ClientParentConnectionContext`,
and `H2ServerParentConnectionContext`;
- Enhance tests to make sure behavior for all use-cases does not change;

Result:

The last handler in the pipeline does not wait for handshake if it's already done.