### PR TITLE
LoadBalancer should always consider the first events as initial state

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -240,29 +240,15 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         return result;
     }
 
-    private static <ResolvedAddress> boolean onlyAvailable(
-            final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
-        boolean onlyAvailable = !events.isEmpty();
-        for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
-            if (!AVAILABLE.equals(event.status())) {
-                onlyAvailable = false;
-                break;
-            }
-        }
-        return onlyAvailable;
-    }
-
-    private static <ResolvedAddress, C extends LoadBalancedConnection> boolean notAvailable(
+    private static <ResolvedAddress, C extends LoadBalancedConnection> boolean contains(
             final Host<ResolvedAddress, C> host,
             final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
-        boolean available = false;
         for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
             if (host.address().equals(event.address())) {
-                available = true;
-                break;
+                return true;
             }
         }
-        return !available;
+        return false;
     }
 
     private final class EventSubscriber
@@ -395,18 +381,11 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                 }
                 firstEventsAfterResubscribe = false;
 
-                if (!onlyAvailable(events)) {
-                    // Looks like the current ServiceDiscoverer maintains a state between re-subscribes. It already
-                    // assigned correct states to all hosts. Even if some of them were left UNHEALTHY, we should keep
-                    // running health-checks.
-                    return;
-                }
-                // Looks like the current ServiceDiscoverer doesn't maintain a state between re-subscribes and always
-                // starts from an empty state propagating only AVAILABLE events. To be in sync with the
-                // ServiceDiscoverer we should clean up and close gracefully all hosts that are not present in the
-                // initial collection of events, regardless of their current state.
+                // New Subscription to the ServiceDiscoverer always starts from a state of the world. To be in sync with
+                // the ServiceDiscoverer state, we should clean up and close gracefully all hosts that are not present
+                // in the initial collection of events, regardless of their current state.
                 for (Host<ResolvedAddress, C> host : nextHosts) {
-                    if (notAvailable(host, events)) {
+                    if (!contains(host, events)) {
                         host.closeAsyncGracefully().subscribe();
                     }
                 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -240,29 +240,15 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         return allUnhealthy;
     }
 
-    private static <ResolvedAddress> boolean onlyAvailable(
-            final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
-        boolean onlyAvailable = !events.isEmpty();
-        for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
-            if (!AVAILABLE.equals(event.status())) {
-                onlyAvailable = false;
-                break;
-            }
-        }
-        return onlyAvailable;
-    }
-
-    private static <ResolvedAddress, C extends LoadBalancedConnection> boolean notAvailable(
+    private static <ResolvedAddress, C extends LoadBalancedConnection> boolean contains(
             final Host<ResolvedAddress, C> host,
             final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
-        boolean available = false;
         for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
             if (host.address.equals(event.address())) {
-                available = true;
-                break;
+                return true;
             }
         }
-        return !available;
+        return false;
     }
 
     private final class EventSubscriber
@@ -349,19 +335,12 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
                 }
                 firstEventsAfterResubscribe = false;
 
-                if (!onlyAvailable(events)) {
-                    // Looks like the current ServiceDiscoverer maintains a state between re-subscribes. It already
-                    // assigned correct states to all hosts. Even if some of them were left UNHEALTHY, we should keep
-                    // running health-checks.
-                    return;
-                }
-                // Looks like the current ServiceDiscoverer doesn't maintain a state between re-subscribes and always
-                // starts from an empty state propagating only AVAILABLE events. To be in sync with the
-                // ServiceDiscoverer we should clean up and close gracefully all hosts that are not present in the
-                // initial collection of events, regardless of their current state.
+                // New Subscription to the ServiceDiscoverer always starts from a state of the world. To be in sync with
+                // the ServiceDiscoverer state, we should clean up and close gracefully all hosts that are not present
+                // in the initial collection of events, regardless of their current state.
                 final List<Host<ResolvedAddress, C>> currentHosts = usedHosts;
                 for (Host<ResolvedAddress, C> host : currentHosts) {
-                    if (notAvailable(host, events)) {
+                    if (!contains(host, events)) {
                         host.closeAsyncGracefully().subscribe();
                     }
                 }


### PR DESCRIPTION
Motivation:

Currently, both implementations of the `LoadBalancer` assume 2 possibilities for the first events collection after re-subscribe: "state of the world" or "delta" and try to infer which one it is based on what event statuses are present in the collection. However, it doesn't provide any guarantees because even if SD impl keeps returning deltas after a re-subscribe, a delta can contain only `AVAILABLE` events, but it will be incorrectly interpreted as "state of the world".

Because of Reactive Streams rule clarified in #3002, `LoadBalancer` implementations should always expect "state of the world" for the first events after re-subscribe.

Modifications:

- Remove inference of the first collection of events after re-subscribe and always expect a new subscriber to start from "state of the world".
- Update `resubscribeToEventsWhenAllHostsAreUnhealthy()` test to reflect behavior change.

Result:

Both `LoadBalancer` implementations follow `ServiceDiscoverer` contract and expect the first collection of events after re-subscribe to represent a "state of the world".