### PR TITLE
Clean up some random number generation related to jitter

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -25,6 +25,7 @@ import static io.servicetalk.concurrent.api.RetryStrategies.checkJitterDelta;
 import static io.servicetalk.concurrent.api.RetryStrategies.checkMaxRetries;
 import static io.servicetalk.concurrent.api.RetryStrategies.maxShift;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
+import static io.servicetalk.utils.internal.RandomUtils.nextLongInclusive;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
@@ -275,11 +276,5 @@ public final class RepeatStrategies {
 
     private static Completable terminateRepeat() {
         return failed(TerminateRepeatException.INSTANCE);
-    }
-
-    static long nextLongInclusive(long lowerBound, long upperBound) {
-        return current().nextLong(lowerBound,
-                // Add 1 because the upper bound is non-inclusive in `ThreadLocalRandom.nextLong(lower,upper)`.
-                addWithOverflowProtection(upperBound, 1));
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RepeatStrategies.java
@@ -29,7 +29,6 @@ import static io.servicetalk.utils.internal.RandomUtils.nextLongInclusive;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.ThreadLocalRandom.current;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
@@ -19,8 +19,8 @@ import java.time.Duration;
 import java.util.function.Predicate;
 
 import static io.servicetalk.concurrent.api.Completable.failed;
-import static io.servicetalk.concurrent.api.RepeatStrategies.nextLongInclusive;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
+import static io.servicetalk.utils.internal.RandomUtils.nextLongInclusive;
 import static java.lang.Long.numberOfLeadingZeros;
 import static java.lang.Math.max;
 import static java.lang.Math.min;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/RetryStrategies.java
@@ -19,12 +19,12 @@ import java.time.Duration;
 import java.util.function.Predicate;
 
 import static io.servicetalk.concurrent.api.Completable.failed;
+import static io.servicetalk.concurrent.api.RepeatStrategies.nextLongInclusive;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static java.lang.Long.numberOfLeadingZeros;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.ThreadLocalRandom.current;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
@@ -60,10 +60,8 @@ public final class RetryStrategies {
         requireNonNull(causeFilter);
         final long jitterNanos = delay.toNanos();
         checkFullJitter(jitterNanos);
-        // add 1 because upper bound is non-inclusive.
-        final long upperBound = addWithOverflowProtection(jitterNanos, 1);
         return (retryCount, cause) -> retryCount <= maxRetries && causeFilter.test(cause) ?
-                timerExecutor.timer(current().nextLong(0, upperBound), NANOSECONDS) : failed(cause);
+                timerExecutor.timer(nextLongInclusive(0, jitterNanos), NANOSECONDS) : failed(cause);
     }
 
     /**
@@ -86,10 +84,8 @@ public final class RetryStrategies {
         requireNonNull(causeFilter);
         final long jitterNanos = delay.toNanos();
         checkFullJitter(jitterNanos);
-        // add 1 because upper bound is non-inclusive.
-        final long upperBound = addWithOverflowProtection(jitterNanos, 1);
         return (retryCount, cause) -> causeFilter.test(cause) ?
-                timerExecutor.timer(current().nextLong(0, upperBound), NANOSECONDS) : failed(cause);
+                timerExecutor.timer(nextLongInclusive(0, jitterNanos), NANOSECONDS) : failed(cause);
     }
 
     /**
@@ -114,10 +110,9 @@ public final class RetryStrategies {
         final long jitterNanos = jitter.toNanos();
         checkJitterDelta(jitterNanos, delayNanos);
         final long lowerBound = delayNanos - jitterNanos;
-        // Add 1 because the upper bound is non-inclusive.
-        final long upperBound = addWithOverflowProtection(addWithOverflowProtection(delayNanos, jitterNanos), 1);
+        final long upperBound = addWithOverflowProtection(delayNanos, jitterNanos);
         return (retryCount, cause) -> causeFilter.test(cause) ?
-                timerExecutor.timer(current().nextLong(lowerBound, upperBound), NANOSECONDS) : failed(cause);
+                timerExecutor.timer(nextLongInclusive(lowerBound, upperBound), NANOSECONDS) : failed(cause);
     }
 
     /**
@@ -146,10 +141,9 @@ public final class RetryStrategies {
         final long jitterNanos = jitter.toNanos();
         checkJitterDelta(jitterNanos, delayNanos);
         final long lowerBound = delayNanos - jitterNanos;
-        // Add 1 because the upper bound is non-inclusive.
-        final long upperBound = addWithOverflowProtection(addWithOverflowProtection(delayNanos, jitterNanos), 1);
+        final long upperBound = addWithOverflowProtection(delayNanos, jitterNanos);
         return (retryCount, cause) -> retryCount <= maxRetries && causeFilter.test(cause) ?
-                timerExecutor.timer(current().nextLong(lowerBound, upperBound), NANOSECONDS) : failed(cause);
+                timerExecutor.timer(nextLongInclusive(lowerBound, upperBound), NANOSECONDS) : failed(cause);
     }
 
     /**
@@ -177,10 +171,8 @@ public final class RetryStrategies {
         final long maxDelayNanos = maxDelay.toNanos();
         final long maxInitialShift = maxShift(initialDelayNanos);
         return (retryCount, cause) -> causeFilter.test(cause) ?
-                timerExecutor.timer(current().nextLong(0,
-                        // Add 1 because the upper bound is non-inclusive.
-                        addWithOverflowProtection(baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift,
-                                retryCount), 1)), NANOSECONDS)
+                timerExecutor.timer(nextLongInclusive(0,
+                        baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift, retryCount)), NANOSECONDS)
                 : failed(cause);
     }
 
@@ -213,10 +205,8 @@ public final class RetryStrategies {
         final long maxDelayNanos = maxDelay.toNanos();
         final long maxInitialShift = maxShift(initialDelayNanos);
         return (retryCount, cause) -> retryCount <= maxRetries && causeFilter.test(cause) ?
-                timerExecutor.timer(current().nextLong(0,
-                        // Add 1 because the upper bound is non-inclusive.
-                        addWithOverflowProtection(baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift,
-                                retryCount), 1)), NANOSECONDS)
+                timerExecutor.timer(nextLongInclusive(0,
+                        baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift, retryCount)), NANOSECONDS)
                 : failed(cause);
     }
 
@@ -251,10 +241,8 @@ public final class RetryStrategies {
             }
             final long baseDelayNanos = baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift, retryCount);
             final long lowerBound = max(0, baseDelayNanos - jitterNanos);
-            // Add 1 because the upper bound is non-inclusive.
-            final long upperBound = addWithOverflowProtection(
-                    min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos)), 1);
-            return timerExecutor.timer(current().nextLong(lowerBound, upperBound), NANOSECONDS);
+            final long upperBound = min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos));
+            return timerExecutor.timer(nextLongInclusive(lowerBound, upperBound), NANOSECONDS);
         };
     }
 
@@ -293,10 +281,8 @@ public final class RetryStrategies {
             }
             final long baseDelayNanos = baseDelayNanos(initialDelayNanos, maxDelayNanos, maxInitialShift, retryCount);
             return timerExecutor.timer(
-                    current().nextLong(max(0, baseDelayNanos - jitterNanos),
-                            // Add 1 because the upper bound is non-inclusive.
-                            addWithOverflowProtection(
-                                    min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos)), 1)),
+                    nextLongInclusive(max(0, baseDelayNanos - jitterNanos),
+                                    min(maxDelayNanos, addWithOverflowProtection(baseDelayNanos, jitterNanos))),
                     NANOSECONDS);
         };
     }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RepeatStrategiesTest.java
@@ -40,7 +40,7 @@ class RepeatStrategiesTest extends RedoStrategiesTest {
     @Test
     void testBackoff() throws Exception {
         Duration backoff = ofSeconds(1);
-        RepeatStrategy strategy = new RepeatStrategy(repeatWithConstantBackoffDeltaJitter(2, backoff, ofNanos(1),
+        RepeatStrategy strategy = new RepeatStrategy(repeatWithConstantBackoffDeltaJitter(2, backoff, ofNanos(0),
                 timerExecutor));
         io.servicetalk.concurrent.test.internal.TestCompletableSubscriber subscriber = strategy.invokeAndListen();
         verifyDelayWithDeltaJitter(backoff.toNanos(), 1, 1);

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RetryStrategiesTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/RetryStrategiesTest.java
@@ -42,7 +42,7 @@ class RetryStrategiesTest extends RedoStrategiesTest {
     void testBackoff() throws Exception {
         Duration backoff = ofSeconds(1);
         RetryStrategy strategy = new RetryStrategy(retryWithConstantBackoffDeltaJitter(2, cause -> true, backoff,
-                ofNanos(1), timerExecutor));
+                ofNanos(0), timerExecutor));
         io.servicetalk.concurrent.test.internal.TestCompletableSubscriber subscriber =
                 strategy.invokeAndListen(DELIBERATE_EXCEPTION);
         verifyDelayWithDeltaJitter(backoff.toNanos(), 1, 1);

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -797,7 +797,10 @@ final class DefaultDnsClient implements DnsClient {
                 assertInEventloop();
 
                 final long delay = ThreadLocalRandom.current()
-                        .nextLong(remainingTtlNanos, addWithOverflowProtection(remainingTtlNanos, ttlJitterNanos));
+                        .nextLong(remainingTtlNanos,
+                                // add 1 because the upper bound is not inclusive.
+                                addWithOverflowProtection(
+                                        addWithOverflowProtection(remainingTtlNanos, ttlJitterNanos), 1));
                 LOGGER.debug("{} scheduling DNS query for {} after {}ms (TTL={}s, jitter={}ms).",
                         DefaultDnsClient.this, AbstractDnsPublisher.this, NANOSECONDS.toMillis(delay),
                         NANOSECONDS.toSeconds(originalTtlNanos), NANOSECONDS.toMillis(ttlJitterNanos));

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -35,6 +35,7 @@ import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.Resolutio
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutor;
+import io.servicetalk.utils.internal.RandomUtils;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.EventLoop;
@@ -56,7 +57,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
-import io.servicetalk.utils.internal.RandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +75,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.RandomAccess;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.IntFunction;
 import javax.annotation.Nullable;
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -56,6 +56,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
+import io.servicetalk.utils.internal.RandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -796,11 +797,8 @@ final class DefaultDnsClient implements DnsClient {
             private void scheduleQuery0(final long remainingTtlNanos, final long originalTtlNanos) {
                 assertInEventloop();
 
-                final long delay = ThreadLocalRandom.current()
-                        .nextLong(remainingTtlNanos,
-                                // add 1 because the upper bound is not inclusive.
-                                addWithOverflowProtection(
-                                        addWithOverflowProtection(remainingTtlNanos, ttlJitterNanos), 1));
+                final long delay = RandomUtils.nextLongInclusive(remainingTtlNanos,
+                                addWithOverflowProtection(remainingTtlNanos, ttlJitterNanos));
                 LOGGER.debug("{} scheduling DNS query for {} after {}ms (TTL={}s, jitter={}ms).",
                         DefaultDnsClient.this, AbstractDnsPublisher.this, NANOSECONDS.toMillis(delay),
                         NANOSECONDS.toSeconds(originalTtlNanos), NANOSECONDS.toMillis(ttlJitterNanos));

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -62,6 +62,7 @@ import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static java.lang.Integer.toHexString;
 import static java.lang.System.identityHashCode;
 import static java.util.Collections.emptyList;
@@ -212,7 +213,9 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         final long upperNanos = config.healthCheckResubscribeUpperBound;
         final long currentTimeNanos = config.executor.currentTime(NANOSECONDS);
         final long result = currentTimeNanos + (lowerNanos == upperNanos ? lowerNanos :
-                ThreadLocalRandom.current().nextLong(lowerNanos, upperNanos));
+                ThreadLocalRandom.current().nextLong(lowerNanos,
+                        // add 1 because the upper bound is not inclusive.
+                        addWithOverflowProtection(upperNanos, 1)));
         LOGGER.debug("{}: current time {}, next resubscribe attempt can be performed at {}.",
                 lb, currentTimeNanos, result);
         return result;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -211,8 +211,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         final long lowerNanos = config.healthCheckResubscribeLowerBound;
         final long upperNanos = config.healthCheckResubscribeUpperBound;
         final long currentTimeNanos = config.executor.currentTime(NANOSECONDS);
-        final long result = currentTimeNanos + (lowerNanos == upperNanos ? lowerNanos :
-                RandomUtils.nextLongInclusive(lowerNanos, upperNanos));
+        final long result = currentTimeNanos + RandomUtils.nextLongInclusive(lowerNanos, upperNanos);
         LOGGER.debug("{}: current time {}, next resubscribe attempt can be performed at {}.",
                 lb, currentTimeNanos, result);
         return result;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -35,6 +35,7 @@ import io.servicetalk.concurrent.api.SourceAdapters;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
 import io.servicetalk.context.api.ContextMap;
 
+import io.servicetalk.utils.internal.RandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -213,9 +214,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         final long upperNanos = config.healthCheckResubscribeUpperBound;
         final long currentTimeNanos = config.executor.currentTime(NANOSECONDS);
         final long result = currentTimeNanos + (lowerNanos == upperNanos ? lowerNanos :
-                ThreadLocalRandom.current().nextLong(lowerNanos,
-                        // add 1 because the upper bound is not inclusive.
-                        addWithOverflowProtection(upperNanos, 1)));
+                RandomUtils.nextLongInclusive(lowerNanos, upperNanos));
         LOGGER.debug("{}: current time {}, next resubscribe attempt can be performed at {}.",
                 lb, currentTimeNanos, result);
         return result;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -34,8 +34,8 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.SourceAdapters;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
 import io.servicetalk.context.api.ContextMap;
-
 import io.servicetalk.utils.internal.RandomUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -63,7 +62,6 @@ import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static java.lang.Integer.toHexString;
 import static java.lang.System.identityHashCode;
 import static java.util.Collections.emptyList;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static io.servicetalk.loadbalancer.OutlierDetectorConfig.enforcing;
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
+import static io.servicetalk.utils.internal.RandomUtils.nextLongInclusive;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 
@@ -281,9 +282,7 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
             failureMultiplier++;
         }
         // Finally we add jitter to the ejection time.
-        final long jitterNanos = ThreadLocalRandom.current().nextLong(
-                // add 1 because the upper bound is not inclusive.
-                addWithOverflowProtection(config.maxEjectionTimeJitter().toNanos(), 1));
+        final long jitterNanos = nextLongInclusive(config.maxEjectionTimeJitter().toNanos());
         evictedUntilNanos = currentTimeNanos() + ejectTimeNanos + jitterNanos;
         hostObserver.onHostMarkedUnhealthy(cause);
         if (LOGGER.isDebugEnabled()) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -23,13 +23,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static io.servicetalk.loadbalancer.OutlierDetectorConfig.enforcing;
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.RandomUtils.nextLongInclusive;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
 import io.servicetalk.loadbalancer.LoadBalancerObserver.HostObserver;
 
+import io.servicetalk.utils.internal.RandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,9 +183,8 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
                     currentConfig.failureDetectorIntervalJitter().toNanos();
             final long maxIntervalNanos = addWithOverflowProtection(currentConfig.failureDetectorInterval().toNanos(),
                     currentConfig.failureDetectorIntervalJitter().toNanos());
-            return executor.schedule(checkOutliers, ThreadLocalRandom.current().nextLong(
-                    // + 1 to make the bound inclusive
-                    minIntervalNanos, addWithOverflowProtection(maxIntervalNanos, 1)), TimeUnit.NANOSECONDS);
+            return executor.schedule(checkOutliers, RandomUtils.nextLongInclusive(minIntervalNanos, maxIntervalNanos),
+                    TimeUnit.NANOSECONDS);
         }
 
         private void sequentialCheckOutliers() {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -184,7 +184,7 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
                     currentConfig.failureDetectorIntervalJitter().toNanos());
             return executor.schedule(checkOutliers, ThreadLocalRandom.current().nextLong(
                     // + 1 to make the bound inclusive
-                    minIntervalNanos, maxIntervalNanos + 1), TimeUnit.NANOSECONDS);
+                    minIntervalNanos, addWithOverflowProtection(maxIntervalNanos, 1)), TimeUnit.NANOSECONDS);
         }
 
         private void sequentialCheckOutliers() {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -20,8 +20,8 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.internal.SequentialCancellable;
 import io.servicetalk.loadbalancer.LoadBalancerObserver.HostObserver;
-
 import io.servicetalk.utils.internal.RandomUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -221,7 +221,9 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         final long lower = config.healthCheckResubscribeLowerBound;
         final long upper = config.healthCheckResubscribeUpperBound;
         final long currentTime = config.executor.currentTime(NANOSECONDS);
-        final long result = currentTime + (lower == upper ? lower : ThreadLocalRandom.current().nextLong(lower, upper));
+        final long result = currentTime + (lower == upper ? lower : ThreadLocalRandom.current().nextLong(lower,
+                // add 1 because the upper bound is not inclusive.
+                addWithOverflowProtection(upper, 1)));
         LOGGER.debug("{}: current time {}, next resubscribe attempt can be performed at {}.",
                 lb, currentTime, result);
         return result;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -37,6 +37,7 @@ import io.servicetalk.loadbalancer.Exceptions.StacklessConnectionRejectedExcepti
 import io.servicetalk.loadbalancer.Exceptions.StacklessNoActiveHostException;
 import io.servicetalk.loadbalancer.Exceptions.StacklessNoAvailableHostException;
 
+import io.servicetalk.utils.internal.RandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -221,9 +222,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         final long lower = config.healthCheckResubscribeLowerBound;
         final long upper = config.healthCheckResubscribeUpperBound;
         final long currentTime = config.executor.currentTime(NANOSECONDS);
-        final long result = currentTime + (lower == upper ? lower : ThreadLocalRandom.current().nextLong(lower,
-                // add 1 because the upper bound is not inclusive.
-                addWithOverflowProtection(upper, 1)));
+        final long result = currentTime + (lower == upper ? lower : RandomUtils.nextLongInclusive(lower, upper));
         LOGGER.debug("{}: current time {}, next resubscribe attempt can be performed at {}.",
                 lb, currentTime, result);
         return result;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -222,7 +222,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         final long lower = config.healthCheckResubscribeLowerBound;
         final long upper = config.healthCheckResubscribeUpperBound;
         final long currentTime = config.executor.currentTime(NANOSECONDS);
-        final long result = currentTime + (lower == upper ? lower : RandomUtils.nextLongInclusive(lower, upper));
+        final long result = currentTime + RandomUtils.nextLongInclusive(lower, upper);
         LOGGER.debug("{}: current time {}, next resubscribe attempt can be performed at {}.",
                 lb, currentTime, result);
         return result;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -36,8 +36,8 @@ import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.loadbalancer.Exceptions.StacklessConnectionRejectedException;
 import io.servicetalk.loadbalancer.Exceptions.StacklessNoActiveHostException;
 import io.servicetalk.loadbalancer.Exceptions.StacklessNoAvailableHostException;
-
 import io.servicetalk.utils.internal.RandomUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/RandomUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/RandomUtils.java
@@ -20,7 +20,7 @@ import static java.util.concurrent.ThreadLocalRandom.current;
 /**
  * Internal random utilities.
  */
-public class RandomUtils {
+public final class RandomUtils {
 
     private RandomUtils() {
         // no instances

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/RandomUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/RandomUtils.java
@@ -45,16 +45,19 @@ public final class RandomUtils {
         if (lowerBound > upperBound) {
             throw new IllegalArgumentException("Lower bound cannot be greater than upper bound.");
         }
-        if (upperBound == Long.MAX_VALUE) {
+        if (upperBound == lowerBound) {
+            return upperBound;
+        } else if (upperBound != Long.MAX_VALUE) {
+            // simply add 1 to upper bound to make it inclusive
+            return current().nextLong(lowerBound, upperBound + 1);
+        } else {
             if (lowerBound == Long.MIN_VALUE) {
                 // full range possible which is the simply `nextLong()`.
                 return current().nextLong();
             } else {
-                // be inclusive of MAX_VALUE by shifting lower bound 1 lower and adding 1 to the result.
+                // be inclusive of upperBound == MAX_VALUE by shifting lower bound down by 1 and adding 1 to the result.
                 return current().nextLong(lowerBound - 1, Long.MAX_VALUE) + 1;
             }
-        } else {
-            return current().nextLong(lowerBound, upperBound + 1);
         }
     }
 }

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/RandomUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/RandomUtils.java
@@ -31,10 +31,8 @@ public final class RandomUtils {
      * @param upperBound the inclusive upper bound.
      * @return a random long between 0 and the upper bound, both inclusive.
      */
-    public static long nextLongInclusive(long upperBound) {
-        return current().nextLong(
-                // Add 1 because the upper bound is non-inclusive in `ThreadLocalRandom.nextLong(lower,upper)`.
-                addWithOverflowProtection(upperBound, 1));
+    public static long nextLongInclusive(final long upperBound) {
+        return nextLongInclusive(0, upperBound);
     }
 
     /**
@@ -43,15 +41,20 @@ public final class RandomUtils {
      * @param upperBound the inclusive upper bound.
      * @return a random long between the specified lower and upper bound, both inclusive.
      */
-    public static long nextLongInclusive(long lowerBound, long upperBound) {
-        return current().nextLong(lowerBound,
-                // Add 1 because the upper bound is non-inclusive in `ThreadLocalRandom.nextLong(lower,upper)`.
-                addWithOverflowProtection(upperBound, 1));
-    }
-
-    private static long addWithOverflowProtection(long x, final long y) {
-        //noinspection SuspiciousNameCombination
-        x += y;
-        return x >= 0 ? x : Long.MAX_VALUE;
+    public static long nextLongInclusive(final long lowerBound, final long upperBound) {
+        if (lowerBound > upperBound) {
+            throw new IllegalArgumentException("Lower bound cannot be greater than upper bound.");
+        }
+        if (upperBound == Long.MAX_VALUE) {
+            if (lowerBound == Long.MIN_VALUE) {
+                // full range possible which is the simply `nextLong()`.
+                return current().nextLong();
+            } else {
+                // be inclusive of MAX_VALUE by shifting lower bound 1 lower and adding 1 to the result.
+                return current().nextLong(lowerBound - 1, Long.MAX_VALUE) + 1;
+            }
+        } else {
+            return current().nextLong(lowerBound, upperBound + 1);
+        }
     }
 }

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/RandomUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/RandomUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.utils.internal;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
+
+/**
+ * Internal random utilities.
+ */
+public class RandomUtils {
+
+    private RandomUtils() {
+        // no instances
+    }
+
+    /**
+     * Generate a random long between 0 and the upper bound, both inclusive.
+     * @param upperBound the inclusive upper bound.
+     * @return a random long between 0 and the upper bound, both inclusive.
+     */
+    public static long nextLongInclusive(long upperBound) {
+        return current().nextLong(
+                // Add 1 because the upper bound is non-inclusive in `ThreadLocalRandom.nextLong(lower,upper)`.
+                addWithOverflowProtection(upperBound, 1));
+    }
+
+    /**
+     * Generate a random long between the specified lower and upper bound, both inclusive.
+     * @param lowerBound the inclusive lower bound.
+     * @param upperBound the inclusive upper bound.
+     * @return a random long between the specified lower and upper bound, both inclusive.
+     */
+    public static long nextLongInclusive(long lowerBound, long upperBound) {
+        return current().nextLong(lowerBound,
+                // Add 1 because the upper bound is non-inclusive in `ThreadLocalRandom.nextLong(lower,upper)`.
+                addWithOverflowProtection(upperBound, 1));
+    }
+
+    private static long addWithOverflowProtection(long x, final long y) {
+        //noinspection SuspiciousNameCombination
+        x += y;
+        return x >= 0 ? x : Long.MAX_VALUE;
+    }
+}

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/RandomUtilsTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/RandomUtilsTest.java
@@ -1,0 +1,49 @@
+package io.servicetalk.utils.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RandomUtilsTest {
+
+    @Test
+    void illegalArguments() {
+        repeated(() -> {
+            long lowerBound = current().nextLong(Long.MIN_VALUE + 1, Long.MAX_VALUE);
+            assertThrows(IllegalArgumentException.class, () ->
+                    RandomUtils.nextLongInclusive(lowerBound, lowerBound - 1));
+        });
+    }
+
+    @Test
+    void lowerEqualsUpperBound() {
+        repeated(() -> {
+            final long bound = current().nextLong();
+            assertThat(RandomUtils.nextLongInclusive(bound, bound), equalTo(bound));
+        });
+    }
+
+    @Test
+    void longMaxValue() {
+        repeated(() ->
+            assertThat(RandomUtils.nextLongInclusive(Long.MAX_VALUE - 1, Long.MAX_VALUE),
+                    anyOf(equalTo(Long.MAX_VALUE - 1), equalTo(Long.MAX_VALUE))));
+    }
+
+    @Test
+    void longMinValue() {
+        repeated(() ->
+            assertThat(RandomUtils.nextLongInclusive(Long.MIN_VALUE, Long.MIN_VALUE + 1),
+                    anyOf(equalTo(Long.MIN_VALUE), equalTo(Long.MIN_VALUE + 1))));
+    }
+
+    private static void repeated(Runnable r) {
+        for (int i = 0; i < 100; i++) {
+            r.run();
+        }
+    }
+}

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/RandomUtilsTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/RandomUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.servicetalk.utils.internal;
 
 import org.junit.jupiter.api.Test;

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/RandomUtilsTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/RandomUtilsTest.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.utils.internal;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
 
 import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,40 +25,28 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class RandomUtilsTest {
 
-    @Test
+    @RepeatedTest(100)
     void illegalArguments() {
-        repeated(() -> {
-            long lowerBound = current().nextLong(Long.MIN_VALUE + 1, Long.MAX_VALUE);
-            assertThrows(IllegalArgumentException.class, () ->
-                    RandomUtils.nextLongInclusive(lowerBound, lowerBound - 1));
-        });
+        long lowerBound = current().nextLong(Long.MIN_VALUE + 1, Long.MAX_VALUE);
+        assertThrows(IllegalArgumentException.class, () ->
+                RandomUtils.nextLongInclusive(lowerBound, lowerBound - 1));
     }
 
-    @Test
+    @RepeatedTest(100)
     void lowerEqualsUpperBound() {
-        repeated(() -> {
-            final long bound = current().nextLong();
-            assertThat(RandomUtils.nextLongInclusive(bound, bound), equalTo(bound));
-        });
+        final long bound = current().nextLong();
+        assertThat(RandomUtils.nextLongInclusive(bound, bound), equalTo(bound));
     }
 
-    @Test
+    @RepeatedTest(100)
     void longMaxValue() {
-        repeated(() ->
-            assertThat(RandomUtils.nextLongInclusive(Long.MAX_VALUE - 1, Long.MAX_VALUE),
-                    anyOf(equalTo(Long.MAX_VALUE - 1), equalTo(Long.MAX_VALUE))));
+        assertThat(RandomUtils.nextLongInclusive(Long.MAX_VALUE - 1, Long.MAX_VALUE),
+                anyOf(equalTo(Long.MAX_VALUE - 1), equalTo(Long.MAX_VALUE)));
     }
 
-    @Test
+    @RepeatedTest(100)
     void longMinValue() {
-        repeated(() ->
-            assertThat(RandomUtils.nextLongInclusive(Long.MIN_VALUE, Long.MIN_VALUE + 1),
-                    anyOf(equalTo(Long.MIN_VALUE), equalTo(Long.MIN_VALUE + 1))));
-    }
-
-    private static void repeated(Runnable r) {
-        for (int i = 0; i < 100; i++) {
-            r.run();
-        }
+        assertThat(RandomUtils.nextLongInclusive(Long.MIN_VALUE, Long.MIN_VALUE + 1),
+                anyOf(equalTo(Long.MIN_VALUE), equalTo(Long.MIN_VALUE + 1)));
     }
 }


### PR DESCRIPTION
Motivation:

Many locations where we have a notion of jitter we require the
jitter to be non-zero. This is because we use
`ThreadLocalRandom.nextLong(lower, upper)` where with a zero
jitter the bounds are the same and we get an IAE.

Modifications:

- Add 1 to the upper bound most of our usages of `.nextLong(l,u)`
  to account for the non-inclusive upper bound.
