### PR TITLE
`OpenTelemetryHttpServerFilter`: use root context for new requests

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
@@ -133,7 +133,7 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryFi
                                                        final StreamingHttpRequest request,
                                                        final StreamingHttpResponseFactory responseFactory) {
 
-        final Context parentContext = Context.current();
+        final Context parentContext = Context.root();
         if (!instrumenter.shouldStart(parentContext, request)) {
             return delegate.handle(ctx, request, responseFactory);
         }


### PR DESCRIPTION
Motivation:

For Http server I noticed a bug where the current context was still available even though the context was closed. Leading to the same request under the same trace.

Result:

The context will now be new for server requests and it will simply use a clean state.