### PR TITLE
Update Netty 4.1.110 -> 4.1.111

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ issueManagementUrl=https://github.com/apple/servicetalk/issues
 ciManagementUrl=https://github.com/apple/servicetalk/actions
 
 # dependency versions
-nettyVersion=4.1.110.Final
+nettyVersion=4.1.111.Final
 nettyIoUringVersion=0.0.25.Final
 
 jsr305Version=3.0.2


### PR DESCRIPTION
gprc-java released the fix for compatibility with Netty 4.1.111 in 1.64.1 and 1.65.0, we can upgrade netty now