### PR TITLE
Revert grpc-java back 1.59.1 -> 1.56.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -79,6 +79,6 @@ spotbugsPluginVersion=5.0.13
 
 apacheDirectoryServerVersion=1.5.7
 commonsLangVersion=2.6
-grpcVersion=1.59.1
+grpcVersion=1.56.1
 javaxAnnotationsApiVersion=1.3.5
 jsonUnitVersion=2.38.0


### PR DESCRIPTION
Motivation:

To validate it works as expected with Netty 4.1.103.Final. This is a test dependency anyway.