### PR TITLE
ReplayStrategies.LazyTimeLimitedReplayAccumulator trims and accumulate

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReplayStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReplayStrategies.java
@@ -22,7 +22,6 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -158,23 +157,29 @@ public final class ReplayStrategies {
 
         @Override
         public void accumulate(@Nullable final T t) {
+            final long nanoTime = executor.currentTime(NANOSECONDS);
+            trimExpired(nanoTime);
             if (items.size() >= maxItems) {
                 items.poll();
             }
-            items.add(new TimeStampSignal<>(executor.currentTime(NANOSECONDS), t));
+            items.add(new TimeStampSignal<>(nanoTime, t));
         }
 
         @Override
         public void deliverAccumulation(final Consumer<T> consumer) {
-            final Iterator<TimeStampSignal<T>> itr = items.iterator();
-            final long nanoTime = executor.currentTime(NANOSECONDS);
-            while (itr.hasNext()) {
-                final TimeStampSignal<T> next = itr.next();
-                if (nanoTime - next.timeStamp >= ttlNanos) {
-                    itr.remove();
-                } else {
-                    consumer.accept(next.signal);
-                }
+            if (items.isEmpty()) {
+                return;
+            }
+            trimExpired(executor.currentTime(NANOSECONDS));
+            for (TimeStampSignal<T> next : items) {
+                consumer.accept(next.signal);
+            }
+        }
+
+        private void trimExpired(long nanoTime) {
+            TimeStampSignal<T> next;
+            while ((next = items.peek()) != null && nanoTime - next.timeStamp >= ttlNanos) {
+                items.poll();
             }
         }
     }


### PR DESCRIPTION
Motivation:

The lazy accumulator doesn't eagerly evict items so it can be prone to poor behaviors under certain patterns. One of those patterns is having a large queue limit with a short timeout and infrequent re-subscribes. In this case a producer can fill the queue to the brim despite many elements being expired.

Modifications:

Trim stale entries when accumulating.

Result:

This removes a pathological case and leaves the only remaining pathological case being one where we get a large burst of messages, none of which have expired, and then we have no more new elements or subscribers for long durations which can put unnecessary pressure on the GC.