### PR TITLE
experimental-loadbalancer: rename 'healthChecker' symbols

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -107,7 +107,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
     @Nullable
     private final HealthCheckConfig healthCheckConfig;
     @Nullable
-    private final OutlierDetector<ResolvedAddress, C> healthChecker;
+    private final OutlierDetector<ResolvedAddress, C> outlierDetector;
     private final LoadBalancerObserver loadBalancerObserver;
     private final ListenableAsyncCloseable asyncCloseable;
 
@@ -149,7 +149,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         this.asyncCloseable = toAsyncCloseable(this::doClose);
         // Maintain a Subscriber so signals are always delivered to replay and new Subscribers get the latest signal.
         eventStream.ignoreElements().subscribe();
-        this.healthChecker = outlierDetectorFactory == null ? null : outlierDetectorFactory.apply(lbDescription);
+        this.outlierDetector = outlierDetectorFactory == null ? null : outlierDetectorFactory.apply(lbDescription);
         // We subscribe to events as the very last step so that if we subscribe to an eager service discoverer
         // we already have all the fields initialized.
         subscribeToEvents(false);
@@ -178,8 +178,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                 if (!isClosed) {
                     discoveryCancellable.cancel();
                     eventStreamProcessor.onComplete();
-                    if (healthChecker != null) {
-                        healthChecker.cancel();
+                    if (outlierDetector != null) {
+                        outlierDetector.cancel();
                     }
                 }
                 isClosed = true;
@@ -387,8 +387,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         private Host<ResolvedAddress, C> createHost(ResolvedAddress addr) {
             final LoadBalancerObserver.HostObserver hostObserver = loadBalancerObserver.hostObserver(addr);
             // All hosts will share the healthcheck config of the parent RR loadbalancer.
-            final HealthIndicator indicator = healthChecker == null ?
-                    null : healthChecker.newHealthIndicator(addr, hostObserver);
+            final HealthIndicator indicator = outlierDetector == null ?
+                    null : outlierDetector.newHealthIndicator(addr, hostObserver);
             final Host<ResolvedAddress, C> host = new DefaultHost<>(lbDescription, addr, connectionFactory,
                     linearSearchSpace, hostObserver, healthCheckConfig, indicator);
             if (indicator != null) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -136,17 +136,17 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         }
         final LoadBalancerObserver loadBalancerObserver = this.loadBalancerObserver != null ?
                 this.loadBalancerObserver : NoopLoadBalancerObserver.instance();
-        Function<String, OutlierDetector<ResolvedAddress, C>> healthCheckerSupplier;
-        if (outlierDetectorFactory == null) {
-            healthCheckerSupplier = null;
+        Function<String, OutlierDetector<ResolvedAddress, C>> outlierDetectorFactory;
+        if (this.outlierDetectorFactory == null) {
+            outlierDetectorFactory = null;
         } else {
             final Executor executor = getExecutor();
-            healthCheckerSupplier = (String lbDescrption) ->
-                    outlierDetectorFactory.newHealthChecker(executor, lbDescrption);
+            outlierDetectorFactory = (String lbDescrption) ->
+                    this.outlierDetectorFactory.newOutlierDetector(executor, lbDescrption);
         }
 
         return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, linearSearchSpace, healthCheckConfig,
-                loadBalancerObserver, healthCheckerSupplier);
+                loadBalancerObserver, outlierDetectorFactory);
     }
 
     private static final class DefaultLoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConnection>

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorFactory.java
@@ -31,5 +31,5 @@ public interface OutlierDetectorFactory<ResolvedAddress, C extends LoadBalancedC
      * @param lbDescription a description of the load balancer for logging purposes.
      * @return a new {@link OutlierDetector}.
      */
-    OutlierDetector<ResolvedAddress, C> newHealthChecker(Executor executor, String lbDescription);
+    OutlierDetector<ResolvedAddress, C> newOutlierDetector(Executor executor, String lbDescription);
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetectorFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetectorFactory.java
@@ -36,7 +36,7 @@ public final class XdsOutlierDetectorFactory<ResolvedAddress, C extends LoadBala
     }
 
     @Override
-    public OutlierDetector<ResolvedAddress, C> newHealthChecker(
+    public OutlierDetector<ResolvedAddress, C> newOutlierDetector(
             final Executor executor, String lbDescription) {
         return new XdsOutlierDetector<>(executor, config, lbDescription);
     }


### PR DESCRIPTION
Motivation:

We renamed the HealthChecker interface to OutlierDetector but didn't catch all the symbol names so there are still a few floating around in the code.

Modifications:

Remove them.

Result:

Less confusion.