### PR TITLE
loadbalancer-experimental: reduce dogpiling on hosts after healthy hosts

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -91,6 +91,9 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
             if (failOpen && failOpenHost == null && host.canMakeNewConnections()) {
                 failOpenHost = host;
             }
+
+            // let the scheduler attempt to skip this host for fairness reasons.
+            scheduler.foundUnhealthy(localCursor);
         }
         if (failOpenHost != null) {
             Single<C> result = selectFromHost(failOpenHost, selector, forceNewConnectionAndReserve, context);
@@ -134,22 +137,41 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
     }
 
     private abstract static class Scheduler {
-        abstract int nextHost();
-    }
-
-    private static final class ConstantScheduler extends Scheduler {
 
         private final AtomicInteger index;
-        private final int hostsSize;
+        protected final int hostsSize;
 
-        ConstantScheduler(AtomicInteger index, int hostsSize) {
+        Scheduler(final AtomicInteger index, final int hostsSize) {
             this.index = index;
             this.hostsSize = hostsSize;
         }
 
+        // Get the index of the next host
+        abstract int nextHost();
+
+        protected final int nextIndex() {
+            return index.getAndIncrement();
+        }
+
+        // Let the scheduler know the index was found to be unhealthy in an attempt to avoid causing the node
+        // after an unhealthy node to effectively receive double traffic.
+        final void foundUnhealthy(int index) {
+            int i = this.index.get();
+            if (index == (i - 1) % hostsSize) {
+                this.index.compareAndSet(i, i + 1);
+            }
+        }
+    }
+
+    private static final class ConstantScheduler extends Scheduler {
+
+        ConstantScheduler(AtomicInteger index, int hostsSize) {
+            super(index, hostsSize);
+        }
+
         @Override
         int nextHost() {
-            return (int) (Integer.toUnsignedLong(index.getAndIncrement()) % hostsSize);
+            return (int) (Integer.toUnsignedLong(nextIndex()) % hostsSize);
         }
     }
 
@@ -159,21 +181,19 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
     // See the java-grpc library for more details:
     // https://github.com/grpc/grpc-java/blob/da619e2b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
     private static final class StrideScheduler extends Scheduler {
-
-        private final AtomicInteger index;
         private final int[] weights;
 
         StrideScheduler(AtomicInteger index, int[] weights) {
-            this.index = index;
+            super(index, weights.length);
             this.weights = weights;
         }
 
         @Override
         int nextHost() {
             while (true) {
-                long counter = Integer.toUnsignedLong(index.getAndIncrement());
-                long pass = counter / weights.length;
-                int i = (int) counter % weights.length;
+                long counter = Integer.toUnsignedLong(nextIndex());
+                long pass = counter / hostsSize;
+                int i = (int) counter % hostsSize;
                 // We add a unique offset for each offset which could be anything so long as it's constant throughout
                 // iteration. This is helpful in the  case where weights are [1, .. 1, 5] since the scheduling could
                 // otherwise look something like this:

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -158,7 +158,10 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
         // after an unhealthy node to effectively receive double traffic.
         final void foundUnhealthy(int index) {
             int i = this.index.get();
+            // We have to check against `i - 1` because we perform a getAndIncrement so the index we returned from
+            // `nextIndex()` is one behind where index currently is.
             if (index == (Integer.toUnsignedLong(i) - 1) % hostsSize) {
+                // We do CAS to conditionally advance the cursor only if someone else hasn't already.
                 this.index.compareAndSet(i, i + 1);
             }
         }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinSelectorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinSelectorTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 class RoundRobinSelectorTest {
 
     private boolean failOpen;
-    private AtomicInteger index = new AtomicInteger();
+    private final AtomicInteger index = new AtomicInteger();
     @Nullable
     private HostSelector<String, TestLoadBalancedConnection> selector;
 


### PR DESCRIPTION
Motivation:

Round-robin algorithms very often suffer from bugs where the host after a healthy host will tend to get more traffic. This is because the algorithm will then try to advance to the 'next' index.

Modifications:

If we find a bad host attempt to advance the cursor so the next selection doesn't also pick it.

Result:

Less dogpiling behavior.