### PR TITLE
Move NettyPipelinedConnection from http-netty to transport-netty-inte…

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
@@ -30,6 +30,7 @@ import io.servicetalk.transport.netty.internal.FlushStrategies;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.GlobalExecutionContext;
 import io.servicetalk.transport.netty.internal.NettyConnection;
+import io.servicetalk.transport.netty.internal.NettyPipelinedConnection;
 import io.servicetalk.transport.netty.internal.WriteDemandEstimator;
 
 import io.netty.channel.Channel;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/PipelinedStreamingHttpConnection.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnection;
+import io.servicetalk.transport.netty.internal.NettyPipelinedConnection;
 import io.servicetalk.transport.netty.internal.WriteDemandEstimators;
 
 import javax.annotation.Nullable;

--- a/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
@@ -97,6 +97,11 @@
     <Method name="lambda$static$0"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
+  <!-- Parameters/state is intentional -->
+  <Match>
+    <Class name="io.servicetalk.transport.netty.internal.NettyPipelinedConnection"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
 
   <!-- FIXME: 0.43 - Remove temporary suppression after we can remove deprecated constructors -->
   <Match>

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelinedConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelinedConnection.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
+package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.PublisherSource;
@@ -25,11 +25,6 @@ import io.servicetalk.concurrent.internal.ConcurrentUtils;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.SslConfig;
-import io.servicetalk.transport.netty.internal.FlushStrategy;
-import io.servicetalk.transport.netty.internal.NettyConnection;
-import io.servicetalk.transport.netty.internal.NettyConnectionContext;
-import io.servicetalk.transport.netty.internal.WriteDemandEstimator;
-import io.servicetalk.transport.netty.internal.WriteDemandEstimators;
 
 import io.netty.channel.Channel;
 
@@ -58,7 +53,7 @@ import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
  * @param <Req> Type of requests sent on this connection.
  * @param <Resp> Type of responses read from this connection.
  */
-final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContext {
+public final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContext {
     @SuppressWarnings("rawtypes")
     private static final AtomicIntegerFieldUpdater<NettyPipelinedConnection> writeQueueLockUpdater =
             newUpdater(NettyPipelinedConnection.class, "writeQueueLock");
@@ -80,8 +75,7 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
      * @param connection {@link NettyConnection} requests to which are to be pipelined.
      * @param maxPipelinedRequests The maximum number of pipelined requests.
      */
-    NettyPipelinedConnection(NettyConnection<Resp, Req> connection,
-                             int maxPipelinedRequests) {
+    public NettyPipelinedConnection(final NettyConnection<Resp, Req> connection, int maxPipelinedRequests) {
         this.connection = requireNonNull(connection);
         writeQueue = newUnboundedMpscQueue(min(maxPipelinedRequests, MAX_INIT_QUEUE_SIZE));
         readQueue = newUnboundedMpscQueue(min(maxPipelinedRequests, MAX_INIT_QUEUE_SIZE));
@@ -93,7 +87,7 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
      * impacts how many elements are requested from the {@code requestPublisher} depending upon channel writability.
      * @return Response {@link Publisher} for this request.
      */
-    Publisher<Resp> write(final Publisher<Req> requestPublisher) {
+    public Publisher<Resp> write(final Publisher<Req> requestPublisher) {
         return write(requestPublisher, connection::defaultFlushStrategy, WriteDemandEstimators::newDefaultEstimator);
     }
 
@@ -105,7 +99,7 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
      * impacts how many elements are requested from the {@code requestPublisher} depending upon channel writability.
      * @return Response {@link Publisher} for this request.
      */
-    Publisher<Resp> write(final Publisher<Req> requestPublisher,
+    public Publisher<Resp> write(final Publisher<Req> requestPublisher,
                           final Supplier<FlushStrategy> flushStrategySupplier,
                           final Supplier<WriteDemandEstimator> writeDemandEstimatorSupplier) {
         // Lazy modification of local state required (e.g. nodes, delayed subscriber, queue modifications)
@@ -209,7 +203,7 @@ final class NettyPipelinedConnection<Req, Resp> implements NettyConnectionContex
     }
 
     @Override
-    public Cancellable updateFlushStrategy(final NettyConnectionContext.FlushStrategyProvider strategyProvider) {
+    public Cancellable updateFlushStrategy(final FlushStrategyProvider strategyProvider) {
         return connection.updateFlushStrategy(strategyProvider);
     }
 

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyPipelinedConnectionTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/NettyPipelinedConnectionTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
+package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.PublisherSource;
@@ -29,16 +29,9 @@ import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 import io.servicetalk.transport.api.ConnectionInfo.Protocol;
 import io.servicetalk.transport.api.DefaultExecutionContext;
 import io.servicetalk.transport.api.ExecutionContext;
+import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.RetryableException;
-import io.servicetalk.transport.netty.internal.CloseHandler;
-import io.servicetalk.transport.netty.internal.DefaultNettyConnection;
-import io.servicetalk.transport.netty.internal.EmbeddedDuplexChannel;
-import io.servicetalk.transport.netty.internal.ExecutionContextUtils;
-import io.servicetalk.transport.netty.internal.FlushStrategy;
-import io.servicetalk.transport.netty.internal.NettyConnection;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
-import io.servicetalk.transport.netty.internal.WriteDemandEstimator;
-import io.servicetalk.transport.netty.internal.WriteDemandEstimators;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -64,7 +57,6 @@ import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverCompleteFromSource;
-import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
 import static io.servicetalk.transport.netty.internal.FlushStrategies.defaultFlushStrategy;
 import static io.servicetalk.transport.netty.internal.NettyIoExecutors.fromNettyEventLoop;
@@ -104,8 +96,9 @@ class NettyPipelinedConnectionTest {
         writePublisher2 = new TestPublisher<>();
         when(demandEstimator.estimateRequestN(anyLong())).then(invocation1 -> MAX_VALUE);
         CloseHandler closeHandler = UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
+        ExecutionStrategy executionStrategy = () -> true;
         ExecutionContext<?> executionContext = new DefaultExecutionContext<>(DEFAULT_ALLOCATOR,
-                fromNettyEventLoop(channel.eventLoop(), false), immediate(), defaultStrategy());
+                fromNettyEventLoop(channel.eventLoop(), false), immediate(), executionStrategy);
         final DefaultNettyConnection<Integer, Integer> connection =
                 DefaultNettyConnection.<Integer, Integer>initChannel(channel, executionContext,
                 closeHandler, defaultFlushStrategy(), 0L, null, channel2 -> {


### PR DESCRIPTION
…rnal

Motivation
----------
The NettyPipelinedConnection has no knowledge or implementation details which would tie it to the http package, so it can be moved to transport-netty-internal where also the related NettyConnection itself lives.

Modifications
-------------
Moved the NettyPipelinedConnection to the package, adjusted imports and also moved the test case.

Result
------
The NettyPipelinedConnection can now also be used by other protocol implementations and lives logically next to the NettyConnection class itself.