### PR TITLE
capacity-limiter-api: avoid division in EMA

### DIFF
--- a/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/LatencyTracker.java
+++ b/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/LatencyTracker.java
@@ -61,7 +61,7 @@ interface LatencyTracker {
      */
     final class EMA implements LatencyTracker {
 
-        private final double tau;
+        private final double invTau;
         @Nullable
         private final LatencyTracker calmTracker;
         @Nullable
@@ -75,7 +75,7 @@ interface LatencyTracker {
          * @param halfLifeNs The decay window of the EMA.
          */
         EMA(final long halfLifeNs) {
-            this.tau = halfLifeNs / log(2);
+            this.invTau = 1.0 / (halfLifeNs / log(2));
             this.calmTracker = null;
             this.calmRatio = null;
         }
@@ -94,7 +94,7 @@ interface LatencyTracker {
         EMA(final long halfLifeNs, final LatencyTracker calmTracker,
             final BiFunction<Double, Double, Float> calmRatio) {
             NumberUtils.ensurePositive(halfLifeNs, "halfLifeNs");
-            this.tau = halfLifeNs / log(2);
+            this.invTau = 1.0 / (halfLifeNs / log(2));
             this.calmTracker = requireNonNull(calmTracker);
             this.calmRatio = requireNonNull(calmRatio);
         }
@@ -112,7 +112,7 @@ interface LatencyTracker {
                 }
             }
 
-            final double tmp = (timestampNs - lastTimeNanos) / tau;
+            final double tmp = (timestampNs - lastTimeNanos) * invTau;
             final double w = exp(-tmp);
             ewma = ewma * w + latency * (1d - w);
             lastTimeNanos = timestampNs;


### PR DESCRIPTION
Motivation:

Division is much more expensive than multiplication, certainly when the compliler doesn't know the denominator and can do tricks to mitigate.

Modifications:

In the capacity limiter EMA we have a division operation where the denominator is always the same which is a good candidate for inverting once and turning into a multiplication operation.