### PR TITLE
Add `HttpClients.forMultiAddressUrl()` overload with `ServiceDiscoverer`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -174,6 +174,35 @@ public final class HttpClients {
     /**
      * Creates a {@link MultiAddressHttpClientBuilder} for clients capable of parsing an <a
      * href="https://tools.ietf.org/html/rfc7230#section-5.3.2">absolute-form URL</a>, connecting to multiple addresses
+     * with default {@link LoadBalancer}, using the specified {@link ServiceDiscoverer} and {@link DiscoveryStrategy}.
+     * <p>
+     * When a <a href="https://tools.ietf.org/html/rfc3986#section-4.2">relative URL</a> is passed in the {@link
+     * StreamingHttpRequest#requestTarget(String)} this client requires a {@link HttpHeaderNames#HOST} present in
+     * order to infer the remote address.
+     * <p>
+     * The returned builder can be customized using {@link MultiAddressHttpClientBuilderProvider}.
+     *
+     * @param id a (unique) ID to identify the created {@link MultiAddressHttpClientBuilder}, like a name or a purpose
+     * of the future client that will be built. This helps  {@link MultiAddressHttpClientBuilderProvider} to distinguish
+     * this builder from others.
+     * @param serviceDiscoverer The {@link ServiceDiscoverer} to resolve addresses of remote servers to connect to.
+     * The lifecycle of the provided {@link ServiceDiscoverer} should be managed by the caller.
+     * @param discoveryStrategy {@link DiscoveryStrategy} to use.
+     * @return new builder with default configuration.
+     * @see MultiAddressHttpClientBuilderProvider
+     */
+    public static MultiAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forMultiAddressUrl(
+            final String id,
+            final ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>>
+                    serviceDiscoverer,
+            final DiscoveryStrategy discoveryStrategy) {
+        return applyProviders(id, new DefaultMultiAddressUrlHttpClientBuilder(
+                hostAndPort -> forSingleAddress(serviceDiscoverer, hostAndPort, discoveryStrategy)));
+    }
+
+    /**
+     * Creates a {@link MultiAddressHttpClientBuilder} for clients capable of parsing an <a
+     * href="https://tools.ietf.org/html/rfc7230#section-5.3.2">absolute-form URL</a>, connecting to multiple addresses
      * with default {@link LoadBalancer} and user provided {@link ServiceDiscoverer}.
      * <p>
      * When a <a href="https://tools.ietf.org/html/rfc3986#section-4.2">relative URL</a> is passed in the {@link

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientResolvesOnNewConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientResolvesOnNewConnectionTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
+import io.servicetalk.client.api.DelegatingServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.api.Completable;
@@ -40,6 +41,7 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;
@@ -62,6 +64,7 @@ import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -80,6 +83,32 @@ class HttpClientResolvesOnNewConnectionTest {
             HttpResponse response = client.request(
                     client.get("http://localhost:" + serverHostAndPort(serverContext).port() + '/'));
             assertThat(response.status(), is(OK));
+        }
+    }
+
+    @Test
+    void forMultiAddressUrlWithCustomServiceDiscoverer() throws Exception {
+        AtomicInteger discoverCounter = new AtomicInteger();
+        try (HttpServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             // Use "localhost" to demonstrate that the address will be resolved.
+             BlockingHttpClient client = HttpClients.forMultiAddressUrl(getClass().getSimpleName(),
+                     // Wrap to pretend this is a custom SD:
+                     new DelegatingServiceDiscoverer<HostAndPort, InetSocketAddress,
+                             ServiceDiscovererEvent<InetSocketAddress>>(
+                                     GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer()) {
+                         @Override
+                         public Publisher<Collection<ServiceDiscovererEvent<InetSocketAddress>>> discover(
+                                 HostAndPort hostAndPort) {
+                             discoverCounter.incrementAndGet();
+                             return delegate().discover(hostAndPort);
+                         }
+                     },
+                     ON_NEW_CONNECTION).buildBlocking()) {
+            HttpResponse response = client.request(
+                    client.get("http://localhost:" + serverHostAndPort(serverContext).port() + '/'));
+            assertThat(response.status(), is(OK));
+            assertThat(discoverCounter.get(), is(greaterThan(0)));
         }
     }
 


### PR DESCRIPTION
Motivation:

Users who need multi-address client with
`DiscoveryStrategy.ON_NEW_CONNECTION` and a custom `ServiceDiscoverer`
implementation need a new overload, because this strategy does not allow
changing `ServiceDiscoverer` later.

Modifications:
- Add `HttpClients.forMultiAddressUrl(String, ServiceDiscoverer,
DiscoveryStrategy)` overload;
- Add a test case in `HttpClientResolvesOnNewConnectionTest` that
verifies the new overload can be used to customize `ServiceDiscoverer`;

Result:

Easier can customize `ServiceDiscoverer` when they need a multi-address
client with `DiscoveryStrategy.ON_NEW_CONNECTION`.