### PR TITLE
build.gradle: add Netty Snapshots repository for ci-netty-snapshot.yml

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 15 * * 1-5'
   workflow_dispatch:
+env:
+  ORG_GRADLE_PROJECT_nettyVersion: 4.1+
+  JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
 jobs:
   build:
     name: Netty snapshot on JDK ${{ matrix.java }} ${{ matrix.os }}
@@ -25,15 +28,10 @@ jobs:
       - name: Make gradlew Executable
         run: chmod +x gradlew
       - name: Print Netty Version
-        env:
-          ORG_GRADLE_PROJECT_nettyVersion: 4.1+
-        run: ORG_GRADLE_PROJECT_nettyVersion=4.1+ ./gradlew :servicetalk-grpc-netty:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-codec-http2 -PnettyVersion=4.1+ | head -n 40
+        run: ./gradlew :servicetalk-grpc-netty:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-codec-http2 | head -n 40
       - name: Clean Gradle project
         run: ./gradlew --parallel clean
       - name: Build and Test
-        env:
-          JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
-          ORG_GRADLE_PROJECT_nettyVersion: 4.1.+
         run:  sudo -E env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel test"
       - name: Publish Test Results
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,26 @@ if (!repositories) {
   allprojects {
     buildscript {
       repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
+        gradlePluginPortal()
       }
     }
     repositories {
       mavenCentral()
-      maven { url "https://plugins.gradle.org/m2/" }
+      gradlePluginPortal()
+      if ("$nettyVersion".endsWith("+")) {
+        maven {
+          name "Netty Snapshots"
+          url "https://oss.sonatype.org/content/repositories/snapshots"
+          content {
+            includeGroup "io.netty"
+          }
+        }
+      }
     }
   }
+  println("This machine doesn't have any pre-configured repositories, will use: ${repositories*.name.join(", ")}")
+} else {
+  print("This machine already has some pre-configured repositories, will use: ${repositories*.name.join(", ")}")
 }
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-root"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -16,7 +16,7 @@
 
 if (!repositories) {
   repositories {
-    maven { url "https://plugins.gradle.org/m2/" }
+    gradlePluginPortal()
   }
 } else {
   // We need to manually load ProjectUtils in order to use it at this early point of the script evaluation

--- a/docs/generation/build.gradle
+++ b/docs/generation/build.gradle
@@ -17,7 +17,7 @@
 buildscript {
   if (!repositories) {
     repositories {
-      maven { url "https://plugins.gradle.org/m2/" }
+      gradlePluginPortal()
     }
   }
 


### PR DESCRIPTION
Motivation:

`ci-netty-snapshot.yml` can not use Netty Snapshots because our `build.gradle` script never adds a repo that contains snapshots.