### PR TITLE
loadbalancer-experimental: unbreak API

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -24,6 +24,7 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.loadbalancer.ConnectionPoolStrategy.ConnectionPoolStrategyFactory;
 import io.servicetalk.transport.api.ExecutionStrategy;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -19,9 +19,8 @@ import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.concurrent.api.Executor;
 
-import javax.annotation.Nullable;
-
 import java.time.Duration;
+import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -21,6 +21,8 @@ import io.servicetalk.concurrent.api.Executor;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -82,6 +84,36 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
     public LoadBalancerBuilder<ResolvedAddress, C> connectionPoolConfig(
             ConnectionPoolConfig connectionPoolConfig) {
         delegate = delegate.connectionPoolConfig(connectionPoolConfig);
+        return this;
+    }
+
+    @Override
+    public LoadBalancerBuilder<ResolvedAddress, C> healthCheckerFactory(HealthCheckerFactory healthCheckerFactory) {
+        delegate = delegate.healthCheckerFactory(healthCheckerFactory);
+        return this;
+    }
+
+    @Override
+    public LoadBalancerBuilder<ResolvedAddress, C> healthCheckFailedConnectionsThreshold(int threshold) {
+        delegate = delegate.healthCheckFailedConnectionsThreshold(threshold);
+        return this;
+    }
+
+    @Override
+    public LoadBalancerBuilder<ResolvedAddress, C> healthCheckInterval(Duration interval, Duration jitter) {
+        delegate = delegate.healthCheckInterval(interval, jitter);
+        return this;
+    }
+
+    @Override
+    public LoadBalancerBuilder<ResolvedAddress, C> healthCheckResubscribeInterval(Duration interval, Duration jitter) {
+        delegate = delegate.healthCheckResubscribeInterval(interval, jitter);
+        return this;
+    }
+
+    @Override
+    public LoadBalancerBuilder<ResolvedAddress, C> linearSearchSpace(int searchSpace) {
+        delegate = delegate.linearSearchSpace(searchSpace);
         return this;
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthChecker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthChecker.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+/**
+ * This exists only to preserve API and is not used.
+ */
+// TODO: deprecate this API.
+interface HealthChecker<ResolvedAddress> {
+}

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthCheckerFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthCheckerFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.concurrent.api.Executor;
+
+/**
+ * A factory of {@link OutlierDetector} instances. The factory will be used by load balancer
+ * builders and may make more than one health checker per-load balancer.
+ * @param <ResolvedAddress> the type of the resolved address.
+ */
+// TODO: deprecate this API.
+public interface HealthCheckerFactory<ResolvedAddress> {
+    /**
+     * Create a new {@link OutlierDetector}.
+     * @param executor the {@link Executor} to use for scheduling tasks and obtaining the current time.
+     * @param lbDescription a description of the load balancer for logging purposes.
+     * @return a new {@link OutlierDetector}.
+     */
+    HealthChecker<ResolvedAddress> newHealthChecker(Executor executor, String lbDescription);
+}

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.context.api.ContextMap;
 
+import java.time.Duration;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -62,6 +63,7 @@ import javax.annotation.Nullable;
  * @param <C> The type of connection.
  */
 public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection> {
+
     /**
      * Set the {@code loadBalancingPolicy} to use with this load balancer.
      * @param loadBalancingPolicy the {@code loadBalancingPolicy} to use
@@ -88,6 +90,21 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
      * @see #loadBalancingPolicy(LoadBalancingPolicy)
      */
     LoadBalancerBuilder<ResolvedAddress, C> outlierDetectorConfig(OutlierDetectorConfig outlierDetectorConfig);
+
+    // TODO: note that these are deprecated.
+    LoadBalancerBuilder<ResolvedAddress, C> healthCheckerFactory(HealthCheckerFactory healthCheckerFactory);
+
+    // TODO: note that these are deprecated.
+    LoadBalancerBuilder<ResolvedAddress, C> healthCheckFailedConnectionsThreshold(int threshold);
+
+    // TODO: note that these are deprecated.
+    LoadBalancerBuilder<ResolvedAddress, C> healthCheckInterval(Duration interval, Duration jitter);
+
+    // TODO: note that these are deprecated.
+    LoadBalancerBuilder<ResolvedAddress, C> healthCheckResubscribeInterval(Duration interval, Duration jitter);
+
+    // TODO: note that these are deprecated.
+    LoadBalancerBuilder<ResolvedAddress, C> linearSearchSpace(int searchSpace);
 
     /**
      * Set the {@link ConnectionPoolStrategy} to use with this load balancer.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -24,25 +24,19 @@ import java.util.List;
  * @param <ResolvedAddress> the type of the resolved address
  * @param <C> the type of the load balanced connection
  */
-public abstract class LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection> {
+// TODO: make abstract class and private.
+public interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection> {
 
     /**
      * The default fail-open policy to use for {@link HostSelector} implementations.
      */
-    static final boolean DEFAULT_FAIL_OPEN_POLICY = false;
-
-    LoadBalancingPolicy() {
-        // package private constructor to control proliferation.
-    }
+    boolean DEFAULT_FAIL_OPEN_POLICY = false;
 
     /**
      * The name of the load balancing policy.
      * @return the name of the load balancing policy
      */
-    public abstract String name();
-
-    @Override
-    public abstract String toString();
+    String name();
 
     /**
      * Construct a {@link HostSelector}.
@@ -50,6 +44,6 @@ public abstract class LoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
      * @param targetResource the name of the target resource, useful for debugging purposes.
      * @return a {@link HostSelector}
      */
-    abstract HostSelector<ResolvedAddress, C> buildSelector(
+    HostSelector<ResolvedAddress, C> buildSelector(
             List<Host<ResolvedAddress, C>> hosts, String targetResource);
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -28,11 +28,6 @@ import java.util.List;
 public interface LoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection> {
 
     /**
-     * The default fail-open policy to use for {@link HostSelector} implementations.
-     */
-    boolean DEFAULT_FAIL_OPEN_POLICY = false;
-
-    /**
      * The name of the load balancing policy.
      * @return the name of the load balancing policy
      */

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -193,6 +193,16 @@ public final class OutlierDetectorConfig {
         return failureDetectorInterval;
     }
 
+    // TODO: deprecate this API.
+    public Duration interval() {
+        return failureDetectorInterval();
+    }
+
+    // TODO: deprecate this API.
+    public Duration maxEjectionTimeJitter() {
+        return failureDetectorIntervalJitter();
+    }
+
     /**
      * The base ejection time.
      * The base ejection time is multiplied by the number of consecutive times the host has been ejected to get the
@@ -529,6 +539,16 @@ public final class OutlierDetectorConfig {
             this.failureDetectorInterval = requireNonNull(interval, "interval");
             return failureDetectorInterval(interval, interval.compareTo(DEFAULT_HEALTH_CHECK_INTERVAL) < 0 ?
                     interval.dividedBy(2) : DEFAULT_HEALTH_CHECK_JITTER);
+        }
+
+        // TODO: deprecate this API.
+        public Builder interval(final Duration interval) {
+            return failureDetectorInterval(interval, this.intervalJitter);
+        }
+
+        // TODO: deprecate this API.
+        public Builder maxEjectionTimeJitter(Duration jitter) {
+            return failureDetectorInterval(this.failureDetectorInterval, jitter);
         }
 
         /**

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -75,6 +75,7 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     public static final class Builder {
 
         private static final int DEFAULT_MAX_EFFORT = 5;
+        private static final boolean DEFAULT_FAIL_OPEN_POLICY = false;
 
         private int maxEffort = DEFAULT_MAX_EFFORT;
         private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -40,7 +40,7 @@ import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
  *  *  Choices in Randomized Load Balancing</a>
  */
 public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
-        extends LoadBalancingPolicy<ResolvedAddress, C> {
+        implements LoadBalancingPolicy<ResolvedAddress, C> {
 
     private final int maxEffort;
     private final boolean failOpen;
@@ -54,7 +54,7 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     }
 
     @Override
-    HostSelector<ResolvedAddress, C> buildSelector(
+    public HostSelector<ResolvedAddress, C> buildSelector(
             List<Host<ResolvedAddress, C>> hosts, String targetResource) {
         return new P2CSelector<>(hosts, targetResource, maxEffort, failOpen, random);
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -28,7 +28,7 @@ import java.util.List;
  * @param <C> the type of the load balanced connection
  */
 public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
-        extends LoadBalancingPolicy<ResolvedAddress, C> {
+        implements LoadBalancingPolicy<ResolvedAddress, C> {
 
     private final boolean failOpen;
 
@@ -37,7 +37,7 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
     }
 
     @Override
-    HostSelector<ResolvedAddress, C>
+    public HostSelector<ResolvedAddress, C>
     buildSelector(final List<Host<ResolvedAddress, C>> hosts, final String targetResource) {
         return new RoundRobinSelector<>(hosts, targetResource, failOpen);
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -57,6 +57,8 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
      */
     public static final class Builder {
 
+        private static final boolean DEFAULT_FAIL_OPEN_POLICY = false;
+
         private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;
 
         /**

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthCheckerFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthCheckerFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.concurrent.api.Executor;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A factory of {@link OutlierDetector} instances.
+ * See the {@link OutlierDetector} for a detailed description and history of the xDS protocol.
+ * @param <ResolvedAddress> the type of the resolved address.
+ */
+// TODO: deprecate this API.
+public final class XdsHealthCheckerFactory<ResolvedAddress> implements HealthCheckerFactory<ResolvedAddress> {
+
+    private final OutlierDetectorConfig config;
+
+    public XdsHealthCheckerFactory(final OutlierDetectorConfig config) {
+        this.config = requireNonNull(config, "config");
+    }
+
+    @Override
+    public HealthChecker<ResolvedAddress> newHealthChecker(
+            final Executor executor, String lbDescription) {
+        throw new IllegalStateException("Cannot call newHealthChecker method");
+    }
+
+    OutlierDetectorConfig config() {
+        return config;
+    }
+}

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -197,8 +197,9 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
     private static class TestHealthIndicator implements HealthIndicator<String, TestLoadBalancedConnection> {
 
         private final Set<TestHealthIndicator> indicatorSet;
-        private Host<String, TestLoadBalancedConnection> host;
         final String address;
+        @Nullable
+        private Host<String, TestLoadBalancedConnection> host;
         volatile boolean isHealthy = true;
 
         TestHealthIndicator(final Set<TestHealthIndicator> indicatorSet, final String address) {
@@ -296,7 +297,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
     }
 
-    private static class TestLoadBalancerPolicy extends LoadBalancingPolicy<String, TestLoadBalancedConnection> {
+    private static class TestLoadBalancerPolicy implements LoadBalancingPolicy<String, TestLoadBalancedConnection> {
 
         int rebuilds;
 
@@ -311,7 +312,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         }
 
         @Override
-        HostSelector<String, TestLoadBalancedConnection> buildSelector(
+        public HostSelector<String, TestLoadBalancedConnection> buildSelector(
                 List<Host<String, TestLoadBalancedConnection>> hosts, String targetResource) {
             return new TestSelector(hosts);
         }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -18,6 +18,7 @@ package io.servicetalk.loadbalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.concurrent.api.Executor;
 
+import java.time.Duration;
 import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
@@ -46,6 +47,35 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> connectionPoolConfig(
             ConnectionPoolConfig connectionPoolConfig) {
         throw new IllegalStateException("Cannot set a connection pool strategy for old round robin");
+    }
+
+    @Override
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> healthCheckerFactory(
+            HealthCheckerFactory healthCheckerFactory) {
+        throw new IllegalStateException("Method is deprecated and shouldn't be used.");
+    }
+
+    @Override
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> healthCheckFailedConnectionsThreshold(
+            int threshold) {
+        throw new IllegalStateException("Method is deprecated and shouldn't be used.");
+    }
+
+    @Override
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> healthCheckInterval(
+            Duration interval, Duration jitter) {
+        throw new IllegalStateException("Method is deprecated and shouldn't be used.");
+    }
+
+    @Override
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> healthCheckResubscribeInterval(
+            Duration interval, Duration jitter) {
+        throw new IllegalStateException("Method is deprecated and shouldn't be used.");
+    }
+
+    @Override
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> linearSearchSpace(int searchSpace) {
+        throw new IllegalStateException("Method is deprecated and shouldn't be used.");
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Even though the package is experimental, we need to preserve backwards compatibility for some users.

Modifications:

- Fix the API.
- Mark deprecated methods as deprecated.

## Additional Testing

API compatibility:
```
$ ./gradlew publishToMavenLocal 
$ ./scripts/japicmp.sh 0.42.42 0.42.44-SNAPSHOT
...
Comparing binary compatibility of servicetalk-loadbalancer-experimental-0.42.44-SNAPSHOT.jar against servicetalk-loadbalancer-experimental-0.42.42.jar
No changes.
...
```