### PR TITLE
loadbalancer-experimental: adjust load balancer policy docs and helpers

### DIFF
--- a/servicetalk-examples/http/defaultloadbalancer/src/main/java/io/servicetalk/examples/http/defaultloadbalancer/DefaultLoadBalancerClient.java
+++ b/servicetalk-examples/http/defaultloadbalancer/src/main/java/io/servicetalk/examples/http/defaultloadbalancer/DefaultLoadBalancerClient.java
@@ -24,7 +24,7 @@ import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.loadbalancer.LoadBalancers;
 import io.servicetalk.loadbalancer.OutlierDetectorConfig;
-import io.servicetalk.loadbalancer.P2CLoadBalancingPolicy;
+import io.servicetalk.loadbalancer.P2CLoadBalancingPolicyBuilder;
 import io.servicetalk.transport.api.HostAndPort;
 
 import java.net.InetSocketAddress;
@@ -60,7 +60,7 @@ public final class DefaultLoadBalancerClient {
                         // request count to score hosts. The net result is typically a traffic distribution that will
                         // show a preference toward faster hosts while also rapidly adjust to changes in backend
                         // performance.
-                        new P2CLoadBalancingPolicy.Builder()
+                        new P2CLoadBalancingPolicyBuilder()
                                 // Set the max effort (default: 5). This is the number of times P2C will pick a random
                                 // pair of hosts in search of a healthy host before giving up. When it gives up it will
                                 // either attempt to use one of the hosts regardless of status if `failOpen == true` or

--- a/servicetalk-examples/http/defaultloadbalancer/src/main/java/io/servicetalk/examples/http/defaultloadbalancer/DefaultLoadBalancerClient.java
+++ b/servicetalk-examples/http/defaultloadbalancer/src/main/java/io/servicetalk/examples/http/defaultloadbalancer/DefaultLoadBalancerClient.java
@@ -22,6 +22,7 @@ import io.servicetalk.http.api.FilterableStreamingHttpLoadBalancedConnection;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.loadbalancer.LoadBalancerPolicies;
 import io.servicetalk.loadbalancer.LoadBalancers;
 import io.servicetalk.loadbalancer.OutlierDetectorConfig;
 import io.servicetalk.loadbalancer.P2CLoadBalancingPolicyBuilder;
@@ -60,7 +61,7 @@ public final class DefaultLoadBalancerClient {
                         // request count to score hosts. The net result is typically a traffic distribution that will
                         // show a preference toward faster hosts while also rapidly adjust to changes in backend
                         // performance.
-                        new P2CLoadBalancingPolicyBuilder()
+                        LoadBalancerPolicies.p2c()
                                 // Set the max effort (default: 5). This is the number of times P2C will pick a random
                                 // pair of hosts in search of a healthy host before giving up. When it gives up it will
                                 // either attempt to use one of the hosts regardless of status if `failOpen == true` or

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerProviderConfig.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerProviderConfig.java
@@ -16,10 +16,9 @@
 package io.servicetalk.loadbalancer.experimental;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.loadbalancer.LoadBalancerPolicies;
 import io.servicetalk.loadbalancer.LoadBalancingPolicy;
 import io.servicetalk.loadbalancer.OutlierDetectorConfig;
-import io.servicetalk.loadbalancer.P2CLoadBalancingPolicy;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancingPolicy;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,11 +123,8 @@ final class DefaultLoadBalancerProviderConfig {
     }
 
     <U, C extends LoadBalancedConnection> LoadBalancingPolicy<U, C> getLoadBalancingPolicy() {
-        if (lbPolicy == LBPolicy.P2C) {
-            return new P2CLoadBalancingPolicy.Builder().build();
-        } else {
-            return new RoundRobinLoadBalancingPolicy.Builder().build();
-        }
+        return lbPolicy == LBPolicy.P2C ?
+                LoadBalancerPolicies.p2c().build() : LoadBalancerPolicies.roundRobin().build();
     }
 
     boolean enabledForServiceName(String serviceName) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -198,7 +198,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     private static <ResolvedAddress, C extends LoadBalancedConnection>
     LoadBalancingPolicy<ResolvedAddress, C> defaultLoadBalancingPolicy() {
-        return new RoundRobinLoadBalancingPolicyBuilder().build();
+        return LoadBalancerPolicies.roundRobin().build();
     }
 
     private static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C>

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -198,7 +198,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     private static <ResolvedAddress, C extends LoadBalancedConnection>
     LoadBalancingPolicy<ResolvedAddress, C> defaultLoadBalancingPolicy() {
-        return new RoundRobinLoadBalancingPolicy.Builder().build();
+        return new RoundRobinLoadBalancingPolicyBuilder().build();
     }
 
     private static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C>

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerPolicies.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerPolicies.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+/**
+ * A collections of factories for constructing a {@link LoadBalancingPolicy}.
+ */
+public final class LoadBalancerPolicies {
+
+    private LoadBalancerPolicies() {
+        // no instances.
+    }
+
+    /**
+     * Builder for the round-robin {@link LoadBalancingPolicy}.
+     * Round-robin load balancing is a strategy that maximizes fairness of the request distribution. This comes at the
+     * cost of being unable to bias toward better performing hosts and can only leverage the course grained
+     * healthy/unhealthy status of a host.
+     * @return a builder for the round-robin {@link LoadBalancingPolicy}.
+     */
+    public static RoundRobinLoadBalancingPolicy.Builder roundRobin() {
+        return new RoundRobinLoadBalancingPolicy.Builder();
+    }
+
+    /**
+     * Builder for the power of two choices (P2C) {@link LoadBalancingPolicy}.
+     * Power of Two Choices (P2C) leverages both course grained healthy/unhealthy status of a host plus additional
+     * fine-grained scoring to prioritize hosts that are both healthy and better performing. See the
+     * {@link P2CLoadBalancingPolicy} for more details.
+     * @return a builder for the power of two choices (P2C) {@link LoadBalancingPolicy}.
+     */
+    public static P2CLoadBalancingPolicy.Builder p2c() {
+        return new P2CLoadBalancingPolicy.Builder();
+    }
+}

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerPolicies.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerPolicies.java
@@ -31,8 +31,8 @@ public final class LoadBalancerPolicies {
      * healthy/unhealthy status of a host.
      * @return a builder for the round-robin {@link LoadBalancingPolicy}.
      */
-    public static RoundRobinLoadBalancingPolicy.Builder roundRobin() {
-        return new RoundRobinLoadBalancingPolicy.Builder();
+    public static RoundRobinLoadBalancingPolicyBuilder roundRobin() {
+        return new RoundRobinLoadBalancingPolicyBuilder();
     }
 
     /**
@@ -42,7 +42,7 @@ public final class LoadBalancerPolicies {
      * {@link P2CLoadBalancingPolicy} for more details.
      * @return a builder for the power of two choices (P2C) {@link LoadBalancingPolicy}.
      */
-    public static P2CLoadBalancingPolicy.Builder p2c() {
-        return new P2CLoadBalancingPolicy.Builder();
+    public static P2CLoadBalancingPolicyBuilder p2c() {
+        return new P2CLoadBalancingPolicyBuilder();
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -99,9 +99,13 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
         }
 
         /**
-         * Set whether the host selector should attempt to use an unhealthy {@link Host} as a last resort.
+         * Set whether the selector should fail-open in the event no healthy hosts are found.
+         * When a load balancing policy is configured to fail-open and is unable to find a healthy host, it will attempt
+         * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy
+         * session.
          * Defaults to {@value DEFAULT_FAIL_OPEN_POLICY}.
-         * @param failOpen whether the host selector should attempt to use an unhealthy {@link Host} as a last resort.
+         * @param failOpen if true, will attempt  to select or establish a connection from an arbitrary host even if it
+         *                 is unlikely to return a healthy  session.
          * @return {@code this}
          */
         public Builder failOpen(final boolean failOpen) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -76,6 +76,7 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     /**
      * A builder for immutable {@link P2CLoadBalancingPolicy} instances.
      */
+    @Deprecated // FIXME: 0.42.45 - remove builder.
     public static final class Builder {
 
         private static final boolean DEFAULT_IGNORE_WEIGHTS = false;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -39,6 +39,7 @@ import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
  * @see <a href="https://www.eecs.harvard.edu/~michaelm/postscripts/tpds2001.pdf">Mitzenmacher (2001) The Power of Two
  *  *  Choices in Randomized Load Balancing</a>
  */
+@Deprecated // FIXME: 0.42.45 - make package private
 public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
         extends LoadBalancingPolicy<ResolvedAddress, C> {
 
@@ -48,7 +49,7 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     @Nullable
     private final Random random;
 
-    private P2CLoadBalancingPolicy(final boolean ignoreWeights, final int maxEffort,
+    P2CLoadBalancingPolicy(final boolean ignoreWeights, final int maxEffort,
                                    final boolean failOpen, @Nullable final Random random) {
         this.ignoreWeights = ignoreWeights;
         this.maxEffort = maxEffort;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -37,7 +37,8 @@ import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
  * @param <ResolvedAddress> the type of the resolved address.
  * @param <C> the type of the load balanced connection.
  * @see <a href="https://www.eecs.harvard.edu/~michaelm/postscripts/tpds2001.pdf">Mitzenmacher (2001) The Power of Two
- *  *  Choices in Randomized Load Balancing</a>
+ *    Choices in Randomized Load Balancing</a>
+ *  @deprecated Use {@link P2CLoadBalancingPolicyBuilder}.
  */
 @Deprecated // FIXME: 0.42.45 - make package private
 public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
@@ -75,6 +76,7 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
 
     /**
      * A builder for immutable {@link P2CLoadBalancingPolicy} instances.
+     * @deprecated Use {@link P2CLoadBalancingPolicyBuilder}.
      */
     @Deprecated // FIXME: 0.42.45 - remove builder.
     public static final class Builder {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicyBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicyBuilder.java
@@ -24,6 +24,7 @@ import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 
 /**
  * A builder for immutable {@link P2CLoadBalancingPolicy} instances.
+ * @see LoadBalancerPolicies#p2c()
  */
 public final class P2CLoadBalancingPolicyBuilder {
 
@@ -36,6 +37,10 @@ public final class P2CLoadBalancingPolicyBuilder {
     private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;
     @Nullable
     private Random random;
+
+    P2CLoadBalancingPolicyBuilder() {
+    // package private
+    }
 
     /**
      * Set the maximum number of attempts that P2C will attempt to select a pair with at least one

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicyBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicyBuilder.java
@@ -1,0 +1,85 @@
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+
+import javax.annotation.Nullable;
+import java.util.Random;
+
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
+
+/**
+ * A builder for immutable {@link P2CLoadBalancingPolicy} instances.
+ */
+public final class P2CLoadBalancingPolicyBuilder {
+
+    private static final boolean DEFAULT_IGNORE_WEIGHTS = false;
+    private static final int DEFAULT_MAX_EFFORT = 5;
+    private static final boolean DEFAULT_FAIL_OPEN_POLICY = LoadBalancingPolicy.DEFAULT_FAIL_OPEN_POLICY;
+
+    private boolean ignoreWeights = DEFAULT_IGNORE_WEIGHTS;
+    private int maxEffort = DEFAULT_MAX_EFFORT;
+    private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;
+    @Nullable
+    private Random random;
+
+    /**
+     * Set the maximum number of attempts that P2C will attempt to select a pair with at least one
+     * healthy host.
+     * Defaults to {@value DEFAULT_MAX_EFFORT}.
+     *
+     * @param maxEffort the maximum number of attempts.
+     * @return {@code this}
+     */
+    public P2CLoadBalancingPolicyBuilder maxEffort(final int maxEffort) {
+        this.maxEffort = ensurePositive(maxEffort, "maxEffort");
+        return this;
+    }
+
+    /**
+     * Set whether the selector should fail-open in the event no healthy hosts are found.
+     * When a load balancing policy is configured to fail-open and is unable to find a healthy host, it will attempt
+     * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy
+     * session.
+     * Defaults to {@value DEFAULT_FAIL_OPEN_POLICY}.
+     *
+     * @param failOpen if true, will attempt  to select or establish a connection from an arbitrary host even if it
+     *                 is unlikely to return a healthy  session.
+     * @return {@code this}
+     */
+    public P2CLoadBalancingPolicyBuilder failOpen(final boolean failOpen) {
+        this.failOpen = failOpen;
+        return this;
+    }
+
+    /**
+     * Set whether the host selector should ignore {@link Host}s weight.
+     * Host weight influences the probability it will be selected to serve a request. The host weight can come
+     * from many sources including known host capacity, priority groups, and others, so ignoring weight
+     * information can lead to other features not working properly and should be used with care.
+     * Defaults to {@value DEFAULT_IGNORE_WEIGHTS}.
+     *
+     * @param ignoreWeights whether the host selector should ignore host weight information.
+     * @return {@code this}
+     */
+    public P2CLoadBalancingPolicyBuilder ignoreWeights(final boolean ignoreWeights) {
+        this.ignoreWeights = ignoreWeights;
+        return this;
+    }
+
+    // For testing purposes only.
+    P2CLoadBalancingPolicyBuilder random(Random random) {
+        this.random = random;
+        return this;
+    }
+
+    /**
+     * Construct an immutable {@link P2CLoadBalancingPolicy}.
+     *
+     * @param <ResolvedAddress> the type of the resolved address.
+     * @param <C>               the refined type of the {@link LoadBalancedConnection}.
+     * @return the concrete {@link P2CLoadBalancingPolicy}.
+     */
+    public <ResolvedAddress, C extends LoadBalancedConnection> LoadBalancingPolicy<ResolvedAddress, C> build() {
+        return new P2CLoadBalancingPolicy<>(ignoreWeights, maxEffort, failOpen, random);
+    }
+}

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicyBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicyBuilder.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
 
-import javax.annotation.Nullable;
 import java.util.Random;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -26,8 +26,6 @@ import java.util.List;
  * from an ordered set. If a host is considered unhealthy it is skipped the next host
  * is selected until a healthy host is found or the entire host set has been exhausted.
  *
- * Note: this algorithm doesn't currently support weighted hosts and all weight information will be ignored.
- *
  * @param <ResolvedAddress> the type of the resolved address
  * @param <C> the type of the load balanced connection
  */
@@ -69,9 +67,14 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
         private boolean ignoreWeights = DEFAULT_IGNORE_WEIGHTS;
 
         /**
-         * Set whether the host selector should attempt to use an unhealthy {@link Host} as a last resort.
-         * @param failOpen whether the host selector should attempt to use an unhealthy {@link Host} as a last resort.
-         * @return this {@link P2CLoadBalancingPolicy.Builder}.
+         * Set whether the selector should fail-open in the event no healthy hosts are found.
+         * When a load balancing policy is configured to fail-open and is unable to find a healthy host, it will attempt
+         * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy
+         * session.
+         * Defaults to {@value DEFAULT_FAIL_OPEN_POLICY}.
+         * @param failOpen if true, will attempt  to select or establish a connection from an arbitrary host even if it
+         *                 is unlikely to return a healthy  session.
+         * @return {@code this}
          */
         public Builder failOpen(final boolean failOpen) {
             this.failOpen = failOpen;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -28,6 +28,7 @@ import java.util.List;
  *
  * @param <ResolvedAddress> the type of the resolved address
  * @param <C> the type of the load balanced connection
+ * @deprecated Use {@link RoundRobinLoadBalancingPolicyBuilder}.
  */
 @Deprecated // FIXME: 0.42.45 - make package private
 public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
@@ -59,6 +60,7 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
 
     /**
      * A builder for immutable {@link RoundRobinLoadBalancingPolicy} instances.
+     * @deprecated Use {@link RoundRobinLoadBalancingPolicyBuilder}.
      */
     @Deprecated // FIXME: 0.42.45 - remove builder.
     public static final class Builder {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -29,13 +29,14 @@ import java.util.List;
  * @param <ResolvedAddress> the type of the resolved address
  * @param <C> the type of the load balanced connection
  */
+@Deprecated // FIXME: 0.42.45 - make package private
 public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
         extends LoadBalancingPolicy<ResolvedAddress, C> {
 
     private final boolean failOpen;
     private final boolean ignoreWeights;
 
-    private RoundRobinLoadBalancingPolicy(final boolean failOpen, final boolean ignoreWeights) {
+    RoundRobinLoadBalancingPolicy(final boolean failOpen, final boolean ignoreWeights) {
         this.failOpen = failOpen;
         this.ignoreWeights = ignoreWeights;
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -60,6 +60,7 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
     /**
      * A builder for immutable {@link RoundRobinLoadBalancingPolicy} instances.
      */
+    @Deprecated // FIXME: 0.42.45 - remove builder.
     public static final class Builder {
 
         private static final boolean DEFAULT_IGNORE_WEIGHTS = false;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
@@ -19,6 +19,7 @@ import io.servicetalk.client.api.LoadBalancedConnection;
 
 /**
  * A builder for immutable {@link RoundRobinLoadBalancingPolicy} instances.
+ * @see LoadBalancerPolicies#roundRobin()
  */
 public final class RoundRobinLoadBalancingPolicyBuilder {
 
@@ -27,6 +28,10 @@ public final class RoundRobinLoadBalancingPolicyBuilder {
 
     private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;
     private boolean ignoreWeights = DEFAULT_IGNORE_WEIGHTS;
+
+    RoundRobinLoadBalancingPolicyBuilder() {
+        // package private constructor
+    }
 
     /**
      * Set whether the selector should fail-open in the event no healthy hosts are found.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
@@ -1,0 +1,58 @@
+package io.servicetalk.loadbalancer;
+
+import io.servicetalk.client.api.LoadBalancedConnection;
+
+/**
+ * A builder for immutable {@link RoundRobinLoadBalancingPolicy} instances.
+ */
+public final class RoundRobinLoadBalancingPolicyBuilder {
+
+    private static final boolean DEFAULT_IGNORE_WEIGHTS = false;
+    private static final boolean DEFAULT_FAIL_OPEN_POLICY = LoadBalancingPolicy.DEFAULT_FAIL_OPEN_POLICY;
+
+    private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;
+    private boolean ignoreWeights = DEFAULT_IGNORE_WEIGHTS;
+
+    /**
+     * Set whether the selector should fail-open in the event no healthy hosts are found.
+     * When a load balancing policy is configured to fail-open and is unable to find a healthy host, it will attempt
+     * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy
+     * session.
+     * Defaults to {@value DEFAULT_FAIL_OPEN_POLICY}.
+     *
+     * @param failOpen if true, will attempt  to select or establish a connection from an arbitrary host even if it
+     *                 is unlikely to return a healthy  session.
+     * @return {@code this}
+     */
+    public RoundRobinLoadBalancingPolicyBuilder failOpen(final boolean failOpen) {
+        this.failOpen = failOpen;
+        return this;
+    }
+
+    /**
+     * Set whether the host selector should ignore {@link Host}s weight.
+     * Host weight influences the probability it will be selected to serve a request. The host weight can come
+     * from many sources including known host capacity, priority groups, and others, so ignoring weight
+     * information can lead to other features not working properly and should be used with care.
+     * Defaults to {@value DEFAULT_IGNORE_WEIGHTS}.
+     *
+     * @param ignoreWeights whether the host selector should ignore host weight information.
+     * @return {@code this}
+     */
+    public RoundRobinLoadBalancingPolicyBuilder ignoreWeights(final boolean ignoreWeights) {
+        this.ignoreWeights = ignoreWeights;
+        return this;
+    }
+
+    /**
+     * Construct the immutable {@link RoundRobinLoadBalancingPolicy}.
+     *
+     * @param <ResolvedAddress> the type of the resolved address.
+     * @param <C>               the refined type of the {@link LoadBalancedConnection}.
+     * @return the concrete {@link RoundRobinLoadBalancingPolicy}.
+     */
+    public <ResolvedAddress, C extends LoadBalancedConnection> LoadBalancingPolicy<ResolvedAddress, C>
+    build() {
+        return new RoundRobinLoadBalancingPolicy<>(failOpen, ignoreWeights);
+    }
+}

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
@@ -123,10 +123,11 @@ public final class RoundRobinToDefaultLBMigrationProvider implements RoundRobinL
                     .serviceDiscoveryResubscribeInterval(healthCheckResubscribeInterval, healthCheckResubscribeJitter)
                     .build();
 
-            LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy = new RoundRobinLoadBalancingPolicy.Builder()
-                    .failOpen(false)
-                    .ignoreWeights(true)
-                    .build();
+            LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy =
+                    LoadBalancerPolicies.roundRobin()
+                        .failOpen(false)
+                        .ignoreWeights(true)
+                        .build();
 
             LoadBalancerBuilder<ResolvedAddress, C> builder = LoadBalancers.builder(id);
             if (backgroundExecutor != null) {

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
     private LoadBalancingPolicy<String, TestLoadBalancedConnection> loadBalancingPolicy =
-            new P2CLoadBalancingPolicy.Builder().build();
+            new P2CLoadBalancingPolicyBuilder().build();
     @Nullable
     private Supplier<OutlierDetector<String, TestLoadBalancedConnection>> outlierDetectorFactory;
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
     private LoadBalancingPolicy<String, TestLoadBalancedConnection> loadBalancingPolicy =
-            new P2CLoadBalancingPolicyBuilder().build();
+            LoadBalancerPolicies.p2c().build();
     @Nullable
     private Supplier<OutlierDetector<String, TestLoadBalancedConnection>> outlierDetectorFactory;
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/EagerNewRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/EagerNewRoundRobinLoadBalancerTest.java
@@ -25,6 +25,6 @@ class EagerNewRoundRobinLoadBalancerTest extends EagerLoadBalancerTest {
     @Override
     protected LoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
         return LoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
-                .loadBalancingPolicy(new RoundRobinLoadBalancingPolicy.Builder().build());
+                .loadBalancingPolicy(new RoundRobinLoadBalancingPolicyBuilder().build());
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/EagerNewRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/EagerNewRoundRobinLoadBalancerTest.java
@@ -25,6 +25,6 @@ class EagerNewRoundRobinLoadBalancerTest extends EagerLoadBalancerTest {
     @Override
     protected LoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
         return LoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
-                .loadBalancingPolicy(new RoundRobinLoadBalancingPolicyBuilder().build());
+                .loadBalancingPolicy(LoadBalancerPolicies.roundRobin().build());
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/EagerP2CLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/EagerP2CLoadBalancerTest.java
@@ -25,6 +25,6 @@ public class EagerP2CLoadBalancerTest extends EagerLoadBalancerTest {
     @Override
     protected LoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
         return LoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
-                .loadBalancingPolicy(new P2CLoadBalancingPolicy.Builder().build());
+                .loadBalancingPolicy(new P2CLoadBalancingPolicyBuilder().build());
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/EagerP2CLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/EagerP2CLoadBalancerTest.java
@@ -25,6 +25,6 @@ public class EagerP2CLoadBalancerTest extends EagerLoadBalancerTest {
     @Override
     protected LoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
         return LoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
-                .loadBalancingPolicy(new P2CLoadBalancingPolicyBuilder().build());
+                .loadBalancingPolicy(LoadBalancerPolicies.p2c().build());
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LingeringNewRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LingeringNewRoundRobinLoadBalancerTest.java
@@ -25,6 +25,6 @@ class LingeringNewRoundRobinLoadBalancerTest extends LingeringLoadBalancerTest {
     @Override
     protected LoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
         return LoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
-                .loadBalancingPolicy(new RoundRobinLoadBalancingPolicy.Builder().build());
+                .loadBalancingPolicy(new RoundRobinLoadBalancingPolicyBuilder().build());
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LingeringNewRoundRobinLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LingeringNewRoundRobinLoadBalancerTest.java
@@ -25,6 +25,6 @@ class LingeringNewRoundRobinLoadBalancerTest extends LingeringLoadBalancerTest {
     @Override
     protected LoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
         return LoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
-                .loadBalancingPolicy(new RoundRobinLoadBalancingPolicyBuilder().build());
+                .loadBalancingPolicy(LoadBalancerPolicies.roundRobin().build());
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LingeringP2CLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LingeringP2CLoadBalancerTest.java
@@ -25,6 +25,6 @@ public class LingeringP2CLoadBalancerTest extends LingeringLoadBalancerTest {
     @Override
     protected LoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
         return LoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
-                .loadBalancingPolicy(new P2CLoadBalancingPolicy.Builder().build());
+                .loadBalancingPolicy(new P2CLoadBalancingPolicyBuilder().build());
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LingeringP2CLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LingeringP2CLoadBalancerTest.java
@@ -25,6 +25,6 @@ public class LingeringP2CLoadBalancerTest extends LingeringLoadBalancerTest {
     @Override
     protected LoadBalancerBuilder<String, TestLoadBalancedConnection> baseLoadBalancerBuilder() {
         return LoadBalancers.<String, TestLoadBalancedConnection>builder(getClass().getSimpleName())
-                .loadBalancingPolicy(new P2CLoadBalancingPolicyBuilder().build());
+                .loadBalancingPolicy(LoadBalancerPolicies.p2c().build());
     }
 }


### PR DESCRIPTION
Motivation:

- More detail could be provided for the P2C and RR `failOpen` configuration option since it might not be clear what fail-open mean in that context.
- We could use some helpers to make the different policies more discoverable.

Modifications:

- Adjust the docs for `.failOpen` to add more detail.
- Add LoadBalancerPolicies to aid discoverability of load balancer policies