### PR TITLE
docs: update reactivemanifesto link to github

### DIFF
--- a/docs/modules/ROOT/pages/performance.adoc
+++ b/docs/modules/ROOT/pages/performance.adoc
@@ -81,8 +81,9 @@ of reference counting and buffer pooling is the culprit why you cannot meet your
 look into directly building on top of link:https://netty.io[Netty] instead.
 
 === Reactive core
-ServiceTalk's core design principles aim to enable large scale link:https://www.reactivemanifesto.org[reactive system].
-Responsiveness is an essential part of building a reactive system. ServiceTalk implements
+ServiceTalk's core design principles aim to enable large scale
+link:https://github.com/reactivemanifesto/reactivemanifesto[reactive system]. Responsiveness is an essential part of
+building a reactive system. ServiceTalk implements
 link:https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#specification[Reactive Streams APIs]
 to provide flow controlled, responsive networking abstractions. Such flow controlled systems express a well coordinated
 upper bound on resources (e.g. memory) providing a high level of resiliency in presence of unexpected data spikes.


### PR DESCRIPTION
Motivation:
reactivemanifesto.org is returning 503 which fails the quality/doc build. Point to github for now instead to unblock the build.