### PR TITLE
loadbalancer-experimental: allow configuring the pending request penalty

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
@@ -47,7 +47,7 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
     private final double invTau;
     private final long cancelPenalty;
     private final long errorPenalty;
-    private final long pendingRequestPenalty;
+    private final long concurrentRequestPenalty;
 
     /**
      * Last inserted value to compute weight.
@@ -57,16 +57,16 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
      * Current weighted average.
      */
     private int ewma;
-    private int pendingCount;
-    private long pendingStamp = Long.MIN_VALUE;
+    private int concurrentCount;
+    private long concurrentStamp = Long.MIN_VALUE;
 
     DefaultRequestTracker(final long halfLifeNanos, final long cancelPenalty, final long errorPenalty,
-                          final long pendingRequestPenalty) {
+                          final long concurrentRequestPenalty) {
         ensurePositive(halfLifeNanos, "halfLifeNanos");
         this.invTau = Math.pow((halfLifeNanos / log(2)), -1);
         this.cancelPenalty = cancelPenalty;
         this.errorPenalty = errorPenalty;
-        this.pendingRequestPenalty = pendingRequestPenalty;
+        this.concurrentRequestPenalty = concurrentRequestPenalty;
     }
 
     /**
@@ -80,10 +80,10 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
         final long stamp = lock.writeLock();
         try {
             long timestamp = currentTimeNanos();
-            pendingCount++;
-            if (pendingStamp == Long.MIN_VALUE) {
-                // only update the pending timestamp if it doesn't already have a value.
-                pendingStamp = timestamp;
+            concurrentCount++;
+            if (concurrentStamp == Long.MIN_VALUE) {
+                // only update the concurrent timestamp if it doesn't already have a value.
+                concurrentStamp = timestamp;
             }
             return timestamp;
         } finally {
@@ -104,10 +104,10 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
     private void onComplete(final long startTimeNanos, long penalty) {
         final long stamp = lock.writeLock();
         try {
-            pendingCount--;
+            concurrentCount--;
             // Unconditionally clear the timestamp because we don't know which request set it. This is an acceptable
             // 'error' since otherwise we need to keep a collection of start timestamps.
-            pendingStamp = Long.MIN_VALUE;
+            concurrentStamp = Long.MIN_VALUE;
             updateEwma(penalty, startTimeNanos);
         } finally {
             lock.unlockWrite(stamp);
@@ -117,16 +117,16 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
     @Override
     public final int score() {
         final long lastTimeNanos;
-        final int cPending;
-        final long pendingStamp;
+        final int concurrentCount;
+        final long concurrentStamp;
         int currentEWMA;
         // read all the relevant state using the read lock
         final long stamp = lock.readLock();
         try {
             currentEWMA = ewma;
             lastTimeNanos = this.lastTimeNanos;
-            cPending = pendingCount;
-            pendingStamp = this.pendingStamp;
+            concurrentCount = this.concurrentCount;
+            concurrentStamp = this.concurrentStamp;
         } finally {
             lock.unlockRead(stamp);
         }
@@ -142,26 +142,27 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
         }
 
         if (currentEWMA == 0) {
-            // If EWMA has decayed to 0 (or isn't yet initialized) and there are no pending requests we return the
-            // maximum score to increase the likelihood this entity is selected. If there are pending requests we
+            // If EWMA has decayed to 0 (or isn't yet initialized) and there are no concurrent requests we return the
+            // maximum score to increase the likelihood this entity is selected. If there are concurrent requests we
             // don't yet know the latency characteristics so we return the minimum score to decrease the
             // likelihood this entity is selected.
-            return cPending == 0 ? 0 : MIN_VALUE;
+            return concurrentCount == 0 ? 0 : MIN_VALUE;
         }
 
-        if (cPending > 0 && pendingStamp != Long.MIN_VALUE) {
-            // If we have a request outstanding we should consider how long it has been outstanding so that sudden
+        if (concurrentCount > 0 && concurrentStamp != Long.MIN_VALUE) {
+            // If we have a request concurrent we should consider how long it has been concurrent so that sudden
             // interruptions don't have to wait for timeouts before our scores can be adjusted.
-            currentEWMA = max(currentEWMA, nanoToMillis(currentTimeNanos - pendingStamp));
+            currentEWMA = max(currentEWMA, nanoToMillis(currentTimeNanos - concurrentStamp));
         }
 
-        // Add penalty for pending requests to account for "unaccounted" load.
+        // Add penalty for concurrent requests to account for "unaccounted" load.
         // Penalty is the observed latency if known, else an arbitrarily high value which makes entities for which
         // no latency data has yet been received (eg: request sent but not received), un-selectable.
-        final int pendingPenalty = (int) min(MAX_VALUE, (long) cPending * pendingRequestPenalty * currentEWMA);
+        final int concurrentPenalty = (int) min(MAX_VALUE,
+                (long) concurrentCount * concurrentRequestPenalty * currentEWMA);
         // Since we are measuring latencies and lower latencies are better, we turn the score as negative such that
         // lower the latency, higher the score.
-        return MAX_VALUE - currentEWMA <= pendingPenalty ? MIN_VALUE : -(currentEWMA + pendingPenalty);
+        return MAX_VALUE - currentEWMA <= concurrentPenalty ? MIN_VALUE : -(currentEWMA + concurrentPenalty);
     }
 
     private static int applyPenalty(int currentEWMA, int currentLatency, long penalty) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
@@ -57,7 +57,7 @@ final class NoopOutlierDetector<ResolvedAddress, C extends LoadBalancedConnectio
 
         BasicHealthIndicator() {
             super(outlierDetectorConfig.ewmaHalfLife().toNanos(), outlierDetectorConfig.ewmaCancellationPenalty(),
-                    outlierDetectorConfig.ewmaCancellationPenalty(), outlierDetectorConfig.pendingRequestPenalty());
+                    outlierDetectorConfig.ewmaCancellationPenalty(), outlierDetectorConfig.concurrentRequestPenalty());
         }
 
         @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
@@ -57,7 +57,7 @@ final class NoopOutlierDetector<ResolvedAddress, C extends LoadBalancedConnectio
 
         BasicHealthIndicator() {
             super(outlierDetectorConfig.ewmaHalfLife().toNanos(), outlierDetectorConfig.ewmaCancellationPenalty(),
-                    outlierDetectorConfig.ewmaCancellationPenalty());
+                    outlierDetectorConfig.ewmaCancellationPenalty(), outlierDetectorConfig.pendingRequestPenalty());
         }
 
         @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -66,11 +66,13 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
 
     XdsHealthIndicator(final SequentialExecutor sequentialExecutor, final Executor executor,
                        final Duration ewmaHalfLife, final long cancellationPenalty, final long errorPenalty,
+                       final long pendingRequestPenalty,
                        final boolean cancellationIsError, final ResolvedAddress address, String lbDescription,
                        final HostObserver hostObserver) {
         super(requireNonNull(ewmaHalfLife, "ewmaHalfLife").toNanos(),
                 ensureNonNegative(cancellationPenalty, "cancellationPenalty"),
-                ensureNonNegative(errorPenalty, "errorPenalty"));
+                ensureNonNegative(errorPenalty, "errorPenalty"),
+                ensureNonNegative(pendingRequestPenalty, "pendingRequestPenalty"));
         this.cancellationIsError = cancellationIsError;
         this.sequentialExecutor = requireNonNull(sequentialExecutor, "sequentialExecutor");
         this.executor = requireNonNull(executor, "executor");

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -139,7 +139,7 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
                                HostObserver hostObserver) {
             super(sequentialExecutor, executor, outlierDetectorConfig.ewmaHalfLife(),
                     outlierDetectorConfig.ewmaCancellationPenalty(), outlierDetectorConfig.ewmaErrorPenalty(),
-                    outlierDetectorConfig.pendingRequestPenalty(), outlierDetectorConfig.cancellationIsError(),
+                    outlierDetectorConfig.concurrentRequestPenalty(), outlierDetectorConfig.cancellationIsError(),
                     address, lbDescription, hostObserver);
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -139,7 +139,8 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
                                HostObserver hostObserver) {
             super(sequentialExecutor, executor, outlierDetectorConfig.ewmaHalfLife(),
                     outlierDetectorConfig.ewmaCancellationPenalty(), outlierDetectorConfig.ewmaErrorPenalty(),
-                    outlierDetectorConfig.cancellationIsError(), address, lbDescription, hostObserver);
+                    outlierDetectorConfig.pendingRequestPenalty(), outlierDetectorConfig.cancellationIsError(),
+                    address, lbDescription, hostObserver);
         }
 
         @Override

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
@@ -22,6 +22,7 @@ import java.util.function.LongUnaryOperator;
 
 import static io.servicetalk.loadbalancer.OutlierDetectorConfig.Builder.DEFAULT_CANCEL_PENALTY;
 import static io.servicetalk.loadbalancer.OutlierDetectorConfig.Builder.DEFAULT_ERROR_PENALTY;
+import static io.servicetalk.loadbalancer.OutlierDetectorConfig.Builder.DEFAULT_PENDING_REQUEST_PENALTY;
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -93,7 +94,8 @@ class DefaultRequestTrackerTest {
         private long lastValue;
 
         TestRequestTracker(Duration measurementHalfLife, final LongUnaryOperator nextValueProvider) {
-            super(measurementHalfLife.toNanos(), DEFAULT_CANCEL_PENALTY, DEFAULT_ERROR_PENALTY);
+            super(measurementHalfLife.toNanos(), DEFAULT_CANCEL_PENALTY, DEFAULT_ERROR_PENALTY,
+                    DEFAULT_PENDING_REQUEST_PENALTY);
             this.nextValueProvider = nextValueProvider;
         }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultRequestTrackerTest.java
@@ -21,8 +21,8 @@ import java.time.Duration;
 import java.util.function.LongUnaryOperator;
 
 import static io.servicetalk.loadbalancer.OutlierDetectorConfig.Builder.DEFAULT_CANCEL_PENALTY;
+import static io.servicetalk.loadbalancer.OutlierDetectorConfig.Builder.DEFAULT_CONCURRENT_REQUEST_PENALTY;
 import static io.servicetalk.loadbalancer.OutlierDetectorConfig.Builder.DEFAULT_ERROR_PENALTY;
-import static io.servicetalk.loadbalancer.OutlierDetectorConfig.Builder.DEFAULT_PENDING_REQUEST_PENALTY;
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -95,7 +95,7 @@ class DefaultRequestTrackerTest {
 
         TestRequestTracker(Duration measurementHalfLife, final LongUnaryOperator nextValueProvider) {
             super(measurementHalfLife.toNanos(), DEFAULT_CANCEL_PENALTY, DEFAULT_ERROR_PENALTY,
-                    DEFAULT_PENDING_REQUEST_PENALTY);
+                    DEFAULT_CONCURRENT_REQUEST_PENALTY);
             this.nextValueProvider = nextValueProvider;
         }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -225,7 +225,7 @@ class XdsHealthIndicatorTest {
 
         TestIndicator(final OutlierDetectorConfig config) {
             super(sequentialExecutor, new NormalizedTimeSourceExecutor(testExecutor), ofSeconds(10),
-                    config.ewmaCancellationPenalty(), config.ewmaErrorPenalty(), config.pendingRequestPenalty(),
+                    config.ewmaCancellationPenalty(), config.ewmaErrorPenalty(), config.concurrentRequestPenalty(),
                     config.cancellationIsError(),
                     "address", "description", NoopLoadBalancerObserver.<String>instance().hostObserver("address"));
             this.config = config;

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -225,7 +225,8 @@ class XdsHealthIndicatorTest {
 
         TestIndicator(final OutlierDetectorConfig config) {
             super(sequentialExecutor, new NormalizedTimeSourceExecutor(testExecutor), ofSeconds(10),
-                    config.ewmaCancellationPenalty(), config.ewmaErrorPenalty(), config.cancellationIsError(),
+                    config.ewmaCancellationPenalty(), config.ewmaErrorPenalty(), config.pendingRequestPenalty(),
+                    config.cancellationIsError(),
                     "address", "description", NoopLoadBalancerObserver.<String>instance().hostObserver("address"));
             this.config = config;
         }


### PR DESCRIPTION
Motivation:

The pending request penalty is a way to try to avoid connections with lost of pending requests which results in a more even request distribution. However, the penalty is currently fixed which doesn't allow us to choose how to prioritize between the fastest hosts vs the most fair request distribution.

Modifications:

Make the penalty factor configurable.