### PR TITLE
loadbalancer-experimental: thread the LoadBalancingPolicy into the DefaultLoadBalancer

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -32,11 +32,11 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
 
     private static final double ACCEPTABLE_PERCENT_ERROR = 0.01;
 
-    private final String targetResource;
+    private final String lbDescription;
     private final List<? extends Host<ResolvedAddress, C>> hosts;
-    BaseHostSelector(final List<? extends Host<ResolvedAddress, C>> hosts, final String targetResource) {
+    BaseHostSelector(final List<? extends Host<ResolvedAddress, C>> hosts, final String lbDescription) {
         this.hosts = hosts;
-        this.targetResource = requireNonNull(targetResource, "targetResource");
+        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
     }
 
     protected abstract Single<C> selectConnection0(Predicate<C> selector, @Nullable ContextMap context,
@@ -64,14 +64,14 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
         return hosts;
     }
 
-    protected final String getTargetResource() {
-        return targetResource;
+    protected final String lbDescription() {
+        return lbDescription;
     }
 
     protected final Single<C> noActiveHostsFailure(List<? extends Host<ResolvedAddress, C>> usedHosts) {
-        return failed(Exceptions.StacklessNoActiveHostException.newInstance("Failed to pick an active host for " +
-                        getTargetResource() + ". Either all are busy, expired, or unhealthy: " + usedHosts,
-                this.getClass(), "selectConnection(...)"));
+        return failed(Exceptions.StacklessNoActiveHostException.newInstance(
+                lbDescription() + ": Failed to pick an active host. Either all are busy, expired, or unhealthy: " +
+                        usedHosts, this.getClass(), "selectConnection(...)"));
     }
 
     // This method assumes the host is considered healthy.
@@ -93,7 +93,7 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
 
     private Single<C> noHostsFailure() {
         return failed(Exceptions.StacklessNoAvailableHostException.newInstance(
-                "No hosts are available to connect for " + targetResource + ".",
+                lbDescription() + ": No hosts are available to connect.",
                 this.getClass(), "selectConnection(...)"));
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -26,7 +26,6 @@ import io.servicetalk.loadbalancer.ConnectionPoolStrategy.ConnectionPoolStrategy
 import io.servicetalk.transport.api.ExecutionStrategy;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -161,8 +160,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
                 Publisher<? extends Collection<? extends ServiceDiscovererEvent<ResolvedAddress>>> eventPublisher,
                 ConnectionFactory<ResolvedAddress, C> connectionFactory, String targetResource) {
             return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
-                    DefaultHostPriorityStrategy::new,
-                    loadBalancingPolicy.buildSelector(Collections.emptyList(), targetResource),
+                    DefaultHostPriorityStrategy::new, loadBalancingPolicy,
                     connectionPoolStrategyFactory, connectionFactory,
                     loadBalancerObserverFactory, healthCheckConfig, outlierDetectorFactory);
         }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -47,9 +47,10 @@ public abstract class LoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     /**
      * Construct a {@link HostSelector}.
      * @param hosts          the set of {@link Host}s to select from.
-     * @param targetResource the name of the target resource, useful for debugging purposes.
+     * @param lbDescription a description of the associated {@link io.servicetalk.client.api.LoadBalancer},
+     *                      useful for debugging purposes.
      * @return a {@link HostSelector}
      */
     abstract HostSelector<ResolvedAddress, C> buildSelector(
-            List<Host<ResolvedAddress, C>> hosts, String targetResource);
+            List<Host<ResolvedAddress, C>> hosts, String lbDescription);
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -56,8 +56,8 @@ final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnec
 
     @Override
     HostSelector<ResolvedAddress, C> buildSelector(
-            List<Host<ResolvedAddress, C>> hosts, String targetResource) {
-        return new P2CSelector<>(hosts, targetResource, ignoreWeights, maxEffort, failOpen, random);
+            List<Host<ResolvedAddress, C>> hosts, String lbDescription) {
+        return new P2CSelector<>(hosts, lbDescription, ignoreWeights, maxEffort, failOpen, random);
     }
 
     @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -42,8 +42,8 @@ final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
 
     @Override
     HostSelector<ResolvedAddress, C>
-    buildSelector(final List<Host<ResolvedAddress, C>> hosts, final String targetResource) {
-        return new RoundRobinSelector<>(hosts, targetResource, failOpen, ignoreWeights);
+    buildSelector(final List<Host<ResolvedAddress, C>> hosts, final String lbDescription) {
+        return new RoundRobinSelector<>(hosts, lbDescription, failOpen, ignoreWeights);
     }
 
     @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -55,9 +55,9 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
     private final boolean failOpen;
     private final boolean ignoreWeights;
 
-    RoundRobinSelector(final List<? extends Host<ResolvedAddress, C>> hosts, final String targetResource,
+    RoundRobinSelector(final List<? extends Host<ResolvedAddress, C>> hosts, final String lbDescription,
                        final boolean failOpen, final boolean ignoreWeights) {
-        this(new AtomicInteger(), hosts, targetResource, failOpen, ignoreWeights);
+        this(new AtomicInteger(), hosts, lbDescription, failOpen, ignoreWeights);
     }
 
     private RoundRobinSelector(final AtomicInteger index, final List<? extends Host<ResolvedAddress, C>> hosts,
@@ -104,7 +104,7 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
 
     @Override
     public HostSelector<ResolvedAddress, C> rebuildWithHosts(@Nonnull List<? extends Host<ResolvedAddress, C>> hosts) {
-        return new RoundRobinSelector<>(index, hosts, getTargetResource(), failOpen, ignoreWeights);
+        return new RoundRobinSelector<>(index, hosts, lbDescription(), failOpen, ignoreWeights);
     }
 
     private static Scheduler buildScheduler(AtomicInteger index, List<? extends Host<?, ?>> hosts) {

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -235,8 +235,8 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 "test-service",
                 serviceDiscoveryPublisher,
                 hostPriorityStrategyFactory,
-                loadBalancingPolicy.buildSelector(new ArrayList<>(), "test-service"),
-                LinearSearchConnectionPoolStrategy.<TestLoadBalancedConnection>factory(DEFAULT_LINEAR_SEARCH_SPACE),
+                loadBalancingPolicy,
+                LinearSearchConnectionPoolStrategy.factory(DEFAULT_LINEAR_SEARCH_SPACE),
                 connectionFactory,
                 lbDescription -> NoopLoadBalancerObserver.instance(),
                 null,
@@ -371,7 +371,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
 
         @Override
         HostSelector<String, TestLoadBalancedConnection> buildSelector(
-                List<Host<String, TestLoadBalancedConnection>> hosts, String targetResource) {
+                List<Host<String, TestLoadBalancedConnection>> hosts, String lbDescription) {
             return new TestSelector(hosts);
         }
 


### PR DESCRIPTION
Motivation:

We use `lbDescription` all over the place for observing the
load balancer, but we use the `targetResource` for the HostSelector.

Modifications:

- Change the HostSelector types to use `lbDescription`.
- Thread the LoadBalancingPolicy into the DefaultLoadBalancer so we
  can feed it the `lbDescription`.