### PR TITLE
loadbalancer: fix NormalizedTimeSourceExecutor to work with units other than nanos

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutor.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutor.java
@@ -27,15 +27,16 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  */
 final class NormalizedTimeSourceExecutor extends DelegatingExecutor {
 
-    private final long offset;
+    private final long offsetNanos;
 
     NormalizedTimeSourceExecutor(final Executor delegate) {
         super(delegate);
-        offset = delegate.currentTime(NANOSECONDS);
+        offsetNanos = delegate.currentTime(NANOSECONDS);
     }
 
     @Override
     public long currentTime(final TimeUnit unit) {
-        return delegate().currentTime(unit) - offset;
+        final long elapsedNanos = delegate().currentTime(NANOSECONDS) - offsetNanos;
+        return unit.convert(elapsedNanos, NANOSECONDS);
     }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/NormalizedTimeSourceExecutorTest.java
@@ -24,7 +24,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Long.MIN_VALUE;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -59,5 +62,16 @@ class NormalizedTimeSourceExecutorTest {
         advanceAndVerify(MAX_VALUE - 10, MAX_VALUE);
         advanceAndVerify(10, MAX_VALUE + 10);
         advanceAndVerify(MAX_VALUE - 8, 0);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: initialValue={0}")
+    @ValueSource(longs = {MIN_VALUE, -100, 0, 100, MAX_VALUE})
+    void otherUnits(long initialValue) {
+        setUp(initialValue);
+        testExecutor.advanceTimeByNoExecuteTasks(1, SECONDS);
+        assertThat(executor.currentTime(SECONDS), is(1L));
+        assertThat(executor.currentTime(MILLISECONDS), is(1_000L));
+        assertThat(executor.currentTime(MICROSECONDS), is(1_000_000L));
+        assertThat(executor.currentTime(NANOSECONDS), is(1_000_000_000L));
     }
 }


### PR DESCRIPTION
Motivation:

The time source normalizes itself using nanoseconds regardless
of what units the user is requesting.

Modifications:

- Always get the current time in nanos, normalize, then convert to
  the desired units.

Result:

Better behavior if you request anything other than nanos.