### PR TITLE
Move `DelayedRetry` to `servicetalk-client-api`

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelayedRetry.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelayedRetry.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.client.api;
+
+import java.time.Duration;
+
+/**
+ * An interface that enhances any {@link Exception} to provide a constant {@link Duration delay} to be applied when
+ * it needs to be retried.
+ */
+public interface DelayedRetry {
+
+    /**
+     * A constant delay to apply.
+     *
+     * @return The {@link Duration} to apply as constant delay when retrying
+     */
+    Duration delay();
+
+    /**
+     * Returns original {@link Throwable} this {@link DelayedRetry} represents.
+     *
+     * @return the original {@link Throwable}
+     */
+    Throwable throwable();
+}

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelayedRetryException.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelayedRetryException.java
@@ -18,10 +18,10 @@ package io.servicetalk.client.api;
 import java.time.Duration;
 
 /**
- * An interface that enhances any {@link Exception} to provide a constant {@link Duration delay} to be applied when
- * it needs to be retried.
+ * An interface that enhances any {@link Throwable exception} to provide a constant {@link Duration delay} to be applied
+ * when it needs to be retried.
  */
-public interface DelayedRetry {
+public interface DelayedRetryException {
 
     /**
      * A constant delay to apply.
@@ -31,7 +31,7 @@ public interface DelayedRetry {
     Duration delay();
 
     /**
-     * Returns original {@link Throwable} this {@link DelayedRetry} represents.
+     * Returns original {@link Throwable} this {@link DelayedRetryException} represents.
      *
      * @return the original {@link Throwable}
      */

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -896,7 +896,7 @@ public final class RetryingHttpRequesterFilter
          * @deprecated Use {@link #retryDelayedRetryExceptions(BiFunction)} instead.
          */
         @Deprecated
-        public Builder retryDelayedRetries( // FIXME: 0.43 - remove deprecated method
+        public Builder retryDelayedRetries(// FIXME: 0.43 - remove deprecated method
                 final BiFunction<HttpRequestMetaData, DelayedRetry, BackOffPolicy> mapper) {
             this.retryDelayedRetries = requireNonNull(mapper);
             return this;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -679,7 +679,11 @@ public final class RetryingHttpRequesterFilter
         Duration delay();
 
         @Override
+        @SuppressWarnings("InstanceofIncompatibleInterface")
         default Throwable throwable() {
+            if (this instanceof Throwable) {
+                return (Throwable) this;
+            }
             throw new UnsupportedOperationException("DelayedRetry#throwable() is not supported by " + getClass());
         }
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingHttpRequesterFilter.java
@@ -197,8 +197,8 @@ public final class RetryingHttpRequesterFilter
                 if (backOffPolicy != NO_RETRIES) {
                     final int offsetCount = count - lbNotReadyCount;
                     Completable retryWhen = backOffPolicy.newStrategy(executor).apply(offsetCount, t);
-                    if (t instanceof DelayedRetry) {
-                        final Duration constant = ((DelayedRetry) t).delay();
+                    if (t instanceof io.servicetalk.client.api.DelayedRetry) {
+                        final Duration constant = ((io.servicetalk.client.api.DelayedRetry) t).delay();
                         retryWhen = retryWhen.concat(executor.timer(constant));
                     }
 
@@ -658,18 +658,29 @@ public final class RetryingHttpRequesterFilter
      * <p>
      * Constant delay returned from {@link #delay()} will be additive to the backoff policy defined for a certain
      * retry-able failure.
+     *
+     * @deprecated Use {@link io.servicetalk.client.api.DelayedRetry} instead.
      */
-    public interface DelayedRetry {
+    @Deprecated // FIXME: 0.43 - remove deprecated interface
+    @FunctionalInterface
+    public interface DelayedRetry extends io.servicetalk.client.api.DelayedRetry {
 
         /**
-         * A constant delay to apply in milliseconds.
+         * A constant delay to apply.
+         * <p>
          * The total delay for the retry logic will be the sum of this value and the result of the
          * {@link BackOffPolicy back-off policy} in-use. Consider using 'full-jitter'
          * flavours from the {@link BackOffPolicy} to avoid having another constant delay applied per-retry.
          *
          * @return The {@link Duration} to apply as constant delay when retrying.
          */
+        @Override
         Duration delay();
+
+        @Override
+        default Throwable throwable() {
+            throw new UnsupportedOperationException("DelayedRetry#throwable() is not supported by " + getClass());
+        }
     }
 
     /**
@@ -717,6 +728,10 @@ public final class RetryingHttpRequesterFilter
         private BiFunction<HttpRequestMetaData, DelayedRetry, BackOffPolicy> retryDelayedRetries;
 
         @Nullable
+        private BiFunction<HttpRequestMetaData, io.servicetalk.client.api.DelayedRetry, BackOffPolicy>
+                retryDelayedRetryExceptions;
+
+        @Nullable
         private BiFunction<HttpRequestMetaData, HttpResponseException, BackOffPolicy> retryResponses;
 
         @Nullable
@@ -756,7 +771,7 @@ public final class RetryingHttpRequesterFilter
          * functions (see. {@link #retryDelayedRetries(BiFunction)}, {@link #retryIdempotentRequests(BiFunction)},
          * {@link #retryRetryableExceptions(BiFunction)}, {@link #retryResponses(BiFunction)},
          * {@link #retryOther(BiFunction)}).
-         *
+         * <p>
          * Maximum total retries guards the LB/SD readiness flow, making sure LB connection issues will also be
          * retried with a limit.
          *
@@ -787,7 +802,9 @@ public final class RetryingHttpRequesterFilter
 
         /**
          * The retrying-filter will evaluate for {@link RetryableException}s in the request flow.
-         * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <p>
+         * To disable retries you can return {@link BackOffPolicy#ofNoRetries()} from the {@code mapper}.
+         * <p>
          * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
          *
          * @param mapper The mapper to map the {@link HttpRequestMetaData} and the
@@ -808,7 +825,9 @@ public final class RetryingHttpRequesterFilter
          * <a href="https://reactivex.io/documentation/operators/replay.html">replayable</a>, i.e. multiple subscribes
          * to the payload {@link Publisher} observe the same data. {@link Publisher}s that do not emit any data or
          * which are created from in-memory data are typically replayable.
-         * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <p>
+         * To disable retries you can return {@link BackOffPolicy#ofNoRetries()} from the {@code mapper}.
+         * <p>
          * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
          *
          * @param mapper The mapper to map the {@link HttpRequestMetaData} and the
@@ -836,19 +855,48 @@ public final class RetryingHttpRequesterFilter
         }
 
         /**
+         * The retrying-filter will evaluate the {@link Throwable} marked with
+         * {@link io.servicetalk.client.api.DelayedRetry} interface and use the provided
+         * {@link io.servicetalk.client.api.DelayedRetry#delay() delay} as a constant delay on-top of the
+         * retry period already defined.
+         * <p>
+         * In case a max-delay was set in this builder, the
+         * {@link io.servicetalk.client.api.DelayedRetry#delay() constant-delay} overrides it and takes precedence.
+         * <p>
+         * To disable retries and proceed evaluating other retry functions you can return,
+         * {@link BackOffPolicy#ofNoRetries()} from the passed {@code mapper}.
+         * <p>
+         * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
+         *
+         * @param mapper The mapper to map the {@link HttpRequestMetaData} and the
+         * {@link io.servicetalk.client.api.DelayedRetry delayed-exception} to a {@link BackOffPolicy}.
+         * @return {@code this}.
+         */
+        public Builder retryDelayedRetryExceptions(
+                final BiFunction<HttpRequestMetaData, io.servicetalk.client.api.DelayedRetry, BackOffPolicy> mapper) {
+            this.retryDelayedRetryExceptions = requireNonNull(mapper);
+            return this;
+        }
+
+        /**
          * The retrying-filter will evaluate the {@link DelayedRetry} marker interface
          * of an exception and use the provided {@link DelayedRetry#delay() delay} as a constant delay on-top of the
          * retry period already defined.
+         * <p>
          * In case a max-delay was set in this builder, the {@link DelayedRetry#delay() constant-delay} overrides
          * it and takes precedence.
+         * <p>
          * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <p>
          * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
          *
          * @param mapper The mapper to map the {@link HttpRequestMetaData} and the
          * {@link DelayedRetry delayed-exception} to a {@link BackOffPolicy}.
          * @return {@code this}.
+         * @deprecated Use {@link #retryDelayedRetryExceptions(BiFunction)} instead.
          */
-        public Builder retryDelayedRetries(
+        @Deprecated
+        public Builder retryDelayedRetries( // FIXME: 0.43 - remove deprecated method
                 final BiFunction<HttpRequestMetaData, DelayedRetry, BackOffPolicy> mapper) {
             this.retryDelayedRetries = requireNonNull(mapper);
             return this;
@@ -858,7 +906,9 @@ public final class RetryingHttpRequesterFilter
          * The retrying-filter will evaluate {@link HttpResponseException} that resulted from the
          * {@link #responseMapper(Function)}, and support different retry behaviour according to the
          * {@link HttpRequestMetaData request} and the {@link HttpResponseMetaData response}.
+         * <p>
          * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <p>
          * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
          *
          * @param mapper The mapper to map the {@link HttpRequestMetaData} and the
@@ -874,8 +924,11 @@ public final class RetryingHttpRequesterFilter
         /**
          * Support additional criteria for determining which requests or errors should be
          * retried.
+         * <p>
          * To disable retries you can return {@link BackOffPolicy#NO_RETRIES} from the {@code mapper}.
+         * <p>
          * <strong>It's important that this {@link Function} doesn't block to avoid performance impacts.</strong>
+         *
          * @param mapper {@link BiFunction} that checks whether a given combination of
          * {@link HttpRequestMetaData meta-data} and {@link Throwable cause} should be retried, producing a
          * {@link BackOffPolicy} in such cases.
@@ -925,14 +978,19 @@ public final class RetryingHttpRequesterFilter
                     this.retryRetryableExceptions;
             final BiFunction<HttpRequestMetaData, IOException, BackOffPolicy> retryIdempotentRequests =
                     this.retryIdempotentRequests;
+            final BiFunction<HttpRequestMetaData, io.servicetalk.client.api.DelayedRetry, BackOffPolicy>
+                    retryDelayedRetryExceptions = this.retryDelayedRetryExceptions;
             final BiFunction<HttpRequestMetaData, DelayedRetry, BackOffPolicy> retryDelayedRetries =
                     this.retryDelayedRetries;
             final BiFunction<HttpRequestMetaData, HttpResponseException, BackOffPolicy> retryResponses =
                     this.retryResponses;
             final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> retryOther = this.retryOther;
             // This assumes RetryableExceptions are never written/consumed.
-            final boolean mayReplayRequestPayload = retryIdempotentRequests != null || retryDelayedRetries != null ||
-                    retryResponses != null || retryOther != null;
+            final boolean mayReplayRequestPayload = retryIdempotentRequests != null ||
+                    retryDelayedRetryExceptions != null ||
+                    retryDelayedRetries != null ||
+                    retryResponses != null ||
+                    retryOther != null;
 
             final BiFunction<HttpRequestMetaData, Throwable, BackOffPolicy> allPredicate =
                     (requestMetaData, throwable) -> {
@@ -954,6 +1012,15 @@ public final class RetryingHttpRequesterFilter
                                 && requestMetaData.method().properties().isIdempotent()) {
                             final BackOffPolicy backOffPolicy =
                                     retryIdempotentRequests.apply(requestMetaData, (IOException) throwable);
+                            if (backOffPolicy != NO_RETRIES) {
+                                return backOffPolicy;
+                            }
+                        }
+
+                        if (retryDelayedRetryExceptions != null &&
+                                throwable instanceof io.servicetalk.client.api.DelayedRetry) {
+                            final BackOffPolicy backOffPolicy = retryDelayedRetryExceptions.apply(requestMetaData,
+                                    (io.servicetalk.client.api.DelayedRetry) throwable);
                             if (backOffPolicy != NO_RETRIES) {
                                 return backOffPolicy;
                             }

--- a/servicetalk-traffic-resilience-http/build.gradle
+++ b/servicetalk-traffic-resilience-http/build.gradle
@@ -22,7 +22,6 @@ dependencies {
   api project(":servicetalk-circuit-breaker-api")
   api project(":servicetalk-http-api")
   api project(":servicetalk-http-utils")
-  api project(":servicetalk-http-netty")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/DelayedRetryRequestDroppedException.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/DelayedRetryRequestDroppedException.java
@@ -16,7 +16,7 @@
 package io.servicetalk.traffic.resilience.http;
 
 import io.servicetalk.capacity.limiter.api.RequestDroppedException;
-import io.servicetalk.client.api.DelayedRetry;
+import io.servicetalk.client.api.DelayedRetryException;
 import io.servicetalk.http.api.HttpResponseStatus;
 
 import java.time.Duration;
@@ -32,7 +32,8 @@ import static java.util.Objects.requireNonNull;
  * its up to the application to declare whether a {@link HttpResponseStatus#TOO_MANY_REQUESTS} is a safe-to-retry
  * response, and if so after how much {@link #delay()}.
  */
-public final class DelayedRetryRequestDroppedException extends RequestDroppedException implements DelayedRetry {
+public final class DelayedRetryRequestDroppedException extends RequestDroppedException
+        implements DelayedRetryException {
 
     private static final long serialVersionUID = -7933994513110803151L;
     private final Duration delay;

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/DelayedRetryRequestDroppedException.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/DelayedRetryRequestDroppedException.java
@@ -16,8 +16,8 @@
 package io.servicetalk.traffic.resilience.http;
 
 import io.servicetalk.capacity.limiter.api.RequestDroppedException;
+import io.servicetalk.client.api.DelayedRetry;
 import io.servicetalk.http.api.HttpResponseStatus;
-import io.servicetalk.http.netty.RetryingHttpRequesterFilter;
 
 import java.time.Duration;
 import javax.annotation.Nullable;
@@ -25,13 +25,14 @@ import javax.annotation.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A {@link RuntimeException} to indicate that a request was rejected by a server due to capacity constraints.
+ * A {@link RequestDroppedException} to indicate that a request was dropped by a server due to capacity constraints and
+ * requires a client to delay its retry.
+ * <p>
  * This error reflects the client side application logic and its interpretation of a service response; meaning that
  * its up to the application to declare whether a {@link HttpResponseStatus#TOO_MANY_REQUESTS} is a safe-to-retry
  * response, and if so after how much {@link #delay()}.
  */
-public final class DelayedRetryRequestDroppedException extends RequestDroppedException
-        implements RetryingHttpRequesterFilter.DelayedRetry {
+public final class DelayedRetryRequestDroppedException extends RequestDroppedException implements DelayedRetry {
 
     private static final long serialVersionUID = -7933994513110803151L;
     private final Duration delay;
@@ -99,5 +100,10 @@ public final class DelayedRetryRequestDroppedException extends RequestDroppedExc
     @Override
     public Duration delay() {
         return delay;
+    }
+
+    @Override
+    public Throwable throwable() {
+        return this;
     }
 }

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/RetryableRequestDroppedException.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/RetryableRequestDroppedException.java
@@ -21,7 +21,9 @@ import io.servicetalk.transport.api.RetryableException;
 import javax.annotation.Nullable;
 
 /**
- * A {@link RetryableException} to indicate that a request was rejected by a client/server due to capacity constraints.
+ * A {@link RetryableException retryable} {@link RequestDroppedException} to indicate that a request was dropped by a
+ * client/server due to capacity constraints.
+ * <p>
  * Instances of this exception are expected to be thrown when a client side capacity is reached, thus the exception did
  * not touch the "wire" (network) yet, meaning that its safe to be retried. Retries are useful in the context of
  * capacity, to maximize chances for a request to succeed.

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
@@ -33,7 +33,6 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
-import io.servicetalk.http.netty.RetryingHttpRequesterFilter;
 import io.servicetalk.http.utils.TimeoutHttpRequesterFilter;
 import io.servicetalk.traffic.resilience.http.ClientPeerRejectionPolicy.PassthroughRequestDroppedException;
 import io.servicetalk.transport.api.ServerListenContext;
@@ -70,15 +69,14 @@ import static java.util.Objects.requireNonNull;
  *     <li>The traffic control filter should not be offloaded <u>if possible</u> to avoid situations where
  *     continuous traffic overflows the offloading subsystem.</li>
  *     <li>The traffic control filter should be ordered after a
- *     {@link RetryingHttpRequesterFilter retry-filter} if one is used, to avail the
+ *     {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter} if one is used, to avail the
  *     benefit of retrying requests that failed due to (local or remote) capacity issues.
  *     {@link RetryableRequestDroppedException} are safely retry-able errors, since they occur on the outgoing
  *     side before they even touch the network. {@link DelayedRetryRequestDroppedException} errors on the other
  *     side, are remote rejections, and its up to the application logic to opt-in for them to be retryable, by
- *     configuring the relevant predicate of the {@link RetryingHttpRequesterFilter retry
- *     -filter}</li>
+ *     configuring the relevant predicate of the {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter}</li>
  *     <li>The traffic control filter should be ordered after a
- *     {@link RetryingHttpRequesterFilter retry-filter} to allow an already acquired
+ *     {@code io.servicetalk.http.netty.RetryingHttpRequesterFilter} to allow an already acquired
  *     {@link Ticket permit} to be released in case
  *     of other errors/timeouts of the operation, before retrying to re-acquire a
  *     {@link Ticket permit}. Otherwise, a


### PR DESCRIPTION
Motivation:

Currently, `servicetalk-traffic-resilience-http` module must define `servicetalk-http-netty` as API dependency only to access `RetryingHttpRequesterFilter.DelayedRetry` interface. This can be avoided if we promote this interface to `servicetalk-client-api`.

Modifications:

- Introduce `io.servicetalk.client.api.DelayedRetry` interface;
- Deprecate `io.servicetalk.http.netty.RetryingHttpRequesterFilter.DelayedRetry`;
- Introduce `io.servicetalk.http.netty.RetryingHttpRequesterFilter.Builder.retryDelayedRetryExceptions(BiFunction)`;
- Deprecate `io.servicetalk.http.netty.RetryingHttpRequesterFilter.Builder.retryDelayedRetries(BiFunction)`;
- Update `DelayedRetryRequestDroppedException` to implement `io.servicetalk.client.api.DelayedRetry` instead of `io.servicetalk.http.netty.RetryingHttpRequesterFilter.DelayedRetry`;
- Update javadoc;

Result:

`servicetalk-traffic-resilience-http` doesn't have to define `servicetalk-http-netty` as API dependency.