### PR TITLE
loadbalancer: Add ConnectTracker and make HealthIndicator extend it

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/ConnectTracker.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/ConnectTracker.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+/**
+ * An interface for tracking connection establishment measurements.
+ * This has an intended usage similar to the {@link RequestTracker} but with a focus on connection establishment
+ * metrics.
+ */
+interface ConnectTracker {
+
+    /**
+     * Get the current time in nanoseconds.
+     * Note: this must not be a stateful API. Eg, it does not necessarily have a correlation with any other method call
+     * and such shouldn't be used as a method of counting in the same way that {@link RequestTracker} is used.
+     * @return the current time in nanoseconds.
+     */
+    long beforeConnectStart();
+
+    /**
+     * Callback to notify the parent {@link HealthChecker} that an attempt to connect to this host has succeeded.
+     * @param beforeConnectStart the time that the connection attempt was initiated.
+     */
+    void onConnectSuccess(long beforeConnectStart);
+
+    /**
+     * Callback to notify the parent {@link HealthChecker} that an attempt to connect to this host has failed.
+     * @param beforeConnectStart the time that the connection attempt was initiated.
+     */
+    void onConnectError(long beforeConnectStart);
+}

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/ErrorClass.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/ErrorClass.java
@@ -24,10 +24,6 @@ enum ErrorClass {
      * Failures related to locally enforced timeouts that prevent session establishment with the peer.
      */
     LOCAL_ORIGIN_TIMEOUT(true),
-    /**
-     * Failures related to connection establishment.
-     */
-    LOCAL_ORIGIN_CONNECT_FAILED(true),
 
     /**
      * Failures related to locally enforced timeouts waiting for responses from the peer.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
@@ -34,4 +34,18 @@ interface HealthIndicator extends RequestTracker, ScoreSupplier, Cancellable {
      * @return true if the HealthIndicator considers the host healthy, false otherwise.
      */
     boolean isHealthy();
+
+    /**
+     * Get the current time in nanoseconds.
+     * Note: this must not be a stateful API. Eg, it does not necessarily have a correlation with any other method call
+     * and such shouldn't be used as a method of counting in the same way that {@link RequestTracker} is used.
+     * @return the current time in nanoseconds.
+     */
+    long currentTimeNanos();
+
+    /**
+     * Callback to notify the parent {@link HealthChecker} that an attempt to connect to this host has failed.
+     * @param startTimeNanos the time that the connection attempt was initiated.
+     */
+    void onConnectFailure(long startTimeNanos);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
@@ -26,7 +26,7 @@ import io.servicetalk.concurrent.Cancellable;
  * health check system can give the host information about it's perceived health and the host can give the
  * health check system information about request results.
  */
-interface HealthIndicator extends RequestTracker, ScoreSupplier, Cancellable {
+interface HealthIndicator extends RequestTracker, ConnectTracker, ScoreSupplier, Cancellable {
 
     /**
      * Whether the host is considered healthy by the HealthIndicator.
@@ -34,18 +34,4 @@ interface HealthIndicator extends RequestTracker, ScoreSupplier, Cancellable {
      * @return true if the HealthIndicator considers the host healthy, false otherwise.
      */
     boolean isHealthy();
-
-    /**
-     * Get the current time in nanoseconds.
-     * Note: this must not be a stateful API. Eg, it does not necessarily have a correlation with any other method call
-     * and such shouldn't be used as a method of counting in the same way that {@link RequestTracker} is used.
-     * @return the current time in nanoseconds.
-     */
-    long currentTimeNanos();
-
-    /**
-     * Callback to notify the parent {@link HealthChecker} that an attempt to connect to this host has failed.
-     * @param startTimeNanos the time that the connection attempt was initiated.
-     */
-    void onConnectFailure(long startTimeNanos);
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -88,7 +88,7 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
     protected abstract void doCancel();
 
     @Override
-    protected final long currentTimeNanos() {
+    public final long currentTimeNanos() {
         return executor.currentTime(TimeUnit.NANOSECONDS);
     }
 
@@ -126,9 +126,17 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
     public final void onError(final long beforeStartTimeNs, ErrorClass errorClass) {
         super.onError(beforeStartTimeNs, errorClass);
         // For now, don't consider cancellation to be an error or a success.
-        if (errorClass == ErrorClass.CANCELLED) {
-            return;
+        if (errorClass != ErrorClass.CANCELLED) {
+            doOnError();
         }
+    }
+
+    @Override
+    public void onConnectFailure(long startTimeNanos) {
+        doOnError();
+    }
+
+    private void doOnError() {
         failures.incrementAndGet();
         final int consecutiveFailures = consecutive5xx.incrementAndGet();
         final OutlierDetectorConfig localConfig = currentConfig();

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -132,8 +132,21 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
     }
 
     @Override
-    public void onConnectFailure(long startTimeNanos) {
+    public long beforeConnectStart() {
+        return currentTimeNanos();
+    }
+
+    @Override
+    public void onConnectError(long beforeConnectStart) {
+        // This assumes that the connect request was intended to be used for a request dispatch which
+        // will have now failed. This is not strictly true: a connection can be acquired and simply not
+        // used, but in practice it's a very good assumption.
         doOnError();
+    }
+
+    @Override
+    public void onConnectSuccess(long beforeConnectStart) {
+        // noop: the request path will now determine if the request was a success or failure.
     }
 
     private void doOnError() {

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -246,7 +246,7 @@ class DefaultHostTest {
         Throwable underlying = assertThrows(ExecutionException.class, () ->
                 host.newConnection(cxn -> true, false, null).toFuture().get()).getCause();
         assertEquals(DELIBERATE_EXCEPTION, underlying);
-        verify(healthIndicator, times(1)).currentTimeNanos();
-        verify(healthIndicator, times(1)).onConnectFailure(0L);
+        verify(healthIndicator, times(1)).beforeConnectStart();
+        verify(healthIndicator, times(1)).onConnectError(0L);
     }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -29,11 +29,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
 import static io.servicetalk.loadbalancer.UnhealthyHostConnectionFactory.UNHEALTHY_HOST_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -232,5 +235,18 @@ class DefaultHostTest {
         verify(mockHostObserver, times(1)).onHostCreated("address");
         assertThat(host.score(), is(10));
         verify(healthIndicator, times(1)).score();
+    }
+
+    @Test
+    void connectFailuresAreForwardedToHealthIndicator() {
+        connectionFactory = new TestConnectionFactory(address -> failed(DELIBERATE_EXCEPTION));
+        HealthIndicator healthIndicator = mock(HealthIndicator.class);
+        buildHost(healthIndicator);
+        verify(mockHostObserver, times(1)).onHostCreated("address");
+        Throwable underlying = assertThrows(ExecutionException.class, () ->
+                host.newConnection(cxn -> true, false, null).toFuture().get()).getCause();
+        assertEquals(DELIBERATE_EXCEPTION, underlying);
+        verify(healthIndicator, times(1)).currentTimeNanos();
+        verify(healthIndicator, times(1)).onConnectFailure(0L);
     }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -198,12 +198,16 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
-        public long currentTimeNanos() {
+        public long beforeConnectStart() {
             return 0;
         }
 
         @Override
-        public void onConnectFailure(long startTimeNanos) {
+        public void onConnectSuccess(long beforeConnectStart) {
+        }
+
+        @Override
+        public void onConnectError(long beforeConnectStart) {
         }
 
         @Override

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -198,6 +198,15 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
+        public long currentTimeNanos() {
+            return 0;
+        }
+
+        @Override
+        public void onConnectFailure(long startTimeNanos) {
+        }
+
+        @Override
         public void cancel() {
             synchronized (indicatorSet) {
                 assert indicatorSet.remove(this);

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
@@ -41,7 +41,7 @@ class DefaultRequestTrackerTest {
         Assertions.assertEquals(-500, requestTracker.score());
 
         // error penalty
-        requestTracker.onError(requestTracker.beforeStart(), ErrorClass.LOCAL_ORIGIN_CONNECT_FAILED);
+        requestTracker.onError(requestTracker.beforeStart(), ErrorClass.EXT_ORIGIN_REQUEST_FAILED);
         Assertions.assertEquals(-5000, requestTracker.score());
 
         // cancellation penalty


### PR DESCRIPTION
Motivation:

We can't rely on the request path to pass in connection failures because if we can't get a connection we can never add the observers. That means we need the Host implementation to pass it in directly.

Modifications:

Add a new interface, `ConnectTracker`, that mirrors `RequestTracker` in purpose but with the intent of monitoring session establishment related events and have HealthIndicator extend it.

Result:

We should be able to track connection failures now and factor those into the HealthTracker implementations.