### PR TITLE
loadbalancer-experimental: Add lbDescription to host priority strategy

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
@@ -23,23 +23,24 @@ import java.util.List;
 import java.util.TreeMap;
 
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
+import static java.util.Objects.requireNonNull;
 
 final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
-
-    static final HostPriorityStrategy INSTANCE = new DefaultHostPriorityStrategy();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHostPriorityStrategy.class);
     private static final int DEFAULT_OVER_PROVISION_FACTOR = 140;
 
 
+    private final String lbDescription;
     private final int overProvisionPercentage;
 
-    DefaultHostPriorityStrategy() {
-        this(DEFAULT_OVER_PROVISION_FACTOR);
+    DefaultHostPriorityStrategy(final String lbDescription) {
+        this(lbDescription, DEFAULT_OVER_PROVISION_FACTOR);
     }
 
     // exposed for testing
-    DefaultHostPriorityStrategy(final int overProvisionPercentage) {
+    DefaultHostPriorityStrategy(final String lbDescription, final int overProvisionPercentage) {
+        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
         this.overProvisionPercentage = ensurePositive(overProvisionPercentage, "overProvisionPercentage");
     }
 
@@ -61,7 +62,8 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
         TreeMap<Integer, Group> groups = new TreeMap<>();
         for (T host : hosts) {
             if (host.priority() < 0) {
-                LOGGER.warn("Found illegal priority: {}. Dropping priority grouping data.", host.priority());
+                LOGGER.warn("{}: Found illegal priority: {}. Dropping priority grouping data.",
+                        lbDescription, host.priority());
                 return hosts;
             }
             Group group = groups.computeIfAbsent(host.priority(), i -> new Group());
@@ -73,6 +75,7 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
 
         // If there is only a single group we don't need to adjust weights.
         if (groups.size() == 1) {
+            LOGGER.debug("{}: Single priority group found.");
             return hosts;
         }
 
@@ -84,16 +87,20 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
         }
         if (totalHealthPercentage == 0) {
             // nothing is considered healthy so everything is considered healthy.
+            LOGGER.warn("{}: No healthy priority groups found out of {} groups composed of {} hosts. " +
+                    "Returning the un-prioritized set.", lbDescription, groups.size(), hosts.size());
             return hosts;
         }
 
         List<T> weightedResults = new ArrayList<>();
+        int activeGroups = 0;
         int remainingProbability = 100;
         for (Group group : groups.values()) {
             assert !group.hosts.isEmpty();
             final int groupProbability = Math.min(remainingProbability,
                     group.healthPercentage * 100 / totalHealthPercentage);
             if (groupProbability > 0) {
+                activeGroups++;
                 remainingProbability -= groupProbability;
                 group.addToResults(groupProbability, weightedResults);
             }
@@ -101,12 +108,13 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
                 break;
             }
         }
-        if (weightedResults.isEmpty()) {
-            // This is awkward situation can happen if we don't have any healthy groups.
-            // In that case let's panic and return an un-prioritized set of hosts.
-            LOGGER.warn("No healthy priority groups found. Returning the un-prioritized set.");
-            return hosts;
-        }
+        // We should have at least one host now: if all the hosts were unhealthy the `totalHealthyPercentage` would be
+        // zero and we would have bailed before re-weighting. If the weights of a group were all zero we should have
+        // re-weighted them all equally and added them.
+        assert !weightedResults.isEmpty();
+
+        LOGGER.debug("{}: Host prioritization resulted in {} active groups with a total of {} active hosts.",
+                lbDescription, activeGroups, weightedResults.size());
         return weightedResults;
     }
 
@@ -120,6 +128,9 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
             // to normalize against their group probability.
             double groupTotalWeight = totalWeight(hosts);
             if (groupTotalWeight == 0) {
+                // What to do in this case is debatable: it could be reasonable to consider they weight to still be
+                // zero and skip them. However, we currently yield to the side of availability and interpret them
+                // instead to all receive an equal portion of the groups weight.
                 double weight = ((double) groupProbability) / hosts.size();
                 for (H host : hosts) {
                     host.loadBalancingWeight(weight);

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
@@ -62,7 +62,7 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
         TreeMap<Integer, Group> groups = new TreeMap<>();
         for (T host : hosts) {
             if (host.priority() < 0) {
-                LOGGER.warn("{}: Found illegal priority: {}. Dropping priority grouping data.",
+                LOGGER.warn("{}: Illegal priority: {} (expected priority >=0). Ignoring priority data.",
                         lbDescription, host.priority());
                 return hosts;
             }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
@@ -75,7 +75,7 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
 
         // If there is only a single group we don't need to adjust weights.
         if (groups.size() == 1) {
-            LOGGER.debug("{}: Single priority group found.");
+            LOGGER.debug("{}: Single priority group found.", lbDescription);
             return hosts;
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -135,7 +135,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final String id,
             final String targetResourceName,
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
-            final HostPriorityStrategy priorityStrategy,
+            final Function<String, HostPriorityStrategy> priorityStrategyFactory,
             final HostSelector<ResolvedAddress, C> hostSelector,
             final ConnectionPoolStrategy<C> connectionPoolStrategy,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
@@ -145,7 +145,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         this.targetResource = requireNonNull(targetResourceName);
         this.lbDescription = makeDescription(id, targetResource);
         this.hostSelector = requireNonNull(hostSelector, "hostSelector");
-        this.priorityStrategy = requireNonNull(priorityStrategy, "priorityStrategy");
+        this.priorityStrategy = requireNonNull(
+                priorityStrategyFactory, "priorityStrategyFactory").apply(lbDescription);
         this.connectionPoolStrategy = requireNonNull(connectionPoolStrategy, "connectionPoolStrategy");
         this.eventPublisher = requireNonNull(eventPublisher);
         this.eventStream = fromSource(eventStreamProcessor)

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -167,7 +167,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
                 Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
                 ConnectionFactory<ResolvedAddress, C> connectionFactory, String targetResource) {
             return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
-                    DefaultHostPriorityStrategy.INSTANCE,
+                    DefaultHostPriorityStrategy::new,
                     loadBalancingPolicy.buildSelector(Collections.emptyList(), targetResource),
                     connectionPoolStrategyFactory.buildStrategy(targetResource), connectionFactory,
                     loadBalancerObserverFactory, healthCheckConfig, outlierDetectorFactory);

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategyTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategyTest.java
@@ -253,7 +253,7 @@ class DefaultHostPriorityStrategyTest {
         // 0 we consider them all equal among that group.
         assertThat(result.size(), equalTo(3));
         for (TestPrioritizedHost host : result) {
-            assertThat(host.loadBalancedWeight(), equalTo(100.0/3));
+            assertThat(host.loadBalancedWeight(), equalTo(100.0 / 3));
         }
     }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategyTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategyTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 class DefaultHostPriorityStrategyTest {
 
-    private final HostPriorityStrategy hostPriorityStrategy = new DefaultHostPriorityStrategy(100);
+    private final HostPriorityStrategy hostPriorityStrategy = new DefaultHostPriorityStrategy("", 100);
 
     @Test
     void noPriorities() {
@@ -232,6 +232,28 @@ class DefaultHostPriorityStrategyTest {
         for (int i = 0; i < 3; i++) {
             assertThat(result.get(i).loadBalancedWeight(),
                     approxEqual(result.get(i + 3).loadBalancedWeight() * 66 / 34));
+        }
+    }
+
+    @Test
+    void onlyHealthyNodesAreZeroWeight() {
+        List<TestPrioritizedHost> hosts = makeHosts(6);
+        for (int i = 0; i < hosts.size(); i++) {
+            if (i >= 3) {
+                hosts.get(i).loadBalancingWeight(0);
+                hosts.get(i).priority(1);
+            } else {
+                hosts.get(i).loadBalancingWeight(1);
+                hosts.get(i).isHealthy = false;
+            }
+        }
+
+        List<TestPrioritizedHost> result = hostPriorityStrategy.prioritize(hosts);
+        // We consider weight per-group. Since we only found one healthy group and all the weights were
+        // 0 we consider them all equal among that group.
+        assertThat(result.size(), equalTo(3));
+        for (TestPrioritizedHost host : result) {
+            assertThat(host.loadBalancedWeight(), equalTo(100.0/3));
         }
     }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -50,7 +50,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
     private LoadBalancingPolicy<String, TestLoadBalancedConnection> loadBalancingPolicy =
             LoadBalancingPolicies.p2c().build();
 
-    private HostPriorityStrategy hostPriorityStrategy = DefaultHostPriorityStrategy.INSTANCE;
+    private Function<String, HostPriorityStrategy> hostPriorityStrategyFactory = DefaultHostPriorityStrategy::new;
 
     @Nullable
     private Supplier<OutlierDetector<String, TestLoadBalancedConnection>> outlierDetectorFactory;
@@ -172,7 +172,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
     void changesToPriorityOrWeightTriggerRebuilds() throws Exception {
         final AtomicReference<Double> value = new AtomicReference<>();
         serviceDiscoveryPublisher.onComplete();
-        hostPriorityStrategy = new HostPriorityStrategy() {
+        hostPriorityStrategyFactory = (ignored) -> new HostPriorityStrategy() {
             @Override
             public <T extends PrioritizedHost> List<T> prioritize(List<T> hosts) {
                 assert hosts.size() == 1;
@@ -234,7 +234,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 getClass().getSimpleName(),
                 "test-service",
                 serviceDiscoveryPublisher,
-                hostPriorityStrategy,
+                hostPriorityStrategyFactory,
                 loadBalancingPolicy.buildSelector(new ArrayList<>(), "test-service"),
                 LinearSearchConnectionPoolStrategy.<TestLoadBalancedConnection>factory(DEFAULT_LINEAR_SEARCH_SPACE)
                         .buildStrategy("test-service"),


### PR DESCRIPTION
Motivation:

Logs are going to be exponentially more useful if we know which LB they're tied to but right now the DefaultHostPriorityStrategy is flying blind with regard to it's parent.

Modifications:

Follow the pattern of other components of DefaultLoadBalancer and pass the lbDescription into the construction of the HostPriorityStrategy.

Result:

Better observability.