### PR TITLE
`DnsServiceDiscoverer`: add total resolution timeout

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -437,11 +437,9 @@ final class DefaultDnsClient implements DnsClient {
                     final Future<List<DnsRecord>> resolveFuture =
                             resolver.resolveAll(new DefaultDnsQuestion(name, SRV));
                     final Future<?> timeoutFuture = resolutionTimeoutMillis == 0L ? null : eventLoop.schedule(() -> {
-                        if (promise.isDone()) {
-                            return;
-                        }
-                        if (promise.tryFailure(DnsNameResolverTimeoutException.newInstance(name,
-                                resolutionTimeoutMillis, SRV.toString(), SrvRecordPublisher.class, "doDnsQuery"))) {
+                        if (!promise.isDone() && promise.tryFailure(DnsNameResolverTimeoutException.newInstance(
+                                name, resolutionTimeoutMillis, SRV.toString(),
+                                SrvRecordPublisher.class, "doDnsQuery"))) {
                             resolveFuture.cancel(true);
                         }
                     }, resolutionTimeoutMillis, MILLISECONDS);
@@ -527,12 +525,9 @@ final class DefaultDnsClient implements DnsClient {
                     final Promise<DnsAnswer<InetAddress>> dnsAnswerPromise = eventLoop.newPromise();
                     final Future<List<InetAddress>> resolveFuture = resolver.resolveAll(name);
                     final Future<?> timeoutFuture = resolutionTimeoutMillis == 0L ? null : eventLoop.schedule(() -> {
-                        if (dnsAnswerPromise.isDone()) {
-                            return;
-                        }
-                        if (dnsAnswerPromise.tryFailure(DnsNameResolverTimeoutException.newInstance(
-                                name, resolutionTimeoutMillis, toRecordTypeNames(addressTypes),
-                                ARecordPublisher.class, "doDnsQuery"))) {
+                        if (!dnsAnswerPromise.isDone() && dnsAnswerPromise.tryFailure(
+                                DnsNameResolverTimeoutException.newInstance(name, resolutionTimeoutMillis,
+                                        toRecordTypeNames(addressTypes), ARecordPublisher.class, "doDnsQuery"))) {
                             resolveFuture.cancel(true);
                         }
                     }, resolutionTimeoutMillis, MILLISECONDS);

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DelegatingDnsServiceDiscovererBuilder.java
@@ -117,8 +117,14 @@ public class DelegatingDnsServiceDiscovererBuilder implements DnsServiceDiscover
     }
 
     @Override
-    public DnsServiceDiscovererBuilder queryTimeout(final Duration queryTimeout) {
+    public DnsServiceDiscovererBuilder queryTimeout(final @Nullable Duration queryTimeout) {
         delegate = delegate.queryTimeout(queryTimeout);
+        return this;
+    }
+
+    @Override
+    public DnsServiceDiscovererBuilder resolutionTimeout(final @Nullable Duration resolutionTimeout) {
+        delegate = delegate.resolutionTimeout(resolutionTimeout);
         return this;
     }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsNameResolverTimeoutException.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsNameResolverTimeoutException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import io.servicetalk.concurrent.internal.ThrowableUtils;
+
+import java.net.UnknownHostException;
+
+final class DnsNameResolverTimeoutException extends UnknownHostException {
+    private static final long serialVersionUID = 3089160074512305891L;
+
+    private DnsNameResolverTimeoutException(final String name, final String recordType, final long timeoutMs) {
+        super("Resolution for '" + name + "' [" + recordType + "] timed out after " + timeoutMs + " milliseconds");
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+
+    static DnsNameResolverTimeoutException newInstance(final String name, final long timeoutMs, final String recordType,
+                                                       final Class<?> clazz, final String method) {
+        return ThrowableUtils.unknownStackTrace(new DnsNameResolverTimeoutException(name, recordType, timeoutMs),
+                clazz, method);
+    }
+}

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsResolverAddressTypes.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsResolverAddressTypes.java
@@ -16,6 +16,7 @@
 package io.servicetalk.dns.discovery.netty;
 
 import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.resolver.ResolvedAddressTypes;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 
@@ -51,6 +52,9 @@ public enum DnsResolverAddressTypes {
      * Failure to resolve IPv4 won't result in an error.
      */
     IPV6_PREFERRED_RETURN_ALL;
+
+    private static final String A_AAAA_STRING = DnsRecordType.A + ", " + DnsRecordType.AAAA;
+    private static final String AAAA_A_STRING = DnsRecordType.AAAA + ", " + DnsRecordType.A;
 
     /**
      * The default value, based on "java.net" system properties: {@code java.net.preferIPv4Stack} and
@@ -107,6 +111,24 @@ public enum DnsResolverAddressTypes {
             default:
                 throw new IllegalArgumentException("Unknown value for " + ResolvedAddressTypes.class.getName() +
                         ": " + resolvedAddressTypes);
+        }
+    }
+
+    static String toRecordTypeNames(DnsResolverAddressTypes dnsResolverAddressType) {
+        switch (dnsResolverAddressType) {
+            case IPV4_ONLY:
+                return DnsRecordType.A.toString();
+            case IPV6_ONLY:
+                return DnsRecordType.AAAA.toString();
+            case IPV4_PREFERRED:
+            case IPV4_PREFERRED_RETURN_ALL:
+                return A_AAAA_STRING;
+            case IPV6_PREFERRED:
+            case IPV6_PREFERRED_RETURN_ALL:
+                return AAAA_A_STRING;
+            default:
+                throw new IllegalArgumentException("Unknown value for " + DnsResolverAddressTypes.class.getName() +
+                        ": " + dnsResolverAddressType);
         }
     }
 }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
@@ -41,8 +41,8 @@ public interface DnsServiceDiscovererBuilder {
      * @return {@code this}.
      */
     default DnsServiceDiscovererBuilder consolidateCacheSize(int consolidateCacheSize) {
-        throw new UnsupportedOperationException("DnsServiceDiscovererBuilder#consolidateCacheSize(int) is not " +
-                "supported by " + getClass());
+        throw new UnsupportedOperationException(
+                "DnsServiceDiscovererBuilder#consolidateCacheSize(int) is not supported by " + getClass());
     }
 
     /**
@@ -123,8 +123,8 @@ public interface DnsServiceDiscovererBuilder {
      */
     default DnsServiceDiscovererBuilder ttl(int minSeconds, int maxSeconds, int minCacheSeconds, int maxCacheSeconds,
                                             int negativeCacheSeconds) {
-        throw new UnsupportedOperationException("DnsServiceDiscovererBuilder#ttl(int, int, int, int, int) is not " +
-                "supported by " + getClass());
+        throw new UnsupportedOperationException(
+                "DnsServiceDiscovererBuilder#ttl(int, int, int, int, int) is not supported by " + getClass());
     }
 
     /**
@@ -146,8 +146,8 @@ public interface DnsServiceDiscovererBuilder {
      * @return {@code this}.
      */
     default DnsServiceDiscovererBuilder localAddress(@Nullable SocketAddress localAddress) {
-        throw new UnsupportedOperationException("DnsServiceDiscovererBuilder#localAddress(SocketAddress) is not " +
-                "supported by " + getClass());
+        throw new UnsupportedOperationException(
+                "DnsServiceDiscovererBuilder#localAddress(SocketAddress) is not supported by " + getClass());
     }
 
     /**
@@ -182,6 +182,8 @@ public interface DnsServiceDiscovererBuilder {
 
     /**
      * Set the number of dots which must appear in a name before an initial absolute query is made.
+     * <p>
+     * If not set, the default value is read from {@code ndots} option of {@code /etc/resolv.conf}).
      *
      * @param ndots the ndots value.
      * @return {@code this}.
@@ -189,12 +191,37 @@ public interface DnsServiceDiscovererBuilder {
     DnsServiceDiscovererBuilder ndots(int ndots);
 
     /**
-     * Sets the timeout of each DNS query performed by this service discoverer.
+     * Sets the timeout of each DNS query performed by this service discoverer as part of a resolution request.
+     * <p>
+     * Zero ({@code 0}) disables the timeout. If not set, the default value is read from {@code timeout} option of
+     * {@code /etc/resolv.conf}). Similar to linux systems, this value may be silently capped.
      *
      * @param queryTimeout the query timeout value
-     * @return {@code this}.
+     * @return {@code this}
+     * @see #resolutionTimeout(Duration)
      */
-    DnsServiceDiscovererBuilder queryTimeout(Duration queryTimeout);
+    DnsServiceDiscovererBuilder queryTimeout(@Nullable Duration queryTimeout);
+
+    /**
+     * Sets the total timeout of each DNS resolution performed by this service discoverer.
+     * <p>
+     * Each resolution may execute one or more DNS queries, like following multiple CNAME(s) or trying different search
+     * domains. This is the total timeout for all intermediate queries involved in a single resolution request. Note,
+     * that <a href="https://tools.ietf.org/html/rfc2782">SRV</a> resolutions may generate independent resolutions for
+     * {@code A/AAAA} records. In this case, this timeout will be applied to an {@code SRV} resolution and each
+     * {@code A/AAAA} resolution independently.
+     * <p>
+     * Zero ({@code 0}) disables the timeout. If not set, it defaults to {@link #queryTimeout(Duration) query timeout}
+     * value multiplied by {@code 2}.
+     *
+     * @param resolutionTimeout the query timeout value
+     * @return {@code this}
+     * @see #queryTimeout(Duration)
+     */
+    default DnsServiceDiscovererBuilder resolutionTimeout(@Nullable Duration resolutionTimeout) {
+        throw new UnsupportedOperationException(
+                "DnsServiceDiscovererBuilder#resolutionTimeout(Duration) is not supported by " + getClass());
+    }
 
     /**
      * Sets the list of the protocol families of the address resolved.

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/TestRecordStore.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/TestRecordStore.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import javax.annotation.Nullable;
 
 import static java.util.Collections.emptySet;
@@ -47,6 +48,9 @@ final class TestRecordStore implements RecordStore {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestRecordStore.class);
     private static final int SRV_DEFAULT_WEIGHT = 10;
     private static final int SRV_DEFAULT_PRIORITY = 10;
+
+    private final Set<ServFail> failSet = new HashSet<>();
+    private final Map<QuestionRecord, CountDownLatch> timeouts = new ConcurrentHashMap<>();
     private final Map<String, Map<RecordType, List<ResourceRecord>>> recordsToReturnByDomain =
             new ConcurrentHashMap<>();
 
@@ -89,14 +93,23 @@ final class TestRecordStore implements RecordStore {
         }
     }
 
-    private final Set<ServFail> failSet = new HashSet<>();
-
     public synchronized void addFail(final ServFail fail) {
         failSet.add(fail);
     }
 
     public synchronized void removeFail(final ServFail fail) {
         failSet.remove(fail);
+    }
+
+    public void addTimeout(final String domain, final RecordType recordType) {
+        timeouts.put(new QuestionRecord(domain, recordType, RecordClass.IN), new CountDownLatch(1));
+    }
+
+    public void removeTimeout(final String domain, final RecordType recordType) {
+        CountDownLatch latch = timeouts.remove(new QuestionRecord(domain, recordType, RecordClass.IN));
+        if (latch != null) {
+            latch.countDown();
+        }
     }
 
     public synchronized void addSrv(final String domain, String targetDomain, final int port, final int ttl) {
@@ -218,9 +231,19 @@ final class TestRecordStore implements RecordStore {
         return removed;
     }
 
-    @Nullable
     @Override
     public synchronized Set<ResourceRecord> getRecords(final QuestionRecord questionRecord) throws DnsException {
+        final CountDownLatch timeoutLatch = timeouts.get(questionRecord);
+        if (timeoutLatch != null && timeoutLatch.getCount() > 0) {
+            LOGGER.debug("Holding a thread to generate a timeout for {}", questionRecord);
+            try {
+                timeoutLatch.await();
+            } catch (InterruptedException e) {
+                DnsException dnsException = new DnsException(SERVER_FAILURE);
+                dnsException.initCause(e);
+                throw dnsException;
+            }
+        }
         final String domain = questionRecord.getDomainName();
         if (failSet.contains(ServFail.of(questionRecord))) {
             throw new DnsException(SERVER_FAILURE);


### PR DESCRIPTION
Motivation:

The existing `DnsServiceDiscovererBuilder.queryTimeout` is applied per each UDP/TCP query. If resolution requires multiple CNAME resolutions, retries on a different NS server, or applies a list of search domains, the total time is not capped. As a result, resolution can take significantly longer than originally anticipated.

Modifications:

- Add `DnsServiceDiscovererBuilder.resolutionTimeout` option that can be used to cap total resolution duration with default value set to `2 x queryTimeout`;
- Add tests for `queryTimeout` and `resolutionTimeout`;

Result:

Users can configure the total resolution timeout.