### PR TITLE
Add utility for common validation patterns for `Number`s

### DIFF
--- a/servicetalk-concurrent-api-test/src/main/java/io/servicetalk/concurrent/api/test/InlinePublisherSubscriber.java
+++ b/servicetalk-concurrent-api-test/src/main/java/io/servicetalk/concurrent/api/test/InlinePublisherSubscriber.java
@@ -43,6 +43,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.test.InlineStepVerifier.PublisherEvent.notEqualsOnNext;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
@@ -544,13 +545,10 @@ final class InlinePublisherSubscriber<T> implements Subscriber<T>, InlineVerifia
         private final long minOnNext;
 
         OnNextExpectCountEvent(long minOnNext, long maxOnNext) {
-            if (maxOnNext <= 0) {
-                throw new IllegalArgumentException("maxOnNext: " + maxOnNext + " (expected >0)");
-            }
+            this.maxOnNext = ensurePositive(maxOnNext, "maxOnNext");
             if (maxOnNext < minOnNext) {
                 throw new IllegalArgumentException("maxOnNext " + maxOnNext + " < minOnNext" + minOnNext);
             }
-            this.maxOnNext = maxOnNext;
             this.minOnNext = minOnNext;
         }
 
@@ -574,14 +572,11 @@ final class InlinePublisherSubscriber<T> implements Subscriber<T>, InlineVerifia
         private final Consumer<? super Iterable<? extends T>> signalsConsumer;
 
         OnNextAggregateEvent(long minOnNext, long maxOnNext, Consumer<? super Iterable<? extends T>> signalsConsumer) {
-            if (maxOnNext <= 0) {
-                throw new IllegalArgumentException("maxOnNext: " + maxOnNext + " (expected >0)");
-            }
+            this.maxOnNext = ensurePositive(maxOnNext, "maxOnNext");
             if (maxOnNext < minOnNext) {
                 throw new IllegalArgumentException("maxOnNext " + maxOnNext + " < minOnNext" + minOnNext);
             }
             this.signalsConsumer = requireNonNull(signalsConsumer);
-            this.maxOnNext = maxOnNext;
             this.minOnNext = minOnNext;
         }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.ThrowableUtils.catchUnexpected;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 
 abstract class AbstractPublisherGroupBy<Key, T> extends AbstractNoHandleSubscribePublisher<GroupedPublisher<Key, T>> {
     final Publisher<T> original;
@@ -40,14 +41,8 @@ abstract class AbstractPublisherGroupBy<Key, T> extends AbstractNoHandleSubscrib
     }
 
     AbstractPublisherGroupBy(Publisher<T> original, int queueLimit, int expectedGroupCountHint) {
-        if (expectedGroupCountHint <= 0) {
-            throw new IllegalArgumentException("expectedGroupCountHint " + expectedGroupCountHint + " (expected >0)");
-        }
-        this.initialCapacityForGroups = expectedGroupCountHint;
-        if (queueLimit <= 0) {
-            throw new IllegalArgumentException("queueLimit " + queueLimit + " (expected >0)");
-        }
-        this.queueLimit = queueLimit;
+        this.initialCapacityForGroups = ensurePositive(expectedGroupCountHint, "expectedGroupCountHint");
+        this.queueLimit = ensurePositive(queueLimit, "queueLimit");
         this.original = original;
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherProcessorSignalsHolder.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherProcessorSignalsHolder.java
@@ -26,6 +26,7 @@ import static io.servicetalk.concurrent.api.ProcessorBufferUtils.consumeNextItem
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
@@ -41,10 +42,7 @@ abstract class AbstractPublisherProcessorSignalsHolder<T, Q extends Queue<Object
     private volatile int buffered;
 
     AbstractPublisherProcessorSignalsHolder(final int maxBuffer, final Q signals) {
-        if (maxBuffer <= 0) {
-            throw new IllegalArgumentException("maxBuffer: " + maxBuffer + " (expected > 0)");
-        }
-        this.maxBuffer = maxBuffer;
+        this.maxBuffer = ensurePositive(maxBuffer, "maxBuffer");
         this.signals = requireNonNull(signals);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategies.java
@@ -30,6 +30,7 @@ import static io.servicetalk.concurrent.api.ImmediateExecutor.IMMEDIATE_EXECUTOR
 import static io.servicetalk.concurrent.api.Publisher.defer;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnComplete;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
@@ -130,9 +131,7 @@ public final class BufferStrategies {
     public static <T, BC extends Accumulator<T, B>, B> BufferStrategy<T, Accumulator<T, B>, B> forCountOrTime(
             final int count, final Duration duration, Supplier<BC> accumulatorSupplier,
             final Executor executor) {
-        if (count <= 0) {
-            throw new IllegalArgumentException("count: " + count + " (expected > 0)");
-        }
+        ensurePositive(count, "count");
         requireNonNull(duration);
         requireNonNull(accumulatorSupplier);
         requireNonNull(executor);

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -69,6 +69,7 @@ import static io.servicetalk.concurrent.api.PublisherDoOnUtils.doOnSubscribeSupp
 import static io.servicetalk.concurrent.api.ReplayPublisher.newReplayPublisher;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.utils.internal.DurationUtils.toNanos;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.function.Function.identity;
@@ -999,10 +1000,8 @@ public abstract class Publisher<T> {
      */
     public final <R> Publisher<R> flatMapMergeDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
                                                          int maxConcurrency, int maxDelayedErrorsHint) {
-        if (maxDelayedErrorsHint <= 0) {
-            throw new IllegalArgumentException("maxDelayedErrorsHint " + maxDelayedErrorsHint + " (expected >0)");
-        }
-        return new PublisherFlatMapMerge<>(this, mapper, maxDelayedErrorsHint, maxConcurrency);
+        return new PublisherFlatMapMerge<>(this, mapper, ensurePositive(maxDelayedErrorsHint, "maxDelayedErrorsHint"),
+                maxConcurrency);
     }
 
     /**
@@ -1230,10 +1229,8 @@ public abstract class Publisher<T> {
      */
     public final <R> Publisher<R> flatMapMergeSingleDelayError(
             Function<? super T, ? extends Single<? extends R>> mapper, int maxConcurrency, int maxDelayedErrorsHint) {
-        if (maxDelayedErrorsHint <= 0) {
-            throw new IllegalArgumentException("maxDelayedErrorsHint " + maxDelayedErrorsHint + " (expected >0)");
-        }
-        return new PublisherFlatMapSingle<>(this, mapper, maxDelayedErrorsHint, maxConcurrency);
+        return new PublisherFlatMapSingle<>(this, mapper, ensurePositive(maxDelayedErrorsHint, "maxDelayedErrorsHint"),
+                maxConcurrency);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
@@ -39,6 +39,7 @@ import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUncheck
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.lang.Math.min;
 import static java.lang.Thread.currentThread;
@@ -59,11 +60,8 @@ final class PublisherAsBlockingIterable<T> implements BlockingIterable<T> {
 
     PublisherAsBlockingIterable(final Publisher<T> original, int queueCapacityHint) {
         this.original = requireNonNull(original);
-        if (queueCapacityHint <= 0) {
-            throw new IllegalArgumentException("Invalid queueCapacityHint: " + queueCapacityHint + " (expected > 0).");
-        }
         // Add a sane upper bound to the capacity to reduce buffering.
-        this.queueCapacityHint = min(queueCapacityHint, 128);
+        this.queueCapacityHint = min(ensurePositive(queueCapacityHint, "queueCapacityHint"), 128);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapMerge.java
@@ -42,6 +42,8 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedMpscQueue;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -88,15 +90,9 @@ final class PublisherFlatMapMerge<T, R> extends AbstractAsynchronousPublisherOpe
     PublisherFlatMapMerge(Publisher<T> original, Function<? super T, ? extends Publisher<? extends R>> mapper,
                           int maxDelayedErrors, int maxConcurrency) {
         super(original);
-        if (maxConcurrency <= 0) {
-            throw new IllegalArgumentException("maxConcurrency: " + maxConcurrency + " (expected >0)");
-        }
-        if (maxDelayedErrors < 0) {
-            throw new IllegalArgumentException("maxDelayedErrors: " + maxDelayedErrors + " (expected >=0)");
-        }
         this.mapper = requireNonNull(mapper);
-        this.maxConcurrency = maxConcurrency;
-        this.maxDelayedErrors = maxDelayedErrors;
+        this.maxConcurrency = ensurePositive(maxConcurrency, "maxConcurrency");
+        this.maxDelayedErrors = ensureNonNegative(maxDelayedErrors, "maxDelayedErrors");
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapSingle.java
@@ -46,6 +46,8 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static io.servicetalk.utils.internal.PlatformDependent.newUnboundedMpscQueue;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
@@ -76,15 +78,9 @@ final class PublisherFlatMapSingle<T, R> extends AbstractAsynchronousPublisherOp
     PublisherFlatMapSingle(Publisher<T> original, Function<? super T, ? extends Single<? extends R>> mapper,
                            int maxDelayedErrors, int maxConcurrency) {
         super(original);
-        if (maxConcurrency <= 0) {
-            throw new IllegalArgumentException("maxConcurrency: " + maxConcurrency + " (expected > 0)");
-        }
-        if (maxDelayedErrors < 0) {
-            throw new IllegalArgumentException("maxDelayedErrors: " + maxDelayedErrors + " (expected >=0)");
-        }
         this.mapper = requireNonNull(mapper);
-        this.maxConcurrency = maxConcurrency;
-        this.maxDelayedErrors = maxDelayedErrors;
+        this.maxConcurrency = ensurePositive(maxConcurrency, "maxConcurrency");
+        this.maxDelayedErrors = ensureNonNegative(maxDelayedErrors, "maxDelayedErrors");
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSwitchMap.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSwitchMap.java
@@ -32,6 +32,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.EmptySubscriptions.EMPTY_SUBSCRIPTION;
 import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
 import static io.servicetalk.concurrent.internal.TerminalNotification.error;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
@@ -50,10 +51,7 @@ final class PublisherSwitchMap<T, R> extends AbstractAsynchronousPublisherOperat
                        final int maxDelayedErrors,
                        final Function<? super T, ? extends Publisher<? extends R>> mapper) {
         super(original);
-        if (maxDelayedErrors < 0) {
-            throw new IllegalArgumentException("maxDelayedErrors: " + maxDelayedErrors + " (expected >=0)");
-        }
-        this.maxDelayedErrors = maxDelayedErrors;
+        this.maxDelayedErrors = ensureNonNegative(maxDelayedErrors, "maxDelayedErrors");
         this.mapper = requireNonNull(mapper);
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RangeIntPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RangeIntPublisher.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
@@ -40,12 +41,9 @@ final class RangeIntPublisher extends AbstractSynchronousPublisher<Integer> {
         if (begin > end) {
             throw new IllegalArgumentException("begin(" + begin + ") > end(" + end + ")");
         }
-        if (stride <= 0) {
-            throw new IllegalArgumentException("stride: " + stride + " (expected >0)");
-        }
         this.begin = begin;
         this.end = end;
-        this.stride = stride;
+        this.stride = ensurePositive(stride, "stride");
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReplayStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReplayStrategies.java
@@ -33,6 +33,7 @@ import static io.servicetalk.concurrent.api.SubscriberApiUtils.unwrapNullUncheck
 import static io.servicetalk.concurrent.api.SubscriberApiUtils.wrapNull;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.releaseLock;
 import static io.servicetalk.concurrent.internal.ConcurrentUtils.tryAcquireLock;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -113,10 +114,7 @@ public final class ReplayStrategies {
         private final Deque<Object> items;
 
         MostRecentReplayAccumulator(final int maxItems) {
-            if (maxItems <= 0) {
-                throw new IllegalArgumentException("maxItems: " + maxItems + "(expected >0)");
-            }
-            this.maxItems = maxItems;
+            this.maxItems = ensurePositive(maxItems, "maxItems");
             items = new ArrayDeque<>(min(maxItems, 16));
         }
 
@@ -146,10 +144,7 @@ public final class ReplayStrategies {
             if (ttl.isNegative()) {
                 throw new IllegalArgumentException("ttl: " + ttl + "(expected non-negative)");
             }
-            if (maxItems <= 0) {
-                throw new IllegalArgumentException("maxItems: " + maxItems + "(expected >0)");
-            }
-            this.maxItems = maxItems;
+            this.maxItems = ensurePositive(maxItems, "maxItems");
             this.executor = requireNonNull(executor);
             this.ttlNanos = ttl.toNanos();
             items = new ArrayDeque<>(min(maxItems, 16));
@@ -211,12 +206,10 @@ public final class ReplayStrategies {
             if (ttl.isNegative()) {
                 throw new IllegalArgumentException("ttl: " + ttl + "(expected non-negative)");
             }
-            if (maxItems <= 0) {
-                throw new IllegalArgumentException("maxItems: " + maxItems + "(expected >0)");
-            }
             this.executor = requireNonNull(executor);
             this.ttlNanos = ttl.toNanos();
-            this.maxItems = maxItems;
+            this.maxItems = ensurePositive(maxItems, "maxItems");
+
             // SpMc
             // producer = accumulate (no concurrent access on this method)
             // consumer = accumulate (may poll from queue due to capacity)

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReplayStrategyBuilder.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ReplayStrategyBuilder.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import static io.servicetalk.concurrent.api.Completable.never;
 import static io.servicetalk.concurrent.api.MulticastPublisher.DEFAULT_MULTICAST_QUEUE_LIMIT;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -49,10 +50,7 @@ public final class ReplayStrategyBuilder<T> {
      * @return {@code this}.
      */
     public ReplayStrategyBuilder<T> minSubscribers(int minSubscribers) {
-        if (minSubscribers <= 0) {
-            throw new IllegalArgumentException("minSubscribers: " + minSubscribers + " (expected >0)");
-        }
-        this.minSubscribers = minSubscribers;
+        this.minSubscribers = ensurePositive(minSubscribers, "minSubscribers");
         return this;
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TakeNPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TakeNPublisher.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.internal.EmptySubscriptions.newEmptySubscription;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 
 /**
  * {@link Publisher} that will request a fixed number of elements.
@@ -35,10 +36,7 @@ final class TakeNPublisher<T> extends AbstractSynchronousPublisherOperator<T, T>
 
     TakeNPublisher(Publisher<T> original, long numElements) {
         super(original);
-        if (numElements <= 0) {
-            throw new IllegalArgumentException("numElements: " + numElements + " (expected >= 0)");
-        }
-        this.numElements = numElements;
+        this.numElements = ensureNonNegative(numElements, "numElements");
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TakeNPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TakeNPublisher.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.internal.EmptySubscriptions.newEmptySubscription;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.checkDuplicateSubscription;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
-import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 
 /**
  * {@link Publisher} that will request a fixed number of elements.
@@ -36,7 +36,7 @@ final class TakeNPublisher<T> extends AbstractSynchronousPublisherOperator<T, T>
 
     TakeNPublisher(Publisher<T> original, long numElements) {
         super(original);
-        this.numElements = ensureNonNegative(numElements, "numElements");
+        this.numElements = ensurePositive(numElements, "numElements");
     }
 
     @Override

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -36,6 +36,8 @@ import static io.servicetalk.dns.discovery.netty.DnsClients.asSrvDiscoverer;
 import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.systemDefault;
 import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Boolean.getBoolean;
 import static java.lang.Math.min;
 import static java.lang.System.getProperty;
@@ -156,10 +158,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
 
     @Override
     public DefaultDnsServiceDiscovererBuilder consolidateCacheSize(final int consolidateCacheSize) {
-        if (consolidateCacheSize < 0) {
-            throw new IllegalArgumentException("consolidateCacheSize: " + consolidateCacheSize + " (expected >= 0)");
-        }
-        this.consolidateCacheSize = consolidateCacheSize;
+        this.consolidateCacheSize = ensureNonNegative(consolidateCacheSize, "consolidateCacheSize");
         return this;
     }
 
@@ -172,10 +171,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
      */
     @Deprecated
     public DefaultDnsServiceDiscovererBuilder minTTL(final int minTTLSeconds) {
-        if (minTTLSeconds <= 0) {
-            throw new IllegalArgumentException("minTTLSeconds: " + minTTLSeconds + " (expected > 0)");
-        }
-        this.minTTLSeconds = minTTLSeconds;
+        this.minTTLSeconds = ensurePositive(minTTLSeconds, "minTTLSeconds");
         return this;
     }
 
@@ -211,15 +207,11 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
                     " (expected: 0 <= minCacheSeconds <= minSeconds(" + minSeconds +
                     ") <= maxCacheSeconds <= maxSeconds(" + maxSeconds + "))");
         }
-        if (negativeTTLCacheSeconds < 0) {
-            throw new IllegalArgumentException("negativeTTLCacheSeconds: " + negativeTTLCacheSeconds +
-                    " (expected >= 0)");
-        }
+        this.negativeTTLCacheSeconds = ensureNonNegative(negativeTTLCacheSeconds, "negativeTTLCacheSeconds");
         this.minTTLSeconds = minSeconds;
         this.maxTTLSeconds = maxSeconds;
         this.minTTLCacheSeconds = minCacheSeconds;
         this.maxTTLCacheSeconds = maxCacheSeconds;
-        this.negativeTTLCacheSeconds = negativeTTLCacheSeconds;
         return this;
     }
 
@@ -251,10 +243,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
 
     @Override
     public DefaultDnsServiceDiscovererBuilder maxUdpPayloadSize(final int maxUdpPayloadSize) {
-        if (maxUdpPayloadSize <= 0) {
-            throw new IllegalArgumentException("maxUdpPayloadSize: " + maxUdpPayloadSize + " (expected > 0)");
-        }
-        this.maxUdpPayloadSize = maxUdpPayloadSize;
+        this.maxUdpPayloadSize = ensurePositive(maxUdpPayloadSize, "maxUdpPayloadSize");
         return this;
     }
 
@@ -317,10 +306,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     }
 
     DefaultDnsServiceDiscovererBuilder srvConcurrency(int srvConcurrency) {
-        if (srvConcurrency <= 0) {
-            throw new IllegalArgumentException("srvConcurrency: " + srvConcurrency + " (expected >0)");
-        }
-        this.srvConcurrency = srvConcurrency;
+        this.srvConcurrency = ensurePositive(srvConcurrency, "srvConcurrency");
         return this;
     }
 

--- a/servicetalk-encoding-netty/build.gradle
+++ b/servicetalk-encoding-netty/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(":servicetalk-annotations")
     implementation project(":servicetalk-buffer-netty")
     implementation project(":servicetalk-concurrent-internal")
+    implementation project(":servicetalk-utils-internal")
     implementation "io.netty:netty-codec"
     implementation "com.google.code.findbugs:jsr305"
     implementation "org.slf4j:slf4j-api"

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/ZipCompressionBuilder.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/ZipCompressionBuilder.java
@@ -19,6 +19,8 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.serializer.api.SerializerDeserializer;
 import io.servicetalk.serializer.api.StreamingSerializerDeserializer;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
+
 /**
  * Base class for Zip based content-codecs.
  */
@@ -53,11 +55,7 @@ public abstract class ZipCompressionBuilder {
      * @return {@code this}
      */
     public final ZipCompressionBuilder maxChunkSize(final int maxChunkSize) {
-        if (maxChunkSize <= 0) {
-            throw new IllegalArgumentException("maxChunkSize: " + maxChunkSize + " (expected > 0)");
-        }
-
-        this.maxChunkSize = maxChunkSize;
+        this.maxChunkSize = ensurePositive(maxChunkSize, "maxChunkSize");
         return this;
     }
 

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/ZipContentCodecBuilder.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/ZipContentCodecBuilder.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.compression.JdkZlibEncoder;
 import io.netty.handler.codec.compression.ZlibWrapper;
 
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 
 /**
  * Base class for Zip based content-codecs.
@@ -60,11 +61,7 @@ public abstract class ZipContentCodecBuilder {
      * @return {@code this}
      */
     public final ZipContentCodecBuilder maxChunkSize(final int maxChunkSize) {
-        if (maxChunkSize <= 0) {
-            throw new IllegalArgumentException("maxChunkSize: " + maxChunkSize + " (expected > 0)");
-        }
-
-        this.maxChunkSize = maxChunkSize;
+        this.maxChunkSize = ensurePositive(maxChunkSize, "maxChunkSize");
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2Exception.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2Exception.java
@@ -17,6 +17,7 @@ package io.servicetalk.http.api;
 
 import java.io.IOException;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -36,7 +37,7 @@ public class Http2Exception extends IOException {
      */
     public Http2Exception(final int streamId, final Http2ErrorCode error, final String message) {
         super(message);
-        this.streamId = validateStreamId(streamId);
+        this.streamId = ensureNonNegative(streamId, "streamId");
         this.error = requireNonNull(error);
     }
 
@@ -49,7 +50,7 @@ public class Http2Exception extends IOException {
      */
     public Http2Exception(final int streamId, final Http2ErrorCode error, final Throwable cause) {
         super(cause);
-        this.streamId = validateStreamId(streamId);
+        this.streamId = ensureNonNegative(streamId, "streamId");
         this.error = requireNonNull(error);
     }
 
@@ -63,7 +64,7 @@ public class Http2Exception extends IOException {
      */
     public Http2Exception(final int streamId, final Http2ErrorCode error, final String message, final Throwable cause) {
         super(message, cause);
-        this.streamId = validateStreamId(streamId);
+        this.streamId = ensureNonNegative(streamId, "streamId");
         this.error = requireNonNull(error);
     }
 
@@ -81,13 +82,6 @@ public class Http2Exception extends IOException {
      * @return {@code 0} for the connection stream, {@code > 0} for a non-connection stream, or {@code < 0} if unknown.
      */
     public final int streamId() {
-        return streamId;
-    }
-
-    private static int validateStreamId(int streamId) {
-        if (streamId < 0) {
-            throw new IllegalArgumentException("streamId: " + streamId + "(expected >=0)");
-        }
         return streamId;
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfigBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfigBuilder.java
@@ -38,6 +38,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.SEE_OTHER;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.REDIRECTION_3XX;
 import static io.servicetalk.http.api.HttpResponseStatus.TEMPORARY_REDIRECT;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
@@ -86,10 +87,7 @@ public final class RedirectConfigBuilder {
      * @return {@code this}
      */
     public RedirectConfigBuilder maxRedirects(final int maxRedirects) {
-        if (maxRedirects < 0) {
-            throw new IllegalArgumentException("maxRedirects: " + maxRedirects + " (expected >= 0)");
-        }
-        this.maxRedirects = maxRedirects;
+        this.maxRedirects = ensureNonNegative(maxRedirects, "maxRedirects");
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingStreamingHttpService.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.api.internal.BlockingUtils.futureGetCancelOnInterrupt;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.util.Objects.requireNonNull;
 
@@ -43,11 +44,8 @@ final class StreamingHttpServiceToBlockingStreamingHttpService implements Blocki
 
     StreamingHttpServiceToBlockingStreamingHttpService(final StreamingHttpService original,
                                                        final int demandBatchSize) {
-        if (demandBatchSize <= 0) {
-            throw new IllegalArgumentException("demandBatchSize: " + demandBatchSize + " (expected >0)");
-        }
         this.original = requireNonNull(original);
-        this.demandBatchSize = demandBatchSize;
+        this.demandBatchSize = ensurePositive(demandBatchSize, "demandBatchSize");
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
@@ -20,6 +20,7 @@ import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -67,10 +68,7 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder maxPipelinedRequests(final int maxPipelinedRequests) {
-        if (maxPipelinedRequests <= 0) {
-            throw new IllegalArgumentException("maxPipelinedRequests: " + maxPipelinedRequests + " (expected >0)");
-        }
-        this.maxPipelinedRequests = maxPipelinedRequests;
+        this.maxPipelinedRequests = ensurePositive(maxPipelinedRequests, "maxPipelinedRequests");
         return this;
     }
 
@@ -86,10 +84,7 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder maxStartLineLength(final int maxStartLineLength) {
-        if (maxStartLineLength <= 0) {
-            throw new IllegalArgumentException("maxStartLineLength: " + maxStartLineLength + " (expected >0)");
-        }
-        this.maxStartLineLength = maxStartLineLength;
+        this.maxStartLineLength = ensurePositive(maxStartLineLength, "maxStartLineLength");
         return this;
     }
 
@@ -106,10 +101,7 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder maxHeaderFieldLength(final int maxHeaderFieldLength) {
-        if (maxHeaderFieldLength <= 0) {
-            throw new IllegalArgumentException("maxHeaderFieldLength: " + maxHeaderFieldLength + " (expected >0)");
-        }
-        this.maxHeaderFieldLength = maxHeaderFieldLength;
+        this.maxHeaderFieldLength = ensurePositive(maxHeaderFieldLength, "maxHeaderFieldLength");
         return this;
     }
 
@@ -125,11 +117,7 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder headersEncodedSizeEstimate(final int headersEncodedSizeEstimate) {
-        if (headersEncodedSizeEstimate <= 0) {
-            throw new IllegalArgumentException("headersEncodedSizeEstimate: " + headersEncodedSizeEstimate +
-                    " (expected >0)");
-        }
-        this.headersEncodedSizeEstimate = headersEncodedSizeEstimate;
+        this.headersEncodedSizeEstimate = ensurePositive(headersEncodedSizeEstimate, "headersEncodedSizeEstimate");
         return this;
     }
 
@@ -143,11 +131,7 @@ public final class H1ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H1ProtocolConfigBuilder trailersEncodedSizeEstimate(final int trailersEncodedSizeEstimate) {
-        if (trailersEncodedSizeEstimate <= 0) {
-            throw new IllegalArgumentException("trailersEncodedSizeEstimate: " + trailersEncodedSizeEstimate +
-                    " (expected >0)");
-        }
-        this.trailersEncodedSizeEstimate = trailersEncodedSizeEstimate;
+        this.trailersEncodedSizeEstimate = ensurePositive(trailersEncodedSizeEstimate, "trailersEncodedSizeEstimate");
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -157,7 +157,7 @@ public final class H2ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H2ProtocolConfigBuilder flowControlWindowIncrement(int connectionWindowIncrement) {
-        this.flowControlIncrement = ensurePositive(connectionWindowIncrement, "flowControlIncrement");
+        this.flowControlIncrement = ensurePositive(connectionWindowIncrement, "connectionWindowIncrement");
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_HEADER_LIST_SIZE;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.disabled;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.validateKeepAlivePolicy;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -144,10 +145,7 @@ public final class H2ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H2ProtocolConfigBuilder flowControlQuantum(int flowControlQuantum) {
-        if (flowControlQuantum <= 0) {
-            throw new IllegalArgumentException("flowControlQuantum " + flowControlQuantum + " (expected >0)");
-        }
-        this.flowControlQuantum = flowControlQuantum;
+        this.flowControlQuantum = ensurePositive(flowControlQuantum, "flowControlQuantum");
         return this;
     }
 
@@ -159,11 +157,7 @@ public final class H2ProtocolConfigBuilder {
      * @return {@code this}
      */
     public H2ProtocolConfigBuilder flowControlWindowIncrement(int connectionWindowIncrement) {
-        if (connectionWindowIncrement <= 0) {
-            throw new IllegalArgumentException("connectionWindowIncrement " + connectionWindowIncrement +
-                    " (expected >0)");
-        }
-        this.flowControlIncrement = connectionWindowIncrement;
+        this.flowControlIncrement = ensurePositive(connectionWindowIncrement, "flowControlIncrement");
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -79,6 +79,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpResponseStatus.SWITCHING_PROTOCOLS;
 import static io.servicetalk.http.netty.HeaderUtils.removeTransferEncodingChunked;
 import static io.servicetalk.http.netty.HttpKeepAlive.shouldClose;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Character.isISOControl;
 import static java.lang.Character.isWhitespace;
 import static java.lang.Long.parseUnsignedLong;
@@ -181,15 +182,9 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                       final CloseHandler closeHandler) {
         super(alloc);
         this.closeHandler = requireNonNull(closeHandler);
-        if (maxStartLineLength <= 0) {
-            throw new IllegalArgumentException("maxStartLineLength: " + maxStartLineLength + " (expected >0)");
-        }
-        if (maxHeaderFieldLength <= 0) {
-            throw new IllegalArgumentException("maxHeaderFieldLength: " + maxHeaderFieldLength + " (expected >0)");
-        }
         this.headersFactory = requireNonNull(headersFactory);
-        this.maxStartLineLength = maxStartLineLength;
-        this.maxHeaderFieldLength = maxHeaderFieldLength;
+        this.maxStartLineLength = ensurePositive(maxStartLineLength, "maxStartLineLength");
+        this.maxHeaderFieldLength = ensurePositive(maxHeaderFieldLength, "maxHeaderFieldLength");
         this.allowPrematureClosureBeforePayloadBody = allowPrematureClosureBeforePayloadBody;
         this.allowLFWithoutCR = allowLFWithoutCR;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -66,6 +66,8 @@ import static io.servicetalk.http.api.HttpHeaderValues.CONTINUE;
 import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.time.Duration.ofDays;
 import static java.util.Objects.requireNonNull;
 
@@ -387,10 +389,7 @@ public final class RetryingHttpRequesterFilter
                     "positive value.") : null;
             this.timerExecutor = timerExecutor;
             this.exponential = exponential;
-            if (maxRetries <= 0) {
-                throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected > 0).");
-            }
-            this.maxRetries = maxRetries;
+            this.maxRetries = ensurePositive(maxRetries, "maxRetries");
         }
 
         BackOffPolicy(final int maxRetries) {
@@ -399,10 +398,7 @@ public final class RetryingHttpRequesterFilter
             this.maxDelay = null;
             this.timerExecutor = null;
             this.exponential = false;
-            if (maxRetries < 0) {
-                throw new IllegalArgumentException("maxRetries: " + maxRetries + " (expected >= 0).");
-            }
-            this.maxRetries = maxRetries;
+            this.maxRetries = ensureNonNegative(maxRetries, "maxRetries");
         }
 
         /**

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation project(":servicetalk-http-router-jersey-internal")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-router-utils-internal")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305"
   implementation "com.sun.activation:jakarta.activation"
   implementation "com.sun.xml.bind:jaxb-core"

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/HttpJerseyRouterBuilder.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/HttpJerseyRouterBuilder.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.Application;
 
 import static io.servicetalk.http.utils.HttpRequestUriUtils.getBaseRequestUri;
 import static io.servicetalk.router.utils.internal.DefaultRouteExecutionStrategyFactory.defaultStrategyFactory;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -57,11 +58,8 @@ public final class HttpJerseyRouterBuilder {
      * @return this
      */
     public HttpJerseyRouterBuilder publisherInputStreamQueueCapacity(final int publisherInputStreamQueueCapacity) {
-        if (publisherInputStreamQueueCapacity <= 0) {
-            throw new IllegalArgumentException("Invalid queue capacity: " + publisherInputStreamQueueCapacity
-                    + " (expected > 0).");
-        }
-        this.publisherInputStreamQueueCapacity = publisherInputStreamQueueCapacity;
+        this.publisherInputStreamQueueCapacity =
+                ensurePositive(publisherInputStreamQueueCapacity, "publisherInputStreamQueueCapacity");
         return this;
     }
 

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpRequesterFilter.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 
 /**
  * Limits the response payload size. The filter will throw an exception which may result in stream/connection closure.
@@ -48,10 +49,7 @@ public final class PayloadSizeLimitingHttpRequesterFilter implements
      * @param maxResponsePayloadSize The maximum response payload size allowed.
      */
     public PayloadSizeLimitingHttpRequesterFilter(int maxResponsePayloadSize) {
-        if (maxResponsePayloadSize < 0) {
-            throw new IllegalArgumentException("maxResponsePayloadSize: " + maxResponsePayloadSize + " (expected >=0)");
-        }
-        this.maxResponsePayloadSize = maxResponsePayloadSize;
+        this.maxResponsePayloadSize = ensureNonNegative(maxResponsePayloadSize, "maxResponsePayloadSize");
     }
 
     @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilter.java
@@ -28,6 +28,7 @@ import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.utils.PayloadSizeLimitingHttpRequesterFilter.newLimiter;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 
 /**
  * Limits the request payload size. The filter will throw an exception which may result in stream/connection closure.
@@ -41,10 +42,7 @@ public final class PayloadSizeLimitingHttpServiceFilter implements StreamingHttp
      * @param maxRequestPayloadSize The maximum request payload size allowed.
      */
     public PayloadSizeLimitingHttpServiceFilter(int maxRequestPayloadSize) {
-        if (maxRequestPayloadSize < 0) {
-            throw new IllegalArgumentException("maxRequestPayloadSize: " + maxRequestPayloadSize + " (expected >=0)");
-        }
-        this.maxRequestPayloadSize = maxRequestPayloadSize;
+        this.maxRequestPayloadSize = ensureNonNegative(maxRequestPayloadSize, "maxRequestPayloadSize");
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -33,6 +33,7 @@ import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_JITTER;
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_RESUBSCRIBE_INTERVAL;
 import static io.servicetalk.loadbalancer.HealthCheckConfig.validateHealthCheckIntervals;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection>
@@ -61,11 +62,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     @Override
     public LoadBalancerBuilder<ResolvedAddress, C> linearSearchSpace(int linearSearchSpace) {
-        if (linearSearchSpace <= 0) {
-            throw new IllegalArgumentException("Invalid linear search space: "
-                    + linearSearchSpace + " (expected > 0)");
-        }
-        this.linearSearchSpace = linearSearchSpace;
+        this.linearSearchSpace = ensurePositive(linearSearchSpace, "linearSearchSpace");
         return this;
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Random;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
+
 /**
  * A random selection "power of two choices" load balancing policy.
  * <p>
@@ -83,10 +85,7 @@ final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnec
          * @return this {@link Builder}.
          */
         public Builder maxEffort(final int maxEffort) {
-            if (maxEffort <= 0) {
-                throw new IllegalArgumentException("Invalid maxEffort: " + maxEffort + " (expected > 0)");
-            }
-            this.maxEffort = maxEffort;
+            this.maxEffort = ensurePositive(maxEffort, "maxEffort");
             return this;
         }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -38,6 +38,7 @@ import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_JITTER;
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_RESUBSCRIBE_INTERVAL;
 import static io.servicetalk.loadbalancer.HealthCheckConfig.validateHealthCheckIntervals;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -148,10 +149,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
 
         @Override
         public RoundRobinLoadBalancerFactory.Builder<ResolvedAddress, C> linearSearchSpace(int linearSearchSpace) {
-            if (linearSearchSpace < 0) {
-                throw new IllegalArgumentException("linearSearchSpace: " + linearSearchSpace + " (expected >=0)");
-            }
-            this.linearSearchSpace = linearSearchSpace;
+            this.linearSearchSpace = ensureNonNegative(linearSearchSpace, "linearSearchSpace");
             return this;
         }
 

--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.code.findbugs:jsr305"
   implementation "io.netty:netty-codec"
   implementation "io.netty:netty-transport"

--- a/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
+++ b/servicetalk-opentracing-zipkin-publisher/src/main/java/io/servicetalk/opentracing/zipkin/publisher/reporter/HttpReporter.java
@@ -56,6 +56,7 @@ import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderValues.APPLICATION_JSON;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.time.Duration.ofSeconds;
 import static java.util.Objects.requireNonNull;
 import static zipkin2.CheckResult.OK;
@@ -244,10 +245,7 @@ public final class HttpReporter extends Component implements Reporter<Span>, Asy
          * @return {@code this}.
          */
         public Builder maxConcurrentReports(final int maxConcurrentReports) {
-            if (maxConcurrentReports <= 0) {
-                throw new IllegalArgumentException("maxConcurrentReports: " + maxConcurrentReports + " (expected > 0)");
-            }
-            this.maxConcurrentReports = maxConcurrentReports;
+            this.maxConcurrentReports = ensurePositive(maxConcurrentReports, "maxConcurrentReports");
             return this;
         }
 
@@ -259,12 +257,9 @@ public final class HttpReporter extends Component implements Reporter<Span>, Asy
          * @return {@code this}.
          */
         public Builder batchSpans(final int batchSizeHint, final Duration maxBatchDuration) {
-            if (batchSizeHint <= 0) {
-                throw new IllegalArgumentException("batchSizeHint: " + batchSizeHint + " (expected > 0)");
-            }
-            batchingEnabled = true;
-            this.batchSizeHint = batchSizeHint;
+            this.batchSizeHint = ensurePositive(batchSizeHint, "batchSizeHint");
             this.maxBatchDuration = requireNonNull(maxBatchDuration);
+            batchingEnabled = true;
             return this;
         }
 

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.transport.netty.internal.FlushStrategies.defaultFlushStrategy;
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.addOption;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.net.StandardSocketOptions.SO_KEEPALIVE;
 import static java.util.Objects.requireNonNull;
 
@@ -108,10 +109,8 @@ abstract class AbstractTcpConfig<SslConfigType extends SslConfig> {
         requireNonNull(option);
         requireNonNull(value);
         if (option == ServiceTalkSocketOptions.IDLE_TIMEOUT) {
-            idleTimeoutMs = (Long) value;
-            if (idleTimeoutMs < 0) {
-                throw new IllegalArgumentException("IDLE_TIMEOUT: " + idleTimeoutMs + " (expected>=0)");
-            }
+            final long idleTimeoutMs = (Long) value;
+            this.idleTimeoutMs = ensureNonNegative(idleTimeoutMs, "IDLE_TIMEOUT");
         } else {
             if (options == null) {
                 options = new HashMap<>();

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
@@ -27,6 +27,7 @@ import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.TrustManagerFactory;
 
 import static io.servicetalk.utils.internal.DurationUtils.ensureNonNegative;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -307,10 +308,7 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
      * @see SSLSessionContext#setSessionCacheSize(int)
      */
     public final T sessionCacheSize(long sessionCacheSize) {
-        if (sessionCacheSize < 0) {
-            throw new IllegalArgumentException("sessionCacheSize: " + sessionCacheSize + " (expected >=0)");
-        }
-        this.sessionCacheSize = sessionCacheSize;
+        this.sessionCacheSize = ensureNonNegative(sessionCacheSize, "sessionCacheSize");
         return thisT();
     }
 
@@ -327,10 +325,7 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
      * @see SSLSessionContext#setSessionTimeout(int)
      */
     public final T sessionTimeout(long sessionTimeout) {
-        if (sessionTimeout < 0) {
-            throw new IllegalArgumentException("sessionTimeout: " + sessionTimeout + " (expected >=0)");
-        }
-        this.sessionTimeout = sessionTimeout;
+        this.sessionTimeout = ensureNonNegative(sessionTimeout, "sessionTimeout");
         return thisT();
     }
 
@@ -414,10 +409,7 @@ abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
      * @return {@code this}.
      */
     public final T maxCertificateListBytes(int maxBytes) {
-        if (maxBytes < 0) {
-            throw new IllegalArgumentException("maxBytes: " + maxBytes + " (expected >=0)");
-        }
-        this.maxCertificateListBytes = maxBytes;
+        this.maxCertificateListBytes = ensureNonNegative(maxBytes, "maxBytes");
         return thisT();
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BatchFlush.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BatchFlush.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 
 final class BatchFlush implements FlushStrategy {
@@ -28,10 +29,7 @@ final class BatchFlush implements FlushStrategy {
 
     BatchFlush(Publisher<?> durationBoundaries, int batchSize) {
         this.boundaries = requireNonNull(durationBoundaries);
-        if (batchSize <= 0) {
-            throw new IllegalArgumentException("batchSize: " + batchSize + " (expected > 0)");
-        }
-        this.batchSize = batchSize;
+        this.batchSize = ensurePositive(batchSize, "batchSize");
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/EWMAWriteDemandEstimator.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/EWMAWriteDemandEstimator.java
@@ -16,6 +16,7 @@
 package io.servicetalk.transport.netty.internal;
 
 import static io.servicetalk.transport.netty.internal.OverlappingCapacityAwareEstimator.SizeEstimator.defaultEstimator;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Math.max;
 
 final class EWMAWriteDemandEstimator extends OverlappingCapacityAwareEstimator {
@@ -29,10 +30,7 @@ final class EWMAWriteDemandEstimator extends OverlappingCapacityAwareEstimator {
 
     EWMAWriteDemandEstimator(long sizeAccumulator) {
         super(defaultEstimator());
-        if (sizeAccumulator <= 0) {
-            throw new IllegalArgumentException("sizeAccumulator: " + sizeAccumulator + " (expected >0)");
-        }
-        this.sizeAccumulator = sizeAccumulator;
+        this.sizeAccumulator = ensurePositive(sizeAccumulator, "sizeAccumulator");
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IdleTimeoutInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/IdleTimeoutInitializer.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
+
 /**
  * Initializes the channel with idle timeout handling.
  */
@@ -52,10 +54,7 @@ public class IdleTimeoutInitializer implements ChannelInitializer { // FIXME: 0.
      * @param idleTimeoutMillis timeout in milliseconds.
      */
     public IdleTimeoutInitializer(long idleTimeoutMillis) {
-        if (idleTimeoutMillis <= 0L) {
-            throw new IllegalArgumentException("idleTimeoutMillis: " + idleTimeoutMillis + " (expected >0)");
-        }
-        timeoutMs = idleTimeoutMillis;
+        this.timeoutMs = ensurePositive(idleTimeoutMillis, "idleTimeoutMillis");
     }
 
     @Override

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/NumberUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/NumberUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.utils.internal;
+
+/**
+ * Helper utilities for {@link Number}s.
+ */
+public final class NumberUtils {
+
+    private NumberUtils() {
+        // No instances
+    }
+
+    /**
+     * Ensures the int is positive, excluding zero.
+     *
+     * @param value the int value to validate
+     * @param name name of the variable
+     * @return the passed value if all checks pass
+     * @throws IllegalArgumentException if the passed int is not greater than zero
+     */
+    public static int ensurePositive(final int value, final String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + ": " + value + " (expected > 0)");
+        }
+        return value;
+    }
+
+    /**
+     * Ensures the long is positive, excluding zero.
+     *
+     * @param value the long value to validate
+     * @param name name of the variable
+     * @return the passed value if all checks pass
+     * @throws IllegalArgumentException if the passed long is not greater than zero
+     */
+    public static long ensurePositive(final long value, final String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + ": " + value + " (expected > 0)");
+        }
+        return value;
+    }
+
+    /**
+     * Ensures the int is non-negative.
+     *
+     * @param value the int value to validate
+     * @param name name of the variable
+     * @return the passed value if all checks pass
+     * @throws IllegalArgumentException if the passed int is less than zero
+     */
+    public static int ensureNonNegative(final int value, final String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + ": " + value + " (expected >= 0)");
+        }
+        return value;
+    }
+
+    /**
+     * Ensures the long is non-negative.
+     *
+     * @param value the long value to validate
+     * @param name name of the variable
+     * @return the passed value if all checks pass
+     * @throws IllegalArgumentException if the passed long is less than zero
+     */
+    public static long ensureNonNegative(final long value, final String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + ": " + value + " (expected >= 0)");
+        }
+        return value;
+    }
+}


### PR DESCRIPTION
Motivation:

We have an agreed pattern for validating numbers, but we repeat the same code in all places instead of having a single utility to handle those.

Modifications:
- Add `NumberUtils` to `servicetalk-utils-internal`;
- Use this utility for all number validation use-cases;

Result:

Less code duplication, consistent validation.