### PR TITLE
traffic-resilience-http: Add a finalizer to capacity limiter tickets to ensure cleanup

### DIFF
--- a/servicetalk-traffic-resilience-http/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-traffic-resilience-http/gradle/checkstyle/suppressions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <!-- The list of test cases must be kept single-line each. -->
+  <suppress checks="NoFinalizer"
+            files="io[\\/]servicetalk[\\/]traffic[\\/]resilience[\\/]http[\\/]AbstractTrafficResilienceHttpFilter.java"/>
+</suppressions>

--- a/servicetalk-traffic-resilience-http/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-traffic-resilience-http/gradle/checkstyle/suppressions.xml
@@ -21,5 +21,5 @@
 <suppressions>
   <!-- The list of test cases must be kept single-line each. -->
   <suppress checks="NoFinalizer"
-            files="io[\\/]servicetalk[\\/]traffic[\\/]resilience[\\/]http[\\/]AbstractTrafficResilienceHttpFilter.java"/>
+          files="io[\\/]servicetalk[\\/]traffic[\\/]resilience[\\/]http[\\/]AbstractTrafficResilienceHttpFilter.java"/>
 </suppressions>

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
@@ -384,6 +384,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
                         requestHashCode);
                 ignored();
             }
+            super.finalize();
         }
     }
 }


### PR DESCRIPTION
Motivation:

If a capacity limiter ticket is abandoned it can corrupt the state machine effectively looking like a request that never completes.

Modifications:

Add a finalizer that checks whether the ticket was completed. If it was not it considers the ticket ignored and logs to help fix the leak.