### PR TITLE
Clean up client response payloads on error to free up connections

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -322,6 +322,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                         ctx.builder.retryingHttpRequesterFilter);
             }
 
+            currClientFilterFactory = appendFilter(currClientFilterFactory,
+                    HttpMessageDiscardWatchdogClientFilter.INSTANCE);
+
             // Internal retries must be one of the last filters in the chain.
             currClientFilterFactory = appendFilter(currClientFilterFactory, InternalRetryingHttpClientFilter.INSTANCE);
             FilterableStreamingHttpClient wrappedClient =

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -140,6 +140,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         strategyComputation = new ClientStrategyInfluencerChainBuilder();
         this.loadBalancerFactory = DefaultHttpLoadBalancerFactory.Builder.<R>fromDefaults().build();
         this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
+
+        clientFilterFactory = appendFilter(clientFilterFactory, HttpMessageDiscardWatchdogClientFilter.CLEANER);
     }
 
     private DefaultSingleAddressHttpClientBuilder(@Nullable final U address,
@@ -296,6 +298,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                             targetAddress(ctx)));
 
             ContextAwareStreamingHttpClientFilterFactory currClientFilterFactory = ctx.builder.clientFilterFactory;
+
             if (roConfig.hasProxy() && sslContext == null) {
                 // If we're talking to a proxy over http (not https), rewrite the request-target to absolute-form, as
                 // specified by the RFC: https://tools.ietf.org/html/rfc7230#section-5.3.2
@@ -314,7 +317,12 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 currClientFilterFactory = appendFilter(currClientFilterFactory,
                         ctx.builder.retryingHttpRequesterFilter);
             }
-            // Internal retries must be the last filter in the chain, right before LoadBalancedStreamingHttpClient.
+
+            // This filter cleans up tracked and discarded message payloads.
+            currClientFilterFactory = appendFilter(currClientFilterFactory,
+                    HttpMessageDiscardWatchdogClientFilter.INSTANCE);
+
+            // Internal retries must be one of the last filters in the chain.
             currClientFilterFactory = appendFilter(currClientFilterFactory, InternalRetryingHttpClientFilter.INSTANCE);
             FilterableStreamingHttpClient wrappedClient =
                     currClientFilterFactory.create(lbClient, lb.eventStream(), ctx.sdStatus);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -141,7 +141,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         this.loadBalancerFactory = DefaultHttpLoadBalancerFactory.Builder.<R>fromDefaults().build();
         this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
 
-        clientFilterFactory = appendFilter(clientFilterFactory, HttpMessageDiscardWatchdogClientFilter.CLEANER);
+        connectionFilterFactory = HttpMessageDiscardWatchdogClientFilter.CONNECTION_CLEANER;
+        clientFilterFactory = appendFilter(clientFilterFactory, HttpMessageDiscardWatchdogClientFilter.CLIENT_CLEANER);
     }
 
     private DefaultSingleAddressHttpClientBuilder(@Nullable final U address,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -141,7 +141,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         this.loadBalancerFactory = DefaultHttpLoadBalancerFactory.Builder.<R>fromDefaults().build();
         this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
 
-        connectionFilterFactory = HttpMessageDiscardWatchdogClientFilter.CONNECTION_CLEANER;
         clientFilterFactory = appendFilter(clientFilterFactory, HttpMessageDiscardWatchdogClientFilter.CLIENT_CLEANER);
     }
 
@@ -322,9 +321,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 currClientFilterFactory = appendFilter(currClientFilterFactory,
                         ctx.builder.retryingHttpRequesterFilter);
             }
-
-            currClientFilterFactory = appendFilter(currClientFilterFactory,
-                    HttpMessageDiscardWatchdogClientFilter.INSTANCE);
 
             // Internal retries must be one of the last filters in the chain.
             currClientFilterFactory = appendFilter(currClientFilterFactory, InternalRetryingHttpClientFilter.INSTANCE);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.HttpExecutionStrategies;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.servicetalk.http.netty.HttpMessageDiscardWatchdogServiceFilter.generifyAtomicReference;
+
+/**
+ * Filter which tracks HTTP responses and makes sure that if an exception is raised during filter pipeline
+ * processing message payload bodies are cleaned up.
+ */
+final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpClientFilterFactory {
+
+    private static final ContextMap.Key<AtomicReference<Publisher<?>>> MESSAGE_PUBLISHER_KEY = ContextMap.Key
+            .newKey(HttpMessageDiscardWatchdogClientFilter.class.getName() + ".messagePublisher",
+                    generifyAtomicReference());
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpMessageDiscardWatchdogClientFilter.class);
+
+    /**
+     * Instance of {@link HttpMessageDiscardWatchdogClientFilter}.
+     */
+    static final StreamingHttpClientFilterFactory INSTANCE = new HttpMessageDiscardWatchdogClientFilter();
+
+    /**
+     * Instance of {@link HttpLifecycleObserverRequesterFilter} with the cleaner implementation.
+     */
+    static final StreamingHttpClientFilterFactory CLEANER = new CleanerStreamingHttpClientFilterFactory();
+
+    private HttpMessageDiscardWatchdogClientFilter() {
+        // Singleton
+    }
+
+    @Override
+    public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
+        return new StreamingHttpClientFilter(client) {
+            @Override
+            protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                            final StreamingHttpRequest request) {
+                return delegate.request(request).map(response -> {
+                    // always write the buffer publisher into the request context. When a downstream subscriber
+                    // arrives, mark the message as subscribed explicitly (having a message present and no
+                    // subscription is an indicator that it must be freed later on).
+                    final AtomicReference<Publisher<?>> reference = request.context()
+                            .computeIfAbsent(MESSAGE_PUBLISHER_KEY, key -> new AtomicReference<>());
+                    assert reference != null;
+                    final Publisher<?> previous = reference.getAndSet(response.messageBody());
+                    if (previous != null) {
+                        // If a previous message exists, the Single<StreamingHttpResponse> got resubscribed to
+                        // (i.e. during a retry) and so previous message body needs to be cleaned up.
+                        LOGGER.warn("Automatically draining previous HTTP response message body that was " +
+                                "not consumed. Users-defined retry logic must drain response payload before " +
+                                "retrying.");
+
+                        previous.ignoreElements().subscribe();
+                    }
+
+                    return response.transformMessageBody(msgPublisher -> msgPublisher.beforeSubscriber(() -> {
+                        final AtomicReference<?> maybePublisher = request.context().get(MESSAGE_PUBLISHER_KEY);
+                        if (maybePublisher != null) {
+                            maybePublisher.set(null);
+                        }
+                        return HttpMessageDiscardWatchdogServiceFilter.NoopSubscriber.INSTANCE;
+                    }));
+                });
+            }
+        };
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return HttpExecutionStrategies.offloadNone();
+    }
+
+    private static final class CleanerStreamingHttpClientFilterFactory implements StreamingHttpClientFilterFactory {
+        @Override
+        public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
+            return new StreamingHttpClientFilter(client) {
+                @Override
+                protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                                final StreamingHttpRequest request) {
+                    return delegate.request(request).onErrorResume(originalThrowable -> Single.defer(() -> {
+                        final AtomicReference<?> maybePublisher = request.context().get(MESSAGE_PUBLISHER_KEY);
+                        if (maybePublisher != null) {
+                            Publisher<?> message = (Publisher<?>) maybePublisher.get();
+                            if (message != null) {
+                                // No-one subscribed to the message (or there is none), so if there is a message
+                                // proactively clean it up.
+                                return message.ignoreElements().concat(Single.failed(originalThrowable));
+                            }
+                        }
+                        return Single.failed(originalThrowable);
+                    }));
+                }
+            };
+        }
+
+        @Override
+        public HttpExecutionStrategy requiredOffloads() {
+            return HttpExecutionStrategies.offloadNone();
+        }
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
@@ -172,7 +172,8 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpClien
         }
     }
 
-    private static final class CleanerStreamingHttpConnectionFilterFactory implements StreamingHttpConnectionFilterFactory {
+    private static final class CleanerStreamingHttpConnectionFilterFactory
+            implements StreamingHttpConnectionFilterFactory {
         @Override
         public StreamingHttpConnectionFilter create(final FilterableStreamingHttpConnection connection) {
             return new StreamingHttpConnectionFilter(connection) {
@@ -197,5 +198,4 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpClien
             return HttpExecutionStrategies.offloadNone();
         }
     }
-
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
@@ -81,7 +81,7 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConne
                         // user.
                         LOGGER.warn("Discovered un-drained HTTP response message body which has " +
                                 "been dropped by user code - this is a strong indication of a bug " +
-                                "in a user-defined filter. Responses (or their message body) must " +
+                                "in a user-defined filter. Response payload (message) body must " +
                                 "be fully consumed before retrying.");
                     }
 
@@ -115,7 +115,7 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConne
                                     // tell the user to clean it up.
                                     LOGGER.warn("Discovered un-drained HTTP response message body which has " +
                                             "been dropped by user code - this is a strong indication of a bug " +
-                                            "in a user-defined filter. Responses (or their message body) must " +
+                                            "in a user-defined filter. Response payload (message) body must " +
                                             "be fully consumed before discarding.");
                                 }
                                 return Single.<StreamingHttpResponse>failed(cause).shareContextOnSubscribe();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
@@ -38,8 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.servicetalk.http.netty.HttpMessageDiscardWatchdogServiceFilter.generifyAtomicReference;
 
 /**
- * Filter which tracks HTTP responses and makes sure that if an exception is raised during filter pipeline
- * processing message payload bodies are cleaned up.
+ * Filter which tracks message bodies and warns if they are not discarded properly.
  */
 final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConnectionFilterFactory {
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilter.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
- * Filter which tracks HTTP messages sent by the service, so it can be freed if discarded in the pipeline.
+ * Filter which tracks message bodies and warns if they are not discarded properly.
  */
 final class HttpMessageDiscardWatchdogServiceFilter implements StreamingHttpServiceFilterFactory {
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilter.java
@@ -57,9 +57,9 @@ final class HttpMessageDiscardWatchdogServiceFilter implements StreamingHttpServ
     static final StreamingHttpServiceFilterFactory CLEANER =
             new HttpLifecycleObserverServiceFilter(new CleanerHttpLifecycleObserver());
 
-    static final ContextMap.Key<AtomicReference<Publisher<?>>> MESSAGE_PUBLISHER_KEY = ContextMap.Key
+    private static final ContextMap.Key<AtomicReference<Publisher<?>>> MESSAGE_PUBLISHER_KEY = ContextMap.Key
             .newKey(HttpMessageDiscardWatchdogServiceFilter.class.getName() + ".messagePublisher",
-                    generify(AtomicReference.class));
+                    generifyAtomicReference());
 
     private HttpMessageDiscardWatchdogServiceFilter() {
         // Singleton
@@ -110,11 +110,11 @@ final class HttpMessageDiscardWatchdogServiceFilter implements StreamingHttpServ
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> Class<T> generify(final Class<?> clazz) {
-        return (Class<T>) clazz;
+    static <T> Class<T> generifyAtomicReference() {
+        return (Class<T>) AtomicReference.class;
     }
 
-    private static final class NoopSubscriber implements PublisherSource.Subscriber<Object> {
+    static final class NoopSubscriber implements PublisherSource.Subscriber<Object> {
 
         static final NoopSubscriber INSTANCE = new NoopSubscriber();
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilter.java
@@ -93,10 +93,7 @@ final class HttpMessageDiscardWatchdogServiceFilter implements StreamingHttpServ
                             }
 
                             return response.transformMessageBody(msgPublisher -> msgPublisher.beforeSubscriber(() -> {
-                                final AtomicReference<?> maybePublisher = request.context().get(MESSAGE_PUBLISHER_KEY);
-                                if (maybePublisher != null) {
-                                    maybePublisher.set(null);
-                                }
+                                reference.set(null);
                                 return NoopSubscriber.INSTANCE;
                             }));
                         });

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilterTest.java
@@ -78,7 +78,7 @@ final class HttpMessageDiscardWatchdogClientFilterTest {
      */
     @ParameterizedTest(name = "{displayName} [{index}] filterType={0} expectedException={1} transformer={2}")
     @MethodSource("responseTransformers")
-    void cleansClientResponseMessageBodyIfDiscarded(final FilterType filterType,
+    void warnsIfDiscarded(final FilterType filterType,
                                                     final @Nullable Class<?> expectedException,
                                                     ResponseTransformer transformer)
             throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilterTest.java
@@ -144,6 +144,20 @@ final class HttpMessageDiscardWatchdogClientFilterTest {
                     public String toString() {
                         return "Throws exception in filter which drops message";
                     }
+                }, DeliberateException.class),
+                Arguments.of(new ResponseTransformer() {
+                    @Override
+                    public Single<StreamingHttpResponse> apply(final StreamingHttpRequester requester,
+                                                               final StreamingHttpRequest request) {
+                        return requester
+                                .request(request)
+                                .flatMap(dropped -> Single.failed(new DeliberateException()));
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "Returns a failed Single which drops message";
+                    }
                 }, DeliberateException.class)
         );
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilterTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.DelegatingConnectionFactory;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.internal.DeliberateException;
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.http.api.FilterableStreamingHttpConnection;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
+import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class HttpMessageDiscardWatchdogClientFilterTest {
+
+    @RegisterExtension
+    static final ExecutionContextExtension SERVER_CTX =
+            ExecutionContextExtension.cached("server-io", "server-executor")
+                    .setClassLevel(true);
+    @RegisterExtension
+    static final ExecutionContextExtension CLIENT_CTX =
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
+
+    /**
+     * Asserts that the response message payload is cleaned up properly if discarded in a filter and not
+     * properly cleaned up by the filter body.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] transformer={0}")
+    @MethodSource("responseTransformers")
+    void cleansClientResponseMessageBodyIfDiscarded(ResponseTransformer transformer,
+                                                    @Nullable Class<?> expectedException)
+            throws Exception {
+        final AtomicLong numConnectionsOpened = new AtomicLong(0);
+
+        try (HttpServerContext serverContext = newServerBuilder(SERVER_CTX)
+                .listenStreamingAndAwait((ctx, request, responseFactory) ->
+                        Single.fromSupplier(() -> responseFactory.ok().payloadBody(Publisher.from(ctx.executionContext()
+                                .bufferAllocator().fromUtf8("Hello, World!")))))) {
+            try (StreamingHttpClient client = newClientBuilder(serverContext, CLIENT_CTX)
+                    .appendConnectionFactoryFilter(original ->
+                            new DelegatingConnectionFactory<InetSocketAddress,
+                                    FilterableStreamingHttpConnection>(original) {
+                        @Override
+                        public Single<FilterableStreamingHttpConnection> newConnection(
+                                final InetSocketAddress inetSocketAddress,
+                                @Nullable final ContextMap context,
+                                @Nullable final TransportObserver observer) {
+                            numConnectionsOpened.incrementAndGet();
+                            return delegate().newConnection(inetSocketAddress, context, observer);
+                        }
+                    })
+                    .appendClientFilter(c -> new StreamingHttpClientFilter(c) {
+                        @Override
+                        protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
+                                                                        final StreamingHttpRequest request) {
+                            return transformer.apply(delegate(), request);
+                        }
+                    })
+                    .buildStreaming()) {
+
+                int numRequests = 5;
+                for (int i = 0; i < numRequests; i++) {
+                    if (expectedException == null) {
+                        StreamingHttpResponse response = client.request(client.get("/")).toFuture().get();
+                        assertEquals(HttpResponseStatus.OK, response.status());
+                        // Consume the body to release the connection back to the pool
+                        response.messageBody().ignoreElements().toFuture().get();
+                    } else {
+                        ExecutionException ex = assertThrows(ExecutionException.class,
+                                () -> client.request(client.get("/")).toFuture().get());
+                        assertTrue(ex.getCause().getClass().isAssignableFrom(expectedException));
+                    }
+                }
+                assertEquals(1, numConnectionsOpened.get());
+            }
+        }
+    }
+
+    private static Stream<Arguments> responseTransformers() {
+        return Stream.of(
+                Arguments.of(new ResponseTransformer() {
+                    @Override
+                    public Single<StreamingHttpResponse> apply(final StreamingHttpRequester requester,
+                                                               final StreamingHttpRequest request) {
+                        return requester.request(request);
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "Just delegation, no failure";
+                    }
+                }, null),
+                Arguments.of(new ResponseTransformer() {
+                    @Override
+                    public Single<StreamingHttpResponse> apply(final StreamingHttpRequester requester,
+                                                               final StreamingHttpRequest request) {
+                        return requester
+                                .request(request)
+                                .map(dropped -> {
+                                    throw new DeliberateException();
+                                });
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "Throws exception in filter which drops message";
+                    }
+                }, DeliberateException.class)
+        );
+    }
+
+    interface ResponseTransformer
+            extends BiFunction<StreamingHttpRequester, StreamingHttpRequest, Single<StreamingHttpResponse>> { }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
@@ -69,7 +69,7 @@ final class HttpMessageDiscardWatchdogServiceFilterTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] transformer={0}")
     @MethodSource("responseTransformers")
-    void cleansPayloadBodyIfDiscardedInFilter(final ResponseTransformer transformer) throws Exception {
+    void cleansServiceResponseMessageBodyIfDiscarded(final ResponseTransformer transformer) throws Exception {
         try (HttpServerContext serverContext = newServerBuilder(SERVER_CTX)
                 .appendServiceFilter(service -> new StreamingHttpServiceFilter(service) {
                     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
@@ -69,7 +69,7 @@ final class HttpMessageDiscardWatchdogServiceFilterTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] transformer={0}")
     @MethodSource("responseTransformers")
-    void cleansServiceResponseMessageBodyIfDiscarded(final ResponseTransformer transformer) throws Exception {
+    void warnsIfDiscarded(final ResponseTransformer transformer) throws Exception {
         try (HttpServerContext serverContext = newServerBuilder(SERVER_CTX)
                 .appendServiceFilter(service -> new StreamingHttpServiceFilter(service) {
                     @Override


### PR DESCRIPTION
Motivation
----------
When a client makes a request and during response processing an exception is thrown, the exception bubbles up to the client but the message payload body is then not available to be consumed.

In this case, the underlying pooled connection will not be freed up and a new connection is created.

Modifications
-------------
By tracking the message payloads when responses are bubbled up through the filter chain, we can detect if an error happens and if detected the message payload body is being proactively drained.

This will free up the connection again so it can be reused by a subsequent request.

Result
------
More correct handling of message payload bodies if an exception happens during response filter processing.