### PR TITLE
loadbalancer-experimental: make loadBalancingWeight easier to debug

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -167,6 +167,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
                 Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
                 ConnectionFactory<ResolvedAddress, C> connectionFactory, String targetResource) {
             return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
+                    DefaultHostPriorityStrategy.INSTANCE,
                     loadBalancingPolicy.buildSelector(Collections.emptyList(), targetResource),
                     connectionPoolStrategyFactory.buildStrategy(targetResource), connectionFactory,
                     loadBalancerObserverFactory, healthCheckConfig, outlierDetectorFactory);

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -49,6 +49,9 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
     private LoadBalancingPolicy<String, TestLoadBalancedConnection> loadBalancingPolicy =
             LoadBalancingPolicies.p2c().build();
+
+    private HostPriorityStrategy hostPriorityStrategy = DefaultHostPriorityStrategy.INSTANCE;
+
     @Nullable
     private Supplier<OutlierDetector<String, TestLoadBalancedConnection>> outlierDetectorFactory;
 
@@ -166,6 +169,51 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
     }
 
     @Test
+    void changesToPriorityOrWeightTriggerRebuilds() throws Exception {
+        final AtomicReference<Double> value = new AtomicReference<>();
+        serviceDiscoveryPublisher.onComplete();
+        hostPriorityStrategy = new HostPriorityStrategy() {
+            @Override
+            public <T extends PrioritizedHost> List<T> prioritize(List<T> hosts) {
+                assert hosts.size() == 1;
+                T host = hosts.get(0);
+                value.set(host.loadBalancingWeight());
+                // We want to adjust the weight here so that if the `loadBalancingWeight()` fails to be
+                // reset then the test will fail.
+                host.loadBalancingWeight(0.5 * host.loadBalancingWeight());
+                return hosts;
+            }
+        };
+        lb = newTestLoadBalancer();
+        DefaultLoadBalancer<String, TestLoadBalancedConnection> refinedLb =
+                (DefaultLoadBalancer<String, TestLoadBalancedConnection>) lb;
+
+        // use a simple address. Should have a weight of 1.0;
+        sendServiceDiscoveryEvents(upEvent("address-1"));
+        List<? extends DefaultLoadBalancer.PrioritizedHostImpl<?, ?>> curentHosts = refinedLb.hosts();
+        assertThat(curentHosts, hasSize(1));
+        assertThat(curentHosts.get(0).priority(), equalTo(0));
+        assertThat(curentHosts.get(0).loadBalancingWeight(), equalTo(0.5));
+        assertThat(value.getAndSet(null), equalTo(1.0));
+
+        // send a new event with a different priority group. This should trigger another build.
+        sendServiceDiscoveryEvents(richEvent(upEvent("address-1"), 1.0, 1));
+        curentHosts = refinedLb.hosts();
+        assertThat(curentHosts, hasSize(1));
+        assertThat(curentHosts.get(0).priority(), equalTo(1));
+        assertThat(curentHosts.get(0).loadBalancingWeight(), equalTo(0.5));
+        assertThat(value.getAndSet(null), equalTo(1.0));
+
+        // send a new event with a different weight. This should trigger yet another build.
+        sendServiceDiscoveryEvents(richEvent(upEvent("address-1"), 2.0, 1));
+        curentHosts = refinedLb.hosts();
+        assertThat(curentHosts, hasSize(1));
+        assertThat(curentHosts.get(0).priority(), equalTo(1));
+        assertThat(curentHosts.get(0).loadBalancingWeight(), equalTo(1.0));
+        assertThat(value.getAndSet(null), equalTo(2.0));
+    }
+
+    @Test
     void outlierDetectorIsClosedOnShutdown() throws Exception {
         serviceDiscoveryPublisher.onComplete();
         final TestOutlierDetectorFactory factory = new TestOutlierDetectorFactory();
@@ -186,6 +234,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 getClass().getSimpleName(),
                 "test-service",
                 serviceDiscoveryPublisher,
+                hostPriorityStrategy,
                 loadBalancingPolicy.buildSelector(new ArrayList<>(), "test-service"),
                 LinearSearchConnectionPoolStrategy.<TestLoadBalancedConnection>factory(DEFAULT_LINEAR_SEARCH_SPACE)
                         .buildStrategy("test-service"),
@@ -193,6 +242,11 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 lbDescription -> NoopLoadBalancerObserver.instance(),
                 null,
                 factory);
+    }
+
+    private RichServiceDiscovererEvent<String> richEvent(
+            ServiceDiscovererEvent<String> parent, double weight, int priority) {
+        return new RichServiceDiscovererEvent<>(parent.address(), parent.status(), weight, priority);
     }
 
     private static class TestHealthIndicator implements HealthIndicator<String, TestLoadBalancedConnection> {


### PR DESCRIPTION
Motivation

Because we use mutable state to represent the load balancing weight we need to make sure that it is reset back to the SD weight before we re-run hosts through the transformations. It's currently done when we set the SD weight via `servieDiscoveryWeight(double)` which happens even if it is unchanged, so we change the lb weight even if we don't plan to run it through the transformations again. We will still load balance correctly because we won't rebuild, but it could be really confusing to debug since the lb weight won't reflect transformations.

Modifications

- Separate setting the SD weight and LB weight and before we rebuild reset the LB weight to the current SD weight.
- Add some tests that ensure we set the weight correctly.