### PR TITLE
Use `ChannelCloseUtils` in `SniCompleteChannelSingle`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SniCompleteChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SniCompleteChannelSingle.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.transport.netty.internal.ChannelCloseUtils;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.StacklessClosedChannelException;
 
@@ -75,7 +76,7 @@ final class SniCompleteChannelSingle extends ChannelInitSingle<SniCompletionEven
             } else {
                 // Propagate exception in the pipeline if subscriber is already complete
                 ctx.fireExceptionCaught(cause);
-                ctx.close();
+                ChannelCloseUtils.close(ctx, cause);
             }
         }
 


### PR DESCRIPTION
Motivation:

`SniCompleteChannelSingle` closes the `ChannelHandlerContext` if it can not propagate an error to subscriber but does not use `ChannelCloseUtils` that will associate an error with a connection to correctly report `ConnectionObserver.connectionClosed` events.