### PR TITLE
Improve exceptions thrown when an error happens during proxy `CONNECT`

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
@@ -16,6 +16,8 @@
 package io.servicetalk.grpc.api;
 
 import io.servicetalk.http.api.Http2Exception;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.ProxyConnectResponseException;
 import io.servicetalk.serializer.api.SerializationException;
 
 import java.util.concurrent.CancellationException;
@@ -28,6 +30,7 @@ import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
 import static io.servicetalk.grpc.api.GrpcStatusCode.fromHttp2ErrorCode;
+import static io.servicetalk.grpc.api.GrpcUtils.fromHttpStatus;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -140,6 +143,9 @@ public final class GrpcStatusException extends RuntimeException {
             status = new GrpcStatus(CANCELLED, cause);
         } else if (cause instanceof TimeoutException) {
             status = new GrpcStatus(DEADLINE_EXCEEDED, cause);
+        } else if (cause instanceof ProxyConnectResponseException) {
+            final HttpResponseMetaData response = ((ProxyConnectResponseException) cause).response();
+            status = new GrpcStatus(fromHttpStatus(response.status()), cause);
         } else {
             // Initialize detail because cause is often lost
             status = new GrpcStatus(UNKNOWN, cause, cause.toString());

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ProtocolCompatibilityTest.java
@@ -127,12 +127,14 @@ import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.FAILED_PRECONDITION;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INTERNAL;
 import static io.servicetalk.grpc.api.GrpcStatusCode.INVALID_ARGUMENT;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNAUTHENTICATED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
 import static io.servicetalk.grpc.internal.DeadlineUtils.GRPC_TIMEOUT_HEADER_KEY;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.servicetalk.http.api.HttpResponseStatus.PRECONDITION_FAILED;
+import static io.servicetalk.http.api.HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE;
 import static io.servicetalk.http.api.HttpResponseStatus.REQUEST_TIMEOUT;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.CLIENT_ERROR_4XX;
@@ -541,6 +543,9 @@ class ProtocolCompatibilityTest {
                     // this exception differently internally.
                     assertThat("h2 response code: " + httpCode, stCode, equalTo(UNKNOWN.value()));
                     assertThat("h2 response code: " + httpCode, grpcJavaCode, equalTo(INTERNAL.value()));
+                } else if (httpCode == PROXY_AUTHENTICATION_REQUIRED.code()) {
+                    assertThat("h2 response code: " + httpCode, stCode, equalTo(UNAUTHENTICATED.value()));
+                    assertThat("h2 response code: " + httpCode, grpcJavaCode, equalTo(UNKNOWN.value()));
                 } else if (httpCode == REQUEST_TIMEOUT.code()) {
                     assertThat("h2 response code: " + httpCode, stCode, equalTo(DEADLINE_EXCEEDED.value()));
                     assertThat("h2 response code: " + httpCode, grpcJavaCode, equalTo(UNKNOWN.value()));

--- a/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
@@ -314,4 +314,13 @@
     <Method name="catchPayloadFailure"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
+
+  <!-- Parameters/state is intentional -->
+  <Match>
+    <Class name="io.servicetalk.http.api.ProxyConnectResponseException"/>
+    <Or>
+      <Bug pattern="EI_EXPOSE_REP"/>
+      <Bug pattern="EI_EXPOSE_REP2"/>
+    </Or>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConnectException.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConnectException.java
@@ -13,39 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
-
-import io.servicetalk.transport.api.RetryableException;
+package io.servicetalk.http.api;
 
 import java.io.IOException;
 
 /**
  * An exception while processing
  * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request.
+ *
+ * @see SingleAddressHttpClientBuilder#proxyAddress(Object)
  */
 public class ProxyConnectException extends IOException {
 
     private static final long serialVersionUID = 4453075928788773272L;
 
-    ProxyConnectException(final String message) {
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message
+     */
+    public ProxyConnectException(final String message) {
         super(message);
     }
 
-    ProxyConnectException(final String message, final Throwable cause) {
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message
+     * @param cause the original cause
+     */
+    public ProxyConnectException(final String message, final Throwable cause) {
         super(message, cause);
-    }
-
-    static final class RetryableProxyConnectException extends ProxyConnectException
-            implements RetryableException {
-
-        private static final long serialVersionUID = 5118637083568536242L;
-
-        RetryableProxyConnectException(final String message) {
-            super(message);
-        }
-
-        RetryableProxyConnectException(final String message, final Throwable cause) {
-            super(message, cause);
-        }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConnectResponseException.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConnectResponseException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+/**
+ * A subclass of {@link ProxyConnectException} that indicates an unexpected response status from a proxy received for
+ * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request.
+ *
+ * @see SingleAddressHttpClientBuilder#proxyAddress(Object)
+ */
+public class ProxyConnectResponseException extends ProxyConnectException {
+
+    private static final long serialVersionUID = 5117046591069113007L;
+
+    private final HttpResponseMetaData response;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message
+     * @param response {@link HttpResponseMetaData} of the received response
+     */
+    public ProxyConnectResponseException(final String message, final HttpResponseMetaData response) {
+        super(message);
+        this.response = response;
+    }
+
+    /**
+     * Returns {@link HttpResponseMetaData} that was received in response to
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request.
+     *
+     * @return {@link HttpResponseMetaData} that was received
+     */
+    public HttpResponseMetaData response() {
+        return response;
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -58,7 +58,9 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * always initialized using
      * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request. The actual
      * protocol will be negotiated via <a href="https://tools.ietf.org/html/rfc7301">ALPN extension</a> of TLS protocol,
-     * taking into account HTTP protocols configured via {@link #protocols(HttpProtocolConfig...)} method.
+     * taking into account HTTP protocols configured via {@link #protocols(HttpProtocolConfig...)} method. In case of
+     * any error during {@code CONNECT} process, {@link ProxyConnectException} or {@link ProxyConnectResponseException}
+     * will be thrown when a request attempt is made through the constructed client instance.
      *
      * @param proxyAddress Unresolved address of the proxy. When used with a builder created for a resolved address,
      * {@code proxyAddress} should also be already resolved – otherwise runtime exceptions may occur.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
@@ -19,10 +19,11 @@ import io.servicetalk.client.api.ConnectionFactoryFilter;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.ProxyConnectException;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.netty.AlpnChannelSingle.NoopChannelInitializer;
-import io.servicetalk.http.netty.ProxyConnectException.RetryableProxyConnectException;
+import io.servicetalk.http.netty.ProxyConnectChannelSingle.RetryableProxyConnectException;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpConnector;
@@ -184,7 +185,7 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
             return new RetryableProxyConnectException(channel + " Connection is closed, either received a " +
                     "'Connection: closed' header or closed by the proxy", cause);
         }
-        if (!(cause instanceof ProxyConnectException || cause instanceof ProxyResponseException)) {
+        if (!(cause instanceof ProxyConnectException)) {
             return new RetryableProxyConnectException(channel +
                     " Unexpected exception during an attempt to connect to a proxy", cause);
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyResponseException.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyResponseException.java
@@ -15,22 +15,22 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.ProxyConnectResponseException;
 import io.servicetalk.transport.api.RetryableException;
-
-import java.io.IOException;
 
 /**
  * A proxy response exception, that indicates an unexpected response status from a proxy.
+ *
+ * @deprecated Use {@link ProxyConnectResponseException} instead
  */
-public final class ProxyResponseException extends IOException implements RetryableException {
+@Deprecated // FIXME: 0.43 - remove deprecated class
+public class ProxyResponseException extends ProxyConnectResponseException implements RetryableException {
     private static final long serialVersionUID = -1021287419155443499L;
 
-    private final HttpResponseStatus status;
-
-    ProxyResponseException(final String message, final HttpResponseStatus status) {
-        super(message);
-        this.status = status;
+    ProxyResponseException(final String message, final HttpResponseMetaData response) {
+        super(message, response);
     }
 
     /**
@@ -39,6 +39,6 @@ public final class ProxyResponseException extends IOException implements Retryab
      * @return the {@link HttpResponseStatus} that was received.
      */
     public HttpResponseStatus status() {
-        return status;
+        return response().status();
     }
 }


### PR DESCRIPTION
Motivation:

`ProxyResponseException` is marked as `RetryableException`. However, not all response statuses are retryable. For example, it doesn't make sense to auto-retry if proxy responds with 4xx (proxy auth required, bad request, etc.).
Also, because proxy-related exceptions live in `servicetalk-http-netty`, gprc-api can not access them for better mapping into gRPC status code.

Modifications:

- Move `ProxyConnectException` from `http-netty` to `http-api`;
- Deprecate `ProxyResponseException`, introduce `ProxyConnectResponseException` instead in `http-api`;
- Use a retryable variant of `ProxyConnectResponseException` only for specific status codes from a proxy server are are intended to be retryable;
- Include Channel info in every thrown `ProxyConnectException`;
- Enhance `GrpcStatusException` to recognize `ProxyConnectResponseException`;
- Extract `HttpResponseStatus` -> `GrpcStatusCode` mapping into `GrpcUtils.fromHttpStatus(...)` utility, add support for `PROXY_AUTHENTICATION_REQUIRED` status;
- Enhance tests to verify expected behavior;

Results:

1. `ProxyResponseException` and `ProxyConnectResponseException` are part of `http-api` now.
2. `http-netty` is careful when proxy related exceptions should be marked as `RetryableException` and when not.
3. grpc-api recognizes `ProxyConnectResponseException` and infers better grpc-status instead of always using `UNKNOWN`.