### PR TITLE
`ZipkinReporter`: add trace logging for batching and encoded spans

### DIFF
--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
@@ -130,7 +130,7 @@ public final class HttpReporter extends Component implements Reporter<Span>, Asy
                     .map(span -> {
                         // Always encode spans as list: https://github.com/apple/servicetalk/pull/2092
                         final byte[] bytes = spanEncoder.encodeList(Collections.singletonList(span));
-                        LOGGER.trace("Encoded received span: {}, result={} bytes", span, bytes.length);
+                        LOGGER.trace("Encoded received span={}, bytes={}", span, bytes.length);
                         return allocator.wrap(bytes);
                     });
         } else {
@@ -143,8 +143,8 @@ public final class HttpReporter extends Component implements Reporter<Span>, Asy
                     .filter(accumulate -> !accumulate.isEmpty())
                     .map(bufferedSpans -> {
                         final byte[] bytes = spanEncoder.encodeList(bufferedSpans);
-                        LOGGER.trace("Encoded received list of spans (size={}): {}, result={} bytes",
-                                bufferedSpans.size(), bufferedSpans, bytes.length);
+                        LOGGER.trace("Encoded received list of spans (size={}, bytes={}): {}",
+                                bufferedSpans.size(), bytes.length, bufferedSpans);
                         return allocator.wrap(bytes);
                     });
         }
@@ -297,7 +297,7 @@ public final class HttpReporter extends Component implements Reporter<Span>, Asy
 
         @Override
         public void accumulate(@Nonnull final Span item) {
-            LOGGER.trace("Accumulating received span: {}", item);
+            LOGGER.trace("Accumulating received span={}", item);
             accumulate.add(requireNonNull(item));
         }
 

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
@@ -197,7 +197,7 @@ public final class UdpReporter extends Component implements Reporter<Span>, Asyn
                             public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                                 if (msg instanceof Span) {
                                     byte[] bytes = codec.spanBytesEncoder().encode((Span) msg);
-                                    LOGGER.trace("Encoded received span: {}, result={} bytes", msg, bytes.length);
+                                    LOGGER.trace("Encoded received span={}, bytes={}", msg, bytes.length);
                                     ByteBuf buf = ctx.alloc().buffer(bytes.length).writeBytes(bytes);
                                     ctx.write(new DatagramPacket(buf, (InetSocketAddress) collectorAddress), promise);
                                 } else {

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/UdpReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,6 +197,7 @@ public final class UdpReporter extends Component implements Reporter<Span>, Asyn
                             public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                                 if (msg instanceof Span) {
                                     byte[] bytes = codec.spanBytesEncoder().encode((Span) msg);
+                                    LOGGER.trace("Encoded received span: {}, result={} bytes", msg, bytes.length);
                                     ByteBuf buf = ctx.alloc().buffer(bytes.length).writeBytes(bytes);
                                     ctx.write(new DatagramPacket(buf, (InetSocketAddress) collectorAddress), promise);
                                 } else {


### PR DESCRIPTION
Motivation:

In order to trace batching, trace level logging will be helpful.

Modifications:

- Log every accumulation;
- Log every received span/list after encoding;

Result:

Easier to troubleshoot if there are any issues.