### PR TITLE
Lower initial delay for ServiceDiscovery retries from 8 to 2 seconds

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -104,7 +104,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     private static final StreamingHttpConnectionFilterFactory DEFAULT_IDLE_TIMEOUT_FILTER =
             new IdleTimeoutConnectionFilter(ofMinutes(5));
 
-    static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(8);
+    static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(2);
     static final Duration SD_RETRY_STRATEGY_MAX_DELAY = ofSeconds(256);
 
     @Nullable


### PR DESCRIPTION
Motivation:

Experiments show that majority of ServiceDiscovery queries take only a few milliseconds. Jitter up to 8 seconds causes too long delay before the next retry. Based on observed numbers we can lower the value down to 2 seconds.