### PR TITLE
Add Publisher.switchMap

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -622,8 +622,9 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                     SubscriberUtils.logDuplicateTerminal(this, t);
                     return;
                 }
-                Throwable currPendingError = parent.pendingError;
+
                 if (parent.source.maxDelayedErrors == 0) {
+                    final Throwable currPendingError = parent.pendingError;
                     if (currPendingError == null && pendingErrorUpdater.compareAndSet(parent, null, t)) {
                         try {
                             parent.doCancel(true);
@@ -633,19 +634,8 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
                         }
                     }
                 } else {
-                    if (currPendingError == null) {
-                        if (pendingErrorUpdater.compareAndSet(parent, null, t)) {
-                            currPendingError = t;
-                        } else {
-                            currPendingError = parent.pendingError;
-                            assert currPendingError != null;
-                            addPendingError(pendingErrorCountUpdater, parent,
-                                    parent.source.maxDelayedErrors, currPendingError, t);
-                        }
-                    } else {
-                        addPendingError(pendingErrorCountUpdater, parent,
-                                parent.source.maxDelayedErrors, currPendingError, t);
-                    }
+                    final Throwable currPendingError = addPendingError(pendingErrorUpdater, pendingErrorCountUpdater,
+                            parent, parent.source.maxDelayedErrors, t);
                     if (parent.removeSubscriber(this, unusedDemand)) {
                         parent.enqueueAndDrain(error(currPendingError));
                     } else {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -417,26 +417,15 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
                 cancellableSet.remove(singleCancellable);
                 singleCancellable = null;
 
-                Throwable currPendingError = pendingError;
                 if (source.maxDelayedErrors == 0) {
+                    final Throwable currPendingError = pendingError;
                     if (currPendingError == null &&
                             pendingErrorUpdater.compareAndSet(FlatMapSubscriber.this, null, t)) {
                         onError0(t, true);
                     }
                 } else {
-                    if (currPendingError == null) {
-                        if (pendingErrorUpdater.compareAndSet(FlatMapSubscriber.this, null, t)) {
-                            currPendingError = t;
-                        } else {
-                            currPendingError = pendingError;
-                            assert currPendingError != null;
-                            addPendingError(pendingErrorCountUpdater, FlatMapSubscriber.this, source.maxDelayedErrors,
-                                    currPendingError, t);
-                        }
-                    } else {
-                        addPendingError(pendingErrorCountUpdater, FlatMapSubscriber.this, source.maxDelayedErrors,
-                                currPendingError, t);
-                    }
+                    final Throwable currPendingError = addPendingError(pendingErrorUpdater, pendingErrorCountUpdater,
+                            FlatMapSubscriber.this, source.maxDelayedErrors, t);
                     if (decrementActiveMappedSources()) {
                         enqueueAndDrain(error(currPendingError));
                     } else {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSwitchMap.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSwitchMap.java
@@ -196,7 +196,7 @@ final class PublisherSwitchMap<T, R> extends AbstractAsynchronousPublisherOperat
         private final class RSubscriber implements Subscriber<R> {
             volatile int state;
             @Nullable
-            private final RSubscriber prevPublisher;
+            private RSubscriber prevPublisher;
             @Nullable
             private Subscription localSubscription;
             @Nullable
@@ -210,7 +210,9 @@ final class PublisherSwitchMap<T, R> extends AbstractAsynchronousPublisherOperat
             public void onSubscribe(Subscription subscription) {
                 localSubscription = requireNonNull(subscription);
                 if (prevPublisher != null) {
-                    prevPublisher.dispose(subscription);
+                    final RSubscriber localPrev = prevPublisher;
+                    prevPublisher = null; // Set the reference to null to avoid memory leak.
+                    localPrev.dispose(subscription);
                 } else {
                     switchTo(subscription);
                 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSwitchMap.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSwitchMap.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.internal.TerminalNotification;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.CompositeExceptionUtils.addPendingError;
+import static io.servicetalk.concurrent.api.CompositeExceptionUtils.maxDelayedErrors;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.EmptySubscriptions.EMPTY_SUBSCRIPTION;
+import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
+import static io.servicetalk.concurrent.internal.TerminalNotification.error;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
+
+final class PublisherSwitchMap<T, R> extends AbstractAsynchronousPublisherOperator<T, R> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PublisherSwitchMap.class);
+    private final int maxDelayedErrors;
+    private final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+    PublisherSwitchMap(final Publisher<T> original,
+                       final boolean delayError,
+                       final Function<? super T, ? extends Publisher<? extends R>> mapper) {
+        this(original, maxDelayedErrors(delayError), mapper);
+    }
+
+    PublisherSwitchMap(final Publisher<T> original,
+                       final int maxDelayedErrors,
+                       final Function<? super T, ? extends Publisher<? extends R>> mapper) {
+        super(original);
+        if (maxDelayedErrors < 0) {
+            throw new IllegalArgumentException("maxDelayedErrors: " + maxDelayedErrors + " (expected >=0)");
+        }
+        this.maxDelayedErrors = maxDelayedErrors;
+        this.mapper = requireNonNull(mapper);
+    }
+
+    @Override
+    public Subscriber<? super T> apply(final Subscriber<? super R> subscriber) {
+        return new SwitchSubscriber<>(subscriber, this);
+    }
+
+    private static final class SwitchSubscriber<T, R> implements Subscriber<T> {
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<SwitchSubscriber.RSubscriber> stateUpdater =
+                newUpdater(SwitchSubscriber.RSubscriber.class, "state");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<SwitchSubscriber> pendingErrorCountUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(SwitchSubscriber.class, "pendingErrorCount");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<SwitchSubscriber, Throwable> pendingErrorUpdater =
+                AtomicReferenceFieldUpdater.newUpdater(SwitchSubscriber.class, Throwable.class, "pendingError");
+        private static final int INNER_STATE_IDLE = 0;
+        private static final int INNER_STATE_EMITTING = 1;
+        private static final int INNER_STATE_DISPOSED = 2;
+        private static final int INNER_STATE_COMPLETE = 3;
+        private static final int INNER_STATE_ERROR = 4;
+        private static final int OUTER_STATE_SHIFT = 3;
+        private static final int OUTER_STATE_MASK = -8;
+        private static final int INNER_STATE_MASK = ~OUTER_STATE_MASK;
+        private static final int OUTER_STATE_COMPLETE = 1;
+        private static final int OUTER_STATE_ERROR = 2;
+        private final SequentialSubscription rSubscription = new SequentialSubscription();
+        private final PublisherSwitchMap<T, R> parent;
+        private final Subscriber<? super R> target;
+        @Nullable
+        private Subscription tSubscription;
+        @Nullable
+        private RSubscriber currPublisher;
+        @SuppressWarnings("unused")
+        private volatile int pendingErrorCount;
+        @SuppressWarnings("unused")
+        @Nullable
+        private volatile Throwable pendingError;
+
+        private SwitchSubscriber(final Subscriber<? super R> target,
+                                 final PublisherSwitchMap<T, R> parent) {
+            this.target = target;
+            this.parent = parent;
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            // No need to wrap in ConcurrentSubscription because only the latest RSubscriber interacts with the
+            // tSubscription which is atomically protected by the state variable.
+            tSubscription = requireNonNull(subscription);
+            target.onSubscribe(rSubscription);
+            tSubscription.request(1);
+        }
+
+        @Override
+        public void onNext(@Nullable T t) {
+            final Publisher<? extends R> nextPub = requireNonNull(parent.mapper.apply(t),
+                    () -> "Mapper " + parent.mapper + " returned null");
+            currPublisher = new RSubscriber(currPublisher);
+            toSource(nextPub).subscribe(currPublisher);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (currPublisher != null) {
+                try {
+                    if (parent.maxDelayedErrors <= 0) {
+                        currPublisher.dispose(EMPTY_SUBSCRIPTION);
+                    }
+                } finally {
+                    final Throwable cause = outerErrorUpdateState(t);
+                    if (cause != null) {
+                        target.onError(cause);
+                    }
+                }
+            } else {
+                target.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            // If current publisher isn't null defer terminal signals to that publisher, otherwise terminate here.
+            TerminalNotification terminalNotification = complete();
+            if (currPublisher == null || (terminalNotification = outerCompleteUpdateState()) != null) {
+                terminalNotification.terminate(target);
+            }
+        }
+
+        @Nullable
+        private Throwable outerErrorUpdateState(Throwable t) {
+            assert currPublisher != null;
+            t = addPendingError(pendingErrorUpdater, pendingErrorCountUpdater, this, parent.maxDelayedErrors, t);
+            for (;;) {
+                final int cState = currPublisher.state;
+                if (stateUpdater.compareAndSet(currPublisher, cState, setOuterState(cState, OUTER_STATE_ERROR))) {
+                    final int innerState = getInnerState(cState);
+                    return parent.maxDelayedErrors <= 0 && innerState != INNER_STATE_ERROR ||
+                            (parent.maxDelayedErrors > 0 &&
+                            (innerState == INNER_STATE_ERROR || innerState == INNER_STATE_COMPLETE)) ? t : null;
+                }
+            }
+        }
+
+        @Nullable
+        private TerminalNotification outerCompleteUpdateState() {
+            assert currPublisher != null;
+            for (;;) {
+                final int cState = currPublisher.state;
+                if (stateUpdater.compareAndSet(currPublisher, cState, setOuterState(cState, OUTER_STATE_COMPLETE))) {
+                    final int innerState = getInnerState(cState);
+                    if (parent.maxDelayedErrors <= 0) {
+                        return innerState == INNER_STATE_COMPLETE ? complete() : null;
+                    } else if (innerState == INNER_STATE_ERROR || innerState == INNER_STATE_COMPLETE) {
+                        final Throwable cPendingError = pendingError;
+                        return cPendingError != null ? error(cPendingError) : complete();
+                    }
+                    return null;
+                }
+            }
+        }
+
+        private static int setOuterState(int currState, int newState) {
+            return (newState << OUTER_STATE_SHIFT) | (currState & INNER_STATE_MASK);
+        }
+
+        private static int setInnerState(int currState, int newState) {
+            return (currState & OUTER_STATE_MASK) | newState;
+        }
+
+        private static int getOuterState(int state) {
+            return state >> OUTER_STATE_SHIFT;
+        }
+
+        private static int getInnerState(int state) {
+            return state & INNER_STATE_MASK;
+        }
+
+        private final class RSubscriber implements Subscriber<R> {
+            volatile int state;
+            @Nullable
+            private final RSubscriber prevPublisher;
+            @Nullable
+            private Subscription localSubscription;
+            @Nullable
+            private Subscription nextSubscriptionIfDisposePending;
+
+            private RSubscriber(@Nullable RSubscriber prevPublisher) {
+                this.prevPublisher = prevPublisher;
+            }
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                localSubscription = requireNonNull(subscription);
+                if (prevPublisher != null) {
+                    prevPublisher.dispose(subscription);
+                } else {
+                    switchTo(subscription);
+                }
+            }
+
+            @Override
+            public void onNext(@Nullable R result) {
+                int innerState;
+                for (;;) {
+                    final int cState = state;
+                    innerState = getInnerState(cState);
+                    final int outerState = getOuterState(cState);
+                    if (outerState == OUTER_STATE_ERROR && parent.maxDelayedErrors <= 0) {
+                        return;
+                    } else if (innerState == INNER_STATE_IDLE) {
+                        if (stateUpdater.compareAndSet(this, cState, setInnerState(cState, INNER_STATE_EMITTING))) {
+                            break;
+                        }
+                    } else if (innerState == INNER_STATE_EMITTING) {
+                        // Allow reentry because we don't want to drop data.
+                        break;
+                    } else {
+                        LOGGER.debug("Disposed Subscriber ignoring signal state={} subscriber='{}' onNext='{}'",
+                                cState, SwitchSubscriber.this, result);
+                        // Only states are COMPLETED, ERROR, and DISPOSED.
+                        // DISPOSED -> Subscriber is no longer the newest subscriber, and it is OK to drop data
+                        // because the "newest"/"active" Subscriber is assumed to get the "current" state as the
+                        // first onNext signal and indicated a "switch" and downstream will do a delta between "old"
+                        // and "current" state.
+                        // COMPLETED / ERROR -> This is a terminal state, and re-try/subscribe must happen to reset
+                        // state.
+
+                        // It is OK to not call dataSubscription.itemReceived() because we won't be propagating it
+                        // downstream when we switch to a newer subscriber we want to request more items to preserve
+                        // the demand from downstream Subscription.
+                        return;
+                    }
+                }
+                try {
+                    rSubscription.itemReceived();
+                    target.onNext(result);
+                } finally {
+                    // Only attempt "unlock" if we acquired the lock, otherwise this is reentry and when the stack
+                    // unwinds the lock will be released.
+                    if (innerState == INNER_STATE_IDLE) {
+                        for (;;) {
+                            final int cState = state;
+                            innerState = getInnerState(cState);
+                            if (innerState == INNER_STATE_DISPOSED) {
+                                assert nextSubscriptionIfDisposePending != null;
+                                assert localSubscription != null;
+                                switchWhenDisposed(localSubscription, nextSubscriptionIfDisposePending);
+                            } else if (innerState == INNER_STATE_ERROR || innerState == INNER_STATE_COMPLETE ||
+                                    stateUpdater.compareAndSet(this, cState, setInnerState(cState, INNER_STATE_IDLE))) {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                Throwable currPendingError = null;
+                for (;;) {
+                    final int cState = state;
+                    final int innerState = getInnerState(cState);
+                    if (innerState == INNER_STATE_DISPOSED) {
+                        break;
+                    } else if (parent.maxDelayedErrors <= 0) {
+                        if (stateUpdater.compareAndSet(this, cState, setInnerState(cState, INNER_STATE_ERROR))) {
+                            final int outerState = getOuterState(cState);
+                            if (outerState != OUTER_STATE_ERROR) {
+                                try {
+                                    if (outerState != OUTER_STATE_COMPLETE) {
+                                        assert tSubscription != null;
+                                        tSubscription.cancel();
+                                    }
+                                } finally {
+                                    target.onError(t);
+                                }
+                            }
+                            break;
+                        }
+                    } else {
+                        if (currPendingError == null) {
+                            currPendingError = addPendingError(pendingErrorUpdater, pendingErrorCountUpdater,
+                                    SwitchSubscriber.this, parent.maxDelayedErrors, t);
+                        }
+
+                        if (stateUpdater.compareAndSet(this, cState, setInnerState(cState, INNER_STATE_ERROR))) {
+                            final int outerState = getOuterState(cState);
+                            if (outerState == OUTER_STATE_ERROR || outerState == OUTER_STATE_COMPLETE) {
+                                target.onError(currPendingError);
+                            } else {
+                                // It is possible the outer Publisher will concurrently terminate with this method and
+                                // requesting more is not necessary, but still safe (e.g. no concurrent invocation on
+                                // tSubscription or target).
+                                assert tSubscription != null;
+                                tSubscription.request(1);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                for (;;) {
+                    final int cState = state;
+                    final int innerState = getInnerState(cState);
+                    if (innerState == INNER_STATE_DISPOSED) {
+                        break;
+                    } else if (stateUpdater.compareAndSet(this, cState, setInnerState(cState, INNER_STATE_COMPLETE))) {
+                        final int outerState = getOuterState(cState);
+                        if (outerState == OUTER_STATE_COMPLETE) {
+                            target.onComplete();
+                        } else if (outerState == OUTER_STATE_ERROR && parent.maxDelayedErrors > 0) {
+                            final Throwable cause = pendingError;
+                            assert cause != null;
+                            target.onError(cause);
+                        } else if (outerState != OUTER_STATE_ERROR) {
+                            // It is possible the outer Publisher will concurrently terminate with this method and
+                            // requesting more is not necessary, but still safe (e.g. no concurrent invocation on
+                            // tSubscription or target).
+                            assert tSubscription != null;
+                            tSubscription.request(1);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            void dispose(Subscription nextSubscription) {
+                nextSubscriptionIfDisposePending = nextSubscription;
+                for (;;) {
+                    final int cState = state;
+                    final int innerState = getInnerState(cState);
+                    if (innerState == INNER_STATE_DISPOSED ||
+                            // Don't change state if no delayedErrors, and we have already terminated downstream with an
+                            // error. This prevents duplicated termination if upstream terminates with an error later.
+                            (innerState == INNER_STATE_ERROR && parent.maxDelayedErrors <= 0)) {
+                        break;
+                    } else if (stateUpdater.compareAndSet(this, cState, setInnerState(cState, INNER_STATE_DISPOSED))) {
+                        // if emitting -> onNext will handle after it is done to avoid concurrency
+                        // if idle     -> next element arrived, switch to new Publisher
+                        // if complete / error -> completed before the next element, need to switch when it arrives
+                        if (innerState != INNER_STATE_EMITTING) {
+                            assert localSubscription != null;
+                            switchWhenDisposed(localSubscription, nextSubscription);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            private void switchWhenDisposed(Subscription mySubscription, Subscription nextSubscription) {
+                try {
+                    mySubscription.cancel();
+                } finally {
+                    switchTo(nextSubscription);
+                }
+            }
+
+            private void switchTo(Subscription nextSubscription) {
+                try {
+                    rSubscription.switchTo(nextSubscription);
+                } finally {
+                    assert tSubscription != null;
+                    tSubscription.request(1);
+                }
+            }
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SwitchMapSignal.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SwitchMapSignal.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+/**
+ * A signal containing the data from a series of {@link Publisher}s switched in a serial fashion.
+ * @param <T> Type of the data.
+ * @see Publisher#switchMap(Function)
+ */
+public interface SwitchMapSignal<T> {
+    /**
+     * Returns {@code true} on the first signal from a new {@link Publisher}.
+     * @return {@code true} on the first signal from a new {@link Publisher}.
+     */
+    boolean isSwitched();
+
+    /**
+     * Get the data that was delivered to {@link Subscriber#onNext(Object)}.
+     * @return the data that was delivered to {@link Subscriber#onNext(Object)}.
+     */
+    @Nullable
+    T onNext();
+
+    /**
+     * Convert from a regular {@link Function} to a {@link Function} that emits {@link SwitchMapSignal}.
+     * <p>
+     * <b>This function has state</b>, if used in an operator chain use {@link Publisher#defer(Supplier)} so the state
+     * is unique per each subscribe.
+     * @param function The original function to convert.
+     * @param <T> The input data type.
+     * @param <R> The resulting data type.
+     * @return a {@link Function} that emits {@link SwitchMapSignal}.
+     */
+    static <T, R> Function<T, Publisher<? extends SwitchMapSignal<R>>> toSwitchFunction(
+            Function<? super T, ? extends Publisher<? extends R>> function) {
+        return new Function<T, Publisher<? extends SwitchMapSignal<R>>>() {
+            private boolean seenFirstPublisher;
+
+            @Nullable
+            @Override
+            public Publisher<? extends SwitchMapSignal<R>> apply(T t) {
+                final Publisher<? extends R> rawPublisher = function.apply(t);
+                if (rawPublisher == null) {
+                    return null;
+                }
+                final boolean localSeenFirstPublisher = seenFirstPublisher;
+                seenFirstPublisher = true;
+                if (localSeenFirstPublisher) {
+                    return Publisher.defer(() -> {
+                        final boolean[] seenOnNext = new boolean[1]; // modifiable boolean
+                        return rawPublisher.map(res -> {
+                            final boolean localSeenOnNext = seenOnNext[0];
+                            seenOnNext[0] = true;
+                            return new SwitchMapSignal<R>() {
+                                @Override
+                                public boolean isSwitched() {
+                                    return !localSeenOnNext;
+                                }
+
+                                @Nullable
+                                @Override
+                                public R onNext() {
+                                    return res;
+                                }
+                            };
+                        }).shareContextOnSubscribe();
+                    });
+                } else {
+                    return rawPublisher.map(res -> new SwitchMapSignal<R>() {
+                        @Override
+                        public boolean isSwitched() {
+                            return false;
+                        }
+
+                        @Nullable
+                        @Override
+                        public R onNext() {
+                            return res;
+                        }
+                    });
+                }
+            }
+        };
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherSwitchMapTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherSwitchMapTest.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.internal.DeliberateException;
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Publisher.empty;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.api.Publisher.never;
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.api.SwitchMapSignal.toSwitchFunction;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+final class PublisherSwitchMapTest {
+    private final TestSubscription testSubscription = new TestSubscription();
+    private final TestPublisher<Integer> publisher = new TestPublisher.Builder<Integer>()
+            .disableAutoOnSubscribe().build(sub -> {
+                sub.onSubscribe(testSubscription);
+                return sub;
+            });
+    private final TestPublisherSubscriber<SwitchMapSignal<String>> subscriber =
+            new TestPublisherSubscriber<>();
+
+    @ParameterizedTest(name = "onError={0}, delayError={1}")
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void noSignalsTerminal(boolean onError, boolean delayError) {
+        final TestPublisherSubscriber<String> subscriber = new TestPublisherSubscriber<>();
+        toSource((delayError ? publisher.<String>switchMapDelayError(i -> never()) : publisher.switchMap(i -> never())))
+                .subscribe(subscriber);
+
+        validateTerminal(publisher, subscriber, onError);
+    }
+
+    @ParameterizedTest(name = "onError={0}, delayError={1}")
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void noSwitchMultipleSignals(boolean onError, boolean delayError) throws InterruptedException {
+        final TestSubscription testSubscription2 = new TestSubscription();
+        final TestPublisher<String> publisher2 = new TestPublisher.Builder<String>()
+                .disableAutoOnSubscribe().build(sub -> {
+                    sub.onSubscribe(testSubscription2);
+                    return sub;
+                });
+
+        final int firstT = 0;
+        final String firstR = "foo";
+        final String secondR = "bar";
+        Function<Integer, Publisher<? extends SwitchMapSignal<String>>> func =
+                toSwitchFunction(i -> i == firstT ? publisher2 : never());
+        toSource(delayError ? publisher.switchMapDelayError(func) : publisher.switchMap(func))
+                .subscribe(subscriber);
+
+        subscriber.awaitSubscription().request(2);
+        testSubscription.awaitRequestN(1);
+        publisher.onNext(firstT);
+        // We want to verify cancel at the end, if the source completes we won't cancel so skip completion.
+        if (!(onError && !delayError)) {
+            publisher.onComplete();
+        }
+
+        assertThat(subscriber.pollOnNext(10, TimeUnit.MILLISECONDS), nullValue());
+
+        testSubscription2.awaitRequestN(1);
+        publisher2.onNext(firstR);
+        validateSignal(subscriber.takeOnNext(), firstR, false);
+
+        testSubscription2.awaitRequestN(2);
+        publisher2.onNext(secondR);
+        validateSignal(subscriber.takeOnNext(), secondR, false);
+
+        validateTerminal(publisher2, subscriber, onError);
+        if (onError && !delayError) {
+            testSubscription.awaitCancelled();
+        }
+    }
+
+    @ParameterizedTest(name = "onError={0}, delayError={1}")
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void multipleSwitches(boolean onError, boolean delayError) throws InterruptedException {
+        final TestSubscription testSubscription2 = new TestSubscription();
+        final TestPublisher<String> publisher2 = new TestPublisher.Builder<String>()
+                .disableAutoOnSubscribe().build(sub -> {
+                    sub.onSubscribe(testSubscription2);
+                    return sub;
+                });
+        final TestSubscription testSubscription3 = new TestSubscription();
+        final TestPublisher<String> publisher3 = new TestPublisher.Builder<String>()
+                .disableAutoOnSubscribe().build(sub -> {
+                    sub.onSubscribe(testSubscription3);
+                    return sub;
+                });
+        final TestSubscription testSubscription4 = new TestSubscription();
+        final TestPublisher<String> publisher4 = new TestPublisher.Builder<String>()
+                .disableAutoOnSubscribe().build(sub -> {
+                    sub.onSubscribe(testSubscription4);
+                    return sub;
+                });
+
+        final int firstT = 0;
+        final int secondT = 1;
+        final int thirdT = 2;
+        final String firstR = "foo";
+        final String secondR = "bar";
+        final String thirdR = "baz";
+        final String ignoredR = "IGNORED";
+        Function<Integer, Publisher<? extends SwitchMapSignal<String>>> func = toSwitchFunction(
+                i -> i == firstT ? publisher2 :
+                        i == secondT ? publisher3 :
+                                i == thirdT ? publisher4 : never());
+        toSource(delayError ? publisher.switchMapDelayError(func, 2) : publisher.switchMap(func))
+                .subscribe(subscriber);
+
+        subscriber.awaitSubscription().request(3);
+        testSubscription.awaitRequestN(1);
+        publisher.onNext(firstT);
+
+        testSubscription2.awaitRequestN(1);
+        publisher2.onNext(firstR);
+        validateSignal(subscriber.takeOnNext(), firstR, false);
+
+        // Verify that when delay error is activated, terminating a mapped publisher will keep switching to new
+        // sources and also is delivered when the source publisher terminates.
+        DeliberateException deliberateException = new DeliberateException();
+        if (delayError) {
+            publisher2.onError(deliberateException);
+        } else {
+            publisher2.onComplete();
+        }
+
+        testSubscription.awaitRequestN(2);
+        publisher.onNext(secondT);
+
+        testSubscription2.awaitCancelled();
+        testSubscription3.awaitRequestN(2);
+
+        // Don't emit any items, and assert that switch is still done
+        testSubscription.awaitRequestN(3);
+        publisher.onNext(thirdT);
+        // We want to verify cancel at the end, if the source completes we won't cancel so skip completion.
+        if (!(onError && !delayError)) {
+            publisher.onComplete();
+        }
+        testSubscription3.awaitCancelled();
+        testSubscription4.awaitRequestN(2);
+
+        // Send signals on "old" publishers that we switched from an ignore all the signals.
+        publisher3.onNext(ignoredR);
+        if (onError) {
+            publisher3.onError(new IllegalStateException("should be ignored"));
+        } else {
+            publisher3.onComplete();
+        }
+
+        publisher4.onNext(secondR, thirdR);
+        validateSignal(subscriber.takeOnNext(), secondR, true);
+        validateSignal(subscriber.takeOnNext(), thirdR, false);
+
+        if (delayError) {
+            publisher4.onError(DELIBERATE_EXCEPTION);
+            Throwable cause = subscriber.awaitOnError();
+            assertThat(cause, is(deliberateException));
+            assertThat(asList(cause.getSuppressed()), contains(DELIBERATE_EXCEPTION));
+        } else {
+            validateTerminal(publisher4, subscriber, onError);
+        }
+        if (onError && !delayError) {
+            testSubscription.awaitCancelled();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @ParameterizedTest(name = "offloadFirstDemand={0}, delayError={1}")
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void reentry(boolean offloadFirstDemand, boolean delayError) throws InterruptedException, ExecutionException {
+        final String completeSignal = "complete";
+        BlockingQueue<Object> signals = new LinkedBlockingQueue<>();
+        Executor executor = Executors.newCachedThreadExecutor();
+        try {
+            Function<Integer, Publisher<? extends SwitchMapSignal<Integer>>> func = toSwitchFunction(i -> i == 1 ?
+                    fromSource(new ReentryPublisher(100, 103)) : never());
+            Publisher<Integer> pub = from(1);
+            toSource(delayError ? pub.switchMapDelayError(func) : pub.switchMap(func)
+            ).subscribe(new PublisherSource.Subscriber<SwitchMapSignal<Integer>>() {
+                @Nullable
+                private PublisherSource.Subscription subscription;
+                private boolean seenOnNext;
+
+                @Override
+                public void onSubscribe(PublisherSource.Subscription s) {
+                    subscription = s;
+                    subscription.request(1);
+                }
+
+                @Override
+                public void onNext(@Nullable SwitchMapSignal<Integer> next) {
+                    assert subscription != null;
+                    signals.add(requireNonNull(next));
+                    final boolean localSeenOnNext = seenOnNext;
+                    seenOnNext = true;
+                    if (localSeenOnNext || !offloadFirstDemand) {
+                        subscription.request(1);
+                    } else {
+                        // SequentialSubscription will prevent reentry from onNext when invoked from switchTo, so we
+                        // offload here just to be sure reentry cases are covered.
+                        executor.execute(() -> {
+                            try {
+                                // If this task executes quickly the Publisher may see demand in its loop from
+                                // the request(n) in onSubscribe without triggering reentry from onNext.
+                                Thread.sleep(100);
+                            } catch (InterruptedException e) {
+                                throw new RuntimeException(e);
+                            }
+                            subscription.request(1);
+                        });
+                    }
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    signals.add(t);
+                }
+
+                @Override
+                public void onComplete() {
+                    signals.add(completeSignal);
+                }
+            });
+
+            Object signal = signals.take();
+            assertThat(signal, instanceOf(SwitchMapSignal.class));
+            validateSignal((SwitchMapSignal<Integer>) signal, 100, false);
+            signal = signals.take();
+            assertThat(signal, instanceOf(SwitchMapSignal.class));
+            validateSignal((SwitchMapSignal<Integer>) signal, 101, false);
+            signal = signals.take();
+            assertThat(signal, instanceOf(SwitchMapSignal.class));
+            validateSignal((SwitchMapSignal<Integer>) signal, 102, false);
+            signal = signals.take();
+            assertThat(signal, is(completeSignal));
+        } finally {
+            executor.closeAsync().toFuture().get();
+        }
+    }
+
+    @ParameterizedTest(name = "delayError={0}")
+    @ValueSource(booleans = {true, false})
+    void nullPublisher(boolean delayError) throws InterruptedException {
+        Function<Integer, Publisher<? extends SwitchMapSignal<String>>> func = toSwitchFunction(i -> null);
+        toSource(delayError ? publisher.switchMapDelayError(func) : publisher.switchMap(func))
+                .subscribe(subscriber);
+
+        subscriber.awaitSubscription().request(1);
+        testSubscription.awaitRequestN(1);
+        publisher.onNext(0);
+        assertThat(subscriber.awaitOnError(), instanceOf(NullPointerException.class));
+    }
+
+    @ParameterizedTest(name = "delayError={0}")
+    @ValueSource(booleans = {true, false})
+    void emptyPublisher(boolean delayError) throws InterruptedException {
+        Function<Integer, Publisher<? extends SwitchMapSignal<String>>> func =
+                toSwitchFunction(i -> i == 0 ? empty() : from("foo"));
+        toSource(delayError ? publisher.switchMapDelayError(func) : publisher.switchMap(func))
+                .subscribe(subscriber);
+
+        subscriber.awaitSubscription().request(1);
+        testSubscription.awaitRequestN(1);
+
+        publisher.onNext(0);
+
+        testSubscription.awaitRequestN(2);
+        publisher.onNext(1);
+
+        validateSignal(subscriber.takeOnNext(), "foo", true);
+        validateTerminal(publisher, subscriber, false);
+    }
+
+    @ParameterizedTest(name = "onError={0}")
+    @ValueSource(booleans = {true, false})
+    void delayErrorDeliverAfterOuterTerminates(boolean onError) throws InterruptedException {
+        final TestSubscription testSubscription2 = new TestSubscription();
+        final TestPublisher<String> publisher2 = new TestPublisher.Builder<String>()
+                .disableAutoOnSubscribe().build(sub -> {
+                    sub.onSubscribe(testSubscription2);
+                    return sub;
+                });
+        toSource(publisher.switchMapDelayError(toSwitchFunction(i -> publisher2), 2))
+                .subscribe(subscriber);
+
+        subscriber.awaitSubscription().request(1);
+        testSubscription.awaitRequestN(1);
+
+        publisher.onNext(0);
+        testSubscription.awaitRequestN(2);
+        DeliberateException deliberateException = new DeliberateException();
+        publisher.onError(deliberateException);
+
+        testSubscription2.awaitRequestN(1);
+        publisher2.onNext("foo");
+
+        validateSignal(subscriber.takeOnNext(), "foo", false);
+
+        if (onError) {
+            publisher2.onError(DELIBERATE_EXCEPTION);
+        } else {
+            publisher2.onComplete();
+        }
+
+        Throwable cause = subscriber.awaitOnError();
+        assertThat(cause, is(deliberateException));
+        if (onError) {
+            assertThat(asList(cause.getSuppressed()), contains(DELIBERATE_EXCEPTION));
+        }
+    }
+
+    @ParameterizedTest(name = "onError={0}")
+    @ValueSource(booleans = {true, false})
+    void nonDelayedIgnoresAfterError(boolean onError) throws InterruptedException {
+        final TestSubscription testSubscription2 = new TestSubscription();
+        final TestPublisher<String> publisher2 = new TestPublisher.Builder<String>()
+                .disableAutoOnSubscribe().build(sub -> {
+                    sub.onSubscribe(testSubscription2);
+                    return sub;
+                });
+        toSource(publisher.switchMap(toSwitchFunction(i -> publisher2)))
+                .subscribe(subscriber);
+
+        subscriber.awaitSubscription().request(1);
+        testSubscription.awaitRequestN(1);
+
+        publisher.onNext(0);
+        testSubscription.awaitRequestN(2);
+        if (onError) {
+            publisher.onError(DELIBERATE_EXCEPTION);
+        } else {
+            publisher.onComplete();
+        }
+
+        testSubscription2.awaitRequestN(1);
+        publisher2.onNext("foo");
+
+        if (!onError) {
+            validateSignal(subscriber.takeOnNext(), "foo", false);
+            publisher2.onComplete();
+        }
+
+        if (onError) {
+            assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            subscriber.awaitOnComplete();
+        }
+    }
+
+    @ParameterizedTest(name = "delayError={0}, onComplete={1} rootErrorFirst={2}")
+    @CsvSource({"true,true,true", "true,false,true", "false,true,true",
+                "true,true,false", "true,false,false", "false,true,false"})
+    void onErrorCancelMappedPublisher(boolean delayError, boolean onComplete,
+                                      boolean rootErrorFirst) throws InterruptedException {
+        final TestSubscription testSubscription2 = new TestSubscription();
+        final TestPublisher<String> publisher2 = new TestPublisher.Builder<String>()
+                .disableAutoOnSubscribe().build(sub -> {
+                    sub.onSubscribe(testSubscription2);
+                    return sub;
+                });
+
+        Function<Integer, Publisher<? extends SwitchMapSignal<String>>> func = toSwitchFunction(i -> publisher2);
+        toSource(delayError ? publisher.switchMapDelayError(func, 2) : publisher.switchMap(func))
+                .subscribe(subscriber);
+
+        subscriber.awaitSubscription().request(1);
+        testSubscription.awaitRequestN(1);
+        publisher.onNext(0);
+
+        testSubscription2.awaitRequestN(1);
+        publisher2.onNext("foo");
+        validateSignal(subscriber.takeOnNext(), "foo", false);
+
+        if (delayError) {
+            DeliberateException deliberateException = new DeliberateException();
+            if (rootErrorFirst) {
+                publisher.onError(deliberateException);
+            }
+
+            Throwable secondCause = new IllegalStateException("second exception");
+            if (onComplete) {
+                publisher2.onComplete();
+            } else {
+                publisher2.onError(secondCause);
+            }
+            // With delayError, terminating the mapped publisher must request more demand from the source publisher
+            // as otherwise the source publisher may not terminate.
+            testSubscription.awaitRequestN(2);
+
+            if (rootErrorFirst) {
+                Throwable cause = subscriber.awaitOnError();
+                assertThat(cause, is(deliberateException));
+                if (!onComplete) {
+                    assertThat(asList(cause.getSuppressed()), contains(secondCause));
+                }
+            } else {
+                publisher.onError(deliberateException);
+                Throwable cause = subscriber.awaitOnError();
+                if (onComplete) {
+                    assertThat(cause, is(deliberateException));
+                } else {
+                    assertThat(cause, is(secondCause));
+                    assertThat(asList(cause.getSuppressed()), contains(deliberateException));
+                }
+            }
+            assertThat(testSubscription2.isCancelled(), equalTo(false));
+        } else {
+            publisher.onError(DELIBERATE_EXCEPTION);
+            testSubscription2.awaitCancelled();
+            assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        }
+    }
+
+    private static <R> void validateSignal(@Nullable SwitchMapSignal<R> signal, R data, boolean isSwitched) {
+        assertThat(signal, notNullValue());
+        assertThat(signal.isSwitched(), equalTo(isSwitched));
+        assertThat(signal.onNext(), equalTo(data));
+    }
+
+    private static <P, S> void validateTerminal(TestPublisher<P> publisher, TestPublisherSubscriber<S> subscriber,
+                                                boolean onError) {
+        if (onError) {
+            publisher.onError(DELIBERATE_EXCEPTION);
+            assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        } else {
+            publisher.onComplete();
+            subscriber.awaitOnComplete();
+        }
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherSwitchMapDelayErrorTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherSwitchMapDelayErrorTckTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.reactivestreams.tck.PublisherSwitchMapTckTest.SingleUpstreamDemandOperator;
+
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+import static io.servicetalk.concurrent.api.Publisher.defer;
+import static io.servicetalk.concurrent.api.Publisher.from;
+
+@Test
+public class PublisherSwitchMapDelayErrorTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+    @Override
+    protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
+        return defer(() -> {
+            final SingleUpstreamDemandOperator<Integer> demandOperator = new SingleUpstreamDemandOperator<>();
+            return publisher.liftAsync(demandOperator)
+                    .switchMapDelayError(i ->
+                            from(i).afterOnNext(x -> demandOperator.subscriberRef.get().decrementDemand()));
+        });
+    }
+
+    @Ignore("delay error requires termination of outer publisher")
+    @Override
+    public void required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() {
+    }
+
+    @Ignore("delay error requires termination of outer publisher")
+    @Override
+    public void required_spec309_requestZeroMustSignalIllegalArgumentException() {
+    }
+}

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherSwitchMapTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherSwitchMapTckTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.PublisherOperator;
+import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
+import io.servicetalk.concurrent.internal.FlowControlUtils;
+
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Publisher.defer;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
+
+@Test
+public class PublisherSwitchMapTckTest extends AbstractPublisherOperatorTckTest<Integer> {
+    @Override
+    protected Publisher<Integer> composePublisher(Publisher<Integer> publisher, int elements) {
+        return defer(() -> {
+            final SingleUpstreamDemandOperator<Integer> demandOperator = new SingleUpstreamDemandOperator<>();
+            return publisher.liftAsync(demandOperator)
+                    .switchMap(i -> from(i).afterOnNext(x -> demandOperator.subscriberRef.get().decrementDemand()));
+        });
+    }
+
+    static final class SingleUpstreamDemandOperator<T> implements PublisherOperator<T, T> {
+        final AtomicReference<SingleUpstreamDemandSubscriber<T>> subscriberRef = new AtomicReference<>();
+        @Override
+        public PublisherSource.Subscriber<? super T> apply(final PublisherSource.Subscriber<? super T> subscriber) {
+            SingleUpstreamDemandSubscriber<T> sub = new SingleUpstreamDemandSubscriber<>(subscriber);
+            if (subscriberRef.compareAndSet(null, sub)) {
+                return sub;
+            } else {
+                return new PublisherSource.Subscriber<T>() {
+                    @Override
+                    public void onSubscribe(final Subscription subscription) {
+                        deliverErrorFromSource(subscriber,
+                                new DuplicateSubscribeException(subscriberRef.get(), subscriber));
+                    }
+
+                    @Override
+                    public void onNext(@Nullable final T t) {
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                    }
+
+                    @Override
+                    public void onComplete() {
+                    }
+                };
+            }
+        }
+
+        static final class SingleUpstreamDemandSubscriber<T> implements PublisherSource.Subscriber<T> {
+            private final AtomicLong demand = new AtomicLong();
+            private final PublisherSource.Subscriber<? super T> subscriber;
+            @Nullable
+            private Subscription subscription;
+
+            SingleUpstreamDemandSubscriber(final PublisherSource.Subscriber<? super T> subscriber) {
+                this.subscriber = subscriber;
+            }
+
+            @Override
+            public void onSubscribe(final Subscription s) {
+                this.subscription = s;
+                subscriber.onSubscribe(new Subscription() {
+                    @Override
+                    public void request(final long n) {
+                        if (n <= 0) {
+                            subscription.request(n);
+                        } else if (demand.getAndAccumulate(n, FlowControlUtils::addWithOverflowProtection) == 0) {
+                            subscription.request(1);
+                        }
+                    }
+
+                    @Override
+                    public void cancel() {
+                        subscription.cancel();
+                    }
+                });
+            }
+
+            @Override
+            public void onNext(@Nullable final T t) {
+                subscriber.onNext(t);
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                subscriber.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                subscriber.onComplete();
+            }
+
+            void decrementDemand() {
+                if (demand.decrementAndGet() > 0) {
+                    assert subscription != null;
+                    subscription.request(1);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
Publisher.switchMap can be used to flatten an async stream of
publishers while always taking results from the latest publisher
and cancelling the previous Publisher.