### PR TITLE
Add debug echo statement in netty snapshot action

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Print Netty Version
         env:
           ORG_GRADLE_PROJECT_nettyVersion: 4.1+
-        run: ./gradlew :servicetalk-grpc-netty:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-codec-http2 | grep "io.netty:netty-codec-http2"
+        run: echo "$ORG_GRADLE_PROJECT_nettyVersion" && ./gradlew :servicetalk-grpc-netty:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-codec-http2 | grep "io.netty:netty-codec-http2"
       - name: Build and Test
         env:
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8


### PR DESCRIPTION
Trying to understand if the env variable is being picked up as expected. We expect to see this step print out the latest SNAPSHOT but instead it is printing the latest "Final" version. This works in a local terminal so this step will help us determine whether the issue is with the gradle script of the action itself.