### PR TITLE
`StreamingConnectionFactory` should set hostnameVerificationAlgorithm to an empty string

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -95,7 +95,8 @@ final class StreamingConnectionFactory {
             if (sniHostname == null) {
                 if (peerHost == null) {
                     newPeerHost = toHostAddress(inetAddress);
-                    newSniHostname = hostnameVerificationAlgorithm = null;
+                    newSniHostname = null;
+                    hostnameVerificationAlgorithm = null;
                 } else {
                     newPeerHost = peerHost + '-' + toHostAddress(inetAddress);
                     // We are overriding the peerHost to make it qualified with the resolved address. If sniHostname is
@@ -105,7 +106,8 @@ final class StreamingConnectionFactory {
                         newSniHostname = peerHost;
                         hostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
                     } else {
-                        newSniHostname = hostnameVerificationAlgorithm = null;
+                        newSniHostname = null;
+                        hostnameVerificationAlgorithm = null;
                     }
                 }
             } else {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -96,7 +96,7 @@ final class StreamingConnectionFactory {
                 if (peerHost == null) {
                     newPeerHost = toHostAddress(inetAddress);
                     newSniHostname = null;
-                    hostnameVerificationAlgorithm = null;
+                    hostnameVerificationAlgorithm = "";
                 } else {
                     newPeerHost = peerHost + '-' + toHostAddress(inetAddress);
                     // We are overriding the peerHost to make it qualified with the resolved address. If sniHostname is
@@ -107,7 +107,7 @@ final class StreamingConnectionFactory {
                         hostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
                     } else {
                         newSniHostname = null;
-                        hostnameVerificationAlgorithm = null;
+                        hostnameVerificationAlgorithm = "";
                     }
                 }
             } else {

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslUtils.java
@@ -68,9 +68,12 @@ final class SslUtils {
         setHandshakeTimeout(handler, context);
         SSLEngine engine = handler.engine();
         try {
+            String hostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
             String sniHostname = sslConfig.sniHostname();
             SSLParameters parameters = engine.getSSLParameters();
-            parameters.setEndpointIdentificationAlgorithm(sslConfig.hostnameVerificationAlgorithm());
+            if (hostnameVerificationAlgorithm != null) {
+                parameters.setEndpointIdentificationAlgorithm(hostnameVerificationAlgorithm);
+            }
             if (sniHostname != null) {
                 // https://tools.ietf.org/html/rfc6066#section-3
                 // Multiple names of the same name_type are therefore now prohibited.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslUtils.java
@@ -68,12 +68,9 @@ final class SslUtils {
         setHandshakeTimeout(handler, context);
         SSLEngine engine = handler.engine();
         try {
-            String hostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
             String sniHostname = sslConfig.sniHostname();
             SSLParameters parameters = engine.getSSLParameters();
-            if (hostnameVerificationAlgorithm != null) {
-                parameters.setEndpointIdentificationAlgorithm(hostnameVerificationAlgorithm);
-            }
+            parameters.setEndpointIdentificationAlgorithm(sslConfig.hostnameVerificationAlgorithm());
             if (sniHostname != null) {
                 // https://tools.ietf.org/html/rfc6066#section-3
                 // Multiple names of the same name_type are therefore now prohibited.


### PR DESCRIPTION
Motivation:

There are cases when default algorithm `HTTPS` can be reset if there are no `sniHostname` and no `peerHost`. See
`GrpcSslAndNonSslConnectionsTest` as a reproducer. This flow works well with Netty 4.1, but breaks with Netty 4.2 because Netty uses `HTTPS` by default. If we set it back to `null`, `sun.security.ssl.SSLEngineImpl` ignores it. To disable it later, we should use an empty string.

Modifications:

- Update `StreamingConnectionFactory.withSslConfigPeerHost` to use an empty string instead of `null` when it needs to reset `hostnameVerificationAlgorithm`;

Result:

We can override the previously set endpoint identification algorithm.