### PR TITLE
loadbalancer-experimental: allow configuring whether cancellation is an error

### DIFF
--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerProviderConfig.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerProviderConfig.java
@@ -99,7 +99,7 @@ final class DefaultLoadBalancerProviderConfig {
         ewmaHalfLife = ofMillis(getLong(PROP_EWMA_HALF_LIFE_MS, ofSeconds(10).toMillis()));
         ewmaErrorPenalty = getInt(PROP_EWMA_ERROR_PENALTY, 10);
         ewmaCancellationPenalty = getInt(PROP_EWMA_CANCELLATION_PENALTY, 5);
-        cancellationIsError = getBool(PROP_CANCELLATION_IS_ERROR, false);
+        cancellationIsError = getBool(PROP_CANCELLATION_IS_ERROR, true);
         consecutive5xx = getInt(PROP_CONSECUTIVE_5XX, 5);
         interval = ofMillis(getLong(PROP_INTERVAL_MS, ofSeconds(10).toMillis()));
         baseEjectionTime = ofMillis(getLong(PROP_BASE_EJECTION_TIME_MS, ofSeconds(30).toMillis()));

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -327,7 +327,7 @@ public final class OutlierDetectorConfig {
         static final Duration DEFAULT_EWMA_HALF_LIFE = Duration.ofSeconds(10);
         static final long DEFAULT_CANCEL_PENALTY = 5L;
         static final long DEFAULT_ERROR_PENALTY = 10L;
-        private boolean cancellationIsError;
+        private boolean cancellationIsError = true;
 
         // Default xDS outlier detector settings.
         private static final int DEFAULT_CONSECUTIVE_5XX = 5;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -45,9 +45,9 @@ public final class OutlierDetectorConfig {
     private final Duration ewmaHalfLife;
     private final long ewmaCancellationPenalty;
     private final long ewmaErrorPenalty;
+    private final boolean cancellationIsError;
     private final int failedConnectionsThreshold;
     private final Duration failureDetectorIntervalJitter;
-
     private final Duration serviceDiscoveryResubscribeInterval;
     private final Duration serviceDiscoveryResubscribeJitter;
 
@@ -69,7 +69,8 @@ public final class OutlierDetectorConfig {
     private final Duration maxEjectionTime;
 
     OutlierDetectorConfig(final Duration ewmaHalfLife, final long ewmaCancellationPenalty, final long ewmaErrorPenalty,
-                          int failedConnectionsThreshold, final Duration failureDetectorIntervalJitter,
+                          final boolean cancellationIsError, int failedConnectionsThreshold,
+                          final Duration failureDetectorIntervalJitter,
                           final Duration serviceDiscoveryResubscribeInterval, final Duration serviceDiscoveryResubscribeJitter,
                           // true xDS settings
                           final int consecutive5xx, final Duration failureDetectorInterval, final Duration baseEjectionTime,
@@ -82,6 +83,7 @@ public final class OutlierDetectorConfig {
         this.ewmaHalfLife = requireNonNull(ewmaHalfLife, "ewmaHalfLife");
         this.ewmaCancellationPenalty = ensureNonNegative(ewmaCancellationPenalty, "ewmaCancellationPenalty");
         this.ewmaErrorPenalty = ensureNonNegative(ewmaErrorPenalty, "ewmaErrorPenalty");
+        this.cancellationIsError = cancellationIsError;
         this.failedConnectionsThreshold = failedConnectionsThreshold;
         this.failureDetectorIntervalJitter = requireNonNull(
                 failureDetectorIntervalJitter, "failureDetectorIntervalJitter");
@@ -124,6 +126,14 @@ public final class OutlierDetectorConfig {
      */
     public long ewmaCancellationPenalty() {
         return ewmaCancellationPenalty;
+    }
+
+    /**
+     * Determines whether a cancellation is considered to be an error.
+     * @return whether a cancellation is considered to be an error.
+     */
+    public boolean cancellationIsError() {
+        return cancellationIsError;
     }
 
     /**
@@ -317,6 +327,7 @@ public final class OutlierDetectorConfig {
         static final Duration DEFAULT_EWMA_HALF_LIFE = Duration.ofSeconds(10);
         static final long DEFAULT_CANCEL_PENALTY = 5L;
         static final long DEFAULT_ERROR_PENALTY = 10L;
+        private boolean cancellationIsError;
 
         // Default xDS outlier detector settings.
         private static final int DEFAULT_CONSECUTIVE_5XX = 5;
@@ -408,7 +419,8 @@ public final class OutlierDetectorConfig {
          */
         public OutlierDetectorConfig build() {
             return new OutlierDetectorConfig(ewmaHalfLife, ewmaCancellationPenalty, ewmaErrorPenalty,
-                    failedConnectionsThreshold, intervalJitter, serviceDiscoveryResubscribeInterval, serviceDiscoveryResubscribeJitter,
+                    cancellationIsError, failedConnectionsThreshold, intervalJitter,
+                    serviceDiscoveryResubscribeInterval, serviceDiscoveryResubscribeJitter,
                     // xDS settings
                     consecutive5xx, failureDetectorInterval, baseEjectionTime,
                     maxEjectionPercentage, enforcingConsecutive5xx,
@@ -458,6 +470,16 @@ public final class OutlierDetectorConfig {
          */
         public Builder ewmaErrorPenalty(final long ewmaErrorPenalty) {
             this.ewmaErrorPenalty = ensureNonNegative(ewmaErrorPenalty, "ewmaErrorPenalty");
+            return this;
+        }
+
+        /**
+         * Set whether a cancellation is considered to be an error by the outlier detector.
+         * @param cancellationIsError whether a cancellation is considered to be an error by the outlier detector.
+         * @return {@code this}
+         */
+        public Builder cancellationIsError(final boolean cancellationIsError) {
+            this.cancellationIsError = cancellationIsError;
             return this;
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -137,7 +137,7 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
                                HostObserver hostObserver) {
             super(sequentialExecutor, executor, outlierDetectorConfig.ewmaHalfLife(),
                     outlierDetectorConfig.ewmaCancellationPenalty(), outlierDetectorConfig.ewmaErrorPenalty(),
-                    address, lbDescription, hostObserver);
+                    outlierDetectorConfig.cancellationIsError(), address, lbDescription, hostObserver);
         }
 
         @Override

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -21,11 +21,15 @@ import io.servicetalk.concurrent.api.TestExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.concurrent.TimeUnit;
 
 import static java.time.Duration.ZERO;
 import static java.time.Duration.ofSeconds;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -69,6 +73,18 @@ class XdsHealthIndicatorTest {
                     RequestTracker.ErrorClass.EXT_ORIGIN_REQUEST_FAILED);
         }
         assertFalse(healthIndicator.isHealthy());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void cancellationStatus(boolean cancellationIsError) {
+        config = baseBuilder().cancellationIsError(cancellationIsError).build();
+        initIndicator();
+        for (int i = 0; i < config.consecutive5xx(); i++) {
+            healthIndicator.onRequestError(healthIndicator.beforeRequestStart() + 1,
+                    RequestTracker.ErrorClass.CANCELLED);
+        }
+        assertThat(healthIndicator.isHealthy(), equalTo(!cancellationIsError));
     }
 
     @Test
@@ -216,7 +232,8 @@ class XdsHealthIndicatorTest {
         boolean mayEjectHost = true;
 
         TestIndicator(final OutlierDetectorConfig config) {
-            super(sequentialExecutor, new NormalizedTimeSourceExecutor(testExecutor), ofSeconds(10), 5, 10,
+            super(sequentialExecutor, new NormalizedTimeSourceExecutor(testExecutor), ofSeconds(10),
+                    config.ewmaCancellationPenalty(), config.ewmaErrorPenalty(), config.cancellationIsError(),
                     "address", "description", NoopLoadBalancerObserver.<String>instance().hostObserver("address"));
             this.config = config;
         }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -85,6 +85,7 @@ class XdsHealthIndicatorTest {
                     RequestTracker.ErrorClass.CANCELLED);
         }
         assertThat(healthIndicator.isHealthy(), equalTo(!cancellationIsError));
+        assertEquals(cancellationIsError ? config.consecutive5xx() : 0L, healthIndicator.getFailures());
     }
 
     @Test
@@ -208,15 +209,6 @@ class XdsHealthIndicatorTest {
         healthIndicator.cancel();
         assertEquals(1, healthIndicator.revivalCount);
         assertTrue(healthIndicator.cancelled);
-    }
-
-    @Test
-    void errorClassCancelledIsNotSuccessOrError() {
-        // Note that this is a specific interpretation that we can change: we just need to change the test.
-        healthIndicator.onRequestError(healthIndicator.beforeRequestStart() + 1,
-                RequestTracker.ErrorClass.CANCELLED);
-        assertEquals(0L, healthIndicator.getSuccesses());
-        assertEquals(0L, healthIndicator.getFailures());
     }
 
     private void ejectIndicator(boolean isOutlier) {


### PR DESCRIPTION
Motivation:

Cancellation is ambiguous as to why it was cancelled, although it is most likely due to timeouts. We should let users configure this.

Modifications:

- Make classification of cancellation as an error a configuration option.
- Thread it through, including in the providers.

Result:

More flexible classification of cancellation.