### PR TITLE
loadbalancer-experimental: thread through the ConnectionPoolStrategyFactory

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolStrategy.java
@@ -46,9 +46,9 @@ interface ConnectionPoolStrategy<C extends LoadBalancedConnection> {
 
         /**
          * Provide an instance of the {@link ConnectionPoolStrategy} to use with a {@link Host}.
-         * @param targetResource the resource name, used for logging purposes.
+         * @param lbDescription description of the resource, used for logging purposes.
          * @return an instance of the {@link ConnectionPoolStrategy} to use with a {@link Host}.
          */
-        ConnectionPoolStrategy<C> buildStrategy(String targetResource);
+        ConnectionPoolStrategy<C> buildStrategy(String lbDescription);
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionPoolStrategy.java
@@ -86,6 +86,6 @@ final class CorePoolConnectionPoolStrategy<C extends LoadBalancedConnection>
     static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C> factory(
             int corePoolSize, boolean forceCorePool) {
         ensurePositive(corePoolSize, "corePoolSize");
-        return (targetResource) -> new CorePoolConnectionPoolStrategy<>(corePoolSize, forceCorePool);
+        return (lbDesription) -> new CorePoolConnectionPoolStrategy<>(corePoolSize, forceCorePool);
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -121,7 +121,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
      * @param eventPublisher provides a stream of addresses to connect to.
      * @param priorityStrategyFactory a build of the {@link HostPriorityStrategy} to use with the load balancer.
      * @param hostSelector initial host selector to use with this load balancer.
-     * @param connectionPoolStrategy the connection pool strategy to use with this load balancer.
+     * @param connectionPoolStrategyFactory factory of the connection pool strategy to use with this load balancer.
      * @param connectionFactory a function which creates new connections.
      * @param loadBalancerObserverFactory factory used to build a {@link LoadBalancerObserver} to use with this
      *                                    load balancer.
@@ -137,7 +137,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
             final Function<String, HostPriorityStrategy> priorityStrategyFactory,
             final HostSelector<ResolvedAddress, C> hostSelector,
-            final ConnectionPoolStrategy<C> connectionPoolStrategy,
+            final ConnectionPoolStrategy.ConnectionPoolStrategyFactory<C> connectionPoolStrategyFactory,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
             final LoadBalancerObserverFactory loadBalancerObserverFactory,
             @Nullable final HealthCheckConfig healthCheckConfig,
@@ -147,7 +147,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         this.hostSelector = requireNonNull(hostSelector, "hostSelector");
         this.priorityStrategy = requireNonNull(
                 priorityStrategyFactory, "priorityStrategyFactory").apply(lbDescription);
-        this.connectionPoolStrategy = requireNonNull(connectionPoolStrategy, "connectionPoolStrategy");
+        this.connectionPoolStrategy = requireNonNull(connectionPoolStrategyFactory,
+                "connectionPoolStrategyFactory").buildStrategy(lbDescription);
         this.eventPublisher = requireNonNull(eventPublisher);
         this.eventStream = fromSource(eventStreamProcessor)
                 .replay(1); // Allow for multiple subscribers and provide new subscribers with last signal.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -163,7 +163,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
             return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
                     DefaultHostPriorityStrategy::new,
                     loadBalancingPolicy.buildSelector(Collections.emptyList(), targetResource),
-                    connectionPoolStrategyFactory.buildStrategy(targetResource), connectionFactory,
+                    connectionPoolStrategyFactory, connectionFactory,
                     loadBalancerObserverFactory, healthCheckConfig, outlierDetectorFactory);
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionPoolStrategy.java
@@ -92,6 +92,6 @@ final class LinearSearchConnectionPoolStrategy<C extends LoadBalancedConnection>
 
     static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C> factory(final int linearSearchSpace) {
         ensureNonNegative(linearSearchSpace, "linearSearchSpace");
-        return (targetResource) -> new LinearSearchConnectionPoolStrategy<>(linearSearchSpace);
+        return (lbDescription) -> new LinearSearchConnectionPoolStrategy<>(linearSearchSpace);
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionPoolStrategy.java
@@ -45,14 +45,14 @@ final class P2CConnectionPoolStrategy<C extends LoadBalancedConnection> implemen
 
     private static final Logger LOGGER = LoggerFactory.getLogger(P2CConnectionPoolStrategy.class);
 
-    private final String targetResource;
+    private final String lbDescription;
     private final int maxEffort;
     private final int corePoolSize;
     private final boolean forceCorePool;
 
-    private P2CConnectionPoolStrategy(final String targetResource, final int maxEffort, final int corePoolSize,
+    private P2CConnectionPoolStrategy(final String lbDescription, final int maxEffort, final int corePoolSize,
                               final boolean forceCorePool) {
-        this.targetResource = requireNonNull(targetResource, "targetResource");
+        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
         this.maxEffort = ensureNonNegative(maxEffort, "maxEffort");
         this.corePoolSize = ensureNonNegative(corePoolSize, "corePoolSize");
         this.forceCorePool = forceCorePool;
@@ -108,7 +108,7 @@ final class P2CConnectionPoolStrategy<C extends LoadBalancedConnection> implemen
         }
         if (!singleIteration && LOGGER.isDebugEnabled()) {
             LOGGER.debug("{}: max effort ({}) exhausted while searching through {} candidates.",
-                    targetResource, maxEffort, randomSearchSpace);
+                    lbDescription, maxEffort, randomSearchSpace);
         }
         return null;
     }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -236,8 +236,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 serviceDiscoveryPublisher,
                 hostPriorityStrategyFactory,
                 loadBalancingPolicy.buildSelector(new ArrayList<>(), "test-service"),
-                LinearSearchConnectionPoolStrategy.<TestLoadBalancedConnection>factory(DEFAULT_LINEAR_SEARCH_SPACE)
-                        .buildStrategy("test-service"),
+                LinearSearchConnectionPoolStrategy.<TestLoadBalancedConnection>factory(DEFAULT_LINEAR_SEARCH_SPACE),
                 connectionFactory,
                 lbDescription -> NoopLoadBalancerObserver.instance(),
                 null,


### PR DESCRIPTION
Motivation:

We have a type ConnectionPoolStrategyFactory that is using the `targetResource` name for observability, contrary to the rest of the DefaultLoadBalancer which is using `lbDescription`. This happens because we accept a fully materialized ConnectionPoolStrategy in the DefaultLoadBalancer constructor instead of a factory like most everything else.

Modifications:

- Thread through the factory into the DefaultLoadBalancer constructor.
- Fix the parameter names to reflect that it's now lbDescription being used.