### PR TITLE
Enable Keep-Alive socket option by default

### DIFF
--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.transport.netty.internal.FlushStrategies.defaultFlushStrategy;
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.addOption;
+import static java.net.StandardSocketOptions.SO_KEEPALIVE;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -53,6 +54,7 @@ abstract class AbstractTcpConfig<SslConfigType> {
     private SslConfigType sslConfig;
 
     protected AbstractTcpConfig() {
+        socketOption(SO_KEEPALIVE, true);
     }
 
     protected AbstractTcpConfig(final AbstractTcpConfig<SslConfigType> from) {


### PR DESCRIPTION
Motivation
There are cases where a TCP socket can be disconnected unexpectedly (terminated without adhering to the protocol), and when there is no interaction with the socket, the staleness will not be detected. Its commonly the case where TCP keep-alive is used as a counter measure for such cases, to force the socket to get into the right term state to reflect the actual condition.

Modifications
Changed ST default to always enable Keep-Alive socket option.

Results
Expectation is to always be able to detect stale sockets in the application space, and force streams attached to these socket to react on that condition.
