### PR TITLE
Additional fix for IPv6-derived SNI hostnames

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -120,13 +120,13 @@ final class StreamingConnectionFactory {
         return config;
     }
 
-    private static String toHostAddress(final InetAddress address) {
+    static String toHostAddress(final InetAddress address) {
         final String hostAddress = address.getHostAddress();
-        // Replace colons with dots to satisfy SNIHostName validation
-        return address instanceof Inet6Address ? hostAddress.replace(':', '.') : hostAddress;
+        // Replace colons with dots, and percentages with hyphens, to satisfy SNIHostName validation
+        return address instanceof Inet6Address ? hostAddress.replace(':', '.').replace('%', '-') : hostAddress;
     }
 
-    private static boolean isValidSniHostname(String peerHost) {
+    static boolean isValidSniHostname(String peerHost) {
         try {
             new SNIHostName(peerHost);
             return true;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingConnectionFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingConnectionFactoryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2018-2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StreamingConnectionFactoryTest {
+    static Stream<InetAddress> addresses() throws Exception {
+        Stream.Builder<InetAddress> builder = Stream.builder();
+        builder.add(InetAddress.getLoopbackAddress());
+        builder.add(InetAddress.getLocalHost());
+        builder.add(InetAddress.getByAddress(new byte[4]));
+        builder.add(InetAddress.getByAddress(new byte[16]));
+        builder.add(InetAddress.getByAddress(null, new byte[16]));
+        builder.add(Inet6Address.getByAddress(null, new byte[16], 0));
+        builder.add(Inet6Address.getByAddress("localhost", new byte[16], 0));
+        builder.add(Inet6Address.getByAddress("local_host", new byte[16], 0));
+
+        Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
+        addNetworkInterfaceAddresses(nifs, builder);
+        return builder.build();
+    }
+
+    private static void addNetworkInterfaceAddresses(
+            Enumeration<NetworkInterface> nifs, Stream.Builder<InetAddress> builder) {
+        while (nifs.hasMoreElements()) {
+            NetworkInterface nif = nifs.nextElement();
+            Enumeration<InetAddress> inetAddresses = nif.getInetAddresses();
+            while (inetAddresses.hasMoreElements()) {
+                builder.add(inetAddresses.nextElement());
+            }
+            addNetworkInterfaceAddresses(nif.getSubInterfaces(), builder);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("addresses")
+    void mustConvertInetAddressesToValidHostnames(InetAddress address) throws Exception {
+        String hostAddress = StreamingConnectionFactory.toHostAddress(address);
+        assertTrue(StreamingConnectionFactory.isValidSniHostname(hostAddress), hostAddress);
+    }
+}


### PR DESCRIPTION
Motivation:
PR #2575 replaced colons with dots, but we may also see percentage-sign characters – `%` – in the IPv6 text representation, which would give us errors like the following:

```
java.security.cert.CertificateException: Illegal given domain name: localhost-0.0.0.0.0.0.0.0%0
	at java.base/sun.security.util.HostnameChecker.matchDNS(HostnameChecker.java:193)
	at java.base/sun.security.util.HostnameChecker.match(HostnameChecker.java:103)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:455)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:429)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:283)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:141)
	at io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.checkServerTrusted(EnhancingX509ExtendedTrustManager.java:69)
	...
Caused by: java.lang.IllegalArgumentException: Contains non-LDH ASCII characters
	at java.base/java.net.IDN.toASCIIInternal(IDN.java:296)
	at java.base/java.net.IDN.toASCII(IDN.java:122)
	at java.base/javax.net.ssl.SNIHostName.<init>(SNIHostName.java:99)
	at java.base/sun.security.util.HostnameChecker.matchDNS(HostnameChecker.java:191)
	... 36 more
```

Modifications:
Add an additional `replace(char, char)` call, to replace the colons with underscores. The `replace(char, char)` method is well-optimised in the JDK, so I don't think we can do better with a single loop over an extracted char-array.

Tests were added using a variety of synthetic inet addresses, and all available host addresses, verifying that they can all be converted to valid SNI hostnames.

Result:
Users see expected `CertificateException`: No subject alternative DNS name matching <...> found.