### PR TITLE
Remove usage of deprecated PlatformDependent.throwException

### DIFF
--- a/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/BlockingUtils.java
+++ b/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/BlockingUtils.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.api.Single;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 
 /**
  * Common utility functions to unwrap {@link ExecutionException} from async operations.

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectableBufferOutputStreamTest.java
@@ -46,7 +46,7 @@ import static io.servicetalk.concurrent.api.internal.ConnectablePayloadWriterTes
 import static io.servicetalk.concurrent.api.internal.ConnectablePayloadWriterTest.toRunnable;
 import static io.servicetalk.concurrent.api.internal.ConnectablePayloadWriterTest.verifyCheckedRunnableException;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Runtime.getRuntime;

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriterTest.java
@@ -41,7 +41,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Runtime.getRuntime;

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/CompletableStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/CompletableStepVerifierTest.java
@@ -36,7 +36,7 @@ import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofNanos;

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/PublisherStepVerifierTest.java
@@ -41,7 +41,7 @@ import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofNanos;

--- a/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/SingleStepVerifierTest.java
+++ b/servicetalk-concurrent-api-test/src/test/java/io/servicetalk/concurrent/api/test/SingleStepVerifierTest.java
@@ -38,7 +38,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofNanos;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AutoCloseables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AutoCloseables.java
@@ -16,11 +16,12 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.GracefulAutoCloseable;
-import io.servicetalk.utils.internal.PlatformDependent;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 
 /**
  * A utility class for methods related to {@link AutoCloseable}.
@@ -50,7 +51,7 @@ public final class AutoCloseables {
             try {
                 closable.closeGracefully();
             } catch (Exception e) {
-                PlatformDependent.throwException(e);
+                throwException(e);
             }
         }).toFuture();
         try {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CacheSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CacheSingle.java
@@ -37,7 +37,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFro
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverSuccessFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.logDuplicateTerminal;
 import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CancellableSet.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CancellableSet.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Collections.newSetFromMap;
 
 final class CancellableSet implements Cancellable {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ClosableConcurrentStack.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ClosableConcurrentStack.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeCancellable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompositeCancellable.java
@@ -19,8 +19,8 @@ import io.servicetalk.concurrent.Cancellable;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultBlockingIterableProcessor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultBlockingIterableProcessor.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultBlockingIterableProcessor<T> implements Processor<T> {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastLeafSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastLeafSubscriber.java
@@ -36,7 +36,7 @@ import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedSpscQueue;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 
 abstract class MulticastLeafSubscriber<T> implements Subscriber<T>, Subscription {
     @SuppressWarnings("rawtypes")

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/MulticastPublisher.java
@@ -42,7 +42,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
 import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedMpscQueue;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Comparator.comparingLong;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
@@ -39,7 +39,7 @@ import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUncheck
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Math.min;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableMergeWithPublisherTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/DefaultExecutorTest.java
@@ -50,7 +50,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.time.Duration.ofNanos;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherBufferConcurrencyTest.java
@@ -32,7 +32,7 @@ import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.time.Duration.ofMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.function.UnaryOperator.identity;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherConcatMapIterableTest.java
@@ -41,7 +41,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -344,8 +344,7 @@ class PublisherConcatMapIterableTest {
                     throw DELIBERATE_EXCEPTION;
                 })).subscribe(subscriber);
         subscriber.awaitSubscription();
-        DeliberateException exception = assertThrows(DeliberateException.class,
-                                                     () -> publisher.onComplete());
+        DeliberateException exception = assertThrows(DeliberateException.class, publisher::onComplete);
         assertThat(exception, is(DELIBERATE_EXCEPTION));
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherFlatMapSingleTest.java
@@ -51,7 +51,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.ThreadLocalRandom.current;

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SchedulerOffloadTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Executors.from;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/BlockingTestUtils.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/BlockingTestUtils.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.utils.internal.PlatformDependent;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.internal.ThrowableUtils.unknownStackTrace;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 
 /**
  * Utilities to await results of an asynchronous computation either by blocking the calling thread.
@@ -213,7 +212,7 @@ public final class BlockingTestUtils {
         try {
             awaitIndefinitely(source);
         } catch (ExecutionException | InterruptedException e) {
-            PlatformDependent.throwException(e);
+            throwException(e);
         }
     }
 

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestCompletable.java
@@ -30,8 +30,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestPublisher.java
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
+++ b/servicetalk-concurrent-api/src/testFixtures/java/io/servicetalk/concurrent/api/TestSingle.java
@@ -30,8 +30,8 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.await;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIterable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIterable.java
@@ -21,7 +21,7 @@ import io.servicetalk.concurrent.CloseableIterator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 
 /**
  * An abstract implementation of {@link CloseableIterable} that wraps an {@link Iterable}.

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AutoClosableUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AutoClosableUtils.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.internal;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 
 /**
  * Utilities for {@link AutoCloseable}.

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FutureUtils.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/FutureUtils.java
@@ -18,7 +18,7 @@ package io.servicetalk.concurrent.internal;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Thread.currentThread;
 
 /**

--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ConcurrentUtilsSourceRequestedTest.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ConcurrentUtilsSourceRequestedTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.calculateSourceRequested;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Math.min;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/AwaitUtils.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**

--- a/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
+++ b/servicetalk-concurrent-test-internal/src/main/java/io/servicetalk/concurrent/test/internal/TestPublisherSubscriber.java
@@ -37,7 +37,7 @@ import static io.servicetalk.concurrent.internal.TerminalNotification.error;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.await;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.poll;
 import static io.servicetalk.concurrent.test.internal.AwaitUtils.take;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 

--- a/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/JacksonSerializationProvider.java
+++ b/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/JacksonSerializationProvider.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 
 import static io.servicetalk.buffer.api.Buffer.asOutputStream;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
@@ -76,7 +76,7 @@ import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -314,8 +314,8 @@ class ErrorHandlingTest {
         doAnswer((Answer<Publisher<TestResponse>>) invocation -> {
             Publisher<TestRequest> request = invocation.getArgument(1);
             return request.map(req -> {
-               throwException(toThrow);
-               return null;
+                throwException(toThrow);
+                return null;
             });
         }).when(service).testBiDiStream(any(), any());
         doAnswer(invocation -> {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RequestResponseFactories.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RequestResponseFactories.java
@@ -17,7 +17,7 @@ package io.servicetalk.http.api;
 
 import java.util.concurrent.ExecutionException;
 
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 
 final class RequestResponseFactories {
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingStreamingHttpService.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.api.internal.BlockingUtils.futureGetCancelOnInterrupt;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 
 final class StreamingHttpServiceToBlockingStreamingHttpService implements BlockingStreamingHttpService {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
@@ -59,7 +59,7 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpClientTest.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerAsciiFixLen;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpServiceTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpServiceTest.java
@@ -57,7 +57,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConsumeRequestPayloadOnResponsePathTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConsumeRequestPayloadOnResponsePathTest.java
@@ -30,7 +30,6 @@ import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.api.TrailersTransformer;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.netty.internal.AddressUtils;
-import io.servicetalk.utils.internal.PlatformDependent;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +47,7 @@ import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
 import static io.servicetalk.http.api.StreamingHttpResponses.newTransportResponse;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -92,7 +92,7 @@ class ConsumeRequestPayloadOnResponsePathTest {
                     try {
                         consumePayloadBody(request).toFuture().get();
                     } catch (Exception e) {
-                        PlatformDependent.throwException(e);
+                        throwException(e);
                     }
                     return trailers;
                 }))));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyForClientApiTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyForClientApiTest.java
@@ -44,7 +44,7 @@ import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FullDuplexAndSequentialModeTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FullDuplexAndSequentialModeTest.java
@@ -36,7 +36,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED;
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -101,7 +101,7 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.newSocketAddr
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.CHANNEL_CLOSED_INBOUND;
 import static io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent.GRACEFUL_USER_CLOSING;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.US_ASCII;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
@@ -58,7 +58,7 @@ import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupp
 import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.ExecutorSupplier.CACHED_SERVER;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpOffloadingTest.java
@@ -80,7 +80,7 @@ import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
 import static io.servicetalk.transport.api.IoThreadFactory.IoThread.currentThreadIsIoThread;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Thread.currentThread;
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -59,7 +59,7 @@ import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ERROR_BEFORE_READ;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ERROR_DURING_READ;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_THROW_ERROR;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerEffectiveStrategyTest.java
@@ -48,7 +48,7 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.IO_EXECUTOR_NAME_PREFIX;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.noStrategy;
 import static io.servicetalk.http.netty.InvokingThreadsRecorder.userStrategy;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Character.isDigit;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporterTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporterTest.java
@@ -48,7 +48,7 @@ import static io.servicetalk.opentracing.zipkin.publisher.reporter.SpanUtils.new
 import static io.servicetalk.opentracing.zipkin.publisher.reporter.SpanUtils.verifySpan;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporterTest.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/test/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporterTest.java
@@ -43,7 +43,7 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
 import static io.servicetalk.opentracing.zipkin.publisher.reporter.SpanUtils.newSpan;
 import static io.servicetalk.opentracing.zipkin.publisher.reporter.SpanUtils.verifySpan;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
-import static io.servicetalk.utils.internal.PlatformDependent.throwException;
+import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;


### PR DESCRIPTION
Motivation:
PlatformDependent.throwException was deprecated many releases ago but its usage hasn't been removed.