### PR TITLE
Add support for Optional TLS negotiation for http/1 and http/2

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServerBuilder.java
@@ -90,6 +90,21 @@ public class DelegatingHttpServerBuilder implements HttpServerBuilder {
     }
 
     @Override
+    public HttpServerBuilder sslConfig(final ServerSslConfig config, final boolean acceptInsecureConnections) {
+        delegate = delegate.sslConfig(config, acceptInsecureConnections);
+        return this;
+    }
+
+    @Override
+    public HttpServerBuilder sslConfig(final ServerSslConfig defaultConfig, final Map<String, ServerSslConfig> sniMap,
+                                       final int maxClientHelloLength, final Duration clientHelloTimeout,
+                                       final boolean acceptInsecureConnections) {
+        delegate = delegate.sslConfig(defaultConfig, sniMap, maxClientHelloLength, clientHelloTimeout,
+                acceptInsecureConnections);
+        return this;
+    }
+
+    @Override
     public <T> HttpServerBuilder socketOption(final SocketOption<T> option, final T value) {
         delegate = delegate.socketOption(option, value);
         return this;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -68,6 +68,18 @@ public interface HttpServerBuilder {
     HttpServerBuilder sslConfig(ServerSslConfig config);
 
     /**
+     * Set the SSL/TLS configuration and allows to specify if insecure connections should also be allowed.
+     *
+     * @param config The configuration to use.
+     * @param acceptInsecureConnections if non-TLS connections are accepted on the same socket.
+     * @return {@code this}.
+     */
+    default HttpServerBuilder sslConfig(ServerSslConfig config, boolean acceptInsecureConnections) {
+        throw new UnsupportedOperationException(
+                "sslConfig(ServerSslConfig, boolean) is not supported by " + getClass());
+    }
+
+    /**
      * Set the SSL/TLS and <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> configuration.
      *
      * @param defaultConfig The configuration to use if the client certificate's SNI extension isn't present or the
@@ -93,11 +105,37 @@ public interface HttpServerBuilder {
      * Implementations can round the specified {@link Duration} to full time units, depending on their time granularity.
      * {@link Duration#ZERO Zero (0)} disables timeout.
      * @return {@code this}.
+     * @deprecated use {@link #sslConfig(ServerSslConfig, Map, int, Duration, boolean)} instead.
      */
+    @Deprecated
     default HttpServerBuilder sslConfig(ServerSslConfig defaultConfig, Map<String, ServerSslConfig> sniMap,
                                         int maxClientHelloLength, Duration clientHelloTimeout) {
         throw new UnsupportedOperationException(
-                "sslConfig(ServerSslConfig, Map, int, Durations) is not supported by " + getClass());
+                "sslConfig(ServerSslConfig, Map, int, Duration) is not supported by " + getClass());
+    }
+
+    /**
+     * Set the SSL/TLS and <a href="https://tools.ietf.org/html/rfc6066#section-3">SNI</a> configuration.
+     *
+     * @param defaultConfig The configuration to use if the client certificate's SNI extension isn't present or the
+     * SNI hostname doesn't match any values in {@code sniMap}.
+     * @param sniMap A map where the keys are matched against the client certificate's SNI extension value in order
+     * to provide the corresponding {@link ServerSslConfig}.
+     * @param maxClientHelloLength The maximum length of a
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message in bytes, up to
+     * {@code 2^24 - 1} bytes. Zero ({@code 0}) disables validation.
+     * @param clientHelloTimeout The timeout for waiting until
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message is received.
+     * Implementations can round the specified {@link Duration} to full time units, depending on their time granularity.
+     * @param acceptInsecureConnections if non-TLS connections are accepted on the same socket.
+     * {@link Duration#ZERO Zero (0)} disables timeout.
+     * @return {@code this}.
+     */
+    default HttpServerBuilder sslConfig(ServerSslConfig defaultConfig, Map<String, ServerSslConfig> sniMap,
+                                        int maxClientHelloLength, Duration clientHelloTimeout,
+                                        boolean acceptInsecureConnections) {
+        throw new UnsupportedOperationException(
+                "sslConfig(ServerSslConfig, Map, int, Duration, boolean) is not supported by " + getClass());
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnChannelSingle.java
@@ -135,26 +135,4 @@ final class AlpnChannelSingle extends ChannelInitSingle<String> {
             return false;
         }
     }
-
-    /**
-     * {@link ChannelInitializer} that does not do anything.
-     */
-    static final class NoopChannelInitializer implements ChannelInitializer {
-
-        static final ChannelInitializer INSTANCE = new NoopChannelInitializer();
-
-        private NoopChannelInitializer() {
-            // Singleton
-        }
-
-        @Override
-        public void init(final Channel channel) {
-            // NOOP
-        }
-
-        @Override
-        public ChannelInitializer andThen(final ChannelInitializer after) {
-            return after;
-        }
-    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -22,7 +22,6 @@ import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
-import io.servicetalk.http.netty.AlpnChannelSingle.NoopChannelInitializer;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;
 import io.servicetalk.tcp.netty.internal.TcpConnector;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DeferredServerChannelBinder.java
@@ -19,7 +19,6 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.StreamingHttpService;
-import io.servicetalk.http.netty.AlpnChannelSingle.NoopChannelInitializer;
 import io.servicetalk.http.netty.NettyHttpServer.NettyHttpServerConnection;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
 import io.servicetalk.tcp.netty.internal.TcpServerBinder;
@@ -84,7 +83,7 @@ final class DeferredServerChannelBinder {
                 });
     }
 
-    private static Single<NettyConnectionContext> alpnInitChannel(final SocketAddress listenAddress,
+    static Single<NettyConnectionContext> alpnInitChannel(final SocketAddress listenAddress,
                                                                   final Channel channel,
                                                                   final ReadOnlyHttpServerConfig config,
                                                                   final HttpExecutionContext httpExecutionContext,
@@ -110,7 +109,7 @@ final class DeferredServerChannelBinder {
         });
     }
 
-    private static Single<NettyConnectionContext> sniInitChannel(final SocketAddress listenAddress,
+    static Single<NettyConnectionContext> sniInitChannel(final SocketAddress listenAddress,
                                                                  final Channel channel,
                                                                  final ReadOnlyHttpServerConfig config,
                                                                  final HttpExecutionContext httpExecutionContext,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServerConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServerConfig.java
@@ -49,6 +49,12 @@ final class HttpServerConfig {
         });
     }
 
+    HttpServerConfig(final HttpServerConfig from) {
+        tcpConfig = new TcpServerConfig(from.tcpConfig);
+        httpConfig = new HttpConfig(from.httpConfig);
+        lifecycleObserver = from.lifecycleObserver;
+    }
+
     TcpServerConfig tcpConfig() {
         return tcpConfig;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NoopChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NoopChannelInitializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.transport.netty.internal.ChannelInitializer;
+
+import io.netty.channel.Channel;
+
+/**
+ * {@link ChannelInitializer} that does not do anything.
+ */
+final class NoopChannelInitializer implements ChannelInitializer {
+
+    static final ChannelInitializer INSTANCE = new NoopChannelInitializer();
+
+    private NoopChannelInitializer() {
+        // Singleton
+    }
+
+    @Override
+    public void init(final Channel channel) {
+        // NOOP
+    }
+
+    @Override
+    public ChannelInitializer andThen(final ChannelInitializer after) {
+        return after;
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptionalSslChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptionalSslChannelSingle.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.SingleSource;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.ssl.SslHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Part of a {@link io.netty.channel.ChannelInitializer} which negotiates SSL/non-SSL connections when SSL is enabled.
+ */
+final class OptionalSslChannelSingle extends ChannelInitSingle<Boolean> {
+
+    OptionalSslChannelSingle(final Channel channel) {
+        super(channel, NoopChannelInitializer.INSTANCE);
+    }
+
+    @Override
+    protected ChannelHandler newChannelHandler(final Subscriber<? super Boolean> subscriber) {
+        return new OptionalSslHandler(subscriber);
+    }
+
+    private static final class OptionalSslHandler extends ByteToMessageDecoder {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(OptionalSslHandler.class);
+
+        /**
+         * the length of the ssl record header (in bytes)
+         */
+        private static final int SSL_RECORD_HEADER_LENGTH = 5;
+
+        @Nullable
+        SingleSource.Subscriber<? super Boolean> subscriber;
+
+        OptionalSslHandler(final SingleSource.Subscriber<? super Boolean> subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
+            if (ctx.channel().isActive()) {
+                ctx.read(); // we need to force a read to detect SSL yes/no
+            }
+            super.handlerAdded(ctx);
+        }
+
+        @Override
+        public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+            ctx.read(); // we need to force a read to detect SSL yes/no
+            ctx.fireChannelActive();
+        }
+
+        @Override
+        protected void decode(final ChannelHandlerContext ctx, final ByteBuf in, final List<Object> out) {
+            if (in.readableBytes() < SSL_RECORD_HEADER_LENGTH || subscriber == null) {
+                return;
+            }
+            boolean isEncrypted = SslHandler.isEncrypted(in);
+            LOGGER.debug("{} Detected TLS for this connection: {}", ctx.channel(), isEncrypted);
+            final SingleSource.Subscriber<? super Boolean> subscriberCopy = subscriber;
+            subscriber = null;
+            subscriberCopy.onSuccess(isEncrypted);
+
+            // Need to make sure that when this handler is removed, there is another handler in the pipeline
+            // to pick up the read bytes from ByteToMessageDecoder when this handler is removed.
+            assert ctx.executor().inEventLoop();
+            assert ctx.pipeline().last() != this;
+            ctx.pipeline().remove(this);
+        }
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptionalSslNegotiator.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptionalSslNegotiator.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
+import io.servicetalk.tcp.netty.internal.TcpServerBinder;
+import io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.EarlyConnectionAcceptor;
+import io.servicetalk.transport.api.LateConnectionAcceptor;
+import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
+import io.servicetalk.transport.netty.internal.NettyConnectionContext;
+
+import io.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.SocketAddress;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+
+/**
+ * Negotiates SSL/non-SSL connections when SSL is enabled and {@code acceptInsecureConnections} is true.
+ */
+final class OptionalSslNegotiator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OptionalSslNegotiator.class);
+
+    private OptionalSslNegotiator() {
+        // No instances
+    }
+
+    static Single<HttpServerContext> bind(final HttpExecutionContext executionContext,
+                                          final ReadOnlyHttpServerConfig roConfig,
+                                          final ReadOnlyHttpServerConfig roConfigWithoutSsl,
+                                          final SocketAddress listenAddress,
+                                          @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
+                                          final StreamingHttpService service,
+                                          final boolean drainRequestPayloadBody,
+                                          @Nullable final EarlyConnectionAcceptor earlyConnectionAcceptor,
+                                          @Nullable final LateConnectionAcceptor lateConnectionAcceptor) {
+        final BiFunction<Channel, ConnectionObserver, Single<NettyConnectionContext>> channelInit =
+                (channel, connectionObserver) -> new OptionalSslChannelSingle(channel).flatMap(isTls -> {
+                    assert channel.eventLoop().inEventLoop();
+                    if (isTls) {
+                        final ReadOnlyTcpServerConfig roTcpConfig = roConfig.tcpConfig();
+
+                        // Important: This code needs to be kept in-sync with the similar, but not identical
+                        // code inside DefaultHttpServerBuilder#doBind
+                        if (roTcpConfig.isAlpnConfigured()) {
+                            return DeferredServerChannelBinder.alpnInitChannel(listenAddress, channel,
+                                    roConfig, executionContext,
+                                    service, drainRequestPayloadBody, connectionObserver);
+                        } else if (roTcpConfig.sniMapping() != null) {
+                            return DeferredServerChannelBinder.sniInitChannel(listenAddress, channel,
+                                    roConfig, executionContext,
+                                    service, drainRequestPayloadBody, connectionObserver);
+                        } else if (roConfig.isH2PriorKnowledge()) {
+                            return H2ServerParentConnectionContext.initChannel(listenAddress, channel,
+                                    executionContext, roConfig,
+                                    new TcpServerChannelInitializer(roTcpConfig, connectionObserver,
+                                            executionContext), service,
+                                    drainRequestPayloadBody, connectionObserver);
+                        } else {
+                            return NettyHttpServer.initChannel(channel, executionContext, roConfig,
+                                    new TcpServerChannelInitializer(roTcpConfig, connectionObserver,
+                                            executionContext), service,
+                                    drainRequestPayloadBody, connectionObserver);
+                        }
+                    } else {
+                        if (roConfigWithoutSsl.h2Config() != null) {
+                            return H2ServerParentConnectionContext.initChannel(listenAddress, channel,
+                                    executionContext, roConfigWithoutSsl,
+                                    new TcpServerChannelInitializer(roConfigWithoutSsl.tcpConfig(),
+                                            connectionObserver, executionContext), service,
+                                    drainRequestPayloadBody, connectionObserver);
+                        } else {
+                            return NettyHttpServer.initChannel(channel, executionContext, roConfigWithoutSsl,
+                                    new TcpServerChannelInitializer(roConfigWithoutSsl.tcpConfig(),
+                                            connectionObserver, executionContext), service,
+                                    drainRequestPayloadBody, connectionObserver);
+                        }
+                    }
+                });
+
+        final Consumer<NettyConnectionContext> connectionConsumer = serverConnection -> {
+            if (serverConnection instanceof NettyHttpServer.NettyHttpServerConnection) {
+                ((NettyHttpServer.NettyHttpServerConnection) serverConnection).process(true);
+            }
+        };
+
+        return TcpServerBinder.bind(listenAddress, roConfig.tcpConfig(), executionContext, connectionAcceptor,
+                        channelInit, connectionConsumer, earlyConnectionAcceptor, lateConnectionAcceptor)
+                .map(delegate -> {
+                    LOGGER.debug("Started HTTP server with Optional TLS for address {}", delegate.listenAddress());
+                    // The ServerContext returned by TcpServerBinder takes care of closing the connectionAcceptor.
+                    return new NettyHttpServer.NettyHttpServerContext(delegate, service, executionContext);
+                });
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
@@ -22,7 +22,6 @@ import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.ProxyConnectException;
 import io.servicetalk.http.api.StreamingHttpConnectionFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
-import io.servicetalk.http.netty.AlpnChannelSingle.NoopChannelInitializer;
 import io.servicetalk.http.netty.ProxyConnectChannelSingle.RetryableProxyConnectException;
 import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
 import io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -78,8 +80,9 @@ class AlpnClientAndServerTest {
     private BlockingQueue<HttpProtocolVersion> requestVersion;
     private void setUp(List<String> serverSideProtocols,
                        List<String> clientSideProtocols,
-                       @Nullable HttpProtocolVersion expectedProtocol) throws Exception {
-        serverContext = startServer(serverSideProtocols);
+                       @Nullable HttpProtocolVersion expectedProtocol,
+                       boolean acceptInsecureConnections) throws Exception {
+        serverContext = startServer(serverSideProtocols, acceptInsecureConnections);
         client = startClient(serverContext, clientSideProtocols);
         this.expectedProtocol = expectedProtocol;
     }
@@ -91,50 +94,56 @@ class AlpnClientAndServerTest {
     }
 
     @SuppressWarnings("unused")
-    private static Stream<Arguments> clientExecutors() {
-        return Stream.of(
+    private static Stream<Arguments> arguments() {
+        final List<Arguments> arguments = new ArrayList<>(Arrays.asList(
                 Arguments.of(asList(HTTP_2, HTTP_1_1), asList(HTTP_2, HTTP_1_1),
-                        HttpProtocolVersion.HTTP_2_0, null, null),
+                        HttpProtocolVersion.HTTP_2_0, null, null, false),
                 Arguments.of(asList(HTTP_2, HTTP_1_1), asList(HTTP_1_1, HTTP_2),
-                        HttpProtocolVersion.HTTP_2_0, null, null),
+                        HttpProtocolVersion.HTTP_2_0, null, null, false),
                 Arguments.of(asList(HTTP_2, HTTP_1_1), singletonList(HTTP_2),
-                        HttpProtocolVersion.HTTP_2_0, null, null),
+                        HttpProtocolVersion.HTTP_2_0, null, null, false),
                 Arguments.of(asList(HTTP_2, HTTP_1_1), singletonList(HTTP_1_1),
-                        HttpProtocolVersion.HTTP_1_1, null, null),
+                        HttpProtocolVersion.HTTP_1_1, null, null, false),
 
                 Arguments.of(asList(HTTP_1_1, HTTP_2), asList(HTTP_2, HTTP_1_1),
-                        HttpProtocolVersion.HTTP_1_1, null, null),
+                        HttpProtocolVersion.HTTP_1_1, null, null, false),
                 Arguments.of(asList(HTTP_1_1, HTTP_2), asList(HTTP_1_1, HTTP_2),
-                        HttpProtocolVersion.HTTP_1_1, null, null),
+                        HttpProtocolVersion.HTTP_1_1, null, null, false),
                 Arguments.of(asList(HTTP_1_1, HTTP_2), singletonList(HTTP_2),
-                        HttpProtocolVersion.HTTP_2_0, null, null),
+                        HttpProtocolVersion.HTTP_2_0, null, null, false),
                 Arguments.of(asList(HTTP_1_1, HTTP_2), singletonList(HTTP_1_1),
-                        HttpProtocolVersion.HTTP_1_1, null, null),
+                        HttpProtocolVersion.HTTP_1_1, null, null, false)
+        ));
+        for (boolean acceptInsecureConnections : asList(true, false)) {
+            arguments.addAll(Arrays.asList(
+                    Arguments.of(singletonList(HTTP_2), asList(HTTP_2, HTTP_1_1),
+                            HttpProtocolVersion.HTTP_2_0, null, null, acceptInsecureConnections),
+                    Arguments.of(singletonList(HTTP_2), asList(HTTP_1_1, HTTP_2),
+                            HttpProtocolVersion.HTTP_2_0, null, null, acceptInsecureConnections),
+                    Arguments.of(singletonList(HTTP_2), singletonList(HTTP_2),
+                            HttpProtocolVersion.HTTP_2_0, null, null, acceptInsecureConnections),
+                    Arguments.of(singletonList(HTTP_2), singletonList(HTTP_1_1),
+                            null, ClosedChannelException.class, null, acceptInsecureConnections),
 
-                Arguments.of(singletonList(HTTP_2), asList(HTTP_2, HTTP_1_1),
-                        HttpProtocolVersion.HTTP_2_0, null, null),
-                Arguments.of(singletonList(HTTP_2), asList(HTTP_1_1, HTTP_2),
-                        HttpProtocolVersion.HTTP_2_0, null, null),
-                Arguments.of(singletonList(HTTP_2), singletonList(HTTP_2),
-                        HttpProtocolVersion.HTTP_2_0, null, null),
-                Arguments.of(singletonList(HTTP_2), singletonList(HTTP_1_1),
-                        null, ClosedChannelException.class, null),
-
-                Arguments.of(singletonList(HTTP_1_1), asList(HTTP_2, HTTP_1_1),
-                        HttpProtocolVersion.HTTP_1_1, null, null),
-                Arguments.of(singletonList(HTTP_1_1), asList(HTTP_1_1, HTTP_2),
-                        HttpProtocolVersion.HTTP_1_1, null, null),
-                Arguments.of(singletonList(HTTP_1_1), singletonList(HTTP_2),
-                        null, ClosedChannelException.class, null),
-                Arguments.of(singletonList(HTTP_1_1), singletonList(HTTP_1_1),
-                        HttpProtocolVersion.HTTP_1_1, null, null));
+                    Arguments.of(singletonList(HTTP_1_1), asList(HTTP_2, HTTP_1_1),
+                            HttpProtocolVersion.HTTP_1_1, null, null, acceptInsecureConnections),
+                    Arguments.of(singletonList(HTTP_1_1), asList(HTTP_1_1, HTTP_2),
+                            HttpProtocolVersion.HTTP_1_1, null, null, acceptInsecureConnections),
+                    Arguments.of(singletonList(HTTP_1_1), singletonList(HTTP_2),
+                            null, ClosedChannelException.class, null, acceptInsecureConnections),
+                    Arguments.of(singletonList(HTTP_1_1), singletonList(HTTP_1_1),
+                            HttpProtocolVersion.HTTP_1_1, null, null, acceptInsecureConnections)
+            ));
+        }
+        return arguments.stream();
     }
 
-    private ServerContext startServer(List<String> supportedProtocols) throws Exception {
+    private ServerContext startServer(List<String> supportedProtocols, boolean acceptInsecureConnections)
+            throws Exception {
         return newServerBuilder(SERVER_CTX)
                 .protocols(toProtocolConfigs(supportedProtocols))
                 .sslConfig(new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
-                        DefaultTestCerts::loadServerKey).provider(OPENSSL).build())
+                        DefaultTestCerts::loadServerKey).provider(OPENSSL).build(), acceptInsecureConnections)
                 .listenBlocking((ctx, request, responseFactory) -> {
                     serviceContext.put(ctx);
                     requestVersion.put(request.version());
@@ -174,15 +183,17 @@ class AlpnClientAndServerTest {
         }
     }
 
-    @ParameterizedTest(name = "serverAlpnProtocols={0}, clientAlpnProtocols={1}," +
-            " expectedProtocol={2}, expectedExceptionType={3}")
-    @MethodSource("clientExecutors")
+    @ParameterizedTest(name = "serverSideProtocols={0}, clientSideProtocols={1}," +
+            " expectedProtocol={2}, expectedExceptionType={3}, optionalExceptionWrapperType={4}" +
+            " acceptInsecureConnections={5}")
+    @MethodSource("arguments")
     void testAlpnConnection(List<String> serverSideProtocols,
                             List<String> clientSideProtocols,
                             @Nullable HttpProtocolVersion expectedProtocol,
                             @Nullable Class<? extends Throwable> expectedExceptionType,
-                            @Nullable Class<? extends Throwable> optionalExceptionWrapperType) throws Exception {
-        setUp(serverSideProtocols, clientSideProtocols, expectedProtocol);
+                            @Nullable Class<? extends Throwable> optionalExceptionWrapperType,
+                            boolean acceptInsecureConnections) throws Exception {
+        setUp(serverSideProtocols, clientSideProtocols, expectedProtocol, acceptInsecureConnections);
         if (expectedExceptionType != null) {
             assertThrows(expectedExceptionType, optionalExceptionWrapperType, () -> client.request(client.get("/")));
             return;
@@ -201,15 +212,17 @@ class AlpnClientAndServerTest {
         }
     }
 
-    @ParameterizedTest(name = "serverAlpnProtocols={0}, clientAlpnProtocols={1}," +
-            " expectedProtocol={2}, expectedExceptionType={3}")
-    @MethodSource("clientExecutors")
+    @ParameterizedTest(name = "serverSideProtocols={0}, clientSideProtocols={1}," +
+            " expectedProtocol={2}, expectedExceptionType={3}, optionalExceptionWrapperType={4}," +
+            " acceptInsecureConnections={5}")
+    @MethodSource("arguments")
     void testAlpnClient(List<String> serverSideProtocols,
                         List<String> clientSideProtocols,
                         @Nullable HttpProtocolVersion expectedProtocol,
                         @Nullable Class<? extends Throwable> expectedExceptionType,
-                        @Nullable Class<? extends Throwable> optionalExceptionWrapperType) throws Exception {
-        setUp(serverSideProtocols, clientSideProtocols, expectedProtocol);
+                        @Nullable Class<? extends Throwable> optionalExceptionWrapperType,
+                        boolean acceptInsecureConnections) throws Exception {
+        setUp(serverSideProtocols, clientSideProtocols, expectedProtocol, acceptInsecureConnections);
         if (expectedExceptionType != null) {
             assertThrows(expectedExceptionType, optionalExceptionWrapperType, () -> client.request(client.get("/")));
         } else {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/OptionalSslTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/OptionalSslTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpService;
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig;
+import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslProvider;
+import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.InetSocketAddress;
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
+import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
+import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the behavior and functionality of {@link ReadOnlyTcpServerConfig#acceptInsecureConnections()}.
+ */
+final class OptionalSslTest {
+
+    @RegisterExtension
+    static final ExecutionContextExtension SERVER_CTX =
+            ExecutionContextExtension.cached("server-io", "server-executor")
+                    .setClassLevel(true);
+    @RegisterExtension
+    static final ExecutionContextExtension CLIENT_CTX =
+            ExecutionContextExtension.cached("client-io", "client-executor")
+                    .setClassLevel(true);
+
+    @ParameterizedTest(name = "{displayName} [{index}] acceptInsecureConnections={0}, protocol={1} sslProvider={2}")
+    @MethodSource("args")
+    void acceptsSecureAndInsecureRequests(final boolean acceptInsecureConnections, final HttpProtocol protocol,
+                                          final SslProvider sslProvider)
+            throws Exception {
+        final HttpService service = (ctx, request, responseFactory) -> {
+            if ("/secure".equals(request.path())) {
+                assertNotNull(ctx.sslConfig());
+                assertNotNull(ctx.sslSession());
+            } else {
+                assertNull(ctx.sslConfig());
+                assertNull(ctx.sslSession());
+            }
+            return succeeded(responseFactory.ok().payloadBody("Hello World!", textSerializerUtf8()));
+        };
+
+        try (ServerContext server = serverBuilder(acceptInsecureConnections, sslProvider, protocol)
+                .listenAndAwait(service)) {
+            for (int i = 0; i < 4; i++) {
+                try (BlockingHttpClient client = clientBuilder(server, sslProvider, true, protocol).buildBlocking()) {
+                    final HttpResponse response = client.request(client.get("/secure"));
+                    assertEquals(HttpResponseStatus.OK, response.status());
+                }
+
+                try (BlockingHttpClient client = clientBuilder(server, sslProvider, false, protocol).buildBlocking()) {
+                    final HttpRequest request = client.get("/insecure");
+                    if (acceptInsecureConnections) {
+                        final HttpResponse response = client.request(request);
+                        assertEquals(HttpResponseStatus.OK, response.status());
+                    } else {
+                        assertThrows(ClosedChannelException.class, () -> client.request(request));
+                    }
+                }
+            }
+        }
+    }
+
+    private static Stream<Arguments> args() {
+        List<Arguments> arguments = new ArrayList<>();
+        for (boolean acceptInsecureConnections : asList(true, false)) {
+            for (HttpProtocol protocol : asList(HttpProtocol.HTTP_1, HttpProtocol.HTTP_2)) {
+                for (SslProvider sslProvider : SslProvider.values()) {
+                    arguments.add(Arguments.of(acceptInsecureConnections, protocol, sslProvider));
+                }
+            }
+        }
+        return arguments.stream();
+    }
+
+    private static HttpServerBuilder serverBuilder(final boolean acceptInsecureConnections,
+                                                   final SslProvider sslProvider,
+                                                   final HttpProtocol... protocols) {
+        ServerSslConfigBuilder configBuilder = new ServerSslConfigBuilder(DefaultTestCerts::loadServerPem,
+                DefaultTestCerts::loadServerKey)
+                .provider(sslProvider);
+        return newServerBuilder(SERVER_CTX, protocols)
+                .sslConfig(configBuilder.build(), acceptInsecureConnections);
+    }
+
+    private static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder(
+            final ServerContext ctx, final SslProvider sslProvider, final boolean withSsl,
+            final HttpProtocol... protocols) {
+        final SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                newClientBuilder(ctx, CLIENT_CTX, protocols);
+        if (withSsl) {
+            builder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                    .peerHost(serverPemHostname()).provider(sslProvider).build());
+        }
+        return builder;
+    }
+}

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -147,7 +147,7 @@ abstract class AbstractTcpConfig<SslConfigType extends SslConfig> {
      *
      * @param sslConfig the {@link SslConfigType}.
      */
-    public final void sslConfig(final SslConfigType sslConfig) {
-        this.sslConfig = requireNonNull(sslConfig);
+    public final void sslConfig(final @Nullable SslConfigType sslConfig) {
+        this.sslConfig = sslConfig;
     }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -48,6 +48,7 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
     private final Mapping<String, SslContext> sniMapping;
     private final int sniMaxClientHelloLength;
     private final Duration sniClientHelloTimeout;
+    private final boolean acceptInsecureConnections;
     private final boolean alpnConfigured;
 
     ReadOnlyTcpServerConfig(final TcpServerConfig from) {
@@ -84,6 +85,7 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
         }
         sniMaxClientHelloLength = from.sniMaxClientHelloLength();
         sniClientHelloTimeout = from.sniClientHelloTimeout();
+        acceptInsecureConnections = from.acceptInsecureConnections();
     }
 
     /**
@@ -144,6 +146,15 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig<Ser
 
     Duration sniClientHelloTimeout() {
         return sniClientHelloTimeout;
+    }
+
+    /**
+     * Returns {@code true} if non-TLS connections should also be accepted on TLS-enabled sockets.
+     *
+     * @return {@code true} if non-TLS connections should also be accepted on TLS-enabled sockets.
+     */
+    public boolean acceptInsecureConnections() {
+        return acceptInsecureConnections;
     }
 
     /**

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -54,6 +54,20 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
     private Map<String, ServerSslConfig> sniConfig;
     private int sniMaxClientHelloLength = MAX_CLIENT_HELLO_LENGTH;
     private Duration sniClientHelloTimeout = DEFAULT_CLIENT_HELLO_TIMEOUT;
+    private boolean acceptInsecureConnections;
+
+    public TcpServerConfig() {
+    }
+
+    public TcpServerConfig(final TcpServerConfig from) {
+        super(from);
+        listenOptions = from.listenOptions;
+        transportObserver = from.transportObserver;
+        sniConfig = from.sniConfig;
+        sniMaxClientHelloLength = from.sniMaxClientHelloLength;
+        sniClientHelloTimeout = from.sniClientHelloTimeout;
+        acceptInsecureConnections = from.acceptInsecureConnections;
+    }
 
     @Nullable
     @SuppressWarnings("rawtypes")
@@ -78,6 +92,10 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
         return sniClientHelloTimeout;
     }
 
+    boolean acceptInsecureConnections() {
+        return acceptInsecureConnections;
+    }
+
     /**
      * Sets a {@link TransportObserver} that provides visibility into transport events.
      *
@@ -88,6 +106,19 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
     }
 
     /**
+     * Set the SSL/TLS configuration and allows to specify if insecure connections should also be allowed.
+     *
+     * @param config The configuration to use.
+     * @param acceptInsecureConnections if non-TLS connections are accepted on the same socket.
+     * @return {@code this}.
+     */
+    public TcpServerConfig sslConfig(ServerSslConfig config, boolean acceptInsecureConnections) {
+        sslConfig(config);
+        this.acceptInsecureConnections = acceptInsecureConnections;
+        return this;
+    }
+
+    /**
      * Add SSL/TLS and SNI related config.
      *
      * @param defaultSslConfig the default {@link ServerSslConfig} used when no SNI match is found.
@@ -95,9 +126,10 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
      * found the corresponding {@link ServerSslConfig} is used.
      * @return {@code this}
      */
-    public TcpServerConfig sslConfig(ServerSslConfig defaultSslConfig, Map<String, ServerSslConfig> sniConfig) {
+    public TcpServerConfig sslConfig(@Nullable ServerSslConfig defaultSslConfig,
+                                     @Nullable Map<String, ServerSslConfig> sniConfig) {
         sslConfig(defaultSslConfig);
-        this.sniConfig = requireNonNull(sniConfig);
+        this.sniConfig = sniConfig;
         return this;
     }
 
@@ -125,6 +157,30 @@ public final class TcpServerConfig extends AbstractTcpConfig<ServerSslConfig> {
         }
         this.sniMaxClientHelloLength = maxClientHelloLength;
         this.sniClientHelloTimeout = ensureNonNegative(clientHelloTimeout, "clientHelloTimeout");
+        return this;
+    }
+
+    /**
+     * Add SSL/TLS and SNI related config.
+     *
+     * @param defaultSslConfig the default {@link ServerSslConfig} used when no SNI match is found.
+     * @param sniConfig client SNI hostname values are matched against keys in this {@link Map} and if a match is
+     * found the corresponding {@link ServerSslConfig} is used.
+     * @param maxClientHelloLength the maximum length of a
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message in bytes, up to
+     * {@code 2^24 - 1} bytes. Zero ({@code 0}) disables validation.
+     * @param clientHelloTimeout The timeout for waiting until
+     * <a href="https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2">ClientHello</a> message is received.
+     * Implementations can round the specified {@link Duration} to full time units, depending on their time granularity.
+     * @param acceptInsecureConnections if non-TLS connections are accepted on the same socket.
+     * {@link Duration#ZERO Zero (0)} disables timeout.
+     * @return {@code this}
+     */
+    public TcpServerConfig sslConfig(ServerSslConfig defaultSslConfig, Map<String, ServerSslConfig> sniConfig,
+                                     int maxClientHelloLength, Duration clientHelloTimeout,
+                                     boolean acceptInsecureConnections) {
+        sslConfig(defaultSslConfig, sniConfig, maxClientHelloLength, clientHelloTimeout);
+        this.acceptInsecureConnections = acceptInsecureConnections;
         return this;
     }
 


### PR DESCRIPTION
Motivation
----------
In certain deployment scenarios it can be useful to accept incoming traffic on the same port for both TLS and non-TLS connections. ServiceTalk does not support this at this point, so this changeset aims to add the feature.

Modifications
-------------
User-facing, a new overload option for the sslConfig is introduced which allows the user to specify that insecure connections should also be accepted. When set to true, both http/1 and http/2 protocols are supported, although ServiceTalk does not support h2c cleartext upgrades so this combination is still not supported.

This also works with ALPN and SNI, since the negotiation happens before the TLS connection is fully established.

Internally, the OptionalSslNegotiator will determine if the incoming first bytes of the connection signify a TLS connection or not and will hand it to the right channel initializer afterwards.