### PR TITLE
Remove some uses of `synchronized`

### DIFF
--- a/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiter.java
+++ b/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiter.java
@@ -150,7 +150,7 @@ final class GradientCapacityLimiter implements CapacityLimiter {
      * Needs to be called while holding the lock.
      */
     private int updateLimit(final long timestampNs, final double shortLatencyMillis, final double longLatencyMillis) {
-        assert lock.isLocked();
+        assert lock.isHeldByCurrentThread();
         if (isNaN(longLatencyMillis) || isNaN(shortLatencyMillis) || shortLatencyMillis == 0) {
             return -1;
         }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
@@ -147,7 +147,7 @@ final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
                                     try {
                                         subscriber.onSuccess(result1);
                                     } finally {
-                                        lockRemoveFromMap();C
+                                        lockRemoveFromMap();
                                     }
                                 }
 

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
@@ -134,7 +134,6 @@ final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
                                         // map entry safely.
                                         lock.lock();
                                         try {
-                                            // TODO: may not be v-thread safe.
                                             cancellable.cancel();
                                         } finally {
                                             lock.unlock();

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/CacheConnectionFactory.java
@@ -29,12 +29,17 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.ToIntFunction;
 import javax.annotation.Nullable;
 
 final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncCloseable>
         extends DelegatingConnectionFactory<ResolvedAddress, C> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CacheConnectionFactory.class);
+
+    private final Lock lock = new ReentrantLock();
+    // access to `map` must be protected by `lock`.
     private final Map<ResolvedAddress, Item<C>> map = new HashMap<>();
     private final ToIntFunction<ResolvedAddress> maxConcurrencyFunc;
 
@@ -63,7 +68,8 @@ final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
             }
 
             Single<C> result;
-            synchronized (map) {
+            lock.lock();
+            try {
                 final Item<C> item1 = map.get(resolvedAddress);
                 if (item1 == null || (result = item1.addSubscriber(maxConcurrency)) == null) {
                     final Item<C> item2 = new Item<>();
@@ -110,8 +116,11 @@ final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
                                 }
 
                                 private void lockRemoveFromMap() {
-                                    synchronized (map) {
+                                    lock.lock();
+                                    try {
                                         map.remove(resolvedAddress, item2);
+                                    } finally {
+                                        lock.unlock();
                                     }
                                 }
                             })
@@ -123,8 +132,12 @@ final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
                                         // Acquire the lock before cache operator processes cancel, so if it results
                                         // in an upstream cancel we will be holding the lock and able to remove the
                                         // map entry safely.
-                                        synchronized (map) {
+                                        lock.lock();
+                                        try {
+                                            // TODO: may not be v-thread safe.
                                             cancellable.cancel();
+                                        } finally {
+                                            lock.unlock();
                                         }
                                     });
                                 }
@@ -134,7 +147,7 @@ final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
                                     try {
                                         subscriber.onSuccess(result1);
                                     } finally {
-                                        lockRemoveFromMap();
+                                        lockRemoveFromMap();C
                                     }
                                 }
 
@@ -153,12 +166,17 @@ final class CacheConnectionFactory<ResolvedAddress, C extends ListenableAsyncClo
                                     // pending connection attempt is exceeded. When the single completes we don't need
                                     // to cache the connection anymore because the LoadBalancer above will cache the
                                     // connection. This also help keep memory down from the map.
-                                    synchronized (map) {
+                                    lock.lock();
+                                    try {
                                         map.remove(resolvedAddress, item2);
+                                    } finally {
+                                        lock.unlock();
                                     }
                                 }
                             });
                 }
+            } finally {
+                lock.unlock();
             }
 
             return result.shareContextOnSubscribe();


### PR DESCRIPTION
Motivation:

With java-21 and v-threads synchronization can cause deadlocks because carrier threads cannot release a v-thread that is in a synchronized block.

Modifications:

Identify the cases where we're using synchronization and move them to the equivalent v-thread safe ReentrantLock.

Result:

Better v-thread safety.