### PR TITLE
Fix flaky publisher/OffloadingTest

### DIFF
--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/completable/OffloadingTest.java
@@ -143,8 +143,8 @@ class OffloadingTest extends AbstractCompletableOffloadingTest {
         }
     }
 
-    @ParameterizedTest
-    @EnumSource(OffloadingTest.OffloadCase.class)
+    @ParameterizedTest(name = "{displayName} [{index}]: case={0}")
+    @EnumSource(OffloadCase.class)
     void testOffloading(OffloadCase offloadCase) throws InterruptedException {
         int offloads = testOffloading(offloadCase.offloadOperator, offloadCase.terminal);
         assertThat("Unexpected offloads: " + offloadCase.expectedOffloads,

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/AbstractOffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/internal/AbstractOffloadingTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.concurrent.api.internal;
 import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.ExecutorExtension;
+import io.servicetalk.concurrent.api.Executors;
 import io.servicetalk.concurrent.api.TestExecutor;
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.context.api.ContextMap;
@@ -28,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor;
-import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -80,9 +80,10 @@ public abstract class AbstractOffloadingTest {
     protected static final Matcher<String> OFFLOAD_EXECUTOR = startsWith("TestExecutor");
 
     @RegisterExtension
-    public static final ExecutorExtension<Executor> APP_EXECUTOR_EXT = APP_ISOLATION ?
+    public static final ExecutorExtension<Executor> APP_EXECUTOR_EXT = (APP_ISOLATION ?
             withCachedExecutor(APP_EXECUTOR_PREFIX) :
-            ExecutorExtension.withExecutor(() -> immediate()).setClassLevel(true);
+            ExecutorExtension.withExecutor(Executors::immediate))
+            .setClassLevel(true);
     @RegisterExtension
     public final ExecutorExtension<TestExecutor> testExecutor = ExecutorExtension.withTestExecutor();
 

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/publisher/OffloadingTest.java
@@ -20,8 +20,6 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -50,7 +48,6 @@ import static io.servicetalk.concurrent.api.internal.AbstractOffloadingTest.Capt
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Execution(ExecutionMode.CONCURRENT)
 class OffloadingTest extends AbstractPublisherOffloadingTest {
 
     enum OffloadCase {
@@ -190,7 +187,7 @@ class OffloadingTest extends AbstractPublisherOffloadingTest {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}]: case={0}")
     @EnumSource(OffloadCase.class)
     void testOffloading(OffloadCase offloadCase) throws InterruptedException {
         int offloads = testOffloading(offloadCase.offloadOperator, offloadCase.terminal);

--- a/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/OffloadingTest.java
+++ b/servicetalk-concurrent-api-internal/src/test/java/io/servicetalk/concurrent/api/single/OffloadingTest.java
@@ -142,9 +142,9 @@ class OffloadingTest extends AbstractSingleOffloadingTest {
         }
     }
 
-    @ParameterizedTest
-    @EnumSource(OffloadingTest.OffloadCase.class)
-    void testOffloading(OffloadingTest.OffloadCase offloadCase) throws InterruptedException {
+    @ParameterizedTest(name = "{displayName} [{index}]: case={0}")
+    @EnumSource(OffloadCase.class)
+    void testOffloading(OffloadCase offloadCase) throws InterruptedException {
         int offloads = testOffloading(offloadCase.offloadOperator, offloadCase.terminal);
         assertThat("Unexpected offloads: " + offloadCase.expectedOffloads,
                 offloads, CoreMatchers.is(offloadCase.offloadsExpected));


### PR DESCRIPTION
Motivation:

#2325 says that test failures are caused by
"Executor was not initialized" or `RejectedExecutionException`. This is the only test that uses `ExecutionMode.CONCURRENT` and `ExecutorExtension` for `APP_EXECUTOR_EXT` is not marked as class-level.

Modifications:

- Remove `ExecutionMode.CONCURRENT` from publisher/OffloadingTest;
- Use `setClassLevel` for all static `APP_EXECUTOR_EXT` in `AbstractOffloadingTest`;
- Adjust names of `ParameterizedTest`(s);

Result:

Resolves #2325.