### PR TITLE
loadbalancer-experimental: Thread through the EWMA half life in XdsHealthTracker

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.ScoreSupplier;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.IntBinaryOperator;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.MIN_VALUE;
 import static java.lang.Math.ceil;
@@ -66,9 +67,7 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
     }
 
     DefaultRequestTracker(final long halfLifeNanos, final long cancelPenalty, final long errorPenalty) {
-        if (halfLifeNanos <= 0) {
-            throw new IllegalArgumentException("halfLifeNanos: " + halfLifeNanos + " (expected >0)");
-        }
+        ensurePositive(halfLifeNanos, "halfLifeNanos");
         this.invTau = Math.pow((halfLifeNanos / log(2)), -1);
         this.cancelPenalty = cancelPenalty;
         this.errorPenalty = errorPenalty;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -31,6 +31,7 @@ import static java.util.Objects.requireNonNull;
  */
 final class OutlierDetectorConfig {
 
+    private final Duration ewmaHalfLife;
     private final int consecutive5xx;
     private final Duration interval;
     private final Duration baseEjectionTime;
@@ -55,7 +56,8 @@ final class OutlierDetectorConfig {
     private final Duration maxEjectionTimeJitter;
     private final boolean successfulActiveHealthCheckUnejectHost;
 
-    OutlierDetectorConfig(final int consecutive5xx, final Duration interval, final Duration baseEjectionTime,
+    OutlierDetectorConfig(final Duration ewmaHalfLife,
+                          final int consecutive5xx, final Duration interval, final Duration baseEjectionTime,
                           final int maxEjectionPercentage, final int enforcingConsecutive5xx,
                           final int enforcingSuccessRate, final int successRateMinimumHosts,
                           final int successRateRequestVolume, final int successRateStdevFactor,
@@ -66,6 +68,7 @@ final class OutlierDetectorConfig {
                           final int enforcingFailurePercentageLocalOrigin, final int failurePercentageMinimumHosts,
                           final int failurePercentageRequestVolume, final Duration maxEjectionTime,
                           final Duration maxEjectionTimeJitter, final boolean successfulActiveHealthCheckUnejectHost) {
+        this.ewmaHalfLife = requireNonNull(ewmaHalfLife, "ewmaHalfLife");
         this.consecutive5xx = consecutive5xx;
         this.interval = requireNonNull(interval, "interval");
         this.baseEjectionTime = requireNonNull(baseEjectionTime, "baseEjectionTime");
@@ -89,6 +92,14 @@ final class OutlierDetectorConfig {
         this.maxEjectionTime = requireNonNull(maxEjectionTime, "maxEjectionTime");
         this.maxEjectionTimeJitter = requireNonNull(maxEjectionTimeJitter, "maxEjectionTimeJitter");
         this.successfulActiveHealthCheckUnejectHost = successfulActiveHealthCheckUnejectHost;
+    }
+
+    /**
+     * The Exponentially Weighted Moving Average (EWMA) half life.
+     * @return the Exponentially Weighted Moving Average (EWMA) half life.
+     */
+    public Duration ewmaHalfLife() {
+        return ewmaHalfLife;
     }
 
     /**
@@ -299,6 +310,7 @@ final class OutlierDetectorConfig {
      * A builder for {@link OutlierDetectorConfig} instances.
      */
     public static class Builder {
+        private Duration ewmaHalfLife = Duration.ofSeconds(10);
         private int consecutive5xx = 5;
 
         private Duration interval = Duration.ofSeconds(10);
@@ -346,7 +358,8 @@ final class OutlierDetectorConfig {
         private boolean successfulActiveHealthCheckUnejectHost = true;
 
         OutlierDetectorConfig build() {
-            return new OutlierDetectorConfig(consecutive5xx, interval, baseEjectionTime,
+            return new OutlierDetectorConfig(ewmaHalfLife, consecutive5xx,
+                    interval, baseEjectionTime,
                     maxEjectionPercentage, enforcingConsecutive5xx,
                     enforcingSuccessRate, successRateMinimumHosts,
                     successRateRequestVolume, successRateStdevFactor,
@@ -358,6 +371,19 @@ final class OutlierDetectorConfig {
                     failurePercentageRequestVolume, maxEjectionTime,
                     maxEjectionTimeJitter,
                     successfulActiveHealthCheckUnejectHost);
+        }
+
+        /**
+         * Set the Exponentially Weighted Moving Average (EWMA) half life.
+         * Defaults to 10 seconds.
+         * @param ewmaHalfLife the half life for latency data.
+         * @return {@code this}
+         */
+        public Builder ewmaHalfLife(final Duration ewmaHalfLife) {
+            requireNonNull(ewmaHalfLife, "ewmaHalfLife");
+            ensureNonNegative(ewmaHalfLife.toNanos(), "ewmaHalfLife");
+            this.ewmaHalfLife = ewmaHalfLife;
+            return this;
         }
 
         /**

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -96,7 +96,7 @@ final class OutlierDetectorConfig {
 
     /**
      * The Exponentially Weighted Moving Average (EWMA) half-life.
-     * In the context of an exponentially weighted moving average, the half-life means the time at which historical
+     * In the context of an exponentially weighted moving average, the half-life means the time during which historical
      * data has the same weight as a new sample.
      * @return the Exponentially Weighted Moving Average (EWMA) half-life.
      */
@@ -377,7 +377,7 @@ final class OutlierDetectorConfig {
 
         /**
          * Set the Exponentially Weighted Moving Average (EWMA) half-life.
-         * In the context of an exponentially weighted moving average, the half-life means the time at which historical
+         * In the context of an exponentially weighted moving average, the half-life means the time during which historical
          * data has the same weight as a new sample.
          * Defaults to 10 seconds.
          * @param ewmaHalfLife the half-life for latency data.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -95,8 +95,10 @@ final class OutlierDetectorConfig {
     }
 
     /**
-     * The Exponentially Weighted Moving Average (EWMA) half life.
-     * @return the Exponentially Weighted Moving Average (EWMA) half life.
+     * The Exponentially Weighted Moving Average (EWMA) half-life.
+     * In the context of an exponentially weighted moving averages, the half-life means the time at which historical
+     * data has the same weight as a new sample.
+     * @return the Exponentially Weighted Moving Average (EWMA) half-life.
      */
     public Duration ewmaHalfLife() {
         return ewmaHalfLife;
@@ -374,9 +376,11 @@ final class OutlierDetectorConfig {
         }
 
         /**
-         * Set the Exponentially Weighted Moving Average (EWMA) half life.
+         * Set the Exponentially Weighted Moving Average (EWMA) half-life.
+         * In the context of an exponentially weighted moving averages, the half-life means the time at which historical
+         * data has the same weight as a new sample.
          * Defaults to 10 seconds.
-         * @param ewmaHalfLife the half life for latency data.
+         * @param ewmaHalfLife the half-life for latency data.
          * @return {@code this}
          */
         public Builder ewmaHalfLife(final Duration ewmaHalfLife) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -96,7 +96,7 @@ final class OutlierDetectorConfig {
 
     /**
      * The Exponentially Weighted Moving Average (EWMA) half-life.
-     * In the context of an exponentially weighted moving averages, the half-life means the time at which historical
+     * In the context of an exponentially weighted moving average, the half-life means the time at which historical
      * data has the same weight as a new sample.
      * @return the Exponentially Weighted Moving Average (EWMA) half-life.
      */
@@ -377,7 +377,7 @@ final class OutlierDetectorConfig {
 
         /**
          * Set the Exponentially Weighted Moving Average (EWMA) half-life.
-         * In the context of an exponentially weighted moving averages, the half-life means the time at which historical
+         * In the context of an exponentially weighted moving average, the half-life means the time at which historical
          * data has the same weight as a new sample.
          * Defaults to 10 seconds.
          * @param ewmaHalfLife the half-life for latency data.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthChecker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthChecker.java
@@ -23,6 +23,7 @@ import io.servicetalk.loadbalancer.LoadBalancerObserver.HostObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -80,7 +81,7 @@ final class XdsHealthChecker<ResolvedAddress> implements HealthChecker<ResolvedA
 
     @Override
     public HealthIndicator newHealthIndicator(ResolvedAddress address) {
-        XdsHealthIndicator result = new XdsHealthIndicatorImpl(address);
+        XdsHealthIndicator result = new XdsHealthIndicatorImpl(address, kernel.config.ewmaHalfLife());
         sequentialExecutor.execute(() -> indicators.add(result));
         indicatorCount.incrementAndGet();
         return result;
@@ -101,8 +102,8 @@ final class XdsHealthChecker<ResolvedAddress> implements HealthChecker<ResolvedA
 
     private final class XdsHealthIndicatorImpl extends XdsHealthIndicator<ResolvedAddress> {
 
-        XdsHealthIndicatorImpl(final ResolvedAddress address) {
-            super(sequentialExecutor, executor, address, hostObserver);
+        XdsHealthIndicatorImpl(final ResolvedAddress address, Duration ewmaHalfLife) {
+            super(sequentialExecutor, executor, ewmaHalfLife, address, hostObserver);
         }
 
         @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -21,6 +21,7 @@ import io.servicetalk.loadbalancer.LoadBalancerObserver.HostObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -56,8 +57,9 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
     private volatile Long evictedUntilNanos;
 
     XdsHealthIndicator(final SequentialExecutor sequentialExecutor, final Executor executor,
-                       final ResolvedAddress address, final HostObserver<ResolvedAddress> hostObserver) {
-        super(1);
+                       final Duration ewmaHalfLife, final ResolvedAddress address,
+                       final HostObserver<ResolvedAddress> hostObserver) {
+        super(requireNonNull(ewmaHalfLife, "ewmaHalfLife").toNanos());
         this.sequentialExecutor = requireNonNull(sequentialExecutor, "sequentialExecutor");
         this.executor = requireNonNull(executor, "executor");
         assert executor instanceof NormalizedTimeSourceExecutor;

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -212,7 +212,7 @@ class XdsHealthIndicatorTest {
         boolean mayEjectHost = true;
 
         TestIndicator(final OutlierDetectorConfig config) {
-            super(sequentialExecutor, new NormalizedTimeSourceExecutor(testExecutor), "address",
+            super(sequentialExecutor, new NormalizedTimeSourceExecutor(testExecutor), Duration.ofSeconds(10), "address",
                     NoopLoadBalancerObserver.<String>instance().hostObserver());
             this.config = config;
         }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -213,7 +213,7 @@ class XdsHealthIndicatorTest {
 
         TestIndicator(final OutlierDetectorConfig config) {
             super(sequentialExecutor, new NormalizedTimeSourceExecutor(testExecutor), Duration.ofSeconds(10), "address",
-                    "description", NoopLoadBalancerObserver.instance().hostObserver("address"));
+                    "description", NoopLoadBalancerObserver.<String>instance().hostObserver("address"));
             this.config = config;
         }
 


### PR DESCRIPTION
Motivation:

We currently set the ewma lifetime to 1 nanosecond in the XdsHealthTracker and it's not configurable.

Modifications:

- Add a lifetime field to the OutlierDetectorConfig type
- Give it a default of 10 seconds in the Builder