### PR TITLE
ConnectionObserver: provide ConnectionInfo on transport handshake

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -69,7 +69,8 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
     private Single<FilterableStreamingHttpConnection> createConnection(
             final Channel channel, final ConnectionObserver connectionObserver,
             final ReadOnlyTcpClientConfig tcpConfig) {
-        return new AlpnChannelSingle(channel, new TcpClientChannelInitializer(tcpConfig, connectionObserver),
+        return new AlpnChannelSingle(channel,
+                new TcpClientChannelInitializer(tcpConfig, connectionObserver, executionContext, false),
                 ctx -> { /* SslHandler will automatically start handshake on channelActive */ }).flatMap(protocol -> {
             switch (protocol) {
                 case HTTP_1_1:

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,8 @@ final class DeferredServerChannelBinder {
                                                                   final StreamingHttpService service,
                                                                   final boolean drainRequestPayloadBody,
                                                                   final ConnectionObserver observer) {
-        return new AlpnChannelSingle(channel, new TcpServerChannelInitializer(config.tcpConfig(), observer),
+        return new AlpnChannelSingle(channel,
+                new TcpServerChannelInitializer(config.tcpConfig(), observer, httpExecutionContext),
                 // Force a read to get the SSL handshake started. We initialize pipeline before
                 // SslHandshakeCompletionEvent will complete, therefore, no data will be propagated before we finish
                 // initialization.
@@ -117,7 +118,7 @@ final class DeferredServerChannelBinder {
                                                                  final boolean drainRequestPayloadBody,
                                                                  final ConnectionObserver observer) {
         return new SniCompleteChannelSingle(channel,
-                new TcpServerChannelInitializer(config.tcpConfig(), observer)).flatMap(sniEvt -> {
+                new TcpServerChannelInitializer(config.tcpConfig(), observer, httpExecutionContext)).flatMap(sniEvt -> {
             Throwable failureCause = sniEvt.cause();
             if (failureCause != null) {
                 return failed(failureCause);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -55,7 +55,7 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
                 (channel, connectionObserver) -> H2ClientParentConnectionContext.initChannel(channel,
                         executionContext, config.h2Config(), reqRespFactoryFunc.apply(HTTP_2_0),
                         tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(), tcpConfig.sslConfig(),
-                        new TcpClientChannelInitializer(tcpConfig, connectionObserver).andThen(
+                        new TcpClientChannelInitializer(tcpConfig, connectionObserver, executionContext, false).andThen(
                                 new H2ClientParentChannelInitializer(config.h2Config())), connectionObserver,
                         config.allowDropTrailersReadFromTransport()), observer);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();
         return TcpServerBinder.bind(listenAddress, tcpServerConfig, executionContext, connectionAcceptor,
                 (channel, connectionObserver) -> initChannel(listenAddress, channel, executionContext, config,
-                        new TcpServerChannelInitializer(tcpServerConfig, connectionObserver), service,
+                        new TcpServerChannelInitializer(tcpServerConfig, connectionObserver, executionContext), service,
                         drainRequestPayloadBody, connectionObserver),
                 serverConnection -> { /* nothing to do as h2 uses auto read on the parent channel */ },
                         earlyConnectionAcceptor, lateConnectionAcceptor)

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ final class NettyHttpServer {
         final ReadOnlyTcpServerConfig tcpServerConfig = config.tcpConfig();
         return TcpServerBinder.bind(address, tcpServerConfig, executionContext, connectionAcceptor,
                 (channel, connectionObserver) -> initChannel(channel, executionContext, config,
-                        new TcpServerChannelInitializer(tcpServerConfig, connectionObserver), service,
+                        new TcpServerChannelInitializer(tcpServerConfig, connectionObserver, executionContext), service,
                         drainRequestPayloadBody, connectionObserver),
                 serverConnection -> serverConnection.process(true),
                         earlyConnectionAcceptor, lateConnectionAcceptor)

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
@@ -99,7 +99,7 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
         // Disable half-closure to simplify ProxyConnectHandler implementation
         channelConfig.setOption(ALLOW_HALF_CLOSURE, FALSE);
         return new ProxyConnectChannelSingle(channel,
-                new TcpClientChannelInitializer(config.tcpConfig(), observer, config.hasProxy())
+                new TcpClientChannelInitializer(config.tcpConfig(), observer, executionContext, true)
                         .andThen(new HttpClientChannelInitializer(
                                 getByteBufAllocator(executionContext.bufferAllocator()), h1Config, closeHandler)),
                 observer, h1Config.headersFactory(), connectAddress)

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -59,7 +59,7 @@ final class StreamingConnectionFactory {
         // We disable auto read so we can handle stuff in the ConnectionFilter before we accept any content.
         return TcpConnector.connect(null, resolvedAddress, tcpConfig, false, executionContext,
                 (channel, connectionObserver) -> createConnection(channel, executionContext, h1Config, tcpConfig,
-                        new TcpClientChannelInitializer(tcpConfig, connectionObserver, false),
+                        new TcpClientChannelInitializer(tcpConfig, connectionObserver, executionContext, false),
                         connectionObserver),
                 observer);
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -121,7 +121,7 @@ class FlushStrategyOnServerTest {
                     (channel, observer) -> {
                         channel.config().setAutoRead(true);
                         return initChannel(channel, httpExecutionContext, config,
-                                new TcpServerChannelInitializer(tcpReadOnly, observer)
+                                new TcpServerChannelInitializer(tcpReadOnly, observer, httpExecutionContext)
                                         .andThen(channel1 -> channel1.pipeline().addLast(interceptor)), service,
                                 true, observer);
                     },

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -442,7 +442,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                                     SEC.executor(), SEC.ioExecutor(),
                                     forPipelinedRequestResponse(false, channel.config()), defaultFlushStrategy(), 0L,
                                     null,
-                                    new TcpServerChannelInitializer(sConfig, observer).andThen(
+                                    new TcpServerChannelInitializer(sConfig, observer, SEC).andThen(
                                             channel2 -> {
                                                 serverChannelRef.compareAndSet(null, channel2);
                                                 serverChannelLatch.countDown();
@@ -461,7 +461,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                                         closeHandler, defaultFlushStrategy(), 0L,
                                         cConfig.tcpConfig().sslConfig(),
                                         new TcpClientChannelInitializer(cConfig.tcpConfig(),
-                                                connectionObserver)
+                                                connectionObserver, CEC, false)
                                                 .andThen(new HttpClientChannelInitializer(
                                                         getByteBufAllocator(CEC.bufferAllocator()),
                                                         cConfig.h1Config(), closeHandler))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -180,6 +180,11 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
         private class AsyncContextCaptureConnectionObserver implements ConnectionObserver {
 
             @Override
+            public void onConnectionInitialization(final ConnectionInfo info) {
+                // AsyncContext is unknown at this point because this event is triggered by network
+            }
+
+            @Override
             public void onDataRead(final int size) {
                 // AsyncContext is unknown at this point because this event is triggered by network
             }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -180,11 +180,6 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
         private class AsyncContextCaptureConnectionObserver implements ConnectionObserver {
 
             @Override
-            public void onConnectionInitialization(final ConnectionInfo info) {
-                // AsyncContext is unknown at this point because this event is triggered by network
-            }
-
-            @Override
             public void onDataRead(final int size) {
                 // AsyncContext is unknown at this point because this event is triggered by network
             }
@@ -200,7 +195,7 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
-            public void onTransportHandshakeComplete() {
+            public void onTransportHandshakeComplete(final ConnectionInfo info) {
                 // AsyncContext is unknown at this point because this event is triggered by network
             }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -170,6 +170,8 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
 
         verify(clientTransportObserver).onNewConnection(any(), any());
         verify(serverTransportObserver, await()).onNewConnection(any(), any());
+        verify(clientConnectionObserver).onConnectionInitialization(any());
+        verify(serverConnectionObserver, await()).onConnectionInitialization(any());
         verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
         if (protocol == HTTP_1) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverTest.java
@@ -170,10 +170,8 @@ class HttpTransportObserverTest extends AbstractNettyHttpServerTest {
 
         verify(clientTransportObserver).onNewConnection(any(), any());
         verify(serverTransportObserver, await()).onNewConnection(any(), any());
-        verify(clientConnectionObserver).onConnectionInitialization(any());
-        verify(serverConnectionObserver, await()).onConnectionInitialization(any());
-        verify(clientConnectionObserver).onTransportHandshakeComplete();
-        verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
+        verify(clientConnectionObserver).onTransportHandshakeComplete(any());
+        verify(serverConnectionObserver, await()).onTransportHandshakeComplete(any());
         if (protocol == HTTP_1) {
             verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
             verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -378,14 +378,14 @@ class HttpsProxyTest {
 
     private void verifyProxyConnectFailed(Throwable cause) {
         order.verify(transportObserver).onNewConnection(any(), any());
-        order.verify(connectionObserver).onTransportHandshakeComplete();
+        order.verify(connectionObserver).onTransportHandshakeComplete(any());
         order.verify(connectionObserver).onProxyConnect(any());
         order.verify(proxyConnectObserver).proxyConnectFailed(cause);
     }
 
     private void verifyProxyConnectComplete() {
         order.verify(transportObserver).onNewConnection(any(), any());
-        order.verify(connectionObserver).onTransportHandshakeComplete();
+        order.verify(connectionObserver).onTransportHandshakeComplete(any());
         order.verify(connectionObserver).onProxyConnect(any());
         order.verify(proxyConnectObserver).proxyConnectComplete(any());
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -181,8 +181,7 @@ class SecurityHandshakeObserverTest {
             ConnectionObserver connectionObserver, SecurityHandshakeObserver securityHandshakeObserver,
             HttpProtocol expectedProtocol, boolean failHandshake) {
         order.verify(transportObserver).onNewConnection(any(), any());
-        order.verify(connectionObserver).onConnectionInitialization(any());
-        order.verify(connectionObserver).onTransportHandshakeComplete();
+        order.verify(connectionObserver).onTransportHandshakeComplete(any());
         order.verify(connectionObserver).onSecurityHandshake();
         if (failHandshake) {
             ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -181,6 +181,7 @@ class SecurityHandshakeObserverTest {
             ConnectionObserver connectionObserver, SecurityHandshakeObserver securityHandshakeObserver,
             HttpProtocol expectedProtocol, boolean failHandshake) {
         order.verify(transportObserver).onNewConnection(any(), any());
+        order.verify(connectionObserver).onConnectionInitialization(any());
         order.verify(connectionObserver).onTransportHandshakeComplete();
         order.verify(connectionObserver).onSecurityHandshake();
         if (failHandshake) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -87,7 +87,7 @@ class ServerRespondsOnClosingTest {
             return fromSource(responseProcessor);
         };
         serverConnection = initChannel(channel, httpExecutionContext, config, new TcpServerChannelInitializer(
-                config.tcpConfig(), connectionObserver),
+                config.tcpConfig(), connectionObserver, httpExecutionContext),
                 toStreamingHttpService(offloadNone(), service), true,
                 connectionObserver).toFuture().get();
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
@@ -140,6 +140,10 @@ class SslCertificateCompressionTest {
         public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
             return new ConnectionObserver() {
                 @Override
+                public void onConnectionInitialization(final ConnectionInfo info) {
+                }
+
+                @Override
                 public void onDataRead(final int size) {
                     if (inHandshake) {
                         handshakeBytesRead += size;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
@@ -139,9 +139,6 @@ class SslCertificateCompressionTest {
         @Override
         public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
             return new ConnectionObserver() {
-                @Override
-                public void onConnectionInitialization(final ConnectionInfo info) {
-                }
 
                 @Override
                 public void onDataRead(final int size) {
@@ -178,7 +175,7 @@ class SslCertificateCompressionTest {
                 }
 
                 @Override
-                public void onTransportHandshakeComplete() {
+                public void onTransportHandshakeComplete(final ConnectionInfo info) {
                 }
 
                 @Override

--- a/servicetalk-tcp-netty-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-tcp-netty-internal/gradle/spotbugs/main-exclusions.xml
@@ -54,4 +54,14 @@
     <Method name="lambda$handleSubscribe$1"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
+
+  <!-- FIXME: 0.43 - Remove temporary suppression after we can remove deprecated constructors -->
+  <Match>
+    <Class name="io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer"/>
+    <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer"/>
+    <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
@@ -17,6 +17,7 @@ package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.logging.api.UserDataLoggerConfig;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 
 import io.netty.channel.ChannelOption;
@@ -34,7 +35,7 @@ import static java.util.Collections.unmodifiableMap;
  *
  * @param <SecurityConfig> type of security configuration
  */
-abstract class AbstractReadOnlyTcpConfig<SecurityConfig> {
+abstract class AbstractReadOnlyTcpConfig<SecurityConfig extends SslConfig> {
     @SuppressWarnings("rawtypes")
     private final Map<ChannelOption, Object> options;
     private final long idleTimeoutMs;
@@ -106,4 +107,12 @@ abstract class AbstractReadOnlyTcpConfig<SecurityConfig> {
      */
     @Nullable
     public abstract SslContext sslContext();
+
+    /**
+     * Get the {@link SslConfig}.
+     *
+     * @return the {@link SslConfig}, or {@code null} if SSL/TLS is not configured.
+     */
+    @Nullable
+    public abstract SecurityConfig sslConfig();
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -40,7 +40,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @param <SslConfigType> type of {@link SslConfig}.
  */
-abstract class AbstractTcpConfig<SslConfigType> {
+abstract class AbstractTcpConfig<SslConfigType extends SslConfig> {
 
     @Nullable
     @SuppressWarnings("rawtypes")

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnectionInfo.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnectionInfo.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.tcp.netty.internal;
+
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ExecutionContext;
+import io.servicetalk.transport.api.SslConfig;
+
+import io.netty.channel.Channel;
+
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLSession;
+
+import static io.servicetalk.transport.netty.internal.SocketOptionUtils.getOption;
+
+final class TcpConnectionInfo implements ConnectionInfo {
+
+    private static final Protocol TCP_PROTOCOL = () -> "TCP";
+
+    private final Channel channel;
+    private final ExecutionContext<?> executionContext;
+    @Nullable
+    private final SslConfig sslConfig;
+    private final long idleTimeoutMs;
+
+    TcpConnectionInfo(final Channel channel,
+                      final ExecutionContext<?> executionContext,
+                      @Nullable final SslConfig sslConfig,
+                      final long idleTimeoutMs) {
+        this.channel = channel;
+        this.executionContext = executionContext;
+        this.sslConfig = sslConfig;
+        this.idleTimeoutMs = idleTimeoutMs;
+    }
+
+    @Override
+    public SocketAddress localAddress() {
+        return channel.localAddress();
+    }
+
+    @Override
+    public SocketAddress remoteAddress() {
+        return channel.remoteAddress();
+    }
+
+    @Override
+    public ExecutionContext<?> executionContext() {
+        return executionContext;
+    }
+
+    @Nullable
+    @Override
+    public SslConfig sslConfig() {
+        return sslConfig;
+    }
+
+    @Nullable
+    @Override
+    public SSLSession sslSession() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public <T> T socketOption(final SocketOption<T> option) {
+        return getOption(option, channel.config(), idleTimeoutMs);
+    }
+
+    @Override
+    public Protocol protocol() {
+        return TCP_PROTOCOL;
+    }
+
+    @Override
+    public String toString() {
+        return channel.toString();
+    }
+}

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.logging.api.UserDataLoggerConfig;
+import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.ConnectionObserverInitializer;
 import io.servicetalk.transport.netty.internal.IdleTimeoutInitializer;
@@ -28,6 +30,8 @@ import io.servicetalk.transport.netty.internal.WireLoggingInitializer;
 import io.netty.channel.Channel;
 
 import javax.annotation.Nullable;
+
+import static io.servicetalk.transport.netty.internal.ExecutionContextUtils.channelExecutionContext;
 
 /**
  * {@link ChannelInitializer} for TCP.
@@ -41,14 +45,36 @@ public class TcpServerChannelInitializer implements ChannelInitializer {    // F
      *
      * @param config to use for initialization.
      * @param observer {@link ConnectionObserver} to report network events.
+     * @deprecated Use
+     * {@link #TcpServerChannelInitializer(ReadOnlyTcpServerConfig, ConnectionObserver, ExecutionContext)}
      */
+    @Deprecated
+    @SuppressWarnings("DataFlowIssue")
     public TcpServerChannelInitializer(final ReadOnlyTcpServerConfig config,
                                        final ConnectionObserver observer) {
+        this(config, observer, null);
+    }
+
+    /**
+     * Creates a {@link ChannelInitializer} for the {@code config}.
+     *
+     * @param config to use for initialization.
+     * @param observer {@link ConnectionObserver} to report network events.
+     * @param executionContext {@link ExecutionContext} to use for {@link ConnectionInfo} reporting.
+     */
+    @SuppressWarnings("ConstantValue")
+    public TcpServerChannelInitializer(final ReadOnlyTcpServerConfig config,
+                                       final ConnectionObserver observer,
+                                       final ExecutionContext<?> executionContext) {
         ChannelInitializer delegate = ChannelInitializer.defaultInitializer();
 
         if (observer != NoopConnectionObserver.INSTANCE) {
-            delegate = delegate.andThen(
-                    new ConnectionObserverInitializer(observer, config.sslContext() != null, false));
+            delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
+                    channel -> new TcpConnectionInfo(channel,
+                            // ExecutionContext can be null if users used deprecated ctor
+                            executionContext == null ? null : channelExecutionContext(channel, executionContext),
+                            config.sslConfig(), config.idleTimeoutMs()),
+                    config.sslConfig() != null, false));
         }
 
         if (config.idleTimeoutMs() > 0L) {
@@ -56,10 +82,12 @@ public class TcpServerChannelInitializer implements ChannelInitializer {    // F
         }
 
         if (config.sniMapping() != null) {
+            assert config.sslConfig() != null;
             assert config.sslContext() != null;
             delegate = delegate.andThen(new SniServerChannelInitializer(config.sniMapping(),
                     config.sniMaxClientHelloLength(), config.sniClientHelloTimeout().toMillis()));
         } else if (config.sslContext() != null) {
+            assert config.sslConfig() != null;
             delegate = delegate.andThen(new SslServerChannelInitializer(config.sslContext()));
         }
 

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
@@ -173,7 +173,11 @@ final class SecureTcpTransportObserverErrorsTest extends AbstractTransportObserv
             clientConnected.countDown();
         });
         verify(clientTransportObserver, await()).onNewConnection(any(), any());
+        verify(clientConnectionObserver, await()).onConnectionInitialization(any());
+        verify(clientConnectionObserver, await()).onTransportHandshakeComplete();
         verify(serverTransportObserver, await()).onNewConnection(any(), any());
+        verify(serverConnectionObserver, await()).onConnectionInitialization(any());
+        verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
         switch (errorReason) {
             case SECURE_CLIENT_TO_PLAIN_SERVER:
                 verify(clientConnectionObserver, await()).onSecurityHandshake();

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
@@ -173,11 +173,9 @@ final class SecureTcpTransportObserverErrorsTest extends AbstractTransportObserv
             clientConnected.countDown();
         });
         verify(clientTransportObserver, await()).onNewConnection(any(), any());
-        verify(clientConnectionObserver, await()).onConnectionInitialization(any());
-        verify(clientConnectionObserver, await()).onTransportHandshakeComplete();
+        verify(clientConnectionObserver, await()).onTransportHandshakeComplete(any());
         verify(serverTransportObserver, await()).onNewConnection(any(), any());
-        verify(serverConnectionObserver, await()).onConnectionInitialization(any());
-        verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
+        verify(serverConnectionObserver, await()).onTransportHandshakeComplete(any());
         switch (errorReason) {
             case SECURE_CLIENT_TO_PLAIN_SERVER:
                 verify(clientConnectionObserver, await()).onSecurityHandshake();

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
@@ -76,8 +76,10 @@ class SecureTcpTransportObserverTest extends AbstractTransportObserverTest {
         verify(clientTransportObserver).onNewConnection(any(), any());
         verify(serverTransportObserver, await()).onNewConnection(any(), any());
 
+        verify(clientConnectionObserver).onConnectionInitialization(any());
         verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
+        verify(serverConnectionObserver, await()).onConnectionInitialization(any());
         verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
@@ -76,11 +76,9 @@ class SecureTcpTransportObserverTest extends AbstractTransportObserverTest {
         verify(clientTransportObserver).onNewConnection(any(), any());
         verify(serverTransportObserver, await()).onNewConnection(any(), any());
 
-        verify(clientConnectionObserver).onConnectionInitialization(any());
-        verify(clientConnectionObserver).onTransportHandshakeComplete();
+        verify(clientConnectionObserver).onTransportHandshakeComplete(any());
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
-        verify(serverConnectionObserver, await()).onConnectionInitialization(any());
-        verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
+        verify(serverConnectionObserver, await()).onTransportHandshakeComplete(any());
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
         // handshake starts

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
@@ -142,11 +142,9 @@ final class TcpTransportObserverErrorsTest extends AbstractTransportObserverTest
         if (errorSource != ErrorSource.CONNECTION_REFUSED) {
             assertThat(connection, is(notNullValue()));
             verify(serverTransportObserver, await()).onNewConnection(any(), any());
-            verify(clientConnectionObserver).onConnectionInitialization(any());
-            verify(clientConnectionObserver).onTransportHandshakeComplete();
+            verify(clientConnectionObserver).onTransportHandshakeComplete(any());
             verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
-            verify(serverConnectionObserver, await()).onConnectionInitialization(any());
-            verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
+            verify(serverConnectionObserver, await()).onTransportHandshakeComplete(any());
             verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
         } else {
             assertThat(connection, is(nullValue()));
@@ -188,7 +186,6 @@ final class TcpTransportObserverErrorsTest extends AbstractTransportObserverTest
         }
         switch (errorSource) {
             case CONNECTION_REFUSED:
-                verify(clientConnectionObserver).onConnectionInitialization(any());
                 break;
             case CONNECTION_ACCEPTOR:
             case PIPELINE:

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
@@ -142,8 +142,10 @@ final class TcpTransportObserverErrorsTest extends AbstractTransportObserverTest
         if (errorSource != ErrorSource.CONNECTION_REFUSED) {
             assertThat(connection, is(notNullValue()));
             verify(serverTransportObserver, await()).onNewConnection(any(), any());
+            verify(clientConnectionObserver).onConnectionInitialization(any());
             verify(clientConnectionObserver).onTransportHandshakeComplete();
             verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
+            verify(serverConnectionObserver, await()).onConnectionInitialization(any());
             verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
             verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
         } else {
@@ -186,6 +188,7 @@ final class TcpTransportObserverErrorsTest extends AbstractTransportObserverTest
         }
         switch (errorSource) {
             case CONNECTION_REFUSED:
+                verify(clientConnectionObserver).onConnectionInitialization(any());
                 break;
             case CONNECTION_ACCEPTOR:
             case PIPELINE:

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
@@ -48,11 +48,9 @@ class TcpTransportObserverTest extends AbstractTransportObserverTest {
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
         verify(clientTransportObserver).onNewConnection(any(), any());
         verify(serverTransportObserver, await()).onNewConnection(any(), any());
-        verify(clientConnectionObserver).onConnectionInitialization(any());
-        verify(clientConnectionObserver).onTransportHandshakeComplete();
+        verify(clientConnectionObserver).onTransportHandshakeComplete(any());
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
-        verify(serverConnectionObserver, await()).onConnectionInitialization(any());
-        verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
+        verify(serverConnectionObserver, await()).onTransportHandshakeComplete(any());
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
         Buffer content = connection.executionContext().bufferAllocator().fromAscii("Hello");

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverTest.java
@@ -48,8 +48,10 @@ class TcpTransportObserverTest extends AbstractTransportObserverTest {
         NettyConnection<Buffer, Buffer> connection = client.connectBlocking(CLIENT_CTX, serverAddress);
         verify(clientTransportObserver).onNewConnection(any(), any());
         verify(serverTransportObserver, await()).onNewConnection(any(), any());
+        verify(clientConnectionObserver).onConnectionInitialization(any());
         verify(clientConnectionObserver).onTransportHandshakeComplete();
         verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
+        verify(serverConnectionObserver, await()).onConnectionInitialization(any());
         verify(serverConnectionObserver, await()).onTransportHandshakeComplete();
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpClient.java
@@ -97,7 +97,7 @@ final class TcpClient {
                         executionContext.bufferAllocator(), executionContext.executor(), executionContext.ioExecutor(),
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
                         config.sslConfig(),
-                        new TcpClientChannelInitializer(config, connectionObserver).andThen(
+                        new TcpClientChannelInitializer(config, connectionObserver, executionContext, false).andThen(
                                 channel2 -> channel2.pipeline().addLast(BufferHandler.INSTANCE)),
                         executionContext.executionStrategy(), TCP, connectionObserver, true, __ -> false),
                 observer);

--- a/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
+++ b/servicetalk-tcp-netty-internal/src/testFixtures/java/io/servicetalk/tcp/netty/internal/TcpServer.java
@@ -87,7 +87,7 @@ public class TcpServer {
                         executionContext.bufferAllocator(), executionContext.executor(), executionContext.ioExecutor(),
                         UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, config.flushStrategy(), config.idleTimeoutMs(),
                         config.sslConfig(),
-                        new TcpServerChannelInitializer(config, connectionObserver)
+                        new TcpServerChannelInitializer(config, connectionObserver, executionContext)
                                 .andThen(getChannelInitializer(service, executionContext)), executionStrategy, TCP,
                         connectionObserver, false, __ -> false),
                 serverConnection -> service.apply(serverConnection)

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -55,12 +55,6 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onConnectionInitialization(final ConnectionInfo info) {
-            first.onConnectionInitialization(info);
-            second.onConnectionInitialization(info);
-        }
-
-        @Override
         public void onDataRead(final int size) {
             first.onDataRead(size);
             second.onDataRead(size);
@@ -79,9 +73,9 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onTransportHandshakeComplete() {
-            first.onTransportHandshakeComplete();
-            second.onTransportHandshakeComplete();
+        public void onTransportHandshakeComplete(final ConnectionInfo info) {
+            first.onTransportHandshakeComplete(info);
+            second.onTransportHandshakeComplete(info);
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -55,6 +55,12 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void onConnectionInitialization(final ConnectionInfo info) {
+            first.onConnectionInitialization(info);
+            second.onConnectionInitialization(info);
+        }
+
+        @Override
         public void onDataRead(final int size) {
             first.onDataRead(size);
             second.onDataRead(size);

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -70,11 +70,6 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onConnectionInitialization(final ConnectionInfo info) {
-            safeReport(() -> observer.onConnectionInitialization(info), observer, "connection initialization");
-        }
-
-        @Override
         public void onDataRead(final int size) {
             safeReport(() -> observer.onDataRead(size), observer, "data read");
         }
@@ -90,8 +85,8 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onTransportHandshakeComplete() {
-            safeReport(observer::onTransportHandshakeComplete, observer, "flush");
+        public void onTransportHandshakeComplete(final ConnectionInfo info) {
+            safeReport(() -> observer.onTransportHandshakeComplete(info), observer, "transport handshake complete");
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -70,6 +70,11 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void onConnectionInitialization(final ConnectionInfo info) {
+            safeReport(() -> observer.onConnectionInitialization(info), observer, "connection initialization");
+        }
+
+        @Override
         public void onDataRead(final int size) {
             safeReport(() -> observer.onDataRead(size), observer, "data read");
         }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,21 @@ import javax.net.ssl.SSLSession;
  * is closed.
  */
 public interface ConnectionObserver {
+
+    /**
+     * Callback when a connection starts initialization and {@link ConnectionInfo} becomes available.
+     * <p>
+     * This callback is invoked before any other callback on this observer.
+     *
+     * @param info {@link ConnectionInfo} for the connection that starts initialization. Note that the
+     * {@link ConnectionInfo#sslSession()} will always return {@code null} since it is called before the
+     * {@link ConnectionObserver#onSecurityHandshake() security handshake} is performed (and as a result no SSL session
+     * has been established). Also, {@link ConnectionInfo#protocol()} will return L4 (transport) protocol.
+     * Finalized {@link ConnectionInfo} will be available via {@link #connectionEstablished(ConnectionInfo)} or
+     * {@link #multiplexedConnectionEstablished(ConnectionInfo)} callbacks.
+     */
+    default void onConnectionInitialization(ConnectionInfo info) {  // FIXME: 0.43 - consider removing default impl
+    }
 
     /**
      * Callback when {@code size} bytes are read from the connection.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -48,6 +48,10 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void onConnectionInitialization(final ConnectionInfo info) {
+        }
+
+        @Override
         public void onDataRead(final int size) {
         }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -48,10 +48,6 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onConnectionInitialization(final ConnectionInfo info) {
-        }
-
-        @Override
         public void onDataRead(final int size) {
         }
 
@@ -64,7 +60,7 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onTransportHandshakeComplete() {
+        public void onTransportHandshakeComplete(final ConnectionInfo info) {
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
@@ -97,4 +97,11 @@
     <Method name="lambda$static$0"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
+
+  <!-- FIXME: 0.43 - Remove temporary suppression after we can remove deprecated constructors -->
+  <Match>
+    <Class name="io.servicetalk.transport.netty.internal.ConnectionObserverInitializer$PartialConnectionInfo"/>
+    <Method name="executionContext"/>
+    <Bug pattern="NP_NONNULL_RETURN_VIOLATION"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -57,6 +57,10 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public void onConnectionInitialization(final ConnectionInfo info) {
+        }
+
+        @Override
         public void onDataRead(final int size) {
         }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -57,10 +57,6 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onConnectionInitialization(final ConnectionInfo info) {
-        }
-
-        @Override
         public void onDataRead(final int size) {
         }
 
@@ -73,7 +69,7 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
-        public void onTransportHandshakeComplete() {
+        public void onTransportHandshakeComplete(final ConnectionInfo info) {
         }
 
         @Override


### PR DESCRIPTION
Motivation:

If connection fails with an exception before one of the "established" methods were invoked, users don't have access to meaningful information, like `SslConfig`, SocketOptions, channelId (for correlation with wire logs), local address, etc.

Modifications:

- Add `ConnectionObserver.onTransportHandshakeComplete(ConnectionInfo)` callback that gives users a ST view of the netty's `Channel`;
- Deprecate pre-existing `ConnectionObserver.onTransportHandshakeComplete()`;

Results:

1. Users can collect more information about a connection if it's failed before "established".
2. Users can get Channel's ID for reporting `ProxyConnectObserver` events and security handshake failures.