### PR TITLE
Add initializer API for HTTP proxy `CONNECT` request

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
@@ -76,8 +76,8 @@ public class DelegatingSingleAddressHttpClientBuilder<U, R> implements SingleAdd
 
     @Override
     public SingleAddressHttpClientBuilder<U, R> proxyAddress(
-            final U proxyAddress, final Consumer<StreamingHttpRequest> requestInitializer) {
-        delegate = delegate.proxyAddress(proxyAddress, requestInitializer);
+            final U proxyAddress, final Consumer<StreamingHttpRequest> connectRequestInitializer) {
+        delegate = delegate.proxyAddress(proxyAddress, connectRequestInitializer);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2022-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import io.servicetalk.transport.api.IoExecutor;
 
 import java.net.SocketOption;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -70,6 +71,13 @@ public class DelegatingSingleAddressHttpClientBuilder<U, R> implements SingleAdd
     @Override
     public SingleAddressHttpClientBuilder<U, R> proxyAddress(final U proxyAddress) {
         delegate = delegate.proxyAddress(proxyAddress);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientBuilder<U, R> proxyAddress(
+            final U proxyAddress, final Consumer<StreamingHttpRequest> requestInitializer) {
+        delegate = delegate.proxyAddress(proxyAddress, requestInitializer);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -78,7 +78,7 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * request. It can be used to add headers, like {@link HttpHeaderNames#PROXY_AUTHORIZATION}, debugging info, etc.
      * @return {@code this}.
      */
-    default SingleAddressHttpClientBuilder<U, R> proxyAddress(  // FIXME: 0.43 - remove default impl
+    default SingleAddressHttpClientBuilder<U, R> proxyAddress(// FIXME: 0.43 - remove default impl
             U proxyAddress, Consumer<StreamingHttpRequest> connectRequestInitializer) {
         throw new UnsupportedOperationException(
                 "Setting proxy address with request initializer is not yet supported by " + getClass().getName());

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import io.servicetalk.transport.api.TransportObserver;
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -61,6 +62,26 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
     default SingleAddressHttpClientBuilder<U, R> proxyAddress(U proxyAddress) { // FIXME: 0.43 - remove default impl
         throw new UnsupportedOperationException("Setting proxy address is not yet supported by "
                 + getClass().getName());
+    }
+
+    /**
+     * Configure proxy to serve as an intermediary for requests.
+     * <p>
+     * If the client talks to a proxy over http (not https, {@link #sslConfig(ClientSslConfig) ClientSslConfig} is NOT
+     * configured), it will rewrite the request-target to
+     * <a href="https://tools.ietf.org/html/rfc7230#section-5.3.2">absolute-form</a>, as specified by the RFC.
+     *
+     * @param proxyAddress Unresolved address of the proxy. When used with a builder created for a resolved address,
+     * {@code proxyAddress} should also be already resolved – otherwise runtime exceptions may occur.
+     * @param requestInitializer {@link Consumer} of {@link StreamingHttpRequest} that can be used to add additional
+     * info to <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request.
+     * It can be used to add headers, like {@link HttpHeaderNames#PROXY_AUTHORIZATION}, debugging information, etc.
+     * @return {@code this}.
+     */
+    default SingleAddressHttpClientBuilder<U, R> proxyAddress(U proxyAddress,   // FIXME: 0.43 - remove default impl
+                                                              Consumer<StreamingHttpRequest> requestInitializer) {
+        throw new UnsupportedOperationException(
+                "Setting proxy address with request initializer is not yet supported by " + getClass().getName());
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -73,13 +73,13 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      *
      * @param proxyAddress Unresolved address of the proxy. When used with a builder created for a resolved address,
      * {@code proxyAddress} should also be already resolved – otherwise runtime exceptions may occur.
-     * @param requestInitializer {@link Consumer} of {@link StreamingHttpRequest} that can be used to add additional
-     * info to <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request.
-     * It can be used to add headers, like {@link HttpHeaderNames#PROXY_AUTHORIZATION}, debugging information, etc.
+     * @param connectRequestInitializer {@link Consumer} of {@link StreamingHttpRequest} that can be used to add
+     * additional info to <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a>
+     * request. It can be used to add headers, like {@link HttpHeaderNames#PROXY_AUTHORIZATION}, debugging info, etc.
      * @return {@code this}.
      */
-    default SingleAddressHttpClientBuilder<U, R> proxyAddress(U proxyAddress,   // FIXME: 0.43 - remove default impl
-                                                              Consumer<StreamingHttpRequest> requestInitializer) {
+    default SingleAddressHttpClientBuilder<U, R> proxyAddress(  // FIXME: 0.43 - remove default impl
+            U proxyAddress, Consumer<StreamingHttpRequest> connectRequestInitializer) {
         throw new UnsupportedOperationException(
                 "Setting proxy address with request initializer is not yet supported by " + getClass().getName());
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -49,11 +49,16 @@ import java.util.function.Predicate;
 public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
     /**
      * Configure proxy to serve as an intermediary for requests.
+     * <p>
+     * If the client talks to a proxy over http (not https, {@link #sslConfig(ClientSslConfig) ClientSslConfig} is NOT
+     * configured), it will rewrite the request-target to
+     * <a href="https://tools.ietf.org/html/rfc7230#section-5.3.2">absolute-form</a>, as specified by the RFC.
+     *
      * @param proxyAddress Unresolved address of the proxy. When used with a builder created for a resolved address,
      * {@code proxyAddress} should also be already resolved – otherwise runtime exceptions may occur.
      * @return {@code this}.
      */
-    default SingleAddressHttpClientBuilder<U, R> proxyAddress(U proxyAddress) {
+    default SingleAddressHttpClientBuilder<U, R> proxyAddress(U proxyAddress) { // FIXME: 0.43 - remove default impl
         throw new UnsupportedOperationException("Setting proxy address is not yet supported by "
                 + getClass().getName());
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019, 2021-2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TerminalSignalConsumer;
-import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpEventKey;
 import io.servicetalk.http.api.HttpExecutionContext;
@@ -39,6 +38,7 @@ import io.servicetalk.transport.api.IoThreadFactory;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
+import io.netty.channel.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +66,7 @@ import static io.servicetalk.transport.netty.internal.FlushStrategies.flushOnEnd
 import static java.util.Objects.requireNonNull;
 
 abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext>
-        implements FilterableStreamingHttpConnection {
+        implements NettyFilterableStreamingHttpConnection {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractStreamingHttpConnection.class);
     static final IgnoreConsumedEvent<Integer> ZERO_MAX_CONCURRENCY_EVENT = new IgnoreConsumedEvent<>(0);
@@ -168,7 +168,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     }
 
     @Override
-    public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+    public final Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
         return defer(() -> {
             Publisher<Object> flatRequest;
             // See https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -258,6 +258,11 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
     @Override
     public final StreamingHttpResponseFactory httpResponseFactory() {
         return reqRespFactory;
+    }
+
+    @Override
+    public Channel nettyChannel() {
+        return connection.nettyChannel();
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -455,9 +455,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
     @Override
     public SingleAddressHttpClientBuilder<U, R> proxyAddress(
-            final U proxyAddress, final Consumer<StreamingHttpRequest> requestInitializer) {
+            final U proxyAddress, final Consumer<StreamingHttpRequest> connectRequestInitializer) {
         this.proxyAddress(proxyAddress);
-        this.proxyConnectRequestInitializer = requireNonNull(requestInitializer);
+        this.proxyConnectRequestInitializer = requireNonNull(connectRequestInitializer);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,14 +278,17 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 H2ProtocolConfig h2Config = roConfig.h2Config();
                 connectionFactory = new AlpnLBHttpConnectionFactory<>(roConfig, executionContext,
                         connectionFilterFactory, new AlpnReqRespFactoryFunc(
-                                executionContext.bufferAllocator(),
-                                h1Config == null ? null : h1Config.headersFactory(),
-                                h2Config == null ? null : h2Config.headersFactory()),
+                        executionContext.bufferAllocator(),
+                        h1Config == null ? null : h1Config.headersFactory(),
+                        h2Config == null ? null : h2Config.headersFactory()),
+                        connectionFactoryStrategy, connectionFactoryFilter,
+                        ctx.builder.loadBalancerFactory::toLoadBalancedConnection);
+            } else if (roConfig.hasProxy() && sslContext != null) {
+                connectionFactory = new ProxyConnectLBHttpConnectionFactory<>(roConfig, executionContext,
+                        connectionFilterFactory, reqRespFactory,
                         connectionFactoryStrategy, connectionFactoryFilter,
                         ctx.builder.loadBalancerFactory::toLoadBalancedConnection);
             } else {
-                H1ProtocolConfig h1Config = roConfig.h1Config();
-                assert h1Config != null;
                 connectionFactory = new PipelinedLBHttpConnectionFactory<>(roConfig, executionContext,
                         connectionFilterFactory, reqRespFactory,
                         connectionFactoryStrategy, connectionFactoryFilter,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyFilterableStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyFilterableStreamingHttpConnection.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+
+import io.netty.channel.Channel;
+
+/**
+ * {@link FilterableStreamingHttpConnection} that also gives access to Netty {@link Channel}.
+ */
+interface NettyFilterableStreamingHttpConnection extends FilterableStreamingHttpConnection {
+
+    /**
+     * Return the Netty {@link Channel} backing this connection.
+     *
+     * @return the Netty {@link Channel} backing this connection.
+     */
+    Channel nettyChannel();
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.buildStreaming;
+import static java.util.Objects.requireNonNull;
 
 final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
     PipelinedLBHttpConnectionFactory(
@@ -39,6 +40,7 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
             final ProtocolBinding protocolBinding) {
         super(config, executionContext, version -> reqRespFactory, connectStrategy, connectionFactoryFilter,
                 connectionFilterFunction, protocolBinding);
+        requireNonNull(config.h1Config(), "H1ProtocolConfig is required");
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2019-2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.ConnectionFactoryFilter;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ExecutionStrategy;
+import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.DeferSslHandler;
+import io.servicetalk.transport.netty.internal.StacklessClosedChannelException;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.http.api.HttpHeaderNames.HOST;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
+import static io.servicetalk.http.netty.StreamingConnectionFactory.buildStreaming;
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+import static java.util.Objects.requireNonNull;
+
+final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
+        extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
+
+    private final String connectAddress;
+
+    ProxyConnectLBHttpConnectionFactory(
+            final ReadOnlyHttpClientConfig config, final HttpExecutionContext executionContext,
+            @Nullable final StreamingHttpConnectionFilterFactory connectionFilterFunction,
+            final StreamingHttpRequestResponseFactory reqRespFactory,
+            final ExecutionStrategy connectStrategy,
+            final ConnectionFactoryFilter<ResolvedAddress, FilterableStreamingHttpConnection> connectionFactoryFilter,
+            final ProtocolBinding protocolBinding) {
+        super(config, executionContext, version -> reqRespFactory, connectStrategy, connectionFactoryFilter,
+                connectionFilterFunction, protocolBinding);
+        requireNonNull(config.h1Config(), "H1ProtocolConfig is required");
+        assert config.connectAddress() != null;
+        connectAddress = config.connectAddress().toString();
+    }
+
+    @Override
+    Single<FilterableStreamingHttpConnection> newFilterableConnection(final ResolvedAddress resolvedAddress,
+                                                                      final TransportObserver observer) {
+        assert config.h1Config() != null;
+        return buildStreaming(executionContext, resolvedAddress, config, observer)
+                .map(c -> new PipelinedStreamingHttpConnection(c, config.h1Config(),
+                        reqRespFactoryFunc.apply(HTTP_1_1), config.allowDropTrailersReadFromTransport()))
+                .flatMap(this::processConnect);
+    }
+
+    private Single<FilterableStreamingHttpConnection> processConnect(final NettyFilterableStreamingHttpConnection c) {
+        try {
+            // Send CONNECT request: https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6
+            // Host header value must be equal to CONNECT request target, see
+            // https://github.com/haproxy/haproxy/issues/1159
+            // https://datatracker.ietf.org/doc/html/rfc7230#section-5.4:
+            //   If the target URI includes an authority component, then a client MUST send a field-value
+            //   for Host that is identical to that authority component
+            final StreamingHttpRequest request = c.connect(connectAddress).setHeader(HOST, connectAddress);
+            // No need to offload because there is no user code involved
+            request.context().put(HTTP_EXECUTION_STRATEGY_KEY, offloadNone());
+            return c.request(request)
+                    .flatMap(response -> {
+                        // Successful response to CONNECT never has a message body, and we are not interested in payload
+                        // body for any non-200 status code. Drain it asap to free connection and RS resources before
+                        // starting TLS handshake or propagating an error.
+                        if (response.status().statusClass() != SUCCESSFUL_2XX) {
+                            return drainPropagateError(response, new ProxyResponseException(c +
+                                    " Non-successful response from proxy CONNECT " + connectAddress, response.status()))
+                                    .shareContextOnSubscribe();
+                        }
+                        return response.messageBody().ignoreElements()
+                                .concat(handshake(c))
+                                .shareContextOnSubscribe();
+                    })
+                    // Close recently created connection in case of any error while it connects to the proxy:
+                    .onErrorResume(t -> closePropagateError(c, t));
+            // We do not apply shareContextOnSubscribe() here to isolate a context for `CONNECT` request.
+        } catch (Throwable t) {
+            return closePropagateError(c, t);
+        }
+    }
+
+    private Single<FilterableStreamingHttpConnection> handshake(
+            final NettyFilterableStreamingHttpConnection connection) {
+        return Single.defer(() -> {
+            final SingleSource.Processor<FilterableStreamingHttpConnection, FilterableStreamingHttpConnection>
+                    processor = newSingleProcessor();
+            final Channel channel = connection.nettyChannel();
+            assert channel.eventLoop().inEventLoop();
+            channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                @Override
+                public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+                    if (evt instanceof SslHandshakeCompletionEvent) {
+                        SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
+                        if (event.isSuccess()) {
+                            processor.onSuccess(connection);
+                        } else {
+                            processor.onError(event.cause());
+                        }
+                        channel.pipeline().remove(this);
+                    }
+                    ctx.fireUserEventTriggered(evt);
+                }
+            });
+
+            final Single<FilterableStreamingHttpConnection> result;
+            final DeferSslHandler deferSslHandler = channel.pipeline().get(DeferSslHandler.class);
+            if (deferSslHandler == null) {
+                if (!channel.isActive()) {
+                    result = Single.failed(StacklessClosedChannelException.newInstance(connection +
+                                    " Connection is closed, either received a 'Connection: closed' header or" +
+                                    " closed by the proxy. Investigate logs on a proxy side to identify the cause.",
+                            ProxyConnectLBHttpConnectionFactory.class, "handshake"));
+                } else {
+                    result = Single.failed(new IllegalStateException(connection +
+                            " Unexpected connection state: failed to find a handler of type " +
+                            DeferSslHandler.class + " in the channel pipeline."));
+                }
+            } else {
+                deferSslHandler.ready();
+                result = fromSource(processor);
+            }
+            return result.shareContextOnSubscribe();
+        });
+    }
+
+    private static Single<FilterableStreamingHttpConnection> drainPropagateError(
+            final StreamingHttpResponse response, final Throwable error) {
+        return safeCompletePropagateError(response.messageBody().ignoreElements(), error);
+    }
+
+    private static Single<FilterableStreamingHttpConnection> closePropagateError(
+            final FilterableStreamingHttpConnection connection, final Throwable error) {
+        return safeCompletePropagateError(connection.closeAsync(), error);
+    }
+
+    private static Single<FilterableStreamingHttpConnection> safeCompletePropagateError(
+            final Completable completable, final Throwable error) {
+        return completable
+                .onErrorResume(closeError -> Completable.failed(addSuppressed(error, closeError)))
+                .concat(Single.failed(error));
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
@@ -77,7 +77,8 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
                 .flatMap(this::processConnect);
     }
 
-    private Single<FilterableStreamingHttpConnection> processConnect(final NettyFilterableStreamingHttpConnection c) {
+    // Visible for testing
+    Single<FilterableStreamingHttpConnection> processConnect(final NettyFilterableStreamingHttpConnection c) {
         try {
             // Send CONNECT request: https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6
             // Host header value must be equal to CONNECT request target, see

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactoryTest.java
@@ -29,6 +29,8 @@ import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.netty.AbstractLBHttpConnectionFactory.ProtocolBinding;
+import io.servicetalk.transport.api.ClientSslConfig;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.ConnectExecutionStrategy;
 import io.servicetalk.transport.netty.internal.DeferSslHandler;
 
@@ -73,6 +75,7 @@ import static org.mockito.Mockito.when;
 
 class ProxyConnectLBHttpConnectionFactoryTest {
 
+    private static final ClientSslConfig DEFAULT_SSL_CONFIG = new ClientSslConfigBuilder().build();
     private static final StreamingHttpRequestResponseFactory REQ_RES_FACTORY =
             new DefaultStreamingHttpRequestResponseFactory(DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE,
                     HTTP_1_1);
@@ -116,6 +119,7 @@ class ProxyConnectLBHttpConnectionFactoryTest {
 
         HttpClientConfig config = new HttpClientConfig();
         config.connectAddress(CONNECT_ADDRESS);
+        config.tcpConfig().sslConfig(DEFAULT_SSL_CONFIG);
         config.protocolConfigs().protocols(h1Default());
         connectionFactory = new ProxyConnectLBHttpConnectionFactory<>(config.asReadOnly(),
                 executionContext, null, REQ_RES_FACTORY, ConnectExecutionStrategy.offloadNone(),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactoryTest.java
@@ -31,7 +31,6 @@ import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.netty.AbstractLBHttpConnectionFactory.ProtocolBinding;
 import io.servicetalk.transport.api.ConnectExecutionStrategy;
 import io.servicetalk.transport.netty.internal.DeferSslHandler;
-import io.servicetalk.transport.netty.internal.NettyConnectionContext;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -301,9 +300,5 @@ class ProxyConnectLBHttpConnectionFactoryTest {
 
     private void assertConnectionClosed() {
         assertThat("Closure of the connection was not triggered", connectionClose.isSubscribed(), is(true));
-    }
-
-    private interface NettyHttpConnectionContext extends HttpConnectionContext, NettyConnectionContext {
-        // no methods
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.client.api.ConnectionFactory;
+import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.TestCompletable;
@@ -26,10 +26,9 @@ import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
-import io.servicetalk.http.api.HttpExecutionStrategies;
-import io.servicetalk.http.api.HttpExecutionStrategy;
-import io.servicetalk.http.api.StreamingHttpRequestFactory;
+import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.netty.AbstractLBHttpConnectionFactory.ProtocolBinding;
 import io.servicetalk.transport.api.ConnectExecutionStrategy;
 import io.servicetalk.transport.netty.internal.DeferSslHandler;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
@@ -38,6 +37,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -46,9 +46,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.stubbing.Answer;
 
 import java.nio.channels.ClosedChannelException;
-import java.util.Queue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
@@ -60,7 +57,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
-import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -75,23 +72,24 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class ProxyConnectConnectionFactoryFilterTest {
+class ProxyConnectLBHttpConnectionFactoryTest {
 
-    private static final StreamingHttpRequestFactory REQ_FACTORY = new DefaultStreamingHttpRequestResponseFactory(
-            DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
+    private static final StreamingHttpRequestResponseFactory REQ_RES_FACTORY =
+            new DefaultStreamingHttpRequestResponseFactory(DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE,
+                    HTTP_1_1);
     private static final String CONNECT_ADDRESS = "foo.bar";
-    private static final String RESOLVED_ADDRESS = "bar.foo";
 
-    private final FilterableStreamingHttpConnection connection;
+    private final NettyFilterableStreamingHttpConnection connection;
     private final TestCompletable connectionClose;
     private final TestPublisher<Object> messageBody;
     private final TestSingleSubscriber<FilterableStreamingHttpConnection> subscriber;
+    private final ProxyConnectLBHttpConnectionFactory<String> connectionFactory;
 
-    ProxyConnectConnectionFactoryFilterTest() {
+    ProxyConnectLBHttpConnectionFactoryTest() {
         HttpExecutionContext executionContext = new HttpExecutionContextBuilder().build();
         HttpConnectionContext connectionContext = mock(HttpConnectionContext.class);
         when(connectionContext.executionContext()).thenReturn(executionContext);
-        connection = mock(FilterableStreamingHttpConnection.class);
+        connection = mock(NettyFilterableStreamingHttpConnection.class);
         when(connection.connectionContext()).thenReturn(connectionContext);
         connectionClose = new TestCompletable.Builder().build(subscriber -> {
             subscriber.onSubscribe(IGNORE_CANCEL);
@@ -116,6 +114,13 @@ class ProxyConnectConnectionFactoryFilterTest {
         });
 
         subscriber = new TestSingleSubscriber<>();
+
+        HttpClientConfig config = new HttpClientConfig();
+        config.connectAddress(CONNECT_ADDRESS);
+        config.protocolConfigs().protocols(h1Default());
+        connectionFactory = new ProxyConnectLBHttpConnectionFactory<>(config.asReadOnly(),
+                executionContext, null, REQ_RES_FACTORY, ConnectExecutionStrategy.offloadNone(),
+                ConnectionFactoryFilter.identity(), mock(ProtocolBinding.class));
     }
 
     private static ChannelPipeline configurePipeline(@Nullable SslHandshakeCompletionEvent event) {
@@ -134,22 +139,14 @@ class ProxyConnectConnectionFactoryFilterTest {
         when(pipeline.get(DeferSslHandler.class)).thenReturn(mock(DeferSslHandler.class));
     }
 
-    private void configureConnectionContext(final ChannelPipeline pipeline) {
-        configureConnectionContext(pipeline, HttpExecutionStrategies.defaultStrategy());
-    }
-
-    private void configureConnectionContext(final ChannelPipeline pipeline,
-                                            final HttpExecutionStrategy executionStrategy) {
+    private void configureConnectionNettyChannel(final ChannelPipeline pipeline) {
         Channel channel = mock(Channel.class);
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(true);
+        when(channel.eventLoop()).thenReturn(eventLoop);
         when(channel.pipeline()).thenReturn(pipeline);
         when(pipeline.channel()).thenReturn(channel);
-
-        HttpExecutionContext executionContext = new HttpExecutionContextBuilder()
-                .executionStrategy(executionStrategy).build();
-        NettyHttpConnectionContext nettyContext = mock(NettyHttpConnectionContext.class);
-        when(nettyContext.executionContext()).thenReturn(executionContext);
-        when(nettyContext.nettyChannel()).thenReturn(channel);
-        when(connection.connectionContext()).thenReturn(nettyContext);
+        when(connection.nettyChannel()).thenReturn(channel);
     }
 
     private void configureRequestSend() {
@@ -160,21 +157,11 @@ class ProxyConnectConnectionFactoryFilterTest {
     }
 
     private void configureConnectRequest() {
-        when(connection.connect(any())).thenReturn(REQ_FACTORY.connect(CONNECT_ADDRESS));
+        when(connection.connect(any())).thenReturn(REQ_RES_FACTORY.connect(CONNECT_ADDRESS));
     }
 
     private void subscribeToProxyConnectionFactory() {
-        subscribeToProxyConnectionFactory(c -> { });
-    }
-
-    private void subscribeToProxyConnectionFactory(Consumer<FilterableStreamingHttpConnection> onSuccess) {
-        @SuppressWarnings("unchecked")
-        ConnectionFactory<String, FilterableStreamingHttpConnection> original = mock(ConnectionFactory.class);
-        when(original.newConnection(any(), any(), any())).thenReturn(succeeded(connection));
-        toSource(new ProxyConnectConnectionFactoryFilter<String, FilterableStreamingHttpConnection>(
-                CONNECT_ADDRESS, ConnectExecutionStrategy.offloadNone())
-                .create(original).newConnection(RESOLVED_ADDRESS, null, null).afterOnSuccess(onSuccess))
-                .subscribe(subscriber);
+        toSource(connectionFactory.processConnect(connection)).subscribe(subscriber);
     }
 
     @Test
@@ -218,31 +205,12 @@ class ProxyConnectConnectionFactoryFilterTest {
         assertConnectionClosed();
     }
 
-    @Test
-    void cannotAccessNettyChannel() {
-        // Does not implement NettyConnectionContext:
-        HttpExecutionContext executionContext = new HttpExecutionContextBuilder().build();
-
-        HttpConnectionContext connectionContext = mock(HttpConnectionContext.class);
-        when(connectionContext.executionContext()).thenReturn(executionContext);
-
-        when(connection.connectionContext()).thenReturn(connectionContext);
-
-        configureRequestSend();
-        configureConnectRequest();
-        subscribeToProxyConnectionFactory();
-
-        assertThat(subscriber.awaitOnError(), instanceOf(ClassCastException.class));
-        assertConnectPayloadConsumed(true);
-        assertConnectionClosed();
-    }
-
     @ParameterizedTest(name = "{displayName} [{index}] ttl={0}")
     @ValueSource(booleans = {true, false})
     void noDeferSslHandler(boolean channelActive) {
         ChannelPipeline pipeline = configurePipeline(SslHandshakeCompletionEvent.SUCCESS);
         // Do not configureDeferSslHandler(pipeline);
-        configureConnectionContext(pipeline);
+        configureConnectionNettyChannel(pipeline);
         Channel channel = pipeline.channel();
         when(channel.isActive()).thenReturn(channelActive);
         configureRequestSend();
@@ -266,7 +234,7 @@ class ProxyConnectConnectionFactoryFilterTest {
         ChannelPipeline pipeline = configurePipeline(SslHandshakeCompletionEvent.SUCCESS);
         when(pipeline.get(DeferSslHandler.class)).thenThrow(DELIBERATE_EXCEPTION);
 
-        configureConnectionContext(pipeline);
+        configureConnectionNettyChannel(pipeline);
         configureRequestSend();
         configureConnectRequest();
         subscribeToProxyConnectionFactory();
@@ -281,7 +249,7 @@ class ProxyConnectConnectionFactoryFilterTest {
         ChannelPipeline pipeline = configurePipeline(new SslHandshakeCompletionEvent(DELIBERATE_EXCEPTION));
 
         configureDeferSslHandler(pipeline);
-        configureConnectionContext(pipeline);
+        configureConnectionNettyChannel(pipeline);
         configureRequestSend();
         configureConnectRequest();
         subscribeToProxyConnectionFactory();
@@ -297,7 +265,7 @@ class ProxyConnectConnectionFactoryFilterTest {
         ChannelPipeline pipeline = configurePipeline(null); // Do not generate any SslHandshakeCompletionEvent
 
         configureDeferSslHandler(pipeline);
-        configureConnectionContext(pipeline);
+        configureConnectionNettyChannel(pipeline);
         configureRequestSend();
         configureConnectRequest();
         subscribeToProxyConnectionFactory();
@@ -314,7 +282,7 @@ class ProxyConnectConnectionFactoryFilterTest {
     void successfulConnect() {
         ChannelPipeline pipeline = configurePipeline(SslHandshakeCompletionEvent.SUCCESS);
         configureDeferSslHandler(pipeline);
-        configureConnectionContext(pipeline);
+        configureConnectionNettyChannel(pipeline);
         configureRequestSend();
         configureConnectRequest();
         subscribeToProxyConnectionFactory();
@@ -322,27 +290,6 @@ class ProxyConnectConnectionFactoryFilterTest {
         assertThat(subscriber.awaitOnSuccess(), is(sameInstance(this.connection)));
         assertConnectPayloadConsumed(true);
         assertThat("Connection closed", connectionClose.isSubscribed(), is(false));
-    }
-
-    @Test
-    void noOffloadingStrategy() {
-        ChannelPipeline pipeline = configurePipeline(SslHandshakeCompletionEvent.SUCCESS);
-        configureDeferSslHandler(pipeline);
-        configureConnectionContext(pipeline, HttpExecutionStrategies.offloadNone());
-        configureRequestSend();
-        configureConnectRequest();
-        Queue<Throwable> errors = new LinkedBlockingQueue<>();
-        Thread testThread = Thread.currentThread();
-        subscribeToProxyConnectionFactory(c -> {
-            if (Thread.currentThread() != testThread) {
-                errors.add(new AssertionError("Unexpected Thread for success " + Thread.currentThread()));
-            }
-        });
-
-        assertNoAsyncErrors(errors);
-        assertThat(subscriber.awaitOnSuccess(), is(sameInstance(this.connection)));
-        assertConnectPayloadConsumed(true);
-        assertThat("Connection closed", !connectionClose.isSubscribed());
     }
 
     private void assertConnectPayloadConsumed(boolean expected) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/StacklessClosedChannelException.java
@@ -18,6 +18,7 @@ package io.servicetalk.transport.netty.internal;
 import io.servicetalk.concurrent.internal.ThrowableUtils;
 
 import java.nio.channels.ClosedChannelException;
+import javax.annotation.Nullable;
 
 /**
  * {@link ClosedChannelException} that will not not fill in the stacktrace but use a cheaper way of producing
@@ -26,7 +27,22 @@ import java.nio.channels.ClosedChannelException;
 public final class StacklessClosedChannelException extends ClosedChannelException {
     private static final long serialVersionUID = -5021225720136487769L;
 
-    private StacklessClosedChannelException() { }
+    @Nullable
+    private final String message;
+
+    private StacklessClosedChannelException() {
+        this(null);
+    }
+
+    private StacklessClosedChannelException(@Nullable final String message) {
+        this.message = message;
+    }
+
+    @Nullable
+    @Override
+    public String getMessage() {
+        return message;
+    }
 
     @Override
     public Throwable fillInStackTrace() {
@@ -41,7 +57,21 @@ public final class StacklessClosedChannelException extends ClosedChannelExceptio
      * @param method The method from which it will be thrown.
      * @return a new instance.
      */
-    public static StacklessClosedChannelException newInstance(Class<?> clazz, String method) {
+    public static StacklessClosedChannelException newInstance(final Class<?> clazz, final String method) {
         return ThrowableUtils.unknownStackTrace(new StacklessClosedChannelException(), clazz, method);
+    }
+
+    /**
+     * Creates a new {@link StacklessClosedChannelException} instance.
+     *
+     * @param message The description message for more information.
+     * @param clazz The class in which this {@link StacklessClosedChannelException} will be used.
+     * @param method The method from which it will be thrown.
+     * @return a new instance.
+     */
+    public static StacklessClosedChannelException newInstance(final String message,
+                                                              final Class<?> clazz,
+                                                              final String method) {
+        return ThrowableUtils.unknownStackTrace(new StacklessClosedChannelException(message), clazz, method);
     }
 }


### PR DESCRIPTION
Motivation:

After #2697 moved HTTP proxy `CONNECT` logic before user-defined
`ConnectionFactoryFilter`s, users lost the ability to intercept `CONNECT`
requests for the purpose of adding custom headers, like auth.

Modifications:

- Add `SingleAddressHttpClientBuilder.proxyAddress(...)` overload that
takes `Consumer<StreamingHttpRequest>` as a 2nd argument;
- Recompute `HttpExecutionStrategy` after `CONNECT` request initializer
is invoked in `ProxyConnectLBHttpConnectionFactory`;
- Enhance `ProxyConnectLBHttpConnectionFactoryTest` to verify that the
initializer is invoked and users can alter the execution strategy;
- Enhance `ProxyTunnel` and `HttpsProxyTest` to verify that new API
can be used to send `Proxy-Authorization` header;

Result:

Users have explicit API to alter HTTP `CONNECT` requests if necessary.

---
Depends on #2697, review only the last commit.