### PR TITLE
Reduce default TLS handshake timeout from 10 to 5 seconds

### DIFF
--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/AbstractSslConfigBuilder.java
@@ -41,7 +41,7 @@ import static java.util.Objects.requireNonNull;
 abstract class AbstractSslConfigBuilder<T extends AbstractSslConfigBuilder<T>> {
 
     // FIXME: 0.43 - make DEFAULT_HANDSHAKE_TIMEOUT constant private
-    static final Duration DEFAULT_HANDSHAKE_TIMEOUT = ofSeconds(10);    // same as default in Netty SslHandler
+    static final Duration DEFAULT_HANDSHAKE_TIMEOUT = ofSeconds(5);
     private static final int DEFAULT_MAX_CERTIFICATE_LIST_BYTES = 32 * 1024;    // 32Kb
 
     @Nullable


### PR DESCRIPTION
Motivation:

10 seconds feels like too high value to hold a connection attempt by waiting for TLS handshake to complete. Because TLS handshake happens before ST writes a request, it's always marked as `RetryableException` and is retried up to 3 times.

Modifications:

- Reduce `DEFAULT_HANDSHAKE_TIMEOUT` from 10 to 5 seconds;

Result:

Less wait time for TLS handshake process that hangs longer than expected.