### PR TITLE
loadbalancer: Pass connection failures to the HealthIndicator

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
@@ -34,4 +34,18 @@ interface HealthIndicator extends RequestTracker, ScoreSupplier, Cancellable {
      * @return true if the HealthIndicator considers the host healthy, false otherwise.
      */
     boolean isHealthy();
+
+    /**
+     * Get the current time in nanoseconds.
+     * Note: this must not be a stateful API. Eg, it does not necessarily have a correlation with any other method call
+     * and such shouldn't be used as a method of counting in the same way that {@link RequestTracker} is used.
+     * @return the current time in nanoseconds.
+     */
+    long currentTimeNanos();
+
+    /**
+     * Callback to notify the parent {@link HealthChecker} that an attempt to connect to this host has failed.
+     * @param startTimeNanos the time that the connection attempt was initiated.
+     */
+    void onConnectFailure(long startTimeNanos);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -88,7 +88,7 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
     protected abstract void doCancel();
 
     @Override
-    protected final long currentTimeNanos() {
+    public final long currentTimeNanos() {
         return executor.currentTime(TimeUnit.NANOSECONDS);
     }
 
@@ -126,9 +126,17 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
     public final void onError(final long beforeStartTimeNs, ErrorClass errorClass) {
         super.onError(beforeStartTimeNs, errorClass);
         // For now, don't consider cancellation to be an error or a success.
-        if (errorClass == ErrorClass.CANCELLED) {
-            return;
+        if (errorClass != ErrorClass.CANCELLED) {
+            doOnError();
         }
+    }
+
+    @Override
+    public void onConnectFailure(long startTimeNanos) {
+        doOnError();
+    }
+
+    private void doOnError() {
         failures.incrementAndGet();
         final int consecutiveFailures = consecutive5xx.incrementAndGet();
         final OutlierDetectorConfig localConfig = currentConfig();

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -29,11 +29,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
 import static io.servicetalk.loadbalancer.UnhealthyHostConnectionFactory.UNHEALTHY_HOST_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -232,5 +235,18 @@ class DefaultHostTest {
         verify(mockHostObserver, times(1)).onHostCreated("address");
         assertThat(host.score(), is(10));
         verify(healthIndicator, times(1)).score();
+    }
+
+    @Test
+    void connectFailuresAreForwardedToHealthIndicator() {
+        connectionFactory = new TestConnectionFactory(address -> failed(DELIBERATE_EXCEPTION));
+        HealthIndicator healthIndicator = mock(HealthIndicator.class);
+        buildHost(healthIndicator);
+        verify(mockHostObserver, times(1)).onHostCreated("address");
+        Throwable underlying = assertThrows(ExecutionException.class, () ->
+                host.newConnection(cxn -> true, false, null).toFuture().get()).getCause();
+        assertEquals(DELIBERATE_EXCEPTION, underlying);
+        verify(healthIndicator, times(1)).currentTimeNanos();
+        verify(healthIndicator, times(1)).onConnectFailure(0L);
     }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -198,6 +198,15 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
+        public long currentTimeNanos() {
+            return 0;
+        }
+
+        @Override
+        public void onConnectFailure(long startTimeNanos) {
+        }
+
+        @Override
         public void cancel() {
             synchronized (indicatorSet) {
                 assert indicatorSet.remove(this);


### PR DESCRIPTION
Motivation:

We can't rely on the request path to pass in connection failures because if we can't get a connection we can never add the observers. That means we need the `Host` implementation to pass it in directly.

Modifications:

Add two new methods to `HealthIndicator` that provide the current time and and a callback for submitting connection failures.

Result:

We should be able to track connection failures now and factor those into the `HealthTracker` implementations.


## Note
See https://github.com/apple/servicetalk/pull/2818 for an alternative which is substantially the same but has a somewhat better feeling organization.