### PR TITLE
Revert "CI: Enable jdk21 builds (#2702)"

### DIFF
--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       # Matrix should be coordinated with ci-prb.yml.
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 20 ]
         os: [ ubuntu-latest ]
     steps:
       - name: Download Artifacts

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 20 ]
         os: [ ubuntu-latest ]
     steps:
       - name: Checkout Code

--- a/.github/workflows/ci-prq-reports.yml
+++ b/.github/workflows/ci-prq-reports.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 20 ]
     steps:
       - name: Download Artifacts
         uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 20 ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,6 @@ task validateLocalDocSite(type: Exec) {
 quality.dependsOn validateLocalDocSite
 
 subprojects {
-  // mockito 5 only supports jdk11+
-  if (JavaVersion.current() < JavaVersion.VERSION_11) {
-    project.setProperty("mockitoCoreVersion", "4.11.0")
-  }
   // Used by ci-release.yaml to determine which modules need to be built/released with JDK11.
   task printJavaTargetCompatibility {
     doLast {

--- a/gradle.properties
+++ b/gradle.properties
@@ -72,8 +72,7 @@ junit5Version=5.9.3
 testngVersion=7.5
 assertJCoreVersion=3.24.2
 hamcrestVersion=2.2
-# mockito version is overridden for <jdk11 in build.gradle
-mockitoCoreVersion=5.5.0
+mockitoCoreVersion=4.11.0
 spotbugsPluginVersion=5.0.13
 
 apacheDirectoryServerVersion=1.5.7

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -280,8 +280,6 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
           xml.enabled = project.ext.isCiBuild
           html.enabled = !project.ext.isCiBuild
         }
-        // https://github.com/spotbugs/spotbugs/issues/2567
-        enabled = JavaVersion.current() < JavaVersion.VERSION_21
       }
 
       tasks.withType(SpotBugsTask).all {


### PR DESCRIPTION
This reverts commit 5d9a29aba9d0754dd96624e953a47946c7460d53.

Pull requests (#2704) consistently failing with:

```
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007fb0efe2ee4d, pid=11813, tid=11816
#
# JRE version: OpenJDK Runtime Environment Zulu21.28+85-CA (21.0+35) (build 21+35)
# Java VM: OpenJDK 64-Bit Server VM Zulu21.28+85-CA (21+35, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x82ee4d]  G1ParCopyClosure<(G1Barrier)0, true>::do_oop(oopDesc**)+0x4d
#
```