### PR TITLE
Add a workflow step to print the Netty snapshot that is being used

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -23,6 +23,10 @@ jobs:
         run: java -version
       - name: Make gradlew Executable
         run: chmod +x gradlew
+      - name: Print Netty Version
+        env:
+          ORG_GRADLE_PROJECT_nettyVersion: 4.1+
+        run: ./gradlew :servicetalk-grpc-netty:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-codec-http2 | grep "io.netty:netty-codec-http2"
       - name: Build and Test
         env:
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8


### PR DESCRIPTION
We are trying to debug a case where it appears that the Netty snapshot workflow does not always run with the latest Netty snapshot. In order to debug, print the version that is being used so we can understand better what might be happening.