### PR TITLE
Turn some jitter related ensurePositive to ensureNonNegative

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -35,7 +35,7 @@ import static io.servicetalk.dns.discovery.netty.DnsClients.asHostAndPortDiscove
 import static io.servicetalk.dns.discovery.netty.DnsClients.asSrvDiscoverer;
 import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.systemDefault;
 import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
-import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
+import static io.servicetalk.utils.internal.DurationUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Boolean.getBoolean;
@@ -217,7 +217,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
 
     @Override
     public DefaultDnsServiceDiscovererBuilder ttlJitter(final Duration ttlJitter) {
-        ensurePositive(ttlJitter, "jitter");
+        ensureNonNegative(ttlJitter, "jitter");
         this.ttlJitter = ttlJitter;
         return this;
     }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -19,7 +19,6 @@ import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.utils.internal.DurationUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +36,7 @@ import static io.servicetalk.dns.discovery.netty.DnsClients.asSrvDiscoverer;
 import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.systemDefault;
 import static io.servicetalk.transport.netty.internal.GlobalExecutionContext.globalExecutionContext;
 import static io.servicetalk.utils.internal.DurationUtils.ensureNonNegative;
+import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Boolean.getBoolean;
@@ -329,7 +329,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
     DefaultDnsServiceDiscovererBuilder srvHostNameRepeatDelay(
             Duration initialDelay, Duration jitter) {
         this.srvHostNameRepeatInitialDelay = ensurePositive(initialDelay, "srvHostNameRepeatInitialDelay");
-        this.srvHostNameRepeatJitter = DurationUtils.ensureNonNegative(jitter, "srvHostNameRepeatJitter");
+        this.srvHostNameRepeatJitter = ensureNonNegative(jitter, "srvHostNameRepeatJitter");
         if (srvHostNameRepeatJitter.toNanos() >= srvHostNameRepeatInitialDelay.toNanos()) {
             throw new IllegalArgumentException("The jitter value should be less than the initial delay.");
         }

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilderTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilderTest.java
@@ -74,7 +74,7 @@ class DefaultDnsServiceDiscovererBuilderTest {
     @Test
     void ttlJitter() {
         assertThrows(IllegalArgumentException.class, () -> builder.ttlJitter(Duration.ofNanos(1).negated()));
-        assertThrows(IllegalArgumentException.class, () -> builder.ttlJitter(Duration.ZERO));
+        assertDoesNotThrow(() -> builder.ttlJitter(Duration.ZERO));
         assertDoesNotThrow(() -> builder.ttlJitter(Duration.ofNanos(1)));
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -65,6 +65,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.EXPECT;
 import static io.servicetalk.http.api.HttpHeaderValues.CONTINUE;
 import static io.servicetalk.http.api.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.NO_RETRIES;
+import static io.servicetalk.utils.internal.DurationUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.DurationUtils.ensurePositive;
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
@@ -384,7 +385,7 @@ public final class RetryingHttpRequesterFilter
                       final boolean exponential,
                       final int maxRetries) {
             this.initialDelay = ensurePositive(initialDelay, "Initial delay should be a positive value.");
-            this.jitter = ensurePositive(jitter, "jitter should be a positive value.");
+            this.jitter = ensureNonNegative(jitter, "jitter should be a non-negative value.");
             this.maxDelay = maxDelay != null ? ensurePositive(maxDelay, "Max delay (if provided), should be a " +
                     "positive value.") : null;
             this.timerExecutor = timerExecutor;


### PR DESCRIPTION
Motivation:

In #2888 we made it possible to have a zero length jitter but in a couple places we continue to assert the jitter is positive despite it being allowed to be 0.

Modifications:

- Fix a couple examples of this.

Result:

More jitters are allowed to be 0.