### PR TITLE
loadbalancer-experimental: Fix some bugs with the xds health checker

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -149,8 +149,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         this.asyncCloseable = toAsyncCloseable(this::doClose);
         // Maintain a Subscriber so signals are always delivered to replay and new Subscribers get the latest signal.
         eventStream.ignoreElements().subscribe();
-        subscribeToEvents(false);
         this.healthChecker = healthCheckerFactory == null ? null : healthCheckerFactory.apply(lbDescription);
+        subscribeToEvents(false);
     }
 
     private void subscribeToEvents(boolean resubscribe) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetector.java
@@ -61,7 +61,7 @@ final class FailurePercentageXdsOutlierDetector implements XdsOutlierDetector {
         if (enoughVolumeHosts < config.failurePercentageMinimumHosts()) {
             // not enough hosts with enough volume to do the analysis.
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Not enough hosts  with sufficient volume to perform ejection: " +
+                LOGGER.debug("Not enough hosts with sufficient volume to perform ejection: " +
                                 "{} total hosts and {} had sufficient volume. Minimum {} required.",
                         indicators.size(), enoughVolumeHosts, config.failurePercentageMinimumHosts());
             }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -708,6 +708,12 @@ public final class OutlierDetectorConfig {
     }
 
     static boolean enforcing(int enforcingPercentage) {
-        return enforcingPercentage >= 100 || ThreadLocalRandom.current().nextInt(100) <= enforcingPercentage;
+        if (enforcingPercentage == 0) {
+            return false;
+        }
+        if (enforcingPercentage >= 100) {
+            return true;
+        }
+        return enforcingPercentage >= ThreadLocalRandom.current().nextInt(100) + 1;
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetector.java
@@ -47,7 +47,7 @@ final class SuccessRateXdsOutlierDetector implements XdsOutlierDetector {
 
     @Override
     public void detectOutliers(OutlierDetectorConfig config, Collection<XdsHealthIndicator> indicators) {
-        LOGGER.trace("Started outlier detection.");
+        LOGGER.debug("Started outlier detection.");
         final double[] successRates = new double[indicators.size()];
         int i = 0;
         int enoughVolumeHosts = 0;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -269,12 +269,19 @@ abstract class XdsHealthIndicator<ResolvedAddress> extends DefaultRequestTracker
         final long jitterNanos = ThreadLocalRandom.current().nextLong(config.maxEjectionTimeJitter().toNanos() + 1);
         evictedUntilNanos = currentTimeNanos() + ejectTimeNanos + jitterNanos;
         hostObserver.onHostMarkedUnhealthy(cause);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.info("{}-{}: ejecting indicator for {} milliseconds",
+                    lbDescription, address, (ejectTimeNanos + jitterNanos) / 1e6);
+        }
         return true;
     }
 
     private void sequentialRevive() {
         assert sequentialExecutor.isCurrentThreadDraining();
         assert !cancelled;
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("{}-{}: host revived", lbDescription, address);
+        }
         evictedUntilNanos = null;
         // Envoy resets the `consecutive5xx` counter on revival. I'm not sure that's the best because chances
         // are reasonable that it's still a bad host, so we'll want to mark it as an outlier again immediately if


### PR DESCRIPTION
Motivation:

There are a few minor bugs to address and we could use a few more debug log messages for the future to help debug.

Modifications:

- Fix the enforcing percentage calculation so that 0% enforcement means it never happens.
- Reorder initialization of the `healthChecker` field in DefaultLoadBalancer so if we subscribe to an eager service discoverer we already have the field initialized.
- Adjust log messages.