### PR TITLE
Preparing for 0.42.45-SNAPSHOT development

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xms2g -Xmx4g -dsa -da -ea:io.servicetalk... -XX:+HeapDumpOnO
 
 # project metadata used for publications
 group=io.servicetalk
-version=0.44.0-SNAPSHOT
+version=0.42.45-SNAPSHOT
 scmHost=github.com
 scmPath=apple/servicetalk
 issueManagementUrl=https://github.com/apple/servicetalk/issues


### PR DESCRIPTION
Motivation:

The previous snapshot version was incorrect.

Modifications:

Fix it.