### PR TITLE
loadbalancer-experimental: properly capture consecutive error signals

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
@@ -35,7 +35,7 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
 
     @Override
     public void detectOutliers(final OutlierDetectorConfig config,
-                               final Collection<XdsHealthIndicator<ResolvedAddress, C>> indicators) {
+                               final Collection<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators) {
         final long[] failurePercentages = new long[indicators.size()];
         int i = 0;
         int enoughVolumeHosts = 0;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
@@ -45,7 +45,7 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
 
     @Override
     public void detectOutliers(final OutlierDetectorConfig config,
-                               final Collection<XdsHealthIndicator<ResolvedAddress, C>> indicators) {
+                               final Collection<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators) {
         LOGGER.debug("Started outlier detection.");
         final double[] successRates = new double[indicators.size()];
         int i = 0;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithm.java
@@ -29,5 +29,6 @@ interface XdsOutlierDetectorAlgorithm<ResolvedAddress, C extends LoadBalancedCon
      * @param config the current {@link OutlierDetectorConfig} to use.
      * @param indicators an ordered list of {@link HealthIndicator} instances to collect stats from.
      */
-    void detectOutliers(OutlierDetectorConfig config, Collection<XdsHealthIndicator<ResolvedAddress, C>> indicators);
+    void detectOutliers(OutlierDetectorConfig config,
+                        Collection<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators);
 }


### PR DESCRIPTION
Motivation:

We have signals from the OutlierDetector to the DefaultLoadBalancer that signals when our endpoints health changes. However, for XdsOutlierDetector, we compute this as the difference on each iteration but consecutive 5xx is tripped immediately, so it may not be captured, and neither will recoveries which are most likely going to flip outside of an outlier detector scan.

Modifications:

- Instead of checking before and after each scan, save the last health status and check if that changed since the last scan.

Result:

We catch health transitions every time instead of only when the happen during an outlier scan.