### PR TITLE
Incorrect state possible after retrying `ServiceDiscoverer` events

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/partition/PartitionAttributes.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/partition/PartitionAttributes.java
@@ -26,7 +26,7 @@ import static java.lang.String.valueOf;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Provide a way to describe a partition using a collection of of attributes. Typically only a single type of any
+ * Provide a way to describe a partition using a collection of attributes. Typically only a single type of any
  * particular {@link Key} exists in each {@link PartitionAttributes}. For example:
  * <pre>
  * { [Key(shard) = "shard X"], [Key(data center) = "data center X"], [Key(is main) = "false/true"] }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingServiceDiscoverer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/RetryingServiceDiscoverer.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.DelegatingServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.concurrent.api.BiIntFunction;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.http.api.HttpExecutionContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.UNAVAILABLE;
+import static io.servicetalk.concurrent.api.RetryStrategies.retryWithExponentialBackoffFullJitter;
+import static java.time.Duration.ofSeconds;
+import static java.util.Collections.emptyMap;
+
+final class RetryingServiceDiscoverer<U, R, E extends ServiceDiscovererEvent<R>>
+        extends DelegatingServiceDiscoverer<U, R, E> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryingServiceDiscoverer.class);
+
+    private static final Duration SD_RETRY_STRATEGY_INIT_DURATION = ofSeconds(2);
+    private static final Duration SD_RETRY_STRATEGY_MAX_DELAY = ofSeconds(128);
+
+    private final String targetResource;
+    private final BiIntFunction<Throwable, ? extends Completable> retryStrategy;
+    private final UnaryOperator<E> makeUnavailable;
+
+    RetryingServiceDiscoverer(final String targetResource,
+                              final ServiceDiscoverer<U, R, E> delegate,
+                              @Nullable BiIntFunction<Throwable, ? extends Completable> retryStrategy,
+                              final HttpExecutionContext executionContext,
+                              final UnaryOperator<E> makeUnavailable) {
+        super(delegate);
+        this.targetResource = targetResource;
+        if (retryStrategy == null) {
+            retryStrategy = retryWithExponentialBackoffFullJitter(__ -> true, SD_RETRY_STRATEGY_INIT_DURATION,
+                    SD_RETRY_STRATEGY_MAX_DELAY, executionContext.executor());
+        }
+        this.retryStrategy = retryStrategy;
+        this.makeUnavailable = makeUnavailable;
+    }
+
+    @Override
+    public Publisher<Collection<E>> discover(final U address) {
+        // The returned publisher is guaranteed to never fail because we retry all errors here. However, LoadBalancer
+        // can still cancel and re-subscribe in attempt to recover from unhealthy state. In this case, we need to
+        // re-initialize the ServiceDiscovererEventsCache and restart from an empty state.
+        return Publisher.defer(() -> {
+            final ServiceDiscovererEventsCache<R, E> eventsCache =
+                    new ServiceDiscovererEventsCache<>(targetResource, makeUnavailable);
+            return delegate().discover(address)
+                    .map(eventsCache::consumeAndFilter)
+                    .beforeOnError(eventsCache::errorSeen)
+                    // terminateOnNextException false -> LB is after this operator, if LB throws do best effort retry
+                    .retryWhen(false, retryStrategy);
+        });
+    }
+
+    private static final class ServiceDiscovererEventsCache<R, E extends ServiceDiscovererEvent<R>> {
+        @SuppressWarnings("rawtypes")
+        private static final Map NONE_RETAINED = emptyMap();
+
+        private final String targetResource;
+        private final UnaryOperator<E> makeUnavailable;
+        private final Map<R, E> currentState = new HashMap<>();
+        private Map<R, E> retainedState = noneRetained();
+
+        private ServiceDiscovererEventsCache(final String targetResource, final UnaryOperator<E> makeUnavailable) {
+            this.targetResource = targetResource;
+            this.makeUnavailable = makeUnavailable;
+        }
+
+        void errorSeen(final Throwable t) {
+            if (retainedState == NONE_RETAINED) {
+                retainedState = new HashMap<>(currentState);
+                currentState.clear();
+            }
+            LOGGER.debug("{} observed an error from ServiceDiscoverer", targetResource, t);
+        }
+
+        Collection<E> consumeAndFilter(final Collection<E> events) {
+            if (retainedState == NONE_RETAINED) {
+                for (E event : events) {
+                    if (UNAVAILABLE.equals(event.status())) {
+                        currentState.remove(event.address());
+                    } else {
+                        currentState.put(event.address(), event);
+                    }
+                }
+                return events;
+            }
+
+            // We have seen an error and re-subscribed upon retry. Based on the Publisher rule 1.10
+            // (https://github.com/reactive-streams/reactive-streams-jvm?tab=readme-ov-file#1.10), each subscribe
+            // expects a different Subscriber. Therefore, discovery Publisher suppose to start from a fresh state. We
+            // should populate currentState with new addresses and deactivate the ones which are not present in the new
+            // collection, but were left in retainedState.
+            assert currentState.isEmpty();
+            final List<E> toReturn = new ArrayList<>(events.size() + retainedState.size());
+            for (E event : events) {
+                final R address = event.address();
+                toReturn.add(event);
+                retainedState.remove(address);
+                if (!UNAVAILABLE.equals(event.status())) {
+                    currentState.put(address, event);
+                }
+            }
+
+            for (E event : retainedState.values()) {
+                assert event.status() != UNAVAILABLE;
+                toReturn.add(makeUnavailable.apply(event));
+            }
+
+            retainedState = noneRetained();
+            return toReturn;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <R, E extends ServiceDiscovererEvent<R>> Map<R, E> noneRetained() {
+            return NONE_RETAINED;
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PartitionedHttpClientTest.java
@@ -67,6 +67,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("deprecation")
 class PartitionedHttpClientTest {
     private static final PartitionAttributes.Key<String> SRV_NAME = PartitionAttributes.Key.newKey();
     private static final PartitionAttributes.Key<Boolean> SRV_LEADER = PartitionAttributes.Key.newKey();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingServiceDiscovererTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingServiceDiscovererTest.java
@@ -67,6 +67,7 @@ class RetryingServiceDiscovererTest {
     private final TestPublisherSubscriber<Collection<ServiceDiscovererEvent<String>>> subscriber =
             new TestPublisherSubscriber<>();
     private final ServiceDiscoverer<String, String, ServiceDiscovererEvent<String>> sd;
+    private final Publisher<Collection<ServiceDiscovererEvent<String>>> discoveryEvents;
 
     RetryingServiceDiscovererTest() {
         @SuppressWarnings("unchecked")
@@ -79,11 +80,12 @@ class RetryingServiceDiscovererTest {
         sd = new RetryingServiceDiscoverer<>(RetryingServiceDiscovererTest.class.getSimpleName(), delegate,
                 (count, t) -> Completable.completed(), GlobalExecutionContext.globalExecutionContext(),
                 e -> new DefaultServiceDiscovererEvent<>(e.address(), UNAVAILABLE));
+        discoveryEvents = sd.discover("any");
     }
 
     @BeforeEach
     void setUp() {
-        toSource(sd.discover("any")).subscribe(subscriber);
+        toSource(discoveryEvents).subscribe(subscriber);
         subscriber.awaitSubscription().request(Long.MAX_VALUE);
     }
 
@@ -234,7 +236,7 @@ class RetryingServiceDiscovererTest {
         subscriber.awaitSubscription().cancel();
         TestPublisherSubscriber<Collection<ServiceDiscovererEvent<String>>> newSubscriber =
                 new TestPublisherSubscriber<>();
-        toSource(sd.discover("any")).subscribe(newSubscriber);
+        toSource(discoveryEvents).subscribe(newSubscriber);
         newSubscriber.awaitSubscription().request(Long.MAX_VALUE);
         sdEvents = pubs.take();
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingServiceDiscovererTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingServiceDiscovererTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
+import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.client.api.ServiceDiscovererEvent;
+import io.servicetalk.client.api.ServiceDiscovererEvent.Status;
+import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.TestPublisher;
+import io.servicetalk.concurrent.test.internal.TestPublisherSubscriber;
+import io.servicetalk.transport.netty.internal.GlobalExecutionContext;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.AVAILABLE;
+import static io.servicetalk.client.api.ServiceDiscovererEvent.Status.UNAVAILABLE;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RetryingServiceDiscovererTest {
+
+    private static final int DEFAULT_POLL_MILLIS = CI ? 30 : 10;
+
+    private final BlockingQueue<TestPublisher<Collection<ServiceDiscovererEvent<String>>>> pubs =
+            new LinkedBlockingQueue<>();
+    private final TestPublisherSubscriber<Collection<ServiceDiscovererEvent<String>>> subscriber =
+            new TestPublisherSubscriber<>();
+    private final ServiceDiscoverer<String, String, ServiceDiscovererEvent<String>> sd;
+
+    RetryingServiceDiscovererTest() {
+        @SuppressWarnings("unchecked")
+        ServiceDiscoverer<String, String, ServiceDiscovererEvent<String>> delegate = mock(ServiceDiscoverer.class);
+        when(delegate.discover(any())).thenReturn(Publisher.defer(() -> {
+            TestPublisher<Collection<ServiceDiscovererEvent<String>>> pub = new TestPublisher<>();
+            pubs.add(pub);
+            return pub;
+        }));
+        sd = new RetryingServiceDiscoverer<>(RetryingServiceDiscovererTest.class.getSimpleName(), delegate,
+                (count, t) -> Completable.completed(), GlobalExecutionContext.globalExecutionContext(),
+                e -> new DefaultServiceDiscovererEvent<>(e.address(), UNAVAILABLE));
+    }
+
+    @BeforeEach
+    void setUp() {
+        toSource(sd.discover("any")).subscribe(subscriber);
+        subscriber.awaitSubscription().request(Long.MAX_VALUE);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        verifyNoEventsReceived();
+        assertThat("Unexpected publisher created", pubs, is(empty()));
+    }
+
+    @Test
+    void errorWithNoAddresses() throws Exception {
+        TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = pubs.take();
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+        sendUpAndVerifyReceived("addr1", sdEvents);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] withDuplicateEvents={0}")
+    @ValueSource(booleans = {false, true})
+    void sameAddressPostRetry(boolean withDuplicateEvents) throws Exception {
+        TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = pubs.take();
+        ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceived("addr1", sdEvents);
+
+        for (int i = 0; i < 3; i++) {
+            sdEvents = triggerRetry(sdEvents);
+            verifyNoEventsReceived();
+
+            if (withDuplicateEvents) {
+                ServiceDiscovererEvent<String> evt1Un = flip(evt1);
+                sdEvents.onNext(asList(evt1, evt1Un, evt1));
+                verifyReceivedEvents(contains(evt1, evt1Un, evt1));
+            } else {
+                sendUpAndVerifyReceived(evt1.address(), sdEvents);
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] withDuplicateEvents={0}")
+    @ValueSource(booleans = {false, true})
+    void newAddressPostRetry(boolean withDuplicateEvents) throws Exception {
+        TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = pubs.take();
+        ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceived("addr9", sdEvents);
+
+        for (int i = 0; i < 3; i++) {
+            sdEvents = triggerRetry(sdEvents);
+            verifyNoEventsReceived();
+
+            ServiceDiscovererEvent<String> evt2 = new DefaultServiceDiscovererEvent<>("addr" + i, AVAILABLE);
+            if (withDuplicateEvents) {
+                sdEvents.onNext(asList(evt2, flip(evt2), evt2));
+                verifyReceivedEvents(contains(evt2, flip(evt2), evt2, flip(evt1)));
+            } else {
+                sdEvents.onNext(singletonList(evt2));
+                verifyReceivedEvents(contains(evt2, flip(evt1)));
+            }
+            evt1 = evt2;
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] withDuplicateEvents={0}")
+    @ValueSource(booleans = {false, true})
+    void overlapAddressPostRetry(boolean withDuplicateEvents) throws Exception {
+        TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = pubs.take();
+
+        ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceived("addr1", sdEvents);
+        ServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceived("addr2", sdEvents);
+        ServiceDiscovererEvent<String> evt3 = sendUpAndVerifyReceived("addr3", sdEvents);
+
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+
+        ServiceDiscovererEvent<String> evt4 = new DefaultServiceDiscovererEvent<>("addr4", AVAILABLE);
+        List<ServiceDiscovererEvent<String>> newState = withDuplicateEvents ?
+                asList(evt2, evt4, evt2, evt4) : asList(evt2, evt4);
+        sdEvents.onNext(newState);
+
+        Collection<ServiceDiscovererEvent<String>> events = receivedEvents(subscriber);
+        assertThat("Unexpected event received", events, hasSize(newState.size() + 2));
+        assertThat("Unexpected event received",
+                events.stream().limit(newState.size()).collect(toList()), contains(newState.toArray()));
+        assertThat("Unexpected event received",
+                events.stream().skip(newState.size()).collect(toList()), containsInAnyOrder(flip(evt1), flip(evt3)));
+
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+
+        ServiceDiscovererEvent<String> evt5 = new DefaultServiceDiscovererEvent<>("addr5", AVAILABLE);
+        newState = withDuplicateEvents ? asList(evt2, evt3, evt5, evt5) : asList(evt2, evt3, evt5);
+        sdEvents.onNext(newState);
+
+        events = receivedEvents(subscriber);
+        assertThat("Unexpected event received", events, hasSize(newState.size() + 1));
+        assertThat("Unexpected event received",
+                events.stream().limit(newState.size()).collect(toList()), contains(newState.toArray()));
+        assertThat("Unexpected event received",
+                events.stream().skip(newState.size()).collect(toList()), containsInAnyOrder(flip(evt4)));
+    }
+
+    @Test
+    void addRemoveBeforeRetry() throws Exception {
+        TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = pubs.take();
+        ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceived("addr1", sdEvents);
+        sendUpAndVerifyReceived(evt1.address(), UNAVAILABLE, sdEvents);
+
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+
+        sendUpAndVerifyReceived("addr1", sdEvents);
+    }
+
+    @Test
+    void removeAfterRetry() throws Exception {
+        TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = pubs.take();
+        ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceived("addr1", sdEvents);
+
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+
+        sdEvents.onNext(asList(evt1, flip(evt1)));
+        verifyReceivedEvents(contains(evt1, flip(evt1)));
+    }
+
+    @Test
+    void addAndRemovePostRetry() throws Exception {
+        TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = pubs.take();
+        ServiceDiscovererEvent<String> evt1 = sendUpAndVerifyReceived("addr1", sdEvents);
+        ServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceived("addr2", sdEvents);
+
+        sdEvents = triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+
+        sdEvents.onNext(asList(evt1, flip(evt1)));
+        verifyReceivedEvents(contains(evt1, flip(evt1), flip(evt2)));
+    }
+
+    @Test
+    void noUnavailableEventsAfterCancel() throws Exception {
+        TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents = pubs.take();
+
+        sendUpAndVerifyReceived("addr1", sdEvents);
+        ServiceDiscovererEvent<String> evt2 = sendUpAndVerifyReceived("addr2", sdEvents);
+        sendUpAndVerifyReceived("addr3", sdEvents);
+
+        triggerRetry(sdEvents);
+        verifyNoEventsReceived();
+
+        // Cancel and re-subscribe should not produce UNAVAILABLE events
+        subscriber.awaitSubscription().cancel();
+        TestPublisherSubscriber<Collection<ServiceDiscovererEvent<String>>> newSubscriber =
+                new TestPublisherSubscriber<>();
+        toSource(sd.discover("any")).subscribe(newSubscriber);
+        newSubscriber.awaitSubscription().request(Long.MAX_VALUE);
+        sdEvents = pubs.take();
+
+        ServiceDiscovererEvent<String> evt4 = new DefaultServiceDiscovererEvent<>("addr4", AVAILABLE);
+        sdEvents.onNext(asList(evt2, evt4));
+        Collection<ServiceDiscovererEvent<String>> events = receivedEvents(newSubscriber);
+        assertThat("Unexpected event received", events, contains(evt2, evt4));
+        verifyNoEventsReceived(subscriber);
+        verifyNoEventsReceived(newSubscriber);
+    }
+
+    private TestPublisher<Collection<ServiceDiscovererEvent<String>>> triggerRetry(
+            TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents)
+            throws Exception {
+        sdEvents.onError(DELIBERATE_EXCEPTION);
+        return pubs.take();
+    }
+
+    private void verifyNoEventsReceived() {
+        verifyNoEventsReceived(subscriber);
+    }
+
+    private void verifyNoEventsReceived(
+            TestPublisherSubscriber<Collection<ServiceDiscovererEvent<String>>> subscriber) {
+        assertThat("Unexpected event received",
+                subscriber.pollOnNext(DEFAULT_POLL_MILLIS, MILLISECONDS), is(nullValue()));
+    }
+
+    private Collection<ServiceDiscovererEvent<String>> receivedEvents(
+            TestPublisherSubscriber<Collection<ServiceDiscovererEvent<String>>> subscriber) {
+        List<Collection<ServiceDiscovererEvent<String>>> items = subscriber.takeOnNext(1);
+        assertThat("Unexpected items received", items, hasSize(1));
+        return items.get(0);
+    }
+
+    private void verifyReceivedEvents(Matcher<? super Collection<ServiceDiscovererEvent<String>>> matcher) {
+        Collection<ServiceDiscovererEvent<String>> events = receivedEvents(subscriber);
+        assertThat("Unexpected event received", events, matcher);
+    }
+
+    private ServiceDiscovererEvent<String> sendUpAndVerifyReceived(String addr,
+                TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents) {
+        return sendUpAndVerifyReceived(addr, AVAILABLE, sdEvents);
+    }
+
+    private ServiceDiscovererEvent<String> sendUpAndVerifyReceived(String addr, Status status,
+                TestPublisher<Collection<ServiceDiscovererEvent<String>>> sdEvents) {
+        ServiceDiscovererEvent<String> evt = new DefaultServiceDiscovererEvent<>(addr, status);
+        sdEvents.onNext(singletonList(evt));
+        Collection<ServiceDiscovererEvent<String>> received = subscriber.takeOnNext(1)
+                .stream()
+                .flatMap(Collection::stream)
+                .collect(toList());
+        assertThat("Unexpected number of events received", received, hasSize(1));
+        Iterator<ServiceDiscovererEvent<String>> iterator = received.iterator();
+        ServiceDiscovererEvent<String> receivedEvt = iterator.next();
+        assertThat("Unexpected event received", receivedEvt.address(), is(addr));
+        assertThat("Unexpected event received", receivedEvt.status(), is(status));
+        assertThat("Unexpected iterator.hasNext()", iterator.hasNext(), is(false));
+        return evt;
+    }
+
+    private static ServiceDiscovererEvent<String> flip(ServiceDiscovererEvent<String> evt) {
+        Status flipped = AVAILABLE.equals(evt.status()) ? UNAVAILABLE : AVAILABLE;
+        return new DefaultServiceDiscovererEvent<>(evt.address(), flipped);
+    }
+}


### PR DESCRIPTION
Motivation:

Clients have a configurable `serviceDiscovererRetryStrategy` to guarantee a steady stream of events to the `LoadBalancer` that never fails. It's necessary at the client level to avoid hanging requests indefinitely and let requests observe failures from ServiceDiscoverer. Also, for `PartitionedHttpClient` it's necessary to guarantee that `GroupedPublisher` never fails.

Retry is effectively a re-subscribe. According to `ServiceDiscoverer` contract (clarified in #3002), each `Subscriber` receives a "state of the world" as the first collection of events. The problem is that the state may change significantly between retries. As a result, unavailable addresses can remain inside the `LoadBalancer` forever. Example:

T1. SD delivers [a,b]
T1. LB receives [a,b]
T1. SD delivers error
T2. SD info changed ("a" got revoked)
T3. Client retries SD
T3. SD delivers [b]
T3. LB receives [b] (but still holds "a")

When we retry `ServiceDiscoverer` errors, we should keep pushing deltas downstream or purge events that are not present in the new "state of the world".

We previously had this protection but it was mistakenly removed in #1949 as part of a broader refactoring around `ServiceDiscoverer` <-> `LoadBalancer` contract.

Modifications:

- Add `RetryingServiceDiscoverer` that handles retries and keeps the state between retries.
- Use it in `DefaultSingleAddressHttpClientBuilder` and `DefaultPartitionedHttpClientBuilder`.
- Use `CastedServiceDiscoverer` to allow modifications for `ServiceDiscovererEvent` after we started to use a wildcard type in #2379.
- Pass consistent `targetResource` identifier to both `RetryingServiceDiscoverer` and `LoadBalancerFactory` to allow state correlation when inspecting heap dump.

Result:

Client keeps pushing deltas to `LoadBalancer` after retrying `ServiceDiscoverer` errors, keeping its state consistent with `ServiceDiscoverer`.