### PR TITLE
`ci-netty-snapshot.yml`: remove Alpha number

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         java: [ 8 ]
         os: [ ubuntu-latest ]
-        netty: [ 4.1+, 4.2.0.Alpha3+ ]
+        netty: [ 4.1+, 4.2.0.Alpha+ ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Without the number we will always take the latest AlphaN version.