### PR TITLE
Fix Content-Length header removal after content compression

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
@@ -123,7 +123,7 @@ public final class ContentEncodingHttpServiceFilter implements StreamingHttpServ
 
                         addContentEncoding(response.headers(), encoder.encodingName());
                         // After we encode the content length is unlikely to still be correct, remove it!
-                        request.headers().remove(CONTENT_LENGTH);
+                        response.headers().remove(CONTENT_LENGTH);
                         return response.transformPayloadBody(bufPub ->
                                 encoder.streamingEncoder().serialize(bufPub, ctx.executionContext().bufferAllocator()));
                     }).shareContextOnSubscribe();


### PR DESCRIPTION
Motivation:
The ContentEncodingHttpServiceFilter is meant to remove the `Content-Length` header if it does compression, because any such header from earlier stages will be incorrect after compression. An incorrect `Content-Length` header will then cause down-stream clients to be confused and potentially stall, timeout, or produce an unexpected close error, when they don't receive their promised number of bytes (most likely fewer than promised, due to compression).

Modifications:
The ContentEncodingHttpServiceFilter incorrectly removed the `Content-Length` header from the _request_ object, and this has been fixed so it now correctly removes the header from the _response_ object. There was a test for this behavior, but the test wasn't actually hitting this code because it used a client that did not advertise support for compressed responses. The test has also been fixed, adding the case where the client supports compressed responses. We now test both that the `Content-Length` header is removed when the response is compressed, and that the header stays when the response is not compressed.

Result:
This fixes the issue showcased by https://github.com/apple/servicetalk/pull/2862