### PR TITLE
loadbalancer: Use a sequential execution concurrency model in DefaultLoadBalancer

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -19,14 +19,17 @@ import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.PublisherSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.Processors;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.SourceAdapters;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
 import io.servicetalk.context.api.ContextMap;
 
@@ -35,21 +38,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Spliterator;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.LoadBalancerReadyEvent.LOAD_BALANCER_NOT_READY_EVENT;
@@ -82,9 +77,6 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultLoadBalancer.class);
 
-    @SuppressWarnings("rawtypes")
-    private static final AtomicReferenceFieldUpdater<DefaultLoadBalancer, List> usedHostsUpdater =
-            AtomicReferenceFieldUpdater.newUpdater(DefaultLoadBalancer.class, List.class, "usedHosts");
 
     @SuppressWarnings("rawtypes")
     private static final AtomicLongFieldUpdater<DefaultLoadBalancer> nextResubscribeTimeUpdater =
@@ -93,13 +85,18 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
     private static final long RESUBSCRIBING = -1L;
 
     private volatile long nextResubscribeTime = RESUBSCRIBING;
+
+    // writes to these fields protected by `executeSequentially` but they can be read from any thread.
     private volatile List<Host<ResolvedAddress, C>> usedHosts = emptyList();
+    private volatile boolean isClosed;
 
     private final String targetResource;
     private final String lbDescription;
     private final HostSelector<ResolvedAddress, C> hostSelector;
     private final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher;
     private final Processor<Object, Object> eventStreamProcessor = newPublisherProcessorDropHeadOnOverflow(32);
+    private final Processor<Runnable, Runnable> sequentialExecutionQueue =
+            newPublisherProcessorDropHeadOnOverflow(Integer.MAX_VALUE);
     private final Publisher<Object> eventStream;
     private final SequentialCancellable discoveryCancellable = new SequentialCancellable();
     private final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory;
@@ -138,30 +135,13 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         this.connectionFactory = requireNonNull(connectionFactory);
         this.linearSearchSpace = linearSearchSpace;
         this.healthCheckConfig = healthCheckConfig;
-        this.asyncCloseable = toAsyncCloseable(graceful -> {
-            discoveryCancellable.cancel();
-            eventStreamProcessor.onComplete();
-            final CompositeCloseable compositeCloseable;
-            for (;;) {
-                List<Host<ResolvedAddress, C>> currentList = usedHosts;
-                if (isClosedList(currentList) ||
-                        usedHostsUpdater.compareAndSet(this, currentList, new ClosedList<>(currentList))) {
-                    compositeCloseable = newCompositeCloseable().appendAll(currentList).appendAll(connectionFactory);
-                    LOGGER.debug("{} is closing {}gracefully. Last seen addresses (size={}): {}.",
-                            this, graceful ? "" : "non", currentList.size(), currentList);
-                    break;
-                }
-            }
-            return (graceful ? compositeCloseable.closeAsyncGracefully() : compositeCloseable.closeAsync())
-                    .beforeOnError(t -> {
-                        if (!graceful) {
-                            usedHosts = new ClosedList<>(emptyList());
-                        }
-                    })
-                    .beforeOnComplete(() -> usedHosts = new ClosedList<>(emptyList()));
-        });
+        this.asyncCloseable = toAsyncCloseable(this::doClose);
         // Maintain a Subscriber so signals are always delivered to replay and new Subscribers get the latest signal.
         eventStream.ignoreElements().subscribe();
+
+        // Start running the events forever.
+        SourceAdapters.fromSource(sequentialExecutionQueue).forEach(DefaultLoadBalancer::safeRun);
+
         subscribeToEvents(false);
     }
 
@@ -177,6 +157,34 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             assert healthCheckConfig.executor instanceof NormalizedTimeSourceExecutor;
             nextResubscribeTime = nextResubscribeTime(healthCheckConfig, this);
         }
+    }
+
+    // This method is called eagerly, meaning the completable will be immediately subscribed to,
+    // so we don't need to do any Completable.defer business.
+    private Completable doClose(final boolean graceful) {
+        CompletableSource.Processor processor = Processors.newCompletableProcessor();
+        executeSequentially(() -> {
+            if (!isClosed) {
+                discoveryCancellable.cancel();
+                eventStreamProcessor.onComplete();
+            }
+            isClosed = true;
+            List<Host<ResolvedAddress, C>> currentList = usedHosts;
+            final CompositeCloseable compositeCloseable = newCompositeCloseable()
+                    .appendAll(currentList)
+                    .appendAll(connectionFactory);
+            LOGGER.debug("{} is closing {}gracefully. Last seen addresses (size={}): {}.",
+                    this, graceful ? "" : "non", currentList.size(), currentList);
+            SourceAdapters.toSource((graceful ? compositeCloseable.closeAsyncGracefully() :
+                    // We only want to empty the host list on error if we're closing non-gracefully.
+                    compositeCloseable.closeAsync().beforeOnError(t ->
+                            executeSequentially(() -> usedHosts = emptyList()))
+                )
+                // we want to always empty out the host list if we complete successfully
+                .beforeOnComplete(() -> executeSequentially(() -> usedHosts = emptyList())))
+                    .subscribe(processor);
+        });
+        return SourceAdapters.fromSource(processor);
     }
 
     private static <R, C extends LoadBalancedConnection> long nextResubscribeTime(
@@ -254,81 +262,71 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                         DefaultLoadBalancer.this);
                 return;
             }
+            executeSequentially(() -> sequentialOnNext(events));
+        }
 
-            boolean sendReadyEvent;
-            List<Host<ResolvedAddress, C>> nextHosts;
-            for (;;) {
-                // TODO: we have some weirdness in the event that we fail the CAS namely that we can create a host
-                //  that never gets used but is orphaned. It's fine so long as there is nothing to close but that
-                //  guarantee may not always hold in the future.
-                @SuppressWarnings("unchecked")
-                List<Host<ResolvedAddress, C>> usedHosts = usedHostsUpdater.get(DefaultLoadBalancer.this);
-                if (isClosedList(usedHosts)) {
-                    // We don't update if the load balancer is closed.
-                    return;
-                }
-                nextHosts = new ArrayList<>(usedHosts.size() + events.size());
-                sendReadyEvent = false;
+        private void sequentialOnNext(Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
+            assert events != null && !events.isEmpty();
 
-                // First we make a map of addresses to events so that we don't get quadratic behavior for diffing.
-                // Unfortunately we need to make this every iteration of the CAS loop since we remove entries
-                // for hosts that already exist. If this results in to many collisions and map rebuilds we should
-                // re-assess how we manage concurrency for list mutations.
-                final Map<ResolvedAddress, ServiceDiscovererEvent<ResolvedAddress>> eventMap = new HashMap<>();
-                for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
-                    ServiceDiscovererEvent<ResolvedAddress> old = eventMap.put(event.address(), event);
-                    if (old != null) {
-                        LOGGER.debug("Multiple ServiceDiscoveryEvent's detected for address {}. Event: {}.",
-                                event.address(), event);
-                    }
-                }
+            if (isClosed) {
+                // nothing to do if the load balancer is closed.
+                return;
+            }
 
-                // First thing we do is go through the existing hosts and see if we need to transfer them. These
-                // will be all existing hosts that either don't have a matching discovery event or are not marked
-                // as unavailable. If they are marked unavailable, we need to close them (which is idempotent).
-                for (Host<ResolvedAddress, C> host : usedHosts) {
-                    ServiceDiscovererEvent<ResolvedAddress> event = eventMap.remove(host.address());
-                    if (event == null) {
-                        // Host doesn't have a SD update so just copy it over.
-                        nextHosts.add(host);
-                    } else if (AVAILABLE.equals(event.status())) {
-                        // We only send the ready event if the previous host list was empty.
-                        sendReadyEvent = usedHosts.isEmpty();
-                        // If the host is already in CLOSED state, we should discard it and create a new entry.
-                        // For duplicate ACTIVE events or for repeated activation due to failed CAS
-                        // of replacing the usedHosts array the marking succeeds so we will not add a new entry.
-                        if (host.markActiveIfNotClosed()) {
-                            nextHosts.add(host);
-                        } else {
-                            nextHosts.add(createHost(event.address()));
-                        }
-                    } else if (EXPIRED.equals(event.status())) {
-                        if (!host.markExpired()) {
-                            nextHosts.add(host);
-                        }
-                    } else if (UNAVAILABLE.equals(event.status())) {
-                        host.markClosed();
-                    } else {
-                        LOGGER.warn("{}: Unsupported Status in event:" +
-                                        " {} (mapped to {}). Leaving usedHosts unchanged: {}",
-                                DefaultLoadBalancer.this, event, event.status(), nextHosts);
-                        nextHosts.add(host);
-                    }
-                }
-                // Now process events that didn't have an existing host. The only ones that we actually care
-                // about are the AVAILABLE events which result in a new host.
-                for (ServiceDiscovererEvent<ResolvedAddress> event : eventMap.values()) {
-                    if (AVAILABLE.equals(event.status())) {
-                        sendReadyEvent = true;
-                        nextHosts.add(createHost(event.address()));
-                    }
-                }
-                // We've now built the new list so now we need to CAS it before we can move on. This should only be
-                // racing with closing hosts and closing the whole LB so it shouldn't be common to lose the race.
-                if (usedHostsUpdater.compareAndSet(DefaultLoadBalancer.this, usedHosts, nextHosts)) {
-                    break;
+            boolean sendReadyEvent = false;
+            final List<Host<ResolvedAddress, C>> nextHosts = new ArrayList<>(usedHosts.size() + events.size());
+            final List<Host<ResolvedAddress, C>> oldUsedHosts = usedHosts;
+            // First we make a map of addresses to events so that we don't get quadratic behavior for diffing.
+            final Map<ResolvedAddress, ServiceDiscovererEvent<ResolvedAddress>> eventMap = new HashMap<>();
+            for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
+                ServiceDiscovererEvent<ResolvedAddress> old = eventMap.put(event.address(), event);
+                if (old != null) {
+                    LOGGER.debug("Multiple ServiceDiscoveryEvent's detected for address {}. Event: {}.",
+                            event.address(), event);
                 }
             }
+
+            // First thing we do is go through the existing hosts and see if we need to transfer them. These
+            // will be all existing hosts that either don't have a matching discovery event or are not marked
+            // as unavailable. If they are marked unavailable, we need to close them.
+            for (Host<ResolvedAddress, C> host : oldUsedHosts) {
+                ServiceDiscovererEvent<ResolvedAddress> event = eventMap.remove(host.address());
+                if (event == null) {
+                    // Host doesn't have a SD update so just copy it over.
+                    nextHosts.add(host);
+                } else if (AVAILABLE.equals(event.status())) {
+                    // We only send the ready event if the previous host list was empty.
+                    sendReadyEvent = oldUsedHosts.isEmpty();
+                    // If the host is already in CLOSED state, we should discard it and create a new entry.
+                    // For duplicate ACTIVE events the marking succeeds, so we will not add a new entry.
+                    if (host.markActiveIfNotClosed()) {
+                        nextHosts.add(host);
+                    } else {
+                        nextHosts.add(createHost(event.address()));
+                    }
+                } else if (EXPIRED.equals(event.status())) {
+                    if (!host.markExpired()) {
+                        nextHosts.add(host);
+                    }
+                } else if (UNAVAILABLE.equals(event.status())) {
+                    host.markClosed();
+                } else {
+                    LOGGER.warn("{}: Unsupported Status in event:" +
+                                    " {} (mapped to {}). Leaving usedHosts unchanged: {}",
+                            DefaultLoadBalancer.this, event, event.status(), nextHosts);
+                    nextHosts.add(host);
+                }
+            }
+            // Now process events that didn't have an existing host. The only ones that we actually care
+            // about are the AVAILABLE events which result in a new host.
+            for (ServiceDiscovererEvent<ResolvedAddress> event : eventMap.values()) {
+                if (AVAILABLE.equals(event.status())) {
+                    sendReadyEvent = true;
+                    nextHosts.add(createHost(event.address()));
+                }
+            }
+            // We've built the new list so now set it for consumption and then send our events.
+            usedHosts = nextHosts;
 
             LOGGER.debug("{}: now using addresses (size={}): {}.",
                     DefaultLoadBalancer.this, nextHosts.size(), nextHosts);
@@ -368,13 +366,20 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             Host<ResolvedAddress, C> host = new DefaultHost<>(DefaultLoadBalancer.this.toString(), addr,
                     connectionFactory, linearSearchSpace, healthCheckConfig);
             host.onClose().afterFinally(() ->
-                    usedHostsUpdater.updateAndGet(DefaultLoadBalancer.this, previousHosts -> {
-                                @SuppressWarnings("unchecked")
-                                List<Host<ResolvedAddress, C>> previousHostsTyped =
-                                        (List<Host<ResolvedAddress, C>>) previousHosts;
-                                return listWithHostRemoved(previousHostsTyped, current -> current == host);
-                            }
-                    )).subscribe();
+                    executeSequentially(() -> {
+                        final List<Host<ResolvedAddress, C>> currentHosts = usedHosts;
+                        if (currentHosts.isEmpty()) {
+                            // Can't remove an entry from an empty list.
+                            return;
+                        }
+                        final List<Host<ResolvedAddress, C>> nextHosts = listWithHostRemoved(
+                                currentHosts, current -> current == host);
+                        usedHosts = nextHosts;
+                        if (nextHosts.isEmpty()) {
+                            // We transitioned from non-empty to empty. That means we're not ready.
+                            eventStreamProcessor.onNext(LOAD_BALANCER_NOT_READY_EVENT);
+                        }
+                    })).subscribe();
             return host;
         }
 
@@ -446,7 +451,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         // It's possible that we're racing with updates from the `onNext` method but since it's intrinsically
         // racy it's fine to do these 'are there any hosts at all' checks here using the total host set.
         if (currentHosts.isEmpty()) {
-            return isClosedList(currentHosts) ? failedLBClosed(targetResource) :
+            return isClosed ? failedLBClosed(targetResource) :
                     // This is the case when SD has emitted some items but none of the hosts are available.
                     failed(Exceptions.StacklessNoAvailableHostException.newInstance(
                             "No hosts are available to connect for " + targetResource + ".",
@@ -504,8 +509,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         return usedHosts.stream().map(host -> ((DefaultHost<ResolvedAddress, C>) host).asEntry()).collect(toList());
     }
 
-    private static boolean isClosedList(List<?> list) {
-        return list.getClass().equals(ClosedList.class);
+    private void executeSequentially(Runnable runnable) {
+        sequentialExecutionQueue.onNext(runnable);
     }
 
     private String makeDescription(String id, String targetResource) {
@@ -515,161 +520,11 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                 '}';
     }
 
-    private static final class ClosedList<T> implements List<T> {
-        private final List<T> delegate;
-
-        private ClosedList(final List<T> delegate) {
-            this.delegate = requireNonNull(delegate);
-        }
-
-        @Override
-        public int size() {
-            return delegate.size();
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return delegate.isEmpty();
-        }
-
-        @Override
-        public boolean contains(final Object o) {
-            return delegate.contains(o);
-        }
-
-        @Override
-        public Iterator<T> iterator() {
-            return delegate.iterator();
-        }
-
-        @Override
-        public void forEach(final Consumer<? super T> action) {
-            delegate.forEach(action);
-        }
-
-        @Override
-        public Object[] toArray() {
-            return delegate.toArray();
-        }
-
-        @Override
-        public <T1> T1[] toArray(final T1[] a) {
-            return delegate.toArray(a);
-        }
-
-        @Override
-        public boolean add(final T t) {
-            return delegate.add(t);
-        }
-
-        @Override
-        public boolean remove(final Object o) {
-            return delegate.remove(o);
-        }
-
-        @Override
-        public boolean containsAll(final Collection<?> c) {
-            return delegate.containsAll(c);
-        }
-
-        @Override
-        public boolean addAll(final Collection<? extends T> c) {
-            return delegate.addAll(c);
-        }
-
-        @Override
-        public boolean addAll(final int index, final Collection<? extends T> c) {
-            return delegate.addAll(c);
-        }
-
-        @Override
-        public boolean removeAll(final Collection<?> c) {
-            return delegate.removeAll(c);
-        }
-
-        @Override
-        public boolean removeIf(final Predicate<? super T> filter) {
-            return delegate.removeIf(filter);
-        }
-
-        @Override
-        public boolean retainAll(final Collection<?> c) {
-            return delegate.retainAll(c);
-        }
-
-        @Override
-        public void replaceAll(final UnaryOperator<T> operator) {
-            delegate.replaceAll(operator);
-        }
-
-        @Override
-        public void sort(final Comparator<? super T> c) {
-            delegate.sort(c);
-        }
-
-        @Override
-        public void clear() {
-            delegate.clear();
-        }
-
-        @Override
-        public T get(final int index) {
-            return delegate.get(index);
-        }
-
-        @Override
-        public T set(final int index, final T element) {
-            return delegate.set(index, element);
-        }
-
-        @Override
-        public void add(final int index, final T element) {
-            delegate.add(index, element);
-        }
-
-        @Override
-        public T remove(final int index) {
-            return delegate.remove(index);
-        }
-
-        @Override
-        public int indexOf(final Object o) {
-            return delegate.indexOf(o);
-        }
-
-        @Override
-        public int lastIndexOf(final Object o) {
-            return delegate.lastIndexOf(o);
-        }
-
-        @Override
-        public ListIterator<T> listIterator() {
-            return delegate.listIterator();
-        }
-
-        @Override
-        public ListIterator<T> listIterator(final int index) {
-            return delegate.listIterator(index);
-        }
-
-        @Override
-        public List<T> subList(final int fromIndex, final int toIndex) {
-            return new ClosedList<>(delegate.subList(fromIndex, toIndex));
-        }
-
-        @Override
-        public Spliterator<T> spliterator() {
-            return delegate.spliterator();
-        }
-
-        @Override
-        public Stream<T> stream() {
-            return delegate.stream();
-        }
-
-        @Override
-        public Stream<T> parallelStream() {
-            return delegate.parallelStream();
+    private static void safeRun(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (Exception ex) {
+            LOGGER.error("Exception caught in sequential execution", ex);
         }
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
@@ -77,7 +77,8 @@ final class SequentialExecutor implements Executor {
             }
             // next isn't the tail but the link hasn't resolved: we must poll until it does.
             while ((n = next.next) == null) {
-                // Still not resolved: try again.
+                // Still not resolved: yield and then try again.
+                Thread.yield();
             }
             next = n;
         }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.concurrent.PublisherSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executor;
+
+import static io.servicetalk.concurrent.api.Processors.newPublisherProcessorDropHeadOnOverflow;
+import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A concurrency primitive for providing thread safety without using locks.
+ *
+ * A {@link SequentialExecutor} is queue of tasks that are executed one at a time in the order they were
+ * received. This provides a way to serialize work between threads without needing to use locks which can
+ * result in thread contention and thread deadlock scenarios.
+ */
+final class SequentialExecutor implements Executor {
+
+    private final Logger logger;
+    private final PublisherSource.Processor<Runnable, Runnable> sequentialExecutionQueue =
+            newPublisherProcessorDropHeadOnOverflow(Integer.MAX_VALUE);
+
+    SequentialExecutor(Class<?> clazz) {
+        this(LoggerFactory.getLogger(clazz));
+    }
+
+    SequentialExecutor(final Logger logger) {
+        this.logger = requireNonNull(logger, "logger");
+        fromSource(sequentialExecutionQueue).forEach(this::safeRun);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        sequentialExecutionQueue.onNext(command);
+    }
+
+    private void safeRun(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (Exception ex) {
+            logger.error("Exception caught in sequential execution", ex);
+        }
+    }
+}

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/SequentialExecutorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/SequentialExecutorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.servicetalk.loadbalancer;
 
 import org.junit.jupiter.api.Test;

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/SequentialExecutorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/SequentialExecutorTest.java
@@ -1,0 +1,116 @@
+package io.servicetalk.loadbalancer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SequentialExecutorTest {
+
+    SequentialExecutor executor = new SequentialExecutor(SequentialExecutorTest.class);
+
+    @Test
+    void tasksAreExecuted() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(2);
+        // submit two tasks and they should both complete.
+        executor.execute(() -> latch.countDown());
+        executor.execute(() -> latch.countDown());
+        latch.await(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void firstTaskIsExecutedByCallingThread() {
+        AtomicReference<Thread> executorThread = new AtomicReference<>();
+        executor.execute(() -> executorThread.set(Thread.currentThread()));
+        assertNotNull(executorThread.get());
+        assertEquals(Thread.currentThread(), executorThread.get());
+    }
+
+    @Test
+    void executionFailuresDontThrowOnSubmission() {
+        executor.execute(() -> {
+            throw null;
+        });
+    }
+
+    @Test
+    void queuedTasksAreExecuted() throws InterruptedException {
+        final CountDownLatch l1 = new CountDownLatch(1);
+        final CountDownLatch l2 = new CountDownLatch(1);
+        Thread t = new Thread(() ->
+        executor.execute(() -> {
+            try {
+                l1.countDown();
+                l2.await();
+            } catch (Exception ex) {
+                throw new AssertionError("Unexpected failure", ex);
+            }
+        }));
+        t.start();
+
+        // wait for t1 to be in the execution loop then submit a task that should be queued.
+        l1.await();
+
+        // note that the behavior of the initial submitting thread executing queued tasks is not critical to
+        // the primitive: we could envision another use as correct implementation where a submitter will
+        // execute the task it just submitted but if there are additional tasks the work gets shifted to a
+        // pooled thread to drain. In that case, the test just needs to be adjusted.
+        final AtomicReference<Thread> executingThread = new AtomicReference<>();
+        executor.execute(() -> executingThread.set(Thread.currentThread()));
+        assertNull(executingThread.get());
+
+        // Now unblock the initial thread and it should also run the second task.
+        l2.countDown();
+        t.join();
+        assertEquals(t, executingThread.get());
+    }
+
+    @Test
+    void tasksAreNotRenentrant() {
+        Queue<Integer> order = new ArrayDeque<>();
+        executor.execute(() -> {
+            // this should be queued for later.
+            executor.execute(() -> order.add(2));
+            order.add(1);
+        });
+
+        assertThat(order, contains(1, 2));
+    }
+
+    @Test
+    void manyThreadsCanSubmitTasksConcurrently() throws InterruptedException {
+        final int threadCount = 100;
+        CountDownLatch completed = new CountDownLatch(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch barrier = new CountDownLatch(1);
+
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(() -> {
+                try {
+                    ready.countDown();
+                    barrier.await(5, TimeUnit.SECONDS);
+                    executor.execute(() -> completed.countDown());
+                } catch (Exception ex) {
+                    throw new AssertionError("unexpected error", ex);
+                }
+            });
+            t.start();
+        }
+        // wait for all the threads to have started
+        ready.await();
+        // release all the threads to submit their work to the executor.
+        barrier.countDown();
+        // all tasks should have completed. Note that all thread are racing with each other to
+        // submit work so the order of work execution isn't important.
+        completed.await(5, TimeUnit.SECONDS);
+    }
+}

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/SequentialExecutorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/SequentialExecutorTest.java
@@ -60,10 +60,10 @@ class SequentialExecutorTest {
         // wait for t1 to be in the execution loop then submit a task that should be queued.
         l1.await();
 
-        // note that the behavior of the initial submitting thread executing queued tasks is not critical to
-        // the primitive: we could envision another use as correct implementation where a submitter will
-        // execute the task it just submitted but if there are additional tasks the work gets shifted to a
-        // pooled thread to drain. In that case, the test just needs to be adjusted.
+        // note that the behavior of the initial submitting thread executing queued tasks is not critical to the
+        // primitive: we could envision another correct implementation where a submitter will  execute the task it just
+        // submitted but if there are additional tasks the work gets shifted to a pooled thread to drain. If we switch
+        // the model, the test should be adjusted to conform to the desired behavior.
         final AtomicReference<Thread> executingThread = new AtomicReference<>();
         executor.execute(() -> executingThread.set(Thread.currentThread()));
         assertNull(executingThread.get());

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/SequentialExecutorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/SequentialExecutorTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,7 +38,7 @@ class SequentialExecutorTest {
         // submit two tasks and they should both complete.
         executor.execute(() -> latch.countDown());
         executor.execute(() -> latch.countDown());
-        latch.await(5, TimeUnit.SECONDS);
+        latch.await();
     }
 
     @Test
@@ -112,7 +111,7 @@ class SequentialExecutorTest {
             Thread t = new Thread(() -> {
                 try {
                     ready.countDown();
-                    barrier.await(5, TimeUnit.SECONDS);
+                    barrier.await();
                     executor.execute(() -> completed.countDown());
                 } catch (Exception ex) {
                     throw new AssertionError("unexpected error", ex);
@@ -126,6 +125,6 @@ class SequentialExecutorTest {
         barrier.countDown();
         // all tasks should have completed. Note that all thread are racing with each other to
         // submit work so the order of work execution isn't important.
-        completed.await(5, TimeUnit.SECONDS);
+        completed.await();
     }
 }


### PR DESCRIPTION
Motivation:

We use an atomic field and CAS operations to manage concurrency in the DefaultLoadBalancer. Because the CAS operation has to succeed before changes have taken affect, it's not easy to make events coordinate with that model. A few examples:
- it will be awkward to add an event observer to the load balancer since we may end up re-doing server-set updates if we fail a CAS.
- there is also a question of ordering of observer events since the observer interactions may get out of order wrt the state mutations that induced them.
- we can't currently send an LOAD_BALANCER_NOT_READY_EVENT when the last host expires because we would risk the event racing with SD updates that triggered related events.

CAS failures may also be relatively common due to re-entrance: SD update events can cause hosts to be closed that that may synchronously cause the hosts `.afterFinally` listeners to remove themselves from the host list, resulting in a followup CAS failure.

Modifications:

- use an unbounded processor as a queue for Runnables that are executed sequentially and funnel sensitive operations through that queue.
- Send the LOAD_BLANACER_NOT_READY_EVENT when a host expires and results in an empty host set.

Result:

- The DefaultLoadBalancer event system is easier to read and is more correct wrt readiness.
- We can add an event observer pattern without worrying about race conditions or accidentally replaying events due to a CAS failure.