### PR TITLE
Mark HTTP/2 connection as closing on exception caught

### DIFF
--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -108,3 +108,9 @@ task testProps(type: Test) {
 test.dependsOn testProps
 // ServiceTalkLibraryPlugin adds a spotbugs task for each sourceSet, we don't need it.
 spotbugsTestProps.enabled = false
+
+tasks.withType(Test).all {
+  testLogging {
+    showStandardStreams = true
+  }
+}

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -108,9 +108,3 @@ task testProps(type: Test) {
 test.dependsOn testProps
 // ServiceTalkLibraryPlugin adds a spotbugs task for each sourceSet, we don't need it.
 spotbugsTestProps.enabled = false
-
-tasks.withType(Test).all {
-  testLogging {
-    showStandardStreams = true
-  }
-}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -199,11 +199,6 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
         }
 
         @Override
-        boolean hasSubscriber() {
-            return subscriber != null;
-        }
-
-        @Override
         void tryCompleteSubscriber() {
             if (subscriber != null) {
                 Subscriber<? super H2ClientParentConnection> subscriberCopy = subscriber;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -214,12 +214,15 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
         }
 
         @Override
-        void tryFailSubscriber(Throwable cause) {
+        boolean tryFailSubscriber(Throwable cause) {
             if (subscriber != null) {
                 close(parentContext.nettyChannel(), cause);
                 Subscriber<? super H2ClientParentConnection> subscriberCopy = subscriber;
                 subscriber = null;
                 subscriberCopy.onError(cause);
+                return true;
+            } else {
+                return false;
             }
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -253,7 +253,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
             cause = wrapIfNecessary(cause);
             parentContext.transportError.onSuccess(cause);
             if (!tryFailSubscriber(cause)) {
-                LOGGER.debug("{} closing h2 parent channel on exception caught", parentContext.nettyChannel(), cause);
+                LOGGER.error("{} closing h2 parent channel on exception caught", parentContext.nettyChannel(), cause);
                 ChannelCloseUtils.close(ctx, cause);
             }
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -261,7 +261,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
             cause = wrapIfNecessary(cause);
             parentContext.transportError.onSuccess(cause);
             if (!tryFailSubscriber(cause)) {
-                LOGGER.error("{} closing h2 parent channel on exception caught", parentContext.nettyChannel(), cause);
+                LOGGER.debug("{} closing h2 parent channel on exception caught", parentContext.nettyChannel(), cause);
                 ChannelCloseUtils.close(ctx, cause);
             }
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -199,8 +199,6 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
             this.observer = observer;
         }
 
-        abstract boolean hasSubscriber();
-
         abstract void tryCompleteSubscriber();
 
         abstract boolean tryFailSubscriber(Throwable cause);
@@ -246,9 +244,7 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         private void doChannelClosed(final String method) {
             parentContext.notifyOnClosingImpl();
 
-            if (hasSubscriber()) {
-                tryFailSubscriber(StacklessClosedChannelException.newInstance(H2ParentConnectionContext.class, method));
-            }
+            tryFailSubscriber(StacklessClosedChannelException.newInstance(H2ParentConnectionContext.class, method));
             parentContext.keepAliveManager.channelClosed();
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -221,11 +221,6 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
         }
 
         @Override
-        boolean hasSubscriber() {
-            return subscriber != null;
-        }
-
-        @Override
         void tryCompleteSubscriber() {
             if (subscriber != null) {
                 Subscriber<? super H2ServerParentConnectionContext> subscriberCopy = subscriber;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -236,12 +236,15 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
         }
 
         @Override
-        void tryFailSubscriber(Throwable cause) {
+        boolean tryFailSubscriber(Throwable cause) {
             if (subscriber != null) {
                 ChannelCloseUtils.close(parentContext.nettyChannel(), cause);
                 Subscriber<? super H2ServerParentConnectionContext> subscriberCopy = subscriber;
                 subscriber = null;
                 subscriberCopy.onError(cause);
+                return true;
+            } else {
+                return false;
             }
         }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -1350,7 +1350,7 @@ class H2PriorKnowledgeFeatureParityTest {
         }
 
         // We expect this to timeout, because we have not completed the outstanding request.
-        assertFalse(onServerCloseLatch.await(30, MILLISECONDS));
+        assertFalse(onServerCloseLatch.await(300, MILLISECONDS));
 
         requestBody.onComplete();
 


### PR DESCRIPTION
Motivation:

Similar to #2675, `H2ParentConnectionContext.AbstractH2ParentConnection` should mark the `Channel` as closing on `exceptionCaught`. If there is no active `Subscriber`, it should enforce channel closure using `ChannelCloseUtils`.
In case users don't have offloading, there is a risk to retry on the same IO thread. We should notify `LoadBalancer` that this connection is closing to avoid retrying on the same connection.

Modifications:

- Invoke `parentContext.notifyOnClosingImpl()` inside `exceptionCaught` before notifying `transportError` and failing subscriber;
- Close the h2 channel if there is no active `Subscriber` to consume the error;
- Remove `H2ParentConnectionContext.hasSubscriber()` that does not seem required anymore;
- Enhance `ConnectionClosedAfterIoExceptionTest` to make sure we fail only the first connect attempt, we capture `RetryableException`s, and capture the callers stack trace if `client.request(...)` fails;

Result:

Retries always select a different connection if existing connection observes an exception.
Fixes #2685.