### PR TITLE
Always require native libraries for running tests

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -229,6 +229,10 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
 
         jvmArgs "-server", "-Xms2g", "-Xmx4g", "-dsa", "-da", "-ea:io.servicetalk...",
                 "-XX:+HeapDumpOnOutOfMemoryError"
+
+        // Always require native libraries for running tests. This helps to make sure transport-level state machine
+        // receives all expected network events from Netty.
+        systemProperty "io.servicetalk.transport.netty.requireNativeLibs", "true"
       }
 
       dependencies {


### PR DESCRIPTION
Motivation:

In rare occasions tests may fail with ambiguous errors. After hours of debugging, the root cause may end up an inability to load native libraries.

Modifications:

- Enforce `io.servicetalk.transport.netty.requireNativeLibs=true` for running tests.

Result:

Significantly simplifies finding the root cause for hanging tests.