### PR TITLE
Improve javadocs for firstOrElse and firstOrError

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -4059,9 +4059,10 @@ Kotlin flatMapLatest</a>
     /**
      * Converts this {@link Publisher} to a {@link Single}.
      * <p>
-     * This operator is useful if the {@link Publisher} that is being converted is potentially empty, in which case
-     * the {@code defaultValueSupplier} will be triggered. If a conversion to {@link Single} is needed where it is
-     * expected that the {@link Publisher} returns exactly one element, consider using {@link #firstOrError()} instead.
+     * This operator is useful if the {@link Publisher} that is being converted is potentially empty (in which case
+     * the {@code defaultValueSupplier} will be triggered) or may emit multiple elements (in which case it will be
+     * cancelled after receiving the first element). If a conversion to {@link Single} is needed where it is expected
+     * that the {@link Publisher} returns exactly one element, consider using {@link #firstOrError()} instead.
      *
      * @param defaultValueSupplier A {@link Supplier} of default value if this {@link Publisher} did not emit any item.
      * @return A {@link Single} that will contain the first item emitted from the this {@link Publisher}.
@@ -4069,13 +4070,15 @@ Kotlin flatMapLatest</a>
      * as returned by the passed {@link Supplier}.
      *
      * @see <a href="https://reactivex.io/documentation/operators/first.html">ReactiveX first operator.</a>
+     * @see #firstOrError()
      */
     public final Single<T> firstOrElse(Supplier<T> defaultValueSupplier) {
         return new PubToSingleFirstOrElse<>(this, defaultValueSupplier);
     }
 
     /**
-     * Converts this {@link Publisher} to a {@link Single}.
+     * Converts this {@link Publisher} to a {@link Single} and ensures that it emits exactly a single
+     * {@link Subscriber#onNext(Object) element} before completion.
      * <p>
      * This operator ensures that the {@link Publisher} emits exactly a single {@link Subscriber#onNext(Object)} to its
      * {@link Subscriber}. If this {@link Publisher} terminates without emitting any
@@ -4084,14 +4087,15 @@ Kotlin flatMapLatest</a>
      * forwarded to the returned {@link Single}.
      * <p>
      * To uphold the guarantees laid out in the previous paragraph, this operator requests two items from the
-     * {@link Publisher}. This means that if the {@link Publisher} neither completes nor returns more than one item,
-     * this operator will not complete. If "one element and then complete" semantics are desired, consider chaining
-     * an {@link #takeAtMost(long)} operator before with a value of one. This will ensure an completion signal after
-     * one item is propagated from the {@link Publisher}.
+     * {@link Publisher}. This means that if the {@link Publisher} does not complete after signaling one element, this
+     * operator will not complete. If "one element and then complete" semantics are desired, consider chaining the
+     * {@link #takeAtMost(long) takeAtMost(1)} operator beforehand. This will ensure a completion signal after one item
+     * is propagated from the {@link Publisher}.
      *
      * @return A {@link Single} that will contain the first item emitted from the this {@link Publisher}.
      * If the source {@link Publisher} does not emit any item, then the returned {@link Single} will terminate with
      * {@link NoSuchElementException}.
+     * @see #firstOrElse(Supplier)
      */
     public final Single<T> firstOrError() {
         return new PubFirstOrError<>(this);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -4058,6 +4058,10 @@ Kotlin flatMapLatest</a>
 
     /**
      * Converts this {@link Publisher} to a {@link Single}.
+     * <p>
+     * This operator is useful if the {@link Publisher} that is being converted is potentially empty, in which case
+     * the {@code defaultValueSupplier} will be triggered. If a conversion to {@link Single} is needed where it is
+     * expected that the {@link Publisher} returns exactly one element, consider using {@link #firstOrError()} instead.
      *
      * @param defaultValueSupplier A {@link Supplier} of default value if this {@link Publisher} did not emit any item.
      * @return A {@link Single} that will contain the first item emitted from the this {@link Publisher}.
@@ -4071,11 +4075,19 @@ Kotlin flatMapLatest</a>
     }
 
     /**
-     * Ensures that this {@link Publisher} emits exactly a single {@link Subscriber#onNext(Object)} to its
+     * Converts this {@link Publisher} to a {@link Single}.
+     * <p>
+     * This operator ensures that the {@link Publisher} emits exactly a single {@link Subscriber#onNext(Object)} to its
      * {@link Subscriber}. If this {@link Publisher} terminates without emitting any
      * items a {@link NoSuchElementException} will be signaled and if this {@link Publisher} emits more than one item,
      * an {@link IllegalArgumentException} will be signaled. Any error emitted by this {@link Publisher} will be
      * forwarded to the returned {@link Single}.
+     * <p>
+     * To uphold the guarantees laid out in the previous paragraph, this operator requests two items from the
+     * {@link Publisher}. This means that if the {@link Publisher} neither completes nor returns more than one item,
+     * this operator will not complete. If "one element and then complete" semantics are desired, consider chaining
+     * an {@link #takeAtMost(long)} operator before with a value of one. This will ensure an completion signal after
+     * one item is propagated from the {@link Publisher}.
      *
      * @return A {@link Single} that will contain the first item emitted from the this {@link Publisher}.
      * If the source {@link Publisher} does not emit any item, then the returned {@link Single} will terminate with


### PR DESCRIPTION
This changeset improves the javadocs for these two methods in clarifying how their behavior differs based on the number of elements and completion signal returned by the upstream Publisher.