### PR TITLE
http-netty: remove unused import breaking checkstyle

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -78,7 +78,6 @@ import static io.servicetalk.http.netty.ContentHeadersTest.Expectation.HAVE_CONT
 import static io.servicetalk.http.netty.ContentHeadersTest.Expectation.HAVE_EXISTING_CONTENT_LENGTH;
 import static io.servicetalk.http.netty.ContentHeadersTest.Expectation.HAVE_NEITHER;
 import static io.servicetalk.http.netty.ContentHeadersTest.Expectation.HAVE_TRANSFER_ENCODING_CHUNKED;
-import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.function.UnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
Motivation:

There is an unused import in ContentHeadersTest that breaks checkstyle.

Modifications:

Remove it.