### PR TITLE
Restore unintentionally removed `RoundRobinLoadBalancerFactory` API

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -79,6 +79,15 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
     }
 
     @Override
+    public LoadBalancer<C> newLoadBalancer(
+            final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
+            final ConnectionFactory<ResolvedAddress, C> connectionFactory,
+            final String targetResource) {
+        return new RoundRobinLoadBalancer<>(id, targetResource, eventPublisher, connectionFactory,
+                linearSearchSpace, healthCheckConfig);
+    }
+
+    @Override
     public ExecutionStrategy requiredOffloads() {
         // We do not block
         return ExecutionStrategy.offloadNone();


### PR DESCRIPTION
Motivation:

japicmp report:
```
***! MODIFIED CLASS: PUBLIC FINAL io.servicetalk.loadbalancer.RoundRobinLoadBalancerFactory  (not serializable)
        ===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
        ===  UNCHANGED SUPERCLASS: java.lang.Object (<- java.lang.Object)
        ---! REMOVED METHOD: PUBLIC(-) io.servicetalk.client.api.LoadBalancer newLoadBalancer(io.servicetalk.concurrent.api.Publisher, io.servicetalk.client.api.ConnectionFactory, java.lang.String)
```