### PR TITLE
release.sh: skip if nothing to commit for gh-pages

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -224,7 +224,7 @@ fi
 echo $files_to_revert | xargs git checkout --
 
 $git add * .nojekyll
-$git commit --author="$GIT_AUTHOR" -m "Publish docs website $version_majorminor"
+$git diff-index --quiet HEAD || $git commit --author="$GIT_AUTHOR" -m "Publish docs website $version_majorminor"
 $git push docs gh-pages
 popd
 


### PR DESCRIPTION
Motivation:

Sometimes it's required to re-run the release script if there was an error with a previous build. In this case, gh-pages are already generated and the 2nd run does not produce any new output. Script fails with "nothing to commit" message.

Modifications:

- Commit gh-pages only if there is a non-empty diff;

Result:

release.sh script does not fail if there are no updates for gh-pages.