### PR TITLE
loadbalancer-experimental: thread lbDescription into the LoadBalancerObserver

### DIFF
--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
@@ -49,7 +49,7 @@ public class DefaultHttpLoadBalancerProvider implements HttpProviders.SingleAddr
         if (config.enabledForServiceName(serviceName)) {
             try {
                 HttpLoadBalancerFactory<R> loadBalancerFactory = new DefaultHttpLoadBalancerFactory<>(
-                        defaultLoadBalancer(serviceName, config));
+                        defaultLoadBalancer(config));
                 builder = builder.loadBalancerFactory(loadBalancerFactory);
                 builder = new LoadBalancerIgnoringBuilder<>(builder, serviceName);
                 LOGGER.info("Enabled DefaultLoadBalancer for service with name {}", serviceName);
@@ -61,10 +61,10 @@ public class DefaultHttpLoadBalancerProvider implements HttpProviders.SingleAddr
     }
 
     private <R> LoadBalancerFactory<R, FilterableStreamingHttpLoadBalancedConnection> defaultLoadBalancer(
-            String serviceName, DefaultLoadBalancerProviderConfig config) {
+            DefaultLoadBalancerProviderConfig config) {
         return LoadBalancers.<R, FilterableStreamingHttpLoadBalancedConnection>
                         builder("experimental-load-balancer")
-                .loadBalancerObserver(new DefaultLoadBalancerObserver(serviceName))
+                .loadBalancerObserver(DefaultLoadBalancerObserver::new)
                 // set up the new features.
                 .outlierDetectorConfig(config.outlierDetectorConfig())
                 .loadBalancingPolicy(config.getLoadBalancingPolicy())

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -31,10 +31,10 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultLoadBalancerObserver.class);
 
-    private final String clientName;
+    private final String lbDescription;
 
-    DefaultLoadBalancerObserver(final String clientName) {
-        this.clientName = requireNonNull(clientName, "clientName");
+    DefaultLoadBalancerObserver(final String lbDescription) {
+        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
     }
 
     @Override
@@ -44,19 +44,19 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
 
     @Override
     public void onNoHostsAvailable() {
-        LOGGER.debug("{}- onNoHostsAvailable()", clientName);
+        LOGGER.debug("{}- onNoHostsAvailable()", lbDescription);
     }
 
     @Override
     public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events, int oldHostSetSize,
                                         int newHostSetSize) {
         LOGGER.debug("{}- onServiceDiscoveryEvent(events: {}, oldHostSetSize: {}, newHostSetSize: {})",
-                clientName, events, oldHostSetSize, newHostSetSize);
+                lbDescription, events, oldHostSetSize, newHostSetSize);
     }
 
     @Override
     public void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exception) {
-        LOGGER.debug("{}- No active hosts available. Host set size: {}.", clientName, hostSetSize, exception);
+        LOGGER.debug("{}- No active hosts available. Host set size: {}.", lbDescription, hostSetSize, exception);
     }
 
     private final class HostObserverImpl implements HostObserver {
@@ -70,35 +70,35 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
         @Override
         public void onHostMarkedExpired(int connectionCount) {
             LOGGER.debug("{}:{}- onHostMarkedExpired(connectionCount: {})",
-                    clientName, resolvedAddress, connectionCount);
+                    lbDescription, resolvedAddress, connectionCount);
         }
 
         @Override
         public void onActiveHostRemoved(int connectionCount) {
             LOGGER.debug("{}:{}- onActiveHostRemoved(connectionCount: {})",
-                    clientName, resolvedAddress, connectionCount);
+                    lbDescription, resolvedAddress, connectionCount);
         }
 
         @Override
         public void onExpiredHostRevived(int connectionCount) {
             LOGGER.debug("{}:{}- onExpiredHostRevived(connectionCount: {})",
-                    clientName, resolvedAddress, connectionCount);
+                    lbDescription, resolvedAddress, connectionCount);
         }
 
         @Override
         public void onExpiredHostRemoved(int connectionCount) {
             LOGGER.debug("{}:{}- onExpiredHostRemoved(connectionCount: {})",
-                    clientName, resolvedAddress, connectionCount);
+                    lbDescription, resolvedAddress, connectionCount);
         }
 
         @Override
         public void onHostMarkedUnhealthy(@Nullable Throwable cause) {
-            LOGGER.debug("{}:{}- onHostMarkedUnhealthy(ex)", clientName, resolvedAddress, cause);
+            LOGGER.debug("{}:{}- onHostMarkedUnhealthy(ex)", lbDescription, resolvedAddress, cause);
         }
 
         @Override
         public void onHostRevived() {
-            LOGGER.debug("{}:{}- onHostRevived()", clientName, resolvedAddress);
+            LOGGER.debug("{}:{}- onHostRevived()", lbDescription, resolvedAddress);
         }
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -132,7 +132,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final HostSelector<ResolvedAddress, C> hostSelector,
             final ConnectionPoolStrategy<C> connectionPoolStrategy,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
-            final LoadBalancerObserver loadBalancerObserver,
+            final LoadBalancerObserverFactory loadBalancerObserverFactory,
             @Nullable final HealthCheckConfig healthCheckConfig,
             final Function<String, OutlierDetector<ResolvedAddress, C>> outlierDetectorFactory) {
         this.targetResource = requireNonNull(targetResourceName);
@@ -144,7 +144,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         this.eventStream = fromSource(eventStreamProcessor)
                 .replay(1); // Allow for multiple subscribers and provide new subscribers with last signal.
         this.connectionFactory = requireNonNull(connectionFactory);
-        this.loadBalancerObserver = requireNonNull(loadBalancerObserver, "loadBalancerObserver");
+        this.loadBalancerObserver = requireNonNull(loadBalancerObserverFactory, "loadBalancerObserverFactory")
+                .newObserver(lbDescription);
         this.healthCheckConfig = healthCheckConfig;
         this.sequentialExecutor = new SequentialExecutor((uncaughtException) ->
                 LOGGER.error("{}: Uncaught exception in {}", this, this.getClass().getSimpleName(), uncaughtException));

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -67,6 +67,13 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
     }
 
     @Override
+    public LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(
+            @Nullable LoadBalancerObserverFactory loadBalancerObserverFactory) {
+        delegate = delegate.loadBalancerObserver(loadBalancerObserverFactory);
+        return this;
+    }
+
+    @Override
     public LoadBalancerBuilder<ResolvedAddress, C> outlierDetectorConfig(OutlierDetectorConfig outlierDetectorConfig) {
         delegate = delegate.outlierDetectorConfig(outlierDetectorConfig);
         return this;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -74,8 +74,23 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
      * Set the {@link LoadBalancerObserver} to use with this load balancer.
      * @param loadBalancerObserver the {@link LoadBalancerObserver} to use, or {@code null} to not use an observer.
      * @return {code this}
+     * @deprecated use the overload that takes a {@link LoadBalancerObserverFactory}
      */
+    @Deprecated // TODO: remove deprecated method after 0.42.45 release.
     LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(@Nullable LoadBalancerObserver loadBalancerObserver);
+
+    /**
+     * Set the {@link LoadBalancerObserverFactory} to use with this load balancer.
+     * @param loadBalancerObserverFactory the {@link LoadBalancerObserverFactory} to use, or {@code null} to not use an
+     *                                    observer.
+     * @return {code this}
+     */
+    // TODO: remove the default implementation after 0.42.45 release.
+    default LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(
+            @Nullable LoadBalancerObserverFactory loadBalancerObserverFactory) {
+        return loadBalancerObserver(loadBalancerObserverFactory == null ? null
+                : loadBalancerObserverFactory.newObserver("<unknown>"));
+    }
 
     /**
      * Set the {@link OutlierDetectorConfig} to use with this load balancer.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserverFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserverFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+/**
+ * Factory of {@link LoadBalancerObserver} instances.
+ */
+public interface LoadBalancerObserverFactory {
+
+    /**
+     * Provide a {@link LoadBalancerObserver} to use with a newly created load balancer.
+     * @param lbDescription the description of the load balancer.
+     * @return a {@link LoadBalancerObserver} to use with a newly created load balancer.
+     */
+    LoadBalancerObserver newObserver(String lbDescription);
+}

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserverFactory.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserverFactory.java
@@ -18,6 +18,7 @@ package io.servicetalk.loadbalancer;
 /**
  * Factory of {@link LoadBalancerObserver} instances.
  */
+@FunctionalInterface
 public interface LoadBalancerObserverFactory {
 
     /**

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -190,7 +190,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 LinearSearchConnectionPoolStrategy.<TestLoadBalancedConnection>factory(DEFAULT_LINEAR_SEARCH_SPACE)
                         .buildStrategy("test-service"),
                 connectionFactory,
-                NoopLoadBalancerObserver.instance(),
+                lbDescription -> NoopLoadBalancerObserver.instance(),
                 null,
                 factory);
     }


### PR DESCRIPTION
Motivation:

We already have a standard resource identifier for use when logging load balancer concerns: lbDescrption. However, we don't use that for the LoadBalancerObserver type because we don't know it on construction.

Modifications:

- Change the LoadBalancerBuilder to take a factory of LoadBalancerObservers which will consume the lbDescription during load balancer construction.
- Deprecate the older API for a release cycle.

Result:

Better logging.