### PR TITLE
Revert "Update com.sun.xml.bind:jaxb-impl 2.3.3 -> 2.3.9"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ slf4jVersion=1.7.36
 javaxActivationVersion=1.2.2
 javaxJaxbApiVersion=2.3.3
 javaxJaxbCoreVersion=2.3.0.1
-javaxJaxbImplVersion=2.3.9
+javaxJaxbImplVersion=2.3.3
 jaxRsVersion=2.1.6
 jerseyVersion=2.41
 


### PR DESCRIPTION
This reverts commit e16b09ec6ca00eb5f6d7947650b6314ad34f532e.

We should be consistent with what version is used by Jersey.