### PR TITLE
Move DefaultHttpLoadBalancerFactory to http-api

### DIFF
--- a/servicetalk-examples/http/defaultloadbalancer/src/main/java/io/servicetalk/examples/http/defaultloadbalancer/DefaultLoadBalancerClient.java
+++ b/servicetalk-examples/http/defaultloadbalancer/src/main/java/io/servicetalk/examples/http/defaultloadbalancer/DefaultLoadBalancerClient.java
@@ -37,8 +37,8 @@ public final class DefaultLoadBalancerClient {
     public static void main(String[] args) throws Exception {
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
                 HttpClients.forSingleAddress("localhost", 8080)
-                .loadBalancerFactory(DefaultHttpLoadBalancerFactory.Builder.from(
-                        loadBalancer("localhost-defaultloadbalancer")).build());
+                .loadBalancerFactory(new DefaultHttpLoadBalancerFactory<>(
+                        loadBalancer("localhost-defaultloadbalancer")));
         try (BlockingHttpClient client = builder.buildBlocking()) {
             HttpResponse response = client.request(client.get("/sayHello"));
             System.out.println(response.toString((name, value) -> value));

--- a/servicetalk-examples/http/defaultloadbalancer/src/main/java/io/servicetalk/examples/http/defaultloadbalancer/DefaultLoadBalancerClient.java
+++ b/servicetalk-examples/http/defaultloadbalancer/src/main/java/io/servicetalk/examples/http/defaultloadbalancer/DefaultLoadBalancerClient.java
@@ -17,10 +17,10 @@ package io.servicetalk.examples.http.defaultloadbalancer;
 
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.DefaultHttpLoadBalancerFactory;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
-import io.servicetalk.http.netty.DefaultHttpLoadBalancerFactory;
 import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.loadbalancer.LoadBalancers;
 import io.servicetalk.loadbalancer.OutlierDetectorConfig;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
+package io.servicetalk.http.api;
 
 import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.LoadBalancer;
@@ -25,18 +25,6 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.context.api.ContextMap;
-import io.servicetalk.http.api.FilterableStreamingHttpConnection;
-import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
-import io.servicetalk.http.api.HttpConnectionContext;
-import io.servicetalk.http.api.HttpEventKey;
-import io.servicetalk.http.api.HttpExecutionContext;
-import io.servicetalk.http.api.HttpExecutionStrategy;
-import io.servicetalk.http.api.HttpLoadBalancerFactory;
-import io.servicetalk.http.api.HttpRequestMethod;
-import io.servicetalk.http.api.StreamingHttpRequest;
-import io.servicetalk.http.api.StreamingHttpResponse;
-import io.servicetalk.http.api.StreamingHttpResponseFactory;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancers;
 
 import java.util.Collection;
 import javax.annotation.Nullable;
@@ -47,9 +35,7 @@ import static java.util.Objects.requireNonNull;
  * Default implementation of {@link HttpLoadBalancerFactory}.
  *
  * @param <ResolvedAddress> The type of address after resolution.
- * @deprecated use {@link io.servicetalk.http.api.DefaultHttpLoadBalancerFactory} instead.
  */
-@Deprecated // FIXME: 0.43 - remove deprecated class
 public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
         implements HttpLoadBalancerFactory<ResolvedAddress> {
     private final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory;
@@ -121,21 +107,8 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
          *
          * @return A {@link DefaultHttpLoadBalancerFactory}.
          */
-        public HttpLoadBalancerFactory<ResolvedAddress> build() {
+        public DefaultHttpLoadBalancerFactory<ResolvedAddress> build() {
             return new DefaultHttpLoadBalancerFactory<>(rawFactory, strategy);
-        }
-
-        /**
-         * Creates a new {@link Builder} instance using the default {@link LoadBalancer} implementation.
-         *
-         * @param <ResolvedAddress> The type of address after resolution for the {@link LoadBalancerFactory} built by
-         * the returned builder.
-         * @return A new {@link Builder}.
-         */
-        public static <ResolvedAddress> Builder<ResolvedAddress> fromDefaults() {
-            return from(RoundRobinLoadBalancers
-                    .<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection>builder(
-                            DefaultHttpLoadBalancerFactory.class.getSimpleName()).build());
         }
 
         /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,11 +103,11 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
         }
 
         /**
-         * Builds a {@link DefaultHttpLoadBalancerFactory} using the properties configured on this builder.
+         * Builds a {@link HttpLoadBalancerFactory} using the properties configured on this builder.
          *
-         * @return A {@link DefaultHttpLoadBalancerFactory}.
+         * @return A {@link HttpLoadBalancerFactory}.
          */
-        public DefaultHttpLoadBalancerFactory<ResolvedAddress> build() {
+        public HttpLoadBalancerFactory<ResolvedAddress> build() {
             return new DefaultHttpLoadBalancerFactory<>(rawFactory, strategy);
         }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
@@ -41,11 +41,15 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
     private final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory;
     private final HttpExecutionStrategy strategy;
 
-    DefaultHttpLoadBalancerFactory(
-            final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory,
-            final HttpExecutionStrategy strategy) {
+    /**
+     * Creates a new instance with execution strategy adapted from the underlying factory.
+     *
+     * @param rawFactory {@link LoadBalancerFactory} to use
+     */
+    public DefaultHttpLoadBalancerFactory(
+            final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory) {
         this.rawFactory = rawFactory;
-        this.strategy = strategy;
+        this.strategy = HttpExecutionStrategy.from(rawFactory.requiredOffloads());
     }
 
     @SuppressWarnings("deprecation")
@@ -83,49 +87,6 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
     @Override
     public HttpExecutionStrategy requiredOffloads() {
         return strategy;
-    }
-
-    /**
-     * A builder for creating instances of {@link DefaultHttpLoadBalancerFactory}.
-     *
-     * @param <ResolvedAddress> The type of address after resolution for the {@link HttpLoadBalancerFactory} built by
-     * this builder.
-     */
-    public static final class Builder<ResolvedAddress> {
-        private final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory;
-        private final HttpExecutionStrategy strategy;
-
-        private Builder(
-                final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory,
-                final HttpExecutionStrategy strategy) {
-            this.rawFactory = rawFactory;
-            this.strategy = strategy;
-        }
-
-        /**
-         * Builds a {@link HttpLoadBalancerFactory} using the properties configured on this builder.
-         *
-         * @return A {@link HttpLoadBalancerFactory}.
-         */
-        public HttpLoadBalancerFactory<ResolvedAddress> build() {
-            return new DefaultHttpLoadBalancerFactory<>(rawFactory, strategy);
-        }
-
-        /**
-         * Creates a new {@link Builder} using the passed {@link LoadBalancerFactory}.
-         *
-         * @param rawFactory {@link LoadBalancerFactory} to use for creating a {@link HttpLoadBalancerFactory} from the
-         * returned {@link Builder}.
-         * @param <ResolvedAddress> The type of address after resolution for a {@link HttpLoadBalancerFactory} created
-         * by the returned {@link Builder}.
-         * @return A new {@link Builder}.
-         */
-        @SuppressWarnings("deprecation")
-        public static <ResolvedAddress> Builder<ResolvedAddress> from(
-                final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory) {
-            final HttpExecutionStrategy strategy = HttpExecutionStrategy.from(rawFactory.requiredOffloads());
-            return new Builder<>(rawFactory, strategy);
-        }
     }
 
     private static final class DefaultFilterableStreamingHttpLoadBalancedConnection

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpLoadBalancerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021, 2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
         return rawFactory.newLoadBalancer(eventPublisher, connectionFactory, targetResource);
     }
 
+    @SuppressWarnings("deprecation")
     @Override   // FIXME: 0.43 - remove deprecated method
     public FilterableStreamingHttpLoadBalancedConnection toLoadBalancedConnection(
             final FilterableStreamingHttpConnection connection) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -131,7 +131,10 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
          * @param <ResolvedAddress> The type of address after resolution for the {@link LoadBalancerFactory} built by
          * the returned builder.
          * @return A new {@link Builder}.
+         * @deprecated use {@link io.servicetalk.http.api.DefaultHttpLoadBalancerFactory} and wrap the raw load balancer
+         *             factory you're interested in using.
          */
+        @Deprecated
         public static <ResolvedAddress> Builder<ResolvedAddress> fromDefaults() {
             return from(RoundRobinLoadBalancers
                     .<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection>builder(

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,29 @@ import io.servicetalk.client.api.ConnectionFactory;
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.LoadBalancerFactory;
 import io.servicetalk.client.api.ReservableRequestConcurrencyController;
+import io.servicetalk.client.api.ScoreSupplier;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
+import io.servicetalk.http.api.HttpConnectionContext;
+import io.servicetalk.http.api.HttpEventKey;
+import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpLoadBalancerFactory;
+import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.loadbalancer.RoundRobinLoadBalancers;
 
 import java.util.Collection;
 import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Default implementation of {@link HttpLoadBalancerFactory}.
@@ -40,9 +52,14 @@ import javax.annotation.Nullable;
 @Deprecated // FIXME: 0.43 - remove deprecated class
 public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
         implements HttpLoadBalancerFactory<ResolvedAddress> {
+    private final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory;
+    private final HttpExecutionStrategy strategy;
 
-    private DefaultHttpLoadBalancerFactory() {
-        // no instances.
+    DefaultHttpLoadBalancerFactory(
+            final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory,
+            final HttpExecutionStrategy strategy) {
+        this.rawFactory = rawFactory;
+        this.strategy = strategy;
     }
 
     @SuppressWarnings("deprecation")
@@ -51,7 +68,7 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
             final String targetResource,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, T> connectionFactory) {
-        throw new UnsupportedOperationException("No instances.");
+        return rawFactory.newLoadBalancer(targetResource, eventPublisher, connectionFactory);
     }
 
     @Override
@@ -59,13 +76,13 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final ConnectionFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> connectionFactory,
             final String targetResource) {
-        throw new UnsupportedOperationException("No instances.");
+        return rawFactory.newLoadBalancer(eventPublisher, connectionFactory, targetResource);
     }
 
     @Override   // FIXME: 0.43 - remove deprecated method
     public FilterableStreamingHttpLoadBalancedConnection toLoadBalancedConnection(
             final FilterableStreamingHttpConnection connection) {
-        throw new UnsupportedOperationException("No instances.");
+        return new DefaultFilterableStreamingHttpLoadBalancedConnection(connection);
     }
 
     @Override
@@ -73,12 +90,13 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
             final FilterableStreamingHttpConnection connection,
             final ReservableRequestConcurrencyController concurrencyController,
             @Nullable final ContextMap context) {
-        throw new UnsupportedOperationException("No instances.");
+        return new HttpLoadBalancerFactory.DefaultFilterableStreamingHttpLoadBalancedConnection(connection,
+                concurrencyController);
     }
 
     @Override
     public HttpExecutionStrategy requiredOffloads() {
-        throw new UnsupportedOperationException("No instances.");
+        return strategy;
     }
 
     /**
@@ -88,12 +106,14 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
      * this builder.
      */
     public static final class Builder<ResolvedAddress> {
-
-        private final io.servicetalk.http.api.DefaultHttpLoadBalancerFactory.Builder<ResolvedAddress> delegate;
+        private final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory;
+        private final HttpExecutionStrategy strategy;
 
         private Builder(
-                final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory) {
-            this.delegate = io.servicetalk.http.api.DefaultHttpLoadBalancerFactory.Builder.from(rawFactory);
+                final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory,
+                final HttpExecutionStrategy strategy) {
+            this.rawFactory = rawFactory;
+            this.strategy = strategy;
         }
 
         /**
@@ -102,7 +122,7 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
          * @return A {@link DefaultHttpLoadBalancerFactory}.
          */
         public HttpLoadBalancerFactory<ResolvedAddress> build() {
-            return delegate.build();
+            return new DefaultHttpLoadBalancerFactory<>(rawFactory, strategy);
         }
 
         /**
@@ -130,7 +150,82 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
         @SuppressWarnings("deprecation")
         public static <ResolvedAddress> Builder<ResolvedAddress> from(
                 final LoadBalancerFactory<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection> rawFactory) {
-            return new Builder<>(rawFactory);
+            final HttpExecutionStrategy strategy = HttpExecutionStrategy.from(rawFactory.requiredOffloads());
+            return new Builder<>(rawFactory, strategy);
+        }
+    }
+
+    private static final class DefaultFilterableStreamingHttpLoadBalancedConnection
+            implements FilterableStreamingHttpLoadBalancedConnection {
+
+        private final FilterableStreamingHttpConnection delegate;
+
+        DefaultFilterableStreamingHttpLoadBalancedConnection(final FilterableStreamingHttpConnection delegate) {
+            this.delegate = requireNonNull(delegate);
+        }
+
+        @Override
+        public int score() {
+            throw new UnsupportedOperationException(
+                    DefaultFilterableStreamingHttpLoadBalancedConnection.class.getName() +
+                            " doesn't support scoring. " + ScoreSupplier.class.getName() +
+                            " is only available through " + HttpLoadBalancerFactory.class.getSimpleName() +
+                            " implementations that support scoring.");
+        }
+
+        @Override
+        public HttpConnectionContext connectionContext() {
+            return delegate.connectionContext();
+        }
+
+        @Override
+        public <T> Publisher<? extends T> transportEventStream(final HttpEventKey<T> eventKey) {
+            return delegate.transportEventStream(eventKey);
+        }
+
+        @Override
+        public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+            return delegate.request(request);
+        }
+
+        @Override
+        public HttpExecutionContext executionContext() {
+            return delegate.executionContext();
+        }
+
+        @Override
+        public StreamingHttpResponseFactory httpResponseFactory() {
+            return delegate.httpResponseFactory();
+        }
+
+        @Override
+        public Completable onClose() {
+            return delegate.onClose();
+        }
+
+        @Override
+        public Completable onClosing() {
+            return delegate.onClosing();
+        }
+
+        @Override
+        public Completable closeAsync() {
+            return delegate.closeAsync();
+        }
+
+        @Override
+        public Completable closeAsyncGracefully() {
+            return delegate.closeAsyncGracefully();
+        }
+
+        @Override
+        public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
+            return delegate.newRequest(method, requestTarget);
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -121,7 +121,7 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
          *
          * @return A {@link DefaultHttpLoadBalancerFactory}.
          */
-        public HttpLoadBalancerFactory<ResolvedAddress> build() {
+        public DefaultHttpLoadBalancerFactory<ResolvedAddress> build() {
             return new DefaultHttpLoadBalancerFactory<>(rawFactory, strategy);
         }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -839,8 +839,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     }
 
     private static <ResolvedAddress> HttpLoadBalancerFactory<ResolvedAddress> defaultLoadBalancer() {
-        return DefaultHttpLoadBalancerFactory.Builder.from(
+        return new DefaultHttpLoadBalancerFactory<>(
                 RoundRobinLoadBalancers.<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection>builder(
-                                DefaultHttpLoadBalancerFactory.class.getSimpleName()).build()).build();
+                                DefaultHttpLoadBalancerFactory.class.getSimpleName()).build());
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -484,14 +484,13 @@ public final class HttpClients {
                         .serviceDiscoverer(usd)
                         .retryServiceDiscoveryErrors(NoRetriesStrategy.INSTANCE)
                         // Disable health-checking:
-                        .loadBalancerFactory(DefaultHttpLoadBalancerFactory.Builder.from(
+                        .loadBalancerFactory(new DefaultHttpLoadBalancerFactory<>(
                                 RoundRobinLoadBalancers.<R, FilterableStreamingHttpLoadBalancedConnection>builder(
                                         // Use a different ID to let providers distinguish this LB from the default one
                                         DefaultHttpLoadBalancerFactory.class.getSimpleName() + '-' +
                                                 DiscoveryStrategy.ON_NEW_CONNECTION.name())
                                         .healthCheckFailedConnectionsThreshold(-1)
-                                        .build())
-                                .build())
+                                        .build()))
                         .appendConnectionFactoryFilter(resolvingConnectionFactory.get());
             default:
                 throw new IllegalArgumentException("Unsupported strategy: " + discoveryStrategy);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -27,6 +27,7 @@ import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.http.api.DefaultHttpLoadBalancerFactory;
 import io.servicetalk.http.api.DelegatingSingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpClient;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.DefaultHttpLoadBalancerFactory;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.Http2SettingsBuilder;
 import io.servicetalk.http.api.HttpProtocolConfig;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
@@ -91,9 +91,9 @@ final class CacheConnectionHttpLoadBalanceFactoryTest {
                      .enableWireLogging("servicetalk-tests-h2-frame-logger", LogLevel.TRACE, () -> false)
                      .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(connectionObserver))
                      .loadBalancerFactory(new CacheConnectionHttpLoadBalanceFactory<>(
-                             DefaultHttpLoadBalancerFactory.Builder.from(RoundRobinLoadBalancers.<InetSocketAddress,
+                             new DefaultHttpLoadBalancerFactory<>(RoundRobinLoadBalancers.<InetSocketAddress,
                                      FilterableStreamingHttpLoadBalancedConnection>builder(getClass().getSimpleName())
-                                     .build()).build(),
+                                     .build()),
                              a -> maxConcurrency))
                      // The accounting for connection caching and the ConcurrencyController are done at different layers
                      // so it is possible the connection caching will give a connection to the load balancer that fails

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -255,13 +255,13 @@ class ClientEffectiveStrategyTest {
                     }
                     if (null != lbStrategy) {
                         HttpLoadBalancerFactory<InetSocketAddress> lfFactory =
-                                DefaultHttpLoadBalancerFactory.Builder.from(
+                                new DefaultHttpLoadBalancerFactory<>(
                                 new LoadBalancerFactoryImpl() {
                                     @Override
                                     public ExecutionStrategy requiredOffloads() {
                                         return lbStrategy;
                                     }
-                                }).build();
+                                });
                         clientBuilder.loadBalancerFactory(lfFactory);
                     }
                     if (null != cfStrategy) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -26,6 +26,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.BlockingStreamingHttpClient;
 import io.servicetalk.http.api.BlockingStreamingHttpResponse;
+import io.servicetalk.http.api.DefaultHttpLoadBalancerFactory;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -32,6 +32,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.BlockingHttpService;
+import io.servicetalk.http.api.DefaultHttpLoadBalancerFactory;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpExecutionStrategy;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -119,12 +119,10 @@ class RetryingHttpRequesterFilterTest {
                 .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok()
                         .addHeader(RETRYABLE_HEADER, "yes"));
         failingConnClientBuilder = forSingleAddress(serverHostAndPort(svcCtx))
-                .loadBalancerFactory(DefaultHttpLoadBalancerFactory.Builder
-                        .from(new InspectingLoadBalancerFactory<>()).build())
+                .loadBalancerFactory(new DefaultHttpLoadBalancerFactory<>(new InspectingLoadBalancerFactory<>()))
                 .appendConnectionFactoryFilter(ClosingConnectionFactory::new);
         normalClientBuilder = forSingleAddress(serverHostAndPort(svcCtx))
-                .loadBalancerFactory(DefaultHttpLoadBalancerFactory.Builder
-                        .from(new InspectingLoadBalancerFactory<>()).build());
+                .loadBalancerFactory(new DefaultHttpLoadBalancerFactory<>(new InspectingLoadBalancerFactory<>()));
         lbSelectInvoked = new AtomicInteger();
     }
 

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
@@ -16,12 +16,12 @@
 package io.servicetalk.loadbalancer.experimental;
 
 import io.servicetalk.client.api.LoadBalancerFactory;
+import io.servicetalk.http.api.DefaultHttpLoadBalancerFactory;
 import io.servicetalk.http.api.DelegatingSingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpLoadBalancerFactory;
 import io.servicetalk.http.api.HttpProviders;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
-import io.servicetalk.http.netty.DefaultHttpLoadBalancerFactory;
 import io.servicetalk.loadbalancer.LoadBalancers;
 import io.servicetalk.transport.api.HostAndPort;
 

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
@@ -55,8 +55,8 @@ public class DefaultHttpLoadBalancerProvider implements HttpProviders.SingleAddr
         final String serviceName = clientNameFromAddress(address);
         if (config.enabledForServiceName(serviceName)) {
             try {
-                HttpLoadBalancerFactory<R> loadBalancerFactory = DefaultHttpLoadBalancerFactory.Builder.<R>from(
-                        defaultLoadBalancer(serviceName)).build();
+                HttpLoadBalancerFactory<R> loadBalancerFactory = new DefaultHttpLoadBalancerFactory<>(
+                        defaultLoadBalancer(serviceName));
                 builder = builder.loadBalancerFactory(loadBalancerFactory);
                 return new LoadBalancerIgnoringBuilder(builder, serviceName);
             } catch (Throwable ex) {


### PR DESCRIPTION
Motivation:

There is nothing netty specific about DefaultHttpLoadBalancerFactory
but it lives in the servicetalk-http-netty package.

Modifications:

- Copy the class to the http-api package.
- Deprecate the http-netty version and forward logic to the http-api
  implementation.
- Fix usages in servicetalk.