### PR TITLE
loadbalancer-experimental: add LB observer method for when the host set changes

### DIFF
--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -59,6 +59,19 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
         LOGGER.debug("{}- No active hosts available. Host set size: {}.", lbDescription, hostSetSize, exception);
     }
 
+    @Override
+    public void onHostSetChanged(Collection<? extends Host> newHosts) {
+        if (LOGGER.isDebugEnabled()) {
+            int healthyCount = 0;
+            for (Host host : newHosts) {
+                if (host.isHealthy()) {
+                    healthyCount++;
+                }
+            }
+            LOGGER.debug("{}- onHostSetChanged(total: {}, healthy: {})", lbDescription, newHosts.size(), healthyCount);
+        }
+    }
+
     private final class HostObserverImpl implements HostObserver {
 
         private final Object resolvedAddress;

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -68,8 +68,8 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
                     healthyCount++;
                 }
             }
-            LOGGER.debug("{}- onHostSetChanged(newHosts: {}). Size: {}, healthy: {}", lbDescription, newHosts,
-                    newHosts.size(), healthyCount);
+            LOGGER.debug("{}- onHostSetChanged(host set size: {}, healthy: {}). New hosts: {}", lbDescription,
+                    newHosts.size(), healthyCount, newHosts);
         }
     }
 

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -68,7 +68,8 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
                     healthyCount++;
                 }
             }
-            LOGGER.debug("{}- onHostSetChanged(total: {}, healthy: {})", lbDescription, newHosts.size(), healthyCount);
+            LOGGER.debug("{}- onHostSetChanged(newHosts: {}). Size: {}, healthy: ", lbDescription, newHosts,
+                    newHosts.size(), healthyCount);
         }
     }
 

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -68,7 +68,7 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
                     healthyCount++;
                 }
             }
-            LOGGER.debug("{}- onHostSetChanged(newHosts: {}). Size: {}, healthy: ", lbDescription, newHosts,
+            LOGGER.debug("{}- onHostSetChanged(newHosts: {}). Size: {}, healthy: {}", lbDescription, newHosts,
                     newHosts.size(), healthyCount);
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -510,7 +510,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         }
         nextHosts = priorityStrategy.prioritize(nextHosts);
         this.hostSelector = hostSelector.rebuildWithHosts(nextHosts);
-        loadBalancerObserver.onHostSetChanged(Collections.unmodifiableCollection(nextHosts));
+        loadBalancerObserver.onHostSetChanged(Collections.unmodifiableList(nextHosts));
     }
 
     @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -510,7 +510,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         }
         nextHosts = priorityStrategy.prioritize(nextHosts);
         this.hostSelector = hostSelector.rebuildWithHosts(nextHosts);
-        loadBalancerObserver.onHostSetChanged(nextHosts);
+        loadBalancerObserver.onHostSetChanged(Collections.unmodifiableCollection(nextHosts));
     }
 
     @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -508,7 +508,9 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         for (PrioritizedHostImpl<?, ?> host : nextHosts) {
             host.loadBalancingWeight(host.serviceDiscoveryWeight());
         }
-        this.hostSelector = hostSelector.rebuildWithHosts(priorityStrategy.prioritize(usedHosts));
+        nextHosts = priorityStrategy.prioritize(nextHosts);
+        this.hostSelector = hostSelector.rebuildWithHosts(nextHosts);
+        loadBalancerObserver.onHostSetChanged(nextHosts);
     }
 
     @Override
@@ -649,7 +651,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
     }
 
     static final class PrioritizedHostImpl<ResolvedAddress, C extends LoadBalancedConnection>
-            implements Host<ResolvedAddress, C>, PrioritizedHost {
+            implements Host<ResolvedAddress, C>, PrioritizedHost, LoadBalancerObserver.Host {
         private final Host<ResolvedAddress, C> delegate;
         private int priority;
         private double serviceDiscoveryWeight;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -55,7 +55,17 @@ public interface LoadBalancerObserver {
     void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exception);
 
     /**
-     * An observer for {@link Host} events.
+     * Callback for when the set of hosts used by the load balancer has changed. This set may not
+     * exactly reflect the state of the service discovery system due to filtering of zero-weight
+     * hosts and forms of sub-setting and thus may only represent the hosts that the selection
+     * algorithm may use.
+     * @param newHosts the new set of hosts used by the selection algorithm.
+     */
+    default void onHostSetChanged(Collection<? extends Host> newHosts) {
+    }
+
+    /**
+     * An observer for {@link io.servicetalk.loadbalancer.Host} events.
      */
     interface HostObserver {
 
@@ -84,14 +94,38 @@ public interface LoadBalancerObserver {
         void onExpiredHostRemoved(int connectionCount);
 
         /**
-         * Callback for when a {@link Host} transitions from healthy to unhealthy.
+         * Callback for when a {@link io.servicetalk.loadbalancer.Host} transitions from healthy to unhealthy.
          * @param cause the most recent cause of the transition.
          */
         void onHostMarkedUnhealthy(@Nullable Throwable cause);
 
         /**
-         * Callback for when a {@link Host} transitions from unhealthy to healthy.
+         * Callback for when a {@link io.servicetalk.loadbalancer.Host} transitions from unhealthy to healthy.
          */
         void onHostRevived();
+    }
+
+    /**
+     * A description of a host.
+     */
+    interface Host {
+        /**
+         * The address of the host.
+         * @return the address of the host.
+         */
+        Object address();
+
+        /**
+         * Determine the health status of this host.
+         * @return whether the host considers itself healthy enough to serve traffic. This is best effort and does not
+         *         guarantee that the request will succeed.
+         */
+        boolean isHealthy();
+
+        /**
+         * The weight of the host, relative to the weights of associated hosts as used for load balancing.
+         * @return the relative weight of the host.
+         */
+        double loadBalancingWeight();
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
@@ -51,6 +51,11 @@ final class NoopLoadBalancerObserver implements LoadBalancerObserver {
         // noop
     }
 
+    @Override
+    public void onHostSetChanged(Collection<? extends Host> newHosts) {
+        // noop
+    }
+
     private static final class NoopHostObserver implements LoadBalancerObserver.HostObserver {
 
         private static final HostObserver INSTANCE = new NoopHostObserver();


### PR DESCRIPTION
Motivation:

It can be valuable to know what the current host set is but we don't have a way to directly observer that right now.

Modifications:

Add a method to the LoadBalancerObserver that can capture when the host set changes and use it in DefaultLoadBalancer.