### PR TITLE
loadbalancer: better LoadBalancerFactory.toString() implementations

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -234,7 +234,7 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
 
     @Override
     public String toString() {
-        return "DefaultHttpLoadBalancerFactory" + System.identityHashCode(this) + "{" +
+        return "DefaultHttpLoadBalancerFactory{" +
                 "rawFactory=" + rawFactory +
                 ", strategy=" + strategy +
                 '}';

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpLoadBalancerFactory.java
@@ -231,4 +231,12 @@ public final class DefaultHttpLoadBalancerFactory<ResolvedAddress>
             return delegate.toString();
         }
     }
+
+    @Override
+    public String toString() {
+        return "DefaultHttpLoadBalancerFactory" + System.identityHashCode(this) + "{" +
+                "rawFactory=" + rawFactory +
+                ", strategy=" + strategy +
+                '}';
+    }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionPoolStrategy.java
@@ -85,7 +85,31 @@ final class CorePoolConnectionPoolStrategy<C extends LoadBalancedConnection>
 
     static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C> factory(
             int corePoolSize, boolean forceCorePool) {
-        ensurePositive(corePoolSize, "corePoolSize");
-        return (lbDesription) -> new CorePoolConnectionPoolStrategy<>(corePoolSize, forceCorePool);
+        return new CorePoolConnectionPoolStrategyFactory<>(corePoolSize, forceCorePool);
+    }
+
+    private static final class CorePoolConnectionPoolStrategyFactory<C extends LoadBalancedConnection>
+            implements ConnectionPoolStrategyFactory<C> {
+
+        private final int corePoolSize;
+        private final boolean forceCorePool;
+
+        public CorePoolConnectionPoolStrategyFactory(int corePoolSize, boolean forceCorePool) {
+            this.corePoolSize = ensurePositive(corePoolSize, "corePoolSize");
+            this.forceCorePool = forceCorePool;
+        }
+
+        @Override
+        public ConnectionPoolStrategy<C> buildStrategy(String lbDescription) {
+            return new CorePoolConnectionPoolStrategy<>(corePoolSize, forceCorePool);
+        }
+
+        @Override
+        public String toString() {
+            return "CorePoolConnectionPoolStrategyFactory{" +
+                    "corePoolSize=" + corePoolSize +
+                    ", forceCorePool=" + forceCorePool +
+                    '}';
+        }
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionPoolStrategy.java
@@ -94,7 +94,7 @@ final class CorePoolConnectionPoolStrategy<C extends LoadBalancedConnection>
         private final int corePoolSize;
         private final boolean forceCorePool;
 
-        public CorePoolConnectionPoolStrategyFactory(int corePoolSize, boolean forceCorePool) {
+        CorePoolConnectionPoolStrategyFactory(int corePoolSize, boolean forceCorePool) {
             this.corePoolSize = ensurePositive(corePoolSize, "corePoolSize");
             this.forceCorePool = forceCorePool;
         }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -170,7 +170,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
         @Override
         public String toString() {
-            return "DefaultLoadBalancerFactory@" + System.identityHashCode(this) + "{" +
+            return "DefaultLoadBalancerFactory{" +
                     "id='" + id + '\'' +
                     ", loadBalancingPolicy=" + loadBalancingPolicy +
                     ", loadBalancerObserverFactory=" + loadBalancerObserverFactory +

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionPoolStrategy.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
-import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Math.min;
 
 /**
@@ -100,7 +99,7 @@ final class LinearSearchConnectionPoolStrategy<C extends LoadBalancedConnection>
 
         private final int linearSearchSpace;
 
-        public LinearSearchConnectionPoolStrategyFactory(final int linearSearchSpace) {
+        LinearSearchConnectionPoolStrategyFactory(final int linearSearchSpace) {
             this.linearSearchSpace = ensureNonNegative(linearSearchSpace, "linearSearchSpace");
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionPoolStrategy.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Math.min;
 
 /**
@@ -91,7 +92,28 @@ final class LinearSearchConnectionPoolStrategy<C extends LoadBalancedConnection>
     }
 
     static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C> factory(final int linearSearchSpace) {
-        ensureNonNegative(linearSearchSpace, "linearSearchSpace");
-        return (lbDescription) -> new LinearSearchConnectionPoolStrategy<>(linearSearchSpace);
+        return new LinearSearchConnectionPoolStrategyFactory<>(linearSearchSpace);
+    }
+
+    private static final class LinearSearchConnectionPoolStrategyFactory<C extends LoadBalancedConnection>
+            implements ConnectionPoolStrategyFactory<C> {
+
+        private final int linearSearchSpace;
+
+        public LinearSearchConnectionPoolStrategyFactory(final int linearSearchSpace) {
+            this.linearSearchSpace = ensureNonNegative(linearSearchSpace, "linearSearchSpace");
+        }
+
+        @Override
+        public ConnectionPoolStrategy<C> buildStrategy(String lbDescription) {
+            return new LinearSearchConnectionPoolStrategy<>(linearSearchSpace);
+        }
+
+        @Override
+        public String toString() {
+            return "LinearSearchConnectionPoolStrategyFactory{" +
+                    "linearSearchSpace=" + linearSearchSpace +
+                    '}';
+        }
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 final class NoopLoadBalancerObserver implements LoadBalancerObserver {
 
     private static final LoadBalancerObserver INSTANCE = new NoopLoadBalancerObserver();
+    private static final LoadBalancerObserverFactory FACTORY_INSTANCE = new NoopLoadBalancerObserverFactory();
 
     private NoopLoadBalancerObserver() {
         // only private instance
@@ -87,7 +88,23 @@ final class NoopLoadBalancerObserver implements LoadBalancerObserver {
         }
     }
 
-    public static LoadBalancerObserver instance() {
+    static LoadBalancerObserver instance() {
         return INSTANCE;
+    }
+
+    static LoadBalancerObserverFactory factory() {
+        return FACTORY_INSTANCE;
+    }
+
+    private static final class NoopLoadBalancerObserverFactory implements LoadBalancerObserverFactory {
+        @Override
+        public LoadBalancerObserver newObserver(String lbDescription) {
+            return INSTANCE;
+        }
+
+        @Override
+        public String toString() {
+            return "NoopLoadBalancerObserverFactory";
+        }
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -319,6 +319,35 @@ public final class OutlierDetectorConfig {
         return ejectionTimeJitter;
     }
 
+    @Override
+    public String toString() {
+        return "OutlierDetectorConfig{" +
+                "ewmaHalfLife=" + ewmaHalfLife +
+                ", ewmaCancellationPenalty=" + ewmaCancellationPenalty +
+                ", ewmaErrorPenalty=" + ewmaErrorPenalty +
+                ", cancellationIsError=" + cancellationIsError +
+                ", failedConnectionsThreshold=" + failedConnectionsThreshold +
+                ", failureDetectorIntervalJitter=" + failureDetectorIntervalJitter +
+                ", serviceDiscoveryResubscribeInterval=" + serviceDiscoveryResubscribeInterval +
+                ", serviceDiscoveryResubscribeJitter=" + serviceDiscoveryResubscribeJitter +
+                ", consecutive5xx=" + consecutive5xx +
+                ", failureDetectorInterval=" + failureDetectorInterval +
+                ", baseEjectionTime=" + baseEjectionTime +
+                ", ejectionTimeJitter=" + ejectionTimeJitter +
+                ", maxEjectionPercentage=" + maxEjectionPercentage +
+                ", enforcingConsecutive5xx=" + enforcingConsecutive5xx +
+                ", enforcingSuccessRate=" + enforcingSuccessRate +
+                ", successRateMinimumHosts=" + successRateMinimumHosts +
+                ", successRateRequestVolume=" + successRateRequestVolume +
+                ", successRateStdevFactor=" + successRateStdevFactor +
+                ", failurePercentageThreshold=" + failurePercentageThreshold +
+                ", enforcingFailurePercentage=" + enforcingFailurePercentage +
+                ", failurePercentageMinimumHosts=" + failurePercentageMinimumHosts +
+                ", failurePercentageRequestVolume=" + failurePercentageRequestVolume +
+                ", maxEjectionTime=" + maxEjectionTime +
+                '}';
+    }
+
     /**
      * A builder for {@link OutlierDetectorConfig} instances.
      */

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionPoolStrategy.java
@@ -151,7 +151,7 @@ final class P2CConnectionPoolStrategy<C extends LoadBalancedConnection> implemen
         private final int corePoolSize;
         private final boolean forceCorePool;
 
-        public P2CConnectionPoolStrategyFactory(
+        P2CConnectionPoolStrategyFactory(
                 final int maxEffort, final int corePoolSize, final boolean forceCorePool) {
             this.maxEffort = ensurePositive(maxEffort, " maxEffort");
             this.corePoolSize = ensureNonNegative(corePoolSize, "corePoolSize");

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionPoolStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionPoolStrategy.java
@@ -141,9 +141,35 @@ final class P2CConnectionPoolStrategy<C extends LoadBalancedConnection> implemen
 
     static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C> factory(
             final int maxEffort, final int corePoolSize, final boolean forceCorePool) {
-        ensurePositive(maxEffort, " maxEffort");
-        ensureNonNegative(corePoolSize, "corePoolSize");
-        return (targetResource) -> new P2CConnectionPoolStrategy<>(
-                targetResource, maxEffort, corePoolSize, forceCorePool);
+        return new P2CConnectionPoolStrategyFactory<>(maxEffort, corePoolSize, forceCorePool);
+    }
+
+    private static final class P2CConnectionPoolStrategyFactory<C extends LoadBalancedConnection>
+            implements ConnectionPoolStrategyFactory<C> {
+
+        private final int maxEffort;
+        private final int corePoolSize;
+        private final boolean forceCorePool;
+
+        public P2CConnectionPoolStrategyFactory(
+                final int maxEffort, final int corePoolSize, final boolean forceCorePool) {
+            this.maxEffort = ensurePositive(maxEffort, " maxEffort");
+            this.corePoolSize = ensureNonNegative(corePoolSize, "corePoolSize");
+            this.forceCorePool = forceCorePool;
+        }
+
+        @Override
+        public ConnectionPoolStrategy<C> buildStrategy(String lbDescription) {
+            return new P2CConnectionPoolStrategy<>(lbDescription, maxEffort, corePoolSize, forceCorePool);
+        }
+
+        @Override
+        public String toString() {
+            return "P2CConnectionPoolStrategyFactory{" +
+                    "maxEffort=" + maxEffort +
+                    ", corePoolSize=" + corePoolSize +
+                    ", forceCorePool=" + forceCorePool +
+                    '}';
+        }
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -67,6 +67,11 @@ final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnec
 
     @Override
     public String toString() {
-        return name() + "(failOpen=" + failOpen + ", maxEffort=" + maxEffort + ')';
+        return "P2CLoadBalancingPolicy{" +
+                "ignoreWeights=" + ignoreWeights +
+                ", maxEffort=" + maxEffort +
+                ", failOpen=" + failOpen +
+                ", random=" + random +
+                '}';
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -53,6 +53,9 @@ final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
 
     @Override
     public String toString() {
-        return name() + "(failOpen=" + failOpen + ")";
+        return "RoundRobinLoadBalancingPolicy{" +
+                "failOpen=" + failOpen +
+                ", ignoreWeights=" + ignoreWeights +
+                '}';
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilderTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilderTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 
-public class DefaultLoadBalancerBuilderTest {
+final class DefaultLoadBalancerBuilderTest {
 
     @Test
     void isTheResultOfLoadBalancersBuilder() {

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilderTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
+
+public class DefaultLoadBalancerBuilderTest {
+
+    @Test
+    void isTheResultOfLoadBalancersBuilder() {
+        LoadBalancerBuilder<String, TestLoadBalancedConnection> builder = LoadBalancers.builder("builder_id");
+        assertThat(builder, instanceOf(DefaultLoadBalancerBuilder.class));
+    }
+
+    @Test
+    void toStringWorks() {
+        DefaultLoadBalancerBuilder<String, TestLoadBalancedConnection> builder =
+                new DefaultLoadBalancerBuilder<>("builder_id");
+        // Make sure the `.toString()` method doesn't throw due to being recursive or something similar.
+        assertThat(builder.build().toString(), startsWith(
+        "DefaultLoadBalancerFactory{" +
+                "id='builder_id', "));
+    }
+}

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -238,7 +238,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 loadBalancingPolicy,
                 LinearSearchConnectionPoolStrategy.factory(DEFAULT_LINEAR_SEARCH_SPACE),
                 connectionFactory,
-                lbDescription -> NoopLoadBalancerObserver.instance(),
+                NoopLoadBalancerObserver.factory(),
                 null,
                 factory);
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthCheckConfig.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/HealthCheckConfig.java
@@ -35,6 +35,10 @@ final class HealthCheckConfig {
     final Duration healthCheckInterval;
     final Duration jitter;
     final int failedThreshold;
+    final Duration resubscribeInterval;
+    final Duration healthCheckResubscribeJitter;
+
+    // Computed from the constructor values.
     final long healthCheckResubscribeLowerBound;
     final long healthCheckResubscribeUpperBound;
 
@@ -43,8 +47,10 @@ final class HealthCheckConfig {
                       final Duration healthCheckResubscribeJitter) {
         this.executor = executor;
         this.healthCheckInterval = healthCheckInterval;
-        this.failedThreshold = failedThreshold;
         this.jitter = healthCheckJitter;
+        this.failedThreshold = failedThreshold;
+        this.resubscribeInterval = resubscribeInterval;
+        this.healthCheckResubscribeJitter = healthCheckResubscribeJitter;
 
         validateHealthCheckIntervals(resubscribeInterval, healthCheckResubscribeJitter);
         this.healthCheckResubscribeLowerBound = resubscribeInterval.minus(healthCheckResubscribeJitter).toNanos();
@@ -64,5 +70,17 @@ final class HealthCheckConfig {
             throw new IllegalArgumentException("interval (" + interval + ") plus jitter (" + jitter +
                     ") must not overflow, current=" + upperBound);
         }
+    }
+
+    @Override
+    public String toString() {
+        return "HealthCheckConfig{" +
+                "executor=" + executor +
+                ", healthCheckInterval=" + healthCheckInterval +
+                ", jitter=" + jitter +
+                ", failedThreshold=" + failedThreshold +
+                ", resubscribeInterval=" + resubscribeInterval +
+                ", healthCheckResubscribeJitter=" + healthCheckResubscribeJitter +
+                '}';
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -95,7 +95,7 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
 
     @Override
     public String toString() {
-        return "RoundRobinLoadBalancerFactory" + System.identityHashCode(this) + "{" +
+        return "RoundRobinLoadBalancerFactory{" +
                 "id='" + id + '\'' +
                 ", linearSearchSpace=" + linearSearchSpace +
                 ", healthCheckConfig=" + healthCheckConfig +

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerFactory.java
@@ -93,6 +93,15 @@ public final class RoundRobinLoadBalancerFactory<ResolvedAddress, C extends Load
         return ExecutionStrategy.offloadNone();
     }
 
+    @Override
+    public String toString() {
+        return "RoundRobinLoadBalancerFactory" + System.identityHashCode(this) + "{" +
+                "id='" + id + '\'' +
+                ", linearSearchSpace=" + linearSearchSpace +
+                ", healthCheckConfig=" + healthCheckConfig +
+                '}';
+    }
+
     /**
      * Builder for {@link RoundRobinLoadBalancerFactory}.
      *


### PR DESCRIPTION
Motivation:

Our LoadBalancerFactory instances all use the default `.toString()` implementation, making them pretty difficult to debug since there are typically a series of proxies and settings that are not visible.

Modifications:

Make the `.toString()` implementations better. We use the standard format along with including the identity hash code to identify uniqueness.