### PR TITLE
loadbalancer-experimental: HostObserver shouldn't need a type param

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
@@ -102,7 +102,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     private final HealthCheckConfig healthCheckConfig;
     @Nullable
     private final HealthIndicator healthIndicator;
-    private final LoadBalancerObserver.HostObserver<Addr> hostObserver;
+    private final LoadBalancerObserver.HostObserver hostObserver;
     private final ConnectionFactory<Addr, ? extends C> connectionFactory;
     private final int linearSearchSpace;
     private final ListenableAsyncCloseable closeable;
@@ -110,7 +110,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
 
     DefaultHost(final String lbDescription, final Addr address,
                 final ConnectionFactory<Addr, ? extends C> connectionFactory,
-                final int linearSearchSpace, final HostObserver<Addr> hostObserver,
+                final int linearSearchSpace, final HostObserver hostObserver,
                 final @Nullable HealthCheckConfig healthCheckConfig, final @Nullable HealthIndicator healthIndicator) {
         this.lbDescription = requireNonNull(lbDescription, "lbDescription");
         this.address = requireNonNull(address, "address");
@@ -122,7 +122,6 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
         this.healthCheckConfig = healthCheckConfig;
         this.hostObserver = requireNonNull(hostObserver, "hostObserver");
         this.closeable = toAsyncCloseable(this::doClose);
-        hostObserver.onHostCreated(address);
     }
 
     @Override
@@ -142,7 +141,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
             return oldConnState;
         });
         if (oldState.state == State.EXPIRED) {
-            hostObserver.onExpiredHostRevived(address, oldState.connections.size());
+            hostObserver.onExpiredHostRevived(oldState.connections.size());
         }
         return oldState.state != State.CLOSED;
     }
@@ -179,7 +178,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
             Object nextState = oldState.connections.isEmpty() ? State.CLOSED : State.EXPIRED;
             if (connStateUpdater.compareAndSet(this, oldState, oldState.toExpired())) {
                 cancelIfHealthCheck(oldState);
-                hostObserver.onHostMarkedExpired(address, oldState.connections.size());
+                hostObserver.onHostMarkedExpired(oldState.connections.size());
                 if (nextState == State.CLOSED) {
                     // Trigger the callback to remove the host from usedHosts array.
                     this.closeAsync().subscribe();
@@ -303,7 +302,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
         }
         // Only if the previous state was a healthcheck should we notify the observer.
         if (oldState.isUnhealthy()) {
-            hostObserver.onHostRevived(address);
+            hostObserver.onHostRevived();
         }
     }
 
@@ -334,7 +333,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
                                     "{} time(s) in a row. Error counting threshold reached, marking this host as " +
                                     "UNHEALTHY for the selection algorithm and triggering background health-checking.",
                             lbDescription, address, healthCheckConfig.failedThreshold, cause);
-                    hostObserver.onHostMarkedUnhealthy(address, cause);
+                    hostObserver.onHostMarkedUnhealthy(cause);
                     nextState.healthCheck.schedule(cause);
                 }
                 break;
@@ -378,7 +377,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
                         cancelIfHealthCheck(previous);
                     }
                     // If we transitioned from unhealth to healthy we need to let the observer know.
-                    hostObserver.onHostRevived(address);
+                    hostObserver.onHostRevived();
                 }
                 break;
             }
@@ -415,7 +414,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
                             // in the next iteration.
                             && connStateUpdater.compareAndSet(this, currentConnState, nextState.toClosed())) {
                         closeAsync().subscribe();
-                        hostObserver.onExpiredHostRemoved(address, nextState.connections.size());
+                        hostObserver.onExpiredHostRemoved(nextState.connections.size());
                         break;
                     }
                 } else {
@@ -468,9 +467,9 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
             LOGGER.debug("{}: closing {} connection(s) {}gracefully to the closed address: {}.",
                     lbDescription, oldState.connections.size(), graceful ? "" : "un", address);
             if (oldState.state == State.ACTIVE) {
-                hostObserver.onActiveHostRemoved(address, oldState.connections.size());
+                hostObserver.onActiveHostRemoved(oldState.connections.size());
             } else if (oldState.state == State.EXPIRED) {
-                hostObserver.onExpiredHostRemoved(address, oldState.connections.size());
+                hostObserver.onExpiredHostRemoved(oldState.connections.size());
             }
             final List<C> connections = oldState.connections;
             return (connections.isEmpty() ? completed() :

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -46,8 +46,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.LoadBalancerReadyEvent.LOAD_BALANCER_NOT_READY_EVENT;
@@ -133,7 +133,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final int linearSearchSpace,
             final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver,
             @Nullable final HealthCheckConfig healthCheckConfig,
-            @Nullable final Supplier<HealthChecker<ResolvedAddress>> healthCheckerFactory) {
+            @Nullable final Function<String, HealthChecker<ResolvedAddress>> healthCheckerFactory) {
         this.targetResource = requireNonNull(targetResourceName);
         this.lbDescription = makeDescription(id, targetResource);
         this.hostSelector = requireNonNull(hostSelector, "hostSelector");
@@ -150,7 +150,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         // Maintain a Subscriber so signals are always delivered to replay and new Subscribers get the latest signal.
         eventStream.ignoreElements().subscribe();
         subscribeToEvents(false);
-        this.healthChecker = healthCheckerFactory == null ? null : healthCheckerFactory.get();
+        this.healthChecker = healthCheckerFactory == null ? null : healthCheckerFactory.apply(lbDescription);
     }
 
     private void subscribeToEvents(boolean resubscribe) {
@@ -383,10 +383,12 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         }
 
         private Host<ResolvedAddress, C> createHost(ResolvedAddress addr) {
+            final LoadBalancerObserver.HostObserver hostObserver = loadBalancerObserver.hostObserver(addr);
             // All hosts will share the healthcheck config of the parent RR loadbalancer.
-            final HealthIndicator indicator = healthChecker == null ? null : healthChecker.newHealthIndicator(addr);
+            final HealthIndicator indicator = healthChecker == null ?
+                    null : healthChecker.newHealthIndicator(addr, hostObserver);
             final Host<ResolvedAddress, C> host = new DefaultHost<>(lbDescription, addr, connectionFactory,
-                    linearSearchSpace, loadBalancerObserver.hostObserver(), healthCheckConfig, indicator);
+                    linearSearchSpace, hostObserver, healthCheckConfig, indicator);
             host.onClose().afterFinally(() ->
                     sequentialExecutor.execute(() -> {
                         final List<Host<ResolvedAddress, C>> currentHosts = usedHosts;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -140,7 +140,8 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
             healthCheckerSupplier = null;
         } else {
             final Executor executor = getExecutor();
-            healthCheckerSupplier = (String lbDescrption) -> healthCheckerFactory.newHealthChecker(executor, lbDescrption);
+            healthCheckerSupplier = (String lbDescrption) ->
+                    healthCheckerFactory.newHealthChecker(executor, lbDescrption);
         }
 
         return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, linearSearchSpace, healthCheckConfig,

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -26,7 +26,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
@@ -135,13 +135,12 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         }
         final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver = this.loadBalancerObserver != null ?
                 this.loadBalancerObserver : NoopLoadBalancerObserver.instance();
-        Supplier<HealthChecker<ResolvedAddress>> healthCheckerSupplier;
+        Function<String, HealthChecker<ResolvedAddress>> healthCheckerSupplier;
         if (healthCheckerFactory == null) {
             healthCheckerSupplier = null;
         } else {
             final Executor executor = getExecutor();
-            healthCheckerSupplier = () -> healthCheckerFactory.newHealthChecker(executor,
-                    loadBalancerObserver.hostObserver());
+            healthCheckerSupplier = (String lbDescrption) -> healthCheckerFactory.newHealthChecker(executor, lbDescrption);
         }
 
         return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, linearSearchSpace, healthCheckConfig,
@@ -156,14 +155,14 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         private final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver;
         private final int linearSearchSpace;
         @Nullable
-        private final Supplier<HealthChecker<ResolvedAddress>> healthCheckerFactory;
+        private final Function<String, HealthChecker<ResolvedAddress>> healthCheckerFactory;
         @Nullable
         private final HealthCheckConfig healthCheckConfig;
 
         DefaultLoadBalancerFactory(final String id, final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy,
                                    final int linearSearchSpace, final HealthCheckConfig healthCheckConfig,
                                    final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver,
-                                   final Supplier<HealthChecker<ResolvedAddress>> healthCheckerFactory) {
+                                   final Function<String, HealthChecker<ResolvedAddress>> healthCheckerFactory) {
             this.id = requireNonNull(id, "id");
             this.loadBalancingPolicy = requireNonNull(loadBalancingPolicy, "loadBalancingPolicy");
             this.loadBalancerObserver = requireNonNull(loadBalancerObserver, "loadBalancerObserver");

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthChecker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthChecker.java
@@ -30,5 +30,5 @@ interface HealthChecker<ResolvedAddress> extends Cancellable {
      * @param address the resolved address of the destination.
      * @return new {@link HealthIndicator}.
      */
-    HealthIndicator newHealthIndicator(ResolvedAddress address);
+    HealthIndicator newHealthIndicator(ResolvedAddress address, LoadBalancerObserver.HostObserver hostObserver);
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthCheckerFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthCheckerFactory.java
@@ -27,9 +27,8 @@ interface HealthCheckerFactory<ResolvedAddress> {
     /**
      * Create a new {@link HealthChecker}.
      * @param executor the {@link Executor} to use for scheduling tasks and obtaining the current time.
-     * @param hostObserver a {@link HostObserver} to notify of
-     *                     relevant host events.
+     * @param lbDescription a description of the load balancer for logging purposes.
      * @return a new {@link HealthChecker}.
      */
-    HealthChecker newHealthChecker(Executor executor, HostObserver<ResolvedAddress> hostObserver);
+    HealthChecker newHealthChecker(Executor executor, String lbDescription);
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthCheckerFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthCheckerFactory.java
@@ -16,7 +16,6 @@
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.loadbalancer.LoadBalancerObserver.HostObserver;
 
 /**
  * A factory of {@link HealthChecker} instances. The factory will be used by load balancer
@@ -30,5 +29,5 @@ interface HealthCheckerFactory<ResolvedAddress> {
      * @param lbDescription a description of the load balancer for logging purposes.
      * @return a new {@link HealthChecker}.
      */
-    HealthChecker newHealthChecker(Executor executor, String lbDescription);
+    HealthChecker<ResolvedAddress> newHealthChecker(Executor executor, String lbDescription);
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -62,35 +62,30 @@ interface LoadBalancerObserver<ResolvedAddress> {
 
         /**
          * Callback for when a host is removed by service discovery.
-         * @param address the resolved address.
          * @param connectionCount the number of open connections when the host was removed.
          */
         void onActiveHostRemoved(int connectionCount);
 
         /**
          * Callback for when an expired host is returned to an active state.
-         * @param address the resolved address.
          * @param connectionCount the number of active connections when the host was revived.
          */
         void onExpiredHostRevived(int connectionCount);
 
         /**
          * Callback for when an expired host is removed.
-         * @param address the resolved address.
          * @param connectionCount the number of open connections when the host was removed.
          */
         void onExpiredHostRemoved(int connectionCount);
 
         /**
          * Callback for when a {@link Host} transitions from healthy to unhealthy.
-         * @param address the resolved address.
          * @param cause the most recent cause of the transition.
          */
         void onHostMarkedUnhealthy(@Nullable Throwable cause);
 
         /**
          * Callback for when a {@link Host} transitions from unhealthy to healthy.
-         * @param address the resolved address.
          */
         void onHostRevived();
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -31,7 +31,7 @@ interface LoadBalancerObserver<ResolvedAddress> {
      * Get a {@link HostObserver}.
      * @return a {@link HostObserver}.
      */
-    HostObserver<ResolvedAddress> hostObserver();
+    HostObserver hostObserver(ResolvedAddress resolvedAddress);
 
     /**
      * Callback for when connection selection fails due to no hosts being available.
@@ -51,55 +51,47 @@ interface LoadBalancerObserver<ResolvedAddress> {
 
     /**
      * An observer for {@link Host} events.
-     * @param <ResolvedAddress> the type of the resolved address.
      */
-    interface HostObserver<ResolvedAddress> {
+    interface HostObserver {
 
         /**
          * Callback for when an active host is marked expired.
-         * @param address the resolved address.
          * @param connectionCount the number of active connections for the host.
          */
-        void onHostMarkedExpired(ResolvedAddress address, int connectionCount);
+        void onHostMarkedExpired(int connectionCount);
 
         /**
          * Callback for when a host is removed by service discovery.
          * @param address the resolved address.
          * @param connectionCount the number of open connections when the host was removed.
          */
-        void onActiveHostRemoved(ResolvedAddress address, int connectionCount);
+        void onActiveHostRemoved(int connectionCount);
 
         /**
          * Callback for when an expired host is returned to an active state.
          * @param address the resolved address.
          * @param connectionCount the number of active connections when the host was revived.
          */
-        void onExpiredHostRevived(ResolvedAddress address, int connectionCount);
+        void onExpiredHostRevived(int connectionCount);
 
         /**
          * Callback for when an expired host is removed.
          * @param address the resolved address.
          * @param connectionCount the number of open connections when the host was removed.
          */
-        void onExpiredHostRemoved(ResolvedAddress address, int connectionCount);
-
-        /**
-         * Callback for when a host is created.
-         * @param address the resolved address.
-         */
-        void onHostCreated(ResolvedAddress address);
+        void onExpiredHostRemoved(int connectionCount);
 
         /**
          * Callback for when a {@link Host} transitions from healthy to unhealthy.
          * @param address the resolved address.
          * @param cause the most recent cause of the transition.
          */
-        void onHostMarkedUnhealthy(ResolvedAddress address, @Nullable Throwable cause);
+        void onHostMarkedUnhealthy(@Nullable Throwable cause);
 
         /**
          * Callback for when a {@link Host} transitions from unhealthy to healthy.
          * @param address the resolved address.
          */
-        void onHostRevived(ResolvedAddress address);
+        void onHostRevived();
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
@@ -29,8 +29,8 @@ final class NoopLoadBalancerObserver<ResolvedAddress> implements LoadBalancerObs
     }
 
     @Override
-    public HostObserver<ResolvedAddress> hostObserver() {
-        return (HostObserver<ResolvedAddress>) NoopHostObserver.INSTANCE;
+    public HostObserver hostObserver(ResolvedAddress resolvedAddress) {
+        return NoopHostObserver.INSTANCE;
     }
 
     @Override
@@ -49,46 +49,40 @@ final class NoopLoadBalancerObserver<ResolvedAddress> implements LoadBalancerObs
         // noop
     }
 
-    private static final class NoopHostObserver<ResolvedAddress> implements
-            LoadBalancerObserver.HostObserver<ResolvedAddress> {
+    private static final class NoopHostObserver implements LoadBalancerObserver.HostObserver {
 
-        private static final HostObserver<Object> INSTANCE = new NoopHostObserver<>();
+        private static final HostObserver INSTANCE = new NoopHostObserver();
 
         private NoopHostObserver() {
         }
 
         @Override
-        public void onHostMarkedExpired(ResolvedAddress resolvedAddress, int connectionCount) {
+        public void onHostMarkedExpired(int connectionCount) {
             // noop
         }
 
         @Override
-        public void onExpiredHostRemoved(ResolvedAddress resolvedAddress, int connectionCount) {
+        public void onExpiredHostRemoved(int connectionCount) {
             // noop
         }
 
         @Override
-        public void onExpiredHostRevived(ResolvedAddress resolvedAddress, int connectionCount) {
+        public void onExpiredHostRevived(int connectionCount) {
             // noop
         }
 
         @Override
-        public void onActiveHostRemoved(ResolvedAddress resolvedAddress, int connectionCount) {
+        public void onActiveHostRemoved(int connectionCount) {
             // noop
         }
 
         @Override
-        public void onHostCreated(ResolvedAddress resolvedAddress) {
+        public void onHostMarkedUnhealthy(Throwable cause) {
             // noop
         }
 
         @Override
-        public void onHostMarkedUnhealthy(ResolvedAddress address, Throwable cause) {
-            // noop
-        }
-
-        @Override
-        public void onHostRevived(ResolvedAddress address) {
+        public void onHostRevived() {
             // noop
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthChecker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthChecker.java
@@ -61,6 +61,7 @@ final class XdsHealthChecker<ResolvedAddress> implements HealthChecker<ResolvedA
 
     private final SequentialExecutor sequentialExecutor;
     private final Executor executor;
+    private final String lbDescription;
     private final Kernel kernel;
     private final AtomicInteger indicatorCount = new AtomicInteger();
     // Protected by `sequentialExecutor`.
@@ -72,6 +73,7 @@ final class XdsHealthChecker<ResolvedAddress> implements HealthChecker<ResolvedA
         this.sequentialExecutor = new SequentialExecutor((uncaughtException) ->
             LOGGER.error("{}: Uncaught exception in " + this.getClass().getSimpleName(), this, uncaughtException));
         this.executor = requireNonNull(executor, "executor");
+        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
         this.kernel = new Kernel(config);
     }
 
@@ -99,7 +101,7 @@ final class XdsHealthChecker<ResolvedAddress> implements HealthChecker<ResolvedA
     private final class XdsHealthIndicatorImpl extends XdsHealthIndicator<ResolvedAddress> {
 
         XdsHealthIndicatorImpl(final ResolvedAddress address, HostObserver hostObserver) {
-            super(sequentialExecutor, executor, address, hostObserver);
+            super(sequentialExecutor, executor, address, lbDescription, hostObserver);
         }
 
         @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthCheckerFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthCheckerFactory.java
@@ -16,7 +16,6 @@
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.loadbalancer.LoadBalancerObserver.HostObserver;
 
 import static java.util.Objects.requireNonNull;
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthCheckerFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthCheckerFactory.java
@@ -35,7 +35,7 @@ final class XdsHealthCheckerFactory<ResolvedAddress> implements HealthCheckerFac
 
     @Override
     public HealthChecker<ResolvedAddress> newHealthChecker(
-            final Executor executor, final HostObserver<ResolvedAddress> hostObserver) {
-        return new XdsHealthChecker<>(executor, hostObserver, config);
+            final Executor executor, String lbDescription) {
+        return new XdsHealthChecker<>(executor, config, lbDescription);
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -42,6 +42,7 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
     private final Executor executor;
     private final HostObserver hostObserver;
     private final ResolvedAddress address;
+    private final String lbDescription;
     private final AtomicInteger consecutive5xx = new AtomicInteger();
     private final AtomicLong successes = new AtomicLong();
     private final AtomicLong failures = new AtomicLong();
@@ -56,12 +57,13 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
     private volatile Long evictedUntilNanos;
 
     XdsHealthIndicator(final SequentialExecutor sequentialExecutor, final Executor executor,
-                       final ResolvedAddress address, final HostObserver hostObserver) {
+                       final ResolvedAddress address, final String lbDescription, final HostObserver hostObserver) {
         super(1);
         this.sequentialExecutor = requireNonNull(sequentialExecutor, "sequentialExecutor");
         this.executor = requireNonNull(executor, "executor");
         assert executor instanceof NormalizedTimeSourceExecutor;
         this.address = requireNonNull(address, "address");
+        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
         this.hostObserver = requireNonNull(hostObserver, "hostObserver");
     }
 
@@ -119,7 +121,9 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
         super.onRequestSuccess(beforeStartTimeNs);
         successes.incrementAndGet();
         consecutive5xx.set(0);
-        LOGGER.trace("Observed success for address {}", address);
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("{}-{}: observed request success", lbDescription, address);
+        }
     }
 
     @Override
@@ -158,15 +162,15 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
                 if (!cancelled && evictedUntilNanos == null &&
                         sequentialTryEject(currentConfig(), CONSECUTIVE_5XX_CAUSE) && // this performs side effects.
                         LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("address {}: observed error which did result in consecutive 5xx ejection. " +
-                                    "Consecutive 5xx: {}, limit: {}.", address, consecutiveFailures,
+                    LOGGER.debug("{}-{}: observed error which did result in consecutive 5xx ejection. " +
+                                    "Consecutive 5xx: {}, limit: {}.", lbDescription, address, consecutiveFailures,
                             localConfig.consecutive5xx());
                 }
             });
         } else {
             if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace("address {}: observed error which didn't result in ejection. " +
-                        "Consecutive 5xx: {}, limit: {}", address, consecutiveFailures, localConfig.consecutive5xx());
+                LOGGER.trace("{}-{}: observed error which didn't result in ejection. Consecutive 5xx: {}, limit: {}",
+                        lbDescription, address, consecutiveFailures, localConfig.consecutive5xx());
             }
         }
     }
@@ -192,23 +196,23 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
             // If we are evicted or just transitioned out of eviction we shouldn't be marked as  an outlier this round.
             // Note that this differs from the envoy behavior. If we want to mimic it, then I think we need to just
             // fall through and maybe attempt to eject again.
-            LOGGER.trace("address {}: markAsOutlier(..) resulted in host revival.", address);
+            LOGGER.trace("{}-{}: markAsOutlier(..) resulted in host revival.", lbDescription, address);
             return false;
         } else if (isOutlier) {
             final boolean result = sequentialTryEject(config, OUTLIER_DETECTOR_CAUSE);
             if (result) {
-                LOGGER.debug("address {}: markAsOutlier(isOutlier = true) resulted in ejection. " +
-                        "Failure multiplier: {}.", address, failureMultiplier);
+                LOGGER.debug("{}-{}: markAsOutlier(isOutlier = true) resulted in ejection. " +
+                        "Failure multiplier: {}.", lbDescription, address, failureMultiplier);
             } else {
-                LOGGER.trace("address {}: markAsOutlier(isOutlier = true) did not result in ejection. " +
-                        "Failure multiplier: {}.", address, failureMultiplier);
+                LOGGER.trace("{}-{}: markAsOutlier(isOutlier = true) did not result in ejection. " +
+                        "Failure multiplier: {}.", lbDescription, address, failureMultiplier);
             }
             return result;
         } else {
             // All we have to do is decrement our failure multiplier.
             failureMultiplier = max(0, failureMultiplier - 1);
-            LOGGER.trace("address {}: markAsOutlier(isOutlier = false). " +
-                    "Failure multiplier: {}", address, failureMultiplier);
+            LOGGER.trace("{}-{}: markAsOutlier(isOutlier = false). " +
+                    "Failure multiplier: {}", lbDescription, address, failureMultiplier);
             return false;
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -40,7 +40,7 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
 
     private final SequentialExecutor sequentialExecutor;
     private final Executor executor;
-    private final HostObserver<ResolvedAddress> hostObserver;
+    private final HostObserver hostObserver;
     private final ResolvedAddress address;
     private final AtomicInteger consecutive5xx = new AtomicInteger();
     private final AtomicLong successes = new AtomicLong();
@@ -56,7 +56,7 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
     private volatile Long evictedUntilNanos;
 
     XdsHealthIndicator(final SequentialExecutor sequentialExecutor, final Executor executor,
-                       final ResolvedAddress address, final HostObserver<ResolvedAddress> hostObserver) {
+                       final ResolvedAddress address, final HostObserver hostObserver) {
         super(1);
         this.sequentialExecutor = requireNonNull(sequentialExecutor, "sequentialExecutor");
         this.executor = requireNonNull(executor, "executor");
@@ -262,7 +262,7 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
         // Finally we add jitter to the ejection time.
         final long jitterNanos = ThreadLocalRandom.current().nextLong(config.maxEjectionTimeJitter().toNanos() + 1);
         evictedUntilNanos = currentTimeNanos() + ejectTimeNanos + jitterNanos;
-        hostObserver.onHostMarkedUnhealthy(address, cause);
+        hostObserver.onHostMarkedUnhealthy(cause);
         return true;
     }
 
@@ -274,7 +274,7 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
         // are reasonable that it's still a bad host, so we'll want to mark it as an outlier again immediately if
         // the next request also fails.
         hostRevived();
-        hostObserver.onHostRevived(address);
+        hostObserver.onHostRevived();
     }
 
     private static final class EjectedCause extends Exception {

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -235,7 +235,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
         final AtomicReference<TestHealthChecker> currentHealthChecker = new AtomicReference<>();
         @Override
-        public HealthChecker newHealthChecker(Executor executor, HostObserver<String> hostObserver) {
+        public HealthChecker newHealthChecker(Executor executor, String lbDescription) {
             assert currentHealthChecker.get() == null;
             TestHealthChecker result = new TestHealthChecker();
             currentHealthChecker.set(result);
@@ -254,7 +254,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
-        public HealthIndicator newHealthIndicator(String address) {
+        public HealthIndicator newHealthIndicator(String address, HostObserver hostObserver) {
             TestHealthIndicator healthIndicator = new TestHealthIndicator(indicatorSet, address);
             synchronized (indicatorSet) {
                 indicatorSet.add(healthIndicator);

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -231,7 +231,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
     }
 
-    private static class TestHealthCheckerFactory implements HealthCheckerFactory<String> {
+    private static class TestHealthCheckerFactory implements HealthCheckerFactory {
 
         final AtomicReference<TestHealthChecker> currentHealthChecker = new AtomicReference<>();
         @Override

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/MockLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/MockLoadBalancerObserver.java
@@ -15,21 +15,22 @@
  */
 package io.servicetalk.loadbalancer;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 interface MockLoadBalancerObserver extends LoadBalancerObserver<String> {
 
     @Override
-    MockHostObserver hostObserver();
+    MockHostObserver hostObserver(String resolvedAddress);
 
-    interface MockHostObserver extends LoadBalancerObserver.HostObserver<String> {
+    interface MockHostObserver extends LoadBalancerObserver.HostObserver {
     }
 
     static MockLoadBalancerObserver mockObserver() {
         MockHostObserver mockHostObserver = mock(MockHostObserver.class);
         MockLoadBalancerObserver loadBalancerObserver = mock(MockLoadBalancerObserver.class);
-        when(loadBalancerObserver.hostObserver()).thenReturn(mockHostObserver);
+        when(loadBalancerObserver.hostObserver(any())).thenReturn(mockHostObserver);
         return loadBalancerObserver;
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthCheckerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthCheckerTest.java
@@ -65,8 +65,11 @@ class XdsHealthCheckerTest {
     }
 
     private XdsHealthChecker<String> buildHealthChecker() {
-        LoadBalancerObserver<String> observer = NoopLoadBalancerObserver.instance();
-        return new XdsHealthChecker<>(new NormalizedTimeSourceExecutor(testExecutor), observer.hostObserver(), config);
+        return new XdsHealthChecker<>(new NormalizedTimeSourceExecutor(testExecutor), config, "");
+    }
+
+    private LoadBalancerObserver.HostObserver observer() {
+        return NoopLoadBalancerObserver.instance().hostObserver("");
     }
 
     @Test
@@ -78,8 +81,8 @@ class XdsHealthCheckerTest {
     void cancellation() {
         config = withAllEnforcing().maxEjectionPercentage(100).build();
         healthChecker = buildHealthChecker();
-        HealthIndicator indicator1 = healthChecker.newHealthIndicator("address-1");
-        HealthIndicator indicator2 = healthChecker.newHealthIndicator("address-2");
+        HealthIndicator indicator1 = healthChecker.newHealthIndicator("address-1", observer());
+        HealthIndicator indicator2 = healthChecker.newHealthIndicator("address-2", observer());
         eject(indicator1);
         eject(indicator2);
         assertFalse(indicator1.isHealthy());
@@ -108,7 +111,7 @@ class XdsHealthCheckerTest {
                 .build();
         healthChecker = buildHealthChecker();
 
-        HealthIndicator indicator1 = healthChecker.newHealthIndicator("address-1");
+        HealthIndicator indicator1 = healthChecker.newHealthIndicator("address-1", observer());
         eject(indicator1);
         assertFalse(indicator1.isHealthy());
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
@@ -133,7 +136,7 @@ class XdsHealthCheckerTest {
         healthChecker = buildHealthChecker();
         List<HealthIndicator> healthIndicators = new ArrayList<>(4);
         for (int i = 0; i < 4; i++) {
-            healthIndicators.add(healthChecker.newHealthIndicator("address-" + i));
+            healthIndicators.add(healthChecker.newHealthIndicator("address-" + i, observer()));
         }
 
         for (HealthIndicator indicator : healthIndicators) {

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -213,7 +213,7 @@ class XdsHealthIndicatorTest {
 
         TestIndicator(final OutlierDetectorConfig config) {
             super(sequentialExecutor, new NormalizedTimeSourceExecutor(testExecutor), "address",
-                    NoopLoadBalancerObserver.<String>instance().hostObserver());
+                    NoopLoadBalancerObserver.<String>instance().hostObserver("address"));
             this.config = config;
         }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -213,7 +213,7 @@ class XdsHealthIndicatorTest {
 
         TestIndicator(final OutlierDetectorConfig config) {
             super(sequentialExecutor, new NormalizedTimeSourceExecutor(testExecutor), "address",
-                    NoopLoadBalancerObserver.<String>instance().hostObserver("address"));
+                    "description", NoopLoadBalancerObserver.<String>instance().hostObserver("address"));
             this.config = config;
         }
 


### PR DESCRIPTION
Motivation:

The current HostObserver API requires one to pass in the ResolvedAddress on each callback. This means that every place we want to observer events also needs to know the address which can be a pain.

Modifications:

- Drop the type parameter from `HostObserver`
- Make `LoadBalancerObserver` take the address as a parameter of the `hostObserver(..)` method
- Modify the `HealthChecker` interfaces to take the `HostObserver` during construction of the associated `HealthIndicator`