### PR TITLE
protobuf: Add unit test for empty map value deserialization

### DIFF
--- a/servicetalk-data-protobuf/src/test/proto/test_message.proto
+++ b/servicetalk-data-protobuf/src/test/proto/test_message.proto
@@ -25,3 +25,7 @@ option java_outer_classname = "TestProtos";
 message DummyMessage {
     string message = 1;
 }
+
+message MapMessage {
+    map<string, string> attributes = 1;
+}


### PR DESCRIPTION
Motivation:
It is valid to not encode an empty map value and token, and we don't have a unit test to verify this behavior.