### PR TITLE
loadbalancer-experimental: remove deprecated API's

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Random;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
-
 /**
  * A random selection "power of two choices" load balancing policy.
  * <p>
@@ -38,10 +36,8 @@ import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
  * @param <C> the type of the load balanced connection.
  * @see <a href="https://www.eecs.harvard.edu/~michaelm/postscripts/tpds2001.pdf">Mitzenmacher (2001) The Power of Two
  *    Choices in Randomized Load Balancing</a>
- *  @deprecated Use {@link P2CLoadBalancingPolicyBuilder}.
  */
-@Deprecated // FIXME: 0.42.45 - make package private
-public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
+final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
         extends LoadBalancingPolicy<ResolvedAddress, C> {
 
     private final boolean ignoreWeights;
@@ -72,80 +68,5 @@ public final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     @Override
     public String toString() {
         return name() + "(failOpen=" + failOpen + ", maxEffort=" + maxEffort + ')';
-    }
-
-    /**
-     * A builder for immutable {@link P2CLoadBalancingPolicy} instances.
-     * @deprecated Use {@link P2CLoadBalancingPolicyBuilder}.
-     */
-    @Deprecated // FIXME: 0.42.45 - remove builder.
-    public static final class Builder {
-
-        private static final boolean DEFAULT_IGNORE_WEIGHTS = false;
-        private static final int DEFAULT_MAX_EFFORT = 5;
-
-        private boolean ignoreWeights = DEFAULT_IGNORE_WEIGHTS;
-        private int maxEffort = DEFAULT_MAX_EFFORT;
-        private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;
-        @Nullable
-        private Random random;
-
-        /**
-         * Set the maximum number of attempts that P2C will attempt to select a pair with at least one
-         * healthy host.
-         * Defaults to {@value DEFAULT_MAX_EFFORT}.
-         * @param maxEffort the maximum number of attempts.
-         * @return {@code this}
-         */
-        public Builder maxEffort(final int maxEffort) {
-            this.maxEffort = ensurePositive(maxEffort, "maxEffort");
-            return this;
-        }
-
-        /**
-         * Set whether the selector should fail-open in the event no healthy hosts are found.
-         * When a load balancing policy is configured to fail-open and is unable to find a healthy host, it will attempt
-         * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy
-         * session.
-         * Defaults to {@value DEFAULT_FAIL_OPEN_POLICY}.
-         * @param failOpen if true, will attempt  to select or establish a connection from an arbitrary host even if it
-         *                 is unlikely to return a healthy  session.
-         * @return {@code this}
-         */
-        public Builder failOpen(final boolean failOpen) {
-            this.failOpen = failOpen;
-            return this;
-        }
-
-        /**
-         * Set whether the host selector should ignore {@link Host}s weight.
-         * Host weight influences the probability it will be selected to serve a request. The host weight can come
-         * from many sources including known host capacity, priority groups, and others, so ignoring weight
-         * information can lead to other features not working properly and should be used with care.
-         * Defaults to {@value DEFAULT_IGNORE_WEIGHTS}.
-         *
-         * @param ignoreWeights whether the host selector should ignore host weight information.
-         * @return {@code this}
-         */
-        public Builder ignoreWeights(final boolean ignoreWeights) {
-            this.ignoreWeights = ignoreWeights;
-            return this;
-        }
-
-        // For testing purposes only.
-        Builder random(Random random) {
-            this.random = random;
-            return this;
-        }
-
-        /**
-         * Construct an immutable {@link P2CLoadBalancingPolicy}.
-         * @param <ResolvedAddress> the type of the resolved address.
-         * @param <C> the refined type of the {@link LoadBalancedConnection}.
-         * @return the concrete {@link P2CLoadBalancingPolicy}.
-         */
-        public <ResolvedAddress, C extends LoadBalancedConnection> P2CLoadBalancingPolicy<ResolvedAddress, C> build() {
-            return new P2CLoadBalancingPolicy<>(ignoreWeights, maxEffort, failOpen, random);
-        }
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -28,10 +28,8 @@ import java.util.List;
  *
  * @param <ResolvedAddress> the type of the resolved address
  * @param <C> the type of the load balanced connection
- * @deprecated Use {@link RoundRobinLoadBalancingPolicyBuilder}.
  */
-@Deprecated // FIXME: 0.42.45 - make package private
-public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
+final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnection>
         extends LoadBalancingPolicy<ResolvedAddress, C> {
 
     private final boolean failOpen;
@@ -56,59 +54,5 @@ public final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends Load
     @Override
     public String toString() {
         return name() + "(failOpen=" + failOpen + ")";
-    }
-
-    /**
-     * A builder for immutable {@link RoundRobinLoadBalancingPolicy} instances.
-     * @deprecated Use {@link RoundRobinLoadBalancingPolicyBuilder}.
-     */
-    @Deprecated // FIXME: 0.42.45 - remove builder.
-    public static final class Builder {
-
-        private static final boolean DEFAULT_IGNORE_WEIGHTS = false;
-
-        private boolean failOpen = DEFAULT_FAIL_OPEN_POLICY;
-        private boolean ignoreWeights = DEFAULT_IGNORE_WEIGHTS;
-
-        /**
-         * Set whether the selector should fail-open in the event no healthy hosts are found.
-         * When a load balancing policy is configured to fail-open and is unable to find a healthy host, it will attempt
-         * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy
-         * session.
-         * Defaults to {@value DEFAULT_FAIL_OPEN_POLICY}.
-         * @param failOpen if true, will attempt  to select or establish a connection from an arbitrary host even if it
-         *                 is unlikely to return a healthy  session.
-         * @return {@code this}
-         */
-        public Builder failOpen(final boolean failOpen) {
-            this.failOpen = failOpen;
-            return this;
-        }
-
-        /**
-         * Set whether the host selector should ignore {@link Host}s weight.
-         * Host weight influences the probability it will be selected to serve a request. The host weight can come
-         * from many sources including known host capacity, priority groups, and others, so ignoring weight
-         * information can lead to other features not working properly and should be used with care.
-         * Defaults to {@value DEFAULT_IGNORE_WEIGHTS}.
-         *
-         * @param ignoreWeights whether the host selector should ignore host weight information.
-         * @return {@code this}
-         */
-        public Builder ignoreWeights(final boolean ignoreWeights) {
-            this.ignoreWeights = ignoreWeights;
-            return this;
-        }
-
-        /**
-         * Construct the immutable {@link RoundRobinLoadBalancingPolicy}.
-         * @param <ResolvedAddress> the type of the resolved address.
-         * @param <C> the refined type of the {@link LoadBalancedConnection}.
-         * @return the concrete {@link RoundRobinLoadBalancingPolicy}.
-         */
-        public <ResolvedAddress, C extends LoadBalancedConnection> RoundRobinLoadBalancingPolicy<ResolvedAddress, C>
-        build() {
-            return new RoundRobinLoadBalancingPolicy<>(failOpen, ignoreWeights);
-        }
     }
 }


### PR DESCRIPTION
Motivation:

Now that 0.42.44 is released we can remove the deprecated API's.
This includes making some LoadBalancingPolicy classes package
private and removing their internal builders.

Modifications:

Remove the deprecated API's.