### PR TITLE
loadbalancer-experimental: tighten up load balancing policy

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -24,18 +24,25 @@ import java.util.List;
  * @param <ResolvedAddress> the type of the resolved address
  * @param <C> the type of the load balanced connection
  */
-public interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection> {
+public abstract class LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection> {
 
     /**
      * The default fail-open policy to use for {@link HostSelector} implementations.
      */
-    boolean DEFAULT_FAIL_OPEN_POLICY = false;
+    static final boolean DEFAULT_FAIL_OPEN_POLICY = false;
+
+    LoadBalancingPolicy() {
+        // package private constructor to control proliferation.
+    }
 
     /**
      * The name of the load balancing policy.
      * @return the name of the load balancing policy
      */
-    String name();
+    public abstract String name();
+
+    @Override
+    public abstract String toString();
 
     /**
      * Construct a {@link HostSelector}.
@@ -43,6 +50,6 @@ public interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConn
      * @param targetResource the name of the target resource, useful for debugging purposes.
      * @return a {@link HostSelector}
      */
-    HostSelector<ResolvedAddress, C> buildSelector(
+    abstract HostSelector<ResolvedAddress, C> buildSelector(
             List<Host<ResolvedAddress, C>> hosts, String targetResource);
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -40,7 +40,7 @@ import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
  *  *  Choices in Randomized Load Balancing</a>
  */
 public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
-        implements LoadBalancingPolicy<ResolvedAddress, C> {
+        extends LoadBalancingPolicy<ResolvedAddress, C> {
 
     private final int maxEffort;
     private final boolean failOpen;
@@ -54,7 +54,7 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     }
 
     @Override
-    public HostSelector<ResolvedAddress, C> buildSelector(
+    HostSelector<ResolvedAddress, C> buildSelector(
             List<Host<ResolvedAddress, C>> hosts, String targetResource) {
         return new P2CSelector<>(hosts, targetResource, maxEffort, failOpen, random);
     }
@@ -66,7 +66,7 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
 
     @Override
     public String toString() {
-        return name() + "(maxEffort=" + maxEffort + ')';
+        return name() + "(failOpen=" + failOpen + ", maxEffort=" + maxEffort + ')';
     }
 
     /**

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -28,7 +28,7 @@ import java.util.List;
  * @param <C> the type of the load balanced connection
  */
 public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
-        implements LoadBalancingPolicy<ResolvedAddress, C> {
+        extends LoadBalancingPolicy<ResolvedAddress, C> {
 
     private final boolean failOpen;
 
@@ -37,7 +37,7 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
     }
 
     @Override
-    public HostSelector<ResolvedAddress, C>
+    HostSelector<ResolvedAddress, C>
     buildSelector(final List<Host<ResolvedAddress, C>> hosts, final String targetResource) {
         return new RoundRobinSelector<>(hosts, targetResource, failOpen);
     }
@@ -45,6 +45,11 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
     @Override
     public String name() {
         return "RoundRobin";
+    }
+
+    @Override
+    public String toString() {
+        return name() + "(failOpen=" + failOpen + ")";
     }
 
     /**

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -294,17 +294,22 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
     }
 
-    private static class TestLoadBalancerPolicy implements LoadBalancingPolicy<String, TestLoadBalancedConnection> {
+    private static class TestLoadBalancerPolicy extends LoadBalancingPolicy<String, TestLoadBalancedConnection> {
 
         int rebuilds;
 
         @Override
         public String name() {
-            return "test-selector";
+            return "TestPolicy";
         }
 
         @Override
-        public HostSelector<String, TestLoadBalancedConnection> buildSelector(
+        public String toString() {
+            return name() + "()";
+        }
+
+        @Override
+        HostSelector<String, TestLoadBalancedConnection> buildSelector(
                 List<Host<String, TestLoadBalancedConnection>> hosts, String targetResource) {
             return new TestSelector(hosts);
         }


### PR DESCRIPTION
Motivation:

The LoadBalancingPolicy interface suffers from the same problems that the OutlierDetectorFactory did, namely that it's more powerful than users need.

Modifications:

- Make the LoadBalancingPolicy an abstract class with package private constructor to let us control its proliferation for now.

Result:

A more constrained API. We can always open it up more later if we want to.