### PR TITLE
loadbalancer-experimental: Make LoadBalancerObserver public

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  * An observer that provides visibility into a {@link io.servicetalk.client.api.LoadBalancer}
  * @param <ResolvedAddress> the type of the resolved address.
  */
-interface LoadBalancerObserver<ResolvedAddress> {
+public interface LoadBalancerObserver<ResolvedAddress> {
 
     /**
      * Get a {@link HostObserver}.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -22,13 +22,14 @@ import java.util.Collection;
 import javax.annotation.Nullable;
 
 /**
- * An observer that provides visibility into a {@link io.servicetalk.client.api.LoadBalancer}
+ * An observer that provides visibility into a {@link io.servicetalk.client.api.LoadBalancer}.
  * @param <ResolvedAddress> the type of the resolved address.
  */
 public interface LoadBalancerObserver<ResolvedAddress> {
 
     /**
      * Get a {@link HostObserver}.
+     * @param resolvedAddress the resolved address of the host.
      * @return a {@link HostObserver}.
      */
     HostObserver hostObserver(ResolvedAddress resolvedAddress);
@@ -40,14 +41,19 @@ public interface LoadBalancerObserver<ResolvedAddress> {
 
     /**
      * Callback for monitoring the changes due to a service discovery update.
+     * @param events the collection of {@link ServiceDiscovererEvent}s received by the load balancer.
+     * @param oldHostSetSize the size of the previous host set.
+     * @param newHostSetSize the new size of  the host set.
      */
     void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events,
                                  int oldHostSetSize, int newHostSetSize);
 
     /**
      * Callback for when connection selection fails due to all hosts being inactive.
+     * @param hostSetSize the size of the current host set.
+     * @param exception an exception with more details about the failure.
      */
-    void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exn);
+    void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exception);
 
     /**
      * An observer for {@link Host} events.


### PR DESCRIPTION
Motivation:

We want to let users add custom observer logic but the interface is private.

Modifications:

Make the interface public.