### PR TITLE
`DefaultHostAndPort`: equals and hashCode are not consistent

### DIFF
--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DefaultHostAndPort.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DefaultHostAndPort.java
@@ -17,6 +17,7 @@ package io.servicetalk.transport.api;
 
 import javax.annotation.Nullable;
 
+import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
 import static io.servicetalk.utils.internal.NetworkUtils.isValidIpV4Address;
 import static io.servicetalk.utils.internal.NetworkUtils.isValidIpV6Address;
 import static java.lang.Integer.parseInt;
@@ -150,17 +151,22 @@ final class DefaultHostAndPort implements HostAndPort {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof DefaultHostAndPort)) {
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DefaultHostAndPort rhs = (DefaultHostAndPort) o;
-        return port == rhs.port() && hostName.equalsIgnoreCase(rhs.hostName());
+
+        final DefaultHostAndPort that = (DefaultHostAndPort) o;
+        return port == that.port && hostName.equalsIgnoreCase(that.hostName);
     }
 
     @Override
     public int hashCode() {
-        return 31 * (31 + port) + hostName.hashCode();
+        // Similar to InetSocketAddressHolder
+        return caseInsensitiveHashCode(hostName) + port;
     }
 
     private static boolean isValidPort(int port) {

--- a/servicetalk-transport-api/src/test/java/io/servicetalk/transport/api/HostAndPortTest.java
+++ b/servicetalk-transport-api/src/test/java/io/servicetalk/transport/api/HostAndPortTest.java
@@ -19,13 +19,34 @@ import org.junit.jupiter.api.Test;
 
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 final class HostAndPortTest {
+
+    @Test
+    void equalsAndHashCode() {
+        HostAndPort hp1 = HostAndPort.of("servicetalk.io", 443);
+        HostAndPort hp2 = HostAndPort.of("ServiceTalk.io", 443);
+
+        assertThat(hp1, is(not(sameInstance(hp2))));
+        assertThat(hp1, is(equalTo(hp2)));
+        assertThat(hp1.hashCode(), is(equalTo(hp2.hashCode())));
+
+        Map<HostAndPort, Object> map = new HashMap<>();
+        Object value = new Object();
+        map.put(hp1, value);
+        assertThat(map.get(hp2), is(value));
+    }
+
     @Test
     void hostConstructorNormalizesIpv6() {
         HostAndPort hp1 = HostAndPort.of("[::1]", 9999);


### PR DESCRIPTION
Motivation:

If two instances of `DefaultHostAndPort` are created with hostname in different case, they pass `equals` check but don't have a consistent `hashCode`. As a result, users can't query a `Map` entry with keys in different case.
Side-effect of that is a multi-address http client that may have multiple instances of a single-address client for the same hostname in different cases, preventing it from reusing connections.

Modifications:
- Implement `DefaultHostAndPort.hashCode()` in a consistent way with `InetSocketAddressHolder` where `hostName` hash is computed in case-insensitive mode.
- Re-generate `DefaultHostAndPort.equals(...)` implementation to allow a check by reference.
- Enhance `DefaultMultiAddressUrlHttpClientBuilderTest` to demonstrate that the problem went away.

Result:

1. `DefaultHostAndPort` can be used as a case-insensitive key for maps, matching definition of the host name in URL.
2. Multi-address client correctly recognizes the same host name in case-insensitive way.