### PR TITLE
transport-netty-internal: Finish reading when input shutdown

### DIFF
--- a/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
@@ -109,4 +109,9 @@
     <Method name="executionContext"/>
     <Bug pattern="NP_NONNULL_RETURN_VIOLATION"/>
   </Match>
+  <Match>
+    <Class name="io.servicetalk.transport.netty.internal.NettyChannelListenableAsyncCloseable"/>
+    <Method name="&lt;init&gt;"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Motivation:

Netty 4.2 changed the behavior of its epoll implementation to and that resulted in not receiving the ChannelInputShutdownReadComplete event. This is because we don't have a read interest set at the time because it's an idle client channel and we now won't get the event until we attempt to read.

Modifications:

Watch for the ChannelInputShutdownEvent and if we get it trigger a read. This will cause the event loop to drain any remaining bytes from the channel and emit the event.

Result:

4.2 build should pass more tests.

Testing
======
The tests passing using 4.2 Alpha3 snapshots in this PR: https://github.com/apple/servicetalk/pull/3014