### PR TITLE
Introduce a cache for Publishers that tracks subscriptions to manage the cache

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherCache.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherCache.java
@@ -35,17 +35,17 @@ public final class PublisherCache<K, T> {
     private final MulticastStrategy<T> multicastStrategy;
     private final Map<K, Holder<T>> publisherCache;
 
+    PublisherCache(final MulticastStrategy<T> multicastStrategy) {
+        this.multicastStrategy = multicastStrategy;
+        this.publisherCache = new HashMap<>();
+    }
+
     /**
      * Create a new PublisherCache where the cached publishers must be configured with a multicast or replay operator
      * by the multicastSupplier function.
      *
      * @param multicastStrategy a strategy used for wrapping new cache values.
      */
-    PublisherCache(final MulticastStrategy<T> multicastStrategy) {
-        this.multicastStrategy = multicastStrategy;
-        this.publisherCache = new HashMap<>();
-    }
-
     public static <K, T> PublisherCache<K, T> create() {
         return new PublisherCache<>(MulticastStrategy.identity());
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherCache.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherCache.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+/**
+ * A cache of publishers, Keys must correctly implement Object::hashCode and Object::equals.
+ * Publishers can be created as either multicast or with a replay configuration. Subscriptions
+ * are tracked by the cache and Publishers are removed when there are no more subscriptions.
+ *
+ * @param <K> a key type suitable for use as a Map key, that correctly implements hashCode/equals.
+ * @param <T> the type of the publisher that is cached.
+ */
+public final class PublisherCache<K, T> {
+    private final MulticastStrategy<T> multicastStrategy;
+    private final Function<K, Publisher<T>> publisherSupplier;
+    private final Map<K, Holder<T>> publisherCache;
+
+    PublisherCache(
+            final Function<K, Publisher<T>> publisherSupplier,
+            final MulticastStrategy<T> multicastStrategy) {
+        this.publisherSupplier = publisherSupplier;
+        this.multicastStrategy = multicastStrategy;
+        this.publisherCache = new HashMap<>();
+    }
+
+    /**
+     * Create a new PublisherCache where the cached publishers will be configured for multicast for all
+     * consumers of a specific key. The publisherSupplier will be invoked when the cache does not contain a
+     * publisher for the requested key.
+     *
+     * @param publisherSupplier a function that takes the key and returns a new publisher corresponding to that key.
+     * @return a new publisher from the publisherSupplier if not contained in the cache, otherwise the cached publisher.
+     * @param <K> a key type suitable for use as a Map key.
+     * @param <T> the type of the Publisher contained in the cache.
+     */
+    public static <K, T> PublisherCache<K, T> multicast(Function<K, Publisher<T>> publisherSupplier) {
+        return new PublisherCache<>(publisherSupplier, MulticastStrategy.wrapMulticast());
+    }
+
+    /**
+     * Create a new PublisherCache where the cacehed publishers will be configured for replay given the privided
+     * ReplayStrategy. The publisherSupplier will be invoked when the cache does not contain a publisher for
+     * the requested key.
+     *
+     * @param publisherSupplier a function that takes the key and returns a new publisher corresponding to that key.
+     * @param replayStrategy a replay strategy to be used by a newly cached publisher.
+     * @return a new publisher from the publisherSupplier if not contained in the cache, otherwise the cached publisher.
+     * @param <K> a key type suitable for use as a Map key.
+     * @param <T> the type of the Publisher contained in the cache.
+     */
+    public static <K, T> PublisherCache<K, T> replay(
+            Function<K, Publisher<T>> publisherSupplier,
+            ReplayStrategy<T> replayStrategy) {
+        return new PublisherCache<>(publisherSupplier, MulticastStrategy.wrapReplay(replayStrategy));
+    }
+
+    public Publisher<T> get(K key) {
+        return Publisher.defer(() -> {
+            synchronized (publisherCache) {
+                if (publisherCache.containsKey(key)) {
+                    return publisherCache.get(key).publisher;
+                }
+
+                final Holder<T> item2 = new Holder<>();
+                publisherCache.put(key, item2);
+
+                final Publisher<T> newPublisher = publisherSupplier.apply(key)
+                        .liftSync(subscriber -> new Subscriber<T>() {
+                            @Override
+                            public void onSubscribe(Subscription subscription) {
+                                subscriber.onSubscribe(new Subscription() {
+                                    @Override
+                                    public void request(long n) {
+                                        subscription.request(n);
+                                    }
+
+                                    @Override
+                                    public void cancel() {
+                                        try {
+                                            assert Thread.holdsLock(publisherCache);
+                                            publisherCache.remove(key, item2);
+                                        } finally {
+                                            subscription.cancel();
+                                        }
+                                    }
+                                });
+                            }
+
+                            @Override
+                            public void onNext(@Nullable T next) {
+                                subscriber.onNext(next);
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                lockRemoveFromMap();
+                                subscriber.onError(t);
+                            }
+
+                            @Override
+                            public void onComplete() {
+                                lockRemoveFromMap();
+                                subscriber.onComplete();
+                            }
+
+                            private void lockRemoveFromMap() {
+                                synchronized (publisherCache) {
+                                    publisherCache.remove(key, item2);
+                                }
+                            }
+                        });
+
+                item2.publisher = multicastStrategy.apply(newPublisher)
+                        .liftSync(subscriber -> new Subscriber<T>() {
+                            @Override
+                            public void onSubscribe(Subscription subscription) {
+                                subscriber.onSubscribe(new Subscription() {
+                                    @Override
+                                    public void request(long n) {
+                                        subscription.request(n);
+                                    }
+
+                                    @Override
+                                    public void cancel() {
+                                        synchronized (publisherCache) {
+                                            subscription.cancel();
+                                        }
+                                    }
+                                });
+                            }
+
+                            @Override
+                            public void onNext(@Nullable T next) {
+                                subscriber.onNext(next);
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                try {
+                                    subscriber.onError(t);
+                                } finally {
+                                    lockRemoveFromMap();
+                                }
+                            }
+
+                            @Override
+                            public void onComplete() {
+                                try {
+                                    subscriber.onComplete();
+                                } finally {
+                                    lockRemoveFromMap();
+                                }
+                            }
+
+                            private void lockRemoveFromMap() {
+                                synchronized (publisherCache) {
+                                    publisherCache.remove(key, item2);
+                                }
+                            }
+                        });
+                return item2.publisher;
+            }
+        });
+    }
+
+    private static final class Holder<T> {
+        @Nullable
+        Publisher<T> publisher;
+    }
+
+    @FunctionalInterface
+    private interface MulticastStrategy<T> {
+        Publisher<T> apply(Publisher<T> cached);
+
+        static <T> MulticastStrategy<T> wrapMulticast() {
+            return cached -> cached.multicast(1, true);
+        }
+
+        static <T> MulticastStrategy<T> wrapMulticast(int minSubscribers) {
+            return cached -> cached.multicast(minSubscribers, true);
+        }
+
+        static <T> MulticastStrategy<T> wrapMulticast(int minSubscribers, int queueLimit) {
+            return cached -> cached.multicast(minSubscribers, queueLimit);
+        }
+
+        static <T> MulticastStrategy<T> wrapReplay(final ReplayStrategy<T> strategy) {
+            return cached -> cached.replay(strategy);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherCache.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherCache.java
@@ -232,7 +232,7 @@ public final class PublisherCache<K, T> {
      * @param <T> the type of the {@link Publisher}.
      */
     @FunctionalInterface
-    interface MulticastStrategy<T> {
+    private interface MulticastStrategy<T> {
         Publisher<T> apply(Publisher<T> cached);
 
         static <T> MulticastStrategy<T> identity() {

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherCacheTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherCacheTest.java
@@ -15,22 +15,25 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.concurrent.api.PublisherCache.MulticastStrategy;
 import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.servicetalk.concurrent.api.PublisherCache.MulticastStrategy.wrapMulticast;
+import static io.servicetalk.concurrent.api.PublisherCache.MulticastStrategy.wrapReplay;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-
 class PublisherCacheTest {
     private TestPublisher<Integer> testPublisher;
-    private PublisherCache<String, Integer> publisherCache;
     private AtomicInteger upstreamSubscriptionCount;
     private AtomicBoolean isUpstreamUnsubsrcibed;
     private AtomicInteger upstreamCacheRequestCount;
@@ -41,182 +44,172 @@ class PublisherCacheTest {
         this.upstreamSubscriptionCount = new AtomicInteger(0);
         this.isUpstreamUnsubsrcibed = new AtomicBoolean(false);
         this.upstreamCacheRequestCount = new AtomicInteger(0);
-        this.publisherCache = PublisherCache.multicast((_ignore) -> {
+    }
+
+    private PublisherCache<String, Integer> publisherCache(final MulticastStrategy<Integer> strategy) {
+        return new PublisherCache<>((_ignore) -> {
             upstreamCacheRequestCount.incrementAndGet();
             return testPublisher.afterOnSubscribe(subscription ->
                     upstreamSubscriptionCount.incrementAndGet()
             ).afterFinally(() -> isUpstreamUnsubsrcibed.set(true));
-        });
+        }, strategy);
     }
 
     @Test
-    public void testMultipleSubscribersReceiveCachedResults() {
+    public void multipleSubscribersToSameKeyReceiveMulticastEvents() {
+        final PublisherCache<String, Integer> publisherCache = publisherCache(wrapMulticast());
+
         final TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
-        SourceAdapters.toSource(publisherCache.get("foo")).subscribe(subscriber1);
-        final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
+        toSource(publisherCache.get("foo")).subscribe(subscriber1);
+        final Subscription subscription1 = subscriber1.awaitSubscription();
 
         // the first subscriber receives the initial event
         subscription1.request(1);
         testPublisher.onNext(1);
         assertThat(subscriber1.takeOnNext(), is(1));
 
-        // the second subscriber receives the cached event
+        // the second subscriber receives the cached publisher
         final TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
-        SourceAdapters.toSource(publisherCache.get("bar")).subscribe(subscriber2);
-        final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
-
-        subscription2.request(1);
-        assertThat(subscriber2.takeOnNext(), is(1));
-
-        // subscribe with the first request
-        assertThat(upstreamSubscriptionCount.get(), is(1));
+        toSource(publisherCache.get("foo")).subscribe(subscriber2);
+        final Subscription subscription2 = subscriber2.awaitSubscription();
 
         // all subscribers receive all subsequent events
         subscription1.request(1);
         subscription2.request(1);
         testPublisher.onNext(2);
-
         assertThat(subscriber1.takeOnNext(), is(2));
         assertThat(subscriber2.takeOnNext(), is(2));
+
+        // subscribe with the first request
+        assertThat(upstreamSubscriptionCount.get(), is(1));
 
         // make sure we still only have subscribed once
         assertThat(upstreamSubscriptionCount.get(), is(1));
         assertThat(upstreamCacheRequestCount.get(), is(1));
     }
 
-    // @Test
-    // public void testDiscovererAccumulatesEvents() {
-    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
-    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber1);
-    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
-    //
-    //     // the first subscriber receives the initial event
-    //     subscription1.request(4);
-    //
-    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of())));
-    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())));
-    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT3, Map.of())));
-    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT4, Map.of())));
-    //
-    //     // Subscriber 1 receives individual events
-    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of())));
-    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())));
-    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT3, Map.of())));
-    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT4, Map.of())));
-    //
-    //     final var subscriber2 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
-    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber2);
-    //     final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
-    //
-    //     // Subscriber 2 receives a batch of accumulated events
-    //     subscription2.request(1);
-    //     assertThat(subscriber2.takeOnNext(), containsInAnyOrder(
-    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of()),
-    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of()),
-    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT3, Map.of()),
-    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT4, Map.of())
-    //     ));
-    //
-    //     assertThat(upstreamCacheRequestCount.get(), is(1));
-    // }
-    //
-    // @Test
-    // public void testDiscovererAccumulatesRemoveEvents() {
-    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
-    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber1);
-    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
-    //
-    //     // the first subscriber receives the initial event
-    //     subscription1.request(4);
-    //
-    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of())));
-    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())));
-    //     currentEventPublisher.get().onNext(List.of(new RemoveEvent(SERVICE, ENDPOINT1)));
-    //
-    //     // Subscriber 1 receives individual events
-    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of())));
-    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())));
-    //     assertThat(subscriber1.takeOnNext(), contains(new RemoveEvent(SERVICE, ENDPOINT1)));
-    //
-    //     final var subscriber2 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
-    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber2);
-    //     final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
-    //
-    //     // Subscriber 2 receives a batch of accumulated events
-    //     subscription2.request(1);
-    //     assertThat(subscriber2.takeOnNext(), containsInAnyOrder(
-    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())
-    //     ));
-    //
-    //     assertThat(upstreamCacheRequestCount.get(), is(1));
-    // }
-    //
-    // @Test
-    // public void testDiscovererConvertsModifyEventsToAddEvents() {
-    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
-    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber1);
-    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
-    //
-    //     // the first subscriber receives the initial event
-    //     subscription1.request(4);
-    //
-    //     final Map<String, Attribute> initialAttributes = Map.of();
-    //     final Map<String, Attribute> updateAttributes = Map.of("attr1", new LongAttribute(1));
-    //
-    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, initialAttributes)));
-    //     currentEventPublisher.get().onNext(List.of(new UpdateEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, updateAttributes)));
-    //
-    //     // Subscriber 1 receives individual events
-    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, initialAttributes)));
-    //     assertThat(subscriber1.takeOnNext(), contains(new UpdateEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, updateAttributes)));
-    //
-    //     final var subscriber2 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
-    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber2);
-    //     final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
-    //
-    //     // Subscriber 2 receives a batch of accumulated events
-    //     subscription2.request(1);
-    //     assertThat(subscriber2.takeOnNext(), containsInAnyOrder(
-    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, updateAttributes)
-    //     ));
-    //
-    //     assertThat(upstreamCacheRequestCount.get(), is(1));
-    // }
-    //
-    // @Test
-    // public void testUnSubscribeUpstreamAndInvalidateCacheWhenEmpty() {
-    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
-    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber1);
-    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
-    //
-    //     assertThat(upstreamSubscriptionCount.get(), is(1));
-    //
-    //     final var subscriber2 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
-    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber2);
-    //     final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
-    //
-    //     assertThat(upstreamSubscriptionCount.get(), is(1));
-    //
-    //     subscription1.cancel();
-    //     assertThat(isUpstreamUnsubsrcibed.get(), is(false));
-    //
-    //     subscription2.cancel();
-    //     assertThat(isUpstreamUnsubsrcibed.get(), is(true));
-    //
-    //     assertThat(upstreamCacheRequestCount.get(), is(1));
-    // }
-    //
-    // @Test
-    // public void testErrorFromUpstreamInvalidatesCacheEntryAndRequestsANewStream() {
-    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
-    //     // use a stupid "always" retry policy to force the situation
-    //     final var discovery = discoveryService.discover(SERVICE).retry((i, cause) -> true);
-    //     SourceAdapters.toSource(discovery).subscribe(subscriber1);
-    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
-    //
-    //     subscription1.request(2);
-    //     currentEventPublisher.get().onError(new Exception("bad stuff happened"));
-    //
-    //     assertThat(upstreamCacheRequestCount.get(), is(2));
-    // }
+    @Test
+    public void minSubscribersMulticastPolicySubscribesUpstreamOnce() {
+        final PublisherCache<String, Integer> publisherCache = publisherCache(wrapMulticast());
+
+        final TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
+        toSource(publisherCache.get("foo")).subscribe(subscriber1);
+        final Subscription subscription1 = subscriber1.awaitSubscription();
+
+        assertThat(upstreamSubscriptionCount.get(), is(1));
+
+        final TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
+        toSource(publisherCache.get("foo")).subscribe(subscriber2);
+        final Subscription subscription2 = subscriber2.awaitSubscription();
+
+        assertThat(upstreamSubscriptionCount.get(), is(1));
+
+        subscription1.cancel();
+        assertThat(isUpstreamUnsubsrcibed.get(), is(false));
+
+        subscription2.cancel();
+        assertThat(isUpstreamUnsubsrcibed.get(), is(true));
+
+        assertThat(upstreamCacheRequestCount.get(), is(1));
+    }
+
+    @Test
+    public void unSubscribeUpstreamAndInvalidateCacheWhenEmpty() {
+        final PublisherCache<String, Integer> publisherCache = publisherCache(wrapMulticast());
+
+        final TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
+        toSource(publisherCache.get("foo")).subscribe(subscriber1);
+        final Subscription subscription1 = subscriber1.awaitSubscription();
+
+        assertThat(upstreamSubscriptionCount.get(), is(1));
+
+        final TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
+        toSource(publisherCache.get("foo")).subscribe(subscriber2);
+        final Subscription subscription2 = subscriber2.awaitSubscription();
+
+        assertThat(upstreamSubscriptionCount.get(), is(1));
+
+        subscription1.cancel();
+        assertThat(isUpstreamUnsubsrcibed.get(), is(false));
+
+        subscription2.cancel();
+        assertThat(isUpstreamUnsubsrcibed.get(), is(true));
+
+        assertThat(upstreamCacheRequestCount.get(), is(1));
+    }
+
+    @Test
+    public void cacheSubscriptionAndUnsubscriptionWithMulticastMinSubscribers() {
+        final PublisherCache<String, Integer> publisherCache = publisherCache(wrapMulticast(2));
+
+        final TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
+        toSource(publisherCache.get("foo")).subscribe(subscriber1);
+        final Subscription subscription1 = subscriber1.awaitSubscription();
+
+        assertThat(upstreamSubscriptionCount.get(), is(0));
+
+        final TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
+        toSource(publisherCache.get("foo")).subscribe(subscriber2);
+        final Subscription subscription2 = subscriber2.awaitSubscription();
+
+        assertThat(upstreamSubscriptionCount.get(), is(1));
+
+        subscription1.cancel();
+        assertThat(isUpstreamUnsubsrcibed.get(), is(false));
+
+        subscription2.cancel();
+        assertThat(isUpstreamUnsubsrcibed.get(), is(true));
+
+        assertThat(upstreamCacheRequestCount.get(), is(1));
+    }
+
+    @Test
+    public void cacheSubscriptionAndUnsubscriptionWithReplay() {
+        final PublisherCache<String, Integer> publisherCache = publisherCache(
+                wrapReplay(ReplayStrategies.<Integer>historyBuilder(1)
+                        .cancelUpstream(true)
+                        .minSubscribers(1)
+                        .build()));
+
+        final TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
+        toSource(publisherCache.get("foo")).subscribe(subscriber1);
+        final Subscription subscription1 = subscriber1.awaitSubscription();
+
+        subscription1.request(3);
+        testPublisher.onNext(1, 2, 3);
+        assertThat(subscriber1.takeOnNext(3), is(Arrays.asList(1, 2, 3)));
+
+        final TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
+        toSource(publisherCache.get("foo")).subscribe(subscriber2);
+        final Subscription subscription2 = subscriber2.awaitSubscription();
+
+        assertThat(upstreamSubscriptionCount.get(), is(1));
+
+        subscription2.request(1);
+        assertThat(subscriber2.takeOnNext(), is(3));
+
+        subscription1.cancel();
+        assertThat(isUpstreamUnsubsrcibed.get(), is(false));
+
+        subscription2.cancel();
+        assertThat(isUpstreamUnsubsrcibed.get(), is(true));
+
+        assertThat(upstreamCacheRequestCount.get(), is(1));
+    }
+
+    @Test
+    public void testErrorFromUpstreamInvalidatesCacheEntryAndRequestsANewStream() {
+        final PublisherCache<String, Integer> publisherCache = publisherCache(wrapMulticast());
+
+        final TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
+        // use an "always" retry policy to force the situation
+        final Publisher<Integer> discovery = publisherCache.get("foo").retry((i, cause) -> true);
+        toSource(discovery).subscribe(subscriber1);
+        final Subscription subscription1 = subscriber1.awaitSubscription();
+
+        subscription1.request(2);
+        testPublisher.onError(new Exception("bad stuff happened"));
+
+        assertThat(upstreamCacheRequestCount.get(), is(2));
+    }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherCacheTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/PublisherCacheTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+class PublisherCacheTest {
+    private TestPublisher<Integer> testPublisher;
+    private PublisherCache<String, Integer> publisherCache;
+    private AtomicInteger upstreamSubscriptionCount;
+    private AtomicBoolean isUpstreamUnsubsrcibed;
+    private AtomicInteger upstreamCacheRequestCount;
+
+    @BeforeEach
+    public void setup() {
+        this.testPublisher = new TestPublisher<>();
+        this.upstreamSubscriptionCount = new AtomicInteger(0);
+        this.isUpstreamUnsubsrcibed = new AtomicBoolean(false);
+        this.upstreamCacheRequestCount = new AtomicInteger(0);
+        this.publisherCache = PublisherCache.multicast((_ignore) -> {
+            upstreamCacheRequestCount.incrementAndGet();
+            return testPublisher.afterOnSubscribe(subscription ->
+                    upstreamSubscriptionCount.incrementAndGet()
+            ).afterFinally(() -> isUpstreamUnsubsrcibed.set(true));
+        });
+    }
+
+    @Test
+    public void testMultipleSubscribersReceiveCachedResults() {
+        final TestPublisherSubscriber<Integer> subscriber1 = new TestPublisherSubscriber<>();
+        SourceAdapters.toSource(publisherCache.get("foo")).subscribe(subscriber1);
+        final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
+
+        // the first subscriber receives the initial event
+        subscription1.request(1);
+        testPublisher.onNext(1);
+        assertThat(subscriber1.takeOnNext(), is(1));
+
+        // the second subscriber receives the cached event
+        final TestPublisherSubscriber<Integer> subscriber2 = new TestPublisherSubscriber<>();
+        SourceAdapters.toSource(publisherCache.get("bar")).subscribe(subscriber2);
+        final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
+
+        subscription2.request(1);
+        assertThat(subscriber2.takeOnNext(), is(1));
+
+        // subscribe with the first request
+        assertThat(upstreamSubscriptionCount.get(), is(1));
+
+        // all subscribers receive all subsequent events
+        subscription1.request(1);
+        subscription2.request(1);
+        testPublisher.onNext(2);
+
+        assertThat(subscriber1.takeOnNext(), is(2));
+        assertThat(subscriber2.takeOnNext(), is(2));
+
+        // make sure we still only have subscribed once
+        assertThat(upstreamSubscriptionCount.get(), is(1));
+        assertThat(upstreamCacheRequestCount.get(), is(1));
+    }
+
+    // @Test
+    // public void testDiscovererAccumulatesEvents() {
+    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
+    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber1);
+    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
+    //
+    //     // the first subscriber receives the initial event
+    //     subscription1.request(4);
+    //
+    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of())));
+    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())));
+    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT3, Map.of())));
+    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT4, Map.of())));
+    //
+    //     // Subscriber 1 receives individual events
+    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of())));
+    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())));
+    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT3, Map.of())));
+    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT4, Map.of())));
+    //
+    //     final var subscriber2 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
+    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber2);
+    //     final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
+    //
+    //     // Subscriber 2 receives a batch of accumulated events
+    //     subscription2.request(1);
+    //     assertThat(subscriber2.takeOnNext(), containsInAnyOrder(
+    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of()),
+    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of()),
+    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT3, Map.of()),
+    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT4, Map.of())
+    //     ));
+    //
+    //     assertThat(upstreamCacheRequestCount.get(), is(1));
+    // }
+    //
+    // @Test
+    // public void testDiscovererAccumulatesRemoveEvents() {
+    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
+    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber1);
+    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
+    //
+    //     // the first subscriber receives the initial event
+    //     subscription1.request(4);
+    //
+    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of())));
+    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())));
+    //     currentEventPublisher.get().onNext(List.of(new RemoveEvent(SERVICE, ENDPOINT1)));
+    //
+    //     // Subscriber 1 receives individual events
+    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, Map.of())));
+    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())));
+    //     assertThat(subscriber1.takeOnNext(), contains(new RemoveEvent(SERVICE, ENDPOINT1)));
+    //
+    //     final var subscriber2 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
+    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber2);
+    //     final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
+    //
+    //     // Subscriber 2 receives a batch of accumulated events
+    //     subscription2.request(1);
+    //     assertThat(subscriber2.takeOnNext(), containsInAnyOrder(
+    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT2, Map.of())
+    //     ));
+    //
+    //     assertThat(upstreamCacheRequestCount.get(), is(1));
+    // }
+    //
+    // @Test
+    // public void testDiscovererConvertsModifyEventsToAddEvents() {
+    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
+    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber1);
+    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
+    //
+    //     // the first subscriber receives the initial event
+    //     subscription1.request(4);
+    //
+    //     final Map<String, Attribute> initialAttributes = Map.of();
+    //     final Map<String, Attribute> updateAttributes = Map.of("attr1", new LongAttribute(1));
+    //
+    //     currentEventPublisher.get().onNext(List.of(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, initialAttributes)));
+    //     currentEventPublisher.get().onNext(List.of(new UpdateEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, updateAttributes)));
+    //
+    //     // Subscriber 1 receives individual events
+    //     assertThat(subscriber1.takeOnNext(), contains(new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, initialAttributes)));
+    //     assertThat(subscriber1.takeOnNext(), contains(new UpdateEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, updateAttributes)));
+    //
+    //     final var subscriber2 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
+    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber2);
+    //     final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
+    //
+    //     // Subscriber 2 receives a batch of accumulated events
+    //     subscription2.request(1);
+    //     assertThat(subscriber2.takeOnNext(), containsInAnyOrder(
+    //             new AddEvent(SERVICE, new KubernetesEndpointEvent.Condition(true), ENDPOINT1, updateAttributes)
+    //     ));
+    //
+    //     assertThat(upstreamCacheRequestCount.get(), is(1));
+    // }
+    //
+    // @Test
+    // public void testUnSubscribeUpstreamAndInvalidateCacheWhenEmpty() {
+    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
+    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber1);
+    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
+    //
+    //     assertThat(upstreamSubscriptionCount.get(), is(1));
+    //
+    //     final var subscriber2 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
+    //     SourceAdapters.toSource(discoveryService.discover(SERVICE)).subscribe(subscriber2);
+    //     final PublisherSource.Subscription subscription2 = subscriber2.awaitSubscription();
+    //
+    //     assertThat(upstreamSubscriptionCount.get(), is(1));
+    //
+    //     subscription1.cancel();
+    //     assertThat(isUpstreamUnsubsrcibed.get(), is(false));
+    //
+    //     subscription2.cancel();
+    //     assertThat(isUpstreamUnsubsrcibed.get(), is(true));
+    //
+    //     assertThat(upstreamCacheRequestCount.get(), is(1));
+    // }
+    //
+    // @Test
+    // public void testErrorFromUpstreamInvalidatesCacheEntryAndRequestsANewStream() {
+    //     final var subscriber1 = new TestPublisherSubscriber<Collection<KubernetesEndpointEvent>>();
+    //     // use a stupid "always" retry policy to force the situation
+    //     final var discovery = discoveryService.discover(SERVICE).retry((i, cause) -> true);
+    //     SourceAdapters.toSource(discovery).subscribe(subscriber1);
+    //     final PublisherSource.Subscription subscription1 = subscriber1.awaitSubscription();
+    //
+    //     subscription1.request(2);
+    //     currentEventPublisher.get().onError(new Exception("bad stuff happened"));
+    //
+    //     assertThat(upstreamCacheRequestCount.get(), is(2));
+    // }
+}


### PR DESCRIPTION
Motivation:

Handling the caching of Publishers comes up often and correctly managing the cache can be tricky and error prone to implement correctly. Scenarios where caching of Publishers can be useful include those similar to the multicast and replay operators but have the added dimension of asynchronous access, for instance multiple requests which need to consume the same data.

Modifications:

Add a PublisherCache utility that manages the lifecycle of a cached Publisher. A publisher is removed from the cache when it no longer has any subscriptions.