### PR TITLE
Add `DelegatingServiceDiscoverer` to client-api

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingServiceDiscoverer.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingServiceDiscoverer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api;
+
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+
+import java.util.Collection;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link ServiceDiscoverer} that delegates all methods to another {@link ServiceDiscoverer}.
+ *
+ * @param <UnresolvedAddress> The type of address before resolution.
+ * @param <ResolvedAddress> The type of address after resolution.
+ * @param <E> Type of {@link ServiceDiscovererEvent}s published from {@link #discover(Object)}.
+ */
+public class DelegatingServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
+        E extends ServiceDiscovererEvent<ResolvedAddress>>
+        implements ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> {
+    private final ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> delegate;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param delegate {@link ServiceDiscoverer} to which all methods are delegated.
+     */
+    public DelegatingServiceDiscoverer(final ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    /**
+     * Returns the {@link ServiceDiscoverer} delegate.
+     *
+     * @return Delegate {@link ServiceDiscoverer}.
+     */
+    protected final ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> delegate() {
+        return delegate;
+    }
+
+    @Override
+    public Publisher<Collection<E>> discover(final UnresolvedAddress address) {
+        return delegate.discover(address);
+    }
+
+    @Override
+    public Completable onClose() {
+        return delegate.onClose();
+    }
+
+    @Override
+    public Completable onClosing() {
+        return delegate.onClosing();
+    }
+
+    @Override
+    public Completable closeAsync() {
+        return delegate.closeAsync();
+    }
+
+    @Override
+    public Completable closeAsyncGracefully() {
+        return delegate.closeAsyncGracefully();
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "{delegate=" + delegate() + '}';
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.buffer.api.CharSequences;
 import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.ConnectionFactoryFilter;
+import io.servicetalk.client.api.DelegatingServiceDiscoverer;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
@@ -761,44 +762,6 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         public Publisher<Collection<E>> discover(final U u) {
             // terminateOnNextException false -> LB is after this operator, if LB throws do best effort retry.
             return delegate().discover(u).retryWhen(false, retryStrategy);
-        }
-    }
-
-    private abstract static class DelegatingServiceDiscoverer<U, R, E extends ServiceDiscovererEvent<R>>
-            implements ServiceDiscoverer<U, R, E> {
-        private final ServiceDiscoverer<U, R, E> delegate;
-
-        DelegatingServiceDiscoverer(final ServiceDiscoverer<U, R, E> delegate) {
-            this.delegate = requireNonNull(delegate);
-        }
-
-        final ServiceDiscoverer<U, R, E> delegate() {
-            return delegate;
-        }
-
-        @Override
-        public Completable onClose() {
-            return delegate.onClose();
-        }
-
-        @Override
-        public Completable onClosing() {
-            return delegate.onClosing();
-        }
-
-        @Override
-        public Completable closeAsync() {
-            return delegate.closeAsync();
-        }
-
-        @Override
-        public Completable closeAsyncGracefully() {
-            return delegate.closeAsyncGracefully();
-        }
-
-        @Override
-        public String toString() {
-            return this.getClass().getSimpleName() + "{delegate=" + delegate() + '}';
         }
     }
 


### PR DESCRIPTION
Motivation:

`DelegatingServiceDiscoverer` is a helpful utility to reduce boilerplate when users need to implement a filter for `ServiceDiscoverer`. We provide "delegate" classes for other use-cases, would be helpful to have one for `ServiceDiscoverer` too.

Modifications:
- Add `io.servicetalk.client.api.DelegatingServiceDiscoverer`;
- Use new utility instead of internal variant inside `DefaultSingleAddressHttpClientBuilder`;

Result:

Easier for users to implement a filter for `ServiceDiscoverer`.