### PR TITLE
loadbalancer-experimental: break test dependency cycle

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerProviderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerProviderTest.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.loadbalancer.experimental;
+package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
-import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.loadbalancer.experimental.DefaultHttpLoadBalancerProvider;
 import io.servicetalk.transport.api.HostAndPort;
 
 import org.junit.jupiter.api.AfterEach;
@@ -28,7 +28,6 @@ import java.net.InetSocketAddress;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
 
 @Execution(ExecutionMode.SAME_THREAD)
 class DefaultHttpLoadBalancerProviderTest {
@@ -41,30 +40,30 @@ class DefaultHttpLoadBalancerProviderTest {
     }
 
     @Test
-    void defaultsToNoHost() throws Exception {
+    void defaultsToNoHost() {
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
                 HttpClients.forSingleAddress("testhost", 80);
-        assertThat(builder, not(instanceOf(DefaultHttpLoadBalancerProvider.LoadBalancerIgnoringBuilder.class)));
+        assertThat(builder, instanceOf(DefaultSingleAddressHttpClientBuilder.class));
     }
 
     @Test
-    void isNotUsedForUnmatchedHost() throws Exception {
+    void isNotUsedForUnmatchedHost() {
         System.setProperty(PROPERTY_NAME, "notthisone");
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
                 HttpClients.forSingleAddress("testhost", 80);
-        assertThat(builder, not(instanceOf(DefaultHttpLoadBalancerProvider.LoadBalancerIgnoringBuilder.class)));
+        assertThat(builder, instanceOf(DefaultSingleAddressHttpClientBuilder.class));
     }
 
     @Test
-    void isNotUsedForUnmatchedHostInList() throws Exception {
+    void isNotUsedForUnmatchedHostInList() {
         System.setProperty(PROPERTY_NAME, "notthisone,foo");
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
                 HttpClients.forSingleAddress("testhost", 80);
-        assertThat(builder, not(instanceOf(DefaultHttpLoadBalancerProvider.LoadBalancerIgnoringBuilder.class)));
+        assertThat(builder, instanceOf(DefaultSingleAddressHttpClientBuilder.class));
     }
 
     @Test
-    void isUsedForMatchedHost() throws Exception {
+    void isUsedForMatchedHost() {
         System.setProperty(PROPERTY_NAME, "testhost");
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
                 HttpClients.forSingleAddress("testhost", 80);
@@ -72,7 +71,7 @@ class DefaultHttpLoadBalancerProviderTest {
     }
 
     @Test
-    void isUsedForMatchedHostInList() throws Exception {
+    void isUsedForMatchedHostInList() {
         System.setProperty(PROPERTY_NAME, "testhost,foo");
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
                 HttpClients.forSingleAddress("testhost", 80);
@@ -80,7 +79,7 @@ class DefaultHttpLoadBalancerProviderTest {
     }
 
     @Test
-    void isUsedForAnyHost() throws Exception {
+    void isUsedForAnyHost() {
         System.setProperty(PROPERTY_NAME, "*");
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> builder =
                 HttpClients.forSingleAddress("anyhostname", 80);

--- a/servicetalk-loadbalancer-experimental-provider/build.gradle
+++ b/servicetalk-loadbalancer-experimental-provider/build.gradle
@@ -25,12 +25,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-loadbalancer")
   implementation project(":servicetalk-loadbalancer-experimental")
-  implementation project(":servicetalk-http-api")
-
-  testImplementation project(":servicetalk-http-netty")
-  testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.apache.logging.log4j:log4j-core"
-  testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 
   implementation "com.google.code.findbugs:jsr305"
   implementation "org.slf4j:slf4j-api"

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultHttpLoadBalancerProvider.java
@@ -93,12 +93,13 @@ public class DefaultHttpLoadBalancerProvider implements HttpProviders.SingleAddr
     }
 
     // Exposed for testing
-    static final class LoadBalancerIgnoringBuilder<U, R>
+    public static final class LoadBalancerIgnoringBuilder<U, R>
             extends DelegatingSingleAddressHttpClientBuilder<U, R> {
 
         private final String serviceName;
 
-        LoadBalancerIgnoringBuilder(final SingleAddressHttpClientBuilder<U, R> delegate, final String serviceName) {
+        private LoadBalancerIgnoringBuilder(
+                final SingleAddressHttpClientBuilder<U, R> delegate, final String serviceName) {
             super(delegate);
             this.serviceName = serviceName;
         }


### PR DESCRIPTION
Motivation:

IJ can get upset that there is a dependency cycle between http-netty and loadbalancer-experimental-provider because the provider module depends on http-netty as a test dependency.

Modifications:

Move the tests from loadbalancer-experimental-provider to htp-netty and remove the test dependency. This is a better test structure anyway because if people have http-netty on the classpath it should load the provider.

Result:

Better test structure and fix IJ tools.