### PR TITLE
Add `Publisher.fromInputStream(InputStream, ByteArrayMapper)`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ByteArrayMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ByteArrayMapper.java
@@ -31,7 +31,7 @@ public interface ByteArrayMapper<T> {
     /**
      * Maps a specified {@code byte[]} buffer region into a {@code T}.
      * <p>
-     * The mapper can operate only with the specified region of the {@code buffer}, which can be safely used without a
+     * The mapper can operate only within the specified region of the {@code buffer}, which can be safely used without a
      * need to copy data. Access to other parts of the buffer may lead to unexpected results and due care should be
      * taken to avoid leaking that data through the returned type {@code T}.
      *

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ByteArrayMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ByteArrayMapper.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.api.FromInputStreamPublisher.ToByteArrayMapper;
+
+import static io.servicetalk.concurrent.api.FromInputStreamPublisher.DEFAULT_MAX_BUFFER_SIZE;
+import static io.servicetalk.concurrent.api.FromInputStreamPublisher.ToByteArrayMapper.DEFAULT_TO_BYTE_ARRAY_MAPPER;
+
+/**
+ * A mapper to transform {@code byte[]} buffer regions into a desired type {@code T}.
+ *
+ * @param <T> Type of the result of this mapper
+ */
+@FunctionalInterface
+public interface ByteArrayMapper<T> {
+
+    /**
+     * Maps a specified {@code byte[]} buffer region into a {@code T}.
+     * <p>
+     * The mapper can operate only with the specified region of the {@code buffer}. Access to other parts of the buffer
+     * may lead to unexpected results. The specified region can be safely used by the mapper without a need to copy
+     * data.
+     *
+     * @param buffer {@code byte[]} buffer with data
+     * @param offset the offset of the region
+     * @param length the length of the region
+     * @return result of type {@code T}
+     */
+    T map(byte[] buffer, int offset, int length);
+
+    /**
+     * Returns the maximum allowed buffer size for the {@link #map(byte[], int, int)} operation.
+     * <p>
+     * Must be a positive number.
+     *
+     * @return the maximum allowed buffer size for the {@link #map(byte[], int, int)} operation
+     */
+    default int maxBufferSize() {
+        return DEFAULT_MAX_BUFFER_SIZE;
+    }
+
+    /**
+     * Mapper from the buffer region to an independent {@code byte[]} buffer.
+     * <p>
+     * Returns {@link #toByteArray(int)} with default {@link #maxBufferSize()}.
+     *
+     * @return a mapper from the buffer region to an independent {@code byte[]} buffer
+     */
+    static ByteArrayMapper<byte[]> toByteArray() {
+        return DEFAULT_TO_BYTE_ARRAY_MAPPER;
+    }
+
+    /**
+     * Mapper from the buffer region to an independent {@code byte[]} buffer.
+     * <p>
+     * Returns the original {@code byte[]} buffer as-is if it was completely full of data or allocates a new buffer for
+     * the specified length and copies data. Returned {@code byte[]} buffer is always completely full.
+     *
+     * @param maxBufferSize the value for {@link #maxBufferSize()}
+     * @return a mapper from the buffer region to an independent {@code byte[]} buffer
+     */
+    static ByteArrayMapper<byte[]> toByteArray(final int maxBufferSize) {
+        return new ToByteArrayMapper(maxBufferSize);
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ByteArrayMapper.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/ByteArrayMapper.java
@@ -31,9 +31,9 @@ public interface ByteArrayMapper<T> {
     /**
      * Maps a specified {@code byte[]} buffer region into a {@code T}.
      * <p>
-     * The mapper can operate only with the specified region of the {@code buffer}. Access to other parts of the buffer
-     * may lead to unexpected results. The specified region can be safely used by the mapper without a need to copy
-     * data.
+     * The mapper can operate only with the specified region of the {@code buffer}, which can be safely used without a
+     * need to copy data. Access to other parts of the buffer may lead to unexpected results and due care should be
+     * taken to avoid leaking that data through the returned type {@code T}.
      *
      * @param buffer {@code byte[]} buffer with data
      * @param offset the offset of the region

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -4522,9 +4522,12 @@ Kotlin flatMapLatest</a>
      * InputStream#read(byte[], int, int)}.
      * @return a new {@link Publisher} that when subscribed will emit all data from the {@link InputStream} to the
      * {@link Subscriber} and then {@link Subscriber#onComplete()}.
+     * @deprecated Use {@link #fromInputStream(InputStream, ByteArrayMapper)} with
+     * {@link ByteArrayMapper#toByteArray()}.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     public static Publisher<byte[]> fromInputStream(InputStream stream) {
-        return new FromInputStreamPublisher(stream);
+        return fromInputStream(stream, ByteArrayMapper.toByteArray());
     }
 
     /**
@@ -4552,9 +4555,45 @@ Kotlin flatMapLatest</a>
      * and emitted by the returned {@link Publisher}.
      * @return a new {@link Publisher} that when subscribed will emit all data from the {@link InputStream} to the
      * {@link Subscriber} and then {@link Subscriber#onComplete()}.
+     * @deprecated Use {@link #fromInputStream(InputStream, ByteArrayMapper)} with
+     * {@link ByteArrayMapper#toByteArray(int)}.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated method
     public static Publisher<byte[]> fromInputStream(InputStream stream, int readChunkSize) {
-        return new FromInputStreamPublisher(stream, readChunkSize);
+        return fromInputStream(stream, ByteArrayMapper.toByteArray(readChunkSize));
+    }
+
+    /**
+     * Create a new {@link Publisher} that when subscribed will emit all data from the {@link InputStream} to the
+     * {@link Subscriber} as a mapped type {@code T} and then {@link Subscriber#onComplete()}.
+     * <p>
+     * The resulting publisher is not replayable and supports only a single {@link Subscriber}.
+     * <p>
+     * After a returned {@link Publisher} is subscribed, it owns the passed {@link InputStream}, meaning that the
+     * {@link InputStream} will be automatically closed when the {@link Publisher} is cancelled or terminated. Not
+     * necessary to close the {@link InputStream} after subscribe, but it should be closed when control flow never
+     * subscribes to the returned {@link Publisher}.
+     * <p>
+     * The Reactive Streams specification provides two criteria (
+     * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#3.4">3.4</a>, and
+     * <a href="https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#3.5">3.5</a>) stating
+     * the {@link Subscription} should be "responsive". The responsiveness of the associated {@link Subscription}s will
+     * depend upon the behavior of the {@code stream} below. Make sure the {@link Executor} for this execution chain
+     * can tolerate this responsiveness and any blocking behavior.
+     * <p>
+     * Given the blocking nature of {@link InputStream}, assume {@link Subscription#request(long)} can block when the
+     * underlying {@link InputStream} blocks on {@link InputStream#read(byte[], int, int)}.
+     *
+     * @param stream provides the data in the form of {@code byte[]} buffer regions for the specified
+     * {@link ByteArrayMapper}.
+     * @param mapper a mapper to transform raw {@code byte[]} buffer regions into a desired type {@code T} to be emitted
+     * to the {@link Subscriber} by the returned {@link Publisher}.
+     * @param <T> Type of the items emitted by the returned {@link Publisher}.
+     * @return a new {@link Publisher} that when subscribed will emit all data from the {@link InputStream} to the
+     * {@link Subscriber} as a mapped type {@code T} and then {@link Subscriber#onComplete()}.
+     */
+    public static <T> Publisher<T> fromInputStream(InputStream stream, ByteArrayMapper<T> mapper) {
+        return new FromInputStreamPublisher<>(stream, mapper);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
+import static io.servicetalk.concurrent.api.Publisher.fromInputStream;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.lang.Integer.MAX_VALUE;
@@ -69,7 +70,7 @@ class FromInputStreamPublisherTest {
     @BeforeEach
     void setup() {
         inputStream = mock(InputStream.class);
-        pub = new FromInputStreamPublisher(inputStream);
+        pub = fromInputStream(inputStream);
     }
 
     @Test
@@ -374,7 +375,7 @@ class FromInputStreamPublisherTest {
         // calls to "broken" available() should consistently return `0`.
         initChunkedStream(bigBuff, of(3, 0, 0, 4, 0, 0, 5, 0, 0, 2, 0, 0,    0, 0,       4, 0),
                                    of(3, 7,    4, 4,    5, 2, 2, 2, 1, 2, 1, 1, 1, 1, 1, 4, 0));
-        pub = new FromInputStreamPublisher(inputStream, readChunkSize);
+        pub = fromInputStream(inputStream, readChunkSize);
 
         if (readChunkSize > bigBuff.length) {
             byte[][] items = {
@@ -418,7 +419,7 @@ class FromInputStreamPublisherTest {
         // returns a non zero value, we should return a chunk value of "chunks[idx - 1] - number of read bytes".
         initChunkedStream(bigBuff, of(0, 1, 0, 7, 0, 8, 1,  0, 17, 10, 2, 0),
                                    of(2,    8,    9,    1, 18,     10, 2, 0));
-        pub = new FromInputStreamPublisher(inputStream, 8);
+        pub = fromInputStream(inputStream, 8);
 
         byte[][] items = {
                 // available < readChunkSize
@@ -444,7 +445,7 @@ class FromInputStreamPublisherTest {
     void readChunkSizeRespectedWhenAvailableNotImplemented(int chunkSize) throws Throwable {
         initChunkedStream(bigBuff, ofAll(0), ofAll(chunkSize));
         int readChunkSize = 5;
-        pub = new FromInputStreamPublisher(inputStream, readChunkSize);
+        pub = fromInputStream(inputStream, readChunkSize);
 
         // expect 8 emitted items
         // [ 0,  1,  2,  3,  4]

--- a/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/JacksonSerializerMessageBodyReaderWriter.java
+++ b/servicetalk-data-jackson-jersey/src/main/java/io/servicetalk/data/jackson/jersey/JacksonSerializerMessageBodyReaderWriter.java
@@ -231,7 +231,7 @@ final class JacksonSerializerMessageBodyReaderWriter implements MessageBodyReade
     }
 
     private static Publisher<Buffer> toBufferPublisher(final InputStream is, final BufferAllocator a) {
-        return fromInputStream(is).map(a::wrap);
+        return fromInputStream(is, a::wrap);
     }
 
     // FIXME: 0.43 - Remove deprecations

--- a/servicetalk-data-protobuf-jersey/src/main/java/io/servicetalk/data/protobuf/jersey/ProtobufSerializerMessageBodyReaderWriter.java
+++ b/servicetalk-data-protobuf-jersey/src/main/java/io/servicetalk/data/protobuf/jersey/ProtobufSerializerMessageBodyReaderWriter.java
@@ -168,7 +168,7 @@ final class ProtobufSerializerMessageBodyReaderWriter implements MessageBodyRead
     }
 
     private static Publisher<Buffer> toBufferPublisher(final InputStream is, final BufferAllocator a) {
-        return fromInputStream(is).map(a::wrap);
+        return fromInputStream(is, a::wrap);
     }
 
     private static <T> Single<T> deserialize(

--- a/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsResource.java
+++ b/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsResource.java
@@ -219,7 +219,7 @@ public class HelloWorldJaxRsResource {
                                          @FormDataParam("file") InputStream file) {
         final BufferAllocator allocator = ctx.executionContext().bufferAllocator();
         return from(allocator.fromAscii("Hello multipart! Content: "))
-                .concat(fromInputStream(file).map(allocator::wrap))
+                .concat(fromInputStream(file, allocator::wrap))
                 .collect(allocator::newCompositeBuffer,
                         (collector, item) -> ((CompositeBuffer) collector).addBuffer(item));
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpRequest.java
@@ -197,8 +197,7 @@ final class DefaultBlockingStreamingHttpRequest extends AbstractDelegatingHttpRe
 
     @Override
     public BlockingStreamingHttpRequest payloadBody(final InputStream payloadBody) {
-        original.payloadBody(fromInputStream(payloadBody)
-                .map(bytes -> original.payloadHolder().allocator().wrap(bytes)));
+        original.payloadBody(fromInputStream(payloadBody, original.payloadHolder().allocator()::wrap));
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultBlockingStreamingHttpResponse.java
@@ -81,8 +81,7 @@ final class DefaultBlockingStreamingHttpResponse extends AbstractDelegatingHttpR
 
     @Override
     public BlockingStreamingHttpResponse payloadBody(final InputStream payloadBody) {
-        original.payloadBody(fromInputStream(payloadBody)
-                .map(bytes -> original.payloadHolder().allocator().wrap(bytes)));
+        original.payloadBody(fromInputStream(payloadBody, original.payloadHolder().allocator()::wrap));
         return this;
     }
 

--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/AbstractMessageBodyReaderWriter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/AbstractMessageBodyReaderWriter.java
@@ -89,7 +89,7 @@ abstract class AbstractMessageBodyReaderWriter<Source, T, SourceOfT, WrappedSour
         return handleEntityStream(entityStream, allocator, bodyFunction,
                 (is, a) -> bodyFunction
                         .andThen(sourceFunction)
-                        .apply(fromInputStream(is).map(a::wrap), a));
+                        .apply(fromInputStream(is, a::wrap), a));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Existing `Publisher.fromInputStream(InputStream)` contract has a side effect of an extra allocation in case the pre-allocated byte-array was not completely full of data.

Modifications:

- Add `Publisher.fromInputStream(InputStream, ByteArrayMapper)` that allows users to decide how to use the buffer region with data;
- Deprecate pre-existing `Publisher.fromInputStream(InputStream)` and `Publisher.fromInputStream(InputStream, int)` overloads;
- Update all existing use-cases to use `BufferAllocator.wrap` as a method reference as a `ByteArrayMapper`;

Result:

No impact on throughput and latency for `BlockingStreamingHttpClient` requests with `InputStream` payload (8Kb, 16Kb, 24Kb), but significant reduction in memory allocations and number of GC runs per benchmark:

Allocations: ~2Gb/s -> ~1.4Gb/s
Young Collection GC Count: 29 -> 23
Alloc Outside TLABs: 7.33 GiB -> 5.04 GiB