### PR TITLE
h2: disable auto read for stream channels

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyChannelPublisher.java
@@ -46,6 +46,10 @@ final class NettyChannelPublisher<T> extends SubscribablePublisher<T> {
     private boolean requested;
     @Nullable
     private SubscriptionImpl subscription;
+    /**
+     * The size of the queue is bound by {@link SubscriptionImpl#request(long)} demand. Using reactive operators to
+     * transform data and letting ServiceTalk subscribe will take care of backpressure automatically.
+     */
     @Nullable
     private Queue<Object> pending;
     @Nullable


### PR DESCRIPTION
Motivation:
HTTP/2 stream/child channel use cases don't disable autoRead explicitly. This means we may read and queue more data than desirable.

Modifications:
- Disable auto read for h2 stream/child channels.