### PR TITLE
Downgrade log4j 2.22.1 -> 2.21.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ nettyIoUringVersion=0.0.25.Final
 
 jsr305Version=3.0.2
 
-log4jVersion=2.22.1
+log4jVersion=2.21.1
 slf4jVersion=1.7.36
 
 javaxActivationVersion=1.2.2


### PR DESCRIPTION
Builds fail with 
```
Cannot find annotation method 'value()' in type 'BaselineIgnore': class file for aQute.bnd.annotation.baseline.BaselineIgnore not found
```
This annotation was added in 2.22.0