### PR TITLE
Update Netty io_uring 0.0.23 -> 0.0.24

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
 nettyVersion=4.1.100.Final
-nettyIoUringVersion=0.0.23.Final
+nettyIoUringVersion=0.0.24.Final
 
 jsr305Version=3.0.2
 


### PR DESCRIPTION
Fixes #2585.

---

Unfortunately, we can not take it right now bcz version 0.0.24 depends on Netty 4.1.101. See #2747 for more details.