### PR TITLE
loadbalancer: Change generics of LoadBalancerPolicy

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -38,11 +38,9 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         implements LoadBalancerBuilder<ResolvedAddress, C> {
 
     private static final int DEFAULT_LINEAR_SEARCH_SPACE = Integer.MAX_VALUE;
-    private static final LoadBalancingPolicy DEFAULT_LOAD_BALANCING_POLICY =
-            RoundRobinLoadBalancingPolicy.DEFAULT_POLICY;
 
     private final String id;
-    private LoadBalancingPolicy loadBalancingPolicy = DEFAULT_LOAD_BALANCING_POLICY;
+    private LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy = defaultLoadBalancingPolicy();
     private int linearSearchSpace = DEFAULT_LINEAR_SEARCH_SPACE;
 
     @Nullable
@@ -146,5 +144,10 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
                     loadBalancingPolicy.buildSelector(targetResource), connectionFactory, linearSearchSpace,
                     healthCheckConfig);
         }
+    }
+
+    private static <ResolvedAddress, C extends LoadBalancedConnection>
+    LoadBalancingPolicy<ResolvedAddress, C> defaultLoadBalancingPolicy() {
+        return new RoundRobinLoadBalancingPolicy.Builder().build();
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -71,7 +71,8 @@ interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection>
      * @param loadBalancingPolicy the policy to use
      * @return {@code this}
      */
-    LoadBalancerBuilder<ResolvedAddress, C> loadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy);
+    LoadBalancerBuilder<ResolvedAddress, C> loadBalancingPolicy(
+            LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy);
 
     /**
      * This {@link LoadBalancer} may monitor hosts to which connection establishment has failed

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -20,7 +20,7 @@ import io.servicetalk.client.api.LoadBalancedConnection;
 /**
  * Definition of the selector mechanism used for load balancing.
  */
-interface LoadBalancingPolicy {
+interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection> {
     /**
      * The name of the load balancing policy
      * @return the name of the load balancing policy
@@ -32,6 +32,5 @@ interface LoadBalancingPolicy {
      * @param targetResource the name of the target resource, useful for debugging purposes.
      * @return a {@link HostSelector}
      */
-    <ResolvedAddress, C extends LoadBalancedConnection> HostSelector<ResolvedAddress, C>
-    buildSelector(String targetResource);
+    HostSelector<ResolvedAddress, C> buildSelector(String targetResource);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -34,12 +34,8 @@ import javax.annotation.Nullable;
  * - if neither host is healthy, repeat selection process until max-effort.
  * - pick the 'best' host of the two options.
  */
-final class P2CLoadBalancingPolicy implements LoadBalancingPolicy {
-
-    /**
-     * The default P2C load balancing policy.
-     */
-    public static final P2CLoadBalancingPolicy DEFAULT_POLICY = new Builder().build();
+final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
+        implements LoadBalancingPolicy<ResolvedAddress, C> {
 
     private final int maxEffort;
     @Nullable
@@ -51,8 +47,7 @@ final class P2CLoadBalancingPolicy implements LoadBalancingPolicy {
     }
 
     @Override
-    public <ResolvedAddress, C extends LoadBalancedConnection> HostSelector<ResolvedAddress, C>
-    buildSelector(String targetResource) {
+    public HostSelector<ResolvedAddress, C> buildSelector(String targetResource) {
         return new P2CSelector<>(targetResource, maxEffort, random);
     }
 
@@ -99,10 +94,12 @@ final class P2CLoadBalancingPolicy implements LoadBalancingPolicy {
 
         /**
          * Construct an immutable {@link P2CLoadBalancingPolicy}.
+         * @param <ResolvedAddress> the type of the resolved address.
+         * @param <C> the refined type of the {@LoadBalancedConnection}.
          * @return the concrete {@link P2CLoadBalancingPolicy}.
          */
-        P2CLoadBalancingPolicy build() {
-            return new P2CLoadBalancingPolicy(maxEffort, random);
+        public <ResolvedAddress, C extends LoadBalancedConnection> P2CLoadBalancingPolicy<ResolvedAddress, C> build() {
+            return new P2CLoadBalancingPolicy<>(maxEffort, random);
         }
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -24,19 +24,16 @@ import io.servicetalk.client.api.LoadBalancedConnection;
  * from an ordered set. If a host is considered unhealthy it is skipped the next host
  * is selected until a healthy host is found or the entire host set has been exhausted.
  */
-final class RoundRobinLoadBalancingPolicy implements LoadBalancingPolicy {
+final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
+        implements LoadBalancingPolicy<ResolvedAddress, C> {
 
-    /**
-     * The default P2C load balancing policy.
-     */
-    public static final RoundRobinLoadBalancingPolicy DEFAULT_POLICY = new RoundRobinLoadBalancingPolicy();
+    private static final RoundRobinLoadBalancingPolicy<?, ?> DEFAULT_POLICY = new RoundRobinLoadBalancingPolicy<>();
 
     private RoundRobinLoadBalancingPolicy() {
     }
 
     @Override
-    public <ResolvedAddress, C extends LoadBalancedConnection> HostSelector<ResolvedAddress, C>
-    buildSelector(final String targetResource) {
+    public HostSelector<ResolvedAddress, C> buildSelector(final String targetResource) {
         return new RoundRobinSelector<>(targetResource);
     }
 
@@ -52,11 +49,14 @@ final class RoundRobinLoadBalancingPolicy implements LoadBalancingPolicy {
 
         /**
          * Construct the immutable {@link RoundRobinLoadBalancingPolicy}.
+         * @param <ResolvedAddress> the type of the resolved address.
+         * @param <C> the refined type of the {@LoadBalancedConnection}.
          * @return the concrete {@link RoundRobinLoadBalancingPolicy}.
          */
-        public RoundRobinLoadBalancingPolicy build() {
+        public <ResolvedAddress, C extends LoadBalancedConnection> RoundRobinLoadBalancingPolicy<ResolvedAddress, C>
+        build() {
             // Right now there aren't any configurations for round-robin.
-            return DEFAULT_POLICY;
+            return (RoundRobinLoadBalancingPolicy<ResolvedAddress, C>) DEFAULT_POLICY;
         }
     }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -32,7 +32,7 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
 
     @Override
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> loadBalancingPolicy(
-            LoadBalancingPolicy loadBalancingPolicy) {
+            LoadBalancingPolicy<String, TestLoadBalancedConnection> loadBalancingPolicy) {
         throw new IllegalStateException("Cannot set new policy for old round robin");
     }
 


### PR DESCRIPTION
Motivation:

The generic types that represent the resolved address and the real type of the connection are generics to the _method_ of LoadBalancingPolicy.buildSelector. This means the the policy must support all types of addresses and connections making it more difficult to specialize.

Modifications:

Move the generics from the buildSelector method to the LoadBalancerPolicy type itself.