### PR TITLE
`RetryingHttpRequesterFilter`: add on request retry callback

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import io.servicetalk.http.api.HttpHeaderNames;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpClientFilterFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
@@ -48,6 +49,7 @@ import io.servicetalk.transport.api.RetryableException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -90,10 +92,10 @@ public final class RetryingHttpRequesterFilter
     static final int DEFAULT_MAX_TOTAL_RETRIES = 4;
     private static final RetryingHttpRequesterFilter DISABLE_AUTO_RETRIES =
             new RetryingHttpRequesterFilter(true, false, false, 1, null,
-                    (__, ___) -> NO_RETRIES);
+                    (__, ___) -> NO_RETRIES, null);
     private static final RetryingHttpRequesterFilter DISABLE_ALL_RETRIES =
             new RetryingHttpRequesterFilter(false, true, false, 0, null,
-                    (__, ___) -> NO_RETRIES);
+                    (__, ___) -> NO_RETRIES, null);
 
     private final boolean waitForLb;
     private final boolean ignoreSdErrors;
@@ -102,18 +104,22 @@ public final class RetryingHttpRequesterFilter
     @Nullable
     private final Function<HttpResponseMetaData, HttpResponseException> responseMapper;
     private final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryFor;
+    @Nullable
+    private final BiConsumer<HttpRequestMetaData, Throwable> onRequestRetry;
 
     RetryingHttpRequesterFilter(
             final boolean waitForLb, final boolean ignoreSdErrors, final boolean mayReplayRequestPayload,
             final int maxTotalRetries,
             @Nullable final Function<HttpResponseMetaData, HttpResponseException> responseMapper,
-            final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryFor) {
+            final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryFor,
+            @Nullable final BiConsumer<HttpRequestMetaData, Throwable> onRequestRetry) {
         this.waitForLb = waitForLb;
         this.ignoreSdErrors = ignoreSdErrors;
         this.mayReplayRequestPayload = mayReplayRequestPayload;
         this.maxTotalRetries = maxTotalRetries;
         this.responseMapper = responseMapper;
         this.retryFor = retryFor;
+        this.onRequestRetry = onRequestRetry;
     }
 
     @Override
@@ -151,15 +157,20 @@ public final class RetryingHttpRequesterFilter
         private final class OuterRetryStrategy implements BiIntFunction<Throwable, Completable> {
             private final Executor executor;
             private final HttpRequestMetaData requestMetaData;
+            @Nullable
+            private final BiConsumer<HttpRequestMetaData, Throwable> onRetry;
             /**
              * The outer retry strategy handles both "load balancer not ready" and "request failed" cases. This count
              * discounts the former so the ladder strategies only count actual request attempts.
              */
             private int lbNotReadyCount;
 
-            private OuterRetryStrategy(final Executor executor, final HttpRequestMetaData requestMetaData) {
+            private OuterRetryStrategy(final Executor executor,
+                                       final HttpRequestMetaData requestMetaData,
+                                       @Nullable final BiConsumer<HttpRequestMetaData, Throwable> onRetry) {
                 this.executor = executor;
                 this.requestMetaData = requestMetaData;
+                this.onRetry = onRetry;
             }
 
             @Override
@@ -179,40 +190,48 @@ public final class RetryingHttpRequesterFilter
                                     !(lbEvent instanceof LoadBalancerReadyEvent &&
                                             ((LoadBalancerReadyEvent) lbEvent).isReady()))
                             .ignoreElements();
-                    return sdStatus == null ? onHostsAvailable : onHostsAvailable.ambWith(sdStatus);
+                    return applyOnRetryCallback(
+                            sdStatus == null ? onHostsAvailable : onHostsAvailable.ambWith(sdStatus), t);
                 }
 
                 final BackOffPolicy backOffPolicy = retryFor.apply(requestMetaData, t);
                 if (backOffPolicy != NO_RETRIES) {
                     final int offsetCount = count - lbNotReadyCount;
+                    Completable retryWhen = backOffPolicy.newStrategy(executor).apply(offsetCount, t);
                     if (t instanceof DelayedRetry) {
                         final Duration constant = ((DelayedRetry) t).delay();
-                        return backOffPolicy.newStrategy(executor).apply(offsetCount, t)
-                                .concat(executor.timer(constant));
+                        retryWhen = retryWhen.concat(executor.timer(constant));
                     }
 
-                    return backOffPolicy.newStrategy(executor).apply(offsetCount, t);
+                    return applyOnRetryCallback(retryWhen, t);
                 }
 
                 return failed(t);
+            }
+
+            Completable applyOnRetryCallback(final Completable completable, final Throwable t) {
+                return onRetry == null ? completable :
+                        completable.whenOnComplete(() -> onRetry.accept(requestMetaData, t));
             }
         }
 
         // Visible for testing
         BiIntFunction<Throwable, Completable> retryStrategy(final HttpRequestMetaData requestMetaData,
-                                                            final ExecutionContext<HttpExecutionStrategy> context) {
+                                                            final ExecutionContext<HttpExecutionStrategy> context,
+                                                            final boolean forRequest) {
             final HttpExecutionStrategy strategy = requestMetaData.context()
                     .getOrDefault(HTTP_EXECUTION_STRATEGY_KEY, context.executionStrategy());
             assert strategy != null;
             return new OuterRetryStrategy(strategy.isRequestResponseOffloaded() ?
-                    context.executor() : context.ioExecutor(), requestMetaData);
+                    context.executor() : context.ioExecutor(), requestMetaData,
+                    forRequest ? onRequestRetry : null);
         }
 
         @Override
         public Single<? extends FilterableReservedStreamingHttpConnection> reserveConnection(
                 final HttpRequestMetaData metaData) {
             return delegate().reserveConnection(metaData)
-                    .retryWhen(retryStrategy(metaData, executionContext()));
+                    .retryWhen(retryStrategy(metaData, executionContext(), false));
         }
 
         @Override
@@ -251,7 +270,7 @@ public final class RetryingHttpRequesterFilter
             // 1. Metadata is shared across retries
             // 2. Publisher state is restored to original state for each retry
             // duplicatedRequest isn't used below because retryWhen must be applied outside the defer operator for (2).
-            return single.retryWhen(retryStrategy(request, executionContext()));
+            return single.retryWhen(retryStrategy(request, executionContext(), true));
         }
     }
 
@@ -400,6 +419,18 @@ public final class RetryingHttpRequesterFilter
             this.timerExecutor = null;
             this.exponential = false;
             this.maxRetries = ensureNonNegative(maxRetries, "maxRetries");
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() +
+                    "{maxRetries=" + maxRetries +
+                    ", initialDelay=" + initialDelay +
+                    ", jitter=" + jitter +
+                    ", maxDelay=" + maxDelay +
+                    ", exponential=" + exponential +
+                    ", timerExecutor=" + timerExecutor +
+                    '}';
         }
 
         /**
@@ -665,20 +696,19 @@ public final class RetryingHttpRequesterFilter
         private Function<HttpResponseMetaData, HttpResponseException> responseMapper;
 
         @Nullable
-        private BiFunction<HttpRequestMetaData, IOException, BackOffPolicy>
-                retryIdempotentRequests;
+        private BiFunction<HttpRequestMetaData, IOException, BackOffPolicy> retryIdempotentRequests;
 
         @Nullable
-        private BiFunction<HttpRequestMetaData, DelayedRetry, BackOffPolicy>
-                retryDelayedRetries;
+        private BiFunction<HttpRequestMetaData, DelayedRetry, BackOffPolicy> retryDelayedRetries;
 
         @Nullable
-        private BiFunction<HttpRequestMetaData, HttpResponseException, BackOffPolicy>
-                retryResponses;
+        private BiFunction<HttpRequestMetaData, HttpResponseException, BackOffPolicy> retryResponses;
 
         @Nullable
-        private BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy>
-                retryOther;
+        private BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryOther;
+
+        @Nullable
+        private BiConsumer<HttpRequestMetaData, Throwable> onRequestRetry;
 
         /**
          * By default, automatic retries wait for the associated {@link LoadBalancer} to be
@@ -843,6 +873,22 @@ public final class RetryingHttpRequesterFilter
         }
 
         /**
+         * Callback invoked on every {@link StreamingHttpClient#request(StreamingHttpRequest) request} retry attempt.
+         * <p>
+         * This can be used to track when {@link BackOffPolicy} actually decides to retry a request, to update
+         * {@link HttpRequestMetaData request meta-data} before a retry, or implement logging/metrics.
+         *
+         * @param onRequestRetry {@link BiConsumer} with {@link HttpRequestMetaData request meta-data} and
+         * {@link Throwable cause} that is invoked before every
+         * {@link StreamingHttpClient#request(StreamingHttpRequest) request} retry attempt
+         * @return {@code this}
+         */
+        public Builder onRequestRetry(final BiConsumer<HttpRequestMetaData, Throwable> onRequestRetry) {
+            this.onRequestRetry = requireNonNull(onRequestRetry);
+            return this;
+        }
+
+        /**
          * Builds a retrying {@link RetryingHttpRequesterFilter} with this' builders configuration.
          *
          * @return A new retrying {@link RetryingHttpRequesterFilter}
@@ -921,7 +967,7 @@ public final class RetryingHttpRequesterFilter
                         return NO_RETRIES;
                     };
             return new RetryingHttpRequesterFilter(waitForLb, ignoreSdErrors, mayReplayRequestPayload,
-                    maxTotalRetries, responseMapper, allPredicate);
+                    maxTotalRetries, responseMapper, allPredicate, onRequestRetry);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -679,7 +679,7 @@ public final class RetryingHttpRequesterFilter
     public interface RetryCallbacks {
 
         /**
-         * Called before a retry is performed.
+         * Called after a retry decision has been made, but before the retry is performed.
          *
          * @param retryCount a current retry counter value for this attempt
          * @param requestMetaData {@link HttpRequestMetaData} that is being retried
@@ -891,7 +891,8 @@ public final class RetryingHttpRequesterFilter
          * Callback invoked on every {@link StreamingHttpClient#request(StreamingHttpRequest) request} retry attempt.
          * <p>
          * This can be used to track when {@link BackOffPolicy} actually decides to retry a request, to update
-         * {@link HttpRequestMetaData request meta-data} before a retry, or implement logging/metrics.
+         * {@link HttpRequestMetaData request meta-data} before a retry, or implement logging/metrics. However, it
+         * can not be used to influence the retry decision, use other "retry*" functions for that purpose.
          *
          * @param onRequestRetry {@link RetryCallbacks} to get notified on every
          * {@link StreamingHttpClient#request(StreamingHttpRequest) request} retry attempt

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterAutoRetryStrategiesTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterAutoRetryStrategiesTest.java
@@ -105,7 +105,8 @@ class RetryingHttpRequesterFilterAutoRetryStrategiesTest {
         AtomicInteger onRequestRetryCounter = new AtomicInteger();
         final ContextAwareRetryingHttpClientFilter filter = newFilter(new RetryingHttpRequesterFilter.Builder()
                 .retryRetryableExceptions((__, ___) -> ofNoRetries())
-                .onRequestRetry((req, t) -> onRequestRetryCounter.incrementAndGet()), offloading);
+                .onRequestRetry((count, req, t) -> assertThat(onRequestRetryCounter.incrementAndGet(), is(count))),
+                offloading);
 
         Completable retry = applyRetry(filter, 1, RETRYABLE_EXCEPTION);
         toSource(retry).subscribe(retrySubscriber);
@@ -175,7 +176,8 @@ class RetryingHttpRequesterFilterAutoRetryStrategiesTest {
     void defaultForNoAvailableHost(boolean offloading) {
         AtomicInteger onRequestRetryCounter = new AtomicInteger();
         final ContextAwareRetryingHttpClientFilter filter = newFilter(new RetryingHttpRequesterFilter.Builder()
-                .onRequestRetry((req, t) -> onRequestRetryCounter.incrementAndGet()), offloading);
+                .onRequestRetry((count, req, t) -> assertThat(onRequestRetryCounter.incrementAndGet(), is(count))),
+                offloading);
         Completable retry = applyRetry(filter, 1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
         assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterAutoRetryStrategiesTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterAutoRetryStrategiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.stubbing.Answer;
 
 import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
@@ -101,13 +102,15 @@ class RetryingHttpRequesterFilterAutoRetryStrategiesTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     void disableRetryAllRetryableExWithRetryable(boolean offloading) {
-        final ContextAwareRetryingHttpClientFilter filter =
-                newFilter(new RetryingHttpRequesterFilter.Builder()
-                        .retryRetryableExceptions((__, ___) -> ofNoRetries()), offloading);
+        AtomicInteger onRequestRetryCounter = new AtomicInteger();
+        final ContextAwareRetryingHttpClientFilter filter = newFilter(new RetryingHttpRequesterFilter.Builder()
+                .retryRetryableExceptions((__, ___) -> ofNoRetries())
+                .onRequestRetry((req, t) -> onRequestRetryCounter.incrementAndGet()), offloading);
 
         Completable retry = applyRetry(filter, 1, RETRYABLE_EXCEPTION);
         toSource(retry).subscribe(retrySubscriber);
         verifyRetryResultError(RETRYABLE_EXCEPTION);
+        assertThat("Unexpected calls to onRequestRetry.", onRequestRetryCounter.get(), is(0));
     }
 
     @ParameterizedTest
@@ -170,13 +173,15 @@ class RetryingHttpRequesterFilterAutoRetryStrategiesTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     void defaultForNoAvailableHost(boolean offloading) {
-        final ContextAwareRetryingHttpClientFilter filter =
-                newFilter(new RetryingHttpRequesterFilter.Builder(), offloading);
+        AtomicInteger onRequestRetryCounter = new AtomicInteger();
+        final ContextAwareRetryingHttpClientFilter filter = newFilter(new RetryingHttpRequesterFilter.Builder()
+                .onRequestRetry((req, t) -> onRequestRetryCounter.incrementAndGet()), offloading);
         Completable retry = applyRetry(filter, 1, NO_AVAILABLE_HOST);
         toSource(retry).subscribe(retrySubscriber);
         assertThat(retrySubscriber.pollTerminal(10, MILLISECONDS), is(nullValue()));
         lbEvents.onNext(LOAD_BALANCER_READY_EVENT);
         verifyRetryResultCompleted();
+        assertThat("Unexpected calls to onRequestRetry.", onRequestRetryCounter.get(), is(1));
     }
 
     @ParameterizedTest
@@ -255,7 +260,7 @@ class RetryingHttpRequesterFilterAutoRetryStrategiesTest {
                 .maxTotalRetries(Integer.MAX_VALUE), offloading);
         lbEvents.onNext(LOAD_BALANCER_READY_EVENT); // LB is ready before subscribing to the response
         BiIntFunction<Throwable, Completable> retryStrategy =
-                filter.retryStrategy(REQUEST_META_DATA, filter.executionContext());
+                filter.retryStrategy(REQUEST_META_DATA, filter.executionContext(), true);
         for (int i = 1; i <= DEFAULT_MAX_TOTAL_RETRIES * 2; i++) {
             Completable retry = retryStrategy.apply(i, NO_ACTIVE_HOST);
             TestCompletableSubscriber subscriber = new TestCompletableSubscriber();
@@ -316,6 +321,6 @@ class RetryingHttpRequesterFilterAutoRetryStrategiesTest {
     @Nonnull
     private Completable applyRetry(final ContextAwareRetryingHttpClientFilter filter,
                                    final int count, final Throwable t) {
-        return filter.retryStrategy(REQUEST_META_DATA, filter.executionContext()).apply(count, t);
+        return filter.retryStrategy(REQUEST_META_DATA, filter.executionContext(), true).apply(count, t);
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -205,7 +205,8 @@ class RetryingHttpRequesterFilterTest {
         failingClient = failingConnClientBuilder
                 .appendClientFilter(new Builder()
                         .maxTotalRetries(maxTotalRetries)
-                        .onRequestRetry((req, t) -> onRequestRetryCounter.incrementAndGet())
+                        .onRequestRetry((count, req, t) ->
+                                assertThat(onRequestRetryCounter.incrementAndGet(), is(count)))
                         .build())
                 .buildBlocking();
         Exception e = assertThrows(Exception.class, () -> failingClient.request(failingClient.get("/")));
@@ -265,7 +266,8 @@ class RetryingHttpRequesterFilterTest {
                         .retryRetryableExceptions((requestMetaData, e) -> ofNoRetries())
                         // Retry only responses marked so
                         .retryResponses((requestMetaData, throwable) -> ofImmediate(maxTotalRetries - 1))
-                        .onRequestRetry((req, t) -> onRequestRetryCounter.incrementAndGet())
+                        .onRequestRetry((count, req, t) ->
+                                assertThat(onRequestRetryCounter.incrementAndGet(), is(count)))
                         .build())
                 .appendConnectionFilter(c -> {
                     newConnectionCreated.incrementAndGet();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolic
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofImmediateBounded;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy.ofNoRetries;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.Builder;
+import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.DEFAULT_MAX_TOTAL_RETRIES;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.HttpResponseException;
 import static io.servicetalk.http.netty.RetryingHttpRequesterFilter.disableAutoRetries;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
@@ -96,6 +97,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -194,14 +196,22 @@ class RetryingHttpRequesterFilterTest {
         assertThat("Unexpected calls to select.", lbSelectInvoked.get(), is(lessThanOrEqualTo(2)));
     }
 
-    @Test
-    void maxTotalRetries() {
+    @ParameterizedTest(name = "{displayName} [{index}] maxTotalRetries={0}")
+    @ValueSource(ints = {1, 2, 3})
+    void maxTotalRetriesCapsDefaultOfImmediateBoundedBackoffPolicy(int maxTotalRetries) {
+        assertThat("maxTotalRetries higher than default bounds",
+                maxTotalRetries, is(lessThan(DEFAULT_MAX_TOTAL_RETRIES)));
+        AtomicInteger onRequestRetryCounter = new AtomicInteger();
         failingClient = failingConnClientBuilder
-                .appendClientFilter(new Builder().maxTotalRetries(1).build())
+                .appendClientFilter(new Builder()
+                        .maxTotalRetries(maxTotalRetries)
+                        .onRequestRetry((req, t) -> onRequestRetryCounter.incrementAndGet())
+                        .build())
                 .buildBlocking();
         Exception e = assertThrows(Exception.class, () -> failingClient.request(failingClient.get("/")));
         assertThat("Unexpected exception.", e, instanceOf(RetryableException.class));
-        assertThat("Unexpected calls to select.", lbSelectInvoked.get(), is(2));
+        assertThat("Unexpected calls to select.", lbSelectInvoked.get(), is(maxTotalRetries + 1));
+        assertThat("Unexpected calls to onRequestRetry.", onRequestRetryCounter.get(), is(maxTotalRetries));
     }
 
     @Test
@@ -244,6 +254,7 @@ class RetryingHttpRequesterFilterTest {
     void testResponseMapper() {
         AtomicInteger newConnectionCreated = new AtomicInteger();
         AtomicInteger responseDrained = new AtomicInteger();
+        AtomicInteger onRequestRetryCounter = new AtomicInteger();
         final int maxTotalRetries = 4;
         normalClient = normalClientBuilder
                 .appendClientFilter(new Builder()
@@ -254,6 +265,7 @@ class RetryingHttpRequesterFilterTest {
                         .retryRetryableExceptions((requestMetaData, e) -> ofNoRetries())
                         // Retry only responses marked so
                         .retryResponses((requestMetaData, throwable) -> ofImmediate(maxTotalRetries - 1))
+                        .onRequestRetry((req, t) -> onRequestRetryCounter.incrementAndGet())
                         .build())
                 .appendConnectionFilter(c -> {
                     newConnectionCreated.incrementAndGet();
@@ -274,6 +286,8 @@ class RetryingHttpRequesterFilterTest {
         // against actual requests being issued.
         assertThat("Unexpected calls to select.", lbSelectInvoked.get(), allOf(greaterThanOrEqualTo(maxTotalRetries),
                 lessThanOrEqualTo(maxTotalRetries + 1)));
+        assertThat("Unexpected calls to onRequestRetry.", onRequestRetryCounter.get(),
+                allOf(greaterThanOrEqualTo(maxTotalRetries - 1), lessThanOrEqualTo(maxTotalRetries)));
         assertThat("Response payload body was not drained on every mapping", responseDrained.get(),
                 is(maxTotalRetries));
         assertThat("Unexpected number of connections was created", newConnectionCreated.get(), is(1));


### PR DESCRIPTION
Motivation:

There are use-cases when users need to perform an action before the retry, like updating meta-data or logging/metrics. Because all retry functions return `BackoffPolicy`, it's still not known inside the function of `BackoffPolicy` will retry or not because of the retry counts limit.

Modifications:
- Add `RetryingHttpRequesterFilter.Builder.onRequestRetry(BiConsumer)` that users can use to intercept every retry attempt;
- Test that the new callback works for request retries;

Result:

Users can see when the retry actually happens, after backoff time.

If there will be a similar use-case for `reserveConnection` in the future, we will add a separate callback.