### PR TITLE
http-netty: Disable some GraceulConnectionClosureHandling tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,7 @@ issueManagementUrl=https://github.com/apple/servicetalk/issues
 ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
+# on next netty upgrade re-enable the GracefulConnectionCluser tests. See issue #2117
 nettyVersion=4.1.106.Final
 nettyIoUringVersion=0.0.24.Final
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/GracefulConnectionClosureHandlingTest.java
@@ -50,6 +50,7 @@ import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedEx
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -425,6 +426,7 @@ class GracefulConnectionClosureHandlingTest {
         assertNextRequestFails();
     }
 
+    @Disabled("Issue 2117")
     @ParameterizedTest(name = "{index}: protocol={0} secure={1} initiateClosureFromClient={2} useUds={3} viaProxy={4}")
     @MethodSource("data")
     void closeAfterRequestMetaDataSentResponseMetaDataReceived(HttpProtocol protocol,
@@ -517,6 +519,7 @@ class GracefulConnectionClosureHandlingTest {
         assertNextRequestFails();
     }
 
+    @Disabled("Issue 2117")
     @ParameterizedTest(name = "{index}: protocol={0} secure={1} initiateClosureFromClient={2} useUds={3} viaProxy={4}")
     @MethodSource("data")
     void closePipelinedAfterTwoRequestsSentBeforeAnyResponseReceived(HttpProtocol protocol,


### PR DESCRIPTION
Motivation:

The tests are super flaky making it almost impossible to get a clean CI run. The problem was in netty and has been fixed but we're waiting on a release.

Modifications:

- Disable the flaky tests and add some notes to the netty dependency

Relates to #2117.