### PR TITLE
TLS handshake failures are not reported to observers when ALPN is used

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -91,7 +91,7 @@ import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forNonPipelined;
-import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extractSslSessionAndReport;
+import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extractSslSession;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
@@ -137,7 +137,7 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
 
                     pipeline = channel.pipeline();
                     @Nullable
-                    final SSLSession sslSession = extractSslSessionAndReport(sslConfig, pipeline, observer);
+                    final SSLSession sslSession = extractSslSession(sslConfig, pipeline);
                     H2ClientParentConnectionContext connection = new H2ClientParentConnectionContext(channel,
                             executionContext, parentFlushStrategy, idleTimeoutMs, sslConfig, sslSession,
                             new KeepAliveManager(channel, config.keepAlivePolicy()));

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -57,7 +57,7 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HttpExecutionContextUtils.channelExecutionContext;
 import static io.servicetalk.http.netty.NettyHttp2ExceptionUtils.wrapIfNecessary;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.assignConnectionError;
-import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extractSslSessionAndReport;
+import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extractSslSession;
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.getOption;
 
 class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable implements NettyConnectionContext,
@@ -257,9 +257,8 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
         public final void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
             try {
                 if (evt instanceof SslHandshakeCompletionEvent) {
-                    parentContext.sslSession = extractSslSessionAndReport(ctx.pipeline(),
-                            (SslHandshakeCompletionEvent) evt, this::tryFailSubscriber,
-                            waitForSslHandshake && observer != NoopConnectionObserver.INSTANCE);
+                    parentContext.sslSession = extractSslSession(ctx.pipeline(),
+                            (SslHandshakeCompletionEvent) evt, this::tryFailSubscriber);
                     tryCompleteSubscriber();
                 } else if (evt == ChannelInputShutdownReadComplete.INSTANCE || evt == SslCloseCompletionEvent.SUCCESS) {
                     parentContext.keepAliveManager.channelInputShutdown();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -59,7 +59,7 @@ import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forNonPipelined;
-import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extractSslSessionAndReport;
+import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extractSslSession;
 import static java.util.Objects.requireNonNull;
 
 final class H2ServerParentConnectionContext extends H2ParentConnectionContext implements ServerContext {
@@ -144,7 +144,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                     @Nullable
                     final SslConfig sslConfig = config.tcpConfig().sslConfig();
                     @Nullable
-                    final SSLSession sslSession = extractSslSessionAndReport(sslConfig, pipeline, observer);
+                    final SSLSession sslSession = extractSslSession(sslConfig, pipeline);
                     H2ServerParentConnectionContext connection = new H2ServerParentConnectionContext(channel,
                             httpExecutionContext, config.tcpConfig().flushStrategy(),
                             config.tcpConfig().idleTimeoutMs(), sslConfig, sslSession, listenAddress,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocol.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocol.java
@@ -21,6 +21,7 @@ import io.servicetalk.http.api.HttpProtocolVersion;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
@@ -28,6 +29,8 @@ import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 enum HttpProtocol {
     HTTP_1(h1Default(), h1().headersFactory(H2HeadersFactory.INSTANCE).build(), HTTP_1_1),
@@ -54,5 +57,9 @@ enum HttpProtocol {
 
     static H2ProtocolConfigBuilder applyFrameLogger(H2ProtocolConfigBuilder builder) {
         return builder.enableFrameLogging("servicetalk-tests-h2-frame-logger", TRACE, () -> true);
+    }
+
+    static List<List<HttpProtocol>> allCombinations() {
+        return asList(singletonList(HTTP_1), singletonList(HTTP_2), asList(HTTP_2, HTTP_1), asList(HTTP_1, HTTP_2));
     }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -56,6 +56,7 @@ public class TcpServerChannelInitializer implements ChannelInitializer {    // F
         }
 
         if (config.sniMapping() != null) {
+            assert config.sslContext() != null;
             delegate = delegate.andThen(new SniServerChannelInitializer(config.sniMapping(),
                     config.sniMaxClientHelloLength(), config.sniClientHelloTimeout().toMillis()));
         } else if (config.sslContext() != null) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -110,7 +110,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
             ctx.fireChannelActive();
         }
 
-        void reportTcpHandshakeComplete() {
+        private void reportTcpHandshakeComplete() {
             if (!tcpHandshakeComplete) {
                 tcpHandshakeComplete = true;
                 observer.onTransportHandshakeComplete();

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
@@ -76,11 +76,10 @@ public final class NettyPipelineSslUtils {
      * by {@link SslClientChannelInitializer} or {@link SslServerChannelInitializer}
      */
     @Nullable
-    @Deprecated
-    public static SSLSession extractSslSessionAndReport(// FIXME: 0.43 - remove deprecated method
-            @Nullable final SslConfig sslConfig,
-            final ChannelPipeline pipeline,
-            final ConnectionObserver connectionObserver) {
+    @Deprecated // FIXME: 0.43 - remove deprecated method
+    public static SSLSession extractSslSessionAndReport(@Nullable final SslConfig sslConfig,
+                                                        final ChannelPipeline pipeline,
+                                                        final ConnectionObserver connectionObserver) {
         if (sslConfig == null) {
             assert noSslHandlers(pipeline) : "No SslConfig configured but SSL-related handler found in the pipeline";
             return null;
@@ -177,7 +176,7 @@ public final class NettyPipelineSslUtils {
                 pipeline.get(SniHandler.class) == null;
     }
 
-    // FIXME: 0.43 - remove method that won't be used
+    // FIXME: 0.43 - remove method that won't be used after deprecations removed
     private static SSLSession getSslSession(final SslHandler sslHandler,
                                             @Nullable final SecurityHandshakeObserver observer) {
         final SSLSession session = sslHandler.engine().getSession();
@@ -187,7 +186,7 @@ public final class NettyPipelineSslUtils {
         return session;
     }
 
-    // FIXME: 0.43 - remove method that won't be used
+    // FIXME: 0.43 - remove method that won't be used after deprecations removed
     private static void deliverFailureCause(final Consumer<Throwable> failureConsumer, final Throwable cause,
                                             @Nullable final SecurityHandshakeObserver securityObserver) {
         if (securityObserver != null) {
@@ -196,7 +195,7 @@ public final class NettyPipelineSslUtils {
         failureConsumer.accept(cause);
     }
 
-    // FIXME: 0.43 - remove method that won't be used
+    // FIXME: 0.43 - remove method that won't be used after deprecations removed
     @Nullable
     private static SecurityHandshakeObserver lookForHandshakeObserver(final ChannelPipeline pipeline,
                                                                       final boolean shouldReport) {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
@@ -46,7 +46,7 @@ public class SslClientChannelInitializer implements ChannelInitializer {
 
     @Override
     public void init(Channel channel) {
-        final SslHandler sslHandler = newClientSslHandler(sslContext, sslConfig);
+        final SslHandler sslHandler = newClientSslHandler(sslContext, sslConfig, channel);
         channel.pipeline().addLast(deferSslHandler ? new DeferSslHandler(channel, sslHandler) : sslHandler);
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslServerChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslServerChannelInitializer.java
@@ -37,6 +37,6 @@ public final class SslServerChannelInitializer implements ChannelInitializer {
 
     @Override
     public void init(Channel channel) {
-        channel.pipeline().addLast(newServerSslHandler(sslContext));
+        channel.pipeline().addLast(newServerSslHandler(sslContext, channel));
     }
 }


### PR DESCRIPTION
Motivation:

Observed that `AlpnChannelHandler` does not report handshake failure via `SecurityHandshakeObserver`. Moreover, `SslHandler` closes the `Channel` before propagating `SslHandshakeCompletionEvent` in case the handshake fails, which makes our reporting sequence incorrect (`ConnectionObserver.connectionClosed(Throwable)` is invoked before `SecurityHandshakeObserver.handshakeFailed(Throwable)`, but shouldn't).

Modifications:

- Instead of trying to intercept `SslHandshakeCompletionEvent` for all pipeline variations, add a listener for `SslHandler.handshakeFuture()` to reliably get notifications about handshake status before the `Channel` can be closed;
- Enhance `SecurityHandshakeObserverTest` to test failure case and verify ordering of events;
- Enhance `AlpnChannelHandler` to unwrap `SSLException` the same way its parent `ApplicationProtocolNegotiationHandler` does, fail subscriber on `channelInactive` event, close channel if can not propagate `handshakeFailure` to subscriber;
- Deprecate `NettyPipelineSslUtils` methods that are not required anymore;

Result:

`SecurityHandshakeObserver.handshakeFailed(Throwable)` is always reported for all protocol configurations and always happens before `ConnectionObserver.connectionClosed(Throwable)`.