### PR TITLE
loadbalancer-experimental: centralize the default value of LoadBalancingPolicy fail open

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -25,6 +25,12 @@ import java.util.List;
  * @param <C> the type of the load balanced connection
  */
 public interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection> {
+
+    /**
+     * The default fail-open policy to use for {@link HostSelector} implementations.
+     */
+    boolean DEFAULT_FAIL_OPEN_POLICY = false;
+
     /**
      * The name of the load balancing policy.
      * @return the name of the load balancing policy

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -77,7 +77,7 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
         private static final int DEFAULT_MAX_EFFORT = 5;
 
         private int maxEffort = DEFAULT_MAX_EFFORT;
-        private boolean failOpen;
+        private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;
         @Nullable
         private Random random;
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -52,7 +52,7 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
      */
     public static final class Builder {
 
-        private boolean failOpen;
+        private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;
 
         /**
          * Set whether the host selector should attempt to use an unhealthy {@link Host} as a last resort.


### PR DESCRIPTION
Motivation:

We want to ensure the default configuration for different HostSelector implementations is consistent.

Modifications:

- Centralize the definition of the default fail-open policy.