### PR TITLE
http-utils: fix leak in AbstractTimeoutHttpFilter

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
@@ -183,6 +183,11 @@ abstract class AbstractTimeoutHttpFilter implements HttpExecutionStrategyInfluen
                 try {
                     Object current = stateUpdater.getAndSet(this, COMPLETE);
                     if (current instanceof StreamingHttpResponse) {
+                        // Because of the nature of the Single.timeout(..) operator we know that if we get a cancel
+                        // call the message will never be escape the `.timeout(..)` operator because it will have
+                        // taken ownership of the response so it can send its TimeoutException. Therefore, it is our
+                        // responsibility to clean up the message body. This behavior is verified by the
+                        // `responseCompletesBeforeTimeoutWithFollowingCancel` test in the suite.
                         clean((StreamingHttpResponse) current);
                     }
                 } finally {

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
@@ -171,11 +171,13 @@ abstract class AbstractTimeoutHttpFilter implements HttpExecutionStrategyInfluen
 
         private final SingleSource.Subscriber<? super StreamingHttpResponse> delegate;
         @SuppressWarnings("unused")
+        @Nullable
         private volatile Object state;
 
         CleanupSubscriber(final SingleSource.Subscriber<? super StreamingHttpResponse> delegate) {
             this.delegate = delegate;
         }
+
         @Override
         public void onSubscribe(Cancellable cancellable) {
             delegate.onSubscribe(() -> {
@@ -203,7 +205,7 @@ abstract class AbstractTimeoutHttpFilter implements HttpExecutionStrategyInfluen
         }
 
         private void onCancel() {
-            Object current = stateUpdater.compareAndSet(this, null, COMPLETE);
+            Object current = stateUpdater.getAndSet(this, COMPLETE);
             if (current instanceof StreamingHttpResponse) {
                 clean((StreamingHttpResponse) current);
             }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilter.java
@@ -185,9 +185,8 @@ abstract class AbstractTimeoutHttpFilter implements HttpExecutionStrategyInfluen
                     if (current instanceof StreamingHttpResponse) {
                         // Because of the nature of the Single.timeout(..) operator we know that if we get a cancel
                         // call the message will never be escape the `.timeout(..)` operator because it will have
-                        // taken ownership of the response so it can send its TimeoutException. Therefore, it is our
-                        // responsibility to clean up the message body. This behavior is verified by the
-                        // `responseCompletesBeforeTimeoutWithFollowingCancel` test in the suite.
+                        // 'completed'. Therefore, it is our responsibility to clean up the message body. This behavior
+                        // is verified by the `responseCompletesBeforeTimeoutWithFollowingCancel` test in the suite.
                         clean((StreamingHttpResponse) current);
                     }
                 } finally {

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.utils;
 
 import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.TimeSource;
 import io.servicetalk.concurrent.api.DefaultThreadFactory;
 import io.servicetalk.concurrent.api.Executor;
@@ -65,6 +66,7 @@ import static java.time.Duration.ofNanos;
 import static java.time.Duration.ofSeconds;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -241,6 +243,35 @@ abstract class AbstractTimeoutHttpFilterTest {
         response.onSuccess(responseRawWith(payloadBody.beforeCancel(() -> cancelled.set(true))));
         assertThat("No subscribe for payload body", payloadBody.isSubscribed(), is(true));
         assertThat("Payload body wasn't cancelled as part of draining", cancelled.get(), is(true));
+    }
+
+    @ParameterizedTest(name = "{index}: fullRequestResponse={0}")
+    @ValueSource(booleans = {false, true})
+    void responseCompletesBeforeTimeoutWithFollowingCancel(boolean fullRequestResponse) {
+        TestSingle<StreamingHttpResponse> responseSingle = new TestSingle<>();
+        AtomicReference<Cancellable> doCancel = new AtomicReference<>();
+        AtomicBoolean cancelPropagated = new AtomicBoolean();
+        StepVerifiers.create(applyFilter(ofSeconds(DEFAULT_TIMEOUT_SECONDS / 2),
+                        fullRequestResponse, defaultStrategy(), responseSingle.beforeCancel(() ->
+                                cancelPropagated.set(true))).
+                        afterOnSubscribe(doCancel::set))
+                .then(() -> immediate().schedule(() -> {
+                            StreamingHttpResponse response = mock(StreamingHttpResponse.class);
+                            when(response.transformMessageBody(any())).thenReturn(response);
+                            responseSingle.onSuccess(response);
+                        },
+                        ofMillis(1L)))
+                .expectSuccess()
+                .verify();
+        assertThat("No subscribe for response single", responseSingle.isSubscribed(), is(true));
+        responseSingle.isSubscribed();
+        assertThat(doCancel.get(), is(notNullValue()));
+
+        // We rely on the Single.timeout(..) operator to swallow the losing cancellation so that our CleanupSubscriber
+        // doesn't end up being the second subscriber to the response body. If that behavior changes we may need to be
+        // more defensive.
+        doCancel.get().cancel();
+        assertThat(cancelPropagated.get(), is(false));
     }
 
     private static Single<StreamingHttpResponse> responseWith(Publisher<Buffer> payloadBody) {

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/AbstractTimeoutHttpFilterTest.java
@@ -253,8 +253,8 @@ abstract class AbstractTimeoutHttpFilterTest {
         AtomicBoolean cancelPropagated = new AtomicBoolean();
         StepVerifiers.create(applyFilter(ofSeconds(DEFAULT_TIMEOUT_SECONDS / 2),
                         fullRequestResponse, defaultStrategy(), responseSingle.beforeCancel(() ->
-                                cancelPropagated.set(true))).
-                        afterOnSubscribe(doCancel::set))
+                                cancelPropagated.set(true)))
+                        .afterOnSubscribe(doCancel::set))
                 .then(() -> immediate().schedule(() -> {
                             StreamingHttpResponse response = mock(StreamingHttpResponse.class);
                             when(response.transformMessageBody(any())).thenReturn(response);
@@ -264,12 +264,11 @@ abstract class AbstractTimeoutHttpFilterTest {
                 .expectSuccess()
                 .verify();
         assertThat("No subscribe for response single", responseSingle.isSubscribed(), is(true));
-        responseSingle.isSubscribed();
-        assertThat(doCancel.get(), is(notNullValue()));
 
         // We rely on the Single.timeout(..) operator to swallow the losing cancellation so that our CleanupSubscriber
         // doesn't end up being the second subscriber to the response body. If that behavior changes we may need to be
         // more defensive.
+        assertThat(doCancel.get(), is(notNullValue()));
         doCancel.get().cancel();
         assertThat(cancelPropagated.get(), is(false));
     }


### PR DESCRIPTION
Motivation:

The Single.timeout(..) family of operations are part of a class of operations will short-circuit the response based on the cancellation pathway, specifically they will return a TimeoutException down the error path. Because cancellation and the result are intrinsically racy there is currently the possibility that the result will be generated but we cannot return it to the subscriber having already given them an Exception in the error pathway. For values that are stateful this can result in a resource leak. One such leak occurs in the AbstractTimeoutHttpFilter.

Modifications:

Modify the AbstractTimeoutHttpFilter to keep a handle on the resource and make sure we close it if we receive a cancellation. This is a localized fix but appears to be effective.

Result:

One less leak.