### PR TITLE
Trigger channel read for TLS handshake only on the server-side

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SniCompleteChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SniCompleteChannelSingle.java
@@ -51,6 +51,7 @@ final class SniCompleteChannelSingle extends ChannelInitSingle<SniCompletionEven
         @Override
         public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
             super.handlerAdded(ctx);
+            assert ctx.channel().isActive();
             // Force a read to get the SSL handshake started. We initialize pipeline before
             // SslHandshakeCompletionEvent will complete, therefore, no data will be propagated before we finish
             // initialization.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -981,9 +981,11 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
         private void doChannelActive(ChannelHandlerContext ctx) {
             if (waitForSslHandshake) {
-                // Force a read to get the SSL handshake started, any application data that makes it past the SslHandler
-                // will be queued in the NettyChannelPublisher.
-                ctx.read();
+                if (!connection.isClient) {
+                    // Force a read to get the SSL handshake started, any application data that makes it past the
+                    // SslHandler will be queued in the NettyChannelPublisher.
+                    ctx.read();
+                }
             } else if (subscriber != null) {
                 completeSubscriber();
             }


### PR DESCRIPTION
Motivation:

`SslHandler` automatically initiates the handshake and manages reads on the client-side. We need to initiate read only on the server-side.

Modifications:

- `DefaultNettyConnection.doChannelActive` read only if `!isClient`;
- Assert that channel is active when `AlpnChannelHandler` or `SniCompleteChannelHandler` are added and the read is forced;

Result:

No unnecessary read on client-side channels.