### PR TITLE
Restore binary compatibility for `AbstractReadOnlyTcpConfig` impls

### DIFF
--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
@@ -17,6 +17,7 @@ package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.logging.api.UserDataLoggerConfig;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 
 import io.netty.channel.ChannelOption;
@@ -104,4 +105,12 @@ abstract class AbstractReadOnlyTcpConfig {
      */
     @Nullable
     public abstract SslContext sslContext();
+
+    /**
+     * Get the {@link SslConfig}.
+     *
+     * @return the {@link SslConfig}, or {@code null} if SSL/TLS is not configured.
+     */
+    @Nullable
+    public abstract SslConfig sslConfig();
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpClientConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpClientConfig.java
@@ -82,6 +82,7 @@ public final class ReadOnlyTcpClientConfig extends AbstractReadOnlyTcpConfig {
      * @return the {@link ClientSslConfig}, or {@code null} if SSL/TLS is not configured.
      */
     @Nullable
+    @Override
     public ClientSslConfig sslConfig() {
         return sslConfig;
     }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/ReadOnlyTcpServerConfig.java
@@ -114,6 +114,7 @@ public final class ReadOnlyTcpServerConfig extends AbstractReadOnlyTcpConfig {
      * @return the {@link ServerSslConfig}, or {@code null} if SSL/TLS is not configured.
      */
     @Nullable
+    @Override
     public ServerSslConfig sslConfig() {
         return sslConfig;
     }


### PR DESCRIPTION
Motivation:

japicmp.sh flagged it like that:
```
Comparing binary compatibility of servicetalk-tcp-netty-internal-0.42.43-SNAPSHOT.jar against servicetalk-tcp-netty-internal-0.42.42.jar ***! MODIFIED CLASS: PUBLIC FINAL io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig  (not serializable)
        ===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
        ===  UNCHANGED SUPERCLASS: io.servicetalk.tcp.netty.internal.AbstractReadOnlyTcpConfig (<- io.servicetalk.tcp.netty.internal.AbstractReadOnlyTcpConfig)
        ---! REMOVED METHOD: PUBLIC(-) SYNTHETIC(-) BRIDGE(-) io.servicetalk.transport.api.SslConfig sslConfig()
***! MODIFIED CLASS: PUBLIC FINAL io.servicetalk.tcp.netty.internal.ReadOnlyTcpServerConfig  (not serializable)
        ===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
        ===  UNCHANGED SUPERCLASS: io.servicetalk.tcp.netty.internal.AbstractReadOnlyTcpConfig (<- io.servicetalk.tcp.netty.internal.AbstractReadOnlyTcpConfig)
        ---! REMOVED METHOD: PUBLIC(-) SYNTHETIC(-) BRIDGE(-) io.servicetalk.transport.api.SslConfig sslConfig()
```