### PR TITLE
client-api: Add weight as field on ServiceDiscovererEvent

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultServiceDiscovererEvent.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultServiceDiscovererEvent.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
  */
 public final class DefaultServiceDiscovererEvent<T> implements ServiceDiscovererEvent<T> {
     private final T address;
+    private final double weight;
     private final Status status;
 
     /**
@@ -31,13 +32,32 @@ public final class DefaultServiceDiscovererEvent<T> implements ServiceDiscoverer
      * @param status Value returned by {@link #status()}.
      */
     public DefaultServiceDiscovererEvent(T address, Status status) {
+        this(address, 1.0, status);
+    }
+
+    /**
+     * Create a new instance.
+     * @param address The address returned by {@link #address()}.
+     * @param weight The relative weight of the address.
+     * @param status Value returned by {@link #status()}.
+     */
+    public DefaultServiceDiscovererEvent(T address, double weight, Status status) {
+        if (weight < 0 || Double.isNaN(weight) || !Double.isFinite(weight)) {
+            throw new IllegalArgumentException("Weight value most be a finite positive number: " + weight);
+        }
         this.address = requireNonNull(address);
+        this.weight = weight;
         this.status = requireNonNull(status);
     }
 
     @Override
     public T address() {
         return address;
+    }
+
+    @Override
+    public double weight() {
+        return weight;
     }
 
     @Override

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
@@ -40,6 +40,14 @@ public interface ServiceDiscovererEvent<ResolvedAddress> {
     Status status();
 
     /**
+     * The weight of endpoint.
+     * @return the weight of endpoint.
+     */
+    default double weight() {
+        return 1.0;
+    }
+
+    /**
      * Status provided by the {@link ServiceDiscoverer} system that guides the actions of {@link LoadBalancer} upon the
      * bound {@link ServiceDiscovererEvent#address()} (via {@link ServiceDiscovererEvent}).
      */

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
@@ -79,6 +79,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
 
     private final String lbDescription;
     private final Addr address;
+    private final double weight;
     @Nullable
     private final HealthCheckConfig healthCheckConfig;
     @Nullable
@@ -90,13 +91,14 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     private final ListenableAsyncCloseable closeable;
     private volatile ConnState connState = new ConnState(emptyList(), State.ACTIVE, 0, null);
 
-    DefaultHost(final String lbDescription, final Addr address,
+    DefaultHost(final String lbDescription, final Addr address, final double weight,
                 final ConnectionPoolStrategy<C> connectionPoolStrategy,
                 final ConnectionFactory<Addr, ? extends C> connectionFactory,
                 final HostObserver hostObserver, final @Nullable HealthCheckConfig healthCheckConfig,
                 final @Nullable HealthIndicator healthIndicator) {
         this.lbDescription = requireNonNull(lbDescription, "lbDescription");
         this.address = requireNonNull(address, "address");
+        this.weight = weight;
         this.healthIndicator = healthIndicator;
         this.connectionPoolStrategy = requireNonNull(connectionPoolStrategy, "connectionPoolStrategy");
         requireNonNull(connectionFactory, "connectionFactory");
@@ -111,6 +113,11 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     @Override
     public Addr address() {
         return address;
+    }
+
+    @Override
+    public double weight() {
+        return weight;
     }
 
     @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -309,7 +309,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                     } else {
                         // It's a new host, so the set changed.
                         hostSetChanged = true;
-                        nextHosts.add(createHost(event.address()));
+                        nextHosts.add(createHost(event.address(), event.weight()));
                     }
                 } else if (EXPIRED.equals(event.status())) {
                     if (!host.markExpired()) {
@@ -336,7 +336,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                 if (AVAILABLE.equals(event.status())) {
                     sendReadyEvent = true;
                     hostSetChanged = true;
-                    nextHosts.add(createHost(event.address()));
+                    nextHosts.add(createHost(event.address(), event.weight()));
                 }
             }
 
@@ -380,7 +380,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             }
         }
 
-        private Host<ResolvedAddress, C> createHost(ResolvedAddress addr) {
+        private Host<ResolvedAddress, C> createHost(ResolvedAddress addr, double weight) {
             final LoadBalancerObserver.HostObserver hostObserver = loadBalancerObserver.hostObserver(addr);
             // All hosts will share the health check config of the parent load balancer.
             final HealthIndicator indicator = outlierDetector.newHealthIndicator(addr, hostObserver);
@@ -388,7 +388,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             // failed connect threshold is negative, meaning disabled.
             final HealthCheckConfig hostHealthCheckConfig =
                     healthCheckConfig == null || healthCheckConfig.failedThreshold < 0 ? null : healthCheckConfig;
-            final Host<ResolvedAddress, C> host = new DefaultHost<>(lbDescription, addr, connectionPoolStrategy,
+            final Host<ResolvedAddress, C> host = new DefaultHost<>(lbDescription, addr, weight, connectionPoolStrategy,
                     connectionFactory, hostObserver, hostHealthCheckConfig, indicator);
             if (indicator != null) {
                 indicator.setHost(host);

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/Host.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/Host.java
@@ -51,6 +51,8 @@ interface Host<ResolvedAddress, C extends LoadBalancedConnection> extends Listen
      */
     ResolvedAddress address();
 
+    double weight();
+
     /**
      * Determine the health status of this host.
      * @return whether the host considers itself healthy enough to serve traffic. This is best effort and does not


### PR DESCRIPTION
See #2902 for a counter proposal using a map like abstraction.

Motivation:

We're trying out a couple API's that let us add additional metadata to the endpoints provided by ServiceDiscoverer.

Modifications:

This example makes the weight metadata a first class concept on the ServiceDiscovererEvent interface.

I think there are some pros and cons

Pros:
- It's clean.
- It's very clear what the data is and where it comes from.

Cons:
- Everything that needs to be passed through must become a field.
- Right now the protocol defines three key parts: (address, status, metadata) where metadata is 'everything else'. Making meta-data first class fields muddies the waters a bit.
- Changing the meta-data requires making a proxy class and that will rely on all underlying proxies to forward correct data, eg not use the default.