### PR TITLE
Disable `fail-fast` on GitHub Actions for snapshot and release pipelines

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,6 +9,7 @@ jobs:
     name: Release JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         java: [ 8, 11 ]
     steps:

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -10,6 +10,7 @@ jobs:
     name: Snapshot JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         java: [ 8, 11 ]
     steps:


### PR DESCRIPTION
Motivation:

We always use 2 pipelines for snapshots and releases (JDK8 and JDK11) because those build and publish different set of modules. Because they are independent, we should not fail another one if any of them fail.