### PR TITLE
Lower max delay for ServiceDiscovery retries from 256 to 128 seconds

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -105,7 +105,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
             new IdleTimeoutConnectionFilter(ofMinutes(5));
 
     static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(2);
-    static final Duration SD_RETRY_STRATEGY_MAX_DELAY = ofSeconds(256);
+    static final Duration SD_RETRY_STRATEGY_MAX_DELAY = ofSeconds(128);
 
     @Nullable
     private final U address;


### PR DESCRIPTION
Motivation:

256 seconds seems like quite a long delay for retrying SD errors. We agreed to cut it down in half.

Follow-up for #2891