### PR TITLE
Fix discovery flow for `PartitionedHttpClient`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -115,6 +115,9 @@ final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttp
             // build new context, user may have changed anything on the builder from the filter
             final SingleAddressHttpClientBuilder<U, R> builder = requireNonNull(builderFactory.get());
             builder.serviceDiscoverer(sd);
+            // Disable retries at the single-address client level because the original stream is already retried and
+            // partitioned streams never fail.
+            builder.retryServiceDiscoveryErrors(HttpClients.NoRetriesStrategy.INSTANCE);
             setExecutionContext(builder, executionContext);
             if (clientInitializer != null) {
                 clientInitializer.initialize(pa, builder);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClients.java
@@ -589,6 +589,11 @@ public final class HttpClients {
         public Completable apply(final int i, final Throwable t) {
             return Completable.failed(t);
         }
+
+        @Override
+        public String toString() {
+            return NoRetriesStrategy.class.getSimpleName();
+        }
     }
 
     /**


### PR DESCRIPTION
Motivation:

Our load balancers have an ability to cancel and re-subscribe to the `ServiceDiscovery` publisher as an attempt to trigger re-discovery when LB turns into unhealthy state for all addresses. However, for `PartitionedHttpClient` it will result in `DuplicateSubscribeException` because `groupToMany` operator does not support re-subscribes.

Modifications:

- Apply `multicast` operator with `cancelUpstream=false` flag to allow LB of a single-address client to re-subscribe to the same group publisher;
- Disable a retry strategy for `ServiceDiscovery` at single-address client level for partitioned client;
- Implement `NoRetriesStrategy.toString()` for better logging;
- Reproduce described scenario in `PublisherGroupToManyTest`;

Result:

Single-address clients under partitioned client won't fail with `DuplicateSubscribeException` if LB decides to re-subscribe to the group's stream.