### PR TITLE
loadbalancer-experimental: track the length of outstanding requests

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
@@ -17,9 +17,7 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.ScoreSupplier;
 
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.function.IntBinaryOperator;
+import java.util.concurrent.locks.StampedLock;
 
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Integer.MAX_VALUE;
@@ -40,13 +38,11 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * (2019) Algorithms for Unevenly Spaced Time Series: Moving Averages and Other Rolling Operators (4.2 pp. 10)</a>
  */
 abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
-    private static final AtomicIntegerFieldUpdater<DefaultRequestTracker> pendingUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(DefaultRequestTracker.class, "pendingCount");
-    private static final AtomicLongFieldUpdater<DefaultRequestTracker> pendingStampUpdater =
-            AtomicLongFieldUpdater.newUpdater(DefaultRequestTracker.class, "pendingStamp");
     private static final long MAX_MS_TO_NS = NANOSECONDS.convert(MAX_VALUE, MILLISECONDS);
     static final long DEFAULT_CANCEL_PENALTY = 5L;
     static final long DEFAULT_ERROR_PENALTY = 10L;
+
+    private final StampedLock lock = new StampedLock();
     /**
      * Mean lifetime, exponential decay. inverted tau
      */
@@ -62,8 +58,8 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
      * Current weighted average.
      */
     private int ewma;
-    private volatile int pendingCount;
-    private volatile long pendingStamp = Long.MIN_VALUE;
+    private int pendingCount;
+    private long pendingStamp = Long.MIN_VALUE;
 
     DefaultRequestTracker(final long halfLifeNanos) {
         this(halfLifeNanos, DEFAULT_CANCEL_PENALTY, DEFAULT_ERROR_PENALTY);
@@ -84,40 +80,77 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
 
     @Override
     public final long beforeRequestStart() {
-        long stamp = currentTimeNanos();
-        pendingUpdater.incrementAndGet(this);
-        pendingStampUpdater.compareAndSet(this, Long.MIN_VALUE, stamp);
-        return stamp;
+        final long stamp = lock.writeLock();
+        try {
+            long timestamp = currentTimeNanos();
+            pendingCount++;
+            if (pendingStamp == Long.MIN_VALUE) {
+                // only update the pending timestamp if it doesn't already have a value.
+                pendingStamp = timestamp;
+            }
+            return timestamp;
+        } finally {
+            lock.unlockWrite(stamp);
+        }
     }
 
     @Override
     public void onRequestSuccess(final long startTimeNanos) {
-        pendingUpdater.decrementAndGet(this);
-        pendingStampUpdater.set(this, Long.MIN_VALUE);
-        calculateAndStore((ewma, currentLatency) -> currentLatency, startTimeNanos);
+        onComplete(startTimeNanos, 0);
     }
 
     @Override
     public void onRequestError(final long startTimeNanos, ErrorClass errorClass) {
-        pendingUpdater.decrementAndGet(this);
-        pendingStampUpdater.set(this, Long.MIN_VALUE);
-        calculateAndStore(errorClass == ErrorClass.CANCELLED ? this:: cancelPenalty : this::errorPenalty,
-                startTimeNanos);
+        onComplete(startTimeNanos, errorClass == ErrorClass.CANCELLED ? cancelPenalty : errorPenalty);
+    }
+
+    private void onComplete(final long startTimeNanos, long penalty) {
+        final long stamp = lock.writeLock();
+        try {
+            pendingCount--;
+            // Unconditionally clear the timestamp because we don't know which request set it. This is an acceptable
+            // 'error' since otherwise we need to keep a collection of start timestamps.
+            pendingStamp = Long.MIN_VALUE;
+            updateEwma(penalty, startTimeNanos);
+        } finally {
+            lock.unlockWrite(stamp);
+        }
     }
 
     @Override
     public final int score() {
-        int currentEWMA = calculateAndStore((ewma, lastTimeNanos) -> 0, 0);
-        final int cPending = pendingUpdater.get(this);
+        final long lastTimeNanos;
+        final int cPending;
+        final long pendingStamp;
+        int currentEWMA;
+        // read all the relevant state using the read lock
+        final long stamp = lock.readLock();
+        try {
+            currentEWMA = ewma;
+            lastTimeNanos = this.lastTimeNanos;
+            cPending = pendingCount;
+            pendingStamp = this.pendingStamp;
+        } finally {
+            lock.unlockRead(stamp);
+        }
+        // It's fine to get this after releasing the lock since it will still happen after whatever last
+        // wrote the value to `lastTimeNanos`.
+        final long currentTimeNanos = currentTimeNanos();
 
-        // If we have a request outstanding we should consider how long it has been outstanding so that sudden
-        // interruptions don't have to wait for timeouts before our score can be adjusted.
-        if (cPending > 0) {
-            final long pendingStamp = this.pendingStamp;
-            if (pendingStamp != Long.MIN_VALUE) {
-                currentEWMA = max(currentEWMA, nanoToMillis(currentTimeNanos() - pendingStamp));
-            }
-        } else if (currentEWMA == 0) {
+        if (currentEWMA != 0) {
+            // need to apply the exponential decay.
+            final double tmp = (currentTimeNanos - lastTimeNanos) * invTau;
+            final double w = exp(-tmp);
+            currentEWMA = (int) ceil(currentEWMA * w);
+        }
+
+        if (cPending > 0 && pendingStamp != Long.MIN_VALUE) {
+            // If we have a request outstanding we should consider how long it has been outstanding so that sudden
+            // interruptions don't have to wait for timeouts before our scores can be adjusted.
+            currentEWMA = max(currentEWMA, nanoToMillis(currentTimeNanos - pendingStamp));
+        }
+
+        if (currentEWMA == 0) {
             // If EWMA has decayed to 0 (or isn't yet initialized) and there are no pending requests we return the
             // maximum score to increase the likelihood this entity is selected. If there are pending requests we
             // don't yet know the latency characteristics so we return the minimum score to decrease the
@@ -134,39 +167,31 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
         return MAX_VALUE - currentEWMA <= pendingPenalty ? MIN_VALUE : -(currentEWMA + pendingPenalty);
     }
 
-    private int cancelPenalty(int currentEWMA, int currentLatency) {
-        // There is no significance to the choice of this multiplier (other than it is half of the error penalty)
-        // and it is selected to gather empirical evidence as the algorithm is evaluated.
-        return applyPenalty(currentEWMA, currentLatency, cancelPenalty);
-    }
-
-    private int errorPenalty(int currentEWMA, int currentLatency) {
-        // There is no significance to the choice of this multiplier (other than it is double of the cancel penalty)
-        // and it is selected to gather empirical evidence as the algorithm is evaluated.
-        return applyPenalty(currentEWMA, currentLatency, errorPenalty);
-    }
-
     private static int applyPenalty(int currentEWMA, int currentLatency, long penalty) {
         // Relatively large latencies will have a bigger impact on the penalty, while smaller latencies (e.g. premature
         // cancel/error) rely on the penalty.
         return (int) min(MAX_VALUE, max(currentEWMA, currentLatency) * penalty);
     }
 
-    private synchronized int calculateAndStore(final IntBinaryOperator latencyInitializer, long startTimeNanos) {
-        final int nextEWMA;
-        // We capture the current time inside the synchronized block to exploit the monotonic time source
+    // must be called while holding the lock in write mode.
+    private void updateEwma(long penalty, long startTimeNanos) {
+        // We capture the current time while holding the lock to exploit the monotonic time source
         // properties which prevent the time duration from going negative. This will result in a latency penalty
         // as concurrency increases, but is a trade-off for simplicity.
         final long currentTimeNanos = currentTimeNanos();
-        // When modifying the EWMA and lastTime we read/write both values in a synchronized block as they are
+        // When modifying the EWMA and lastTime we read/write both values while holding the lock as they are
         // tightly coupled in the EWMA formula below.
         final int currentEWMA = ewma;
-        final int currentLatency = latencyInitializer.applyAsInt(ewma, nanoToMillis(currentTimeNanos - startTimeNanos));
-        // Note the currentLatency cannot be <0 or else the EWMA equation properties are violated
-        // (e.g. "degree of weighting decrease" is not in [0, 1]).
+        final int currentLatency;
+        if (penalty > 0) {
+            currentLatency = applyPenalty(currentEWMA, nanoToMillis(currentTimeNanos - startTimeNanos), penalty);
+        } else {
+            currentLatency = nanoToMillis(currentTimeNanos - startTimeNanos);
+        }
         assert currentLatency >= 0;
 
         // Peak EWMA from finagle for the score to be extremely sensitive to higher than normal latencies.
+        final int nextEWMA;
         if (currentLatency > currentEWMA) {
             nextEWMA = currentLatency;
         } else {
@@ -176,7 +201,6 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
         }
         lastTimeNanos = currentTimeNanos;
         ewma = nextEWMA;
-        return nextEWMA;
     }
 
     private static int nanoToMillis(long nanos) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
@@ -144,18 +144,18 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
             currentEWMA = (int) ceil(currentEWMA * w);
         }
 
-        if (cPending > 0 && pendingStamp != Long.MIN_VALUE) {
-            // If we have a request outstanding we should consider how long it has been outstanding so that sudden
-            // interruptions don't have to wait for timeouts before our scores can be adjusted.
-            currentEWMA = max(currentEWMA, nanoToMillis(currentTimeNanos - pendingStamp));
-        }
-
         if (currentEWMA == 0) {
             // If EWMA has decayed to 0 (or isn't yet initialized) and there are no pending requests we return the
             // maximum score to increase the likelihood this entity is selected. If there are pending requests we
             // don't yet know the latency characteristics so we return the minimum score to decrease the
             // likelihood this entity is selected.
             return cPending == 0 ? 0 : MIN_VALUE;
+        }
+
+        if (cPending > 0 && pendingStamp != Long.MIN_VALUE) {
+            // If we have a request outstanding we should consider how long it has been outstanding so that sudden
+            // interruptions don't have to wait for timeouts before our scores can be adjusted.
+            currentEWMA = max(currentEWMA, nanoToMillis(currentTimeNanos - pendingStamp));
         }
 
         // Add penalty for pending requests to account for "unaccounted" load.

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
@@ -15,13 +15,11 @@
  */
 package io.servicetalk.loadbalancer;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.function.LongUnaryOperator;
 
-import static java.lang.System.nanoTime;
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -47,7 +45,7 @@ class DefaultRequestTrackerTest {
 
         // cancellation penalty
         requestTracker.onRequestError(requestTracker.beforeRequestStart(), ErrorClass.CANCELLED);
-        assertEquals(-12_500, requestTracker.score());
+        assertEquals(-25_000, requestTracker.score());
 
         // decay
         when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(20).toNanos());
@@ -55,9 +53,9 @@ class DefaultRequestTrackerTest {
     }
 
     @Test
-    void zeroDataScoreIsIntMinValue() {
+    void zeroDataScoreWithPendingRequestIsIntMinValue() {
         final LongUnaryOperator nextValueProvider = mock(LongUnaryOperator.class);
-        when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(1).toNanos());
+        when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(0).toNanos());
         final DefaultRequestTracker requestTracker = new TestRequestTracker(Duration.ofSeconds(1), nextValueProvider);
         assertEquals(0, requestTracker.score());
 
@@ -84,7 +82,7 @@ class DefaultRequestTrackerTest {
         // start to advance time
         when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(1).toNanos());
         // this is 4 because we are calling the time twice...
-        assertEquals(-4000, requestTracker.score());
+        assertEquals(-2000, requestTracker.score());
     }
 
     static final class TestRequestTracker extends DefaultRequestTracker {

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
@@ -23,6 +23,7 @@ import java.util.function.LongUnaryOperator;
 
 import static java.lang.System.nanoTime;
 import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -34,28 +35,61 @@ class DefaultRequestTrackerTest {
         final LongUnaryOperator nextValueProvider = mock(LongUnaryOperator.class);
         when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(1).toNanos());
         final DefaultRequestTracker requestTracker = new TestRequestTracker(Duration.ofSeconds(1), nextValueProvider);
-        Assertions.assertEquals(0, requestTracker.score());
+        assertEquals(0, requestTracker.score());
 
         // upon success score
         requestTracker.onRequestSuccess(requestTracker.beforeRequestStart());
-        Assertions.assertEquals(-500, requestTracker.score());
+        assertEquals(-500, requestTracker.score());
 
         // error penalty
         requestTracker.onRequestError(requestTracker.beforeRequestStart(), ErrorClass.EXT_ORIGIN_REQUEST_FAILED);
-        Assertions.assertEquals(-5000, requestTracker.score());
+        assertEquals(-5000, requestTracker.score());
 
         // cancellation penalty
         requestTracker.onRequestError(requestTracker.beforeRequestStart(), ErrorClass.CANCELLED);
-        Assertions.assertEquals(-12_500, requestTracker.score());
+        assertEquals(-12_500, requestTracker.score());
 
         // decay
         when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(20).toNanos());
-        Assertions.assertEquals(-1, requestTracker.score());
+        assertEquals(-1, requestTracker.score());
+    }
+
+    @Test
+    void zeroDataScoreIsIntMinValue() {
+        final LongUnaryOperator nextValueProvider = mock(LongUnaryOperator.class);
+        when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(1).toNanos());
+        final DefaultRequestTracker requestTracker = new TestRequestTracker(Duration.ofSeconds(1), nextValueProvider);
+        assertEquals(0, requestTracker.score());
+
+        // upon success score
+        requestTracker.beforeRequestStart();
+        assertEquals(Integer.MIN_VALUE, requestTracker.score());
+    }
+
+    @Test
+    void outstandingLatencyIsTracked() {
+        final LongUnaryOperator nextValueProvider = mock(LongUnaryOperator.class);
+        when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(0).toNanos());
+
+        final DefaultRequestTracker requestTracker = new TestRequestTracker(Duration.ofSeconds(1), nextValueProvider);
+        assertEquals(0, requestTracker.score());
+
+        // upon success score
+        requestTracker.onRequestSuccess(requestTracker.beforeRequestStart());
+        // super quick, so our score is the max it can be which is 0.
+        assertEquals(0, requestTracker.score());
+
+        // start a request
+        assertEquals(0, requestTracker.beforeRequestStart());
+        // start to advance time
+        when(nextValueProvider.applyAsLong(anyLong())).thenAnswer(__ -> ofSeconds(1).toNanos());
+        // this is 4 because we are calling the time twice...
+        assertEquals(-4000, requestTracker.score());
     }
 
     static final class TestRequestTracker extends DefaultRequestTracker {
         private final LongUnaryOperator nextValueProvider;
-        private long lastValue = nanoTime();
+        private long lastValue;
 
         TestRequestTracker(Duration measurementHalfLife, final LongUnaryOperator nextValueProvider) {
             super(measurementHalfLife.toNanos(), DEFAULT_CANCEL_PENALTY, DEFAULT_ERROR_PENALTY);


### PR DESCRIPTION
Motivation:

DefaultRequestTracker is intended to track how long requests are
taking but right now it can only add data once it gets a response.
As requests start to pile up we get a multiplicative effect but
we don't consider how long requests have remained outstanding.

Modifications:

- Keep track of how long a request has been pending by marking
  its start time and considering it when computing score.
- Switch to a StampedLock and adjust our score method so we
  can take a read-lock on the scoring path.
- Make our counters owned by the StampedLock: we have to take
  the write lock again on `beforeRequestStart()` method but it
  should be the same cost as atomics in the un-contended case.

Result:

We're more sensitive to sudden failures.