### PR TITLE
Optimize protocol negotiation with Optional TLS

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -411,6 +411,10 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
         if (roConfig.tcpConfig().sslConfig() != null && roConfig.tcpConfig().acceptInsecureConnections()) {
             HttpServerConfig configWithoutSsl = new HttpServerConfig(config);
             configWithoutSsl.tcpConfig().sslConfig(null);
+            if (roConfig.h1Config() != null && roConfig.h2Config() != null) {
+                // For non-SSL, if both H1 and H2 are configured at the same time we force-fallback to H1
+                configWithoutSsl.httpConfig().protocols(roConfig.h1Config());
+            }
             ReadOnlyHttpServerConfig roConfigWithoutSsl = configWithoutSsl.asReadOnly();
             return OptionalSslNegotiator.bind(executionContext, roConfig, roConfigWithoutSsl, address,
                     connectionAcceptor, service, drainRequestPayloadBody, earlyConnectionAcceptor,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -95,27 +95,27 @@ class AlpnClientAndServerTest {
 
     @SuppressWarnings("unused")
     private static Stream<Arguments> arguments() {
-        final List<Arguments> arguments = new ArrayList<>(Arrays.asList(
-                Arguments.of(asList(HTTP_2, HTTP_1_1), asList(HTTP_2, HTTP_1_1),
-                        HttpProtocolVersion.HTTP_2_0, null, null, false),
-                Arguments.of(asList(HTTP_2, HTTP_1_1), asList(HTTP_1_1, HTTP_2),
-                        HttpProtocolVersion.HTTP_2_0, null, null, false),
-                Arguments.of(asList(HTTP_2, HTTP_1_1), singletonList(HTTP_2),
-                        HttpProtocolVersion.HTTP_2_0, null, null, false),
-                Arguments.of(asList(HTTP_2, HTTP_1_1), singletonList(HTTP_1_1),
-                        HttpProtocolVersion.HTTP_1_1, null, null, false),
-
-                Arguments.of(asList(HTTP_1_1, HTTP_2), asList(HTTP_2, HTTP_1_1),
-                        HttpProtocolVersion.HTTP_1_1, null, null, false),
-                Arguments.of(asList(HTTP_1_1, HTTP_2), asList(HTTP_1_1, HTTP_2),
-                        HttpProtocolVersion.HTTP_1_1, null, null, false),
-                Arguments.of(asList(HTTP_1_1, HTTP_2), singletonList(HTTP_2),
-                        HttpProtocolVersion.HTTP_2_0, null, null, false),
-                Arguments.of(asList(HTTP_1_1, HTTP_2), singletonList(HTTP_1_1),
-                        HttpProtocolVersion.HTTP_1_1, null, null, false)
-        ));
+        final List<Arguments> arguments = new ArrayList<>();
         for (boolean acceptInsecureConnections : asList(true, false)) {
             arguments.addAll(Arrays.asList(
+                    Arguments.of(asList(HTTP_2, HTTP_1_1), asList(HTTP_2, HTTP_1_1),
+                            HttpProtocolVersion.HTTP_2_0, null, null, acceptInsecureConnections),
+                    Arguments.of(asList(HTTP_2, HTTP_1_1), asList(HTTP_1_1, HTTP_2),
+                            HttpProtocolVersion.HTTP_2_0, null, null, acceptInsecureConnections),
+                    Arguments.of(asList(HTTP_2, HTTP_1_1), singletonList(HTTP_2),
+                            HttpProtocolVersion.HTTP_2_0, null, null, acceptInsecureConnections),
+                    Arguments.of(asList(HTTP_2, HTTP_1_1), singletonList(HTTP_1_1),
+                            HttpProtocolVersion.HTTP_1_1, null, null, acceptInsecureConnections),
+
+                    Arguments.of(asList(HTTP_1_1, HTTP_2), asList(HTTP_2, HTTP_1_1),
+                            HttpProtocolVersion.HTTP_1_1, null, null, acceptInsecureConnections),
+                    Arguments.of(asList(HTTP_1_1, HTTP_2), asList(HTTP_1_1, HTTP_2),
+                            HttpProtocolVersion.HTTP_1_1, null, null, acceptInsecureConnections),
+                    Arguments.of(asList(HTTP_1_1, HTTP_2), singletonList(HTTP_2),
+                            HttpProtocolVersion.HTTP_2_0, null, null, acceptInsecureConnections),
+                    Arguments.of(asList(HTTP_1_1, HTTP_2), singletonList(HTTP_1_1),
+                            HttpProtocolVersion.HTTP_1_1, null, null, acceptInsecureConnections),
+
                     Arguments.of(singletonList(HTTP_2), asList(HTTP_2, HTTP_1_1),
                             HttpProtocolVersion.HTTP_2_0, null, null, acceptInsecureConnections),
                     Arguments.of(singletonList(HTTP_2), asList(HTTP_1_1, HTTP_2),


### PR DESCRIPTION
Motivation
----------
The initial support for Optional TLS did only allow insecure connections if either H1 or H2 is enabled, but not protocols at the same time. This is a limitation when used together with ALPN on secure connections and can be improved.

Modifications
-------------
This changeset makes sure that ALPN support still works when optional TLS is configured. In the case where both H1 and H2 are enabled on the server side and a insecure connection has been negotiated, the code now falls back to H1 support only. This means that h2c cleartext upgrades are not supported, but they haven't been supported inside ServiceTalk anyways.

Result
------
Best possible ALPN support at the moment in combination with Optional TLS.