### PR TITLE
mdc-utils: Make LoggerStringWriter thread friendly

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilterTest.java
@@ -57,6 +57,8 @@ final class HttpMessageDiscardWatchdogClientFilterTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpMessageDiscardWatchdogClientFilterTest.class);
 
+    private final LoggerStringWriter loggerStringWriter = new LoggerStringWriter();
+
     @RegisterExtension
     static final ExecutionContextExtension SERVER_CTX =
             ExecutionContextExtension.cached("server-io", "server-executor")
@@ -68,12 +70,12 @@ final class HttpMessageDiscardWatchdogClientFilterTest {
 
     @BeforeEach
     public void setup() {
-        LoggerStringWriter.reset();
+        loggerStringWriter.reset();
     }
 
     @AfterEach
     public void tearDown() {
-        LoggerStringWriter.remove();
+        loggerStringWriter.remove();
     }
 
     /**
@@ -132,7 +134,7 @@ final class HttpMessageDiscardWatchdogClientFilterTest {
                     }
                 }
 
-                String output = LoggerStringWriter.stableAccumulated(1000);
+                String output = loggerStringWriter.stableAccumulated(1000);
                 LOGGER.info("Logger output: {}", output);
             }
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
@@ -57,14 +57,16 @@ final class HttpMessageDiscardWatchdogServiceFilterTest {
             ExecutionContextExtension.cached("client-io", "client-executor")
                     .setClassLevel(true);
 
+    private final LoggerStringWriter loggerStringWriter = new LoggerStringWriter();
+
     @BeforeEach
     public void setup() {
-        LoggerStringWriter.reset();
+        loggerStringWriter.reset();
     }
 
     @AfterEach
     public void tearDown() {
-        LoggerStringWriter.remove();
+        loggerStringWriter.remove();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] transformer={0}")
@@ -91,7 +93,7 @@ final class HttpMessageDiscardWatchdogServiceFilterTest {
                 assertEquals(0, response.payloadBody().readableBytes());
             }
 
-            String output = LoggerStringWriter.stableAccumulated(CI ? 5000 : 1000);
+            String output = loggerStringWriter.stableAccumulated(CI ? 5000 : 1000);
             if (!output.contains("Discovered un-drained HTTP response message body which " +
                     "has been dropped by user code")) {
                 throw new AssertionError("Logs didn't contain the expected output:\n" + output);

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilterTest.java
@@ -47,7 +47,6 @@ import java.lang.invoke.MethodHandles;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.assertContainsMdcPair;
-import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.stableAccumulated;
 import static io.servicetalk.opentelemetry.http.TestUtils.SPAN_STATE_SERIALIZER;
 import static io.servicetalk.opentelemetry.http.TestUtils.TRACING_TEST_LOG_LINE_PREFIX;
 import static io.servicetalk.opentelemetry.http.TestUtils.TestTracingClientLoggerFilter;
@@ -62,17 +61,19 @@ class OpenTelemetryHttpRequestFilterTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+    private final LoggerStringWriter loggerStringWriter = new LoggerStringWriter();
+
     @RegisterExtension
     static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
 
     @BeforeEach
     public void setup() {
-        LoggerStringWriter.reset();
+        loggerStringWriter.reset();
     }
 
     @AfterEach
     public void tearDown() {
-        LoggerStringWriter.remove();
+        loggerStringWriter.remove();
     }
 
     @Test
@@ -86,7 +87,7 @@ class OpenTelemetryHttpRequestFilterTest {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
-                verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl,
+                verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
                 assertThat(otelTesting.getSpans()).hasSize(1);
@@ -116,7 +117,7 @@ class OpenTelemetryHttpRequestFilterTest {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
-                verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl,
+                verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
                 assertThat(otelTesting.getSpans()).hasSize(2);
@@ -173,7 +174,7 @@ class OpenTelemetryHttpRequestFilterTest {
                 } finally {
                     span.end();
                 }
-                    verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl,
+                    verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                         serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                         TRACING_TEST_LOG_LINE_PREFIX);
                     assertThat(otelTesting.getSpans()).hasSize(3);
@@ -219,7 +220,7 @@ class OpenTelemetryHttpRequestFilterTest {
                     .addHeader("some-request-header", "request-header-value")).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
-                verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl,
+                verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
                 assertThat(otelTesting.getSpans()).hasSize(1);

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilterTest.java
@@ -46,7 +46,6 @@ import java.net.URL;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.stableAccumulated;
 import static io.servicetalk.opentelemetry.http.OpenTelemetryHttpRequestFilterTest.verifyTraceIdPresentInLogs;
 import static io.servicetalk.opentelemetry.http.TestUtils.SPAN_STATE_SERIALIZER;
 import static io.servicetalk.opentelemetry.http.TestUtils.TRACING_TEST_LOG_LINE_PREFIX;
@@ -60,14 +59,16 @@ class OpenTelemetryHttpServerFilterTest {
     @RegisterExtension
     static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
 
+    private final LoggerStringWriter loggerStringWriter = new LoggerStringWriter();
+
     @BeforeEach
     public void setup() {
-        LoggerStringWriter.reset();
+        loggerStringWriter.reset();
     }
 
     @AfterEach
     public void tearDown() {
-        LoggerStringWriter.remove();
+        loggerStringWriter.remove();
     }
 
     @Test
@@ -78,7 +79,7 @@ class OpenTelemetryHttpServerFilterTest {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
-                verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl,
+                verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
                 assertThat(otelTesting.getSpans()).hasSize(1);
@@ -125,7 +126,7 @@ class OpenTelemetryHttpServerFilterTest {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
-                verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl,
+                verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
                 assertThat(otelTesting.getSpans()).hasSize(2);
@@ -176,7 +177,7 @@ class OpenTelemetryHttpServerFilterTest {
             } finally {
                 span.end();
             }
-            verifyTraceIdPresentInLogs(stableAccumulated(1000), "/",
+            verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), "/",
                 serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                 TRACING_TEST_LOG_LINE_PREFIX);
             assertThat(otelTesting.getSpans()).hasSize(2);
@@ -209,7 +210,7 @@ class OpenTelemetryHttpServerFilterTest {
                     .toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
-                verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl,
+                verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
                 assertThat(otelTesting.getSpans()).hasSize(1);

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpRequesterFilterTest.java
@@ -58,7 +58,6 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.stableAccumulated;
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
 import static io.servicetalk.opentracing.http.TestUtils.SPAN_STATE_SERIALIZER;
 import static io.servicetalk.opentracing.http.TestUtils.TRACING_TEST_LOG_LINE_PREFIX;
@@ -87,18 +86,20 @@ import static org.mockito.MockitoAnnotations.initMocks;
 class TracingHttpRequesterFilterTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(TracingHttpRequesterFilterTest.class);
 
+    private final LoggerStringWriter loggerStringWriter = new LoggerStringWriter();
+
     @Mock
     private Tracer mockTracer;
 
     @BeforeEach
     public void setup() {
         initMocks(this);
-        LoggerStringWriter.reset();
+        loggerStringWriter.reset();
     }
 
     @AfterEach
     public void tearDown() {
-        LoggerStringWriter.remove();
+        loggerStringWriter.remove();
     }
 
     @Test
@@ -130,8 +131,8 @@ class TracingHttpRequesterFilterTest {
                 assertEquals(OK.code(), lastFinishedSpan.tags().get(HTTP_STATUS.getKey()));
                 assertFalse(lastFinishedSpan.tags().containsKey(ERROR.getKey()));
 
-                verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl, serverSpanState.traceId,
-                        serverSpanState.spanId, null, TRACING_TEST_LOG_LINE_PREFIX);
+                verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
+                        serverSpanState.traceId, serverSpanState.spanId, null, TRACING_TEST_LOG_LINE_PREFIX);
             }
         }
     }
@@ -171,9 +172,9 @@ class TracingHttpRequesterFilterTest {
                         assertEquals(requestUrl, lastFinishedSpan.tags().get(HTTP_URL.getKey()));
                         assertEquals(OK.code(), lastFinishedSpan.tags().get(HTTP_STATUS.getKey()));
                         assertFalse(lastFinishedSpan.tags().containsKey(ERROR.getKey()));
-
-                        verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl, serverSpanState.traceId,
-                            serverSpanState.spanId, serverSpanState.parentSpanId, TRACING_TEST_LOG_LINE_PREFIX);
+                        verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
+                                serverSpanState.traceId, serverSpanState.spanId, serverSpanState.parentSpanId,
+                                TRACING_TEST_LOG_LINE_PREFIX);
                     } finally {
                         clientSpan.finish();
                     }

--- a/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
+++ b/servicetalk-opentracing-http/src/test/java/io/servicetalk/opentracing/http/TracingHttpServiceFilterTest.java
@@ -56,7 +56,6 @@ import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.stableAccumulated;
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
 import static io.servicetalk.opentracing.http.TestUtils.SPAN_STATE_SERIALIZER;
 import static io.servicetalk.opentracing.http.TestUtils.TRACING_TEST_LOG_LINE_PREFIX;
@@ -85,18 +84,20 @@ import static org.mockito.MockitoAnnotations.initMocks;
 class TracingHttpServiceFilterTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(TracingHttpServiceFilterTest.class);
 
+    private final LoggerStringWriter loggerStringWriter = new LoggerStringWriter();
+
     @Mock
     private Tracer mockTracer;
 
     @BeforeEach
     public void setup() {
         initMocks(this);
-        LoggerStringWriter.reset();
+        loggerStringWriter.reset();
     }
 
     @AfterEach
     public void tearDown() {
-        LoggerStringWriter.remove();
+        loggerStringWriter.remove();
     }
 
     private static ServerContext buildServer(CountingInMemorySpanEventListener spanListener) throws Exception {
@@ -204,7 +205,7 @@ class TracingHttpServiceFilterTest {
             assertNull(lastFinishedSpan);
         }
 
-        verifyTraceIdPresentInLogs(stableAccumulated(1000), requestUrl, serverSpanState.traceId,
+        verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl, serverSpanState.traceId,
                 serverSpanState.spanId, serverSpanState.parentSpanId, TRACING_TEST_LOG_LINE_PREFIX);
     }
 

--- a/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
+++ b/servicetalk-opentracing-log4j2/src/test/java/io/servicetalk/opentracing/log4j2/ServiceTalkTracingThreadContextMapTest.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.assertContainsMdcPair;
-import static io.servicetalk.log4j2.mdc.utils.LoggerStringWriter.stableAccumulated;
 import static io.servicetalk.opentracing.asynccontext.AsyncContextInMemoryScopeManager.SCOPE_MANAGER;
 import static io.servicetalk.opentracing.internal.TracingIdUtils.idOrNullAsValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,14 +35,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class ServiceTalkTracingThreadContextMapTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTalkTracingThreadContextMapTest.class);
 
+    private final LoggerStringWriter loggerStringWriter = new LoggerStringWriter();
+
     @BeforeEach
     public void setup() {
-        LoggerStringWriter.reset();
+        loggerStringWriter.reset();
     }
 
     @AfterEach
     public void tearDown() {
-        LoggerStringWriter.remove();
+        loggerStringWriter.remove();
     }
 
     @Test
@@ -60,7 +61,7 @@ class ServiceTalkTracingThreadContextMapTest {
         tracer.activateSpan(span);
 
         LOGGER.debug("testing logging and MDC");
-        String v = stableAccumulated(1000);
+        String v = loggerStringWriter.stableAccumulated(1000);
         assertContainsMdcPair(v, "traceId=", span.context().toTraceId());
         assertContainsMdcPair(v, "spanId=", span.context().toSpanId());
         assertContainsMdcPair(v, "parentSpanId=", idOrNullAsValue(span.context().parentSpanId()));


### PR DESCRIPTION
Motivation:

We have seen some flakyness in HttpMessageDiscardWatchdogServiceFilterTest that may be related to thread safety for the test log appender. Specifically,
- The sink, a StringWriter, is globally shared so it can be reset by concurrently running tests.
- The underlying StringWriter itself isn't thread safe and it's possible for it to be concurrent written to and read from.

Modifications:

- Make a new (thread safe) StringWriter for each thread. Based on the usage pattern for the LoggerStringWriter methods this should have the effect of having a unique writer per test.
- Make a thread-safe proxy for the StringWriter so it's safe to write and read from concurrently.

Closes https://github.com/apple/servicetalk/issues/2756. (hopefully)