### PR TITLE
loadbalancer-experimental: make more interfaces public

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -66,7 +66,7 @@ import javax.annotation.Nullable;
  * @param <ResolvedAddress> The resolved address type.
  * @param <C> The type of connection.
  */
-interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection> {
+public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection> {
     /**
      * Set the {@code loadBalancingPolicy} to use with this load balancer.
      * @param loadBalancingPolicy the {@code loadBalancingPolicy} to use

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -358,7 +358,11 @@ public final class OutlierDetectorConfig {
 
         private boolean successfulActiveHealthCheckUnejectHost = true;
 
-        OutlierDetectorConfig build() {
+        /**
+         * Build the OutlierDetectorConfig.
+         * @return the OutlierDetectorConfig.
+         */
+        public OutlierDetectorConfig build() {
             return new OutlierDetectorConfig(ewmaHalfLife, consecutive5xx,
                     interval, baseEjectionTime,
                     maxEjectionPercentage, enforcingConsecutive5xx,

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthCheckerFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthCheckerFactory.java
@@ -28,7 +28,7 @@ public final class XdsHealthCheckerFactory<ResolvedAddress> implements HealthChe
 
     private final OutlierDetectorConfig config;
 
-    XdsHealthCheckerFactory(final OutlierDetectorConfig config) {
+    public XdsHealthCheckerFactory(final OutlierDetectorConfig config) {
         this.config = requireNonNull(config, "config");
     }
 


### PR DESCRIPTION
Motivation:

There were a few more interfaces that need to be public before things are really usable.

Modifications:

Make them public.