### PR TITLE
loadbalancer-experimental: DefaultLoadBalancer logs settings on startup

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
@@ -57,7 +57,7 @@ final class NoopOutlierDetector<ResolvedAddress, C extends LoadBalancedConnectio
 
         BasicHealthIndicator() {
             super(outlierDetectorConfig.ewmaHalfLife().toNanos(), outlierDetectorConfig.ewmaCancellationPenalty(),
-                    outlierDetectorConfig.ewmaCancellationPenalty(), outlierDetectorConfig.concurrentRequestPenalty());
+                    outlierDetectorConfig.ewmaErrorPenalty(), outlierDetectorConfig.concurrentRequestPenalty());
         }
 
         @Override
@@ -94,5 +94,16 @@ final class NoopOutlierDetector<ResolvedAddress, C extends LoadBalancedConnectio
         public void setHost(Host<ResolvedAddress, C> host) {
             // noop
         }
+    }
+
+    @Override
+    public String toString() {
+        return "NoopOutlierDetector{" +
+                "ewmaHalfLife=" + outlierDetectorConfig.ewmaHalfLife() +
+                ", ewmaCancellationPenalty=" + outlierDetectorConfig.ewmaCancellationPenalty() +
+                ", ewmaErrorPenalty=" + outlierDetectorConfig.ewmaErrorPenalty() +
+                ", concurrentRequestPenalty=" + outlierDetectorConfig.concurrentRequestPenalty() +
+                ", executor=" + executor +
+                '}';
     }
 }


### PR DESCRIPTION
Motivation:

As DefaultLoadBalancer becomes the norm it can be helpful to track its activation via log messages.

Modifications:

- Emit a log message on startup that includes the lb description and important settings.
- Fix a bug where the cancellation penalty was inadvertently used for the error penalty.
- Cancel the update stream from the OutlierDetector when the lb closes.