### PR TITLE
Enhance HttpMessageDiscardWatchdogServiceFilterTest output

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
@@ -45,7 +45,6 @@ import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
 import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
 import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class HttpMessageDiscardWatchdogServiceFilterTest {
 
@@ -93,8 +92,10 @@ final class HttpMessageDiscardWatchdogServiceFilterTest {
             }
 
             String output = LoggerStringWriter.stableAccumulated(CI ? 5000 : 1000);
-            assertTrue(output.contains("Discovered un-drained HTTP response message body which " +
-                    "has been dropped by user code"));
+            if (!output.contains("Discovered un-drained HTTP response message body which " +
+                    "has been dropped by user code")) {
+                throw new AssertionError("Logs didn't contain the expected output:\n" + output);
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

Despite increasing the timeout, the test in HttpMessageDiscardWatchdogServiceFilterTest is still flaky and we're not sure why.

Modifications:

- emit the entire output that was missing the expected log entry.

Result:

It should be a bit easier to debug the cause of the flakyness.