### PR TITLE
FromInputStreamPublisher: avoid extra allocation of a buffer

### DIFF
--- a/servicetalk-concurrent-api/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-concurrent-api/gradle/checkstyle/suppressions.xml
@@ -24,4 +24,8 @@
   <!-- mapOnError supports re-throwing a Throwable from onError(Throwable) -->
   <suppress checks="IllegalThrowsCheck" files="io[\\/]servicetalk[\\/]concurrent[\\/]api[\\/]ScanWithMapper.java"/>
   <suppress checks="IllegalThrowsCheck" files="io[\\/]servicetalk[\\/]concurrent[\\/]api[\\/]ScanMapper.java"/>
+
+  <!-- Extra whitespace makes it easier to read doNotFailOnInputStreamWithBrokenAvailableCall() stream inputs -->
+  <suppress checks="SingleSpaceSeparator"
+            files="io[\\/]servicetalk[\\/]concurrent[\\/]api[\\/]FromInputStreamPublisherTest.java"/>
 </suppressions>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
@@ -173,7 +173,9 @@ final class FromInputStreamPublisher extends Publisher<byte[]> implements Publis
         private void readAndDeliver(final Subscriber<? super byte[]> subscriber) {
             try {
                 do {
-                    int readByte = -1;
+                    // Initialize readByte with a negative value different from END_OF_FILE as an indicator that it was
+                    // not initialized.
+                    int readByte = Integer.MIN_VALUE;
                     // Can't fully trust available(), but it's a reasonable hint to mitigate blocking on read().
                     int available = stream.available();
                     if (available == 0) {


### PR DESCRIPTION
Motivation:

In #2949 we optimized a case when `available()` is not implemented and always returns `0`. However, we de-optimized a use-case when it's implemented because the last call to `available()` always returns 0, but we still allocate a buffer of size `readChunkSize` that won't be used.

Modifications:
- Enhance `doNotFailOnInputStreamWithBrokenAvailableCall(...)` test before any changes for better test coverage.
- Remove `byte[] buffer` from a class variable. It can be a local variable because it's never reused in practice. Only the last `buffer` won't be nullified, but we don't need it after that.
- When `available()` returns `0`, try reading a single byte and then recheck availability instead of always falling back to
`readChunkSize`.
- Adjust `doNotFailOnInputStreamWithBrokenAvailableCall()` test to account for the 2nd call to `available()`;
- Add `singleReadTriggersMoreAvailability()` test to simulate when the 2nd call to `available()` returns positive value;

Result:

1. No allocation of a `buffer` that won't be used at the EOF.
2. Account for new availability if it appears after a `read()`.

---

Benchmark results:

<img width="483" alt="image" src="https://github.com/apple/servicetalk/assets/3968288/4f85d9aa-9c3c-4765-a4d0-25bd4a213abf">

The effect is visible for 256B and 16Kb payloads (less than 1 readChunkSize) because for them an allocation of an extra `buffer` is a bigger contributor.
`available()` of 0 means it always returns `0`, `true` - it always returns a real value. Used in-memory `ByteArrayInputStream` with overridden `available()` method.