### PR TITLE
Revert dependency upgrades before the release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -98,6 +98,6 @@ spotbugsPluginVersion=5.0.13
 
 apacheDirectoryServerVersion=1.5.7
 commonsLangVersion=2.6
-grpcVersion=1.62.2
+grpcVersion=1.64.0
 javaxAnnotationsApiVersion=1.3.5
 jsonUnitVersion=2.38.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ issueManagementUrl=https://github.com/apple/servicetalk/issues
 ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
-nettyVersion=4.1.111.Final
+nettyVersion=4.1.110.Final
 nettyIoUringVersion=0.0.25.Final
 
 jsr305Version=3.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -74,7 +74,7 @@ opentelemetryInstrumentationVersion=1.28.0-alpha
 
 # gRPC
 protobufGradlePluginVersion=0.9.4
-protobufVersion=3.25.3
+protobufVersion=3.25.1
 protoGoogleCommonProtosVersion=2.29.0
 javaPoetVersion=1.13.0
 shadowPluginVersion=8.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -75,7 +75,7 @@ opentelemetryInstrumentationVersion=1.28.0-alpha
 # gRPC
 protobufGradlePluginVersion=0.9.4
 protobufVersion=3.25.3
-protoGoogleCommonProtosVersion=2.37.0
+protoGoogleCommonProtosVersion=2.29.0
 javaPoetVersion=1.13.0
 shadowPluginVersion=8.1.1
 


### PR DESCRIPTION
We have to revert netty because of the issue with grpc-java: `https://github.com/netty/netty/issues/14126`.
Also reverting protobuf and commons protos to match versions from grpc-java 1.64.0.