### PR TITLE
servicetalk-http-netty: fix some tests using relative request targets with CONNECT requests

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -78,6 +78,7 @@ import static io.servicetalk.http.netty.ContentHeadersTest.Expectation.HAVE_CONT
 import static io.servicetalk.http.netty.ContentHeadersTest.Expectation.HAVE_EXISTING_CONTENT_LENGTH;
 import static io.servicetalk.http.netty.ContentHeadersTest.Expectation.HAVE_NEITHER;
 import static io.servicetalk.http.netty.ContentHeadersTest.Expectation.HAVE_TRANSFER_ENCODING_CHUNKED;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.function.UnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -310,13 +311,13 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
     }
 
     private static HttpRequest newAggregatedRequest(final HttpRequestMethod requestMethod) {
-        return awaitSingleIndefinitelyNonNull(newRequest(requestMethod, "/", HTTP_1_1,
+        return awaitSingleIndefinitelyNonNull(newRequest(requestMethod, requestTarget(requestMethod), HTTP_1_1,
                 headersFactory.newHeaders(), DEFAULT_ALLOCATOR, headersFactory).toRequest())
                 .payloadBody(PAYLOAD, textSerializerUtf8());
     }
 
     private static StreamingHttpRequest newStreamingRequest(final HttpRequestMethod requestMethod) {
-        return newRequest(requestMethod, "/", HTTP_1_1, headersFactory.newHeaders(),
+        return newRequest(requestMethod, requestTarget(requestMethod), HTTP_1_1, headersFactory.newHeaders(),
                 DEFAULT_ALLOCATOR, headersFactory).payloadBody(from(PAYLOAD), appSerializerUtf8FixLen());
     }
 
@@ -329,6 +330,12 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
         return newResponse(status, HTTP_1_1, headersFactory.newHeaders(),
                 DEFAULT_ALLOCATOR, headersFactory)
                 .payloadBody(from(PAYLOAD), appSerializerUtf8FixLen());
+    }
+
+    private static String requestTarget(HttpRequestMethod requestMethod) {
+        // CONNECT requests MUST have a request target in authority form.
+        // https://datatracker.ietf.org/doc/html/rfc7230#section-5.3.3
+        return CONNECT.equals(requestMethod) ? "localhost:8080" : "/";
     }
 
     private static <T> UnaryOperator<T> describe(UnaryOperator<T> operator, String description) {


### PR DESCRIPTION
Motivation:

CONNECT requests must only have an authority-form header per the spec (https://datatracker.ietf.org/doc/html/rfc7230#section-5.3.3) but we have a
few tests that generate a series of tests cases that are setting relative form
request targets with that HTTP method.

Modifications:

Patch those tests to use authority form when generating requests.