### PR TITLE
loadbalancer: Add the ErrorClass enum and use it in RequestTracker

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
@@ -93,15 +93,10 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
     }
 
     @Override
-    public void onCancel(final long startTimeNanos) {
+    public void onError(final long startTimeNanos, ErrorClass errorClass, Throwable cause) {
         pendingUpdater.decrementAndGet(this);
-        calculateAndStore(this::cancelPenalty, startTimeNanos);
-    }
-
-    @Override
-    public void onError(final long startTimeNanos) {
-        pendingUpdater.decrementAndGet(this);
-        calculateAndStore(this::errorPenalty, startTimeNanos);
+        calculateAndStore(errorClass == ErrorClass.CANCELLED ? this:: cancelPenalty : this::errorPenalty,
+                startTimeNanos);
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
@@ -93,7 +93,7 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
     }
 
     @Override
-    public void onError(final long startTimeNanos, ErrorClass errorClass, Throwable cause) {
+    public void onError(final long startTimeNanos, ErrorClass errorClass) {
         pendingUpdater.decrementAndGet(this);
         calculateAndStore(errorClass == ErrorClass.CANCELLED ? this:: cancelPenalty : this::errorPenalty,
                 startTimeNanos);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/ErrorClass.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/ErrorClass.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+/**
+ * Enumeration of the main failure classes.
+ */
+enum ErrorClass {
+
+    /**
+     * Failures related to locally enforced timeouts that prevent session establishment with the peer.
+     */
+    LOCAL_ORIGIN_TIMEOUT(true),
+    /**
+     * Failures related to connection establishment.
+     */
+    LOCAL_ORIGIN_CONNECT_FAILED(true),
+
+    /**
+     * Failures related to locally enforced timeouts waiting for responses from the peer.
+     */
+    EXT_ORIGIN_TIMEOUT(false),
+
+    /**
+     * Failures returned from the remote peer. This will be things like 5xx responses.
+     */
+    EXT_ORIGIN_REQUEST_FAILED(false),
+
+    /**
+     * Failure due to cancellation.
+     */
+    CANCELLED(true),
+
+    /**
+     * Failure for an unknown reason.
+     */
+    UNKNOWN(false);
+
+    private final boolean isLocal;
+    ErrorClass(boolean isLocal) {
+        this.isLocal = isLocal;
+    }
+
+    public boolean isLocal() {
+        return isLocal;
+    }
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/ErrorClass.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/ErrorClass.java
@@ -42,12 +42,7 @@ enum ErrorClass {
     /**
      * Failure due to cancellation.
      */
-    CANCELLED(true),
-
-    /**
-     * Failure for an unknown reason.
-     */
-    UNKNOWN(false);
+    CANCELLED(true);
 
     private final boolean isLocal;
     ErrorClass(boolean isLocal) {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
@@ -17,13 +17,11 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.context.api.ContextMap;
 
-import javax.annotation.Nullable;
-
 /**
  * A tracker of latency of an action over time.
  * <p>
  * The usage of the RequestTracker is intended to follow the simple workflow:
- * - At initiation of an action for which a request is must call {@link RequestTracker#beforeStart()} and safe the
+ * - At initiation of an action for which a request is must call {@link RequestTracker#beforeStart()} and save the
  *   timestamp much like would be done when using a stamped lock.
  * - Once the request event is complete only one of the {@link RequestTracker#onSuccess(long)} or
  *   {@link RequestTracker#onError(long, ErrorClass, Throwable)} methods must be called and called exactly once.
@@ -56,7 +54,6 @@ interface RequestTracker {
      *
      * @param beforeStartTimeNs return value from {@link #beforeStart()}.
      * @param errorClass the class of error that triggered this method.
-     * @param cause the specific cause of the error, if available. Primarily for observability.
      */
-    void onError(long beforeStartTimeNs, ErrorClass errorClass, @Nullable Throwable cause);
+    void onError(long beforeStartTimeNs, ErrorClass errorClass);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
@@ -17,6 +17,8 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.context.api.ContextMap;
 
+import javax.annotation.Nullable;
+
 /**
  * A tracker of latency of an action over time.
  */
@@ -40,16 +42,11 @@ interface RequestTracker {
     void onSuccess(long beforeStartTimeNs);
 
     /**
-     * Records cancellation of the action for which latency is to be tracked.
-     *
-     * @param beforeStartTimeNs return value from {@link #beforeStart()}.
-     */
-    void onCancel(long beforeStartTimeNs);
-
-    /**
      * Records a failed completion of the action for which latency is to be tracked.
      *
      * @param beforeStartTimeNs return value from {@link #beforeStart()}.
+     * @param errorClass the class of error that triggered this method.
+     * @param cause the specific cause of the error, if available. Primarily for observability.
      */
-    void onError(long beforeStartTimeNs);
+    void onError(long beforeStartTimeNs, ErrorClass errorClass, @Nullable Throwable cause);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
@@ -21,6 +21,16 @@ import javax.annotation.Nullable;
 
 /**
  * A tracker of latency of an action over time.
+ * <p>
+ * The usage of the RequestTracker is intended to follow the simple workflow:
+ * - At initiation of an action for which a request is must call {@link RequestTracker#beforeStart()} and safe the
+ *   timestamp much like would be done when using a stamped lock.
+ * - Once the request event is complete only one of the {@link RequestTracker#onSuccess(long)} or
+ *   {@link RequestTracker#onError(long, ErrorClass, Throwable)} methods must be called and called exactly once.
+ * In other words, every call to {@link RequestTracker#beforeStart()} must be followed by exactly one call to either of
+ * the completion methods {@link RequestTracker#onSuccess(long)} or
+ * {@link RequestTracker#onError(long, ErrorClass, Throwable)}. Failure to do so can cause state corruption in the
+ * {@link RequestTracker} implementations which may track not just latency but also the outstanding requests.
  */
 interface RequestTracker {
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RootSwayingLeafRequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RootSwayingLeafRequestTracker.java
@@ -47,16 +47,9 @@ final class RootSwayingLeafRequestTracker implements RequestTracker {
     }
 
     @Override
-    public void onCancel(final long beforeStartTimeNs) {
+    public void onError(final long beforeStartTimeNs, ErrorClass errorClass, Throwable cause) {
         // Tracks both levels
-        root.onCancel(beforeStartTimeNs);
-        leaf.onCancel(beforeStartTimeNs);
-    }
-
-    @Override
-    public void onError(final long beforeStartTimeNs) {
-        // Tracks both levels
-        root.onError(beforeStartTimeNs);
-        leaf.onError(beforeStartTimeNs);
+        root.onError(beforeStartTimeNs, errorClass, cause);
+        leaf.onError(beforeStartTimeNs, errorClass, cause);
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RootSwayingLeafRequestTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RootSwayingLeafRequestTracker.java
@@ -47,9 +47,9 @@ final class RootSwayingLeafRequestTracker implements RequestTracker {
     }
 
     @Override
-    public void onError(final long beforeStartTimeNs, ErrorClass errorClass, Throwable cause) {
+    public void onError(final long beforeStartTimeNs, ErrorClass errorClass) {
         // Tracks both levels
-        root.onError(beforeStartTimeNs, errorClass, cause);
-        leaf.onError(beforeStartTimeNs, errorClass, cause);
+        root.onError(beforeStartTimeNs, errorClass);
+        leaf.onError(beforeStartTimeNs, errorClass);
     }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -214,7 +214,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
-        public void onError(long beforeStartTime, ErrorClass errorClass, Throwable cause) {
+        public void onError(long beforeStartTime, ErrorClass errorClass) {
         }
     }
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -214,11 +214,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
-        public void onCancel(long beforeStartTimeNs) {
-        }
-
-        @Override
-        public void onError(long beforeStartTime) {
+        public void onError(long beforeStartTime, ErrorClass errorClass, Throwable cause) {
         }
     }
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
@@ -41,8 +41,12 @@ class DefaultRequestTrackerTest {
         Assertions.assertEquals(-500, requestTracker.score());
 
         // error penalty
-        requestTracker.onError(requestTracker.beforeStart());
+        requestTracker.onError(requestTracker.beforeStart(), ErrorClass.LOCAL_ORIGIN_CONNECT_FAILED, null);
         Assertions.assertEquals(-5000, requestTracker.score());
+
+        // cancellation penalty
+        requestTracker.onError(requestTracker.beforeStart(), ErrorClass.CANCELLED, null);
+        Assertions.assertEquals(-12_500, requestTracker.score());
 
         // decay
         when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(20).toNanos());

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
@@ -41,11 +41,11 @@ class DefaultRequestTrackerTest {
         Assertions.assertEquals(-500, requestTracker.score());
 
         // error penalty
-        requestTracker.onError(requestTracker.beforeStart(), ErrorClass.LOCAL_ORIGIN_CONNECT_FAILED, null);
+        requestTracker.onError(requestTracker.beforeStart(), ErrorClass.LOCAL_ORIGIN_CONNECT_FAILED);
         Assertions.assertEquals(-5000, requestTracker.score());
 
         // cancellation penalty
-        requestTracker.onError(requestTracker.beforeStart(), ErrorClass.CANCELLED, null);
+        requestTracker.onError(requestTracker.beforeStart(), ErrorClass.CANCELLED);
         Assertions.assertEquals(-12_500, requestTracker.score());
 
         // decay


### PR DESCRIPTION
Motivation:

RequestTracker has three observer methods: `onSuccess`, `onCancel`, and `onError`. onCancel is really a special case of `onError` but it can be helpful to distinguish them at times which leads to the more general problem: it is often helpful to know what kind of error it was so we can establish the origin.

Modifications:

- Add the `ErrorClass` enum for classifying `RequestTracker` errors.
- Consolidate the `onCancel` method into the `onError` method by having a `CANCELLED` variant of the `ErrorClass` enum.
- Also thread through an optional `Throwable` on the `onError` method so lower levels can log the specific cause, if it exists.

Result:

Less methods and more information about the origin of errors. This should also let us extract the L4 health checker from the DefaultHost implementation and into it's own HealthChecker implementation. However, that will be done as a follow up.