### PR TITLE
Clone the RR load balancer in preparation for refactoring

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -617,7 +617,6 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         return asyncCloseable.closeAsyncGracefully();
     }
 
-    // Visible for testing
     @Override
     public List<Map.Entry<ResolvedAddress, List<C>>> usedAddresses() {
         return usedHosts.stream().map(Host::asEntry).collect(toList());

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -154,8 +154,9 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
             return this;
         }
 
-        // In the future we'll elevate this to the RoundRobinLoadBalancerBuilder interface.
-        public RoundRobinLoadBalancerBuilder<ResolvedAddress, C> useNewRoundRobin(boolean useNewRoundRobin) {
+        // In the future we may elevate this to the RoundRobinLoadBalancerBuilder interface or pick another
+        // route to transition to the new load balancer structure.
+        RoundRobinLoadBalancerBuilder<ResolvedAddress, C> useNewRoundRobin(boolean useNewRoundRobin) {
             this.useNewRoundRobin = useNewRoundRobin;
             return this;
         }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/TestableLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/TestableLoadBalancer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.client.api.LoadBalancer;
+
+import java.util.List;
+import java.util.Map;
+
+// An intermediate interface so we can universally expose the current list of addresses. This should become
+// unnecessary once we extract the logic of managing the host list from the load balancer itself into it's
+// own abstraction.
+interface TestableLoadBalancer<ResolvedAddress, C extends LoadBalancedConnection> extends LoadBalancer<C> {
+
+    List<Map.Entry<ResolvedAddress, List<C>>> usedAddresses();
+}

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerNewRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerNewRoundRobinLoadBalancerTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+public class EagerNewRoundRobinLoadBalancerTest extends EagerRoundRobinLoadBalancerTest {
+    @Override
+    protected RoundRobinLoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
+        return ((RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>)
+                super.baseLoadBalancerBuilder()).useNewRoundRobin(true);
+    }
+}

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerNewRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/EagerNewRoundRobinLoadBalancerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.loadbalancer;
 
-public class EagerNewRoundRobinLoadBalancerTest extends EagerRoundRobinLoadBalancerTest {
+class EagerNewRoundRobinLoadBalancerTest extends EagerRoundRobinLoadBalancerTest {
     @Override
     protected RoundRobinLoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
         return ((RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>)

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringNewRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringNewRoundRobinLoadBalancerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringNewRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LingeringNewRoundRobinLoadBalancerTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+class LingeringNewRoundRobinLoadBalancerTest extends LingeringRoundRobinLoadBalancerTest {
+    @Override
+    protected RoundRobinLoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
+        return ((RoundRobinLoadBalancerFactory.Builder<String, TestLoadBalancedConnection>)
+                super.baseLoadBalancerBuilder()).useNewRoundRobin(true);
+    }
+}


### PR DESCRIPTION
Motivation:

We are going to start refactoring our load balancing components
and in order to preserve the current stable form until we can build
confidence in it we're cloning RoundRobinLoadBalancer into another
class (currently identical other than name) which we can then start
to pull apart.

Modifications:

- Add a private interface TestableLoadBalancer to expose a generic
  way of surfacing the current host set for tests.
- Clone RoundRobinLoadBalancer into NewRoundRobinLoadBalancer which
  is currently identical to the original other than it's name.
- Thread through the option to switch round robin load balancer
  implementation in the tests so we can detect regressions in the
  new implementation without text-copying the tests. When we get to
  the point we want to try it out we can start to surface the switch
  in the public interfaces.