### PR TITLE
loadbalancer-experimental: fix some linter warnings/errors

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -75,7 +75,8 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
     }
 
     // This method assumes the host is considered healthy.
-    protected final @Nullable Single<C> selectFromHost(Host<ResolvedAddress, C> host, Predicate<C> selector,
+    @Nullable
+    protected final Single<C> selectFromHost(Host<ResolvedAddress, C> host, Predicate<C> selector,
             boolean forceNewConnectionAndReserve, @Nullable ContextMap contextMap) {
         // First see if we can get an existing connection regardless of health status.
         if (!forceNewConnectionAndReserve) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -59,7 +59,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     @Override
     public LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(
             @Nullable LoadBalancerObserver loadBalancerObserver) {
-        return loadBalancerObserver(ignored -> loadBalancerObserver);
+        return loadBalancerObserver(loadBalancerObserver == null ? null : ignored -> loadBalancerObserver);
     }
 
     @Override
@@ -71,8 +71,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     @Override
     public LoadBalancerBuilder<ResolvedAddress, C> outlierDetectorConfig(OutlierDetectorConfig outlierDetectorConfig) {
-        this.outlierDetectorConfig = outlierDetectorConfig == null ?
-                OutlierDetectorConfig.DEFAULT_CONFIG : outlierDetectorConfig;
+        this.outlierDetectorConfig = outlierDetectorConfig;
         return this;
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -71,7 +71,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     @Override
     public LoadBalancerBuilder<ResolvedAddress, C> outlierDetectorConfig(OutlierDetectorConfig outlierDetectorConfig) {
-        this.outlierDetectorConfig = outlierDetectorConfig;
+        this.outlierDetectorConfig = requireNonNull(outlierDetectorConfig, "outlierDetectorConfig");
         return this;
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
@@ -19,6 +19,7 @@ import io.servicetalk.client.api.NoActiveHostException;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 
 import java.util.Collection;
+import javax.annotation.Nullable;
 
 final class NoopLoadBalancerObserver implements LoadBalancerObserver {
 
@@ -78,7 +79,7 @@ final class NoopLoadBalancerObserver implements LoadBalancerObserver {
         }
 
         @Override
-        public void onHostMarkedUnhealthy(Throwable cause) {
+        public void onHostMarkedUnhealthy(@Nullable Throwable cause) {
             // noop
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
@@ -86,7 +86,6 @@ final class SequentialExecutor implements Executor {
         final Thread thisThread = Thread.currentThread();
         currentDrainingThread = thisThread;
         for (;;) {
-            assert next != null;
             try {
                 next.runnable.run();
             } catch (Throwable ex) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -125,7 +125,8 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
         // than the eviction time technically prescribes.
         if (evictedUntilNanos <= currentTimeNanos()) {
             sequentialExecutor.execute(() -> {
-                if (!cancelled && this.evictedUntilNanos != null && this.evictedUntilNanos <= currentTimeNanos()) {
+                final Long innerEvictedUntilNanos = this.evictedUntilNanos;
+                if (!cancelled && innerEvictedUntilNanos != null && innerEvictedUntilNanos <= currentTimeNanos()) {
                     sequentialRevive();
                 }
             });

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -111,7 +111,7 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
         kernel.cancel();
         sequentialExecutor.execute(() -> {
             List<XdsHealthIndicator<ResolvedAddress, C>> indicatorList = new ArrayList<>(indicators);
-            for (XdsHealthIndicator indicator : indicatorList) {
+            for (XdsHealthIndicator<ResolvedAddress, C> indicator : indicatorList) {
                 indicator.sequentialCancel();
             }
             assert indicators.isEmpty();
@@ -248,7 +248,7 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
         public void detectOutliers(final OutlierDetectorConfig config,
                                    final Collection<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators) {
             int unhealthy = 0;
-            for (XdsHealthIndicator indicator : indicators) {
+            for (XdsHealthIndicator<ResolvedAddress, C> indicator : indicators) {
                 // Hosts can still be marked unhealthy due to consecutive failures.
                 final boolean isHealthy = indicator.isHealthy();
                 if (isHealthy) {


### PR DESCRIPTION
Motivation:

We have a few warnings and errors that are popping up that can be
addressed. Most revolve around the use of raw types and nullability.

Modifications:

Fix the warnings and errors.