### PR TITLE
loadbalancer: fix observer name pattern

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -46,6 +46,11 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
     }
 
     @Override
+    public final int hostSetSize() {
+        return hosts.size();
+    }
+
+    @Override
     public final boolean isUnHealthy() {
         // TODO: in the future we may want to make this more of a "are at least X hosts available" question
         //  so that we can compose a group of selectors into a priority set.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -69,4 +69,11 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
      * @return whether the load balancer believes itself unhealthy enough and unlikely to successfully serve traffic.
      */
     boolean isUnHealthy();
+
+    /**
+     * The size of the host candidate pool for this host selector.
+     * Note that this is primarily for observability purposes.
+     * @return the size of the host candidate pool for this host selector.
+     */
+    int hostSetSize();
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -36,19 +36,23 @@ interface LoadBalancerObserver<ResolvedAddress> {
     /**
      * Callback for when connection selection fails due to no hosts being available.
      */
-    void noHostsAvailable();
+    void onNoHostsAvailable();
 
     /**
      * Callback for monitoring the changes due to a service discovery update.
      */
-    void serviceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events,
-                               int oldHostSetSize, int newHostSetSize);
+    void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events,
+                                 int oldHostSetSize, int newHostSetSize);
 
     /**
      * Callback for when connection selection fails due to all hosts being inactive.
      */
-    void noActiveHostsAvailable(int hostSetSize, NoActiveHostException exn);
+    void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exn);
 
+    /**
+     * An observer for {@link Host} events.
+     * @param <ResolvedAddress> the type of the resolved address.
+     */
     interface HostObserver<ResolvedAddress> {
 
         /**
@@ -56,45 +60,45 @@ interface LoadBalancerObserver<ResolvedAddress> {
          * @param address the resolved address.
          * @param connectionCount the number of active connections for the host.
          */
-        void hostMarkedExpired(ResolvedAddress address, int connectionCount);
+        void onHostMarkedExpired(ResolvedAddress address, int connectionCount);
 
         /**
          * Callback for when a host is removed by service discovery.
          * @param address the resolved address.
          * @param connectionCount the number of connections that were associated with the host.
          */
-        void activeHostRemoved(ResolvedAddress address, int connectionCount);
+        void onActiveHostRemoved(ResolvedAddress address, int connectionCount);
 
         /**
          * Callback for when an expired host is returned to an active state.
          * @param address the resolved address.
          * @param connectionCount the number of active connections when the host was revived.
          */
-        void expiredHostRevived(ResolvedAddress address, int connectionCount);
+        void onExpiredHostRevived(ResolvedAddress address, int connectionCount);
 
         /**
          * Callback for when an expired host is removed.
          * @param address the resolved address.
          */
-        void expiredHostRemoved(ResolvedAddress address);
+        void onExpiredHostRemoved(ResolvedAddress address);
 
         /**
          * Callback for when a host is created.
          * @param address the resolved address.
          */
-        void hostCreated(ResolvedAddress address);
+        void onHostCreated(ResolvedAddress address);
 
         /**
          * Callback for when a {@link Host} transitions from healthy to unhealthy.
          * @param address the resolved address.
          * @param cause the most recent cause of the transition.
          */
-        void hostMarkedUnhealthy(ResolvedAddress address, @Nullable Throwable cause);
+        void onHostMarkedUnhealthy(ResolvedAddress address, @Nullable Throwable cause);
 
         /**
          * Callback for when a {@link Host} transitions from unhealthy to healthy.
          * @param address the resolved address.
          */
-        void hostRevived(ResolvedAddress address);
+        void onHostRevived(ResolvedAddress address);
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
@@ -34,18 +34,18 @@ final class NoopLoadBalancerObserver<ResolvedAddress> implements LoadBalancerObs
     }
 
     @Override
-    public void noHostsAvailable() {
+    public void onNoHostsAvailable() {
         // noop
     }
 
     @Override
-    public void noActiveHostsAvailable(int hostSetSize, NoActiveHostException exn) {
+    public void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exn) {
         // noop
     }
 
     @Override
-    public void serviceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events,
-                                      int oldHostSetSize, int newHostSetSize) {
+    public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events,
+                                        int oldHostSetSize, int newHostSetSize) {
         // noop
     }
 
@@ -58,37 +58,37 @@ final class NoopLoadBalancerObserver<ResolvedAddress> implements LoadBalancerObs
         }
 
         @Override
-        public void hostMarkedExpired(ResolvedAddress resolvedAddress, int connectionCount) {
+        public void onHostMarkedExpired(ResolvedAddress resolvedAddress, int connectionCount) {
             // noop
         }
 
         @Override
-        public void expiredHostRemoved(ResolvedAddress resolvedAddress) {
+        public void onExpiredHostRemoved(ResolvedAddress resolvedAddress) {
             // noop
         }
 
         @Override
-        public void expiredHostRevived(ResolvedAddress resolvedAddress, int connectionCount) {
+        public void onExpiredHostRevived(ResolvedAddress resolvedAddress, int connectionCount) {
             // noop
         }
 
         @Override
-        public void activeHostRemoved(ResolvedAddress resolvedAddress, int connectionCount) {
+        public void onActiveHostRemoved(ResolvedAddress resolvedAddress, int connectionCount) {
             // noop
         }
 
         @Override
-        public void hostCreated(ResolvedAddress resolvedAddress) {
+        public void onHostCreated(ResolvedAddress resolvedAddress) {
             // noop
         }
 
         @Override
-        public void hostMarkedUnhealthy(ResolvedAddress address, Throwable cause) {
+        public void onHostMarkedUnhealthy(ResolvedAddress address, Throwable cause) {
             // noop
         }
 
         @Override
-        public void hostRevived(ResolvedAddress address) {
+        public void onHostRevived(ResolvedAddress address) {
             // noop
         }
     }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -152,6 +152,11 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
             public boolean isUnHealthy() {
                 return false;
             }
+
+            @Override
+            public int hostSetSize() {
+                return hosts.size();
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation:

Most observers have methods that start with 'on' for event methods. That didn't happen with LoadBalancerObserver.

Modifications:

- Fix the observer method names.
- Use the `onNoActiveHostsAvailable` event.