### PR TITLE
Disable all quality tasks for jakarta modules

### DIFF
--- a/servicetalk-data-jackson-jersey3-jakarta10/build.gradle
+++ b/servicetalk-data-jackson-jersey3-jakarta10/build.gradle
@@ -44,7 +44,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-data-jackson-jersey3-jakarta10/build.gradle
+++ b/servicetalk-data-jackson-jersey3-jakarta10/build.gradle
@@ -36,19 +36,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-checkstyleTest {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-spotbugsMain {
-  enabled false
-}
-
-spotbugsTest {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-data-jackson-jersey3-jakarta9/build.gradle
+++ b/servicetalk-data-jackson-jersey3-jakarta9/build.gradle
@@ -44,7 +44,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-data-jackson-jersey3-jakarta9/build.gradle
+++ b/servicetalk-data-jackson-jersey3-jakarta9/build.gradle
@@ -36,19 +36,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-checkstyleTest {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-spotbugsMain {
-  enabled false
-}
-
-spotbugsTest {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-data-protobuf-jersey3-jakarta10/build.gradle
+++ b/servicetalk-data-protobuf-jersey3-jakarta10/build.gradle
@@ -43,19 +43,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-checkstyleTest {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-spotbugsMain {
-  enabled false
-}
-
-spotbugsTest {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-data-protobuf-jersey3-jakarta10/build.gradle
+++ b/servicetalk-data-protobuf-jersey3-jakarta10/build.gradle
@@ -51,7 +51,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-data-protobuf-jersey3-jakarta9/build.gradle
+++ b/servicetalk-data-protobuf-jersey3-jakarta9/build.gradle
@@ -43,19 +43,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-checkstyleTest {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-spotbugsMain {
-  enabled false
-}
-
-spotbugsTest {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-data-protobuf-jersey3-jakarta9/build.gradle
+++ b/servicetalk-data-protobuf-jersey3-jakarta9/build.gradle
@@ -51,7 +51,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-router-jersey3-jakarta10-internal/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10-internal/build.gradle
@@ -36,15 +36,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-spotbugsMain {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-spotbugsTest {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-router-jersey3-jakarta10-internal/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10-internal/build.gradle
@@ -44,7 +44,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-router-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10/build.gradle
@@ -36,27 +36,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-checkstyleTest {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-checkstyleTestFixtures {
-  enabled false
-}
-
-spotbugsMain {
-  enabled false
-}
-
-spotbugsTest {
-  enabled false
-}
-
-spotbugsTestFixtures {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-router-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10/build.gradle
@@ -44,7 +44,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-router-jersey3-jakarta9-internal/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9-internal/build.gradle
@@ -36,15 +36,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-spotbugsMain {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-spotbugsTest {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-router-jersey3-jakarta9-internal/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9-internal/build.gradle
@@ -44,7 +44,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-router-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9/build.gradle
@@ -36,27 +36,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-checkstyleTest {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-checkstyleTestFixtures {
-  enabled false
-}
-
-spotbugsMain {
-  enabled false
-}
-
-spotbugsTest {
-  enabled false
-}
-
-spotbugsTestFixtures {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-router-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9/build.gradle
@@ -44,7 +44,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-security-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-security-jersey3-jakarta10/build.gradle
@@ -44,7 +44,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-security-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-security-jersey3-jakarta10/build.gradle
@@ -36,19 +36,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-checkstyleTest {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-spotbugsMain {
-  enabled false
-}
-
-spotbugsTest {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-security-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-security-jersey3-jakarta9/build.gradle
@@ -44,7 +44,7 @@ tasks.withType(Pmd).all {
   enabled false
 }
 
-tasks.withType(SpotBugsTask).all {
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).all {
   enabled false
 }
 

--- a/servicetalk-http-security-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-security-jersey3-jakarta9/build.gradle
@@ -36,19 +36,15 @@ compileTestJava {
   options.release = compileJava.options.release
 }
 
-checkstyleMain {
+tasks.withType(Checkstyle).all {
   enabled false
 }
 
-checkstyleTest {
+tasks.withType(Pmd).all {
   enabled false
 }
 
-spotbugsMain {
-  enabled false
-}
-
-spotbugsTest {
+tasks.withType(SpotBugsTask).all {
   enabled false
 }
 


### PR DESCRIPTION
Motivation:

Not all tasks were correctly disabled.

Modifications:

- Disable by task type;

Result:

All unnecessary tasks should be disabled for jakarta modules.