### PR TITLE
Remove more offloadNever usage

### DIFF
--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingClient.java
@@ -134,7 +134,7 @@ public final class DebuggingClient {
                          * most useful for being able to directly trace through situations that would normally involve a
                          * thread handoff.
                          */
-                        // .executionStrategy(HttpExecutionStrategies.offloadNever())
+                        // .executionStrategy(HttpExecutionStrategies.offloadNone())
 
                         /*
                          * 3. Enables detailed logging of I/O events and I/O states.

--- a/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
+++ b/servicetalk-examples/grpc/debugging/src/main/java/io/servicetalk/examples/grpc/debugging/DebuggingServer.java
@@ -132,7 +132,7 @@ public final class DebuggingServer {
                          * most useful for being able to directly trace through situations that would normally involve a
                          * thread handoff.
                          */
-                        //.executionStrategy(HttpExecutionStrategies.offloadNever())
+                        //.executionStrategy(HttpExecutionStrategies.offloadNone())
 
                         /*
                          * 3. Enables detailed logging of I/O events and I/O states.

--- a/servicetalk-examples/grpc/execution-strategy/src/main/java/io/servicetalk/examples/grpc/strategies/ExecutionStrategyServer.java
+++ b/servicetalk-examples/grpc/execution-strategy/src/main/java/io/servicetalk/examples/grpc/strategies/ExecutionStrategyServer.java
@@ -35,7 +35,7 @@ import io.grpc.examples.strategies.HelloRequest;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNone;
 
 /**
  * Extends the async "Hello World" example to demonstrate support for alternative execution strategies and executors.
@@ -67,7 +67,7 @@ public final class ExecutionStrategyServer {
             // -> no offloading, route executed on IoExecutor
             System.out.printf("\n%d : no offloading server, async route\n", port);
             ServerContext asyncServer = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNone()))
                     .listenAndAwait((GreeterService)
                             (ctx, request) -> getReplySingle(request, "no offloading server, async route"));
             closeEverything.prepend(asyncServer);
@@ -76,7 +76,7 @@ public final class ExecutionStrategyServer {
             // -> no offloading, route executed on IoExecutor
             System.out.printf("\n%d : no offloading server, blocking route\n", port);
             ServerContext blockingServer = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNone()))
                     .listenAndAwait((Greeter.BlockingGreeterService)
                             (ctx, request) -> getReply(request, "no offloading server, blocking route"));
             closeEverything.prepend(blockingServer);
@@ -85,7 +85,7 @@ public final class ExecutionStrategyServer {
             // -> route offloaded to global executor
             System.out.printf("\n%d : no offloading server, default offloading for the route\n", port);
             ServerContext noOffloadsServerRouteOffloads = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNone()))
                     .listenAndAwait(new Greeter.ServiceFactory.Builder()
                             .sayHello(defaultStrategy(),
                                     (ctx, request) -> getReplySingle(request,
@@ -97,7 +97,7 @@ public final class ExecutionStrategyServer {
             // -> route offloaded to global executor
             System.out.printf("\n%d: no offloading server, custom offloading for the route\n", port);
             ServerContext noOffloadsServerRouteOffloadCustom = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNone()))
                     .listenAndAwait(new Greeter.ServiceFactory.Builder().sayHello(CUSTOM_STRATEGY,
                                     (ctx, request) -> getReplySingle(request,
                                             "no offloading server, custom offloading for the route"))
@@ -118,7 +118,7 @@ public final class ExecutionStrategyServer {
             // -> route offloaded to global executor
             System.out.printf("\n%d : default server, no offloading route\n", port);
             ServerContext noOffloadsRoute = GrpcServers.forPort(port++)
-                    .listenAndAwait(new Greeter.ServiceFactory.Builder().sayHello(offloadNever(),
+                    .listenAndAwait(new Greeter.ServiceFactory.Builder().sayHello(offloadNone(),
                                     (ctx, request) -> getReplySingle(request, "default server, no offloading route"))
                             .build());
             closeEverything.prepend(noOffloadsRoute);
@@ -136,9 +136,9 @@ public final class ExecutionStrategyServer {
             // -> no offloading, route executed on IoExecutor
             System.out.printf("\n%d : no offloading server, no offloading route\n", port);
             ServerContext noOffloadsServerRoute = GrpcServers.forPort(port++)
-                    .initializeHttp(init -> init.executionStrategy(offloadNever()))
+                    .initializeHttp(init -> init.executionStrategy(offloadNone()))
                     .listenAndAwait(new Greeter.ServiceFactory.Builder()
-                            .sayHello(offloadNever(),
+                            .sayHello(offloadNone(),
                                     (ctx, request) ->
                                             getReplySingle(request, "no offloading server, no offloading route"))
                             .build());

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleClient.java
@@ -164,7 +164,7 @@ public final class DebuggingExampleClient {
                  * most useful for being able to directly trace through situations that would normally involve a
                  * thread handoff.
                  */
-                // .executionStrategy(HttpExecutionStrategies.offloadNever())
+                // .executionStrategy(HttpExecutionStrategies.offloadNone())
 
                 /*
                  * 3. Enables detailed logging of I/O events and I/O states.

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleServer.java
@@ -159,7 +159,7 @@ public final class DebuggingExampleServer {
                  * most useful for being able to directly trace through situations that would normally involve a
                  * thread handoff.
                  */
-                // .executionStrategy(HttpExecutionStrategies.offloadNever())
+                // .executionStrategy(HttpExecutionStrategies.offloadNone())
 
                 /*
                  * 3. Enables detailed logging of I/O events and I/O states.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRoutes.java
@@ -42,7 +42,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNone;
 import static io.servicetalk.grpc.api.GrpcHeaderValues.GRPC_CONTENT_TYPE_PROTO_SUFFIX;
 import static io.servicetalk.grpc.api.GrpcRouter.verifyNoOverrides;
 import static io.servicetalk.grpc.api.GrpcUtils.compressors;
@@ -193,7 +193,7 @@ public abstract class GrpcRoutes<Service extends GrpcService> {
             return saved;
         }
         return getAndValidateRouteExecutionStrategyAnnotationIfPresent(method, clazz, strategyFactory, errors,
-                offloadNever());
+                offloadNone());
     }
 
     /**

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/customtransport/Utils.java
@@ -27,7 +27,6 @@ import io.servicetalk.concurrent.internal.DefaultContextMap;
 import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.encoding.api.ContentCodec;
 import io.servicetalk.grpc.api.GrpcExecutionContext;
-import io.servicetalk.grpc.api.GrpcExecutionStrategies;
 import io.servicetalk.grpc.api.GrpcExecutionStrategy;
 import io.servicetalk.grpc.api.GrpcServiceContext;
 import io.servicetalk.grpc.api.MethodDescriptor;
@@ -58,6 +57,7 @@ import javax.net.ssl.SSLSession;
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNone;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
@@ -97,7 +97,7 @@ final class Utils {
 
         @Override
         public GrpcExecutionStrategy executionStrategy() {
-            return GrpcExecutionStrategies.offloadNever();
+            return offloadNone();
         }
     }
 

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ErrorHandlingTest.java
@@ -73,7 +73,7 @@ import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNone;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
@@ -422,7 +422,7 @@ class ErrorHandlingTest {
 
     static Collection<Arguments> data() {
         GrpcExecutionStrategy[] strategies =
-                new GrpcExecutionStrategy[]{offloadNever(), defaultStrategy()};
+                new GrpcExecutionStrategy[]{offloadNone(), defaultStrategy()};
         List<Arguments> data = new ArrayList<>(strategies.length * 2 * TestMode.values().length);
         for (GrpcExecutionStrategy serverStrategy : strategies) {
             for (GrpcExecutionStrategy clientStrategy : strategies) {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyConfigurationFailuresTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyConfigurationFailuresTest.java
@@ -30,7 +30,7 @@ import io.servicetalk.router.api.RouteExecutionStrategyFactory;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNone;
 import static io.servicetalk.router.utils.internal.DefaultRouteExecutionStrategyFactory.getUsingDefaultStrategyFactory;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -109,7 +109,7 @@ class ExecutionStrategyConfigurationFailuresTest {
     private static final TesterService MISCONFIGURED_SERVICE = new MisconfiguredService();
     private static final BlockingTesterService MISCONFIGURED_BLOCKING_SERVICE = new MisconfiguredBlockingService();
     private static final RouteExecutionStrategyFactory<GrpcExecutionStrategy> STRATEGY_FACTORY =
-            id -> "test".equals(id) ? offloadNever() : getUsingDefaultStrategyFactory(id);
+            id -> "test".equals(id) ? offloadNone() : getUsingDefaultStrategyFactory(id);
 
     @Test
     void usingServiceFactoryAsyncService() {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ExecutionStrategyTest.java
@@ -47,7 +47,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.grpc.api.GrpcExecutionStrategies.defaultStrategy;
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNone;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_EXEC_ID_STRATEGY_ASYNC_SERVICE;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_EXEC_ID_STRATEGY_BLOCKING_SERVICE;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE;
@@ -126,7 +126,7 @@ class ExecutionStrategyTest {
         NO_OFFLOADS {
             @Override
             void configureContextExecutionStrategy(GrpcServerBuilder builder) {
-                builder.initializeHttp(b -> b.executionStrategy(offloadNever()));
+                builder.initializeHttp(b -> b.executionStrategy(offloadNone()));
             }
         };
 
@@ -173,10 +173,10 @@ class ExecutionStrategyTest {
             ServiceFactory getServiceFactory() {
                 return new ServiceFactory.Builder()
                         .routeExecutionStrategyFactory(STRATEGY_FACTORY)
-                        .test(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
-                        .testBiDiStream(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
-                        .testResponseStream(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
-                        .testRequestStream(offloadNever(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .test(offloadNone(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .testBiDiStream(offloadNone(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .testResponseStream(offloadNone(), DEFAULT_STRATEGY_ASYNC_SERVICE)
+                        .testRequestStream(offloadNone(), DEFAULT_STRATEGY_ASYNC_SERVICE)
                         .build();
             }
         },
@@ -219,10 +219,10 @@ class ExecutionStrategyTest {
             ServiceFactory getServiceFactory() {
                 return new ServiceFactory.Builder()
                         .routeExecutionStrategyFactory(STRATEGY_FACTORY)
-                        .testBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
-                        .testBiDiStreamBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
-                        .testResponseStreamBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
-                        .testRequestStreamBlocking(offloadNever(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testBlocking(offloadNone(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testBiDiStreamBlocking(offloadNone(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testResponseStreamBlocking(offloadNone(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
+                        .testRequestStreamBlocking(offloadNone(), DEFAULT_STRATEGY_BLOCKING_SERVICE)
                         .build();
             }
         };

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcRouterConfigurationTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcRouterConfigurationTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNever;
+import static io.servicetalk.grpc.api.GrpcExecutionStrategies.offloadNone;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_NO_OFFLOADS_STRATEGY_ASYNC_SERVICE;
 import static io.servicetalk.grpc.netty.ExecutionStrategyTestServices.CLASS_NO_OFFLOADS_STRATEGY_BLOCKING_SERVICE;
@@ -143,36 +143,36 @@ class GrpcRouterConfigurationTest {
         final TesterService asyncService = DEFAULT_STRATEGY_ASYNC_SERVICE;
         testCanNotOverrideAlreadyRegisteredPath(TestRpc.PATH, builder -> builder
                 .test(asyncService)
-                .test(offloadNever(), asyncService));
+                .test(offloadNone(), asyncService));
 
         testCanNotOverrideAlreadyRegisteredPath(TestBiDiStreamRpc.PATH, builder -> builder
                 .testBiDiStream(asyncService)
-                .testBiDiStream(offloadNever(), asyncService));
+                .testBiDiStream(offloadNone(), asyncService));
 
         testCanNotOverrideAlreadyRegisteredPath(TestResponseStreamRpc.PATH, builder -> builder
                 .testResponseStream(asyncService)
-                .testResponseStream(offloadNever(), asyncService));
+                .testResponseStream(offloadNone(), asyncService));
 
         testCanNotOverrideAlreadyRegisteredPath(TestRequestStreamRpc.PATH, builder -> builder
                 .testRequestStream(asyncService)
-                .testRequestStream(offloadNever(), asyncService));
+                .testRequestStream(offloadNone(), asyncService));
 
         final BlockingTesterService blockingService = DEFAULT_STRATEGY_BLOCKING_SERVICE;
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestRpc.PATH, builder -> builder
                 .testBlocking(blockingService)
-                .testBlocking(offloadNever(), blockingService));
+                .testBlocking(offloadNone(), blockingService));
 
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestBiDiStreamRpc.PATH, builder -> builder
                 .testBiDiStreamBlocking(blockingService)
-                .testBiDiStreamBlocking(offloadNever(), blockingService));
+                .testBiDiStreamBlocking(offloadNone(), blockingService));
 
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestResponseStreamRpc.PATH, builder -> builder
                 .testResponseStreamBlocking(blockingService)
-                .testResponseStreamBlocking(offloadNever(), blockingService));
+                .testResponseStreamBlocking(offloadNone(), blockingService));
 
         testCanNotOverrideAlreadyRegisteredPath(BlockingTestRequestStreamRpc.PATH, builder -> builder
                 .testRequestStreamBlocking(blockingService)
-                .testRequestStreamBlocking(offloadNever(), blockingService));
+                .testRequestStreamBlocking(offloadNone(), blockingService));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
offloadNever is deprecated, we should minimize its usage internally just for backwards compatability and testing.