### PR TITLE
loadbalancer: Some style cleanups for the new LB

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -35,7 +35,7 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
         return targetResource;
     }
 
-    protected final Single<C> noActiveHostsException(List<Host<ResolvedAddress, C>> usedHosts) {
+    protected final Single<C> noActiveHosts(List<Host<ResolvedAddress, C>> usedHosts) {
         return failed(Exceptions.StacklessNoActiveHostException.newInstance("Failed to pick an active host for " +
                         getTargetResource() + ". Either all are busy, expired, or unhealthy: " + usedHosts,
                 this.getClass(), "selectConnection(...)"));

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
@@ -48,6 +48,7 @@ import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 import static java.util.stream.Collectors.toList;
 
@@ -99,13 +100,14 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     private final ListenableAsyncCloseable closeable;
     private volatile ConnState connState = ACTIVE_EMPTY_CONN_STATE;
 
-    DefaultHost(String lbDescription, Addr address, ConnectionFactory<Addr, ? extends C> connectionFactory,
+    DefaultHost(final String lbDescription, final Addr address,
+                final ConnectionFactory<Addr, ? extends C> connectionFactory,
                 int linearSearchSpace, @Nullable HealthCheckConfig healthCheckConfig) {
-        this.lbDescription = lbDescription;
-        this.address = address;
-        this.healthCheckConfig = healthCheckConfig;
-        this.connectionFactory = connectionFactory;
+        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
+        this.address = requireNonNull(address, "address");
         this.linearSearchSpace = linearSearchSpace;
+        this.connectionFactory = requireNonNull(connectionFactory, "connectionFactory");
+        this.healthCheckConfig = healthCheckConfig;
         this.closeable = toAsyncCloseable(graceful ->
                 graceful ? doClose(AsyncCloseable::closeAsyncGracefully) : doClose(AsyncCloseable::closeAsync));
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
@@ -73,7 +73,7 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
                 // try to make a new one if the host is healthy. If it's not healthy, we fail
                 // and let the higher level retries decide what to do.
                 if (!host.isActiveAndHealthy()) {
-                    return noActiveHostsException(hosts);
+                    return noActiveHosts(hosts);
                 }
                 return host.newConnection(selector, forceNewConnectionAndReserve, context);
             default:
@@ -127,7 +127,7 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
             // Neither are healthy and capable of making a connection: fall through, perhaps for another attempt.
         }
         // Max effort exhausted. We failed to find a healthy and active host.
-        return noActiveHostsException(hosts);
+        return noActiveHosts(hosts);
     }
 
     private Random getRandom() {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -70,7 +70,7 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
             }
         }
         if (pickedHost == null) {
-            return noActiveHostsException(usedHosts);
+            return noActiveHosts(usedHosts);
         }
         // We have a host but no connection was selected: create a new one.
         return pickedHost.newConnection(selector, forceNewConnectionAndReserve, context);


### PR DESCRIPTION
Motivation:

There are some style and naming inconsistencies that can be cleaned up.

Modifications:

- rename `BaseSelector.noActiveHostsException` to `noActiveHosts`.
- Enforce constructor arguments to be non-null in `DefaultHost`.