### PR TITLE
Fix bug in http/grpc logging observer that prevented request Throwables to be logged

### DIFF
--- a/servicetalk-grpc-utils/build.gradle
+++ b/servicetalk-grpc-utils/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation "com.google.code.findbugs:jsr305"
 
   testImplementation project(":servicetalk-test-resources")
+  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-grpc-utils/build.gradle
+++ b/servicetalk-grpc-utils/build.gradle
@@ -18,10 +18,19 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   implementation platform(project(":servicetalk-dependencies"))
+  testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   api project(":servicetalk-grpc-api")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305"
+
+  testImplementation project(":servicetalk-test-resources")
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 }
+
+spotbugsTest.enabled = false

--- a/servicetalk-grpc-utils/build.gradle
+++ b/servicetalk-grpc-utils/build.gradle
@@ -33,5 +33,3 @@ dependencies {
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 }
-
-spotbugsTest.enabled = false

--- a/servicetalk-grpc-utils/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-grpc-utils/gradle/spotbugs/test-exclusions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<FindBugsFilter>
+  <!-- Fields are usually initialized in @BeforeClass/@Before methods instead of constructors for tests -->
+  <Match>
+    <Source name="~.*Test\.java"/>
+    <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+  </Match>
+</FindBugsFilter>

--- a/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserver.java
+++ b/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserver.java
@@ -47,7 +47,11 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
      * @param logLevel The level to log at
      */
     LoggingGrpcLifecycleObserver(final String loggerName, final LogLevel logLevel) {
-        this.logger = newLogger(loggerName, logLevel);
+        this(newLogger(loggerName, logLevel));
+    }
+
+    LoggingGrpcLifecycleObserver(FixedLevelLogger logger) {
+        this.logger = logger;
     }
 
     @Override
@@ -177,10 +181,10 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
             final HttpRequestMetaData requestMetaData = this.requestMetaData;
             assert requestMetaData != null;
             final HttpResponseMetaData responseMetaData = this.responseMetaData;
-            Object requestResult = unwrapResult(this.requestResult);
-            if (requestResult == null) {
+            Object unwrappedRequestResult = unwrapResult(this.requestResult);
+            if (unwrappedRequestResult == null) {
                 // It's possible that request can be cancelled before transport subscribed to its payload body
-                requestResult = Result.cancelled;
+                unwrappedRequestResult = Result.cancelled;
             }
             if (responseMetaData != null) {
                 logger.log("connection='{}' " +
@@ -189,7 +193,7 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
                 "responseResult={} responseTime={}ms totalTime={}ms",
                 connInfo == null ? "unknown" : connInfo,
                 requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                requestMetaData.headers().size(), requestSize, requestTrailersCount, requestResult,
+                requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
                 responseMetaData.status().code(), responseMetaData.headers().size(), responseSize,
                 responseTrailersCount, grpcStatus, unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
                 combine(responseResult, requestResult));
@@ -199,7 +203,7 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
                 "responseResult={} responseTime={}ms totalTime={}ms",
                 connInfo == null ? "unknown" : connInfo,
                 requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                requestMetaData.headers().size(), requestSize, requestTrailersCount, requestResult,
+                requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
                 unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
                 combine(responseResult, requestResult));
             }

--- a/servicetalk-grpc-utils/src/test/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserverTest.java
+++ b/servicetalk-grpc-utils/src/test/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserverTest.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.grpc.utils;
 
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.grpc.api.GrpcLifecycleObserver;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpProtocolVersion;
@@ -74,7 +75,7 @@ class LoggingGrpcLifecycleObserverTest {
     @Test
     void testOnRequestError() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
-        Throwable requestError = new RuntimeException("fake request error");
+        Throwable requestError = new DeliberateException();
         observer.onRequest(mockRequestMetadata);
         ((GrpcLifecycleObserver.GrpcRequestObserver) observer).onRequestError(requestError);
         observer.onResponseCancel();
@@ -95,7 +96,7 @@ class LoggingGrpcLifecycleObserverTest {
     void testOnResponseError() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
         observer.onRequest(mockRequestMetadata);
-        Throwable responseError = new RuntimeException("fake response error");
+        Throwable responseError = new DeliberateException();
         observer.onResponseError(responseError);
         observer.onExchangeFinally();
         verify(mockLogger).log(anyString(),
@@ -113,8 +114,8 @@ class LoggingGrpcLifecycleObserverTest {
     @Test
     void testCombinedError() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
-        Throwable requestError = new RuntimeException("fake request error");
-        Throwable responseError = new RuntimeException("fake response error");
+        Throwable requestError = new DeliberateException();
+        Throwable responseError = new DeliberateException();
         observer.onRequest(mockRequestMetadata);
         ((GrpcLifecycleObserver.GrpcRequestObserver) observer).onRequestError(requestError);
         observer.onResponseError(responseError);
@@ -136,7 +137,7 @@ class LoggingGrpcLifecycleObserverTest {
     void testOnResponseErrorWithMetadata() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
         observer.onRequest(mockRequestMetadata);
-        Throwable responseError = new RuntimeException("fake response error");
+        Throwable responseError = new DeliberateException();
         observer.onResponse(mockResponseMetadata);
         observer.onResponseError(responseError);
         observer.onExchangeFinally();

--- a/servicetalk-grpc-utils/src/test/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserverTest.java
+++ b/servicetalk-grpc-utils/src/test/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserverTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.utils;
+
+import io.servicetalk.grpc.api.GrpcLifecycleObserver;
+import io.servicetalk.http.api.HttpHeaders;
+import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.logging.api.LogLevel;
+import io.servicetalk.logging.slf4j.internal.FixedLevelLogger;
+import io.servicetalk.transport.api.ConnectionInfo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LoggingGrpcLifecycleObserverTest {
+
+    private HttpRequestMetaData mockRequestMetadata;
+    private HttpResponseMetaData mockResponseMetadata;
+    private FixedLevelLogger mockLogger;
+    private GrpcLifecycleObserver.GrpcExchangeObserver observer;
+
+    @BeforeEach
+    public void setUp() {
+        mockRequestMetadata = mock(HttpRequestMetaData.class);
+        when(mockRequestMetadata.headers()).thenReturn(mock(HttpHeaders.class));
+        when(mockRequestMetadata.method()).thenReturn(HttpRequestMethod.GET);
+        when(mockRequestMetadata.requestTarget()).thenReturn("/foo/bar");
+        when(mockRequestMetadata.version()).thenReturn(HttpProtocolVersion.HTTP_2_0);
+
+        mockResponseMetadata = mock(HttpResponseMetaData.class);
+        when(mockResponseMetadata.status()).thenReturn(HttpResponseStatus.OK);
+        when(mockResponseMetadata.headers()).thenReturn(mock(HttpHeaders.class));
+
+        mockLogger = mock(FixedLevelLogger.class);
+        when(mockLogger.logLevel()).thenReturn(LogLevel.INFO);
+
+        observer = new LoggingGrpcLifecycleObserver(mockLogger).onNewExchange();
+    }
+
+    @Test
+    void testFactoryMethod() {
+        assertThat(observer, isA(GrpcLifecycleObserver.GrpcRequestObserver.class));
+        assertThat(observer, isA(GrpcLifecycleObserver.GrpcResponseObserver.class));
+    }
+
+    @Test
+    void testOnRequestError() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        Throwable requestError = new RuntimeException("fake request error");
+        observer.onRequest(mockRequestMetadata);
+        ((GrpcLifecycleObserver.GrpcRequestObserver) observer).onRequestError(requestError);
+        observer.onResponseCancel();
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                eq(0), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong(), // duration
+                eq(requestError));
+    }
+
+    @Test
+    void testOnResponseError() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        observer.onRequest(mockRequestMetadata);
+        Throwable responseError = new RuntimeException("fake response error");
+        observer.onResponseError(responseError);
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                eq(0), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong(), // duration
+                eq(responseError));
+    }
+
+    @Test
+    void testCombinedError() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        Throwable requestError = new RuntimeException("fake request error");
+        Throwable responseError = new RuntimeException("fake response error");
+        observer.onRequest(mockRequestMetadata);
+        ((GrpcLifecycleObserver.GrpcRequestObserver) observer).onRequestError(requestError);
+        observer.onResponseError(responseError);
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                any(), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong(), // duration
+                eq(responseError));
+        assertThat(responseError.getSuppressed()[0], is(requestError));
+    }
+
+    @Test
+    void testOnResponseErrorWithMetadata() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        observer.onRequest(mockRequestMetadata);
+        Throwable responseError = new RuntimeException("fake response error");
+        observer.onResponse(mockResponseMetadata);
+        observer.onResponseError(responseError);
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                eq(0), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                eq(HttpResponseStatus.OK.code()), // responseCode
+                eq(0), // response Header Size
+                eq(0L), // responseSize
+                eq(0), // responseTrailersCount
+                any(), // grpcStatus
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong(), // duration
+                eq(responseError));
+    }
+}

--- a/servicetalk-http-utils/build.gradle
+++ b/servicetalk-http-utils/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-concurrent-reactivestreams"))
   testImplementation testFixtures(project(":servicetalk-http-api"))
+  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-concurrent-api-test")
   testImplementation project(":servicetalk-transport-netty")

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
@@ -45,7 +45,11 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
      * @param logLevel The level to log at
      */
     LoggingHttpLifecycleObserver(final String loggerName, final LogLevel logLevel) {
-        this.logger = newLogger(loggerName, logLevel);
+        this(newLogger(loggerName, logLevel));
+    }
+
+    LoggingHttpLifecycleObserver(FixedLevelLogger logger) {
+        this.logger = logger;
     }
 
     @Override
@@ -168,10 +172,10 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
             final HttpRequestMetaData requestMetaData = this.requestMetaData;
             assert requestMetaData != null;
             final HttpResponseMetaData responseMetaData = this.responseMetaData;
-            Object requestResult = unwrapResult(this.requestResult);
-            if (requestResult == null) {
+            Object unwrappedRequestResult = unwrapResult(this.requestResult);
+            if (unwrappedRequestResult == null) {
                 // It's possible that request can be cancelled before transport subscribed to its payload body
-                requestResult = Result.cancelled;
+                unwrappedRequestResult = Result.cancelled;
             }
             assert responseResult != null;
             if (responseMetaData != null) {
@@ -181,7 +185,7 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
                 "responseTime={}ms totalTime={}ms",
                 connInfo == null ? "unknown" : connInfo,
                 requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                requestMetaData.headers().size(), requestSize, requestTrailersCount, requestResult,
+                requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
                 responseMetaData.status().code(), responseMetaData.headers().size(), responseSize,
                 responseTrailersCount, unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
                 combine(responseResult, requestResult));
@@ -191,7 +195,7 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
                 "responseResult={} responseTime={}ms totalTime={}ms",
                 connInfo == null ? "unknown" : connInfo,
                 requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                requestMetaData.headers().size(), requestSize, requestTrailersCount, requestResult,
+                requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
                 unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
                 combine(responseResult, requestResult));
             }

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.http.utils;
 
+import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpProtocolVersion;
@@ -74,7 +75,7 @@ class LoggingHttpLifecycleObserverTest {
     @Test
     void testOnRequestError() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
-        Throwable requestError = new RuntimeException("fake request error");
+        Throwable requestError = new DeliberateException();
         observer.onRequest(mockRequestMetadata);
         ((HttpLifecycleObserver.HttpRequestObserver) observer).onRequestError(requestError);
         observer.onResponseCancel();
@@ -95,7 +96,7 @@ class LoggingHttpLifecycleObserverTest {
     void testOnResponseError() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
         observer.onRequest(mockRequestMetadata);
-        Throwable responseError = new RuntimeException("fake response error");
+        Throwable responseError = new DeliberateException();
         observer.onResponseError(responseError);
         observer.onExchangeFinally();
         verify(mockLogger).log(anyString(),
@@ -113,8 +114,8 @@ class LoggingHttpLifecycleObserverTest {
     @Test
     void testCombinedError() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
-        Throwable requestError = new RuntimeException("fake request error");
-        Throwable responseError = new RuntimeException("fake response error");
+        Throwable requestError = new DeliberateException();
+        Throwable responseError = new DeliberateException();
         observer.onRequest(mockRequestMetadata);
         ((HttpLifecycleObserver.HttpRequestObserver) observer).onRequestError(requestError);
         observer.onResponseError(responseError);
@@ -136,7 +137,7 @@ class LoggingHttpLifecycleObserverTest {
     void testOnResponseErrorWithMetadata() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
         observer.onRequest(mockRequestMetadata);
-        Throwable responseError = new RuntimeException("fake response error");
+        Throwable responseError = new DeliberateException();
         observer.onResponse(mockResponseMetadata);
         observer.onResponseError(responseError);
         observer.onExchangeFinally();

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.http.api.HttpHeaders;
+import io.servicetalk.http.api.HttpLifecycleObserver;
+import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.logging.api.LogLevel;
+import io.servicetalk.logging.slf4j.internal.FixedLevelLogger;
+import io.servicetalk.transport.api.ConnectionInfo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LoggingHttpLifecycleObserverTest {
+    private HttpRequestMetaData mockRequestMetadata;
+    private HttpResponseMetaData mockResponseMetadata;
+    private FixedLevelLogger mockLogger;
+
+    private HttpLifecycleObserver.HttpExchangeObserver observer;
+
+    @BeforeEach
+    void setUp() {
+        mockRequestMetadata = mock(HttpRequestMetaData.class);
+        when(mockRequestMetadata.headers()).thenReturn(mock(HttpHeaders.class));
+        when(mockRequestMetadata.method()).thenReturn(HttpRequestMethod.GET);
+        when(mockRequestMetadata.requestTarget()).thenReturn("/foo/bar");
+        when(mockRequestMetadata.version()).thenReturn(HttpProtocolVersion.HTTP_2_0);
+
+        mockResponseMetadata = mock(HttpResponseMetaData.class);
+        when(mockResponseMetadata.status()).thenReturn(HttpResponseStatus.OK);
+        when(mockResponseMetadata.headers()).thenReturn(mock(HttpHeaders.class));
+
+        mockLogger = mock(FixedLevelLogger.class);
+        when(mockLogger.logLevel()).thenReturn(LogLevel.INFO);
+
+        observer = new LoggingHttpLifecycleObserver(mockLogger).onNewExchange();
+    }
+
+    @Test
+    void testFactoryMethod() {
+        assertThat(observer, isA(HttpLifecycleObserver.HttpRequestObserver.class));
+        assertThat(observer, isA(HttpLifecycleObserver.HttpResponseObserver.class));
+    }
+
+    @Test
+    void testOnRequestError() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        Throwable requestError = new RuntimeException("fake request error");
+        observer.onRequest(mockRequestMetadata);
+        ((HttpLifecycleObserver.HttpRequestObserver) observer).onRequestError(requestError);
+        observer.onResponseCancel();
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                eq(0), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong(), // duration
+                eq(requestError));
+    }
+
+    @Test
+    void testOnResponseError() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        observer.onRequest(mockRequestMetadata);
+        Throwable responseError = new RuntimeException("fake response error");
+        observer.onResponseError(responseError);
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                eq(0), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong(), // duration
+                eq(responseError));
+    }
+
+    @Test
+    void testCombinedError() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        Throwable requestError = new RuntimeException("fake request error");
+        Throwable responseError = new RuntimeException("fake response error");
+        observer.onRequest(mockRequestMetadata);
+        ((HttpLifecycleObserver.HttpRequestObserver) observer).onRequestError(requestError);
+        observer.onResponseError(responseError);
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                any(), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong(), // duration
+                eq(responseError));
+        assertThat(responseError.getSuppressed()[0], is(requestError));
+    }
+
+    @Test
+    void testOnResponseErrorWithMetadata() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        observer.onRequest(mockRequestMetadata);
+        Throwable responseError = new RuntimeException("fake response error");
+        observer.onResponse(mockResponseMetadata);
+        observer.onResponseError(responseError);
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                eq(0), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                eq(HttpResponseStatus.OK.code()), // responseCode
+                eq(0), // response Header Size
+                eq(0L), // responseSize
+                eq(0), // responseTrailersCount
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong(), // duration
+                eq(responseError));
+    }
+}


### PR DESCRIPTION
Motivation:

LoggingHttpLifecycleObserver and LoggingGrpcLifecycleObserver included a bug that prevented request exceptions to be logged.

Modifications:

- Update LoggingHttpLifecycleObserver and LoggingGrpcLifecycleObserver to include the Throwable as the last argument in the logger call
- Add tests for the two components

Result:

The Logger object will be called with a Throwable as last argument instead of null in case of request errors. Most logging frameworks implementing slf4j will print the full stacktraces in this situation.