### PR TITLE
http-netty: Properly set the host header for MultiAddressUrlClient

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -76,7 +76,6 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.setExecutionContext;
 import static io.servicetalk.http.utils.HostHeaderHttpRequesterFilter.AUTHORITY_KEY;
-import static io.servicetalk.utils.internal.NetworkUtils.isValidIpV6Address;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -75,7 +75,7 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.DefaultSingleAddressHttpClientBuilder.setExecutionContext;
-import static io.servicetalk.http.utils.HostHeaderHttpRequesterFilter.AUTHORITY_KEY;
+import static io.servicetalk.http.netty.MultiAddressCompatibleHostHeaderHttpRequestFilter.AUTHORITY_KEY;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -105,7 +105,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
             new IdleTimeoutConnectionFilter(ofMinutes(5));
 
     // We use this static field instead of the lambda syntax so that we can detect if the default is in use or not.
-    private static Function<Object, CharSequence> DEFAULT_HOST_TO_CHAR_SEQUENCE_FUNCTION =
+    private static final Function<Object, CharSequence> DEFAULT_HOST_TO_CHAR_SEQUENCE_FUNCTION =
             DefaultSingleAddressHttpClientBuilder::toAuthorityForm;
 
     static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(8);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -104,7 +104,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     private static final StreamingHttpConnectionFilterFactory DEFAULT_IDLE_TIMEOUT_FILTER =
             new IdleTimeoutConnectionFilter(ofMinutes(5));
 
-    // We use this static field instead of the lambda syntax so that we can detect if the default is in use or not.
+    // We use this static field instead of the lambda syntax so that we can use reference equality to
+    // determine if the default is in use or not.
     private static final Function<Object, CharSequence> DEFAULT_HOST_TO_CHAR_SEQUENCE_FUNCTION =
             DefaultSingleAddressHttpClientBuilder::toAuthorityForm;
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -104,6 +104,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     private static final StreamingHttpConnectionFilterFactory DEFAULT_IDLE_TIMEOUT_FILTER =
             new IdleTimeoutConnectionFilter(ofMinutes(5));
 
+    // We use this static field instead of the lambda syntax so that we can detect if the default is in use or not.
+    private static Function<Object, CharSequence> DEFAULT_HOST_TO_CHAR_SEQUENCE_FUNCTION =
+            DefaultSingleAddressHttpClientBuilder::toAuthorityForm;
+
     static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(8);
     static final Duration SD_RETRY_STRATEGY_MAX_DELAY = ofSeconds(256);
 
@@ -117,7 +121,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     private HttpLoadBalancerFactory<R> loadBalancerFactory;
     private ServiceDiscoverer<U, R, ? extends ServiceDiscovererEvent<R>> serviceDiscoverer;
     private Function<U, CharSequence> hostToCharSequenceFunction =
-            DefaultSingleAddressHttpClientBuilder::toAuthorityForm;
+            (Function<U, CharSequence>) DEFAULT_HOST_TO_CHAR_SEQUENCE_FUNCTION;
     private boolean addHostHeaderFallbackFilter = true;
     private boolean addIdleTimeoutConnectionFilter = true;
     @Nullable
@@ -313,7 +317,9 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
             }
             if (ctx.builder.addHostHeaderFallbackFilter) {
                 currClientFilterFactory = appendFilter(currClientFilterFactory, new HostHeaderHttpRequesterFilter(
-                        ctx.builder.hostToCharSequenceFunction.apply(ctx.builder.address)));
+                        ctx.builder.hostToCharSequenceFunction.apply(ctx.builder.address),
+                        // only for the default do we want to prefer synthesizing from the request
+                        ctx.builder.hostToCharSequenceFunction == DEFAULT_HOST_TO_CHAR_SEQUENCE_FUNCTION));
             }
 
             FilterableStreamingHttpClient lbClient = closeOnException.prepend(

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -316,10 +316,11 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                         ctx.builder.proxyAbsoluteAddressFilterFactory());
             }
             if (ctx.builder.addHostHeaderFallbackFilter) {
-                currClientFilterFactory = appendFilter(currClientFilterFactory, new HostHeaderHttpRequesterFilter(
-                        ctx.builder.hostToCharSequenceFunction.apply(ctx.builder.address),
-                        // only for the default do we want to prefer synthesizing from the request
-                        ctx.builder.hostToCharSequenceFunction == DEFAULT_HOST_TO_CHAR_SEQUENCE_FUNCTION));
+                currClientFilterFactory = appendFilter(currClientFilterFactory,
+                        new MultiAddressCompatibleHostHeaderHttpRequestFilter(
+                            ctx.builder.hostToCharSequenceFunction.apply(ctx.builder.address),
+                            // only for the default do we want to prefer synthesizing from the request
+                            ctx.builder.hostToCharSequenceFunction == DEFAULT_HOST_TO_CHAR_SEQUENCE_FUNCTION));
             }
 
             FilterableStreamingHttpClient lbClient = closeOnException.prepend(

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/MultiAddressCompatibleHostHeaderHttpRequestFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/MultiAddressCompatibleHostHeaderHttpRequestFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.utils.HostHeaderHttpRequesterFilter;
+
+import static io.servicetalk.http.api.HttpHeaderNames.HOST;
+
+final class MultiAddressCompatibleHostHeaderHttpRequestFilter extends HostHeaderHttpRequesterFilter {
+
+    static final ContextMap.Key<CharSequence> AUTHORITY_KEY =
+            ContextMap.Key.newKey("request-authority", CharSequence.class);
+
+    private final boolean preferSynthesizeFromRequest;
+
+    MultiAddressCompatibleHostHeaderHttpRequestFilter(final CharSequence fallbackHost,
+                                                      final boolean preferSynthesizeFromRequest) {
+        super(fallbackHost);
+        this.preferSynthesizeFromRequest = preferSynthesizeFromRequest;
+    }
+
+    @Override
+    protected void setHostHeader(HttpRequestMetaData request) {
+        if (preferSynthesizeFromRequest) {
+            final CharSequence hostHeader = request.context().get(AUTHORITY_KEY);
+            if (hostHeader != null) {
+                request.headers().set(HOST, hostHeader);
+                return;
+            }
+        }
+        super.setHostHeader(request);
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -270,6 +270,16 @@ class MultiAddressUrlHttpClientTest {
             request = client.get(format("http://%s:%d/200", serverHost, serverPort));
             // the host header should exactly match the authority provided.
             requestAndValidate(client, request, OK, "/200", serverHost + ":" + serverPort);
+
+            // Excludes userinfo and the '@'
+            request = client.get(format("http://user:pass@%s/200", serverHost, serverPort));
+            // the host header should exactly match the authority provided.
+            requestAndValidate(client, request, OK, "/200", serverHost);
+
+            // Doesn't normalize
+            request = client.get("http://LocalHost/200");
+            // the host header should exactly match the authority provided.
+            requestAndValidate(client, request, OK, "/200", "LocalHost");
         }
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -318,12 +318,6 @@ class MultiAddressUrlHttpClientTest {
     }
 
     private static void requestAndValidate(final StreamingHttpClient client, final StreamingHttpRequest request,
-                                           final HttpResponseStatus expectedStatus, final String expectedRequestTarget)
-            throws Exception {
-        requestAndValidate(client, request, expectedStatus, expectedRequestTarget, null);
-    }
-
-    private static void requestAndValidate(final StreamingHttpClient client, final StreamingHttpRequest request,
                                            final HttpResponseStatus expectedStatus, final String expectedRequestTarget,
                                            final String expectedHostHeader) throws Exception {
         StreamingHttpResponse response = awaitIndefinitelyNonNull(client.request(request));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -266,13 +266,18 @@ class MultiAddressUrlHttpClientTest {
             // the host header should exactly match the authority provided.
             requestAndValidate(client, request, OK, "/200", serverHost);
 
+            // Request without a port in the authority
+            request = client.get(format("http://%s/200", serverHost));
+            // the host header should exactly match the authority provided.
+            requestAndValidate(client, request, OK, "/200", serverHost);
+
             // Request with a port in the authority
             request = client.get(format("http://%s:%d/200", serverHost, serverPort));
             // the host header should exactly match the authority provided.
             requestAndValidate(client, request, OK, "/200", serverHost + ":" + serverPort);
 
             // Excludes userinfo and the '@'
-            request = client.get(format("http://user:pass@%s/200", serverHost, serverPort));
+            request = client.get(format("http://user:pass@%s/200", serverHost));
             // the host header should exactly match the authority provided.
             requestAndValidate(client, request, OK, "/200", serverHost);
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -86,6 +86,7 @@ class MultiAddressUrlHttpClientTest {
     private static final String INVALID_HOSTNAME = "invalid.";
     private static final String X_REQUESTED_LOCATION = "X-Requested-Location";
     private static final String X_RECEIVED_REQUEST_TARGET = "X-Received-Request-Target";
+    private static final String X_RECEIVED_HOST_HEADER = "X-Received-Host-Header";
 
     private static CompositeCloseable afterClassCloseables;
     private static StreamingHttpService httpService;
@@ -124,6 +125,9 @@ class MultiAddressUrlHttpClientTest {
                 }
             } catch (Exception e) {
                 response = factory.badRequest();
+            }
+            if (request.headers().contains(HOST)) {
+                response.setHeader(X_RECEIVED_HOST_HEADER, request.headers().get(HOST));
             }
             return succeeded(response.setHeader(CONTENT_LENGTH, ZERO)
                     .setHeader(X_RECEIVED_REQUEST_TARGET, request.requestTarget()));
@@ -195,25 +199,25 @@ class MultiAddressUrlHttpClientTest {
         StreamingHttpRequest request = client.get(format("http://%s/200?param=value#tag", hostHeader));
         // value in the HOST header should be ignored:
         request.headers().set(HOST, format("%s:%d", INVALID_HOSTNAME, 8080));
-        requestAndValidate(client, request, OK, "/200?param=value#tag");
+        requestAndValidate(client, request, OK, "/200?param=value#tag", INVALID_HOSTNAME + ":" + 8080);
     }
 
     @Test
     void requestWithAbsoluteFormRequestTargetWithoutHostHeader() throws Exception {
         StreamingHttpRequest request = client.get(format("http://%s/200?param=value#tag", hostHeader));
-        requestAndValidate(client, request, OK, "/200?param=value#tag");
+        requestAndValidate(client, request, OK, "/200?param=value#tag", hostHeader);
     }
 
     @Test
     void requestWithAbsoluteFormRequestTargetWithoutPath() throws Exception {
         StreamingHttpRequest request = client.get(format("http://%s", hostHeader));
-        requestAndValidate(client, request, BAD_REQUEST, "/");
+        requestAndValidate(client, request, BAD_REQUEST, "/", hostHeader);
     }
 
     @Test
     void requestWithAbsoluteFormRequestTargetWithoutPathWithParams() throws Exception {
         StreamingHttpRequest request = client.get(format("http://%s?param=value", hostHeader));
-        requestAndValidate(client, request, BAD_REQUEST, "/?param=value");
+        requestAndValidate(client, request, BAD_REQUEST, "/?param=value", hostHeader);
     }
 
     @Test
@@ -257,14 +261,14 @@ class MultiAddressUrlHttpClientTest {
     void requestWithRedirect() throws Exception {
         StreamingHttpRequest request = client.get(format("http://%s/301", hostHeader))
                 .setHeader(X_REQUESTED_LOCATION, format("http://%s/200", hostHeader));  // Location for redirect
-        requestAndValidate(client, request, OK, "/200");
+        requestAndValidate(client, request, OK, "/200", hostHeader);
     }
 
     @Test
     void requestWithRelativeRedirect() throws Exception {
         StreamingHttpRequest request = client.get(format("http://%s/301", hostHeader))
                 .setHeader(X_REQUESTED_LOCATION, "/200");  // Location for redirect
-        requestAndValidate(client, request, OK, "/200");
+        requestAndValidate(client, request, OK, "/200", hostHeader);
     }
 
     @Test
@@ -272,7 +276,7 @@ class MultiAddressUrlHttpClientTest {
         try (StreamingHttpClient client = HttpClients
                 .forMultiAddressUrl(ID).defaultHttpPort(serverPort).buildStreaming()) {
             StreamingHttpRequest request = client.get(format("http://%s/200", serverHost));
-            requestAndValidate(client, request, OK, "/200");
+            requestAndValidate(client, request, OK, "/200", serverHost);
         }
     }
 
@@ -282,7 +286,8 @@ class MultiAddressUrlHttpClientTest {
         try (StreamingHttpClient client = HttpClients
                 .forMultiAddressUrl(ID).defaultHttpPort(illegalPort).buildStreaming()) {
             StreamingHttpRequest request = client.get(format("http://%s:%d/200", serverHost, serverPort));
-            requestAndValidate(client, request, OK, "/200");
+            // the host header should exactly match the authority provided.
+            requestAndValidate(client, request, OK, "/200", serverHost + ":" + serverPort);
         }
     }
 
@@ -309,17 +314,26 @@ class MultiAddressUrlHttpClientTest {
     private static void makeGetRequestAndValidate(final StreamingHttpClient client, final String hostHeader,
                                                   final HttpResponseStatus status) throws Exception {
         StreamingHttpRequest request = client.get(format("http://%s/%d?param=value#tag", hostHeader, status.code()));
-        requestAndValidate(client, request, status, format("/%d?param=value#tag", status.code()));
+        requestAndValidate(client, request, status, format("/%d?param=value#tag", status.code()), hostHeader);
     }
 
     private static void requestAndValidate(final StreamingHttpClient client, final StreamingHttpRequest request,
                                            final HttpResponseStatus expectedStatus, final String expectedRequestTarget)
             throws Exception {
+        requestAndValidate(client, request, expectedStatus, expectedRequestTarget, null);
+    }
+
+    private static void requestAndValidate(final StreamingHttpClient client, final StreamingHttpRequest request,
+                                           final HttpResponseStatus expectedStatus, final String expectedRequestTarget,
+                                           final String expectedHostHeader) throws Exception {
         StreamingHttpResponse response = awaitIndefinitelyNonNull(client.request(request));
+        // Our request should be modified with the host header at this point.
         assertThat(response.status(), is(expectedStatus));
         final CharSequence receivedRequestTarget = response.headers().get(X_RECEIVED_REQUEST_TARGET);
         assertThat(receivedRequestTarget, is(notNullValue()));
         assertThat(receivedRequestTarget.toString(), is(expectedRequestTarget));
+        final CharSequence receivedHostHeader = response.headers().get(X_RECEIVED_HOST_HEADER);
+            assertThat(receivedHostHeader.toString(), is(expectedHostHeader));
     }
 
     private static ServerContext startNewLocalServer(final StreamingHttpService httpService,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MultiAddressUrlHttpClientTest.java
@@ -258,6 +258,22 @@ class MultiAddressUrlHttpClientTest {
     }
 
     @Test
+    void exactRequestAuthorityIsRepresentedInHostHeader() throws Exception {
+        try (StreamingHttpClient client = HttpClients
+                .forMultiAddressUrl(ID).defaultHttpPort(serverPort).buildStreaming()) {
+            // Request without a port in the authority
+            StreamingHttpRequest request = client.get(format("http://%s/200", serverHost));
+            // the host header should exactly match the authority provided.
+            requestAndValidate(client, request, OK, "/200", serverHost);
+
+            // Request with a port in the authority
+            request = client.get(format("http://%s:%d/200", serverHost, serverPort));
+            // the host header should exactly match the authority provided.
+            requestAndValidate(client, request, OK, "/200", serverHost + ":" + serverPort);
+        }
+    }
+
+    @Test
     void requestWithRedirect() throws Exception {
         StreamingHttpRequest request = client.get(format("http://%s/301", hostHeader))
                 .setHeader(X_REQUESTED_LOCATION, format("http://%s/200", hostHeader));  // Location for redirect

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/HostHeaderHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/HostHeaderHttpRequesterFilter.java
@@ -67,8 +67,6 @@ public final class HostHeaderHttpRequesterFilter implements StreamingHttpClientF
         this.preferSynthesizeFromRequest = preferSynthesizeFromRequest;
     }
 
-
-
     @Override
     public StreamingHttpClientFilter create(final FilterableStreamingHttpClient client) {
         return new StreamingHttpClientFilter(client) {

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/HostHeaderHttpRequesterFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/HostHeaderHttpRequesterFilter.java
@@ -94,7 +94,7 @@ public class HostHeaderHttpRequesterFilter implements StreamingHttpClientFilterF
     }
 
     /**
-     * Attempt to set the host header for requests that don't already contain a host header and are not HTTP/1.0
+     * Attempt to set the host header for requests that don't already contain a host header and are not HTTP/1.0.
      * @param request the request on which to set the host header.
      */
     protected void setHostHeader(final HttpRequestMetaData request) {


### PR DESCRIPTION
Motivation:

Users of the MultiAddressHttpClientBuilder are expected to put in a request target that includes the authority, which may or may not include the port. The authority should be directly reflected in the `Host` header but right now we will add both host and port regardless of what was specified. This is described in https://datatracker.ietf.org/doc/html/rfc7230#section-5.4.

Modifications:

Copy the authority information directly from the request when overrides haven't been specified.

See https://github.com/apple/servicetalk/pull/2868 for an implementation that is simpler to follow but disregards user intent wrt `SingleClientAddressBuilder.hostHeaderFallback(..)` and potentially filters.