### PR TITLE
loadbalancer-experimental: Remove type param from LoadBalancerObserver

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -108,7 +108,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
     private final HealthCheckConfig healthCheckConfig;
     @Nullable
     private final HealthChecker<ResolvedAddress> healthChecker;
-    private final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver;
+    private final LoadBalancerObserver loadBalancerObserver;
     private final ListenableAsyncCloseable asyncCloseable;
 
     /**
@@ -131,7 +131,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final HostSelector<ResolvedAddress, C> hostSelector,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
             final int linearSearchSpace,
-            final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver,
+            final LoadBalancerObserver loadBalancerObserver,
             @Nullable final HealthCheckConfig healthCheckConfig,
             @Nullable final Function<String, HealthChecker<ResolvedAddress>> healthCheckerFactory) {
         this.targetResource = requireNonNull(targetResourceName);

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -50,7 +50,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     @Nullable
     private Executor backgroundExecutor;
     @Nullable
-    private LoadBalancerObserver<ResolvedAddress> loadBalancerObserver;
+    private LoadBalancerObserver loadBalancerObserver;
     @Nullable
     private HealthCheckerFactory<ResolvedAddress> healthCheckerFactory;
     private Duration healthCheckInterval = DEFAULT_HEALTH_CHECK_INTERVAL;
@@ -79,7 +79,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     @Override
     public LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(
-            @Nullable LoadBalancerObserver<ResolvedAddress> loadBalancerObserver) {
+            @Nullable LoadBalancerObserver loadBalancerObserver) {
         this.loadBalancerObserver = loadBalancerObserver;
         return this;
     }
@@ -134,7 +134,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
                     healthCheckInterval, healthCheckJitter, healthCheckFailedConnectionsThreshold,
                     healthCheckResubscribeInterval, healthCheckResubscribeJitter);
         }
-        final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver = this.loadBalancerObserver != null ?
+        final LoadBalancerObserver loadBalancerObserver = this.loadBalancerObserver != null ?
                 this.loadBalancerObserver : NoopLoadBalancerObserver.instance();
         Function<String, HealthChecker<ResolvedAddress>> healthCheckerSupplier;
         if (healthCheckerFactory == null) {
@@ -154,7 +154,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
         private final String id;
         private final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy;
-        private final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver;
+        private final LoadBalancerObserver loadBalancerObserver;
         private final int linearSearchSpace;
         @Nullable
         private final Function<String, HealthChecker<ResolvedAddress>> healthCheckerFactory;
@@ -163,7 +163,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
         DefaultLoadBalancerFactory(final String id, final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy,
                                    final int linearSearchSpace, final HealthCheckConfig healthCheckConfig,
-                                   final LoadBalancerObserver<ResolvedAddress> loadBalancerObserver,
+                                   final LoadBalancerObserver loadBalancerObserver,
                                    final Function<String, HealthChecker<ResolvedAddress>> healthCheckerFactory) {
             this.id = requireNonNull(id, "id");
             this.loadBalancingPolicy = requireNonNull(loadBalancingPolicy, "loadBalancingPolicy");

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -62,7 +62,7 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
 
     @Override
     public LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(
-            @Nullable LoadBalancerObserver<ResolvedAddress> loadBalancerObserver) {
+            @Nullable LoadBalancerObserver loadBalancerObserver) {
         delegate = delegate.loadBalancerObserver(loadBalancerObserver);
         return this;
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -80,8 +80,7 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
      * @param loadBalancerObserver the {@link LoadBalancerObserver} to use, or {@code null} to not use an observer.
      * @return {code this}
      */
-    LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(
-            @Nullable LoadBalancerObserver<ResolvedAddress> loadBalancerObserver);
+    LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(@Nullable LoadBalancerObserver loadBalancerObserver);
 
     /**
      * Set the {@link HealthCheckerFactory} to use with this load balancer.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -23,16 +23,15 @@ import javax.annotation.Nullable;
 
 /**
  * An observer that provides visibility into a {@link io.servicetalk.client.api.LoadBalancer}.
- * @param <ResolvedAddress> the type of the resolved address.
  */
-public interface LoadBalancerObserver<ResolvedAddress> {
+public interface LoadBalancerObserver {
 
     /**
      * Get a {@link HostObserver}.
      * @param resolvedAddress the resolved address of the host.
      * @return a {@link HostObserver}.
      */
-    HostObserver hostObserver(ResolvedAddress resolvedAddress);
+    HostObserver hostObserver(Object resolvedAddress);
 
     /**
      * Callback for when connection selection fails due to no hosts being available.
@@ -45,7 +44,7 @@ public interface LoadBalancerObserver<ResolvedAddress> {
      * @param oldHostSetSize the size of the previous host set.
      * @param newHostSetSize the new size of  the host set.
      */
-    void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events,
+    void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events,
                                  int oldHostSetSize, int newHostSetSize);
 
     /**

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
@@ -20,16 +20,16 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 
 import java.util.Collection;
 
-final class NoopLoadBalancerObserver<ResolvedAddress> implements LoadBalancerObserver<ResolvedAddress> {
+final class NoopLoadBalancerObserver implements LoadBalancerObserver {
 
-    private static final LoadBalancerObserver<Object> INSTANCE = new NoopLoadBalancerObserver<>();
+    private static final LoadBalancerObserver INSTANCE = new NoopLoadBalancerObserver();
 
     private NoopLoadBalancerObserver() {
         // only private instance
     }
 
     @Override
-    public HostObserver hostObserver(ResolvedAddress resolvedAddress) {
+    public HostObserver hostObserver(Object resolvedAddress) {
         return NoopHostObserver.INSTANCE;
     }
 
@@ -44,7 +44,7 @@ final class NoopLoadBalancerObserver<ResolvedAddress> implements LoadBalancerObs
     }
 
     @Override
-    public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events,
+    public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events,
                                         int oldHostSetSize, int newHostSetSize) {
         // noop
     }
@@ -87,7 +87,7 @@ final class NoopLoadBalancerObserver<ResolvedAddress> implements LoadBalancerObs
         }
     }
 
-    public static <T> LoadBalancerObserver<T> instance() {
-        return (LoadBalancerObserver<T>) INSTANCE;
+    public static LoadBalancerObserver instance() {
+        return INSTANCE;
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/MockLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/MockLoadBalancerObserver.java
@@ -19,10 +19,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-interface MockLoadBalancerObserver extends LoadBalancerObserver<String> {
+interface MockLoadBalancerObserver extends LoadBalancerObserver {
 
     @Override
-    MockHostObserver hostObserver(String resolvedAddress);
+    MockHostObserver hostObserver(Object resolvedAddress);
 
     interface MockHostObserver extends LoadBalancerObserver.HostObserver {
     }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -38,7 +38,7 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
 
     @Override
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> loadBalancerObserver(
-            LoadBalancerObserver<String> loadBalancerObserver) {
+            LoadBalancerObserver loadBalancerObserver) {
         throw new IllegalStateException("Cannot set a load balancer observer for old round robin");
     }
 


### PR DESCRIPTION
Motivation:

The observers almost never care what the concrete type is and only use the resolved address via its `.toString()` and comparison operations.

Modifications:

Remove the type parameter.

Result:

Easer to use LoadBalancerObserver.