### PR TITLE
Enhance header name validation exception message

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/DefaultHttpHeadersNameValidationBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/api/DefaultHttpHeadersNameValidationBenchmark.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Arrays;
+
+/*
+ * This benchmark measures performance of header name validation in DefaultHttpHeaders:
+ *
+ * ByteProcessor as a method-reference:
+ * Benchmark                                            (count)  (invalid)   Mode  Cnt        Score        Error  Units
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader        4      false  thrpt    5  8438734.025 ± 165801.745  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader        4       true  thrpt    5   339720.292 ±   5379.742  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader        8      false  thrpt    5  4833763.689 ±  31037.631  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader        8       true  thrpt    5   167820.982 ±    349.719  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader       16      false  thrpt    5  2537292.742 ±  11400.611  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader       16       true  thrpt    5    84582.812 ±    168.087  ops/s
+ *
+ * ByteProcessor as an instance of a static inner class with extra state:
+ * Benchmark                                            (count)  (invalid)   Mode  Cnt        Score        Error  Units
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader        4      false  thrpt    5  8562586.842 ± 210534.848  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader        4       true  thrpt    5   274093.669 ±   1818.531  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader        8      false  thrpt    5  5024017.665 ±  32830.519  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader        8       true  thrpt    5   135011.887 ±   1832.187  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader       16      false  thrpt    5  2523554.519 ±   8780.660  ops/s
+ * DefaultHttpHeadersNameValidationBenchmark.addHeader       16       true  thrpt    5    68474.840 ±   1154.751  ops/s
+ */
+@Fork(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 5)
+@Measurement(iterations = 5, time = 10)
+@BenchmarkMode(Mode.Throughput)
+public class DefaultHttpHeadersNameValidationBenchmark {
+
+    @Param({"4", "8", "16"})
+    private int count;
+    @Param({"false", "true"})
+    private boolean invalid;
+    private String[] names;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        String baseValue = "header-" + (invalid ? (char) 0 : 'x') + "-name-";
+        names = new String[count];
+        Arrays.setAll(names, i -> baseValue + i);
+    }
+
+    @Benchmark
+    public HttpHeaders addHeader(Blackhole blackhole) {
+        HttpHeaders headers = DefaultHttpHeadersFactory.INSTANCE.newHeaders();
+        for (String name : names) {
+            try {
+                headers.add(name, "value");
+            } catch (IllegalArgumentException e) {
+                blackhole.consume(e);
+            }
+        }
+        return headers;
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
@@ -588,7 +588,7 @@ final class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> impl
      * @param name The filed-name to validate.
      */
     private static void validateHeaderName(final CharSequence name) {
-        validateToken(name);
+        validateToken(name, "header name");
     }
 
     /**

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -153,7 +153,7 @@ public final class DefaultHttpSetCookie implements HttpSetCookie {
                         }
                         name = setCookieString.subSequence(begin, i);
                         if (validateContent) {
-                            validateToken(name);
+                            validateToken(name, "set-cookie name");
                         }
                         parseState = ParseState.ParsingValue;
                     } else if (parseState == ParseState.Unknown) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -913,7 +913,7 @@ public final class HeaderUtils {
             int test = 10;
             while (test <= value && test <= 1_000_000_000) {
                 ++length;
-                test = (test << 3) + (test << 1);   // equivalent of "test *= 10;"
+                test *= 10;
             }
             return length;
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -885,8 +885,8 @@ public final class HeaderUtils {
         private String message(final byte value) {
             final int codePoint = value & 0xff;
             final int idx = this.idx;
-            final StringBuilder sb = new StringBuilder(40 + stringSize(idx) + what.length() + token.length() +
-                    EXPECTED.length())
+            final StringBuilder sb = new StringBuilder(40 + intToStringLength(idx) + what.length() +
+                    token.length() + EXPECTED.length())
                     .append('\'')   // 1
                     .append((char) codePoint)   // 1
                     .append("' (0x")    // 5
@@ -904,15 +904,18 @@ public final class HeaderUtils {
             return sb.toString();
         }
 
-        private static int stringSize(final int value) {
+        /**
+         * Calculates the length of {@link Integer#toString(int)} for the specified value.
+         */
+        private static int intToStringLength(final int value) {
             assert value >= 0;
-            int size = 0;
-            int tmp = 1;
-            while (tmp <= value && tmp <= 1_000_000_000) {
-                ++size;
-                tmp = (tmp << 3) + (tmp << 1);
+            int length = 1;
+            int test = 10;
+            while (test <= value && test <= 1_000_000_000) {
+                ++length;
+                test = (test << 3) + (test << 1);   // equivalent of "test *= 10;"
             }
-            return size;
+            return length;
         }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMethod.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMethod.java
@@ -95,7 +95,7 @@ public final class HttpRequestMethod implements Comparable<HttpRequestMethod> {
             throw new IllegalArgumentException("Invalid HTTP request method name: cannot be empty");
         }
         try {
-            validateToken(name);
+            validateToken(name, "request method");
             return name;
         } catch (IllegalCharacterException e) {
             throw new IllegalArgumentException("Invalid HTTP request method name: " + name, e);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -686,7 +686,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         try {
             headers.add(name, value);
         } catch (IllegalCharacterException cause) {
-            throw invalidHeaderName(name, parsingLine, cause);
+            throw invalidHeaderName(parsingLine, cause);
         }
         // Consume the header line bytes from the buffer.
         consumeCRLF(buffer, lfIndex);
@@ -696,9 +696,10 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         return new DecoderException(message + (parsingLine - 1));
     }
 
-    private static DecoderException invalidHeaderName(final CharSequence name, final int parsingLine,
+    private static DecoderException invalidHeaderName(final int parsingLine,
                                                       final IllegalCharacterException cause) {
-        throw new StacklessDecoderException("Invalid header name in line " + (parsingLine - 1) + ": " + name, cause);
+        throw new StacklessDecoderException(
+                "Invalid character in line " + (parsingLine - 1) + ": " + cause.getMessage(), cause);
     }
 
     private static DecoderException invalidHeaderValue(final CharSequence name, final int parsingLine,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -686,7 +686,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         try {
             headers.add(name, value);
         } catch (IllegalCharacterException cause) {
-            throw invalidHeaderName(parsingLine, cause);
+            throw invalidHeaderName(name, parsingLine, cause);
         }
         // Consume the header line bytes from the buffer.
         consumeCRLF(buffer, lfIndex);
@@ -696,10 +696,11 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         return new DecoderException(message + (parsingLine - 1));
     }
 
-    private static DecoderException invalidHeaderName(final int parsingLine,
+    private static DecoderException invalidHeaderName(final CharSequence name, final int parsingLine,
                                                       final IllegalCharacterException cause) {
+        final String msg = cause.getMessage();
         throw new StacklessDecoderException(
-                "Invalid character in line " + (parsingLine - 1) + ": " + cause.getMessage(), cause);
+                "Invalid header name in line " + (parsingLine - 1) + ": " + (msg != null ? msg : name), cause);
     }
 
     private static DecoderException invalidHeaderValue(final CharSequence name, final int parsingLine,

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/IllegalCharacterException.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/IllegalCharacterException.java
@@ -17,7 +17,6 @@ package io.servicetalk.utils.internal;
 
 import javax.annotation.Nullable;
 
-import static java.lang.Character.toChars;
 import static java.lang.Integer.toHexString;
 
 /**
@@ -25,6 +24,15 @@ import static java.lang.Integer.toHexString;
  */
 public final class IllegalCharacterException extends IllegalArgumentException {
     private static final long serialVersionUID = 5109746801766842145L;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message description message.
+     */
+    public IllegalCharacterException(final String message) {
+        super(message);
+    }
 
     /**
      * Creates a new instance.
@@ -50,7 +58,7 @@ public final class IllegalCharacterException extends IllegalArgumentException {
         final int codePoint = value & 0xff;
         final StringBuilder sb = new StringBuilder(expected == null ? 10 : 23 + expected.length())
                 .append('\'')
-                .append(toChars(codePoint))
+                .append((char) codePoint)
                 .append("' (0x")
                 .append(toHexString(0x100 | codePoint), 1, 3);  // to 2 digit hex number
         return (expected == null ? sb.append(')') : sb.append("), expected [").append(expected).append(']')).toString();


### PR DESCRIPTION
Motivation:

Provide more details about a illegal header name.

Modifications:

- Use `TokenValidatingProcessor` that captures more context for generating an exception message, if necessary;
- Add benchmark to measure performance before/after change;

Result:

Users can see what header name has an illegal character as well as the position (index) of an illegal character.

---
This approach captures more context and doesn't use another try-catch with wrapping, but allocates a new lambda for every token validation.

When users add/set illegal header name:

before
```
Exception in thread "main" io.servicetalk.utils.internal.IllegalCharacterException: '�' (0x00), expected [! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA]
	at io.servicetalk.http.api.HeaderUtils.validateTokenChar(HeaderUtils.java:831)
	at io.servicetalk.buffer.api.CharSequences.forEachByte(CharSequences.java:126)
	at io.servicetalk.http.api.HeaderUtils.validateToken(HeaderUtils.java:243)
	at io.servicetalk.http.api.DefaultHttpHeaders.validateHeaderName(DefaultHttpHeaders.java:591)
	at io.servicetalk.http.api.DefaultHttpHeaders.validateKey(DefaultHttpHeaders.java:572)
	at io.servicetalk.http.api.DefaultHttpHeaders.validateKey(DefaultHttpHeaders.java:45)
	at io.servicetalk.http.api.MultiMap.putExclusive(MultiMap.java:272)
	at io.servicetalk.http.api.DefaultHttpHeaders.set(DefaultHttpHeaders.java:672)
	at io.servicetalk.http.api.HttpMetaData.setHeader(HttpMetaData.java:126)
	at io.servicetalk.http.api.HttpRequestMetaData.setHeader(HttpRequestMetaData.java:486)
	at io.servicetalk.http.api.StreamingHttpRequest.setHeader(StreamingHttpRequest.java:324)
	at io.servicetalk.http.api.DefaultHttpRequest.setHeader(DefaultHttpRequest.java:168)
	at io.servicetalk.examples.http.helloworld.blocking.BlockingHelloWorldClient.main(BlockingHelloWorldClient.java:32)
```

after
```
Exception in thread "main" io.servicetalk.utils.internal.IllegalCharacterException: '�' (0x00) at index=7 in header name 'header-�-name', expected [! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA]
	at io.servicetalk.http.api.HeaderUtils$TokenValidatingProcessor.process(HeaderUtils.java:879)
	at io.servicetalk.buffer.api.CharSequences.forEachByte(CharSequences.java:126)
	at io.servicetalk.http.api.HeaderUtils.validateToken(HeaderUtils.java:246)
	at io.servicetalk.http.api.DefaultHttpHeaders.validateHeaderName(DefaultHttpHeaders.java:591)
	at io.servicetalk.http.api.DefaultHttpHeaders.validateKey(DefaultHttpHeaders.java:572)
	at io.servicetalk.http.api.DefaultHttpHeaders.validateKey(DefaultHttpHeaders.java:45)
	at io.servicetalk.http.api.MultiMap.putExclusive(MultiMap.java:272)
	at io.servicetalk.http.api.DefaultHttpHeaders.set(DefaultHttpHeaders.java:672)
	at io.servicetalk.http.api.HttpMetaData.setHeader(HttpMetaData.java:126)
	at io.servicetalk.http.api.HttpRequestMetaData.setHeader(HttpRequestMetaData.java:486)
	at io.servicetalk.http.api.StreamingHttpRequest.setHeader(StreamingHttpRequest.java:324)
	at io.servicetalk.http.api.DefaultHttpRequest.setHeader(DefaultHttpRequest.java:168)
	at io.servicetalk.examples.http.helloworld.blocking.BlockingHelloWorldClient.main(BlockingHelloWorldClient.java:32)
```

When an illegal header name is received over network:

before
```
2024-05-13 13:51:24,884 servicetalk-global-io-executor-1-2 [WARN ] NettyHttpServer$ErrorLoggingHttpSubscriber - [id: 0xeb527ce7, L:/127.0.0.1:8080 - R:/127.0.0.1:51347] Can not decode a message, no more requests will be received on this HTTP/1.1 connection, closing it due to:
io.servicetalk.http.netty.HttpObjectDecoder$StacklessDecoderException: Invalid header name in line 2: header-�-name
Caused by: io.servicetalk.utils.internal.IllegalCharacterException: '�' (0x00), expected [! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA]
	at io.servicetalk.http.api.HeaderUtils.validateTokenChar(HeaderUtils.java:831) ~[servicetalk-http-api/:?]
	at io.netty.buffer.AbstractByteBuf.forEachByteAsc0(AbstractByteBuf.java:1301) ~[netty-buffer-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.buffer.AbstractByteBuf.forEachByte(AbstractByteBuf.java:1281) ~[netty-buffer-4.1.109.Final.jar:4.1.109.Final]
	at io.servicetalk.buffer.netty.NettyBuffer.forEachByte(NettyBuffer.java:840) ~[servicetalk-buffer-netty/:?]
	at io.servicetalk.buffer.netty.WrappedBuffer.forEachByte(WrappedBuffer.java:784) ~[servicetalk-buffer-netty/:?]
	at io.servicetalk.buffer.api.AsciiBuffer.forEachByte(AsciiBuffer.java:132) ~[servicetalk-buffer-api/:?]
	at io.servicetalk.buffer.api.CharSequences.forEachByte(CharSequences.java:123) ~[servicetalk-buffer-api/:?]
	at io.servicetalk.http.api.HeaderUtils.validateToken(HeaderUtils.java:243) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.DefaultHttpHeaders.validateHeaderName(DefaultHttpHeaders.java:591) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.DefaultHttpHeaders.validateKey(DefaultHttpHeaders.java:572) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.DefaultHttpHeaders.validateKey(DefaultHttpHeaders.java:45) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.MultiMap.put(MultiMap.java:226) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.DefaultHttpHeaders.add(DefaultHttpHeaders.java:638) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.netty.HttpObjectDecoder.parseHeaderLine(HttpObjectDecoder.java:687) ~[servicetalk-http-netty/:?]
	at io.servicetalk.http.netty.HttpObjectDecoder.parseAllHeaders(HttpObjectDecoder.java:788) ~[servicetalk-http-netty/:?]
	at io.servicetalk.http.netty.HttpObjectDecoder.readHeaders(HttpObjectDecoder.java:718) ~[servicetalk-http-netty/:?]
	at io.servicetalk.http.netty.HttpObjectDecoder.decode(HttpObjectDecoder.java:299) ~[servicetalk-http-netty/:?]
	at io.servicetalk.transport.netty.internal.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:365) ~[servicetalk-transport-netty-internal/:?]
	at io.servicetalk.transport.netty.internal.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:321) ~[servicetalk-transport-netty-internal/:?]
	at io.servicetalk.transport.netty.internal.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:185) ~[servicetalk-transport-netty-internal/:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer$CopyByteBufHandler.channelRead(CopyByteBufHandlerChannelInitializer.java:98) [servicetalk-transport-netty-internal/:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.kqueue.AbstractKQueueStreamChannel$KQueueStreamUnsafe.readReady(AbstractKQueueStreamChannel.java:544) [netty-transport-classes-kqueue-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.kqueue.AbstractKQueueChannel$AbstractKQueueUnsafe.readReady(AbstractKQueueChannel.java:387) [netty-transport-classes-kqueue-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.kqueue.KQueueEventLoop.processReady(KQueueEventLoop.java:218) [netty-transport-classes-kqueue-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.kqueue.KQueueEventLoop.run(KQueueEventLoop.java:296) [netty-transport-classes-kqueue-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) [netty-common-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-common-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.109.Final.jar:4.1.109.Final]
	at java.base/java.lang.Thread.run(Thread.java:829) [?:?]
```

after
```
2024-05-13 13:47:33,234 servicetalk-global-io-executor-1-3 [WARN ] NettyHttpServer$ErrorLoggingHttpSubscriber - [id: 0xcb92ece0, L:/127.0.0.1:8080 - R:/127.0.0.1:51203] Can not decode a message, no more requests will be received on this HTTP/1.1 connection, closing it due to:
io.servicetalk.http.netty.HttpObjectDecoder$StacklessDecoderException: Invalid character in line 2: '�' (0x00) at index=7 in header name 'header-�-name', expected [! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA]Caused by: io.servicetalk.utils.internal.IllegalCharacterException: '�' (0x00) at index=7 in header name 'header-�-name', expected [! / # / $ / % / & / ' / * / + / - / . / ^ / _ / ` / | / ~ / DIGIT / ALPHA]
	at io.servicetalk.http.api.HeaderUtils$TokenValidatingProcessor.process(HeaderUtils.java:879) ~[servicetalk-http-api/:?]
	at io.netty.buffer.AbstractByteBuf.forEachByteAsc0(AbstractByteBuf.java:1301) ~[netty-buffer-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.buffer.AbstractByteBuf.forEachByte(AbstractByteBuf.java:1281) ~[netty-buffer-4.1.109.Final.jar:4.1.109.Final]
	at io.servicetalk.buffer.netty.NettyBuffer.forEachByte(NettyBuffer.java:840) ~[servicetalk-buffer-netty/:?]
	at io.servicetalk.buffer.netty.WrappedBuffer.forEachByte(WrappedBuffer.java:784) ~[servicetalk-buffer-netty/:?]
	at io.servicetalk.buffer.api.AsciiBuffer.forEachByte(AsciiBuffer.java:132) ~[servicetalk-buffer-api/:?]
	at io.servicetalk.buffer.api.CharSequences.forEachByte(CharSequences.java:123) ~[servicetalk-buffer-api/:?]
	at io.servicetalk.http.api.HeaderUtils.validateToken(HeaderUtils.java:246) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.DefaultHttpHeaders.validateHeaderName(DefaultHttpHeaders.java:591) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.DefaultHttpHeaders.validateKey(DefaultHttpHeaders.java:572) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.DefaultHttpHeaders.validateKey(DefaultHttpHeaders.java:45) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.MultiMap.put(MultiMap.java:226) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.api.DefaultHttpHeaders.add(DefaultHttpHeaders.java:638) ~[servicetalk-http-api/:?]
	at io.servicetalk.http.netty.HttpObjectDecoder.parseHeaderLine(HttpObjectDecoder.java:687) ~[servicetalk-http-netty/:?]
	at io.servicetalk.http.netty.HttpObjectDecoder.parseAllHeaders(HttpObjectDecoder.java:788) ~[servicetalk-http-netty/:?]
	at io.servicetalk.http.netty.HttpObjectDecoder.readHeaders(HttpObjectDecoder.java:718) ~[servicetalk-http-netty/:?]
	at io.servicetalk.http.netty.HttpObjectDecoder.decode(HttpObjectDecoder.java:299) ~[servicetalk-http-netty/:?]
	at io.servicetalk.transport.netty.internal.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:365) ~[servicetalk-transport-netty-internal/:?]
	at io.servicetalk.transport.netty.internal.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:321) ~[servicetalk-transport-netty-internal/:?]
	at io.servicetalk.transport.netty.internal.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:185) ~[servicetalk-transport-netty-internal/:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer$CopyByteBufHandler.channelRead(CopyByteBufHandlerChannelInitializer.java:98) [servicetalk-transport-netty-internal/:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) [netty-transport-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.kqueue.AbstractKQueueStreamChannel$KQueueStreamUnsafe.readReady(AbstractKQueueStreamChannel.java:544) [netty-transport-classes-kqueue-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.kqueue.AbstractKQueueChannel$AbstractKQueueUnsafe.readReady(AbstractKQueueChannel.java:387) [netty-transport-classes-kqueue-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.kqueue.KQueueEventLoop.processReady(KQueueEventLoop.java:218) [netty-transport-classes-kqueue-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.channel.kqueue.KQueueEventLoop.run(KQueueEventLoop.java:296) [netty-transport-classes-kqueue-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) [netty-common-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-common-4.1.109.Final.jar:4.1.109.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.109.Final.jar:4.1.109.Final]
	at java.base/java.lang.Thread.run(Thread.java:829) [?:?]
```