### PR TITLE
loadbalancer-experimental: remove the generic load balancer factory methods

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -177,7 +177,23 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         public <T extends C> LoadBalancer<T> newLoadBalancer(String targetResource,
              Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
              ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-            return new DefaultLoadBalancer<ResolvedAddress, T>(id, targetResource, eventPublisher,
+            throw new IllegalStateException("Generic constructor not supported by " +
+                    DefaultLoadBalancer.class.getSimpleName());
+        }
+
+        @Override
+        public <T extends C> LoadBalancer<T> newLoadBalancer(
+                Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
+                ConnectionFactory<ResolvedAddress, T> connectionFactory) {
+            throw new IllegalStateException("Generic constructor not supported by " +
+                    DefaultLoadBalancer.class.getSimpleName());
+        }
+
+        @Override
+        public LoadBalancer<C> newLoadBalancer(
+                Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
+                ConnectionFactory<ResolvedAddress, C> connectionFactory, String targetResource) {
+            return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
                     loadBalancingPolicy.buildSelector(Collections.emptyList(), targetResource), connectionFactory,
                     linearSearchSpace, loadBalancerObserver, healthCheckConfig, healthCheckerFactory);
         }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -177,7 +177,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         public <T extends C> LoadBalancer<T> newLoadBalancer(String targetResource,
              Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
              ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-            throw new IllegalStateException("Generic constructor not supported by " +
+            throw new UnsupportedOperationException("Generic constructor not supported by " +
                     DefaultLoadBalancer.class.getSimpleName());
         }
 
@@ -185,7 +185,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         public <T extends C> LoadBalancer<T> newLoadBalancer(
                 Publisher<? extends ServiceDiscovererEvent<ResolvedAddress>> eventPublisher,
                 ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-            throw new IllegalStateException("Generic constructor not supported by " +
+            throw new UnsupportedOperationException("Generic constructor not supported by " +
                     DefaultLoadBalancer.class.getSimpleName());
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -36,8 +36,7 @@ public interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConn
      * @param hosts          the set of {@link Host}s to select from.
      * @param targetResource the name of the target resource, useful for debugging purposes.
      * @return a {@link HostSelector}
-     * @param <T> the refined type of the connections over which to load balance
      */
-    <T extends C> HostSelector<ResolvedAddress, T> buildSelector(
-            List<Host<ResolvedAddress, T>> hosts, String targetResource);
+    HostSelector<ResolvedAddress, C> buildSelector(
+            List<Host<ResolvedAddress, C>> hosts, String targetResource);
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -54,8 +54,8 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     }
 
     @Override
-    public <T extends C> HostSelector<ResolvedAddress, T> buildSelector(
-            List<Host<ResolvedAddress, T>> hosts, String targetResource) {
+    public HostSelector<ResolvedAddress, C> buildSelector(
+            List<Host<ResolvedAddress, C>> hosts, String targetResource) {
         return new P2CSelector<>(hosts, targetResource, maxEffort, failOpen, random);
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -37,8 +37,8 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
     }
 
     @Override
-    public <T extends C> HostSelector<ResolvedAddress, T>
-    buildSelector(final List<Host<ResolvedAddress, T>> hosts, final String targetResource) {
+    public HostSelector<ResolvedAddress, C>
+    buildSelector(final List<Host<ResolvedAddress, C>> hosts, final String targetResource) {
         return new RoundRobinSelector<>(hosts, targetResource, failOpen);
     }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -279,8 +279,8 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
-        public <T extends TestLoadBalancedConnection> HostSelector<String, T> buildSelector(
-                List<Host<String, T>> hosts, String targetResource) {
+        public HostSelector<String, TestLoadBalancedConnection> buildSelector(
+                List<Host<String, TestLoadBalancedConnection>> hosts, String targetResource) {
             return new TestSelector(hosts);
         }
 


### PR DESCRIPTION
Motivation:

The LoadBalancerFactory has methods that are generic in type T extends LoadBalancedConnection which are deprecated. The generic type is infectious and doesn't serve a concrete purpose, thus why the methods are deprecated.

Modifications:

- drop support for the deprecated factory methods
- drop the generics that were required in the LoadBalancerPolicy interface

Result:

Cleaner code.