### PR TITLE
Convert scheme to lower case when parsing URI

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Uri3986.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Uri3986.java
@@ -173,7 +173,7 @@ final class Uri3986 implements Uri {
                 if (i == 0) {
                     throw new IllegalArgumentException("Invalid URI format: no scheme before colon (':')");
                 }
-                parsedScheme = getLowercaseScheme(uri.substring(0, i));
+                parsedScheme = getLowerCaseScheme(uri.substring(0, i));
                 begin = ++i;
                 // We don't enforce the following, browsers still generate these types of requests.
                 // https://tools.ietf.org/html/rfc3986#section-3.3
@@ -200,7 +200,7 @@ final class Uri3986 implements Uri {
         this.uri = uri;
     }
 
-    private static String getLowercaseScheme(String scheme) {
+    private static String getLowerCaseScheme(String scheme) {
         if (regionMatches(scheme, true, 0, HTTP_SCHEME, 0, HTTP_SCHEME.length())) {
             if (scheme.length() == 4) {
                 return HTTP_SCHEME;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Uri3986.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Uri3986.java
@@ -17,9 +17,11 @@
 package io.servicetalk.http.api;
 
 import java.nio.charset.Charset;
+import java.util.Locale;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.buffer.api.CharSequences.regionMatches;
 import static io.servicetalk.http.api.UriComponentType.FRAGMENT;
 import static io.servicetalk.http.api.UriComponentType.HOST_NON_IP;
 import static io.servicetalk.http.api.UriComponentType.PATH;
@@ -38,6 +40,8 @@ import static io.servicetalk.http.api.UriUtils.parsePort;
 final class Uri3986 implements Uri {
     @SuppressWarnings({"StringOperationCanBeSimplified", "PMD.StringInstantiation"})
     private static final String NULL_COMPONENT = new String(""); // instance equality required!
+    private static final String HTTP_SCHEME = "http";
+    private static final String HTTPS_SCHEME = "https";
     private final String uri;
     @Nullable
     private final String scheme;
@@ -169,7 +173,7 @@ final class Uri3986 implements Uri {
                 if (i == 0) {
                     throw new IllegalArgumentException("Invalid URI format: no scheme before colon (':')");
                 }
-                parsedScheme = uri.substring(0, i);
+                parsedScheme = getLowercaseScheme(uri.substring(0, i));
                 begin = ++i;
                 // We don't enforce the following, browsers still generate these types of requests.
                 // https://tools.ietf.org/html/rfc3986#section-3.3
@@ -194,6 +198,18 @@ final class Uri3986 implements Uri {
         port = parsedPort;
         path = parsedPath;
         this.uri = uri;
+    }
+
+    private static String getLowercaseScheme(String scheme) {
+        if (regionMatches(scheme, true, 0, HTTP_SCHEME, 0, HTTP_SCHEME.length())) {
+            if (scheme.length() == 4) {
+                return HTTP_SCHEME;
+            }
+            if (scheme.length() == 5 && (scheme.charAt(4) == 's' || scheme.charAt(4) == 'S')) {
+                return HTTPS_SCHEME;
+            }
+        }
+        return scheme.toLowerCase(Locale.ENGLISH);
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Uri3986.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Uri3986.java
@@ -21,7 +21,6 @@ import java.util.Locale;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.buffer.api.CharSequences.regionMatches;
 import static io.servicetalk.http.api.UriComponentType.FRAGMENT;
 import static io.servicetalk.http.api.UriComponentType.HOST_NON_IP;
 import static io.servicetalk.http.api.UriComponentType.PATH;
@@ -173,7 +172,7 @@ final class Uri3986 implements Uri {
                 if (i == 0) {
                     throw new IllegalArgumentException("Invalid URI format: no scheme before colon (':')");
                 }
-                parsedScheme = getLowerCaseScheme(uri.substring(0, i));
+                parsedScheme = getLowerCaseScheme(uri, i);
                 begin = ++i;
                 // We don't enforce the following, browsers still generate these types of requests.
                 // https://tools.ietf.org/html/rfc3986#section-3.3
@@ -200,16 +199,13 @@ final class Uri3986 implements Uri {
         this.uri = uri;
     }
 
-    private static String getLowerCaseScheme(String scheme) {
-        if (regionMatches(scheme, true, 0, HTTP_SCHEME, 0, HTTP_SCHEME.length())) {
-            if (scheme.length() == 4) {
-                return HTTP_SCHEME;
-            }
-            if (scheme.length() == 5 && (scheme.charAt(4) == 's' || scheme.charAt(4) == 'S')) {
-                return HTTPS_SCHEME;
-            }
+    private static String getLowerCaseScheme(final String uri, final int endIndex) {
+        if (endIndex == 4 && uri.regionMatches(true, 0, HTTP_SCHEME, 0, 4)) {
+            return HTTP_SCHEME;
+        } else if (endIndex == 5 && uri.regionMatches(true, 0, HTTPS_SCHEME, 0, 5)) {
+            return HTTPS_SCHEME;
         }
-        return scheme.toLowerCase(Locale.ENGLISH);
+        return uri.substring(0, endIndex).toLowerCase(Locale.ENGLISH);
     }
 
     @Override

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/Uri3986Test.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/Uri3986Test.java
@@ -33,7 +33,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -181,9 +180,6 @@ class Uri3986Test {
         String https1 = new Uri3986("https://test.com").scheme();
         String https2 = new Uri3986("HTTPS://test.com").scheme();
         assertThat("different https", https1, sameInstance(https2));
-
-        String httpss = new Uri3986("HTTPSS://test.com").scheme();
-        assertThat("same https and httpss", https1, not(sameInstance(httpss)));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`HttpRequestMetaData#scheme()` javadocs state the result will be lowercase, but this is not always the case because `Uri3986` parses the scheme as-is. As a result, `DefaultMultiAddressUrlHttpClientBuilder` may have more than 1 client instance for the same address if users use URI with different scheme letters case. 
See https://github.com/apple/servicetalk/issues/1423 for details.

Modifications:

- Convert scheme to lower case when parsing `Uri3986` reusing well-known schemes ("http" and "https")

Result:

Fixes #1423.