### PR TITLE
loadbalancer-experimental: add support for weights in round robin

### DIFF
--- a/servicetalk-loadbalancer-experimental/license/LICENSE.grpc-java.txt
+++ b/servicetalk-loadbalancer-experimental/license/LICENSE.grpc-java.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -30,6 +30,8 @@ import static java.util.Objects.requireNonNull;
 abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnection>
         implements HostSelector<ResolvedAddress, C> {
 
+    private static final double ACCEPTABLE_PERCENT_ERROR = 0.01;
+
     private final String targetResource;
     private final List<? extends Host<ResolvedAddress, C>> hosts;
     BaseHostSelector(final List<? extends Host<ResolvedAddress, C>> hosts, final String targetResource) {
@@ -93,6 +95,18 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
         return failed(Exceptions.StacklessNoAvailableHostException.newInstance(
                 "No hosts are available to connect for " + targetResource + ".",
                 this.getClass(), "selectConnection(...)"));
+    }
+
+    static boolean approxEqual(double a, double b) {
+        return Math.abs(a - b) < ACCEPTABLE_PERCENT_ERROR;
+    }
+
+    static boolean isNormalized(double[] probabilities) {
+        double ptotal = 0;
+        for (double p : probabilities) {
+            ptotal += p;
+        }
+        return approxEqual(ptotal, 1);
     }
 
     private static <ResolvedAddress, C extends LoadBalancedConnection> boolean anyHealthy(

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
@@ -29,8 +29,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
-import static java.lang.Math.abs;
-
 /**
  * This {@link LoadBalancer} selection algorithm is based on work by Michael David Mitzenmacher in The Power of Two
  * Choices in Randomized Load Balancing.
@@ -42,8 +40,6 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
         extends BaseHostSelector<ResolvedAddress, C> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(P2CSelector.class);
-
-    private static final double ACCEPTABLE_PERCENT_ERROR = 0.01;
     private static final EntrySelector EMPTY_SELECTOR = new EqualWeightEntrySelector(0);
 
     @Nullable
@@ -318,17 +314,5 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
             pout[large[--l]] = 1;
         }
         return new AliasTableEntrySelector(pout, aliases);
-    }
-
-    private static boolean approxEqual(double a, double b) {
-        return abs(a - b) < ACCEPTABLE_PERCENT_ERROR;
-    }
-
-    private static boolean isNormalized(double[] probabilities) {
-        double ptotal = 0;
-        for (double p : probabilities) {
-            ptotal += p;
-        }
-        return approxEqual(ptotal, 1);
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023, 2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023, 2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023-2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinSelectorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinSelectorTest.java
@@ -29,9 +29,10 @@ import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.loadbalancer.SelectorTestHelpers.PREDICATE;
-import static io.servicetalk.loadbalancer.SelectorTestHelpers.connections;
+import static io.servicetalk.loadbalancer.SelectorTestHelpers.generateHosts;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -50,12 +51,12 @@ class RoundRobinSelectorTest {
     }
 
     void init(List<Host<String, TestLoadBalancedConnection>> hosts) {
-        selector = new RoundRobinSelector<>(hosts, "testResource", failOpen);
+        selector = new RoundRobinSelector<>(hosts, "testResource", failOpen, false);
     }
 
     @Test
     void roundRobining() throws Exception {
-        List<Host<String, TestLoadBalancedConnection>> hosts = connections("addr-1", "addr-2");
+        List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts("addr-1", "addr-2");
         init(hosts);
         List<String> addresses = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
@@ -67,8 +68,84 @@ class RoundRobinSelectorTest {
     }
 
     @Test
+    void roundRobiningWithUnequalWeights() throws Exception {
+        List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts("addr-1", "addr-2", "addr-3");
+        when(hosts.get(0).weight()).thenReturn(1.0);
+        when(hosts.get(1).weight()).thenReturn(2.0);
+        when(hosts.get(2).weight()).thenReturn(3.0);
+        init(hosts);
+        List<String> addresses = new ArrayList<>();
+        for (int i = 0; i < 18; i++) {
+            TestLoadBalancedConnection connection = selector.selectConnection(
+                    PREDICATE, null, true).toFuture().get();
+            addresses.add(connection.address());
+        }
+
+        assertThat(addresses.stream().filter("addr-1"::equals).count(), equalTo(3l));
+        assertThat(addresses.stream().filter("addr-2"::equals).count(), equalTo(6l));
+        assertThat(addresses.stream().filter("addr-3"::equals).count(), equalTo(9l));
+
+        // The stream of selections should be should be
+        // addr-1, addr-2, addr-3
+        // F       T       T
+        // F       F       T
+        // T       T       T
+        // F       T       T <- starting repetition
+        // ...
+        assertThat(addresses, contains(
+                "addr-2", "addr-3", "addr-3",
+                "addr-1", "addr-2", "addr-3",
+                "addr-2", "addr-3", "addr-3",
+                "addr-1", "addr-2", "addr-3",
+                "addr-2", "addr-3", "addr-3",
+                "addr-1", "addr-2", "addr-3"));
+    }
+
+    @Test
+    void unequalWeightsWithATrueZeroWeight() throws Exception {
+        List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts("addr-1", "addr-2");
+        when(hosts.get(0).weight()).thenReturn(0.0);
+        when(hosts.get(1).weight()).thenReturn(1.0);
+        init(hosts);
+        int[] counts = new int[2];
+        for (int i = 0; i < 0xffff + 1; i++) {
+            TestLoadBalancedConnection connection = selector.selectConnection(
+                    PREDICATE, null, true).toFuture().get();
+            if ("addr-1".equals(connection.address())) {
+                counts[0]++;
+            } else {
+                counts[1]++;
+            }
+        }
+
+        assertThat(counts[0], equalTo(0));
+        assertThat(counts[1], equalTo(0xffff + 1));
+    }
+
+    @Test
+    void unequalWeightsWithNearWeight() throws Exception {
+        List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts("addr-1", "addr-2");
+        when(hosts.get(0).weight()).thenReturn(1d / (0xffff * 7));
+        when(hosts.get(1).weight()).thenReturn(1.0);
+        init(hosts);
+        int[] counts = new int[2];
+        for (int i = 0; i < 0xffff + 1; i++) {
+            TestLoadBalancedConnection connection = selector.selectConnection(
+                    PREDICATE, null, true).toFuture().get();
+            if ("addr-1".equals(connection.address())) {
+                counts[0]++;
+            } else {
+                counts[1]++;
+            }
+        }
+
+        assertThat(counts[0], equalTo(1));
+        assertThat(counts[1], equalTo(0xffff));
+    }
+
+    @Test
     void skipUnhealthyHosts() throws Exception {
-        List<Host<String, TestLoadBalancedConnection>> hosts = connections("addr-1", "addr-2");
+        List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts("addr-1", "addr-2");
         when(hosts.get(0).isHealthy()).thenReturn(false);
         init(hosts);
         List<String> addresses = new ArrayList<>();
@@ -83,7 +160,7 @@ class RoundRobinSelectorTest {
     @ParameterizedTest(name = "{displayName} [{index}]: failOpen={0}")
     @ValueSource(booleans = {false, true})
     void noHealthyHosts(boolean failOpen) throws Exception {
-        List<Host<String, TestLoadBalancedConnection>> hosts = connections("addr-1");
+        List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts("addr-1");
         when(hosts.get(0).isHealthy()).thenReturn(false);
         this.failOpen = failOpen;
         init(hosts);
@@ -105,7 +182,7 @@ class RoundRobinSelectorTest {
     @ParameterizedTest(name = "{displayName} [{index}]: unhealthy={0} failOpen={1}")
     @CsvSource({"true,true", "true,false", "false,true", "false,false"})
     void singleInactiveHostWithoutConnections(boolean unhealthy, boolean failOpen) {
-        List<Host<String, TestLoadBalancedConnection>> hosts = connections("addr-1");
+        List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts("addr-1");
         when(hosts.get(0).canMakeNewConnections()).thenReturn(false);
         when(hosts.get(0).pickConnection(PREDICATE, null)).thenReturn(null);
         this.failOpen = failOpen;

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinSelectorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinSelectorTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.loadbalancer.SelectorTestHelpers.PREDICATE;
-import static io.servicetalk.loadbalancer.SelectorTestHelpers.generateHosts;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -69,7 +68,8 @@ class RoundRobinSelectorTest {
 
     @Test
     void roundRobiningWithUnequalWeights() throws Exception {
-        List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts("addr-1", "addr-2", "addr-3");
+        List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts(
+                "addr-1", "addr-2", "addr-3");
         when(hosts.get(0).weight()).thenReturn(1.0);
         when(hosts.get(1).weight()).thenReturn(2.0);
         when(hosts.get(2).weight()).thenReturn(3.0);
@@ -81,9 +81,9 @@ class RoundRobinSelectorTest {
             addresses.add(connection.address());
         }
 
-        assertThat(addresses.stream().filter("addr-1"::equals).count(), equalTo(3l));
-        assertThat(addresses.stream().filter("addr-2"::equals).count(), equalTo(6l));
-        assertThat(addresses.stream().filter("addr-3"::equals).count(), equalTo(9l));
+        assertThat(addresses.stream().filter("addr-1"::equals).count(), equalTo(3L));
+        assertThat(addresses.stream().filter("addr-2"::equals).count(), equalTo(6L));
+        assertThat(addresses.stream().filter("addr-3"::equals).count(), equalTo(9L));
 
         // The stream of selections should be should be
         // addr-1, addr-2, addr-3

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/SelectorTestHelpers.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/SelectorTestHelpers.java
@@ -34,19 +34,19 @@ final class SelectorTestHelpers {
     private SelectorTestHelpers() {
     }
 
-    static List<Host<String, TestLoadBalancedConnection>> connections(int count) {
+    static List<Host<String, TestLoadBalancedConnection>> generateHosts(int count) {
         String[] addresses = new String[count];
         for (int i = 0; i < count; i++) {
             addresses[i] = "address-" + i;
         }
-        return connections(addresses);
+        return generateHosts(addresses);
     }
 
-    static List<Host<String, TestLoadBalancedConnection>> connections(String... addresses) {
-        return connections(true, addresses);
+    static List<Host<String, TestLoadBalancedConnection>> generateHosts(String... addresses) {
+        return generateHosts(true, addresses);
     }
 
-    static List<Host<String, TestLoadBalancedConnection>> connections(boolean equalWeights, String... addresses) {
+    static List<Host<String, TestLoadBalancedConnection>> generateHosts(boolean equalWeights, String... addresses) {
         final List<Host<String, TestLoadBalancedConnection>> results = new ArrayList<>(addresses.length);
         for (String addr : addresses) {
             Host<String, TestLoadBalancedConnection> host = mockHost(addr,


### PR DESCRIPTION
Motivation:

We want to support weighted but don't in the round-robin
HostSelector.

Modifications:

Add weight support to round-robin using the static stride
algorithm common to the grpc libraries.