### PR TITLE
Calculate initial concurrency based on resulting connection protocol

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -39,7 +38,6 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_1_1;
 import static io.servicetalk.http.netty.AlpnIds.HTTP_2;
-import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 
 final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
@@ -94,14 +92,5 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
                     return failed(new IllegalStateException("Unknown ALPN protocol negotiated: " + protocol));
             }
         });
-    }
-
-    @Override
-    ReservableRequestConcurrencyController newConcurrencyController(
-            final FilterableStreamingHttpConnection connection) {
-        // We set initialMaxConcurrency to 1 here because we don't know what type of connection will be created when
-        // ALPN completes. The actual maxConcurrency value will be updated by the MAX_CONCURRENCY stream,
-        // when we create a connection.
-        return newController(connection, 1);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
@@ -55,7 +55,8 @@ public final class H1ProtocolConfigBuilder {
     }
 
     /**
-     * Sets the maximum number of pipelined HTTP requests to queue up.
+     * Sets the maximum number of <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-6.3.2">pipelined</a>
+     * HTTP requests to queue up.
      * <p>
      * Anything above this value will be rejected, {@code 1} means pipelining is disabled and requests/responses are
      * processed sequentially.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -31,8 +30,6 @@ import io.servicetalk.transport.api.TransportObserver;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
-import static io.servicetalk.http.netty.H2ClientParentConnectionContext.DEFAULT_H2_MAX_CONCURRENCY_EVENT;
-import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 
 final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
@@ -61,11 +58,5 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
                         new TcpClientChannelInitializer(tcpConfig, connectionObserver).andThen(
                                 new H2ClientParentChannelInitializer(config.h2Config())), connectionObserver,
                         config.allowDropTrailersReadFromTransport()), observer);
-    }
-
-    @Override
-    ReservableRequestConcurrencyController newConcurrencyController(
-            final FilterableStreamingHttpConnection connection) {
-        return newController(connection, DEFAULT_H2_MAX_CONCURRENCY_EVENT.event());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.client.api.ReservableRequestConcurrencyController;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -28,7 +27,6 @@ import io.servicetalk.transport.api.TransportObserver;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
-import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.newController;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.buildStreaming;
 
 final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
@@ -50,12 +48,5 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
         return buildStreaming(executionContext, resolvedAddress, config, observer)
                 .map(conn -> new PipelinedStreamingHttpConnection(conn, config.h1Config(),
                         reqRespFactoryFunc.apply(HTTP_1_1), config.allowDropTrailersReadFromTransport()));
-    }
-
-    @Override
-    ReservableRequestConcurrencyController newConcurrencyController(
-            final FilterableStreamingHttpConnection connection) {
-        assert config.h1Config() != null;
-        return newController(connection, config.h1Config().maxPipelinedRequests());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2022-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpEventKey;
 import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
@@ -52,7 +53,10 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.MAX_CONCURRENCY_NO_OFFLOADING;
+import static io.servicetalk.http.netty.H2ClientParentConnectionContext.DEFAULT_H2_MAX_CONCURRENCY_EVENT;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
@@ -70,13 +74,14 @@ final class ReservableRequestConcurrencyControllers {
      * Create a new instance of {@link ReservableRequestConcurrencyController}.
      *
      * @param connection {@link FilterableStreamingHttpConnection} for which the controller is required.
-     * @param initialConcurrency The initial maximum value for concurrency, until {@code connection} provides data.
+     * @param config {@link ReadOnlyHttpClientConfig} to access protocols' configurations in order to determine the
+     * initial concurrency.
      * @return a new instance of {@link ReservableRequestConcurrencyController}.
      */
-    static ReservableRequestConcurrencyController newController(
+    static ReservableRequestConcurrencyController newConcurrencyController(
             final FilterableStreamingHttpConnection connection,
-            final int initialConcurrency) {
-        return new ReservableRequestConcurrencyControllerMulti(connection, initialConcurrency);
+            final ReadOnlyHttpClientConfig config) {
+        return new ReservableRequestConcurrencyControllerMulti(connection, config);
     }
 
     /**
@@ -135,8 +140,8 @@ final class ReservableRequestConcurrencyControllers {
 
         AbstractReservableRequestConcurrencyController(
                 final FilterableStreamingHttpConnection connection,
-                final int initialConcurrency) {
-            lastMaxConcurrency = initialConcurrency;
+                final ReadOnlyHttpClientConfig config) {
+            lastMaxConcurrency = initialConcurrency(connection.connectionContext().protocol(), config);
             // Subscribe to onClosing() before maxConcurrency, this order increases the chances of capturing the
             // STATE_QUIT before observing 0 from maxConcurrency which could lead to more ambiguous max concurrency
             // error messages for the users on connection tear-down.
@@ -222,6 +227,24 @@ final class ReservableRequestConcurrencyControllers {
             });
         }
 
+        private static int initialConcurrency(final HttpProtocolVersion protocol,
+                                              final ReadOnlyHttpClientConfig config) {
+            if (protocol.major() == HTTP_2_0.major()) {
+                assert config.h2Config() != null;
+                return DEFAULT_H2_MAX_CONCURRENCY_EVENT.event();
+            } else if (protocol.major() == HTTP_1_1.major()) {
+                if (protocol.minor() >= HTTP_1_1.minor()) {
+                    assert config.h1Config() != null;
+                    return config.h1Config().maxPipelinedRequests();
+                } else {
+                    return 1;   // Versions prior HTTP/1.1 support only a single request-response at a time
+                }
+            } else {
+                throw new IllegalStateException("Cannot infer initialConcurrency value for unknown protocol: " +
+                        protocol);
+            }
+        }
+
         @Override
         public final void requestFinished() {
             pendingRequestsUpdater.decrementAndGet(this);
@@ -279,8 +302,8 @@ final class ReservableRequestConcurrencyControllers {
     private static final class ReservableRequestConcurrencyControllerMulti
             extends AbstractReservableRequestConcurrencyController {
         ReservableRequestConcurrencyControllerMulti(final FilterableStreamingHttpConnection connection,
-                                                    final int initialConcurrency) {
-            super(connection, initialConcurrency);
+                                                    final ReadOnlyHttpClientConfig config) {
+            super(connection, config);
         }
 
         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ReservableRequestConcurrencyControllersTest.java
@@ -22,6 +22,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.TestPublisher;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.IgnoreConsumedEvent;
 
 import org.junit.jupiter.api.Test;
@@ -32,8 +33,9 @@ import static io.servicetalk.client.api.RequestConcurrencyController.Result.Reje
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.MAX_CONCURRENCY_NO_OFFLOADING;
-import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.newController;
+import static io.servicetalk.http.netty.ReservableRequestConcurrencyControllers.newConcurrencyController;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -48,8 +50,8 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void maxConcurrencyRequestAtTime() {
         final int maxRequestCount = 10;
-        RequestConcurrencyController controller = newController(
-                newConnection(from(new IgnoreConsumedEvent<>(maxRequestCount)), never()), maxRequestCount);
+        RequestConcurrencyController controller = newConcurrencyController(
+                newConnection(from(new IgnoreConsumedEvent<>(maxRequestCount)), never()), newConfig(maxRequestCount));
         for (int i = 0; i < 100; ++i) {
             for (int j = 0; j < maxRequestCount; ++j) {
                 assertThat(controller.tryRequest(), is(Accepted));
@@ -63,7 +65,8 @@ class ReservableRequestConcurrencyControllersTest {
 
     @Test
     void limitIsAllowedToIncrease() {
-        RequestConcurrencyController controller = newController(newConnection(limitPublisher, never()), 10);
+        RequestConcurrencyController controller = newConcurrencyController(newConnection(limitPublisher, never()),
+                newConfig(10));
         for (int i = 1; i < 100; ++i) {
             limitPublisher.onNext(new IgnoreConsumedEvent<>(i));
             for (int j = 0; j < i; ++j) {
@@ -79,7 +82,8 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void limitIsAllowedToDecrease() {
         int maxRequestCount = 10;
-        RequestConcurrencyController controller = newController(newConnection(limitPublisher, never()), 10);
+        RequestConcurrencyController controller = newConcurrencyController(newConnection(limitPublisher, never()),
+                newConfig(10));
 
         for (int j = 0; j < maxRequestCount; ++j) {
             assertThat(controller.tryRequest(), is(Accepted));
@@ -96,15 +100,16 @@ class ReservableRequestConcurrencyControllersTest {
 
     @Test
     void noMoreRequestsAfterClose() {
-        RequestConcurrencyController controller = newController(
-                newConnection(from(new IgnoreConsumedEvent<>(1)), completed()), 10);
+        RequestConcurrencyController controller = newConcurrencyController(
+                newConnection(from(new IgnoreConsumedEvent<>(1)), completed()), newConfig(10));
         assertThat(controller.tryRequest(), is(RejectedPermanently));
     }
 
     @Test
     void defaultValueIsUsed() {
         final int maxRequestCount = 10;
-        RequestConcurrencyController controller = newController(newConnection(limitPublisher, never()), 10);
+        RequestConcurrencyController controller = newConcurrencyController(newConnection(limitPublisher, never()),
+                newConfig(10));
         for (int j = 0; j < maxRequestCount; ++j) {
             assertThat(controller.tryRequest(), is(Accepted));
         }
@@ -117,7 +122,7 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void reserveWithNoRequests() throws Exception {
         ReservableRequestConcurrencyController controller =
-                newController(newConnection(from(new IgnoreConsumedEvent<>(10)), never()), 10);
+                newConcurrencyController(newConnection(from(new IgnoreConsumedEvent<>(10)), never()), newConfig(10));
         for (int i = 0; i < 10; ++i) {
             assertTrue(controller.tryReserve());
             assertFalse(controller.tryReserve());
@@ -134,16 +139,26 @@ class ReservableRequestConcurrencyControllersTest {
     @Test
     void reserveFailsWhenPendingRequest() {
         ReservableRequestConcurrencyController controller =
-                newController(newConnection(from(new IgnoreConsumedEvent<>(10)), never()), 10);
+                newConcurrencyController(newConnection(from(new IgnoreConsumedEvent<>(10)), never()), newConfig(10));
         assertThat(controller.tryRequest(), is(Accepted));
         assertFalse(controller.tryReserve());
     }
 
     private static FilterableStreamingHttpConnection newConnection(
             Publisher<? extends ConsumableEvent<Integer>> maxConcurrency, Completable onClosing) {
+        final HttpConnectionContext ctx = mock(HttpConnectionContext.class);
+        doReturn(HTTP_1_1).when(ctx).protocol();
+
         final FilterableStreamingHttpConnection connection = mock(FilterableStreamingHttpConnection.class);
         doReturn(maxConcurrency).when(connection).transportEventStream(MAX_CONCURRENCY_NO_OFFLOADING);
         doReturn(onClosing).when(connection).onClosing();
+        doReturn(ctx).when(connection).connectionContext();
         return connection;
+    }
+
+    private static ReadOnlyHttpClientConfig newConfig(int initialConcurrency) {
+        final HttpClientConfig config = new HttpClientConfig();
+        config.protocolConfigs().protocols(HttpProtocolConfigs.h1().maxPipelinedRequests(initialConcurrency).build());
+        return config.asReadOnly();
     }
 }


### PR DESCRIPTION
Motivation:

`RequestConcurrencyController` is always applied as the top level wrapper of the connection (after all connection-level filters) before returning it back to the `LoadBalancer`. As the result, there is no need to make an earlier decision for `initialConcurrency` value at implementations of `AbstractLBHttpConnectionFactory` (when the final protocol may be unknown) because it can be inferred based on the resulting connection protocol at the time a new
`ReservableRequestConcurrencyController` is created. Early initialization as it's now makes it harder to switch protocols after proxy connect.

Modifications:

- Convert abstract method `AbstractLBHttpConnectionFactory.newConcurrencyController` into a private method;
- Compute `initialConcurrency` based on connection's protocol and `ReadOnlyHttpClientConfig`;

Result:

No need to pre-initialize `initialConcurrency` value in `AbstractLBHttpConnectionFactory` implementations as it will be computed based on the connection's protocol at the time it's required.