### PR TITLE
loadbalancer: remove 'linear search space' notion from DefaultLoadBalancer

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -34,7 +34,6 @@ import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_JITTER;
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_RESUBSCRIBE_INTERVAL;
 import static io.servicetalk.loadbalancer.HealthCheckConfig.validateHealthCheckIntervals;
-import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection>
@@ -44,7 +43,6 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     private final String id;
     private LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy = defaultLoadBalancingPolicy();
-    private int linearSearchSpace = DEFAULT_LINEAR_SEARCH_SPACE;
 
     @Nullable
     private Executor backgroundExecutor;
@@ -61,12 +59,6 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     // package private constructor so users must funnel through providers in `LoadBalancers`
     DefaultLoadBalancerBuilder(final String id) {
         this.id = requireNonNull(id, "id");
-    }
-
-    @Override
-    public LoadBalancerBuilder<ResolvedAddress, C> linearSearchSpace(int linearSearchSpace) {
-        this.linearSearchSpace = ensurePositive(linearSearchSpace, "linearSearchSpace");
-        return this;
     }
 
     @Override
@@ -144,7 +136,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
                     loadBalancerObserver.hostObserver());
         }
 
-        return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, linearSearchSpace, healthCheckConfig,
+        return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, healthCheckConfig,
                 loadBalancerObserver, healthCheckerSupplier);
     }
 
@@ -154,20 +146,18 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         private final String id;
         private final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy;
         private final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver;
-        private final int linearSearchSpace;
         @Nullable
         private final Supplier<HealthChecker<ResolvedAddress>> healthCheckerFactory;
         @Nullable
         private final HealthCheckConfig healthCheckConfig;
 
         DefaultLoadBalancerFactory(final String id, final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy,
-                                   final int linearSearchSpace, final HealthCheckConfig healthCheckConfig,
+                                   final HealthCheckConfig healthCheckConfig,
                                    final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver,
                                    final Supplier<HealthChecker<ResolvedAddress>> healthCheckerFactory) {
             this.id = requireNonNull(id, "id");
             this.loadBalancingPolicy = requireNonNull(loadBalancingPolicy, "loadBalancingPolicy");
             this.loadBalancerObserver = requireNonNull(loadBalancerObserver, "loadBalancerObserver");
-            this.linearSearchSpace = linearSearchSpace;
             this.healthCheckConfig = healthCheckConfig;
             this.healthCheckerFactory = healthCheckerFactory;
         }
@@ -178,7 +168,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
              ConnectionFactory<ResolvedAddress, T> connectionFactory) {
             return new DefaultLoadBalancer<ResolvedAddress, T>(id, targetResource, eventPublisher,
                     loadBalancingPolicy.buildSelector(Collections.emptyList(), targetResource), connectionFactory,
-                    linearSearchSpace, loadBalancerObserver, healthCheckConfig, healthCheckerFactory);
+                    loadBalancerObserver, healthCheckConfig, healthCheckerFactory);
         }
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -109,22 +109,6 @@ interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection>
      */
     LoadBalancerBuilder<ResolvedAddress, C> backgroundExecutor(Executor backgroundExecutor);
 
-    /**
-     * Sets the linear search space to find an available connection for the next host.
-     * <p>
-     * When the next host has already opened connections, this {@link LoadBalancer} will perform a linear search for
-     * a connection that can serve the next request up to a specified number of attempts. If there are more open
-     * connections, selection of remaining connections will be attempted randomly.
-     * <p>
-     * Higher linear search space may help to better identify excess connections in highly concurrent environments,
-     * but may result in slightly increased selection time.
-     *
-     * @param linearSearchSpace the number of attempts for a linear search space, {@code 0} enforces random
-     * selection all the time.
-     * @return {@code this}.
-     */
-    LoadBalancerBuilder<ResolvedAddress, C> linearSearchSpace(int linearSearchSpace);
-
     // TODO: these healthCheck* methods should be moved into their own OutlierDetection configuration instance
     //  and much like the LoadBalancingPolicy, we should be able to add `OutlierDetectionPolicy`s
     /**

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -99,7 +99,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
         return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
                 new RoundRobinSelector<>(Collections.emptyList(), targetResource, false), connectionFactory,
-                linearSearchSpace, NoopLoadBalancerObserver.instance(), healthCheckConfig, null);
+                NoopLoadBalancerObserver.instance(), healthCheckConfig, null);
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -76,7 +76,7 @@ class DefaultHostTest {
     }
 
     private void buildHost(@Nullable HealthIndicator healthIndicator) {
-        host = new DefaultHost<>("lbDescription", DEFAULT_ADDRESS, connectionFactory, Integer.MAX_VALUE,
+        host = new DefaultHost<>("lbDescription", DEFAULT_ADDRESS, connectionFactory,
                 mockHostObserver, healthCheckConfig, healthIndicator);
     }
 
@@ -89,7 +89,7 @@ class DefaultHostTest {
         buildHost();
         verify(mockHostObserver, times(1)).onHostCreated(DEFAULT_ADDRESS);
         // make another one, just for good measure.
-        new DefaultHost<>("lbDescription", "address2", connectionFactory, Integer.MAX_VALUE,
+        new DefaultHost<>("lbDescription", "address2", connectionFactory,
                 mockHostObserver, healthCheckConfig, null);
         verify(mockHostObserver, times(1)).onHostCreated("address2");
     }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -55,12 +55,6 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
     }
 
     @Override
-    public LoadBalancerBuilder<String, TestLoadBalancedConnection> linearSearchSpace(int linearSearchSpace) {
-        underlying = underlying.linearSearchSpace(linearSearchSpace);
-        return this;
-    }
-
-    @Override
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> healthCheckInterval(
             Duration interval, Duration jitter) {
         underlying = underlying.healthCheckInterval(interval, jitter);


### PR DESCRIPTION
Motivation:

The configurable `linearSearchSpace` is used via a strategy for picking among sessions in a particular host but it is not highly used. That may be for good reason: sessions that are beyond the linear search space are always in the odd position of getting picked a lot or seldom, depending on how many sessions there are. There is not way to set how many times it will attempt to pick a random entry after the linear search space.
There is probably room for customizing the connection pool selection strategy but the demand isn't high right now and when we do add it we should make it more modular and customizable.

Modifications:

Delete the notion of a `linearSearchSpace` from the DefaultLoadBalancer.

Result:

Less code to worry about.