### PR TITLE
Align Set-Cookie attribute names with RFC6265 syntax

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpSetCookie.java
@@ -34,13 +34,13 @@ import static java.lang.Integer.toHexString;
  * Default implementation of {@link HttpSetCookie}.
  */
 public final class DefaultHttpSetCookie implements HttpSetCookie {
-    private static final String ENCODED_LABEL_DOMAIN = "; domain=";
-    private static final String ENCODED_LABEL_PATH = "; path=";
-    private static final String ENCODED_LABEL_EXPIRES = "; expires=";
-    private static final String ENCODED_LABEL_MAX_AGE = "; max-age=";
-    private static final String ENCODED_LABEL_HTTP_ONLY = "; httponly";
-    private static final String ENCODED_LABEL_SECURE = "; secure";
-    private static final String ENCODED_LABEL_SAMESITE = "; samesite=";
+    private static final String ENCODED_LABEL_DOMAIN = "; Domain=";
+    private static final String ENCODED_LABEL_PATH = "; Path=";
+    private static final String ENCODED_LABEL_EXPIRES = "; Expires=";
+    private static final String ENCODED_LABEL_MAX_AGE = "; Max-Age=";
+    private static final String ENCODED_LABEL_HTTP_ONLY = "; HttpOnly";
+    private static final String ENCODED_LABEL_SECURE = "; Secure";
+    private static final String ENCODED_LABEL_SAMESITE = "; SameSite=";
 
     private final CharSequence name;
     private final CharSequence value;

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookieTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpSetCookieTest.java
@@ -21,6 +21,7 @@ import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.Lax;
 import static io.servicetalk.http.api.HttpSetCookie.SameSite.None;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
@@ -80,5 +81,18 @@ class DefaultHttpSetCookieTest {
                         null, 1L, None, true, false, true).hashCode(),
                 is(not(new DefaultHttpSetCookie("foo", "bar", "/path", "docs.servicetalk.io",
                         null, 1L, None, true, false, true).hashCode())));
+    }
+
+    @Test
+    void testUppercaseNames() {
+        String encoded = new DefaultHttpSetCookie("foo", "bar", "myPath", "myDomain", "10", 10L, Lax,
+                false, true, true).encoded().toString();
+        assertThat(encoded, containsString("Path=myPath"));
+        assertThat(encoded, containsString("Domain=myDomain"));
+        assertThat(encoded, containsString("Expires=10"));
+        assertThat(encoded, containsString("Max-Age=10"));
+        assertThat(encoded, containsString("SameSite=Lax"));
+        assertThat(encoded, containsString("HttpOnly"));
+        assertThat(encoded, containsString("Secure"));
     }
 }


### PR DESCRIPTION
This changeset aligns the "Set-Cookie" property names with the RFC6265 in the sense that according to the spec (see https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#section-4.1.1) where property names are using camel-case syntax instead of all lower case.

NOTE: The name of an attribute-value pair is not case sensitive. So while they are presented here in CamelCase, such as "HttpOnly" or "SameSite", any case is accepted. E.x.: "httponly", "Httponly", "hTTPoNLY", etc.

This means that this change is purely cosmetic and helps with consistency with other implementations, i.e. Netty.