### PR TITLE
Deprecate `HttpContextKeys.HTTP_TARGET_ADDRESS_BEHIND_PROXY`

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
@@ -49,8 +49,8 @@ public final class HttpContextKeys {
      * @deprecated Use {@link TransportObserverConnectionFactoryFilter} to configure {@link TransportObserver} and then
      * listen {@link ConnectionObserver#onProxyConnect(Object)} callback to distinguish between a regular connection and
      * a connection to the secure HTTP proxy tunnel. For clear text HTTP proxies, consider installing a custom client
-     * filter that will populate {@link HttpRequestMetaData#context()} with a similar key or reach out to us to discuss
-     * ideas.
+     * filter that will populate {@link HttpRequestMetaData#context()} with a similar key or reach out to the
+     * ServiceTalk developers to discuss ideas.
      */
     @Deprecated
     @SuppressWarnings("DeprecatedIsStillUsed")

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
@@ -15,9 +15,12 @@
  */
 package io.servicetalk.http.api;
 
+import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
 import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.context.api.ContextMap.Key;
 import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.TransportObserver;
 
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
 
@@ -43,8 +46,15 @@ public final class HttpContextKeys {
      * HTTP proxy tunneling</a> and a clear text HTTP proxy, check presence of {@link ConnectionInfo#sslConfig()}.
      *
      * @see SingleAddressHttpClientBuilder#proxyAddress(Object)
+     * @deprecated Use {@link TransportObserverConnectionFactoryFilter} to configure {@link TransportObserver} and then
+     * listen {@link ConnectionObserver#onProxyConnect(Object)} callback to distinguish between a regular connection and
+     * a connection to the secure HTTP proxy tunnel. For clear text HTTP proxies, consider installing a custom client
+     * filter that will populate {@link HttpRequestMetaData#context()} with a similar key or reach out to us to discuss
+     * ideas.
      */
-    public static final Key<Object> HTTP_TARGET_ADDRESS_BEHIND_PROXY =
+    @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    public static final Key<Object> HTTP_TARGET_ADDRESS_BEHIND_PROXY =  // FIXME: 0.43 - remove deprecated constant
             newKey("HTTP_TARGET_ADDRESS_BEHIND_PROXY", Object.class);
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbsoluteAddressHttpRequesterFilter.java
@@ -89,6 +89,7 @@ final class AbsoluteAddressHttpRequesterFilter implements StreamingHttpClientFil
         return HttpExecutionStrategies.offloadNone();
     }
 
+    @SuppressWarnings("deprecation")
     private Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                   final StreamingHttpRequest request) {
         return defer(() -> {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -247,6 +247,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
             if (roConfig.hasProxy() && sslContext != null) {
                 assert roConfig.connectAddress() != null;
+                @SuppressWarnings("deprecation")
                 final ConnectionFactoryFilter<R, FilterableStreamingHttpConnection> proxy =
                         new ProxyConnectConnectionFactoryFilter<>(roConfig.connectAddress(), connectionFactoryStrategy);
                 assert !proxy.requiredOffloads().hasOffloads();

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -46,7 +46,10 @@ import static io.servicetalk.http.api.HttpContextKeys.HTTP_TARGET_ADDRESS_BEHIND
  *
  * @param <ResolvedAddress> The type of resolved addresses that can be used for connecting.
  * @param <C> The type of connections created by this factory.
+ * @deprecated This filter won't be required after {@link HttpContextKeys#HTTP_TARGET_ADDRESS_BEHIND_PROXY} is removed.
  */
+@Deprecated // FIXME: 0.43 - remove deprecated class
+@SuppressWarnings("DeprecatedIsStillUsed")
 final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends FilterableStreamingHttpConnection>
         implements ConnectionFactoryFilter<ResolvedAddress, C> {
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -70,6 +70,7 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public Single<C> newConnection(final ResolvedAddress resolvedAddress,
                                        @Nullable ContextMap context,
                                        @Nullable final TransportObserver observer) {
@@ -84,6 +85,7 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
         }
     }
 
+    @SuppressWarnings("deprecation")
     static void logUnexpectedAddress(@Nullable final Object current, final Object expected, final Logger logger) {
         if (current != null && !expected.equals(current)) {
             logger.info("Observed unexpected value for {}: {}, overridden with: {}",


### PR DESCRIPTION
Motivation:

Prior to `ConnectionObserver.ProxyConnectObserver` added in #2711, the sequence of `ConnectionObserver` events was different between regular connections and connection to the proxy tunnels.
`HttpContextKeys.HTTP_TARGET_ADDRESS_BEHIND_PROXY` (#2169) was useful to distinguish when the correct callback inside `ConnectionObserver` before reporting that a new connection is ready to take traffic. After adding `ProxyConnectObserver`, there is no need in this custom key.

Modifications:

- Deprecate `HttpContextKeys.HTTP_TARGET_ADDRESS_BEHIND_PROXY` and describe what is an appropriate replacement for users;

Result:

We will be able to remove
`HttpContextKeys.HTTP_TARGET_ADDRESS_BEHIND_PROXY` in the future releases.