### PR TITLE
Add initializer API for headers of HTTP proxy CONNECT request

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcProxyTunnelTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcProxyTunnelTest.java
@@ -22,6 +22,7 @@ import io.servicetalk.grpc.api.GrpcClientMetadata;
 import io.servicetalk.grpc.api.GrpcStatusCode;
 import io.servicetalk.grpc.api.GrpcStatusException;
 import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.http.api.ProxyConnectResponseException;
 import io.servicetalk.http.api.StreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -89,7 +90,7 @@ class GrpcProxyTunnelTest {
                 .listenAndAwait((Greeter.BlockingGreeterService) (ctx, request) ->
                         HelloReply.newBuilder().setMessage(GREETING_PREFIX + request.getName()).build());
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .initializeHttp(httpBuilder -> httpBuilder.proxyAddress(proxyAddress)
+                .initializeHttp(httpBuilder -> httpBuilder.proxyConfig(ProxyConfig.of(proxyAddress))
                         .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                                 .peerHost(serverPemHostname()).build())
                         .appendConnectionFilter(connection -> new StreamingHttpConnectionFilter(connection) {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcProxyTunnelTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcProxyTunnelTest.java
@@ -22,7 +22,6 @@ import io.servicetalk.grpc.api.GrpcClientMetadata;
 import io.servicetalk.grpc.api.GrpcStatusCode;
 import io.servicetalk.grpc.api.GrpcStatusException;
 import io.servicetalk.http.api.HttpResponseStatus;
-import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.http.api.ProxyConnectResponseException;
 import io.servicetalk.http.api.StreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -57,6 +56,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
 import static io.servicetalk.http.api.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static io.servicetalk.http.api.ProxyConfig.forAddress;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -90,7 +90,7 @@ class GrpcProxyTunnelTest {
                 .listenAndAwait((Greeter.BlockingGreeterService) (ctx, request) ->
                         HelloReply.newBuilder().setMessage(GREETING_PREFIX + request.getName()).build());
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .initializeHttp(httpBuilder -> httpBuilder.proxyConfig(ProxyConfig.of(proxyAddress))
+                .initializeHttp(httpBuilder -> httpBuilder.proxyConfig(forAddress(proxyAddress))
                         .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                                 .peerHost(serverPemHostname()).build())
                         .appendConnectionFilter(connection -> new StreamingHttpConnectionFilter(connection) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
@@ -68,8 +68,15 @@ public class DelegatingSingleAddressHttpClientBuilder<U, R> implements SingleAdd
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public SingleAddressHttpClientBuilder<U, R> proxyAddress(final U proxyAddress) {
         delegate = delegate.proxyAddress(proxyAddress);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientBuilder<U, R> proxyConfig(final ProxyConfig<U> proxyConfig) {
+        delegate = delegate.proxyConfig(proxyConfig);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
@@ -45,7 +45,7 @@ public final class HttpContextKeys {
      * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling#http_tunneling">secure
      * HTTP proxy tunneling</a> and a clear text HTTP proxy, check presence of {@link ConnectionInfo#sslConfig()}.
      *
-     * @see SingleAddressHttpClientBuilder#proxyAddress(Object)
+     * @see SingleAddressHttpClientBuilder#proxyConfig(ProxyConfig)
      * @deprecated Use {@link TransportObserverConnectionFactoryFilter} to configure {@link TransportObserver} and then
      * listen {@link ConnectionObserver#onProxyConnect(Object)} callback to distinguish between a regular connection and
      * a connection to the secure HTTP proxy tunnel. For clear text HTTP proxies, consider installing a custom client

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfig.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.transport.api.ClientSslConfig;
+
+import java.util.function.Consumer;
+
+/**
+ * Configuration for a proxy.
+ *
+ * @param <A> the type of address
+ */
+public interface ProxyConfig<A> {
+
+    /**
+     * Address of the proxy.
+     * <p>
+     * Usually, this is an unresolved proxy address and its type must match the type of address before resolution used
+     * by {@link SingleAddressHttpClientBuilder}. However, if the client builder was created for a resolved address,
+     * this address must also be already resolved. Otherwise, a runtime exceptions will occur.
+     *
+     * @return address of the proxy
+     */
+    A address();
+
+    /**
+     * An initializer for {@link HttpHeaders} related to
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request.
+     * <p>
+     * When this {@link ProxyConfig} is used for secure proxy tunnels (when
+     * {@link SingleAddressHttpClientBuilder#sslConfig(ClientSslConfig) ClientSslConfig} is configured) the tunnel is
+     * always initialized using {@code HTTP/1.1 CONNECT} request. This {@link Consumer} can be used to set custom
+     * {@link HttpHeaders} for that request, like {@link HttpHeaderNames#PROXY_AUTHORIZATION proxy-authorization},
+     * tracing, or any other header.
+     *
+     * @return An initializer for {@link HttpHeaders} related to
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request
+     */
+    Consumer<HttpHeaders> connectRequestHeadersInitializer();
+
+    /**
+     * Returns a {@link ProxyConfig} for the specified {@code address}.
+     * <p>
+     * All other {@link ProxyConfig} options will use their default values applied by {@link ProxyConfigBuilder}.
+     *
+     * @param address Address of the proxy
+     * @param <A> the type of address
+     * @return a {@link ProxyConfig} for the specified {@code address}
+     * @see ProxyConfigBuilder
+     */
+    static <A> ProxyConfig<A> of(A address) {
+        return new ProxyConfigBuilder<>(address).build();
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfig.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfig.java
@@ -31,7 +31,7 @@ public interface ProxyConfig<A> {
      * <p>
      * Usually, this is an unresolved proxy address and its type must match the type of address before resolution used
      * by {@link SingleAddressHttpClientBuilder}. However, if the client builder was created for a resolved address,
-     * this address must also be already resolved. Otherwise, a runtime exceptions will occur.
+     * this address must also be already resolved. Otherwise, a runtime exception will occur.
      *
      * @return address of the proxy
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfig.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfig.java
@@ -62,7 +62,7 @@ public interface ProxyConfig<A> {
      * @return a {@link ProxyConfig} for the specified {@code address}
      * @see ProxyConfigBuilder
      */
-    static <A> ProxyConfig<A> of(A address) {
+    static <A> ProxyConfig<A> forAddress(A address) {
         return new ProxyConfigBuilder<>(address).build();
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfigBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfigBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Builder for {@link ProxyConfig}.
+ *
+ * @param <A> the type of address
+ */
+public final class ProxyConfigBuilder<A> {
+
+    private final A address;
+    private Consumer<HttpHeaders> connectRequestHeadersInitializer = __ -> { };
+
+    /**
+     * Creates a new instance.
+     *
+     * @param address Proxy address
+     * @see ProxyConfig#address()
+     */
+    public ProxyConfigBuilder(final A address) {
+        this.address = requireNonNull(address);
+    }
+
+    /**
+     * Sets an initializer for {@link HttpHeaders} related to
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request.
+     *
+     * @param connectRequestHeadersInitializer {@link Consumer} that can be used to set custom {@link HttpHeaders} for
+     * {@code HTTP/1.1 CONNECT} request (auth, tracing, etc.)
+     * @return {@code this}
+     * @see ProxyConfig#connectRequestHeadersInitializer()
+     */
+    public ProxyConfigBuilder<A> connectRequestHeadersInitializer(
+            final Consumer<HttpHeaders> connectRequestHeadersInitializer) {
+        this.connectRequestHeadersInitializer = requireNonNull(connectRequestHeadersInitializer);
+        return this;
+    }
+
+    /**
+     * Builds a new {@link ProxyConfig}.
+     *
+     * @return a new {@link ProxyConfig}.
+     */
+    public ProxyConfig<A> build() {
+        return new DefaultProxyConfig<>(address, connectRequestHeadersInitializer);
+    }
+
+    private static final class DefaultProxyConfig<A> implements ProxyConfig<A> {
+
+        private final A address;
+        private final Consumer<HttpHeaders> connectRequestHeadersInitializer;
+
+        private DefaultProxyConfig(final A address, final Consumer<HttpHeaders> connectRequestHeadersInitializer) {
+            this.address = address;
+            this.connectRequestHeadersInitializer = connectRequestHeadersInitializer;
+        }
+
+        @Override
+        public A address() {
+            return address;
+        }
+
+        @Override
+        public Consumer<HttpHeaders> connectRequestHeadersInitializer() {
+            return connectRequestHeadersInitializer;
+        }
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfigBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfigBuilder.java
@@ -33,7 +33,7 @@ public final class ProxyConfigBuilder<A> {
 
         @Override
         public String toString() {
-            return "NOOP";
+            return "NOOP_HEADERS_CONSUMER";
         }
     };
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfigBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfigBuilder.java
@@ -26,8 +26,19 @@ import static java.util.Objects.requireNonNull;
  */
 public final class ProxyConfigBuilder<A> {
 
+    private static final Consumer<HttpHeaders> NOOP_HEADERS_CONSUMER = new Consumer<HttpHeaders>() {
+        @Override
+        public void accept(final HttpHeaders headers) {
+        }
+
+        @Override
+        public String toString() {
+            return "NOOP";
+        }
+    };
+
     private final A address;
-    private Consumer<HttpHeaders> connectRequestHeadersInitializer = __ -> { };
+    private Consumer<HttpHeaders> connectRequestHeadersInitializer = NOOP_HEADERS_CONSUMER;
 
     /**
      * Creates a new instance.
@@ -81,6 +92,37 @@ public final class ProxyConfigBuilder<A> {
         @Override
         public Consumer<HttpHeaders> connectRequestHeadersInitializer() {
             return connectRequestHeadersInitializer;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DefaultProxyConfig)) {
+                return false;
+            }
+
+            final DefaultProxyConfig<?> that = (DefaultProxyConfig<?>) o;
+            if (!address.equals(that.address)) {
+                return false;
+            }
+            return connectRequestHeadersInitializer.equals(that.connectRequestHeadersInitializer);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = address.hashCode();
+            result = 31 * result + connectRequestHeadersInitializer.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() +
+                    "{address=" + address +
+                    ", connectRequestHeadersInitializer=" + connectRequestHeadersInitializer +
+                    '}';
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConnectException.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConnectException.java
@@ -21,7 +21,7 @@ import java.io.IOException;
  * An exception while processing
  * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request.
  *
- * @see SingleAddressHttpClientBuilder#proxyAddress(Object)
+ * @see SingleAddressHttpClientBuilder#proxyConfig(ProxyConfig)
  */
 public class ProxyConnectException extends IOException {
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConnectResponseException.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConnectResponseException.java
@@ -19,7 +19,7 @@ package io.servicetalk.http.api;
  * A subclass of {@link ProxyConnectException} that indicates an unexpected response status from a proxy received for
  * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request.
  *
- * @see SingleAddressHttpClientBuilder#proxyAddress(Object)
+ * @see SingleAddressHttpClientBuilder#proxyConfig(ProxyConfig)
  */
 public class ProxyConnectResponseException extends ProxyConnectException {
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfigBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfigBuilder.java
@@ -295,6 +295,11 @@ public final class RedirectConfigBuilder {
         return this;
     }
 
+    /**
+     * Builds a new {@link RedirectConfig}.
+     *
+     * @return a new {@link RedirectConfig}
+     */
     public RedirectConfig build() {
         return new DefaultRedirectConfig(maxRedirects,
                 allowedStatuses == null ? DEFAULT_ALLOWED_STATUSES : toSet(allowedStatuses),

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -65,7 +65,7 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * @param proxyAddress Unresolved address of the proxy. When used with a builder created for a resolved address,
      * {@code proxyAddress} should also be already resolved – otherwise runtime exceptions may occur.
      * @return {@code this}.
-     * @deprecated Use {@link #proxyConfig(ProxyConfig)} with {@link ProxyConfig#of(Object)}.
+     * @deprecated Use {@link #proxyConfig(ProxyConfig)} with {@link ProxyConfig#forAddress(Object)}.
      */
     // FIXME: 0.43 - remove deprecated method
     @Deprecated
@@ -93,7 +93,7 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * @param proxyConfig Configuration for a proxy. When used with a builder created for a resolved address,
      * {@link ProxyConfig#address()} must also be already resolved – otherwise runtime exceptions will occur.
      * @return {@code this}.
-     * @see ProxyConfig#of(Object)
+     * @see ProxyConfig#forAddress(Object)
      * @see ProxyConfigBuilder
      */
     // FIXME: 0.43 - consider removing default impl

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -48,7 +48,7 @@ import java.util.function.Predicate;
  */
 public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<U, R, ServiceDiscovererEvent<R>> {
     /**
-     * Configure proxy to serve as an intermediary for requests.
+     * Configures a proxy to serve as an intermediary for requests.
      * <p>
      * If the client talks to a proxy over http (not https, {@link #sslConfig(ClientSslConfig) ClientSslConfig} is NOT
      * configured), it will rewrite the request-target to
@@ -65,10 +65,40 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * @param proxyAddress Unresolved address of the proxy. When used with a builder created for a resolved address,
      * {@code proxyAddress} should also be already resolved – otherwise runtime exceptions may occur.
      * @return {@code this}.
+     * @deprecated Use {@link #proxyConfig(ProxyConfig)} with {@link ProxyConfig#of(Object)}.
      */
-    default SingleAddressHttpClientBuilder<U, R> proxyAddress(U proxyAddress) { // FIXME: 0.43 - remove default impl
-        throw new UnsupportedOperationException("Setting proxy address is not yet supported by "
-                + getClass().getName());
+    // FIXME: 0.43 - remove deprecated method
+    @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    default SingleAddressHttpClientBuilder<U, R> proxyAddress(U proxyAddress) {
+        proxyConfig(new ProxyConfigBuilder<>(proxyAddress).build());
+        return this;
+    }
+
+    /**
+     * Configures a proxy to serve as an intermediary for requests.
+     * <p>
+     * If the client talks to a proxy over http (not https, {@link #sslConfig(ClientSslConfig) ClientSslConfig} is NOT
+     * configured), it will rewrite the request-target to
+     * <a href="https://tools.ietf.org/html/rfc7230#section-5.3.2">absolute-form</a>, as specified by the RFC.
+     * <p>
+     * For secure proxy tunnels (when {@link #sslConfig(ClientSslConfig) ClientSslConfig} is configured) the tunnel is
+     * always initialized using
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6">HTTP/1.1 CONNECT</a> request. The actual
+     * protocol will be negotiated via <a href="https://tools.ietf.org/html/rfc7301">ALPN extension</a> of TLS protocol,
+     * taking into account HTTP protocols configured via {@link #protocols(HttpProtocolConfig...)} method. In case of
+     * any error during {@code CONNECT} process, {@link ProxyConnectException} or {@link ProxyConnectResponseException}
+     * will be thrown when a request attempt is made through the constructed client instance.
+     *
+     * @param proxyConfig Configuration for a proxy. When used with a builder created for a resolved address,
+     * {@link ProxyConfig#address()} must also be already resolved – otherwise runtime exceptions will occur.
+     * @return {@code this}.
+     * @see ProxyConfig#of(Object)
+     * @see ProxyConfigBuilder
+     */
+    // FIXME: 0.43 - consider removing default impl
+    default SingleAddressHttpClientBuilder<U, R> proxyConfig(ProxyConfig<U> proxyConfig) {
+        throw new UnsupportedOperationException("Setting proxy config is not yet supported by " + getClass().getName());
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.Http2Settings;
+import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientConfig;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.DelegatingClientSslConfig;
@@ -27,11 +28,14 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_ENABLE_PUSH;
 import static io.servicetalk.http.netty.HttpServerConfig.httpAlpnProtocols;
 import static io.servicetalk.utils.internal.NetworkUtils.isValidIpV4Address;
 import static io.servicetalk.utils.internal.NetworkUtils.isValidIpV6Address;
+import static java.util.Objects.requireNonNull;
 
 final class HttpClientConfig {
 
     private final TcpClientConfig tcpConfig;
     private final HttpConfig protocolConfigs;
+    @Nullable
+    private ProxyConfig<?> proxyConfig;
     @Nullable
     private CharSequence connectAddress;
     @Nullable
@@ -61,6 +65,7 @@ final class HttpClientConfig {
     HttpClientConfig(final HttpClientConfig from) {
         tcpConfig = new TcpClientConfig(from.tcpConfig());
         protocolConfigs = new HttpConfig(from.protocolConfigs());
+        proxyConfig = from.proxyConfig;
         connectAddress = from.connectAddress;
         fallbackPeerHost = from.fallbackPeerHost;
         fallbackPeerPort = from.fallbackPeerPort;
@@ -78,12 +83,18 @@ final class HttpClientConfig {
     }
 
     @Nullable
+    ProxyConfig<?> proxyConfig() {
+        return proxyConfig;
+    }
+
+    @Nullable
     CharSequence connectAddress() {
         return connectAddress;
     }
 
-    void connectAddress(@Nullable final CharSequence connectAddress) {
-        this.connectAddress = connectAddress;
+    void proxy(final ProxyConfig<?> proxyConfig, final CharSequence connectAddress) {
+        this.proxyConfig = requireNonNull(proxyConfig);
+        this.connectAddress = requireNonNull(connectAddress);
     }
 
     void fallbackPeerHost(@Nullable String fallbackPeerHost) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.Http2Settings;
+import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientConfig;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.DelegatingClientSslConfig;
 
 import java.util.List;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_ENABLE_PUSH;
@@ -35,9 +37,7 @@ final class HttpClientConfig {
     private final TcpClientConfig tcpConfig;
     private final HttpConfig protocolConfigs;
     @Nullable
-    private ProxyConfig<?> proxyConfig;
-    @Nullable
-    private CharSequence connectAddress;
+    private ProxyConfig<String> proxyConfig;
     @Nullable
     private String fallbackPeerHost;
     private int fallbackPeerPort = -1;
@@ -66,7 +66,6 @@ final class HttpClientConfig {
         tcpConfig = new TcpClientConfig(from.tcpConfig());
         protocolConfigs = new HttpConfig(from.protocolConfigs());
         proxyConfig = from.proxyConfig;
-        connectAddress = from.connectAddress;
         fallbackPeerHost = from.fallbackPeerHost;
         fallbackPeerPort = from.fallbackPeerPort;
         inferPeerHost = from.inferPeerHost;
@@ -83,18 +82,15 @@ final class HttpClientConfig {
     }
 
     @Nullable
-    ProxyConfig<?> proxyConfig() {
+    ProxyConfig<String> proxyConfig() {
         return proxyConfig;
     }
 
-    @Nullable
-    CharSequence connectAddress() {
-        return connectAddress;
-    }
-
-    void proxy(final ProxyConfig<?> proxyConfig, final CharSequence connectAddress) {
-        this.proxyConfig = requireNonNull(proxyConfig);
-        this.connectAddress = requireNonNull(connectAddress);
+    void proxyConfig(final CharSequence connectAddress, final ProxyConfig<?> proxyConfig) {
+        // Original ProxyConfig.address() is used only by DefaultSingleAddressHttpClientBuilder. For the actual
+        // ProxyConnectLBHttpConnectionFactory, we need only "connectAddress". To simplify internal state, we override
+        // ProxyConfig.address() with "connectAddress" and delegate all other methods to original ProxyConfig.
+        this.proxyConfig = new DelegatingProxyConfig(connectAddress.toString(), proxyConfig);
     }
 
     void fallbackPeerHost(@Nullable String fallbackPeerHost) {
@@ -178,5 +174,57 @@ final class HttpClientConfig {
         // https://tools.ietf.org/html/rfc6066#section-3
         // Literal IPv4 and IPv6 addresses are not permitted in "HostName".
         return peerHost == null || isValidIpV4Address(peerHost) || isValidIpV6Address(peerHost) ? null : peerHost;
+    }
+
+    private static final class DelegatingProxyConfig implements ProxyConfig<String> {
+
+        private final String address;
+        private final ProxyConfig<?> delegate;
+
+        DelegatingProxyConfig(final String address, final ProxyConfig<?> delegate) {
+            this.address = requireNonNull(address);
+            this.delegate = requireNonNull(delegate);
+        }
+
+        @Override
+        public String address() {
+            return address;
+        }
+
+        @Override
+        public Consumer<HttpHeaders> connectRequestHeadersInitializer() {
+            return delegate.connectRequestHeadersInitializer();
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DelegatingProxyConfig)) {
+                return false;
+            }
+
+            final DelegatingProxyConfig that = (DelegatingProxyConfig) o;
+            if (!address.equals(that.address)) {
+                return false;
+            }
+            return delegate.equals(that.delegate);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = address.hashCode();
+            result = 31 * result + delegate.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() +
+                    "{address='" + address + '\'' +
+                    ", delegate=" + delegate +
+                    '}';
+        }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -36,6 +36,7 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.MultiAddressHttpClientBuilder;
 import io.servicetalk.http.api.MultiAddressHttpClientBuilder.SingleAddressInitializer;
 import io.servicetalk.http.api.PartitionedHttpClientBuilder;
+import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.transport.api.HostAndPort;
@@ -305,7 +306,7 @@ public final class HttpClients {
      * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)}
      * if you want to disable this behavior.
      * <p>
-     * Note, if {@link SingleAddressHttpClientBuilder#proxyAddress(Object) a proxy} is configured for this client,
+     * Note, if {@link SingleAddressHttpClientBuilder#proxyConfig(ProxyConfig) a proxy} is configured for this client,
      * the proxy address also needs to be already resolved. Otherwise, runtime exceptions will be thrown when
      * the client is built.
      * <p>
@@ -328,7 +329,7 @@ public final class HttpClients {
      * if you want to override that value or {@link SingleAddressHttpClientBuilder#hostHeaderFallback(boolean)} if you
      * want to disable this behavior.
      * <p>
-     * Note, if {@link SingleAddressHttpClientBuilder#proxyAddress(Object) a proxy} is configured for this client,
+     * Note, if {@link SingleAddressHttpClientBuilder#proxyConfig(ProxyConfig) a proxy} is configured for this client,
      * the proxy address also needs to be already resolved. Otherwise, runtime exceptions will be thrown when
      * the client is built.
      * <p>

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectChannelSingle.java
@@ -60,26 +60,23 @@ final class ProxyConnectChannelSingle extends ChannelInitSingle<Channel> {
 
     private final ConnectionObserver observer;
     private final HttpHeadersFactory headersFactory;
-    private final String connectAddress;
-    private final ProxyConfig<?> proxyConfig;
+    private final ProxyConfig<String> proxyConfig;
 
     ProxyConnectChannelSingle(final Channel channel,
                               final ChannelInitializer channelInitializer,
                               final ConnectionObserver observer,
                               final HttpHeadersFactory headersFactory,
-                              final String connectAddress,
-                              final ProxyConfig<?> proxyConfig) {
+                              final ProxyConfig<String> proxyConfig) {
         super(channel, channelInitializer);
         this.observer = observer;
         this.headersFactory = headersFactory;
-        this.connectAddress = connectAddress;
         this.proxyConfig = proxyConfig;
         assert !channel.config().isAutoRead();
     }
 
     @Override
     protected ChannelHandler newChannelHandler(final Subscriber<? super Channel> subscriber) {
-        return new ProxyConnectHandler(observer, headersFactory, connectAddress, proxyConfig, subscriber);
+        return new ProxyConnectHandler(observer, headersFactory, proxyConfig, subscriber);
     }
 
     private static final class ProxyConnectHandler extends ChannelDuplexHandler {
@@ -88,8 +85,7 @@ final class ProxyConnectChannelSingle extends ChannelInitSingle<Channel> {
 
         private final ConnectionObserver observer;
         private final HttpHeadersFactory headersFactory;
-        private final String connectAddress;
-        private final ProxyConfig<?> proxyConfig;
+        private final ProxyConfig<String> proxyConfig;
         @Nullable
         private Subscriber<? super Channel> subscriber;
         @Nullable
@@ -99,12 +95,10 @@ final class ProxyConnectChannelSingle extends ChannelInitSingle<Channel> {
 
         private ProxyConnectHandler(final ConnectionObserver observer,
                                     final HttpHeadersFactory headersFactory,
-                                    final String connectAddress,
-                                    final ProxyConfig<?> proxyConfig,
+                                    final ProxyConfig<String> proxyConfig,
                                     final Subscriber<? super Channel> subscriber) {
             this.observer = observer;
             this.headersFactory = headersFactory;
-            this.connectAddress = connectAddress;
             this.proxyConfig = proxyConfig;
             this.subscriber = subscriber;
         }
@@ -123,8 +117,8 @@ final class ProxyConnectChannelSingle extends ChannelInitSingle<Channel> {
         }
 
         private void sendConnectRequest(final ChannelHandlerContext ctx) {
-            final HttpRequestMetaData request = newRequestMetaData(HTTP_1_1, CONNECT, connectAddress,
-                    headersFactory.newHeaders()).addHeader(HOST, connectAddress);
+            final HttpRequestMetaData request = newRequestMetaData(HTTP_1_1, CONNECT, proxyConfig.address(),
+                    headersFactory.newHeaders()).addHeader(HOST, proxyConfig.address());
             proxyConfig.connectRequestHeadersInitializer().accept(request.headers());
             connectObserver = observer.onProxyConnect(request);
             ctx.writeAndFlush(request).addListener(f -> {
@@ -147,7 +141,7 @@ final class ProxyConnectChannelSingle extends ChannelInitSingle<Channel> {
                 }
                 response = (HttpResponseMetaData) msg;
                 if (response.status().statusClass() != SUCCESSFUL_2XX) {
-                    failSubscriber(ctx, unsuccessfulResponse(ctx.channel(), response, connectAddress));
+                    failSubscriber(ctx, unsuccessfulResponse(ctx.channel(), response, proxyConfig.address()));
                 }
                 // We do not complete subscriber here because we need to wait for the HttpResponseDecoder state machine
                 // to complete. Completion will be signalled by InboundDataEndEvent. Any other messages before that are
@@ -201,7 +195,7 @@ final class ProxyConnectChannelSingle extends ChannelInitSingle<Channel> {
             connectObserver.proxyConnectComplete(response);
             ctx.pipeline().remove(this);
             final Channel channel = ctx.channel();
-            LOGGER.debug("{} Received successful response from proxy on CONNECT {}", channel, connectAddress);
+            LOGGER.debug("{} Received successful response from proxy on CONNECT {}", channel, proxyConfig.address());
             final Subscriber<? super Channel> subscriberCopy = subscriber;
             subscriber = null;
             subscriberCopy.onSuccess(channel);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -25,7 +25,6 @@ import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpContextKeys;
 import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
-import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.TransportObserver;
 
 import org.slf4j.Logger;
@@ -57,8 +56,8 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
 
     private final String connectAddress;
 
-    ProxyConnectConnectionFactoryFilter(final CharSequence connectAddress, final ExecutionStrategy connectStrategy) {
-        this.connectAddress = connectAddress.toString();
+    ProxyConnectConnectionFactoryFilter(final String connectAddress) {
+        this.connectAddress = connectAddress;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectConnectionFactoryFilter.java
@@ -73,7 +73,6 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
         }
 
         @Override
-        @SuppressWarnings("deprecation")
         public Single<C> newConnection(final ResolvedAddress resolvedAddress,
                                        @Nullable ContextMap context,
                                        @Nullable final TransportObserver observer) {
@@ -88,7 +87,6 @@ final class ProxyConnectConnectionFactoryFilter<ResolvedAddress, C extends Filte
         }
     }
 
-    @SuppressWarnings("deprecation")
     static void logUnexpectedAddress(@Nullable final Object current, final Object expected, final Logger logger) {
         if (current != null && !expected.equals(current)) {
             logger.info("Observed unexpected value for {}: {}, overridden with: {}",

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
@@ -66,7 +66,6 @@ import static java.lang.Boolean.TRUE;
  */
 final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
         extends AbstractLBHttpConnectionFactory<ResolvedAddress> {
-    private final String connectAddress;
 
     ProxyConnectLBHttpConnectionFactory(
             final ReadOnlyHttpClientConfig config, final HttpExecutionContext executionContext,
@@ -80,8 +79,6 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
         assert config.hasProxy() : "Unexpected hasProxy flag";
         assert config.tcpConfig().sslContext() != null : "Proxy CONNECT works only for TLS connections";
         assert config.proxyConfig() != null : "ProxyConfig is required";
-        assert config.connectAddress() != null : "Address (authority) for CONNECT request is required";
-        this.connectAddress = config.connectAddress().toString();
     }
 
     @Override
@@ -103,7 +100,7 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
                 new TcpClientChannelInitializer(config.tcpConfig(), observer, executionContext, true)
                         .andThen(new HttpClientChannelInitializer(
                                 getByteBufAllocator(executionContext.bufferAllocator()), h1Config, closeHandler)),
-                observer, h1Config.headersFactory(), connectAddress, config.proxyConfig())
+                observer, h1Config.headersFactory(), config.proxyConfig())
                 .flatMap(ProxyConnectLBHttpConnectionFactory::handshake)
                 .flatMap(protocol -> finishConnectionInitialization(protocol, channel, closeHandler, observer))
                 .onErrorMap(cause -> handleException(cause, channel));

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
@@ -79,6 +79,7 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
                 connectionFilterFunction, protocolBinding);
         assert config.hasProxy() : "Unexpected hasProxy flag";
         assert config.tcpConfig().sslContext() != null : "Proxy CONNECT works only for TLS connections";
+        assert config.proxyConfig() != null : "ProxyConfig is required";
         assert config.connectAddress() != null : "Address (authority) for CONNECT request is required";
         this.connectAddress = config.connectAddress().toString();
     }
@@ -102,7 +103,7 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
                 new TcpClientChannelInitializer(config.tcpConfig(), observer, executionContext, true)
                         .andThen(new HttpClientChannelInitializer(
                                 getByteBufAllocator(executionContext.bufferAllocator()), h1Config, closeHandler)),
-                observer, h1Config.headersFactory(), connectAddress)
+                observer, h1Config.headersFactory(), connectAddress, config.proxyConfig())
                 .flatMap(ProxyConnectLBHttpConnectionFactory::handshake)
                 .flatMap(protocol -> finishConnectionInitialization(protocol, channel, closeHandler, observer))
                 .onErrorMap(cause -> handleException(cause, channel));

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021, 2023 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,7 @@ final class ReadOnlyHttpClientConfig {
     @Nullable
     private final H2ProtocolConfig h2Config;
     @Nullable
-    private final ProxyConfig<?> proxyConfig;
-    @Nullable
-    private final CharSequence connectAddress;
+    private final ProxyConfig<String> proxyConfig;
     private final boolean allowDropTrailers;
 
     ReadOnlyHttpClientConfig(final HttpClientConfig from) {
@@ -38,7 +36,6 @@ final class ReadOnlyHttpClientConfig {
         h1Config = configs.h1Config();
         h2Config = configs.h2Config();
         proxyConfig = from.proxyConfig();
-        connectAddress = from.connectAddress();
         allowDropTrailers = configs.allowDropTrailersReadFromTransport();
     }
 
@@ -65,16 +62,11 @@ final class ReadOnlyHttpClientConfig {
     }
 
     @Nullable
-    ProxyConfig<?> proxyConfig() {
+    ProxyConfig<String> proxyConfig() {
         return proxyConfig;
     }
 
-    @Nullable
-    CharSequence connectAddress() {
-        return connectAddress;
-    }
-
     boolean hasProxy() {
-        return connectAddress != null;
+        return proxyConfig != null;
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpClientConfig.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 
 import javax.annotation.Nullable;
@@ -26,6 +27,8 @@ final class ReadOnlyHttpClientConfig {
     @Nullable
     private final H2ProtocolConfig h2Config;
     @Nullable
+    private final ProxyConfig<?> proxyConfig;
+    @Nullable
     private final CharSequence connectAddress;
     private final boolean allowDropTrailers;
 
@@ -34,6 +37,7 @@ final class ReadOnlyHttpClientConfig {
         tcpConfig = from.tcpConfig().asReadOnly();
         h1Config = configs.h1Config();
         h2Config = configs.h2Config();
+        proxyConfig = from.proxyConfig();
         connectAddress = from.connectAddress();
         allowDropTrailers = configs.allowDropTrailersReadFromTransport();
     }
@@ -58,6 +62,11 @@ final class ReadOnlyHttpClientConfig {
 
     boolean isH2PriorKnowledge() {
         return h2Config != null && h1Config == null;
+    }
+
+    @Nullable
+    ProxyConfig<?> proxyConfig() {
+        return proxyConfig;
     }
 
     @Nullable

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -200,7 +201,7 @@ final class ConnectionCloseHeaderHandlingTest {
                     });
 
             client = (viaProxy ? HttpClients.forSingleAddress(serverHostAndPort(serverContext))
-                    .proxyAddress(proxyAddress)
+                    .proxyConfig(ProxyConfig.of(proxyAddress))
                     .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                             .peerHost(serverPemHostname()).build()) :
                     HttpClients.forResolvedAddress(serverContext.listenAddress()))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionCloseHeaderHandlingTest.java
@@ -20,7 +20,6 @@ import io.servicetalk.concurrent.BlockingIterator;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpServerBuilder;
-import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -68,6 +67,7 @@ import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.ProxyConfig.forAddress;
 import static io.servicetalk.http.netty.GracefulConnectionClosureHandlingTest.RAW_STRING_SERIALIZER;
 import static io.servicetalk.http.netty.HttpsProxyTest.safeClose;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
@@ -201,7 +201,7 @@ final class ConnectionCloseHeaderHandlingTest {
                     });
 
             client = (viaProxy ? HttpClients.forSingleAddress(serverHostAndPort(serverContext))
-                    .proxyConfig(ProxyConfig.of(proxyAddress))
+                    .proxyConfig(forAddress(proxyAddress))
                     .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
                             .peerHost(serverPemHostname()).build()) :
                     HttpClients.forResolvedAddress(serverContext.listenAddress()))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -30,6 +30,7 @@ import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpStreamingSerializer;
+import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
@@ -245,7 +246,7 @@ class GracefulConnectionClosureHandlingTest {
         serverContext.onClose().whenFinally(serverContextClosed::countDown).subscribe();
 
         SingleAddressHttpClientBuilder<?, ? extends SocketAddress> clientBuilder = viaProxy ?
-                forSingleAddress(serverHostAndPort(serverContext)).proxyAddress(proxyAddress) :
+                forSingleAddress(serverHostAndPort(serverContext)).proxyConfig(ProxyConfig.of(proxyAddress)) :
                 forResolvedAddress(serverContext.listenAddress());
 
         if (secure) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -30,7 +30,6 @@ import io.servicetalk.http.api.HttpPayloadWriter;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpStreamingSerializer;
-import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.http.api.ReservedStreamingHttpConnection;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
@@ -84,6 +83,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.stringStreamingSerializer;
+import static io.servicetalk.http.api.ProxyConfig.forAddress;
 import static io.servicetalk.http.netty.CloseUtils.onGracefulClosureStarted;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.disabled;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.whenIdleFor;
@@ -246,7 +246,7 @@ class GracefulConnectionClosureHandlingTest {
         serverContext.onClose().whenFinally(serverContextClosed::countDown).subscribe();
 
         SingleAddressHttpClientBuilder<?, ? extends SocketAddress> clientBuilder = viaProxy ?
-                forSingleAddress(serverHostAndPort(serverContext)).proxyConfig(ProxyConfig.of(proxyAddress)) :
+                forSingleAddress(serverHostAndPort(serverContext)).proxyConfig(forAddress(proxyAddress)) :
                 forResolvedAddress(serverContext.listenAddress());
 
         if (secure) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMultiProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMultiProxyTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 
@@ -109,7 +110,7 @@ class HttpMultiProxyTest {
                 .forMultiAddressUrl(getClass().getSimpleName())
                 .initializer((scheme, address, builder) -> {
                     if (address.port() == serverBehindProxyAddress.port()) {
-                        builder.proxyAddress(proxyAddress);
+                        builder.proxyConfig(ProxyConfig.of(proxyAddress));
                     }
                 })
                 .buildBlocking();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMultiProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMultiProxyTest.java
@@ -18,7 +18,6 @@ package io.servicetalk.http.netty;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpResponse;
-import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 
@@ -33,6 +32,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static io.servicetalk.http.api.ProxyConfig.forAddress;
 import static io.servicetalk.http.netty.HttpsProxyTest.safeClose;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -110,7 +110,7 @@ class HttpMultiProxyTest {
                 .forMultiAddressUrl(getClass().getSimpleName())
                 .initializer((scheme, address, builder) -> {
                     if (address.port() == serverBehindProxyAddress.port()) {
-                        builder.proxyConfig(ProxyConfig.of(proxyAddress));
+                        builder.proxyConfig(forAddress(proxyAddress));
                     }
                 })
                 .buildBlocking();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProxyTest.java
@@ -19,7 +19,6 @@ import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpResponse;
-import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.netty.HttpsProxyTest.TargetAddressCheckConnectionFactoryFilter;
 import io.servicetalk.transport.api.HostAndPort;
@@ -42,6 +41,7 @@ import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static io.servicetalk.http.api.ProxyConfig.forAddress;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
 import static io.servicetalk.http.netty.HttpsProxyTest.safeClose;
@@ -127,7 +127,7 @@ class HttpProxyTest {
         assert serverAddress != null && proxyAddress != null;
 
         try (BlockingHttpClient client = clientBuilderFactory.apply(serverAddress)
-                .proxyConfig(ProxyConfig.of(proxyAddress))
+                .proxyConfig(forAddress(proxyAddress))
                 .protocols(clientProtocol.config)
                 .appendConnectionFactoryFilter(new TargetAddressCheckConnectionFactoryFilter(targetAddress, false))
                 .buildBlocking()) {
@@ -147,18 +147,18 @@ class HttpProxyTest {
                         .protocols(protocol.config);
 
         final AtomicInteger otherProxyRequestCount = new AtomicInteger();
-        try (BlockingHttpClient client = builder.proxyConfig(ProxyConfig.of(proxyAddress)).buildBlocking();
-            HttpClient otherProxyClient = HttpClients.forMultiAddressUrl(getClass().getSimpleName())
+        try (BlockingHttpClient client = builder.proxyConfig(forAddress(proxyAddress)).buildBlocking();
+             HttpClient otherProxyClient = HttpClients.forMultiAddressUrl(getClass().getSimpleName())
                 .initializer((scheme, address, builder1) -> builder1.protocols(protocol.config))
                 .build();
-            ServerContext otherProxyContext = HttpServers.forAddress(localAddress(0))
+             ServerContext otherProxyContext = HttpServers.forAddress(localAddress(0))
                 .protocols(protocol.config)
                 .listenAndAwait((ctx, request, responseFactory) -> {
                     otherProxyRequestCount.incrementAndGet();
                     return otherProxyClient.request(request);
                 });
              BlockingHttpClient otherClient = builder
-                     .proxyConfig(ProxyConfig.of(serverHostAndPort(otherProxyContext)))
+                     .proxyConfig(forAddress(serverHostAndPort(otherProxyContext)))
                      .protocols(protocol.config)
                      .appendConnectionFactoryFilter(new TargetAddressCheckConnectionFactoryFilter(targetAddress, false))
                      .buildBlocking()) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProxyTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.ProxyConfig;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.netty.HttpsProxyTest.TargetAddressCheckConnectionFactoryFilter;
 import io.servicetalk.transport.api.HostAndPort;
@@ -126,7 +127,7 @@ class HttpProxyTest {
         assert serverAddress != null && proxyAddress != null;
 
         try (BlockingHttpClient client = clientBuilderFactory.apply(serverAddress)
-                .proxyAddress(proxyAddress)
+                .proxyConfig(ProxyConfig.of(proxyAddress))
                 .protocols(clientProtocol.config)
                 .appendConnectionFactoryFilter(new TargetAddressCheckConnectionFactoryFilter(targetAddress, false))
                 .buildBlocking()) {
@@ -146,7 +147,7 @@ class HttpProxyTest {
                         .protocols(protocol.config);
 
         final AtomicInteger otherProxyRequestCount = new AtomicInteger();
-        try (BlockingHttpClient client = builder.proxyAddress(proxyAddress).buildBlocking();
+        try (BlockingHttpClient client = builder.proxyConfig(ProxyConfig.of(proxyAddress)).buildBlocking();
             HttpClient otherProxyClient = HttpClients.forMultiAddressUrl(getClass().getSimpleName())
                 .initializer((scheme, address, builder1) -> builder1.protocols(protocol.config))
                 .build();
@@ -156,7 +157,8 @@ class HttpProxyTest {
                     otherProxyRequestCount.incrementAndGet();
                     return otherProxyClient.request(request);
                 });
-             BlockingHttpClient otherClient = builder.proxyAddress(serverHostAndPort(otherProxyContext))
+             BlockingHttpClient otherClient = builder
+                     .proxyConfig(ProxyConfig.of(serverHostAndPort(otherProxyContext)))
                      .protocols(protocol.config)
                      .appendConnectionFactoryFilter(new TargetAddressCheckConnectionFactoryFilter(targetAddress, false))
                      .buildBlocking()) {


### PR DESCRIPTION
Motivation:

After https://github.com/apple/servicetalk/pull/2697 moved HTTP proxy `CONNECT` logic before user-defined
`ConnectionFactoryFilter`s, users lost the ability to intercept
`CONNECT` requests for the purpose of adding custom headers, like auth,
tracing, etc.

Modifications:

- Introduce `ProxyConfig` and `ProxyConfigBuilder` in `http-api` that
can be used to provide additional options for proxy behavior;
- Add `SingleAddressHttpClientBuilder.proxyConfig(...)` overload that
takes `ProxyConfig`;
- Deprecate pre-existing `SingleAddressHttpClientBuilder.proxyAddress()`
method, recommend switching to new API;
- Enhance `HttpsProxyTest` to verify that new API can be used to send
`Proxy-Authorization` header;

Result:

Users have explicit API to alter HTTP `CONNECT` request headers, if
necessary.