### PR TITLE
Add validation for `H1ProtocolConfigBuilder` setters

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
@@ -67,6 +67,9 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder maxPipelinedRequests(final int maxPipelinedRequests) {
+        if (maxPipelinedRequests <= 0) {
+            throw new IllegalArgumentException("maxPipelinedRequests: " + maxPipelinedRequests + " (expected >0)");
+        }
         this.maxPipelinedRequests = maxPipelinedRequests;
         return this;
     }
@@ -83,6 +86,9 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder maxStartLineLength(final int maxStartLineLength) {
+        if (maxStartLineLength <= 0) {
+            throw new IllegalArgumentException("maxStartLineLength: " + maxStartLineLength + " (expected >0)");
+        }
         this.maxStartLineLength = maxStartLineLength;
         return this;
     }
@@ -100,6 +106,9 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder maxHeaderFieldLength(final int maxHeaderFieldLength) {
+        if (maxHeaderFieldLength <= 0) {
+            throw new IllegalArgumentException("maxHeaderFieldLength: " + maxHeaderFieldLength + " (expected >0)");
+        }
         this.maxHeaderFieldLength = maxHeaderFieldLength;
         return this;
     }
@@ -116,6 +125,10 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder headersEncodedSizeEstimate(final int headersEncodedSizeEstimate) {
+        if (headersEncodedSizeEstimate <= 0) {
+            throw new IllegalArgumentException("headersEncodedSizeEstimate: " + headersEncodedSizeEstimate +
+                    " (expected >0)");
+        }
         this.headersEncodedSizeEstimate = headersEncodedSizeEstimate;
         return this;
     }
@@ -130,6 +143,10 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder trailersEncodedSizeEstimate(final int trailersEncodedSizeEstimate) {
+        if (trailersEncodedSizeEstimate <= 0) {
+            throw new IllegalArgumentException("trailersEncodedSizeEstimate: " + trailersEncodedSizeEstimate +
+                    " (expected >0)");
+        }
         this.trailersEncodedSizeEstimate = trailersEncodedSizeEstimate;
         return this;
     }


### PR DESCRIPTION
Motivation:

`H1ProtocolConfigBuilder` does not validate incoming int parameters.