### PR TITLE
WIP: flaky GracefulConnectionClosureHandlingTest

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -44,6 +44,7 @@ import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslProvider;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
@@ -202,7 +203,7 @@ class GracefulConnectionClosureHandlingTest {
 
         if (secure) {
             serverBuilder.sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
-                    DefaultTestCerts::loadServerKey).build());
+                    DefaultTestCerts::loadServerKey).provider(SslProvider.JDK).build());
         }
 
         HostAndPort proxyAddress = null;
@@ -462,7 +463,7 @@ class GracefulConnectionClosureHandlingTest {
     @RepeatedTest(100)
     void closeAfterRequestMetaDataSentResponseMetaDataReceived() throws Exception {
         // only seems to fail if the connection is secure.
-        boolean secure = false;
+        boolean secure = true;
         closeAfterRequestMetaDataSentResponseMetaDataReceived(HTTP_2, secure, false, false, false);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -444,6 +444,7 @@ class GracefulConnectionClosureHandlingTest {
         StreamingHttpResponse response = responseFuture.get();
         assertResponse(response);
 
+        Thread.sleep(500);
         triggerGracefulClosure();
 
         clientSendRequestPayload.countDown();
@@ -461,7 +462,8 @@ class GracefulConnectionClosureHandlingTest {
     @RepeatedTest(100)
     void closeAfterRequestMetaDataSentResponseMetaDataReceived() throws Exception {
         // only seems to fail if the connection is secure.
-        closeAfterRequestMetaDataSentResponseMetaDataReceived(HTTP_2, true, false, false, false);
+        boolean secure = false;
+        closeAfterRequestMetaDataSentResponseMetaDataReceived(HTTP_2, secure, false, false, false);
     }
 
     @ParameterizedTest(name = "{index}: protocol={0} secure={1} initiateClosureFromClient={2} useUds={3} viaProxy={4}")


### PR DESCRIPTION
It's pretty easy to get this test to pop locally: just run some work to make your system busy and then run the tests. They'll pop nearly 50% of the time but _only with TLS_. The problem also seems to be TLS provider agnostic.