### PR TITLE
client-api: add an exmaple of how to use the ServiceDiscoverer API

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscoverer.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscoverer.java
@@ -24,7 +24,9 @@ import java.util.Collection;
 /**
  * Represents the interaction pattern with a service discovery system. It is assumed that once {@link #discover(Object)}
  * is called that the service discovery system will push data updates or implementations of this interface will poll for
- * data updates. Changes in the available hosts will be communicated via the resulting {@link Publisher}.
+ * data updates. Changes in the available addresses will be communicated via the resulting {@link Publisher}.
+ * <p>
+ * See {@link ServiceDiscovererEvent} for documentation regarding the interpretation of events.
  *
  * @param <UnresolvedAddress> The type of address before resolution.
  * @param <ResolvedAddress> The type of address after resolution.
@@ -37,9 +39,8 @@ public interface ServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
      * {@code address}.
      * <p>
      * In general a call to this method will continue to discover changes related to {@code address} until the
-     * {@link Subscription}
-     * corresponding to the return value is cancelled via {@link Subscription#cancel()} or there are no more changes to
-     * publish.
+     * {@link Subscription} corresponding to the return value is cancelled via {@link Subscription#cancel()} or there
+     * are no more changes to publish.
      * @param address the service address to discover. Examples of what this address maybe are:
      * <ul>
      * <li>hostname/port (e.g. InetAddress)</li>

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscoverer.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscoverer.java
@@ -40,7 +40,7 @@ public interface ServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
      * <p>
      * In general a call to this method will continue to discover changes related to {@code address} until the
      * {@link Subscription} corresponding to the return value is cancelled via {@link Subscription#cancel()} or there
-     * are no more changes to publish.
+     * are no more changes to be published.
      * @param address the service address to discover. Examples of what this address maybe are:
      * <ul>
      * <li>hostname/port (e.g. InetAddress)</li>

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
@@ -19,15 +19,40 @@ import java.util.Locale;
 
 /**
  * Notification from the Service Discovery system that availability for an address has changed.
+ * <p>
+ * Interpreting Events
+ * <ul>
+ *     <li>When subscribing (or re-subscribing to recovery from faults) to an event stream the initial state is
+ *         considered to be an empty set and the first events received will represent the current state of the world.
+ *         </li>
+ *     <li>Each event represents the current state of the {@link ResolvedAddress} overriding any previously known
+ *         {@link Status} and any associated meta-data.</li>
+ * </ul>
+ * <p>
+ * Example
+ * <p>
+ * We can represent a {@link ServiceDiscovererEvent} as map entries of the form
+ * ({@link ResolvedAddress}, ({@link Status}, meta-data)) where the {@link ResolvedAddress} is the map key.
+ * <pre>
+ * Starting with the initial state of {addr1, (AVAILABLE, meta-1)}. Upon subscribing to the event stream the initial
+ * state is populated via the event (addr1, (AVAILABLE, meta-1)).
+ *
+ * Say the meta-data for address changes resulting in a system state {addr1, (AVAILABLE, meta-2)}. The state change is
+ * be represented by the event (addr1, (AVAILABLE, meta-2)).
+ *
+ * Next the address is removed from the system resulting in the empty state {}. It is up to the
+ * {@link ServiceDiscoverer} whether this will be represented by the {@link Status#UNAVAILABLE} or
+ * {@link Status#EXPIRED} but both are logically equivalent to removal, only with different meanings for how
+ * resources already acquired to the address should be used. Picking UNAVAILABLE, the transition back to the empty state
+ * would be represented by the event (addr1, (UNAVAILABLE, meta-2)).
+ * </pre>
+ * See {@link ServiceDiscoverer} for the interface that defines the source of event streams.
+ *
  * @param <ResolvedAddress> the type of address after resolution.
  */
 public interface ServiceDiscovererEvent<ResolvedAddress> {
     /**
      * Get the resolved address which is the subject of this event.
-     * <p>
-     * Note: all subsequent events for the same address override its {@link #status()} or any additional meta-data
-     * associated with the address.
-     *
      * @return a resolved address that can be used for connecting.
      */
     ResolvedAddress address();

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
@@ -22,9 +22,8 @@ import java.util.Locale;
  * <p>
  * Interpreting Events
  * <ul>
- *     <li>When subscribing (or re-subscribing to recovery from faults) to an event stream the initial state is
- *         considered to be an empty set and the first events received will represent the current state of the world.
- *         </li>
+ *     <li>When subscribing (or re-subscribing to recovery from faults) to an event stream the initial collection of
+ *         events is considered to be the current state of the world.</li>
  *     <li>Each event represents the current state of the {@link ResolvedAddress} overriding any previously known
  *         {@link Status} and any associated meta-data.</li>
  * </ul>
@@ -40,7 +39,7 @@ import java.util.Locale;
  * Say the meta-data for address changes resulting in a system state {addr1, (AVAILABLE, meta-2)}. The state change is
  * be represented by the event (addr1, (AVAILABLE, meta-2)).
  *
- * Next the address is removed from the system resulting in the empty state {}. It is up to the
+ * Next the address is removed from the system resulting in an empty state {}. It is up to the
  * {@link ServiceDiscoverer} whether this will be represented by the {@link Status#UNAVAILABLE} or
  * {@link Status#EXPIRED} but both are logically equivalent to removal, only with different meanings for how
  * resources already acquired to the address should be used. Picking UNAVAILABLE, the transition back to the empty state


### PR DESCRIPTION
Motivation:

The ServiceDiscoverer API and the interpretation of the events is a little tough to find.

Modifications:

- Move the api interpretation to a more prominent place.
- Add some cross references.
- Add an example.

Result:

What is the result of this change?