### PR TITLE
loadbalancer: follow ups to P2C selector logic

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
@@ -62,29 +62,19 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
                 throw new AssertionError("Selector for " + getTargetResource() +
                         " received an empty host set");
             case 1:
-                Host<ResolvedAddress, C> host = hosts.get(0);
-                if (!forceNewConnectionAndReserve) {
-                    C connection = host.pickConnection(selector, context);
-                    if (connection != null) {
-                        return succeeded(connection);
-                    }
-                }
-                // Either we require a new connection or there wasn't one already established so
-                // try to make a new one if the host is healthy. If it's not healthy, we fail
-                // and let the higher level retries decide what to do.
-                if (!host.isActiveAndHealthy()) {
-                    return noActiveHosts(hosts);
-                }
-                return host.newConnection(selector, forceNewConnectionAndReserve, context);
+                // There is only a single host, so we don't need to do any of the looping or comparison logic.
+                Single<C> connection = selectFromHost(hosts.get(0), selector, forceNewConnectionAndReserve, context);
+                return connection == null ? noActiveHosts(hosts) : connection;
             default:
                 return p2c(size, hosts, getRandom(), selector, forceNewConnectionAndReserve, context);
         }
     }
 
-    @Nullable
     private Single<C> p2c(int size, List<Host<ResolvedAddress, C>> hosts, Random random, Predicate<C> selector,
                           boolean forceNewConnectionAndReserve, @Nullable ContextMap contextMap) {
-        for (int j = maxEffort; j > 0; j--) {
+        // If there are only two hosts we only try once since there is no chance we'll select different hosts
+        // on further iterations.
+        for (int j = hosts.size() == 2 ? 1 : maxEffort; j > 0; j--) {
             // Pick two random indexes that don't collide. Limit the range on the second index to 1 less than
             // the max value so that if there is a collision we can safety increment. We also increment if
             // i2 > i1 to avoid biased toward lower numbers since we limited the range by 1.
@@ -102,32 +92,38 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
                 t2 = tmp;
             }
 
-            if (!forceNewConnectionAndReserve) {
-                // First we're going to see if we can get an existing connection regardless of health status. Since t1
-                // is 'better' we'll try it first. If it doesn't have any existing connections we don't fall back to t2
-                // or else we would cause a bias toward hosts with existing connections which could ultimately drive all
-                // traffic to the first host to make a connection in the case of a multiplexed session.
-                C c = t1.pickConnection(selector, contextMap);
-                if (c != null) {
-                    return succeeded(c);
-                }
-                // We now need to consider the health status and make a new connection if either
-                // host is considered healthy.
+            // Attempt to get a connection from t1 first since it's 'better'. If we can't, then try t2.
+            Single<C> result = selectFromHost(t1, selector, forceNewConnectionAndReserve, contextMap);
+            if (result != null) {
+                return result;
             }
-
-            // We either couldn't find a live connection or are being forced to make a new one. Either way we're
-            // going to make a new connection which means we need to consider health.
-            final boolean t1Healthy = t1.isActiveAndHealthy();
-            final boolean t2Healthy = t2.isActiveAndHealthy();
-            if (t1Healthy) {
-                return t1.newConnection(selector, forceNewConnectionAndReserve, contextMap);
-            } else if (t2Healthy) {
-                return t2.newConnection(selector, forceNewConnectionAndReserve, contextMap);
+            result = selectFromHost(t2, selector, forceNewConnectionAndReserve, contextMap);
+            if (result != null) {
+                return result;
             }
-            // Neither are healthy and capable of making a connection: fall through, perhaps for another attempt.
+            // Neither t1 nor t2 yielded a connection. Fall through, potentially for another attempt.
         }
         // Max effort exhausted. We failed to find a healthy and active host.
         return noActiveHosts(hosts);
+    }
+
+    @Nullable
+    private Single<C> selectFromHost(Host<ResolvedAddress, C> host, Predicate<C> selector,
+                                     boolean forceNewConnectionAndReserve, @Nullable ContextMap contextMap) {
+        // First see if we can get an existing connection regardless of health status.
+        if (!forceNewConnectionAndReserve) {
+            C c = host.pickConnection(selector, contextMap);
+            if (c != null) {
+                return succeeded(c);
+            }
+        }
+        // We need to make a new connection to the host but we'll only do so if it's considered healthy.
+        if (host.isActiveAndHealthy()) {
+            return host.newConnection(selector, forceNewConnectionAndReserve, contextMap);
+        }
+
+        // no selectable active connections and the host is unhealthy, so we return `null`.
+        return null;
     }
 
     private Random getRandom() {

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/P2CSelectorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/P2CSelectorTest.java
@@ -19,7 +19,6 @@ import io.servicetalk.client.api.NoActiveHostException;
 import io.servicetalk.concurrent.api.Single;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;


### PR DESCRIPTION
Motivation:

We should try to get existing connections from the non-preferred host if 
we fail to get connections from the preferred.

Modifications:

- adjust the selection logic
- add a test
- don't perform multiple selection attempts if there are only two hosts
- remove unnecessary `@Nullable` annotation since the method never returns null