### PR TITLE
Fix Flaky CancellationTest

### DIFF
--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/CancellationTest.java
@@ -224,13 +224,8 @@ class CancellationTest {
                     jerseyRouter.handle(ctx, req, HTTP_REQ_RES_FACTORY)
             ).flatMap(identity())
                     .beforeOnError((err) -> {
-                        // If subscription cancellation arrives after the resource started to sleep, the cancellation
-                        // will interrupt the sleep which is OK.
-                        boolean sleepInterrupted = err instanceof InterruptedException && err.getMessage()
-                                .contains("sleep interrupted");
-
                         // Ignore racy cancellation, it's ordered safely.
-                        if (!(err instanceof IllegalStateException || sleepInterrupted)) {
+                        if (!(err instanceof IllegalStateException || err instanceof InterruptedException)) {
                             errorRef.compareAndSet(null, err);
                         }
                     })
@@ -254,13 +249,8 @@ class CancellationTest {
 
                 @Override
                 public void onError(final Throwable t) {
-                    // If subscription cancellation arrives after the resource started to sleep, the cancellation
-                    // will interrupt the sleep which is OK.
-                    boolean sleepInterrupted = t instanceof InterruptedException && t.getMessage()
-                            .contains("sleep interrupted");
-
                     // Ignore racy cancellation, it's ordered safely.
-                    if (!(t instanceof IllegalStateException || sleepInterrupted)) {
+                    if (!(t instanceof IllegalStateException || t instanceof InterruptedException)) {
                         errorRef.compareAndSet(null, t);
                     }
                     cancelledLatch.countDown();


### PR DESCRIPTION
Motivation
----------
The CancellationTest#cancelOffload() is reportedly flaky and this PR attempts to solve it.

Modifications
-------------
Investigation found that it looks like on CI the sleeping of the action races with the cancellation of the service single. If the cancellation arrives before the service is executed, the thread sleep will never be triggered and so the test completes fine. If the cancellation does not arrive first, the sleep starts to happen and when the cancellation arrives afterwards the thread is interrupted as part of the cancellation which triggers the exception.

Since interrupts are expected on cancellations, this exception should be caught and ignored since it is legitimate.

Fixes #2036