### PR TITLE
loadbalancer-experimental: support non-sequential priorities

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
@@ -56,8 +56,6 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
         //  remote zones intentionally even if all hosts are well.
         //  https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_runtime
         //      #zone-aware-load-balancing
-        //  The behavior could be structured more as a tree, but it's not obvious how to feed such a tree into the load
-        //  balancer.
         // Consolidate our hosts into their respective priority groups. Since we're going to use a map we must use
         // and ordered map (in this case a TreeMap) so that we can iterate in order of group priority.
         TreeMap<Integer, Group> groups = new TreeMap<>();

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
@@ -102,8 +102,9 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
             }
         }
         if (weightedResults.isEmpty()) {
-            // This is awkward situation can happen if we don't have any healthy nodes.
+            // This is awkward situation can happen if we don't have any healthy groups.
             // In that case let's panic and return an un-prioritized set of hosts.
+            LOGGER.warn("No healthy priority groups found. Returning the un-prioritized set.");
             return hosts;
         }
         return weightedResults;


### PR DESCRIPTION
Motivation:

We currently don't support priority sets that don't have sequential
groups numbers, eg we require groups 0, 1, 2, ... and will reject a
set of groups such as 0, 2, 3, ... This is an artificial constraint.

Modifications:

- Remove the constraint and switch to a TreeMap also make us more
  resilient to an adversarial case of getting a group with a large.
- Close an open question and fail-open if no healthy hosts are found.