### PR TITLE
Introduce defaultHttp(s)Port for MultiAddressHttpClientBuilder

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingMultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingMultiAddressHttpClientBuilder.java
@@ -97,6 +97,18 @@ public class DelegatingMultiAddressHttpClientBuilder<U, R> implements MultiAddre
     }
 
     @Override
+    public MultiAddressHttpClientBuilder<U, R> defaultHttpPort(final int port) {
+        delegate = delegate.defaultHttpPort(port);
+        return this;
+    }
+
+    @Override
+    public MultiAddressHttpClientBuilder<U, R> defaultHttpsPort(final int port) {
+        delegate = delegate.defaultHttpsPort(port);
+        return this;
+    }
+
+    @Override
     public HttpClient build() {
         return delegate.build();
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiAddressHttpClientBuilder.java
@@ -147,4 +147,28 @@ public interface MultiAddressHttpClientBuilder<U, R> extends HttpClientBuilder<U
      * @see RedirectConfigBuilder
      */
     MultiAddressHttpClientBuilder<U, R> followRedirects(@Nullable RedirectConfig config);
+
+    /**
+     * Configures the default port for the HTTP scheme if not explicitly provided as part of the
+     * {@link HttpRequestMetaData#requestTarget()}.
+     *
+     * @param port the port that should be used if not explicitly provided for HTTP requests.
+     * @return {@code this}.
+     */
+    default MultiAddressHttpClientBuilder<U, R> defaultHttpPort(int port) { // FIXME: 0.43 - remove default impl
+        throw new UnsupportedOperationException("Setting defaultHttpPort is not yet supported by "
+                + getClass().getName());
+    }
+
+    /**
+     * Configures the default port for the HTTPS scheme if not explicitly provided as part of the
+     * {@link HttpRequestMetaData#requestTarget()}.
+     *
+     * @param port the port that should be used if not explicitly provided for HTTPS requests.
+     * @return {@code this}.
+     */
+    default MultiAddressHttpClientBuilder<U, R> defaultHttpsPort(int port) { // FIXME: 0.43 - remove default impl
+        throw new UnsupportedOperationException("Setting defaultHttpsPort is not yet supported by "
+                + getClass().getName());
+    }
 }


### PR DESCRIPTION
Motivation
----------
At the moment, if no port number is explicitly provided, the default HTTP and HTTPS ports are used (80 and 443). In some environments it can be useful (i.e. if a client is always talking to a high port number) to not have to specify it on every request.

Modifications
-------------
This changeset introduces two new builder options to allow customizing the defaultHttpPort as well as the defaultHttpsPort and applying it if no explicit port is provided on the request itself.

Result
------
It is now possible to not specify the port number on every request if they diverge from the default 80 or 443 port numbers.