### PR TITLE
`SpliceFlatStreamToMetaSingle`: propagate cancel when races with data

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingle.java
@@ -72,12 +72,12 @@ final class SpliceFlatStreamToMetaSingle<Data, MetaData, Payload> implements Pub
         return new SplicingSubscriber<>(this, subscriber);
     }
 
-    /* Visible for testing */
-    static final class SplicingSubscriber<Data, MetaData, Payload> implements PublisherSource.Subscriber<Object> {
+    private static final class SplicingSubscriber<Data, MetaData, Payload>
+            implements PublisherSource.Subscriber<Object> {
+
         @SuppressWarnings("rawtypes")
-        private static final AtomicReferenceFieldUpdater<SplicingSubscriber, Object>
-                maybePayloadSubUpdater = AtomicReferenceFieldUpdater.newUpdater(SplicingSubscriber.class,
-                Object.class, "maybePayloadSub");
+        private static final AtomicReferenceFieldUpdater<SplicingSubscriber, Object> maybePayloadSubUpdater =
+                AtomicReferenceFieldUpdater.newUpdater(SplicingSubscriber.class, Object.class, "maybePayloadSub");
 
         private static final String CANCELED = "CANCELED";
         private static final String PENDING = "PENDING";

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2019, 2021-2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/JavaNetSoTimeoutHttpConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/JavaNetSoTimeoutHttpConnectionFilterTest.java
@@ -35,6 +35,7 @@ import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -67,6 +68,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@Disabled   // FIXME: remove before merging
 class JavaNetSoTimeoutHttpConnectionFilterTest {
 
     @RegisterExtension

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/JavaNetSoTimeoutHttpConnectionFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/JavaNetSoTimeoutHttpConnectionFilterTest.java
@@ -35,7 +35,6 @@ import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -68,7 +67,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled   // FIXME: remove before merging
 class JavaNetSoTimeoutHttpConnectionFilterTest {
 
     @RegisterExtension

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingleTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SpliceFlatStreamToMetaSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018-2022, 2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Motivation:

Cancellation of the single may race with delivering the first element. If `cancel` wins, we already deliver `CancellationException` if someone subscribes to the payload publisher. However, if `cancel` arrives after  `dataSubscriber.onSuccess(...)` and before someone subscribes to the payload publisher, it's a strong indicator that there was a race and `dataSubscriber` is not interested in it anymore. Therefore, we should pessimistically assume that nobody will ever subscribe to the payload publisher, cancel upstream subscription, and deliver `CancellationException` is someone still subscribes.

Modifications:
- Cancel upstream subscription for both `null` and `PENDING` states if received data cancel;
- Upwrap code around `parent.packer.apply` to assert that this path happens only if `CANCELED`;
- Deliver `CancellationException` is someone still subscribes to the payload publisher after `CANCELED`;
- Fix another bug: do not deliver `dataSubscriber.onError` if `metaSeenInOnNext == true` because it's already terminated (`CANCELED` does not play any role here);
- Log more appropriate message if upstream delivers a terminal event after `payloadSubscriber` is already terminated (`EMPTY_COMPLETED_DELIVERED`);
- Remove duplication around "Duplicate Subscribers are not allowed";

Result:

Network resources receive `cancel` signal and clean up connection state.

---
Note that the original version of this operator had this behavior, but it was changed in https://github.com/apple/servicetalk/commit/38e2c67ff19f67e3e9730d56e379e726e1981aa6
We don't have a full PR for that commit with review comments. Based on the commit description I believe it was fixing a different problem and the change in cancel propagation behavior for `PENDING` state is likely a side-effect of introducing a new state.