### PR TITLE
Enhance clarifications for `ServiceDiscoverer` contract

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscoverer.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscoverer.java
@@ -29,7 +29,9 @@ import java.util.Collection;
  * <p>
  * Because typically a {@link ServiceDiscoverer} implementation runs in the background and doesn't require many compute
  * resources, it's recommended (but not required) to run it and deliver updates on a single thread either for all
- * discoveries or at least for all {@link Subscriber Subscribers} to the same {@link Publisher}.
+ * discoveries or at least for all {@link Subscriber Subscribers} to the same {@link Publisher}. One possible advantage
+ * of a single-threaded model is that it will make debugging easier as discovery events and the logs they generate will
+ * be less susceptible to reordering.
  * <p>
  * See {@link ServiceDiscovererEvent} for documentation regarding the interpretation of events.
  *

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/ServiceDiscovererEvent.java
@@ -15,23 +15,27 @@
  */
 package io.servicetalk.client.api;
 
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+
 import java.util.Locale;
 
 /**
  * Notification from the Service Discovery system that availability for an address has changed.
  * <p>
  * Interpreting Events
- * <ul>
- *     <li>When subscribing (or re-subscribing to recovery from faults) to an event stream the initial collection of
+ * <ol>
+ *     <li>When subscribing (or re-subscribing to recover from failures) to an event stream the initial collection of
  *         events is considered to be the current state of the world.</li>
  *     <li>Each event represents the current state of the {@link ResolvedAddress} overriding any previously known
  *         {@link Status} and any associated meta-data.</li>
- * </ul>
+ * </ol>
+ * Item 1 is required to satisfy
+ * <a href="https://github.com/reactive-streams/reactive-streams-jvm?tab=readme-ov-file#1.10">
+ * Reactive Streams Rule 1.10</a>, which requires every subscribe to happen with a new {@link Subscriber Subscriber}.
+ * As a result, {@link Subscriber Subscriber} needs to know the initial state to start from.
  * <p>
- * Example
- * <p>
- * We can represent a {@link ServiceDiscovererEvent} as map entries of the form
- * ({@link ResolvedAddress}, ({@link Status}, meta-data)) where the {@link ResolvedAddress} is the map key.
+ * Item 2 can be clarified by the following example: we can represent a {@link ServiceDiscovererEvent} as map entries of
+ * the form ({@link ResolvedAddress}, ({@link Status}, meta-data)) where the {@link ResolvedAddress} is the map key.
  * <pre>
  * Starting with the initial state of {addr1, (AVAILABLE, meta-1)}. Upon subscribing to the event stream the initial
  * state is populated via the event (addr1, (AVAILABLE, meta-1)).


### PR DESCRIPTION
Motivation:

Some assumptions that are currently in place are not clarified in documentation for new implementations.

Modifications:

- Clarify that the returned publisher should never complete and must support re-subscribes to handle failures and cancellations.
- Clarify motivation for always starting with the "state of the world" for interpreting `ServiceDiscovererEvent`(s).
- Add recommendation to implement a `ServiceDiscoverer` using a single thread.

Result:

More details for expected behavior of a `ServiceDiscoverer` implementation.