### PR TITLE
Enhance and test sslConfig reset in TcpServerConfig

### DIFF
--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpServerConfigTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpServerConfigTest.java
@@ -16,11 +16,14 @@
 package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.transport.api.ServerSslConfig;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -30,29 +33,43 @@ import static org.mockito.Mockito.mock;
 final class TcpServerConfigTest {
 
     @Test
-    void testAcceptInsecureConnectionsResetWithoutSni() {
-        TcpServerConfig serverConfig = new TcpServerConfig();
-        assertFalse(serverConfig.acceptInsecureConnections());
-        assertNull(serverConfig.sslConfig());
-
-        serverConfig.sslConfig(mock(ServerSslConfig.class), true);
-        assertTrue(serverConfig.acceptInsecureConnections());
-        assertNotNull(serverConfig.sslConfig());
-
-        serverConfig.sslConfig(mock(ServerSslConfig.class));
-        assertFalse(serverConfig.acceptInsecureConnections());
-        assertNotNull(serverConfig.sslConfig());
+    void testDefaultsAreApplied() {
+        assertDefaults(new TcpServerConfig());
     }
 
     @Test
-    void testAcceptInsecureConnectionsResetWithSni() {
+    void testSslResetWithoutSni() {
         TcpServerConfig serverConfig = new TcpServerConfig();
         serverConfig.sslConfig(mock(ServerSslConfig.class), true);
         assertTrue(serverConfig.acceptInsecureConnections());
         assertNotNull(serverConfig.sslConfig());
 
-        serverConfig.sslConfig(mock(ServerSslConfig.class), Collections.emptyMap());
+        serverConfig.sslConfig(null);
+        assertDefaults(serverConfig);
+    }
+
+    @Test
+    void testSslResetWithSni() {
+        TcpServerConfig serverConfig = new TcpServerConfig();
+        ServerSslConfig mockConfig = mock(ServerSslConfig.class);
+        serverConfig.sslConfig(mockConfig, Collections.emptyMap(), 1, Duration.ofSeconds(1), true);
+        assertTrue(serverConfig.acceptInsecureConnections());
+        assertEquals(mockConfig, serverConfig.sslConfig());
+        assertEquals(Collections.emptyMap(), serverConfig.sniConfig());
+        assertEquals(1, serverConfig.sniMaxClientHelloLength());
+        assertEquals(Duration.ofSeconds(1), serverConfig.sniClientHelloTimeout());
+
+        serverConfig.sslConfig(null);
+        assertDefaults(serverConfig);
+    }
+
+    private static void assertDefaults(final TcpServerConfig serverConfig) {
+        assertNull(serverConfig.sslConfig());
+        assertNull(serverConfig.sniConfig());
+        assertNull(serverConfig.listenOptions());
         assertFalse(serverConfig.acceptInsecureConnections());
-        assertNotNull(serverConfig.sslConfig());
+        assertEquals(TcpServerConfig.MAX_CLIENT_HELLO_LENGTH, serverConfig.sniMaxClientHelloLength());
+        assertEquals(TcpServerConfig.DEFAULT_CLIENT_HELLO_TIMEOUT, serverConfig.sniClientHelloTimeout());
+        assertEquals(NoopTransportObserver.INSTANCE, serverConfig.transportObserver());
     }
 }


### PR DESCRIPTION
Motivation
----------
This changeset improves the set and reset functionality for sslConfigs inside the `TcpServerConfig`.

Modifications
-------------
After this change, the validation and defaults are done consistently and all converge in a central method. Tests are added to verify the intended functionality (especially around reset behavior).