### PR TITLE
loadbalancer-experimental-provider: make config options evaluate on LB factory creation

### DIFF
--- a/servicetalk-loadbalancer-experimental-provider/build.gradle
+++ b/servicetalk-loadbalancer-experimental-provider/build.gradle
@@ -18,12 +18,20 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   implementation platform(project(":servicetalk-dependencies"))
+  testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+
   api project(":servicetalk-http-api")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-loadbalancer")
   implementation project(":servicetalk-loadbalancer-experimental")
   implementation project(":servicetalk-http-api")
+
+  testImplementation project(":servicetalk-http-netty")
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.apache.logging.log4j:log4j-core"
+  testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+
   implementation "com.google.code.findbugs:jsr305"
   implementation "org.slf4j:slf4j-api"
 }

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
@@ -28,8 +28,6 @@ import io.servicetalk.transport.api.HostAndPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A client builder provider that supports enabling the new `DefaultLoadBalancer` in applications via property flags.
  * See the packages README.md for more details.
@@ -38,25 +36,18 @@ public class DefaultHttpLoadBalancerProvider implements HttpProviders.SingleAddr
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHttpLoadBalancerProvider.class);
 
-    private final DefaultLoadBalancerProviderConfig config;
-
     public DefaultHttpLoadBalancerProvider() {
-        this(DefaultLoadBalancerProviderConfig.INSTANCE);
-    }
-
-    // exposed for testing
-    DefaultHttpLoadBalancerProvider(final DefaultLoadBalancerProviderConfig config) {
-        this.config = requireNonNull(config, "config");
     }
 
     @Override
     public final <U, R> SingleAddressHttpClientBuilder<U, R> newBuilder(U address,
                                                                   SingleAddressHttpClientBuilder<U, R> builder) {
         final String serviceName = clientNameFromAddress(address);
+        final DefaultLoadBalancerProviderConfig config = DefaultLoadBalancerProviderConfig.instance();
         if (config.enabledForServiceName(serviceName)) {
             try {
                 HttpLoadBalancerFactory<R> loadBalancerFactory = new DefaultHttpLoadBalancerFactory<>(
-                        defaultLoadBalancer(serviceName));
+                        defaultLoadBalancer(serviceName, config));
                 builder = builder.loadBalancerFactory(loadBalancerFactory);
                 builder = new LoadBalancerIgnoringBuilder<>(builder, serviceName);
                 LOGGER.info("Enabled DefaultLoadBalancer for service with name {}", serviceName);
@@ -68,7 +59,7 @@ public class DefaultHttpLoadBalancerProvider implements HttpProviders.SingleAddr
     }
 
     private <R> LoadBalancerFactory<R, FilterableStreamingHttpLoadBalancedConnection> defaultLoadBalancer(
-            String serviceName) {
+            String serviceName, DefaultLoadBalancerProviderConfig config) {
         return LoadBalancers.<R, FilterableStreamingHttpLoadBalancedConnection>
                         builder("experimental-load-balancer")
                 .loadBalancerObserver(new DefaultLoadBalancerObserver(serviceName))
@@ -99,7 +90,8 @@ public class DefaultHttpLoadBalancerProvider implements HttpProviders.SingleAddr
         return serviceName;
     }
 
-    private static final class LoadBalancerIgnoringBuilder<U, R>
+    // Exposed for testing
+    static final class LoadBalancerIgnoringBuilder<U, R>
             extends DelegatingSingleAddressHttpClientBuilder<U, R> {
 
         private final String serviceName;

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerProviderConfig.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerProviderConfig.java
@@ -65,8 +65,6 @@ final class DefaultLoadBalancerProviderConfig {
     private static final String PROP_MAX_EJECTION_TIME_MS = "maxEjectionTimeMs";
     private static final String PROP_EJECTION_TIME_JITTER_MS = "ejectionTimeJitterMs";
 
-    static final DefaultLoadBalancerProviderConfig INSTANCE = new DefaultLoadBalancerProviderConfig();
-
     private final String rawClientsEnabledFor;
     private final Set<String> clientsEnabledFor;
     private final int failedConnectionsThreshold;
@@ -180,6 +178,10 @@ final class DefaultLoadBalancerProviderConfig {
                 ", failurePercentageRequestVolume=" + failurePercentageRequestVolume +
                 ", maxEjectionTime=" + maxEjectionTime +
                 '}';
+    }
+
+    static DefaultLoadBalancerProviderConfig instance() {
+        return new DefaultLoadBalancerProviderConfig();
     }
 
     private static String getString(String name, String defaultValue) {

--- a/servicetalk-loadbalancer-experimental-provider/src/test/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProviderTest.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/test/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProviderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer.experimental;
+
+import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.transport.api.HostAndPort;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.net.InetSocketAddress;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+@Execution(ExecutionMode.SAME_THREAD)
+class DefaultHttpLoadBalancerProviderTest {
+
+    private static final String PROPERTY_NAME = "io.servicetalk.loadbalancer.experimental.clientsEnabledFor";
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty(PROPERTY_NAME);
+    }
+
+    @Test
+    void defaultsToNoHost() throws Exception {
+        SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                HttpClients.forSingleAddress("testhost", 80);
+        assertThat(builder, not(instanceOf(DefaultHttpLoadBalancerProvider.LoadBalancerIgnoringBuilder.class)));
+    }
+
+    @Test
+    void isNotUsedForUnmatchedHost() throws Exception {
+        System.setProperty(PROPERTY_NAME, "notthisone");
+        SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                HttpClients.forSingleAddress("testhost", 80);
+        assertThat(builder, not(instanceOf(DefaultHttpLoadBalancerProvider.LoadBalancerIgnoringBuilder.class)));
+    }
+
+    @Test
+    void isNotUsedForUnmatchedHostInList() throws Exception {
+        System.setProperty(PROPERTY_NAME, "notthisone,foo");
+        SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                HttpClients.forSingleAddress("testhost", 80);
+        assertThat(builder, not(instanceOf(DefaultHttpLoadBalancerProvider.LoadBalancerIgnoringBuilder.class)));
+    }
+
+    @Test
+    void isUsedForMatchedHost() throws Exception {
+        System.setProperty(PROPERTY_NAME, "testhost");
+        SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                HttpClients.forSingleAddress("testhost", 80);
+        assertThat(builder, instanceOf(DefaultHttpLoadBalancerProvider.LoadBalancerIgnoringBuilder.class));
+    }
+
+    @Test
+    void isUsedForMatchedHostInList() throws Exception {
+        System.setProperty(PROPERTY_NAME, "testhost,foo");
+        SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                HttpClients.forSingleAddress("testhost", 80);
+        assertThat(builder, instanceOf(DefaultHttpLoadBalancerProvider.LoadBalancerIgnoringBuilder.class));
+    }
+
+    @Test
+    void isUsedForAnyHost() throws Exception {
+        System.setProperty(PROPERTY_NAME, "*");
+        SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
+                HttpClients.forSingleAddress("anyhostname", 80);
+        assertThat(builder, instanceOf(DefaultHttpLoadBalancerProvider.LoadBalancerIgnoringBuilder.class));
+    }
+}

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProviderTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProviderTest.java
@@ -63,4 +63,11 @@ final class RoundRobinToDefaultLBMigrationProviderTest {
                 "builder", builder);
         assertThat(result, sameInstance(builder));
     }
+
+    @Test
+    void isCorrectlyServiceLoaded() {
+        System.setProperty(PROPERTY_NAME, "true");
+        assertThat(RoundRobinLoadBalancers.builder("builder").build(),
+                instanceOf(DefaultLoadBalancerBuilder.DefaultLoadBalancerFactory.class));
+    }
 }


### PR DESCRIPTION
Motivation:

Providers are loaded as part of a static initializer and that order can happen before or after users set system properties in a non-determinate manner. That makes it tough to be sure the config takes affect when a client is created.

Modifications:

Change the evaluation of parameters to be when a client builder is created. This will make parameter evaluation happen when a client is desired which makes parameter evaluation much easier to reason about and test.