### PR TITLE
loadbalancer: Some follow up feedback for DefaultLoadBalancer

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/LoadBalancerFactory.java
@@ -86,7 +86,7 @@ public interface LoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConn
      * new connections. Returned {@link LoadBalancer} will own the responsibility for this {@link ConnectionFactory}
      * and hence will call {@link ConnectionFactory#closeAsync()} when {@link LoadBalancer#closeAsync()} is called.
      * @param targetResource A {@link String} representation of the target resource for which the created instance
-     * will perform load balancing. Bear in mind, load balancing is performed over the a collection of hosts provided
+     * will perform load balancing. Bear in mind, load balancing is performed over the collection of hosts provided
      * via the {@code eventPublisher} which may not correspond directly to a single unresolved address, but potentially
      * a merged collection.
      * @return a new {@link LoadBalancer}.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -133,7 +133,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final int linearSearchSpace,
             final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver,
             @Nullable final HealthCheckConfig healthCheckConfig,
-            @Nullable final Supplier<HealthChecker> healthCheckerFactory) {
+            @Nullable final Supplier<HealthChecker<ResolvedAddress>> healthCheckerFactory) {
         this.targetResource = requireNonNull(targetResourceName);
         this.lbDescription = makeDescription(id, targetResource);
         this.hostSelector = requireNonNull(hostSelector, "hostSelector");
@@ -145,7 +145,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         this.loadBalancerObserver = requireNonNull(loadBalancerObserver, "loadBalancerObserver");
         this.healthCheckConfig = healthCheckConfig;
         this.sequentialExecutor = new SequentialExecutor((uncaughtException) ->
-                LOGGER.error("{}: Uncaught exception in " + this.getClass().getSimpleName(), this, uncaughtException));
+                LOGGER.error("{}: Uncaught exception in {}", this, this.getClass().getSimpleName(), uncaughtException));
         this.asyncCloseable = toAsyncCloseable(this::doClose);
         // Maintain a Subscriber so signals are always delivered to replay and new Subscribers get the latest signal.
         eventStream.ignoreElements().subscribe();

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
@@ -87,19 +87,19 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
     }
 
     @Override
-    public void observeSuccess(final long startTimeNanos) {
+    public void onSuccess(final long startTimeNanos) {
         pendingUpdater.decrementAndGet(this);
         calculateAndStore((ewma, currentLatency) -> currentLatency, startTimeNanos);
     }
 
     @Override
-    public void observeCancel(final long startTimeNanos) {
+    public void onCancel(final long startTimeNanos) {
         pendingUpdater.decrementAndGet(this);
         calculateAndStore(this::cancelPenalty, startTimeNanos);
     }
 
     @Override
-    public void observeError(final long startTimeNanos) {
+    public void onError(final long startTimeNanos) {
         pendingUpdater.decrementAndGet(this);
         calculateAndStore(this::errorPenalty, startTimeNanos);
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthChecker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ import io.servicetalk.concurrent.Cancellable;
 
 /**
  * The representation of a health checking system for use with load balancing.
- * <p>
- * The core
  */
 interface HealthChecker<ResolvedAddress> extends Cancellable {
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthCheckerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthCheckerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -89,7 +89,8 @@ interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection>
      * {@link HealthChecker}.
      * @return {code this}
      */
-    LoadBalancerBuilder<ResolvedAddress, C> healthCheckerFactory(HealthCheckerFactory healthCheckerFactory);
+    LoadBalancerBuilder<ResolvedAddress, C> healthCheckerFactory(
+            HealthCheckerFactory<ResolvedAddress> healthCheckerFactory);
 
     /**
      * This {@link LoadBalancer} may monitor hosts to which connection establishment has failed

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -36,5 +36,6 @@ interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
      * @param targetResource the name of the target resource, useful for debugging purposes.
      * @return a {@link HostSelector}
      */
-    HostSelector<ResolvedAddress, C> buildSelector(List<Host<ResolvedAddress, C>> hosts, String targetResource);
+    <T extends C> HostSelector<ResolvedAddress, T> buildSelector(
+            List<Host<ResolvedAddress, T>> hosts, String targetResource);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -52,7 +52,8 @@ final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnec
     }
 
     @Override
-    public HostSelector<ResolvedAddress, C> buildSelector(List<Host<ResolvedAddress, C>> hosts, String targetResource) {
+    public <T extends C> HostSelector<ResolvedAddress, T> buildSelector(
+            List<Host<ResolvedAddress, T>> hosts, String targetResource) {
         return new P2CSelector<>(hosts, targetResource, maxEffort, failOpen, random);
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023-2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import io.servicetalk.context.api.ContextMap;
  */
 interface RequestTracker {
 
-    @SuppressWarnings("rawtypes")
     ContextMap.Key<RequestTracker> REQUEST_TRACKER_KEY =
             ContextMap.Key.newKey("request_tracker", RequestTracker.class);
 
@@ -38,19 +37,19 @@ interface RequestTracker {
      *
      * @param beforeStartTimeNs return value from {@link #beforeStart()}.
      */
-    void observeSuccess(long beforeStartTimeNs);
+    void onSuccess(long beforeStartTimeNs);
 
     /**
      * Records cancellation of the action for which latency is to be tracked.
      *
      * @param beforeStartTimeNs return value from {@link #beforeStart()}.
      */
-    void observeCancel(long beforeStartTimeNs);
+    void onCancel(long beforeStartTimeNs);
 
     /**
      * Records a failed completion of the action for which latency is to be tracked.
      *
      * @param beforeStartTimeNs return value from {@link #beforeStart()}.
      */
-    void observeError(long beforeStartTimeNs);
+    void onError(long beforeStartTimeNs);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RootSwayingLeafRequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RootSwayingLeafRequestTracker.java
@@ -40,23 +40,23 @@ final class RootSwayingLeafRequestTracker implements RequestTracker {
     }
 
     @Override
-    public void observeSuccess(final long beforeStartTimeNs) {
+    public void onSuccess(final long beforeStartTimeNs) {
         // Tracks both levels
-        root.observeSuccess(beforeStartTimeNs);
-        leaf.observeSuccess(beforeStartTimeNs);
+        root.onSuccess(beforeStartTimeNs);
+        leaf.onSuccess(beforeStartTimeNs);
     }
 
     @Override
-    public void observeCancel(final long beforeStartTimeNs) {
+    public void onCancel(final long beforeStartTimeNs) {
         // Tracks both levels
-        root.observeCancel(beforeStartTimeNs);
-        leaf.observeCancel(beforeStartTimeNs);
+        root.onCancel(beforeStartTimeNs);
+        leaf.onCancel(beforeStartTimeNs);
     }
 
     @Override
-    public void observeError(final long beforeStartTimeNs) {
+    public void onError(final long beforeStartTimeNs) {
         // Tracks both levels
-        root.observeError(beforeStartTimeNs);
-        leaf.observeError(beforeStartTimeNs);
+        root.onError(beforeStartTimeNs);
+        leaf.onError(beforeStartTimeNs);
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -36,8 +36,8 @@ final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     }
 
     @Override
-    public HostSelector<ResolvedAddress, C>
-    buildSelector(final List<Host<ResolvedAddress, C>> hosts, final String targetResource) {
+    public <T extends C> HostSelector<ResolvedAddress, T>
+    buildSelector(final List<Host<ResolvedAddress, T>> hosts, final String targetResource) {
         return new RoundRobinSelector<>(hosts, targetResource, failOpen);
     }
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -210,15 +210,15 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
-        public void observeSuccess(long beforeStartTime) {
+        public void onSuccess(long beforeStartTime) {
         }
 
         @Override
-        public void observeCancel(long beforeStartTimeNs) {
+        public void onCancel(long beforeStartTimeNs) {
         }
 
         @Override
-        public void observeError(long beforeStartTime) {
+        public void onError(long beforeStartTime) {
         }
     }
 
@@ -270,30 +270,30 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
-        public HostSelector<String, TestLoadBalancedConnection> buildSelector(
-                List<Host<String, TestLoadBalancedConnection>> hosts, String targetResource) {
+        public <T extends TestLoadBalancedConnection> HostSelector<String, T> buildSelector(
+                List<Host<String, T>> hosts, String targetResource) {
             return new TestSelector(hosts);
         }
 
-        private class TestSelector implements HostSelector<String, TestLoadBalancedConnection> {
+        private class TestSelector<C extends TestLoadBalancedConnection> implements HostSelector<String, C> {
 
-            private final List<? extends Host<String, TestLoadBalancedConnection>> hosts;
+            private final List<? extends Host<String, C>> hosts;
 
-            TestSelector(final List<? extends Host<String, TestLoadBalancedConnection>> hosts) {
+            TestSelector(final List<? extends Host<String, C>> hosts) {
                 this.hosts = hosts;
             }
 
             @Override
-            public Single<TestLoadBalancedConnection> selectConnection(
-                    Predicate<TestLoadBalancedConnection> selector, @Nullable ContextMap context,
+            public Single<C> selectConnection(
+                    Predicate<C> selector, @Nullable ContextMap context,
                     boolean forceNewConnectionAndReserve) {
                 return hosts.isEmpty() ? failed(new IllegalStateException("shouldn't be empty"))
                         : hosts.get(0).newConnection(selector, false, context);
             }
 
             @Override
-            public HostSelector<String, TestLoadBalancedConnection> rebuildWithHosts(
-                    List<? extends Host<String, TestLoadBalancedConnection>> hosts) {
+            public HostSelector<String, C> rebuildWithHosts(
+                    List<? extends Host<String, C>> hosts) {
                 rebuilds++;
                 return new TestSelector(hosts);
             }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
@@ -37,11 +37,11 @@ class DefaultRequestTrackerTest {
         Assertions.assertEquals(0, requestTracker.score());
 
         // upon success score
-        requestTracker.observeSuccess(requestTracker.beforeStart());
+        requestTracker.onSuccess(requestTracker.beforeStart());
         Assertions.assertEquals(-500, requestTracker.score());
 
         // error penalty
-        requestTracker.observeError(requestTracker.beforeStart());
+        requestTracker.onError(requestTracker.beforeStart());
         Assertions.assertEquals(-5000, requestTracker.score());
 
         // decay

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -44,7 +44,7 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
 
     @Override
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> healthCheckerFactory(
-            HealthCheckerFactory healthCheckerFactory) {
+            HealthCheckerFactory<String> healthCheckerFactory) {
         throw new IllegalStateException("Cannot set a load balancer health checker for old round robin");
     }
 


### PR DESCRIPTION
Motivation:

There are a few places that can be tightened up in DefaultLoadBalancer.

Modifications:

- Fix some copyright dates that went stale over the new year
- Add some missing type parameters to avoid using raw types
- Make RequestTracker method names more uniform
- Cleanup some comments

Result:

Tighter code.