### PR TITLE
`Amb` operators for `Single` and `Completable` should respect reactive contract 2.3

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AmbSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AmbSingles.java
@@ -78,7 +78,6 @@ final class AmbSingles<T> extends Single<T> {
 
     static final class AmbSubscriber<T> extends DelayedCancellable implements Subscriber<T> {
         private final State<T> state;
-        private volatile boolean propagateCancel = true;
 
         AmbSubscriber(final State<T> state) {
             this.state = state;
@@ -91,21 +90,14 @@ final class AmbSingles<T> extends Single<T> {
 
         @Override
         public void onSuccess(@Nullable final T result) {
-            propagateCancel = false;
+            ignoreCancel();
             state.trySuccess(result);
         }
 
         @Override
         public void onError(final Throwable t) {
-            propagateCancel = false;
+            ignoreCancel();
             state.tryError(t);
-        }
-
-        @Override
-        public void cancel() {
-            if (propagateCancel) {
-                super.cancel();
-            }
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AmbSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AmbSingles.java
@@ -78,6 +78,7 @@ final class AmbSingles<T> extends Single<T> {
 
     static final class AmbSubscriber<T> extends DelayedCancellable implements Subscriber<T> {
         private final State<T> state;
+        private volatile boolean propagateCancel = true;
 
         AmbSubscriber(final State<T> state) {
             this.state = state;
@@ -90,12 +91,21 @@ final class AmbSingles<T> extends Single<T> {
 
         @Override
         public void onSuccess(@Nullable final T result) {
+            propagateCancel = false;
             state.trySuccess(result);
         }
 
         @Override
         public void onError(final Throwable t) {
+            propagateCancel = false;
             state.tryError(t);
+        }
+
+        @Override
+        public void cancel() {
+            if (propagateCancel) {
+                super.cancel();
+            }
         }
     }
 

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleAmbWithAsyncTest.java
@@ -15,20 +15,16 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.test.internal.TestSingleSubscriber;
 import io.servicetalk.context.api.ContextMap;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.never;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,44 +50,6 @@ class SingleAmbWithAsyncTest {
     @RegisterExtension
     static final ExecutorExtension<Executor> SECOND_EXEC = withCachedExecutor(SECOND_EXECUTOR_THREAD_NAME_PREFIX)
             .setClassLevel(true);
-
-    @ParameterizedTest(name = "{displayName} [{index}] terminatesWithSuccess={0} completeFirst={1}")
-    @CsvSource({
-        "true, true",
-        "true, false",
-        "false, true",
-        "false, false"
-    })
-    void terminalSignalDoesNotInvokeCancelOnTheSameCancellable(boolean terminatesWithSuccess, boolean completeFirst) {
-        TestSingle<Integer> first = new TestSingle<>();
-        TestSingle<Integer> second = new TestSingle<>();
-        TestCancellable firstCancellable = new TestCancellable();
-        TestCancellable secondCancellable = new TestCancellable();
-        TestSingleSubscriber<Integer> subscriber = new TestSingleSubscriber<>();
-
-        toSource(first.ambWith(second)).subscribe(subscriber);
-        subscriber.awaitSubscription();
-        first.onSubscribe(firstCancellable);
-        second.onSubscribe(secondCancellable);
-
-        if (terminatesWithSuccess) {
-            if (completeFirst) {
-                first.onSuccess(1);
-            } else {
-                second.onSuccess(1);
-            }
-            assertThat("Unexpected result delivered", subscriber.awaitOnSuccess(), is(1));
-        } else {
-            if (completeFirst) {
-                first.onError(DELIBERATE_EXCEPTION);
-            } else {
-                second.onError(DELIBERATE_EXCEPTION);
-            }
-            assertThat("Unexpected result delivered", subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
-        }
-        assertThat("Another Single not cancelled", secondCancellable.isCancelled(), is(completeFirst));
-        assertThat("Reactive Streams Rule 2.3 violation", firstCancellable.isCancelled(), is(!completeFirst));
-    }
 
     @Test
     void offloadSuccessFromFirst() throws Exception {

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/DelayedCancellable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/DelayedCancellable.java
@@ -56,7 +56,7 @@ public class DelayedCancellable implements Cancellable {
     /**
      * Ignores any subsequent calls to {@link #cancel()}, preventing propagating the cancellation further up the stream.
      */
-    protected void ignoreCancel() {
+    protected final void ignoreCancel() {
         currentUpdater.set(this, IGNORE_CANCEL);
     }
 }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/DelayedCancellable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/DelayedCancellable.java
@@ -52,4 +52,11 @@ public class DelayedCancellable implements Cancellable {
             oldCancellable.cancel();
         }
     }
+
+    /**
+     * Ignores any subsequent calls to {@link #cancel()}, preventing propagating the cancellation further up the stream.
+     */
+    protected void ignoreCancel() {
+        currentUpdater.set(this, IGNORE_CANCEL);
+    }
 }


### PR DESCRIPTION
Motivation
==========
Reactive Streams rule 2.3 mandates, that `Subscriber.onComplete() and Subscriber.onError(Throwable t) MUST NOT call any methods on the Subscription or the Publisher`.

Our current amb operator implementation also performs a cancellation on the Single that just completed, which violates the rule.

Modifications
=============
This changeset modifies the amb operator in a way that all but the one Single which got a termination signal (through `onNext` or `onError`) will get the cancellation propagated.

The test suite is enhanced to cover this scenario, both for `ambWith` as well as the static `amb` factory methods. Since the `Completable` also converts to `Single` underneath, the functionality is transitively available as well.

Result
======
The `amb*` operator variants adhere to reactive streams 2.3 rule.