### PR TITLE
loadbalancer: HostSelector can be rebuilt each time the DefaultLoadBalancer gets a host set update

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -47,7 +47,7 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
     }
 
     @Override
-    public boolean isHealthy() {
+    public final boolean isHealthy() {
         return !allUnhealthy(hosts);
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -21,7 +21,6 @@ import io.servicetalk.context.api.ContextMap;
 
 import java.util.List;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
@@ -37,11 +36,11 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
         this.targetResource = requireNonNull(targetResource, "targetResource");
     }
 
-    protected abstract Single<C> selectConnection0(@Nonnull Predicate<C> selector, @Nullable ContextMap context,
+    protected abstract Single<C> selectConnection0(Predicate<C> selector, @Nullable ContextMap context,
                                          boolean forceNewConnectionAndReserve);
 
     @Override
-    public final Single<C> selectConnection(@Nonnull Predicate<C> selector, @Nullable ContextMap context,
+    public final Single<C> selectConnection(Predicate<C> selector, @Nullable ContextMap context,
                                       boolean forceNewConnectionAndReserve) {
         return hosts.isEmpty() ? noHostsFailure() : selectConnection0(selector, context, forceNewConnectionAndReserve);
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -17,8 +17,12 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap;
 
 import java.util.List;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
 import static java.util.Objects.requireNonNull;
@@ -27,17 +31,34 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
         implements HostSelector<ResolvedAddress, C> {
 
     private final String targetResource;
-    BaseHostSelector(final String targetResource) {
+    private final boolean isEmpty;
+    BaseHostSelector(final boolean isEmpty, final String targetResource) {
+        this.isEmpty = isEmpty;
         this.targetResource = requireNonNull(targetResource, "targetResource");
+    }
+
+    protected abstract Single<C> selectConnection0(@Nonnull Predicate<C> selector, @Nullable ContextMap context,
+                                         boolean forceNewConnectionAndReserve);
+
+    @Override
+    public final Single<C> selectConnection(@Nonnull Predicate<C> selector, @Nullable ContextMap context,
+                                      boolean forceNewConnectionAndReserve) {
+        return isEmpty ? noHostsFailure() : selectConnection0(selector, context, forceNewConnectionAndReserve);
     }
 
     protected final String getTargetResource() {
         return targetResource;
     }
 
-    protected final Single<C> noActiveHosts(List<Host<ResolvedAddress, C>> usedHosts) {
+    protected final Single<C> noActiveHostsFailure(List<Host<ResolvedAddress, C>> usedHosts) {
         return failed(Exceptions.StacklessNoActiveHostException.newInstance("Failed to pick an active host for " +
                         getTargetResource() + ". Either all are busy, expired, or unhealthy: " + usedHosts,
                 this.getClass(), "selectConnection(...)"));
+    }
+
+    private Single<C> noHostsFailure() {
+        return failed(Exceptions.StacklessNoAvailableHostException.newInstance(
+                "No hosts are available to connect for " + targetResource + ".",
+                this.getClass(), "selectConnection0(...)"));
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -48,6 +48,8 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
 
     @Override
     public final boolean isHealthy() {
+        // TODO: in the future we may want to make this more of a "are at least X hosts available" question
+        //  so that we can compose a group of selectors into a priority set.
         return !allUnhealthy(hosts);
     }
 
@@ -67,7 +69,6 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
                 this.getClass(), "selectConnection(...)"));
     }
 
-    // This will be faster than `allHealthy` in the typical case since we expect hosts to be healthy most of the time.
     private static <ResolvedAddress, C extends LoadBalancedConnection> boolean allUnhealthy(
             final List<Host<ResolvedAddress, C>> usedHosts) {
         boolean allUnhealthy = !usedHosts.isEmpty();

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -46,10 +46,10 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
     }
 
     @Override
-    public final boolean isHealthy() {
+    public final boolean isUnHealthy() {
         // TODO: in the future we may want to make this more of a "are at least X hosts available" question
         //  so that we can compose a group of selectors into a priority set.
-        return !allUnhealthy(hosts);
+        return allUnhealthy(hosts);
     }
 
     protected final String getTargetResource() {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -464,7 +464,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         Single<C> result = currentHostSelector.selectConnection(selector, context, forceNewConnectionAndReserve);
         if (healthCheckConfig != null) {
             result = result.beforeOnError(exn -> {
-                if (exn instanceof NoActiveHostException && !currentHostSelector.isHealthy()) {
+                if (exn instanceof NoActiveHostException && currentHostSelector.isUnHealthy()) {
                     final long currNextResubscribeTime = nextResubscribeTime;
                     if (currNextResubscribeTime >= 0 &&
                             healthCheckConfig.executor.currentTime(NANOSECONDS) >= currNextResubscribeTime &&
@@ -550,7 +550,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         }
 
         @Override
-        public boolean isHealthy() {
+        public boolean isUnHealthy() {
             return false;
         }
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -25,6 +25,7 @@ import io.servicetalk.concurrent.api.Publisher;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
@@ -141,8 +142,8 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
              Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
              ConnectionFactory<ResolvedAddress, T> connectionFactory) {
             return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
-                    loadBalancingPolicy.buildSelector(targetResource), connectionFactory, linearSearchSpace,
-                    healthCheckConfig);
+                    loadBalancingPolicy.buildSelector(Collections.emptyList(), targetResource), connectionFactory,
+                    linearSearchSpace, healthCheckConfig);
         }
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -60,4 +60,14 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
      * @return the next selector that should be used for host selection.
      */
     HostSelector<ResolvedAddress, C> rebuildWithHosts(@Nonnull List<Host<ResolvedAddress, C>> hosts);
+
+    /**
+     * Whether the load balancer believes itself healthy enough to serve traffic.
+     * <p>
+     * Note that this is both racy and best effort: just because it is healthy doesn't guarantee that
+     * this selector will be able to successfully serve a request or that if unhealthy a request is
+     * guaranteed to fail.
+     * @return whether the load balancer believes itself healthy enough to serve traffic.
+     */
+    boolean isHealthy();
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -21,7 +21,6 @@ import io.servicetalk.context.api.ContextMap;
 
 import java.util.List;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -47,7 +46,7 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
      * This method will be called concurrently with other selectConnection calls and
      * hostSetChanged calls and must be thread safe under those conditions.
      */
-    Single<C> selectConnection(@Nonnull Predicate<C> selector, @Nullable ContextMap context,
+    Single<C> selectConnection(Predicate<C> selector, @Nullable ContextMap context,
                                boolean forceNewConnectionAndReserve);
 
     /**
@@ -59,7 +58,7 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
      * @param hosts the new list of {@link Host}s the returned selector should choose from.
      * @return the next selector that should be used for host selection.
      */
-    HostSelector<ResolvedAddress, C> rebuildWithHosts(@Nonnull List<Host<ResolvedAddress, C>> hosts);
+    HostSelector<ResolvedAddress, C> rebuildWithHosts(List<Host<ResolvedAddress, C>> hosts);
 
     /**
      * Whether the load balancer believes itself healthy enough to serve traffic.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -52,7 +52,7 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
     /**
      * Generate another HostSelector using the provided host list.
      * <p>
-     * This method is will be called when the host set is updated and provides a way for the
+     * This method will be called when the host set is updated and provides a way for the
      * HostSelector to rebuild any data structures necessary. Note that the method can return
      * {@code this} or a new selector depending on the convenience of implementation.
      * @param hosts the new list of {@link Host}s the returned selector should choose from.
@@ -61,12 +61,12 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
     HostSelector<ResolvedAddress, C> rebuildWithHosts(List<Host<ResolvedAddress, C>> hosts);
 
     /**
-     * Whether the load balancer believes itself healthy enough to serve traffic.
+     * Whether the load balancer believes itself to unhealthy for serving traffic.
      * <p>
-     * Note that this is both racy and best effort: just because it is healthy doesn't guarantee that
-     * this selector will be able to successfully serve a request or that if unhealthy a request is
-     * guaranteed to fail.
-     * @return whether the load balancer believes itself healthy enough to serve traffic.
+     * Note that this is both racy and best effort: just because a {@link HostSelector} is
+     * unhealthy doesn't guarantee that a request will fail nor does a healthy status indicate
+     * that this selector is guaranteed to successfully serve a request.
+     * @return whether the load balancer believes itself unhealthy enough and unlikely to successfully serve traffic.
      */
-    boolean isHealthy();
+    boolean isUnHealthy();
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -17,20 +17,26 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
 
+import java.util.List;
+import javax.annotation.Nonnull;
+
 /**
  * Definition of the selector mechanism used for load balancing.
  */
 interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection> {
     /**
      * The name of the load balancing policy
+     *
      * @return the name of the load balancing policy
      */
     String name();
 
     /**
      * Construct a {@link HostSelector}.
+     * @param hosts          the set of {@link Host}s to select from.
      * @param targetResource the name of the target resource, useful for debugging purposes.
      * @return a {@link HostSelector}
      */
-    HostSelector<ResolvedAddress, C> buildSelector(String targetResource);
+    HostSelector<ResolvedAddress, C> buildSelector(@Nonnull List<Host<ResolvedAddress, C>> hosts,
+                                                   String targetResource);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -18,7 +18,6 @@ package io.servicetalk.loadbalancer;
 import io.servicetalk.client.api.LoadBalancedConnection;
 
 import java.util.List;
-import javax.annotation.Nonnull;
 
 /**
  * Definition of the selector mechanism used for load balancing.
@@ -37,6 +36,5 @@ interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
      * @param targetResource the name of the target resource, useful for debugging purposes.
      * @return a {@link HostSelector}
      */
-    HostSelector<ResolvedAddress, C> buildSelector(@Nonnull List<Host<ResolvedAddress, C>> hosts,
-                                                   String targetResource);
+    HostSelector<ResolvedAddress, C> buildSelector(List<Host<ResolvedAddress, C>> hosts, String targetResource);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -20,7 +20,6 @@ import io.servicetalk.client.api.LoadBalancer;
 
 import java.util.List;
 import java.util.Random;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -49,8 +48,7 @@ final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnec
     }
 
     @Override
-    public HostSelector<ResolvedAddress, C> buildSelector(
-            @Nonnull List<Host<ResolvedAddress, C>> hosts, String targetResource) {
+    public HostSelector<ResolvedAddress, C> buildSelector(List<Host<ResolvedAddress, C>> hosts, String targetResource) {
         return new P2CSelector<>(hosts, targetResource, maxEffort, random);
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -18,7 +18,9 @@ package io.servicetalk.loadbalancer;
 import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.client.api.LoadBalancer;
 
+import java.util.List;
 import java.util.Random;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -47,8 +49,9 @@ final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnec
     }
 
     @Override
-    public HostSelector<ResolvedAddress, C> buildSelector(String targetResource) {
-        return new P2CSelector<>(targetResource, maxEffort, random);
+    public HostSelector<ResolvedAddress, C> buildSelector(
+            @Nonnull List<Host<ResolvedAddress, C>> hosts, String targetResource) {
+        return new P2CSelector<>(hosts, targetResource, maxEffort, random);
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
@@ -46,7 +46,7 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
 
     P2CSelector(@Nonnull List<Host<ResolvedAddress, C>> hosts,
                 final String targetResource, final int maxEffort, @Nullable final Random random) {
-        super(hosts.isEmpty(), targetResource);
+        super(hosts, targetResource);
         this.hosts = hosts;
         this.maxEffort = maxEffort;
         this.random = random;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -44,7 +43,7 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
     private final int maxEffort;
     private final List<Host<ResolvedAddress, C>> hosts;
 
-    P2CSelector(@Nonnull List<Host<ResolvedAddress, C>> hosts,
+    P2CSelector(List<Host<ResolvedAddress, C>> hosts,
                 final String targetResource, final int maxEffort, @Nullable final Random random) {
         super(hosts, targetResource);
         this.hosts = hosts;
@@ -53,15 +52,13 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
     }
 
     @Override
-    public HostSelector<ResolvedAddress, C> rebuildWithHosts(@Nonnull List<Host<ResolvedAddress, C>> hosts) {
+    public HostSelector<ResolvedAddress, C> rebuildWithHosts(List<Host<ResolvedAddress, C>> hosts) {
         return new P2CSelector<>(hosts, getTargetResource(), maxEffort, random);
     }
 
     @Override
-    protected Single<C> selectConnection0(
-            @Nonnull Predicate<C> selector,
-            @Nullable ContextMap context,
-            boolean forceNewConnectionAndReserve) {
+    protected Single<C> selectConnection0(Predicate<C> selector, @Nullable ContextMap context,
+                                          boolean forceNewConnectionAndReserve) {
         final int size = hosts.size();
         switch (size) {
             case 0:

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -28,6 +28,7 @@ import io.servicetalk.transport.api.ExecutionStrategy;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import javax.annotation.Nullable;
@@ -95,7 +96,8 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
             final String targetResource,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-        return new DefaultLoadBalancer<>(id, targetResource, eventPublisher, new RoundRobinSelector<>(targetResource),
+        return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
+                new RoundRobinSelector<>(Collections.emptyList(), targetResource),
                 connectionFactory, linearSearchSpace, healthCheckConfig);
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -17,6 +17,9 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
 
+import java.util.List;
+import javax.annotation.Nonnull;
+
 /**
  * A round-robin load balancing policy.
  *
@@ -33,8 +36,9 @@ final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     }
 
     @Override
-    public HostSelector<ResolvedAddress, C> buildSelector(final String targetResource) {
-        return new RoundRobinSelector<>(targetResource);
+    public HostSelector<ResolvedAddress, C>
+    buildSelector(@Nonnull final List<Host<ResolvedAddress, C>> hosts, final String targetResource) {
+        return new RoundRobinSelector<>(hosts, targetResource);
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -18,7 +18,6 @@ package io.servicetalk.loadbalancer;
 import io.servicetalk.client.api.LoadBalancedConnection;
 
 import java.util.List;
-import javax.annotation.Nonnull;
 
 /**
  * A round-robin load balancing policy.
@@ -37,7 +36,7 @@ final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
 
     @Override
     public HostSelector<ResolvedAddress, C>
-    buildSelector(@Nonnull final List<Host<ResolvedAddress, C>> hosts, final String targetResource) {
+    buildSelector(final List<Host<ResolvedAddress, C>> hosts, final String targetResource) {
         return new RoundRobinSelector<>(hosts, targetResource);
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -39,7 +39,7 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
 
     private RoundRobinSelector(final AtomicInteger index, final List<Host<ResolvedAddress, C>> usedHosts,
                                final String targetResource) {
-        super(usedHosts.isEmpty(), targetResource);
+        super(usedHosts, targetResource);
         this.index = index;
         this.usedHosts = usedHosts;
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
@@ -49,9 +49,19 @@ final class SequentialExecutor implements Executor {
 
     private final ExceptionHandler exceptionHandler;
     private final AtomicReference<Cell> tail = new AtomicReference<>();
+    @Nullable
+    private Thread currentDrainingThread;
 
     SequentialExecutor(final ExceptionHandler exceptionHandler) {
         this.exceptionHandler = requireNonNull(exceptionHandler, "exceptionHandler");
+    }
+
+    public boolean isCurrentThreadDraining() {
+        // Even though `currentDrainingThread` is not a volatile field this is thread safe:
+        // the only way that `currentDrainingThread` will ever equal this thread, even if
+        // we get a stale value, is if _this_ thread set it.
+        // The null check is just an optimization: it's really the second check that matters.
+        return currentDrainingThread != null && currentDrainingThread == Thread.currentThread();
     }
 
     @Override
@@ -72,6 +82,8 @@ final class SequentialExecutor implements Executor {
     }
 
     private void drain(Cell next) {
+        final Thread thisThread = Thread.currentThread();
+        currentDrainingThread = thisThread;
         for (;;) {
             assert next != null;
             try {
@@ -85,10 +97,14 @@ final class SequentialExecutor implements Executor {
             if (n == null) {
                 // There doesn't seem to be another element linked. See if it was the tail and if so terminate draining.
                 // Note that a successful CAS established a happens-before relationship with future draining threads.
+                // Note that we also have to clear the draining thread before the CAS to prevent races.
+                currentDrainingThread = null;
                 if (tail.compareAndSet(next, null)) {
                     break;
                 }
-                // next isn't the tail but the link hasn't resolved: we must poll until it does.
+                // Next isn't the tail but the link hasn't resolved: we must re-set the draining thread and poll until
+                // it does resolve then we can keep on trucking.
+                currentDrainingThread = thisThread;
                 while ((n = next.next) == null) {
                     // Still not resolved: yield and then try again.
                     Thread.yield();

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -16,20 +16,20 @@
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.context.api.ContextMap;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Single.succeeded;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static io.servicetalk.concurrent.api.Single.failed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
@@ -42,7 +42,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
     }
 
     @Test
-    void hostUpdatesRebuildsSelector() {
+    void newHostsRebuildsSelector() throws Exception {
         // necessary because we're making a new lb.
         serviceDiscoveryPublisher.onComplete();
 
@@ -51,8 +51,46 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         lb = newTestLoadBalancer();
 
         sendServiceDiscoveryEvents(upEvent("address-1"));
+        // We should have rebuilt the LB due to a host update.
+        assertEquals(1, lbPolicy.rebuilds);
+    }
+
+    @Test
+    void removingHostsRebuildsSelector() throws Exception {
+        // necessary because we're making a new lb.
+        serviceDiscoveryPublisher.onComplete();
+
+        final TestLoadBalancerPolicy lbPolicy = new TestLoadBalancerPolicy();
+        loadBalancingPolicy = lbPolicy;
+        lb = newTestLoadBalancer();
+
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+        // We should have rebuilt the LB due to a host update.
+        assertEquals(1, lbPolicy.rebuilds);
+        // take it back down immediate. No connections means we close in the sd event.
         sendServiceDiscoveryEvents(downEvent("address-1"));
-        verify(lbPolicy.hostSelector, times(2)).rebuildWithHosts(ArgumentMatchers.anyList());
+        assertEquals(2, lbPolicy.rebuilds);
+    }
+
+    @Test
+    void lazyHostExpirationRebuildsSelector() throws Exception {
+        // necessary because we're making a new lb.
+        serviceDiscoveryPublisher.onComplete();
+
+        final TestLoadBalancerPolicy lbPolicy = new TestLoadBalancerPolicy();
+        loadBalancingPolicy = lbPolicy;
+        lb = newTestLoadBalancer();
+
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+        // We should have rebuilt the LB due to a host update.
+        assertEquals(1, lbPolicy.rebuilds);
+        // should be an expired but not gone yet because a connection remains.
+        TestLoadBalancedConnection cxn = lb.selectConnection(any(), null).toFuture().get();
+        sendServiceDiscoveryEvents(downEvent("address-1"));
+        assertEquals(1, lbPolicy.rebuilds);
+        // Close the connection and we should see a rebuild.
+        cxn.closeAsync().subscribe();
+        assertEquals(2, lbPolicy.rebuilds);
     }
 
     @Override
@@ -75,17 +113,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
     private static class TestLoadBalancerPolicy implements LoadBalancingPolicy<String, TestLoadBalancedConnection> {
 
-        HostSelector<String, TestLoadBalancedConnection> hostSelector;
-
-        TestLoadBalancerPolicy() {
-            TestLoadBalancedConnection connection = TestLoadBalancedConnection.mockConnection("address");
-            hostSelector = mock(HostSelector.class);
-            when(hostSelector.selectConnection(ArgumentMatchers.any(), ArgumentMatchers.any(),
-                    ArgumentMatchers.anyBoolean()))
-                    .thenReturn(succeeded(connection));
-            when(hostSelector.rebuildWithHosts(ArgumentMatchers.anyList()))
-                    .thenReturn(hostSelector);
-        }
+        int rebuilds;
 
         @Override
         public String name() {
@@ -95,7 +123,36 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         @Override
         public HostSelector<String, TestLoadBalancedConnection> buildSelector(
                 @Nonnull List<Host<String, TestLoadBalancedConnection>> hosts, String targetResource) {
-            return hostSelector;
+            return new TestSelector(hosts);
+        }
+
+        private class TestSelector implements HostSelector<String, TestLoadBalancedConnection> {
+
+            private final List<Host<String, TestLoadBalancedConnection>> hosts;
+
+            TestSelector(final List<Host<String, TestLoadBalancedConnection>> hosts) {
+                this.hosts = hosts;
+            }
+
+            @Override
+            public Single<TestLoadBalancedConnection> selectConnection(
+                    @Nonnull Predicate<TestLoadBalancedConnection> selector, @Nullable ContextMap context,
+                    boolean forceNewConnectionAndReserve) {
+                return hosts.isEmpty() ? failed(new IllegalStateException("shouldn't be empty"))
+                        : hosts.get(0).newConnection(selector, false, context);
+            }
+
+            @Override
+            public HostSelector<String, TestLoadBalancedConnection> rebuildWithHosts(
+                    @Nonnull List<Host<String, TestLoadBalancedConnection>> hosts) {
+                rebuilds++;
+                return new TestSelector(hosts);
+            }
+
+            @Override
+            public boolean isHealthy() {
+                return true;
+            }
         }
     }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -149,8 +149,8 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
             }
 
             @Override
-            public boolean isHealthy() {
-                return true;
+            public boolean isUnHealthy() {
+                return false;
             }
         }
     }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
@@ -122,7 +121,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
         @Override
         public HostSelector<String, TestLoadBalancedConnection> buildSelector(
-                @Nonnull List<Host<String, TestLoadBalancedConnection>> hosts, String targetResource) {
+                List<Host<String, TestLoadBalancedConnection>> hosts, String targetResource) {
             return new TestSelector(hosts);
         }
 
@@ -136,7 +135,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
             @Override
             public Single<TestLoadBalancedConnection> selectConnection(
-                    @Nonnull Predicate<TestLoadBalancedConnection> selector, @Nullable ContextMap context,
+                    Predicate<TestLoadBalancedConnection> selector, @Nullable ContextMap context,
                     boolean forceNewConnectionAndReserve) {
                 return hosts.isEmpty() ? failed(new IllegalStateException("shouldn't be empty"))
                         : hosts.get(0).newConnection(selector, false, context);
@@ -144,7 +143,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
             @Override
             public HostSelector<String, TestLoadBalancedConnection> rebuildWithHosts(
-                    @Nonnull List<Host<String, TestLoadBalancedConnection>> hosts) {
+                    List<Host<String, TestLoadBalancedConnection>> hosts) {
                 rebuilds++;
                 return new TestSelector(hosts);
             }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.TestPublisher;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
+
+    private LoadBalancingPolicy<String, TestLoadBalancedConnection> loadBalancingPolicy =
+            new P2CLoadBalancingPolicy.Builder().build();
+
+    @Override
+    protected boolean eagerConnectionShutdown() {
+        return false;
+    }
+
+    @Test
+    void hostUpdatesRebuildsSelector() {
+        // necessary because we're making a new lb.
+        serviceDiscoveryPublisher.onComplete();
+
+        final TestLoadBalancerPolicy lbPolicy = new TestLoadBalancerPolicy();
+        loadBalancingPolicy = lbPolicy;
+        lb = newTestLoadBalancer();
+
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+        sendServiceDiscoveryEvents(downEvent("address-1"));
+        verify(lbPolicy.hostSelector, times(2)).rebuildWithHosts(ArgumentMatchers.anyList());
+    }
+
+    @Override
+    protected final TestableLoadBalancer<String, TestLoadBalancedConnection> newTestLoadBalancer(
+            final TestPublisher<Collection<ServiceDiscovererEvent<String>>> serviceDiscoveryPublisher,
+            final LoadBalancerTest.DelegatingConnectionFactory connectionFactory) {
+        return (TestableLoadBalancer<String, TestLoadBalancedConnection>)
+                baseLoadBalancerBuilder()
+                        .loadBalancingPolicy(loadBalancingPolicy)
+                        .healthCheckFailedConnectionsThreshold(-1)
+                        .backgroundExecutor(testExecutor)
+                        .build()
+                        .newLoadBalancer(serviceDiscoveryPublisher, connectionFactory, "test-service");
+    }
+
+    private LoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
+        return LoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
+                .loadBalancingPolicy(new P2CLoadBalancingPolicy.Builder().build());
+    }
+
+    private static class TestLoadBalancerPolicy implements LoadBalancingPolicy<String, TestLoadBalancedConnection> {
+
+        HostSelector<String, TestLoadBalancedConnection> hostSelector;
+
+        TestLoadBalancerPolicy() {
+            TestLoadBalancedConnection connection = TestLoadBalancedConnection.mockConnection("address");
+            hostSelector = mock(HostSelector.class);
+            when(hostSelector.selectConnection(ArgumentMatchers.any(), ArgumentMatchers.any(),
+                    ArgumentMatchers.anyBoolean()))
+                    .thenReturn(succeeded(connection));
+            when(hostSelector.rebuildWithHosts(ArgumentMatchers.anyList()))
+                    .thenReturn(hostSelector);
+        }
+
+        @Override
+        public String name() {
+            return "test-selector";
+        }
+
+        @Override
+        public HostSelector<String, TestLoadBalancedConnection> buildSelector(
+                @Nonnull List<Host<String, TestLoadBalancedConnection>> hosts, String targetResource) {
+            return hostSelector;
+        }
+    }
+}

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LoadBalancerTestScaffold.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LoadBalancerTestScaffold.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.ExecutorExtension;
+import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
+import io.servicetalk.concurrent.api.SequentialPublisherSubscriberFunction;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.TestExecutor;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.concurrent.api.TestSubscription;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;
+import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.EXPIRED;
+import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.UNAVAILABLE;
+import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
+import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitely;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+abstract class LoadBalancerTestScaffold {
+
+    @RegisterExtension
+    final ExecutorExtension<TestExecutor> executor = ExecutorExtension.withTestExecutor();
+
+    final List<TestLoadBalancedConnection> connectionsCreated = new CopyOnWriteArrayList<>();
+    final Queue<Runnable> connectionRealizers = new ConcurrentLinkedQueue<>();
+    final SequentialPublisherSubscriberFunction<Collection<ServiceDiscovererEvent<String>>>
+            sequentialPublisherSubscriberFunction = new SequentialPublisherSubscriberFunction<>();
+    final TestPublisher<Collection<ServiceDiscovererEvent<String>>> serviceDiscoveryPublisher =
+            new TestPublisher.Builder<Collection<ServiceDiscovererEvent<String>>>()
+                    .sequentialSubscribers(sequentialPublisherSubscriberFunction)
+                    .build();
+    LoadBalancerTest.DelegatingConnectionFactory connectionFactory =
+            new LoadBalancerTest.DelegatingConnectionFactory(this::newRealizedConnectionSingle);
+
+    @Nullable
+    TestableLoadBalancer<String, TestLoadBalancedConnection> lb;
+    @Nullable
+    TestExecutor testExecutor;
+
+    protected abstract boolean eagerConnectionShutdown();
+
+    @BeforeEach
+    void initialize() {
+        testExecutor = executor.executor();
+        lb = newTestLoadBalancer();
+        connectionsCreated.clear();
+        connectionRealizers.clear();
+    }
+
+    @AfterEach
+    void closeLoadBalancer() throws Exception {
+        awaitIndefinitely(lb.closeAsync());
+        awaitIndefinitely(lb.onClose());
+
+        TestSubscription subscription = new TestSubscription();
+        serviceDiscoveryPublisher.onSubscribe(subscription);
+        assertTrue(subscription.isCancelled());
+
+        connectionsCreated.forEach(cnx -> {
+            try {
+                awaitIndefinitely(cnx.onClose());
+            } catch (final Exception e) {
+                throw new RuntimeException("Connection: " + cnx + " didn't close properly", e);
+            }
+        });
+    }
+
+    final TestableLoadBalancer<String, TestLoadBalancedConnection> newTestLoadBalancer() {
+        return newTestLoadBalancer(serviceDiscoveryPublisher, connectionFactory);
+    }
+
+    abstract TestableLoadBalancer<String, TestLoadBalancedConnection> newTestLoadBalancer(
+            TestPublisher<Collection<ServiceDiscovererEvent<String>>> serviceDiscoveryPublisher,
+            LoadBalancerTest.DelegatingConnectionFactory connectionFactory);
+
+    void sendServiceDiscoveryEvents(final ServiceDiscovererEvent... events) {
+        sendServiceDiscoveryEvents(serviceDiscoveryPublisher, events);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void sendServiceDiscoveryEvents(
+            TestPublisher<Collection<ServiceDiscovererEvent<String>>> serviceDiscoveryPublisher,
+            final ServiceDiscovererEvent... events) {
+        serviceDiscoveryPublisher.onNext(Arrays.asList(events));
+    }
+
+    ServiceDiscovererEvent upEvent(final String address) {
+        return new DefaultServiceDiscovererEvent<>(address, AVAILABLE);
+    }
+
+    ServiceDiscovererEvent downEvent(final String address) {
+        return new DefaultServiceDiscovererEvent<>(address, eagerConnectionShutdown() ? UNAVAILABLE : EXPIRED);
+    }
+
+    ServiceDiscovererEvent downEvent(final String address, ServiceDiscovererEvent.Status status) {
+        return new DefaultServiceDiscovererEvent<>(address, status);
+    }
+
+    Single<TestLoadBalancedConnection> newRealizedConnectionSingle(final String address) {
+        return newRealizedConnectionSingle(address, emptyAsyncCloseable());
+    }
+
+    Single<TestLoadBalancedConnection> newRealizedConnectionSingle(final String address,
+                                                                           final ListenableAsyncCloseable closeable) {
+        return succeeded(newConnection(address, closeable));
+    }
+
+    TestLoadBalancedConnection newConnection(final String address) {
+        return newConnection(address, emptyAsyncCloseable());
+    }
+
+    private TestLoadBalancedConnection newConnection(final String address, final ListenableAsyncCloseable closeable) {
+        final TestLoadBalancedConnection cnx = TestLoadBalancedConnection.mockConnection(address, closeable);
+        connectionsCreated.add(cnx);
+        return cnx;
+    }
+
+    @SafeVarargs
+    static <T> void assertConnectionCount(
+            Iterable<T> addresses, Map.Entry<String, Integer>... addressAndConnCount) {
+        @SuppressWarnings("unchecked")
+        final Matcher<? super T>[] args = (Matcher<? super T>[]) Arrays.stream(addressAndConnCount)
+                .map(ac -> both(hasProperty("key", is(ac.getKey())))
+                        .and(hasProperty("value", hasSize(ac.getValue()))))
+                .collect(Collectors.toList())
+                .toArray(new Matcher[] {});
+        final Matcher<Iterable<? extends T>> iterableMatcher =
+                addressAndConnCount.length == 0 ? emptyIterable() : contains(args);
+        assertThat(addresses, iterableMatcher);
+    }
+
+    <T> void assertAddresses(Iterable<T> addresses, String... address) {
+        @SuppressWarnings("unchecked")
+        final Matcher<? super T>[] args = (Matcher<? super T>[]) Arrays.stream(address)
+                .map(a -> hasProperty("key", is(a)))
+                .collect(Collectors.toList())
+                .toArray(new Matcher[] {});
+        final Matcher<Iterable<? extends T>> iterableMatcher =
+                address.length == 0 ? emptyIterable() : contains(args);
+        assertThat(addresses, iterableMatcher);
+    }
+
+    Map.Entry<String, Integer> connectionsCount(String addr, int count) {
+        return new AbstractMap.SimpleImmutableEntry<>(addr, count);
+    }
+
+    void assertSelectThrows(Matcher<Throwable> matcher) {
+        Exception e = assertThrows(ExecutionException.class, () -> lb.selectConnection(any(), null).toFuture().get());
+        assertThat(e.getCause(), matcher);
+    }
+
+    static <T> Predicate<T> any() {
+        return __ -> true;
+    }
+}


### PR DESCRIPTION
Motivation:

For algorithms like weighted round robin and random we need to
build some data structures for each unique host set.
    
Modifications:

- Add a `.rebuild(List<Host>)` method to the `HostSelector`
  interface. This lets a host potentially rebuild data structures it
  needs to properly balance but only when there is a host set update.
- Add a `.isHealthy()` method to `HostSelector`. This cleaned up
  some questions about which host list is used and may also be
  helpful for future composition of selectors.
- Cleanup some thread safety considerations in DefaultLoadBalancer.