### PR TITLE
loadbalancer-experimental: subscribe is the last thing we do in DefaultLB constructor

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -164,13 +164,14 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         // Maintain a Subscriber so signals are always delivered to replay and new Subscribers get the latest signal.
         eventStream.ignoreElements().subscribe();
         this.outlierDetector = requireNonNull(outlierDetectorFactory, "outlierDetectorFactory").apply(lbDescription);
-        // We subscribe to events as the very last step so that if we subscribe to an eager service discoverer
-        // we already have all the fields initialized.
-        subscribeToEvents(false);
 
         // When we get a health-status event we should update the host set.
         this.outlierDetectorStatusChangeStream = this.outlierDetector.healthStatusChanged().forEach((ignored) ->
             sequentialExecutor.execute(() -> sequentialUpdateUsedHosts(usedHosts)));
+
+        // We subscribe to events as the very last step so that if we subscribe to an eager service discoverer
+        // we already have all the fields initialized.
+        subscribeToEvents(false);
 
         LOGGER.info("{}: starting load balancer. Load balancing policy: {}, outlier detection: {}", this,
                 loadBalancingPolicy, outlierDetector);


### PR DESCRIPTION
Motivation:

We want all the fields initialized before we subscribe to the SD events so if something happens and an attempt is made to close before construction is complete we don't end up with a NPE somewhere.

Modifications:

- Move the outlier detection stream cancellation assignment to before the subscription.
