### PR TITLE
loadbalancer-experimental: Fix conflation of maxEjectionTimeJitter

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -280,7 +280,7 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
             failureMultiplier++;
         }
         // Finally we add jitter to the ejection time.
-        final long jitterNanos = ThreadLocalRandom.current().nextLong(config.maxEjectionTimeJitter().toNanos() + 1);
+        final long jitterNanos = ThreadLocalRandom.current().nextLong(config.ejectionTimeJitter().toNanos() + 1);
         evictedUntilNanos = currentTimeNanos() + ejectTimeNanos + jitterNanos;
         hostObserver.onHostMarkedUnhealthy(cause);
         if (LOGGER.isDebugEnabled()) {

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -53,9 +53,9 @@ class XdsHealthIndicatorTest {
 
     private OutlierDetectorConfig.Builder baseBuilder() {
         return new OutlierDetectorConfig.Builder()
-                .maxEjectionTime(ofSeconds(300), ZERO)
                 .maxEjectionTime(ofSeconds(MAX_EJECTION_SECONDS))
-                .baseEjectionTime(ofSeconds(1));
+                .baseEjectionTime(ofSeconds(1))
+                .ejectionTimeJitter(ZERO);
     }
 
     private void initIndicator() {
@@ -146,7 +146,7 @@ class XdsHealthIndicatorTest {
         // make sure out configuration is actually correct
         assertEquals(ofSeconds(1), config.baseEjectionTime());
         assertEquals(ofSeconds(MAX_EJECTION_SECONDS), config.maxEjectionTime());
-        assertEquals(ZERO, config.maxEjectionTimeJitter());
+        assertEquals(ZERO, config.ejectionTimeJitter());
 
         // Eject as many times in a row to get the ejection time maxed out.
         for (long i = 0; i < MAX_EJECTION_SECONDS; i++) {

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithmTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithmTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +29,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import static java.lang.Math.max;
-import static java.time.Duration.ofSeconds;
+import static java.time.Duration.ZERO;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -50,7 +49,7 @@ class XdsOutlierDetectorAlgorithmTest {
     private OutlierDetectorConfig.Builder withAllEnforcing() {
         return new OutlierDetectorConfig.Builder()
                 // set the jitters to zero to make time more predictable
-                .maxEjectionTime(ofSeconds(300), Duration.ZERO)
+                .ejectionTimeJitter(ZERO)
                 // set enforcing rates to 100% so that we don't have to deal with statics
                 .enforcingConsecutive5xx(100)
                 .enforcingFailurePercentage(100)

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsOutlierDetectorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsOutlierDetectorTest.java
@@ -31,7 +31,7 @@ class XdsOutlierDetectorTest {
     private final TestExecutor executor = new TestExecutor();
     OutlierDetectorConfig config = new OutlierDetectorConfig.Builder()
             .failureDetectorInterval(Duration.ofSeconds(5), Duration.ZERO)
-            .maxEjectionTime(Duration.ofMinutes(5), Duration.ZERO)
+            .ejectionTimeJitter(Duration.ZERO)
             .build();
 
     @Nullable


### PR DESCRIPTION
Motivation:

The notion of ejection time jitter is currently named `maxEjectionTimeJitter` which is easy to associate with `maxEjectionTime`. However, that's not how it's used: it's used as a simple ejection time jitter.

Modifications:

- rename the notion to simply `ejectionTimeJitter`
- fix the maxEjectionTime(..) methods

## Notes on jitter

There is currently an asymmetry between the ejection time jitter and detection interval jitter. Specifically, the ejection time jitter is strictly additive whereas interval jitter is a sort of bracketing jitter. The former is much easier to reason about and doesn't introduce a dependence while the latter stipulates that the jitter must be less than the base time itself. However, the bracketing jitter _appears_ to be more common in ST. I don't know that we have to solve this asymmetry right now but it's something we should clean up at some point.