### PR TITLE
Restore API/ABI compatibility with version 0.42.37

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyResponseException.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyResponseException.java
@@ -41,4 +41,9 @@ public class ProxyResponseException extends ProxyConnectResponseException implem
     public HttpResponseStatus status() {
         return response().status();
     }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -56,7 +56,7 @@ public interface ConnectionObserver {
      * @deprecated Use {@link #onTransportHandshakeComplete(ConnectionInfo)}
      */
     @Deprecated
-    default void onTransportHandshakeComplete() {
+    default void onTransportHandshakeComplete() {   // FIXME: 0.43 - remove deprecated method
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -69,6 +69,11 @@ public final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
+        public void onTransportHandshakeComplete() {
+        }
+
+        @Override
         public void onTransportHandshakeComplete(final ConnectionInfo info) {
         }
 


### PR DESCRIPTION
Motivation:

`japicmp.sh` shows the following warnings:
```
Comparing binary compatibility of servicetalk-http-netty-0.42.38-SNAPSHOT.jar against servicetalk-http-netty-0.42.37.jar
***! MODIFIED CLASS: PUBLIC NON_FINAL (<- FINAL) io.servicetalk.http.netty.ProxyResponseException  (Serializable removed)
        ===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
        ---! REMOVED SUPERCLASS: java.io.IOException
        ---! REMOVED METHOD: PUBLIC(-) java.lang.String toString()

Comparing binary compatibility of servicetalk-transport-netty-internal-0.42.38-SNAPSHOT.jar against servicetalk-transport-netty-internal-0.42.37.jar
***! MODIFIED CLASS: PUBLIC STATIC FINAL io.servicetalk.transport.netty.internal.NoopTransportObserver$NoopConnectionObserver  (not serializable)
        ===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
        ===  UNCHANGED SUPERCLASS: java.lang.Object (<- java.lang.Object)
        ---! REMOVED METHOD: PUBLIC(-) void onTransportHandshakeComplete()
```

Modifications:

- Restore `ProxyResponseException.toString()`;
- Restore `NoopTransportObserver.onTransportHandshakeComplete()`;

Result:

Less warnings produced by `japicmp.sh` script.