### PR TITLE
ProtobufSerializer minimize getSerializedSize() usage

### DIFF
--- a/servicetalk-data-protobuf/src/main/java/io/servicetalk/data/protobuf/ProtobufSerializer.java
+++ b/servicetalk-data-protobuf/src/main/java/io/servicetalk/data/protobuf/ProtobufSerializer.java
@@ -70,7 +70,7 @@ final class ProtobufSerializer<T extends MessageLite> implements SerializerDeser
         }
 
         // Forward write index of our buffer
-        buffer.writerIndex(writerIdx + toSerialize.getSerializedSize());
+        buffer.writerIndex(writerIdx + out.getTotalBytesWritten());
     }
 
     @Override
@@ -92,7 +92,7 @@ final class ProtobufSerializer<T extends MessageLite> implements SerializerDeser
             }
 
             T result = parser.parseFrom(in);
-            serializedData.skipBytes(result.getSerializedSize());
+            serializedData.skipBytes(in.getTotalBytesRead());
             return result;
         } catch (InvalidProtocolBufferException e) {
             throw new SerializationException(e);


### PR DESCRIPTION
Motivation:
ProtobufSerializer uses `MessageLite.getSerializedSize()` on each serialization operation. This method may require a deep traversal of all internal objects and require intermediate allocations (e.g. for maps) to compute the actual size.

Modifications:
- Use `CodedOutputStream.getTotalBytesWritten()` and `CodedInputStream.getTotalBytesRead()` to determine how many bytes were generated/consumed during serialization.