### PR TITLE
Avoid race b/w ServiceDiscoverer events after cancel and re-subscribe

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -297,7 +297,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             // (https://github.com/reactive-streams/reactive-streams-jvm?tab=readme-ov-file#1.8) new events will
             // stop eventually but not guaranteed to stop immediately after cancellation or could race with cancel.
             // Therefore, we should check that this is the current Subscriber before processing new events.
-            if (healthCheckConfig != null && currentSubscriber != this) {
+            if (currentSubscriber != this) {
                 LOGGER.debug("{}: received new events after cancelling previous subscription, discarding: {}",
                         DefaultLoadBalancer.this, events);
                 return;

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LoadBalancerTestScaffold.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LoadBalancerTestScaffold.java
@@ -116,26 +116,27 @@ abstract class LoadBalancerTestScaffold {
             TestPublisher<Collection<ServiceDiscovererEvent<String>>> serviceDiscoveryPublisher,
             TestConnectionFactory connectionFactory);
 
-    void sendServiceDiscoveryEvents(final ServiceDiscovererEvent... events) {
+    @SafeVarargs
+    final void sendServiceDiscoveryEvents(final ServiceDiscovererEvent<String>... events) {
         sendServiceDiscoveryEvents(serviceDiscoveryPublisher, events);
     }
 
     @SuppressWarnings("unchecked")
     private void sendServiceDiscoveryEvents(
             TestPublisher<Collection<ServiceDiscovererEvent<String>>> serviceDiscoveryPublisher,
-            final ServiceDiscovererEvent... events) {
+            final ServiceDiscovererEvent<String>... events) {
         serviceDiscoveryPublisher.onNext(Arrays.asList(events));
     }
 
-    ServiceDiscovererEvent upEvent(final String address) {
+    ServiceDiscovererEvent<String> upEvent(final String address) {
         return new DefaultServiceDiscovererEvent<>(address, AVAILABLE);
     }
 
-    ServiceDiscovererEvent downEvent(final String address) {
+    ServiceDiscovererEvent<String> downEvent(final String address) {
         return new DefaultServiceDiscovererEvent<>(address, eagerConnectionShutdown() ? UNAVAILABLE : EXPIRED);
     }
 
-    ServiceDiscovererEvent downEvent(final String address, ServiceDiscovererEvent.Status status) {
+    ServiceDiscovererEvent<String> downEvent(final String address, ServiceDiscovererEvent.Status status) {
         return new DefaultServiceDiscovererEvent<>(address, status);
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -135,6 +135,8 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
     @SuppressWarnings("unused")
     private volatile int index;
     private volatile List<Host<ResolvedAddress, C>> usedHosts = emptyList();
+    @Nullable
+    private volatile EventSubscriber currentSubscriber;
 
     private final String id;
     private final String targetResource;
@@ -207,10 +209,13 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         // This method is invoked only when we are in RESUBSCRIBING state. Only one thread can own this state.
         assert nextResubscribeTime == RESUBSCRIBING;
         if (resubscribe) {
+            assert healthCheckConfig != null : "Resubscribe can happen only when health-checking is configured";
             LOGGER.debug("{}: resubscribing to the ServiceDiscoverer event publisher.", this);
             discoveryCancellable.cancelCurrent();
         }
-        toSource(eventPublisher).subscribe(new EventSubscriber(resubscribe));
+        final EventSubscriber eventSubscriber = new EventSubscriber(resubscribe);
+        this.currentSubscriber = eventSubscriber;
+        toSource(eventPublisher).subscribe(eventSubscriber);
         if (healthCheckConfig != null) {
             assert healthCheckConfig.executor instanceof NormalizedTimeSourceExecutor;
             nextResubscribeTime = nextResubscribeTime(healthCheckConfig, this);
@@ -274,6 +279,15 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         public void onNext(@Nullable final Collection<? extends ServiceDiscovererEvent<ResolvedAddress>> events) {
             if (events == null) {
                 LOGGER.debug("{}: unexpectedly received null instead of events.", RoundRobinLoadBalancer.this);
+                return;
+            }
+            // According to Reactive Streams Rule 1.8
+            // (https://github.com/reactive-streams/reactive-streams-jvm?tab=readme-ov-file#1.8) new events will
+            // stop eventually but not guaranteed to stop immediately after cancellation or could race with cancel.
+            // Therefore, we should check that this is the current Subscriber before processing new events.
+            if (healthCheckConfig != null && currentSubscriber != this) {
+                LOGGER.debug("{}: received new events after cancelling previous subscription, discarding: {}",
+                        RoundRobinLoadBalancer.this, events);
                 return;
             }
             for (ServiceDiscovererEvent<ResolvedAddress> event : events) {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -285,7 +285,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             // (https://github.com/reactive-streams/reactive-streams-jvm?tab=readme-ov-file#1.8) new events will
             // stop eventually but not guaranteed to stop immediately after cancellation or could race with cancel.
             // Therefore, we should check that this is the current Subscriber before processing new events.
-            if (healthCheckConfig != null && currentSubscriber != this) {
+            if (currentSubscriber != this) {
                 LOGGER.debug("{}: received new events after cancelling previous subscription, discarding: {}",
                         RoundRobinLoadBalancer.this, events);
                 return;


### PR DESCRIPTION
Motivation:

#2514 added an ability for `LoadBalancer` to cancel discovery stream and
re-subscribe in attempt to trigger a new resolution when its internal
state became `UNHEALTHY`. However, it did not account for a possibility
of new events racing with cancellation or a Publisher not stopping
updates immediately. As a result, it's possible to end up in a corrupted
state if the old `EventSubscriber` receives new events after a new
`EventSubscriber` received a new "state of the world".

Modifications:

- Track the current `EventSubscriber` and process events only if it's
current.
- Enhance `resubscribeToEventsWhenAllHostsAreUnhealthy()` to simulate
the described behavior.

Result:

New "state of the world" can not be corrupted by events emitted for the
old `EventSubscriber`.

---
Depends on #3004, review only the 2nd commit: https://github.com/apple/servicetalk/pull/3005/commits/d48d8f59053a567670f803b82ac6e23d4719e39f