### PR TITLE
Fallback to `readChunkSize` if `InputStream.available()` not implemented

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2021, 2023-2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
                     int available = stream.available();
                     if (available == 0) {
                         // Work around InputStreams that don't strictly honor the 0 == EOF contract.
-                        available = buffer != null ? buffer.length : 1;
+                        available = buffer != null ? buffer.length : readChunkSize;
                     }
                     available = fillBufferAvoidingBlocking(available);
                     emitSingleBuffer(subscriber);
@@ -212,6 +212,8 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
                 b = buffer;
                 buffer = null;
             } else {
+                // this extra copy is necessary when we read the last chunk and total number of bytes read before EOF
+                // is less than guesstimated buffer size
                 b = new byte[writeIdx];
                 arraycopy(buffer, 0, b, 0, writeIdx);
             }

--- a/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFromInputStreamTckTest.java
+++ b/servicetalk-concurrent-reactivestreams/src/test/java/io/servicetalk/concurrent/reactivestreams/tck/PublisherFromInputStreamTckTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.reactivestreams.tck;
+
+import io.servicetalk.concurrent.api.Publisher;
+
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+
+@Test
+public class PublisherFromInputStreamTckTest extends AbstractPublisherTckTest<byte[]> {
+
+    @Override
+    protected Publisher<byte[]> createServiceTalkPublisher(long elements) {
+        return Publisher.fromInputStream(new ByteArrayInputStream(new byte[(int) elements]), 1);
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return TckUtils.maxElementsFromPublisher();
+    }
+}


### PR DESCRIPTION
Motivation:

`FromInputStreamPublisher` attempts to read only 1 byte when `InputStream.available()` is not implemented. As a result, users of blocking streaming API with payload body as `InputStream` may write and flush by 1 byte if their `InputStream` implementation always returns 0 available bytes (default).

Modifications:

- Consider `available()` as a best effort to avoid blocking. If it returns 0 bytes, attempt to read up to `readChunkSize` bytes;

Result:

Improved efficiency of writing `InputStream` data for outgoing requests.