### PR TITLE
Implement HTTP proxy CONNECT with ALPN

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcProxyTunnelTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcProxyTunnelTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap.Key;
+import io.servicetalk.grpc.api.DefaultGrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.netty.ProxyResponseException;
+import io.servicetalk.http.netty.ProxyTunnel;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.ServerSslConfigBuilder;
+
+import io.grpc.examples.helloworld.Greeter;
+import io.grpc.examples.helloworld.Greeter.BlockingGreeterClient;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+
+import static io.servicetalk.context.api.ContextMap.Key.newKey;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
+import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GrpcProxyTunnelTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GrpcProxyTunnelTest.class);
+    private static final String AUTH_TOKEN = "aGVsbG86d29ybGQ=";
+    private static final String GREETING_PREFIX = "Hello ";
+    private static final Key<ConnectionInfo> CONNECTION_INFO_KEY =
+            newKey("CONNECTION_INFO_KEY", ConnectionInfo.class);
+
+    private final ProxyTunnel proxyTunnel;
+    private final HostAndPort proxyAddress;
+    private final ServerContext serverContext;
+    private final BlockingGreeterClient client;
+
+    GrpcProxyTunnelTest() throws Exception {
+        proxyTunnel = new ProxyTunnel();
+        proxyAddress = proxyTunnel.startProxy();
+        serverContext = GrpcServers.forAddress(localAddress(0))
+                .initializeHttp(httpBuilder -> httpBuilder
+                        .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
+                                DefaultTestCerts::loadServerKey).build()))
+                .listenAndAwait((Greeter.BlockingGreeterService) (ctx, request) ->
+                        HelloReply.newBuilder().setMessage(GREETING_PREFIX + request.getName()).build());
+        client = GrpcClients.forAddress(serverHostAndPort(serverContext))
+                .initializeHttp(httpBuilder -> httpBuilder.proxyAddress(proxyAddress)
+                        .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                                .peerHost(serverPemHostname()).build())
+                        .appendConnectionFilter(connection -> new StreamingHttpConnectionFilter(connection) {
+                            @Override
+                            public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                                return delegate().request(request)
+                                        .whenOnSuccess(response -> response.context()
+                                                .put(CONNECTION_INFO_KEY, connection.connectionContext()));
+                            }
+                        }))
+                .buildBlocking(new Greeter.ClientFactory());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        safeClose(client);
+        safeClose(serverContext);
+        safeClose(proxyTunnel);
+    }
+
+    private static void safeClose(AutoCloseable closeable) {
+        try {
+            closeable.close();
+        } catch (Exception e) {
+            LOGGER.error("Unexpected exception while closing", e);
+        }
+    }
+
+    @Test
+    void testRequest() throws Exception {
+        String name = "foo";
+        GrpcClientMetadata metaData = new DefaultGrpcClientMetadata();
+        HelloReply reply = client.sayHello(metaData, HelloRequest.newBuilder().setName(name).build());
+        assertThat(reply.getMessage(), is(GREETING_PREFIX + name));
+        ConnectionInfo connectionInfo = metaData.responseContext().get(CONNECTION_INFO_KEY);
+        assertThat(connectionInfo, is(notNullValue()));
+        assertThat(connectionInfo.protocol(), is(HTTP_2_0));
+        assertThat(connectionInfo.sslConfig(), is(notNullValue()));
+        assertThat(connectionInfo.sslSession(), is(notNullValue()));
+        assertThat(((InetSocketAddress) connectionInfo.remoteAddress()).getPort(), is(proxyAddress.port()));
+        assertThat(proxyTunnel.connectCount(), is(1));
+    }
+
+    @Test
+    void testProxyAuthRequired() throws Exception {
+        proxyTunnel.basicAuthToken(AUTH_TOKEN);
+        GrpcStatusException e = assertThrows(GrpcStatusException.class,
+                () -> client.sayHello(HelloRequest.newBuilder().setName("foo").build()));
+        assertThat(e.status().code(), is(UNKNOWN));
+        Throwable cause = e.getCause();
+        assertThat(cause, is(instanceOf(ProxyResponseException.class)));
+        assertThat(((ProxyResponseException) cause).status(), is(PROXY_AUTHENTICATION_REQUIRED));
+    }
+
+    @Test
+    void testBadProxyResponse() throws Exception {
+        proxyTunnel.badResponseProxy();
+        GrpcStatusException e = assertThrows(GrpcStatusException.class,
+                () -> client.sayHello(HelloRequest.newBuilder().setName("foo").build()));
+        assertThat(e.status().code(), is(UNKNOWN));
+        Throwable cause = e.getCause();
+        assertThat(cause, is(instanceOf(ProxyResponseException.class)));
+        assertThat(((ProxyResponseException) cause).status(), is(INTERNAL_SERVER_ERROR));
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,12 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * If the client talks to a proxy over http (not https, {@link #sslConfig(ClientSslConfig) ClientSslConfig} is NOT
      * configured), it will rewrite the request-target to
      * <a href="https://tools.ietf.org/html/rfc7230#section-5.3.2">absolute-form</a>, as specified by the RFC.
+     * <p>
+     * For secure proxy tunnels (when {@link #sslConfig(ClientSslConfig) ClientSslConfig} is configured) the tunnel is
+     * always initialized using
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request. The actual
+     * protocol will be negotiated via <a href="https://tools.ietf.org/html/rfc7301">ALPN extension</a> of TLS protocol,
+     * taking into account HTTP protocols configured via {@link #protocols(HttpProtocolConfig...)} method.
      *
      * @param proxyAddress Unresolved address of the proxy. When used with a builder created for a resolved address,
      * {@code proxyAddress} should also be already resolved – otherwise runtime exceptions may occur.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
@@ -46,11 +46,6 @@ final class AlpnChannelSingle extends ChannelInitSingle<String> {
     private final Consumer<ChannelHandlerContext> onHandlerAdded;
 
     AlpnChannelSingle(final Channel channel,
-                      final ChannelInitializer channelInitializer) {
-        this(channel, channelInitializer, __ -> { });
-    }
-
-    AlpnChannelSingle(final Channel channel,
                       final ChannelInitializer channelInitializer,
                       final Consumer<ChannelHandlerContext> onHandlerAdded) {
         super(channel, channelInitializer);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
@@ -31,28 +31,35 @@ import io.netty.handler.ssl.SslHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 
 import static io.servicetalk.http.netty.AlpnIds.HTTP_1_1;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.assignConnectionError;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link Single} that initializes ALPN handler and completes after protocol negotiation.
  */
 final class AlpnChannelSingle extends ChannelInitSingle<String> {
-    private final boolean forceChannelRead;
+    private final Consumer<ChannelHandlerContext> onHandlerAdded;
+
+    AlpnChannelSingle(final Channel channel,
+                      final ChannelInitializer channelInitializer) {
+        this(channel, channelInitializer, __ -> { });
+    }
 
     AlpnChannelSingle(final Channel channel,
                       final ChannelInitializer channelInitializer,
-                      final boolean forceChannelRead) {
+                      final Consumer<ChannelHandlerContext> onHandlerAdded) {
         super(channel, channelInitializer);
-        this.forceChannelRead = forceChannelRead;
+        this.onHandlerAdded = requireNonNull(onHandlerAdded);
     }
 
     @Override
     protected ChannelHandler newChannelHandler(final Subscriber<? super String> subscriber) {
-        return new AlpnChannelHandler(subscriber, forceChannelRead);
+        return new AlpnChannelHandler(subscriber, onHandlerAdded);
     }
 
     /**
@@ -65,24 +72,19 @@ final class AlpnChannelSingle extends ChannelInitSingle<String> {
 
         @Nullable
         private SingleSource.Subscriber<? super String> subscriber;
-        private final boolean forceRead;
+        private final Consumer<ChannelHandlerContext> onHandlerAdded;
 
         AlpnChannelHandler(final SingleSource.Subscriber<? super String> subscriber,
-                           final boolean forceRead) {
+                           final Consumer<ChannelHandlerContext> onHandlerAdded) {
             super(HTTP_1_1);
             this.subscriber = subscriber;
-            this.forceRead = forceRead;
+            this.onHandlerAdded = onHandlerAdded;
         }
 
         @Override
         public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
             super.handlerAdded(ctx);
-            if (forceRead) {
-                // Force a read to get the SSL handshake started. We initialize pipeline before
-                // SslHandshakeCompletionEvent will complete, therefore, no data will be propagated before we finish
-                // initialization.
-                ctx.read();
-            }
+            onHandlerAdded.accept(ctx);
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -70,7 +70,7 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
             final Channel channel, final ConnectionObserver connectionObserver,
             final ReadOnlyTcpClientConfig tcpConfig) {
         return new AlpnChannelSingle(channel,
-                new TcpClientChannelInitializer(tcpConfig, connectionObserver), false).flatMap(protocol -> {
+                new TcpClientChannelInitializer(tcpConfig, connectionObserver)).flatMap(protocol -> {
             switch (protocol) {
                 case HTTP_1_1:
                     final H1ProtocolConfig h1Config = config.h1Config();
@@ -89,8 +89,12 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
                             new H2ClientParentChannelInitializer(h2Config),
                             connectionObserver, config.allowDropTrailersReadFromTransport());
                 default:
-                    return failed(new IllegalStateException("Unknown ALPN protocol negotiated: " + protocol));
+                    return unknownAlpnProtocol(protocol);
             }
         });
+    }
+
+    static Single<FilterableStreamingHttpConnection> unknownAlpnProtocol(final String protocol) {
+        return failed(new IllegalStateException("Unknown ALPN protocol negotiated: " + protocol));
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -69,8 +69,8 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
     private Single<FilterableStreamingHttpConnection> createConnection(
             final Channel channel, final ConnectionObserver connectionObserver,
             final ReadOnlyTcpClientConfig tcpConfig) {
-        return new AlpnChannelSingle(channel,
-                new TcpClientChannelInitializer(tcpConfig, connectionObserver)).flatMap(protocol -> {
+        return new AlpnChannelSingle(channel, new TcpClientChannelInitializer(tcpConfig, connectionObserver),
+                ctx -> { /* SslHandler will automatically start handshake on channelActive */ }).flatMap(protocol -> {
             switch (protocol) {
                 case HTTP_1_1:
                     final H1ProtocolConfig h1Config = config.h1Config();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -232,8 +232,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 return computedStrategy;
             }
         };
-        if (roConfig.h2Config() != null && roConfig.hasProxy()) {
-            throw new IllegalStateException("Proxying is not yet supported with HTTP/2");
+        final SslContext sslContext = roConfig.tcpConfig().sslContext();
+        if (roConfig.hasProxy() && sslContext == null && roConfig.h2Config() != null) {
+            throw new IllegalStateException("Proxying is not yet supported with plaintext HTTP/2");
         }
 
         // Track resources that potentially need to be closed when an exception is thrown during buildStreaming
@@ -247,7 +248,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
             final ExecutionStrategy connectionFactoryStrategy =
                     ctx.builder.strategyComputation.buildForConnectionFactory();
 
-            final SslContext sslContext = roConfig.tcpConfig().sslContext();
             if (roConfig.hasProxy() && sslContext != null) {
                 assert roConfig.connectAddress() != null;
                 final ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> proxy =
@@ -266,14 +266,14 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                     ctx.builder.addIdleTimeoutConnectionFilter ?
                             appendConnectionFilter(ctx.builder.connectionFilterFactory, DEFAULT_IDLE_TIMEOUT_FILTER) :
                             ctx.builder.connectionFilterFactory;
-            if (roConfig.isH2PriorKnowledge()) {
+            if (!roConfig.hasProxy() && roConfig.isH2PriorKnowledge()) {
                 H2ProtocolConfig h2Config = roConfig.h2Config();
                 assert h2Config != null;
                 connectionFactory = new H2LBHttpConnectionFactory<>(roConfig, executionContext,
                         connectionFilterFactory, reqRespFactory,
                         connectionFactoryStrategy, connectionFactoryFilter,
                         ctx.builder.loadBalancerFactory::toLoadBalancedConnection);
-            } else if (roConfig.tcpConfig().preferredAlpnProtocol() != null) {
+            } else if (!roConfig.hasProxy() && roConfig.tcpConfig().preferredAlpnProtocol() != null) {
                 H1ProtocolConfig h1Config = roConfig.h1Config();
                 H2ProtocolConfig h2Config = roConfig.h2Config();
                 connectionFactory = new AlpnLBHttpConnectionFactory<>(roConfig, executionContext,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
@@ -23,14 +23,21 @@ import io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitiali
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
 
 import java.util.ArrayDeque;
+import java.util.List;
 import java.util.Queue;
 
 import static java.lang.Math.min;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 
 final class HttpClientChannelInitializer implements ChannelInitializer {
+
+    private static final List<Class<? extends ChannelHandler>> HANDLERS = unmodifiableList(asList(
+            HttpRequestEncoder.class, HttpResponseDecoder.class, CopyByteBufHandlerChannelInitializer.handlerClass()));
 
     private final ChannelInitializer delegate;
 
@@ -60,5 +67,16 @@ final class HttpClientChannelInitializer implements ChannelInitializer {
     @Override
     public void init(final Channel channel) {
         delegate.init(channel);
+    }
+
+    /**
+     * A list of {@link ChannelHandler} classes added to the {@link ChannelPipeline} in reverse order
+     * (from last to first).
+     *
+     * @return A list of {@link ChannelHandler} classes added to the {@link ChannelPipeline} in reverse order
+     * (from last to first).
+     */
+    static List<Class<? extends ChannelHandler>> handlers() {
+        return HANDLERS;
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedLBHttpConnectionFactory.java
@@ -47,7 +47,8 @@ final class PipelinedLBHttpConnectionFactory<ResolvedAddress> extends AbstractLB
     Single<FilterableStreamingHttpConnection> newFilterableConnection(final ResolvedAddress resolvedAddress,
                                                                       final TransportObserver observer) {
         assert config.h1Config() != null;
-        return buildStreaming(executionContext, resolvedAddress, config, observer)
+        return buildStreaming(executionContext, resolvedAddress, config.tcpConfig(), config.h1Config(),
+                config.hasProxy(), observer)
                 .map(conn -> new PipelinedStreamingHttpConnection(conn, config.h1Config(),
                         reqRespFactoryFunc.apply(HTTP_1_1), config.allowDropTrailersReadFromTransport()));
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
@@ -16,7 +16,6 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectionFactoryFilter;
-import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
@@ -25,25 +24,28 @@ import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.netty.AlpnChannelSingle.NoopChannelInitializer;
+import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer;
+import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
 import io.servicetalk.transport.netty.internal.DeferSslHandler;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 import io.servicetalk.transport.netty.internal.StacklessClosedChannelException;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Processors.newSingleProcessor;
-import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpContextKeys.HTTP_EXECUTION_STRATEGY_KEY;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
+import static io.servicetalk.http.netty.AlpnLBHttpConnectionFactory.unknownAlpnProtocol;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.StreamingConnectionFactory.buildStreaming;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 
@@ -67,7 +69,6 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
             final ProtocolBinding protocolBinding) {
         super(config, executionContext, version -> reqRespFactory, connectStrategy, connectionFactoryFilter,
                 connectionFilterFunction, protocolBinding);
-        assert config.h1Config() != null : "H1ProtocolConfig is required";
         assert config.tcpConfig().sslContext() != null : "Proxy CONNECT works only for TLS connections";
         assert config.connectAddress() != null : "Address (authority) for CONNECT request is required";
         connectAddress = config.connectAddress().toString();
@@ -76,9 +77,13 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
     @Override
     Single<FilterableStreamingHttpConnection> newFilterableConnection(final ResolvedAddress resolvedAddress,
                                                                       final TransportObserver observer) {
-        assert config.h1Config() != null;
-        return buildStreaming(executionContext, resolvedAddress, config, observer)
-                .map(c -> new PipelinedStreamingHttpConnection(c, config.h1Config(),
+        final H1ProtocolConfig h1Config = config.h1Config() != null ? config.h1Config() : h1Default();
+        return buildStreaming(executionContext, resolvedAddress, config.tcpConfig(), h1Config, config.hasProxy(),
+                observer)
+                // Always create PipelinedStreamingHttpConnection because:
+                // 1. buildStreaming creates a CloseHandler for pipelined request-response
+                // 2. in case ALPN negotiates HTTP/1.x we won't need to change the connection
+                .map(c -> new PipelinedStreamingHttpConnection(c, h1Config,
                         reqRespFactoryFunc.apply(HTTP_1_1), config.allowDropTrailersReadFromTransport()))
                 .flatMap(this::processConnect);
     }
@@ -121,27 +126,10 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
     private Single<FilterableStreamingHttpConnection> handshake(
             final NettyFilterableStreamingHttpConnection connection) {
         return Single.defer(() -> {
-            final SingleSource.Processor<FilterableStreamingHttpConnection, FilterableStreamingHttpConnection>
-                    processor = newSingleProcessor();
             final Channel channel = connection.nettyChannel();
             assert channel.eventLoop().inEventLoop();
-            channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-                @Override
-                public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
-                    if (evt instanceof SslHandshakeCompletionEvent) {
-                        SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
-                        if (event.isSuccess()) {
-                            processor.onSuccess(connection);
-                        } else {
-                            processor.onError(event.cause());
-                        }
-                        channel.pipeline().remove(this);
-                    }
-                    ctx.fireUserEventTriggered(evt);
-                }
-            });
 
-            final Single<FilterableStreamingHttpConnection> result;
+            final Single<String> result;
             final DeferSslHandler deferSslHandler = channel.pipeline().get(DeferSslHandler.class);
             if (deferSslHandler == null) {
                 if (!channel.isActive()) {
@@ -155,8 +143,39 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
                             DeferSslHandler.class + " in the channel pipeline."));
                 }
             } else {
-                deferSslHandler.ready();
-                result = fromSource(processor);
+                result = new AlpnChannelSingle(channel, NoopChannelInitializer.INSTANCE, __ -> deferSslHandler.ready());
+            }
+            return result.shareContextOnSubscribe();
+        }).flatMap(protocol -> {
+            final Single<FilterableStreamingHttpConnection> result;
+            switch (protocol) {
+                case AlpnIds.HTTP_1_1:
+                    // Nothing to do, HTTP/1.1 pipeline is already initialized
+                    result = Single.succeeded(connection);
+                    break;
+                case AlpnIds.HTTP_2:
+                    final Channel channel = connection.nettyChannel();
+                    assert channel.eventLoop().inEventLoop();
+                    // Remove HTTP/1.1 handlers:
+                    channel.pipeline().remove(HttpRequestEncoder.class);
+                    channel.pipeline().remove(HttpResponseDecoder.class);
+                    channel.pipeline().remove(CopyByteBufHandlerChannelInitializer.handlerClass());
+                    channel.pipeline().remove(DefaultNettyConnection.handlerClass());
+                    // Initialize HTTP/2:
+                    final H2ProtocolConfig h2Config = config.h2Config();
+                    assert h2Config != null;
+                    final ReadOnlyTcpClientConfig tcpConfig = config.tcpConfig();
+                    result = H2ClientParentConnectionContext.initChannel(channel, executionContext,
+                            h2Config, reqRespFactoryFunc.apply(HTTP_2_0), tcpConfig.flushStrategy(),
+                            tcpConfig.idleTimeoutMs(), tcpConfig.sslConfig(),
+                            new H2ClientParentChannelInitializer(h2Config),
+                            // FIXME: propagate real observer
+                            NoopConnectionObserver.INSTANCE, config.allowDropTrailersReadFromTransport())
+                            .cast(FilterableStreamingHttpConnection.class);
+                    break;
+                default:
+                    result = unknownAlpnProtocol(protocol);
+                    break;
             }
             return result.shareContextOnSubscribe();
         });

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -50,14 +50,13 @@ final class StreamingConnectionFactory {
 
     static <ResolvedAddress> Single<? extends NettyConnection<Object, Object>> buildStreaming(
             final HttpExecutionContext executionContext, final ResolvedAddress resolvedAddress,
-            final ReadOnlyHttpClientConfig roConfig, final TransportObserver observer) {
-        final ReadOnlyTcpClientConfig tcpConfig = withSslConfigPeerHost(resolvedAddress, roConfig.tcpConfig());
-        final H1ProtocolConfig h1Config = roConfig.h1Config();
-        assert h1Config != null;
+            final ReadOnlyTcpClientConfig originalTcpConfig, final H1ProtocolConfig h1Config, boolean hasProxy,
+            final TransportObserver observer) {
+        final ReadOnlyTcpClientConfig tcpConfig = withSslConfigPeerHost(resolvedAddress, originalTcpConfig);
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
         return TcpConnector.connect(null, resolvedAddress, tcpConfig, false, executionContext,
                 (channel, connectionObserver) -> createConnection(channel, executionContext, h1Config, tcpConfig,
-                        new TcpClientChannelInitializer(tcpConfig, connectionObserver, roConfig.hasProxy()),
+                        new TcpClientChannelInitializer(tcpConfig, connectionObserver, hasProxy),
                         connectionObserver),
                 observer);
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -153,11 +153,14 @@ class HttpsProxyTest {
     void testConnectionRequest(List<HttpProtocol> protocols) throws Exception {
         setUp(protocols);
         assert client != null;
+        assert proxyAddress != null;
         HttpProtocolVersion expectedVersion = protocols.get(0).version;
         try (ReservedBlockingHttpConnection connection = client.reserveConnection(client.get("/"))) {
             assertThat(connection.connectionContext().protocol(), is(expectedVersion));
             assertThat(connection.connectionContext().sslConfig(), is(notNullValue()));
             assertThat(connection.connectionContext().sslSession(), is(notNullValue()));
+            assertThat(((InetSocketAddress) connection.connectionContext().remoteAddress()).getPort(),
+                    is(proxyAddress.port()));
 
             HttpRequest request = connection.get("/path");
             assertThat(request.version(), is(expectedVersion));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactoryTest.java
@@ -63,7 +63,6 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
-import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -126,7 +125,6 @@ class ProxyConnectLBHttpConnectionFactoryTest {
         HttpClientConfig config = new HttpClientConfig();
         config.connectAddress(CONNECT_ADDRESS);
         config.tcpConfig().sslConfig(DEFAULT_SSL_CONFIG);
-        config.protocolConfigs().protocols(h1Default());
         connectionFactory = new ProxyConnectLBHttpConnectionFactory<>(config.asReadOnly(),
                 executionContext, null, REQ_RES_FACTORY, ConnectExecutionStrategy.offloadNone(),
                 ConnectionFactoryFilter.identity(), mock(ProtocolBinding.class));

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CopyByteBufHandlerChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CopyByteBufHandlerChannelInitializer.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
@@ -56,13 +57,13 @@ public final class CopyByteBufHandlerChannelInitializer implements ChannelInitia
     }
 
     /**
-     * Return {@link Class} of the {@link ChannelInboundHandler} in case there is a need to remove the handler from the
+     * Return {@link Class} of the {@link ChannelHandler} in case there is a need to remove the handler from the
      * {@link ChannelPipeline}.
      *
-     * @return {@link Class} of the {@link ChannelInboundHandler} in case there is a need to remove the handler from the
+     * @return {@link Class} of the {@link ChannelHandler} in case there is a need to remove the handler from the
      * {@link ChannelPipeline}.
      */
-    public static Class<? extends ChannelInboundHandler> handlerClass() {
+    public static Class<? extends ChannelHandler> handlerClass() {
         return CopyByteBufHandler.class;
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CopyByteBufHandlerChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CopyByteBufHandlerChannelInitializer.java
@@ -56,6 +56,17 @@ public final class CopyByteBufHandlerChannelInitializer implements ChannelInitia
     }
 
     /**
+     * Return {@link Class} of the {@link ChannelInboundHandler} in case there is a need to remove the handler from the
+     * {@link ChannelPipeline}.
+     *
+     * @return {@link Class} of the {@link ChannelInboundHandler} in case there is a need to remove the handler from the
+     * {@link ChannelPipeline}.
+     */
+    public static Class<? extends ChannelInboundHandler> handlerClass() {
+        return CopyByteBufHandler.class;
+    }
+
+    /**
      * This handler has to be added to the {@link ChannelPipeline} when {@link PooledByteBufAllocator} is used for
      * reading data from the socket. The allocated {@link ByteBuf}s must be copied and released before handed over to
      * the user.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -53,6 +53,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
@@ -522,6 +523,17 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 pipeline.addLast(nettyInboundHandler);
             }
         };
+    }
+
+    /**
+     * Return {@link Class} of the {@link ChannelInboundHandler} in case there is a need to remove the handler from the
+     * {@link ChannelPipeline}.
+     *
+     * @return {@link Class} of the {@link ChannelInboundHandler} in case there is a need to remove the handler from the
+     * {@link ChannelPipeline}.
+     */
+    public static Class<? extends ChannelInboundHandler> handlerClass() {
+        return NettyToStChannelHandler.class;
     }
 
     private static boolean shouldWaitForSslHandshake(@Nullable final SSLSession sslSession,

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -52,8 +52,8 @@ import io.servicetalk.transport.netty.internal.WriteStreamSubscriber.AbortedFirs
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
@@ -526,13 +526,14 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
     }
 
     /**
-     * Return {@link Class} of the {@link ChannelInboundHandler} in case there is a need to remove the handler from the
+     * Return {@link Class} of the {@link ChannelHandler} in case there is a need to remove the handler from the
      * {@link ChannelPipeline}.
      *
-     * @return {@link Class} of the {@link ChannelInboundHandler} in case there is a need to remove the handler from the
+     * @return {@link Class} of the {@link ChannelHandler} in case there is a need to remove the handler from the
      * {@link ChannelPipeline}.
      */
-    public static Class<? extends ChannelInboundHandler> handlerClass() {
+    // FIXME: remove this method in a follow-up RP, after refactoring for ProxyConnectObserver is complete.
+    public static Class<? extends ChannelHandler> handlerClass() {
         return NettyToStChannelHandler.class;
     }
 


### PR DESCRIPTION
Motivation:

Proxies that behave like blind forwarding tunnel do not care what protocol will be
used after the tunnel is established. Because we always enforce TLS for such tunnels,
we can rely on ALPN to negotiate expected protocol after the tunnel is established.
This will allow gRPC use cases to operate via tunneling proxies.

Modifications:
- Enhance `ProxyConnectLBHttpConnectionFactory` to take ALPN results into account
before finishing connection initialization;
- Enhance `HttpsProxyTest` to validate proxy tunnel works for any combination of the
configured protocols;
- Enhance `ProxyConnectLBHttpConnectionFactory` to validate new use-cases;
- Add `GrpcProxyTunnelTest`;

Results:

1. HTTP users can negotiate HTTP/2 after proxy tunnel is established.
2. gRPC users can use proxy tunnels.
---

Depends on #2697, review only starting from "Implement HTTP proxy CONNECT with ALPN" commit.