### PR TITLE
ci-netty-snapshot.yml: use 4.2.0.Alpha2+

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         java: [ 8 ]
         os: [ ubuntu-latest ]
-        netty: [ 4.1+, 4.2+ ]
+        netty: [ 4.1+, 4.2.0.Alpha2+ ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Motivation:

Netty accidentally released 4.2.1.Alpha1-SNAPSHOT, which gets a higher priority. We need to pin 4.2.0.Alpha2+