### PR TITLE
Extract round-robin host selection from the NewRoundRobinLoadBalancer

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,35 +21,20 @@ import io.servicetalk.context.api.ContextMap;
 
 import java.util.List;
 import java.util.function.Predicate;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
  * Interface abstracting away the method of host selection.
- *
- * This is useful for supporting multiple load balancing algorithms such as round-robin,
- * weighted round-robin, random, and least-loaded where each algorithm only needing to concern
- * itself with the data structures important to the algorithm itself.
  */
 interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
 
     /**
-     * Notify the selector that the set of available hosts has changed.
-     *
-     * This method gives the host selector the opportunity to modify or rebuild any
-     * internal data structures that it uses in it's job of distributing traffic amongst
-     * the hosts.
-     * This method will not be called concurrently.
-     *
-     * @param hosts the current set of available hosts.
-     */
-    void hostSetChanged(List<Host<ResolvedAddress, C>> hosts);
-
-    /**
-     * Select or establish a new connection from an exist Host.
+     * Select or establish a new connection from an existing Host.
      *
      * This method will be called concurrently with other selectConnection calls and
      * hostSetChanged calls and must be thread safe under those conditions.
      */
-    Single<C> selectConnection(Predicate<C> selector, @Nullable ContextMap context,
-                               boolean forceNewConnectionAndReserve);
+    Single<C> selectConnection(@Nonnull List<Host<ResolvedAddress, C>> hosts, @Nonnull Predicate<C> selector,
+                               @Nullable ContextMap context, boolean forceNewConnectionAndReserve);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
+
+import java.util.List;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+
+/**
+ * Interface abstracting away the method of host selection.
+ *
+ * This is useful for supporting multiple load balancing algorithms such as round-robin,
+ * weighted round-robin, random, and least-loaded where each algorithm only needing to concern
+ * itself with the data structures important to the algorithm itself.
+ */
+interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
+
+    /**
+     * Notify the selector that the set of available hosts has changed.
+     *
+     * This method gives the host selector the opportunity to modify or rebuild any
+     * internal data structures that it uses in it's job of distributing traffic amongst
+     * the hosts.
+     * This method will not be called concurrently.
+     *
+     * @param hosts the current set of available hosts.
+     */
+    void hostSetChanged(List<Host<ResolvedAddress, C>> hosts);
+
+    /**
+     * Select or establish a new connection from an exist Host.
+     *
+     * This method will be called concurrently with other selectConnection calls and
+     * hostSetChanged calls and must be thread safe under those conditions.
+     */
+    Single<C> selectConnection(Predicate<C> selector, @Nullable ContextMap context,
+                               boolean forceNewConnectionAndReserve);
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NewRoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NewRoundRobinLoadBalancer.java
@@ -303,7 +303,6 @@ final class NewRoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedCon
             }
 
             final List<Host<ResolvedAddress, C>> currentHosts = usedHosts;
-            hostSelector.hostSetChanged(currentHosts);
             if (firstEventsAfterResubscribe) {
                 // We can enter this path only if we re-subscribed because all previous hosts were UNHEALTHY.
                 if (events.isEmpty()) {
@@ -454,7 +453,7 @@ final class NewRoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedCon
                             NewRoundRobinLoadBalancer.class, "selectConnection0(...)"));
         }
 
-        Single<C> result = hostSelector.selectConnection(selector, context, forceNewConnectionAndReserve);
+        Single<C> result = hostSelector.selectConnection(currentHosts, selector, context, forceNewConnectionAndReserve);
         if (healthCheckConfig != null) {
             result = result.beforeOnError(exn -> {
                 if (exn instanceof Exceptions.StacklessNoActiveHostException && allUnhealthy(currentHosts)) {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NewRoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NewRoundRobinLoadBalancer.java
@@ -42,7 +42,6 @@ import java.util.ListIterator;
 import java.util.Map.Entry;
 import java.util.Spliterator;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
@@ -61,7 +60,6 @@ import static io.servicetalk.concurrent.api.AsyncCloseables.toAsyncCloseable;
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessorDropHeadOnOverflow;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
-import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static java.lang.Integer.toHexString;
@@ -86,9 +84,7 @@ final class NewRoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedCon
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<NewRoundRobinLoadBalancer, List> usedHostsUpdater =
             AtomicReferenceFieldUpdater.newUpdater(NewRoundRobinLoadBalancer.class, List.class, "usedHosts");
-    @SuppressWarnings("rawtypes")
-    private static final AtomicIntegerFieldUpdater<NewRoundRobinLoadBalancer> indexUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(NewRoundRobinLoadBalancer.class, "index");
+
     @SuppressWarnings("rawtypes")
     private static final AtomicLongFieldUpdater<NewRoundRobinLoadBalancer> nextResubscribeTimeUpdater =
             AtomicLongFieldUpdater.newUpdater(NewRoundRobinLoadBalancer.class, "nextResubscribeTime");
@@ -96,12 +92,11 @@ final class NewRoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedCon
     private static final long RESUBSCRIBING = -1L;
 
     private volatile long nextResubscribeTime = RESUBSCRIBING;
-    @SuppressWarnings("unused")
-    private volatile int index;
     private volatile List<Host<ResolvedAddress, C>> usedHosts = emptyList();
 
     private final String targetResource;
     private final String lbDescription;
+    private final RoundRobinSelector<ResolvedAddress, C> algorithm;
     private final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher;
     private final Processor<Object, Object> eventStreamProcessor = newPublisherProcessorDropHeadOnOverflow(32);
     private final Publisher<Object> eventStream;
@@ -134,6 +129,7 @@ final class NewRoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedCon
             @Nullable final HealthCheckConfig healthCheckConfig) {
         this.targetResource = requireNonNull(targetResourceName);
         this.lbDescription = makeDescription(id, targetResource);
+        this.algorithm = new RoundRobinSelector<>(targetResource);
         this.eventPublisher = requireNonNull(eventPublisher);
         this.eventStream = fromSource(eventStreamProcessor)
                 .replay(1); // Allow for multiple subscribers and provide new subscribers with last signal.
@@ -444,6 +440,33 @@ final class NewRoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedCon
         return defer(() -> selectConnection0(c -> true, context, true).shareContextOnSubscribe());
     }
 
+    private Single<C> selectConnection0(final Predicate<C> selector, @Nullable final ContextMap context,
+                                        final boolean forceNewConnectionAndReserve) {
+        final List<Host<ResolvedAddress, C>> currentHosts = this.usedHosts;
+        if (currentHosts.isEmpty()) {
+            return isClosedList(currentHosts) ? failedLBClosed(targetResource) :
+                    // This is the case when SD has emitted some items but none of the hosts are available.
+                    failed(Exceptions.StacklessNoAvailableHostException.newInstance(
+                            "No hosts are available to connect for " + targetResource + ".",
+                            NewRoundRobinLoadBalancer.class, "selectConnection0(...)"));
+        }
+
+        Single<C> result = algorithm.selectConnection(currentHosts, selector, context, forceNewConnectionAndReserve);
+        if (healthCheckConfig != null) {
+            result = result.beforeOnError(exn -> {
+                if (exn instanceof Exceptions.StacklessNoActiveHostException && allUnhealthy(currentHosts)) {
+                    final long currNextResubscribeTime = nextResubscribeTime;
+                    if (currNextResubscribeTime >= 0 &&
+                            healthCheckConfig.executor.currentTime(NANOSECONDS) >= currNextResubscribeTime &&
+                            nextResubscribeTimeUpdater.compareAndSet(this, currNextResubscribeTime, RESUBSCRIBING)) {
+                            subscribeToEvents(true);
+                    }
+                }
+            });
+        }
+        return result;
+    }
+
     @Override
     public Publisher<Object> eventStream() {
         return eventStream;
@@ -452,58 +475,6 @@ final class NewRoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedCon
     @Override
     public String toString() {
         return lbDescription;
-    }
-
-    private Single<C> selectConnection0(final Predicate<C> selector, @Nullable final ContextMap context,
-                                        final boolean forceNewConnectionAndReserve) {
-        final List<Host<ResolvedAddress, C>> usedHosts = this.usedHosts;
-        if (usedHosts.isEmpty()) {
-            return isClosedList(usedHosts) ? failedLBClosed(targetResource) :
-                // This is the case when SD has emitted some items but none of the hosts are available.
-                failed(Exceptions.StacklessNoAvailableHostException.newInstance(
-                        "No hosts are available to connect for " + targetResource + ".",
-                        NewRoundRobinLoadBalancer.class, "selectConnection0(...)"));
-        }
-
-        // try one loop over hosts and if all are expired, give up
-        final int cursor = (indexUpdater.getAndIncrement(this) & Integer.MAX_VALUE) % usedHosts.size();
-        Host<ResolvedAddress, C> pickedHost = null;
-        for (int i = 0; i < usedHosts.size(); ++i) {
-            // for a particular iteration we maintain a local cursor without contention with other requests
-            final int localCursor = (cursor + i) % usedHosts.size();
-            final Host<ResolvedAddress, C> host = usedHosts.get(localCursor);
-            assert host != null : "Host can't be null.";
-
-            if (!forceNewConnectionAndReserve) {
-                // First see if an existing connection can be used
-                C connection = host.pickConnection(selector, context);
-                if (connection != null) {
-                    return succeeded(connection);
-                }
-            }
-
-            // Don't open new connections for expired or unhealthy hosts, try a different one.
-            // Unhealthy hosts have no open connections – that's why we don't fail earlier, the loop will not progress.
-            if (host.isActiveAndHealthy()) {
-                pickedHost = host;
-                break;
-            }
-        }
-        if (pickedHost == null) {
-            if (healthCheckConfig != null && allUnhealthy(usedHosts)) {
-                final long currNextResubscribeTime = nextResubscribeTime;
-                if (currNextResubscribeTime >= 0 &&
-                        healthCheckConfig.executor.currentTime(NANOSECONDS) >= currNextResubscribeTime &&
-                        nextResubscribeTimeUpdater.compareAndSet(this, currNextResubscribeTime, RESUBSCRIBING)) {
-                    subscribeToEvents(true);
-                }
-            }
-            return failed(Exceptions.StacklessNoActiveHostException.newInstance("Failed to pick an active host for " +
-                            targetResource + ". Either all are busy, expired, or unhealthy: " + usedHosts,
-                    NewRoundRobinLoadBalancer.class, "selectConnection0(...)"));
-        }
-        // No connection was selected: create a new one.
-        return pickedHost.newConnection(selector, forceNewConnectionAndReserve, context);
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.context.api.ContextMap;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Predicate;
@@ -27,6 +26,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
+import static java.util.Objects.requireNonNull;
 
 final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection>
         implements HostSelector<ResolvedAddress, C> {
@@ -36,25 +36,18 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
             AtomicIntegerFieldUpdater.newUpdater(RoundRobinSelector.class, "index");
 
     private final String targetResource;
-    private volatile List<Host<ResolvedAddress, C>> hosts;
     @SuppressWarnings("unused")
     private volatile int index;
 
-    RoundRobinSelector(String targetResource) {
-        this.targetResource = targetResource;
-        hosts = Collections.emptyList();
-    }
-
-    @Override
-    public void hostSetChanged(List<Host<ResolvedAddress, C>> hosts) {
-        this.hosts = hosts;
+    RoundRobinSelector(final String targetResource) {
+        this.targetResource = requireNonNull(targetResource);
     }
 
     @Override
     public Single<C> selectConnection(
+            final List<Host<ResolvedAddress, C>> usedHosts,
             final Predicate<C> selector, @Nullable final ContextMap context,
             final boolean forceNewConnectionAndReserve) {
-        final List<Host<ResolvedAddress, C>> usedHosts = hosts;
         // try one loop over hosts and if all are expired, give up
         final int cursor = (indexUpdater.getAndIncrement(this) & Integer.MAX_VALUE) % usedHosts.size();
         Host<ResolvedAddress, C> pickedHost = null;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.Single.failed;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+
+final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection> {
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<RoundRobinSelector> indexUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(RoundRobinSelector.class, "index");
+
+    private final String targetResource;
+    @SuppressWarnings("unused")
+    private volatile int index;
+
+    RoundRobinSelector(String targetResource) {
+        this.targetResource = targetResource;
+    }
+
+    Single<C> selectConnection(
+            final List<Host<ResolvedAddress, C>> usedHosts,
+            final Predicate<C> selector, @Nullable final ContextMap context,
+            final boolean forceNewConnectionAndReserve) {
+        // try one loop over hosts and if all are expired, give up
+        final int cursor = (indexUpdater.getAndIncrement(this) & Integer.MAX_VALUE) % usedHosts.size();
+        Host<ResolvedAddress, C> pickedHost = null;
+        for (int i = 0; i < usedHosts.size(); ++i) {
+            // for a particular iteration we maintain a local cursor without contention with other requests
+            final int localCursor = (cursor + i) % usedHosts.size();
+            final Host<ResolvedAddress, C> host = usedHosts.get(localCursor);
+            assert host != null : "Host can't be null.";
+
+            if (!forceNewConnectionAndReserve) {
+                // First see if an existing connection can be used
+                C connection = host.pickConnection(selector, context);
+                if (connection != null) {
+                    return succeeded(connection);
+                }
+            }
+
+            // Don't open new connections for expired or unhealthy hosts, try a different one.
+            // Unhealthy hosts have no open connections – that's why we don't fail earlier, the loop will not progress.
+            if (host.isActiveAndHealthy()) {
+                pickedHost = host;
+                break;
+            }
+        }
+        if (pickedHost == null) {
+            return failed(Exceptions.StacklessNoActiveHostException.newInstance("Failed to pick an active host for " +
+                            targetResource + ". Either all are busy, expired, or unhealthy: " + usedHosts,
+                    this.getClass(), "selectConnection(...)"));
+        }
+        // We have a host but no connection was selected: create a new one.
+        return pickedHost.newConnection(selector, forceNewConnectionAndReserve, context);
+    }
+}


### PR DESCRIPTION
Motivation:
    
We want to be able to swap out load balancer algorithms but right
now that is in-lined in the same file as the host set management.

Modifications:

- Define the internal `HostSelector` interface.
- Extract the host selection algorithm into it's own class
  `RoundRobinSelector`.
