### PR TITLE
Expose global A/AAAA and SRV DNS `ServiceDiscoverer` instances

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Executors.java
@@ -44,8 +44,8 @@ public final class Executors {
      * by calling {@link Runnable#run()} on the calling thread. {@link Executor#schedule(Runnable, long, TimeUnit)} will
      * use a global scheduler.
      * <p>
-     * The lifecycle of this instance shouldn't need to be managed by the user. Don't attempt to close the returned
-     * instance of {@link Executor}.
+     * The lifecycle of this instance shouldn't need to be managed by the user. The returned instance of
+     * {@link Executor} must not be closed.
      *
      * @return An {@link Executor} that executes all tasks submitted via {@link Executor#execute(Runnable)}
      * immediately on the calling thread.
@@ -60,8 +60,8 @@ public final class Executors {
      * It creates as many threads as required but reuses threads when possible. It is therefore 'safe to block' when
      * using it.
      * <p>
-     * The lifecycle of this instance shouldn't need to be managed by the user. Don't attempt to close the returned
-     * instance of {@link Executor}.
+     * The lifecycle of this instance shouldn't need to be managed by the user. The returned instance of
+     * {@link Executor} must not be closed.
      *
      * @return An {@link Executor} which serves as a global mechanism for executing concurrent operations.
      */

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscoverers.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscoverers.java
@@ -76,8 +76,8 @@ public final class DnsServiceDiscoverers {
      * The returned instance can be customized using {@link DnsServiceDiscovererBuilderProvider} by targeting
      * {@value GLOBAL_A_ID} identity.
      * <p>
-     * The lifecycle of this instance shouldn't need to be managed by the user. Don't attempt to close the returned
-     * instance of {@link ServiceDiscoverer}.
+     * The lifecycle of this instance shouldn't need to be managed by the user. The returned instance of
+     * {@link ServiceDiscoverer} must not be closed.
      *
      * @return the singleton instance
      */
@@ -94,8 +94,8 @@ public final class DnsServiceDiscoverers {
      * The returned instance can be customized using {@link DnsServiceDiscovererBuilderProvider} by targeting
      * {@value GLOBAL_SRV_ID} identity.
      * <p>
-     * The lifecycle of this instance shouldn't need to be managed by the user. Don't attempt to close the returned
-     * instance of {@link ServiceDiscoverer}.
+     * The lifecycle of this instance shouldn't need to be managed by the user. The returned instance of
+     * {@link ServiceDiscoverer} must not be closed.
      *
      * @return the singleton instance
      */

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -57,10 +57,10 @@ import java.util.function.Supplier;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.Publisher.failed;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalSrvDnsServiceDiscoverer;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.mappingServiceDiscoverer;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.resolvedServiceDiscoverer;
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscoverers.globalARecordsDnsServiceDiscoverer;
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscoverers.globalSrvRecordsDnsServiceDiscoverer;
+import static io.servicetalk.http.netty.InternalServiceDiscoverers.mappingServiceDiscoverer;
+import static io.servicetalk.http.netty.InternalServiceDiscoverers.resolvedServiceDiscoverer;
 import static io.servicetalk.utils.internal.ServiceLoaderUtils.loadProviders;
 import static java.util.function.Function.identity;
 
@@ -301,9 +301,9 @@ public final class HttpClients {
      */
     public static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> forSingleAddress(
             final HostAndPort address, final DiscoveryStrategy discoveryStrategy) {
-        return forSingleAddress(globalDnsServiceDiscoverer(), address, discoveryStrategy,
-                GlobalDnsServiceDiscoverer::unresolvedServiceDiscoverer,
-                ResolvingConnectionFactoryFilter::withGlobalDnsServiceDiscoverer);
+        return forSingleAddress(globalARecordsDnsServiceDiscoverer(), address, discoveryStrategy,
+                InternalServiceDiscoverers::unresolvedServiceDiscoverer,
+                ResolvingConnectionFactoryFilter::withGlobalARecordsDnsServiceDiscoverer);
     }
 
     /**
@@ -321,7 +321,7 @@ public final class HttpClients {
     public static SingleAddressHttpClientBuilder<String, InetSocketAddress> forServiceAddress(
             final String serviceName) {
         final ServiceDiscoverer<String, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> sd =
-                globalSrvDnsServiceDiscoverer();
+                globalSrvRecordsDnsServiceDiscoverer();
         return applyProviders(serviceName,
                 new DefaultSingleAddressHttpClientBuilder<>(serviceName, sd))
                 // We need to pass SD into constructor to align types, but providers won't see that.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ResolvingConnectionFactoryFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ResolvingConnectionFactoryFilter.java
@@ -38,13 +38,13 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscoverers.globalARecordsDnsServiceDiscoverer;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A {@link ConnectionFactoryFilter} that will resolve the passed unresolved {@link InetSocketAddress} on each attempt
- * to create a {@link ConnectionFactory#newConnection(Object, ContextMap, TransportObserver) new connection} using
- * {@link GlobalDnsServiceDiscoverer#globalDnsServiceDiscoverer()}.
+ * A {@link ConnectionFactoryFilter} that will resolve the passed {@link U unresolved address} on each attempt
+ * to create a {@link ConnectionFactory#newConnection(Object, ContextMap, TransportObserver) new connection} using the
+ * passed {@link ServiceDiscoverer}.
  *
  * @param <U> the type of address before resolution (unresolved address)
  * @param <R> the type of address after resolution (resolved address)
@@ -123,14 +123,14 @@ final class ResolvingConnectionFactoryFilter<U, R>
                 '}';
     }
 
-    static ResolvingConnectionFactoryFilter<HostAndPort, InetSocketAddress> withGlobalDnsServiceDiscoverer() {
+    static ResolvingConnectionFactoryFilter<HostAndPort, InetSocketAddress> withGlobalARecordsDnsServiceDiscoverer() {
         return DefaultResolvingConnectionFactoryFilterInitializer.INSTANCE;
     }
 
     private static final class DefaultResolvingConnectionFactoryFilterInitializer {
 
         static final ResolvingConnectionFactoryFilter<HostAndPort, InetSocketAddress> INSTANCE =
-                new ResolvingConnectionFactoryFilter<>(HostAndPort::of, globalDnsServiceDiscoverer());
+                new ResolvingConnectionFactoryFilter<>(HostAndPort::of, globalARecordsDnsServiceDiscoverer());
 
         private DefaultResolvingConnectionFactoryFilterInitializer() {
             // Singleton

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilderTest.java
@@ -29,7 +29,7 @@ import java.net.SocketAddress;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.mappingServiceDiscoverer;
+import static io.servicetalk.http.netty.InternalServiceDiscoverers.mappingServiceDiscoverer;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ForResolvedAddressTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ForResolvedAddressTest.java
@@ -28,9 +28,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import java.net.InetSocketAddress;
 
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscoverers.globalARecordsDnsServiceDiscoverer;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.mappingServiceDiscoverer;
+import static io.servicetalk.http.netty.InternalServiceDiscoverers.mappingServiceDiscoverer;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.toResolvedInetSocketAddress;
@@ -76,7 +76,7 @@ class ForResolvedAddressTest {
     @Test
     void hostAndPortThrowIfSdChanges() {
         ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> otherSd =
-                globalDnsServiceDiscoverer();
+                globalARecordsDnsServiceDiscoverer();
         HostAndPort address = HostAndPort.of("127.0.0.1", 8080);
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
                 () -> HttpClients.forResolvedAddress(address).serviceDiscoverer(otherSd));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientResolvesOnNewConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientResolvesOnNewConnectionTest.java
@@ -49,8 +49,8 @@ import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.UNAVAILABL
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
 import static io.servicetalk.concurrent.api.Publisher.never;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscoverers.globalARecordsDnsServiceDiscoverer;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
 import static io.servicetalk.http.netty.HttpClients.DiscoveryStrategy.ON_NEW_CONNECTION;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -95,8 +95,7 @@ class HttpClientResolvesOnNewConnectionTest {
              BlockingHttpClient client = HttpClients.forMultiAddressUrl(getClass().getSimpleName(),
                      // Wrap to pretend this is a custom SD:
                      new DelegatingServiceDiscoverer<HostAndPort, InetSocketAddress,
-                             ServiceDiscovererEvent<InetSocketAddress>>(
-                                     GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer()) {
+                             ServiceDiscovererEvent<InetSocketAddress>>(globalARecordsDnsServiceDiscoverer()) {
                          @Override
                          public Publisher<Collection<ServiceDiscovererEvent<InetSocketAddress>>> discover(
                                  HostAndPort hostAndPort) {
@@ -175,7 +174,7 @@ class HttpClientResolvesOnNewConnectionTest {
     @Test
     void attemptToOverrideServiceDiscovererThrows() {
         ServiceDiscoverer<HostAndPort, InetSocketAddress, ServiceDiscovererEvent<InetSocketAddress>> otherSd =
-                globalDnsServiceDiscoverer();
+                globalARecordsDnsServiceDiscoverer();
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
                 () -> HttpClients.forSingleAddress("servicetalk.io", 80, ON_NEW_CONNECTION).serviceDiscoverer(otherSd));
         assertThat(e.getMessage(), allOf(containsString(ON_NEW_CONNECTION.name()), containsString(otherSd.toString())));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -48,6 +48,7 @@ import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitelyN
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscoverers.globalARecordsDnsServiceDiscoverer;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpHeaderNames.LOCATION;
@@ -67,7 +68,6 @@ import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.servicetalk.http.api.HttpResponseStatus.SEE_OTHER;
 import static io.servicetalk.http.api.HttpResponseStatus.UNAUTHORIZED;
-import static io.servicetalk.http.netty.GlobalDnsServiceDiscoverer.globalDnsServiceDiscoverer;
 import static io.servicetalk.transport.netty.internal.AddressUtils.hostHeader;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -151,7 +151,7 @@ class MultiAddressUrlHttpClientTest {
                     return Publisher.failed(new UnknownHostException(
                             "Special domain name \"" + INVALID_HOSTNAME + "\" always returns NXDOMAIN"));
                 }
-                return globalDnsServiceDiscoverer().discover(hostAndPort);
+                return globalARecordsDnsServiceDiscoverer().discover(hostAndPort);
             }
 
             @Override


### PR DESCRIPTION
Motivation:

If users need to wrap a `ServiceDiscoverer` to apply a filtering logic, currently they have to create their own instance of DNS `ServiceDiscoverer`. As a result, their use-cases uses separate DNS cache, while other use-cases in the classpath that do not require wrapping use global instance and share DNS cache.

Modifications:

- Add 2 new static methods in `DnsServiceDiscoverers`: `globalARecordsDnsServiceDiscoverer()`, and
`globalSrvRecordsDnsServiceDiscoverer()`;
- Remove similar instances from `GlobalDnsServiceDiscoverer`, rename it to `InternalServiceDiscoverers`;

Result:

Users can grab a global DNS SD instance and apply wrapping/filtering if necessary.