### PR TITLE
Upgrade Netty 4.1.98 -> 4.1.99

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ issueManagementUrl=https://github.com/apple/servicetalk/issues
 ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
-nettyVersion=4.1.98.Final
+nettyVersion=4.1.99.Final
 nettyIoUringVersion=0.0.22.Final
 
 jsr305Version=3.0.2


### PR DESCRIPTION
Motivation:

Netty 4.1.99 includes fixes that allow the use of JDK 21.

Modifications:

Upgrade Netty from 4.1.98 to 4.1.99.