### PR TITLE
Bump netty and grpc dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ issueManagementUrl=https://github.com/apple/servicetalk/issues
 ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
-nettyVersion=4.1.100.Final
+nettyVersion=4.1.101.Final
 nettyIoUringVersion=0.0.23.Final
 
 jsr305Version=3.0.2
@@ -79,6 +79,6 @@ spotbugsPluginVersion=5.0.13
 
 apacheDirectoryServerVersion=1.5.7
 commonsLangVersion=2.6
-grpcVersion=1.56.1
+grpcVersion=1.59.1
 javaxAnnotationsApiVersion=1.3.5
 jsonUnitVersion=2.38.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
 nettyVersion=4.1.101.Final
-nettyIoUringVersion=0.0.23.Final
+nettyIoUringVersion=0.0.24.Final
 
 jsr305Version=3.0.2
 


### PR DESCRIPTION
Motivation:

There have been version bumps and we can now
upgrade our netty and grpc dependencies.

Modifications:

- bump netty from 4.1.100.Final to 4.1.101.Final
- bump netty io_uring from 0.0.23.Final to 0.0.24.Final
- bump grpc from 1.56.1 to 1.59.1

Fixes https://github.com/apple/servicetalk/issues/2585.