### PR TITLE
Add `TransportConfig` to control low level transport settings

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServerBuilder.java
@@ -24,6 +24,7 @@ import io.servicetalk.transport.api.EarlyConnectionAcceptor;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.LateConnectionAcceptor;
 import io.servicetalk.transport.api.ServerSslConfig;
+import io.servicetalk.transport.api.TransportConfig;
 import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
@@ -92,6 +93,12 @@ public class DelegatingHttpServerBuilder implements HttpServerBuilder {
     @Override
     public HttpServerBuilder sslConfig(final ServerSslConfig config, final boolean acceptInsecureConnections) {
         delegate = delegate.sslConfig(config, acceptInsecureConnections);
+        return this;
+    }
+
+    @Override
+    public HttpServerBuilder transportConfig(final TransportConfig transportConfig) {
+        delegate = delegate.transportConfig(transportConfig);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingSingleAddressHttpClientBuilder.java
@@ -25,6 +25,7 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.TransportConfig;
 
 import java.net.SocketOption;
 import java.util.function.BooleanSupplier;
@@ -218,6 +219,12 @@ public class DelegatingSingleAddressHttpClientBuilder<U, R> implements SingleAdd
     @Override
     public SingleAddressHttpClientBuilder<U, R> inferSniHostname(final boolean shouldInfer) {
         delegate = delegate.inferSniHostname(shouldInfer);
+        return this;
+    }
+
+    @Override
+    public SingleAddressHttpClientBuilder<U, R> transportConfig(final TransportConfig transportConfig) {
+        delegate = delegate.transportConfig(transportConfig);
         return this;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -31,6 +31,8 @@ import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.LateConnectionAcceptor;
 import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
+import io.servicetalk.transport.api.TransportConfig;
+import io.servicetalk.transport.api.TransportConfigBuilder;
 import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
@@ -113,12 +115,25 @@ public interface HttpServerBuilder {
     }
 
     /**
+     * Set the transport configuration.
+     *
+     * @param transportConfig {@link TransportConfig} to use.
+     * @return {@code this}.
+     * @see TransportConfigBuilder
+     */
+    // FIXME: 0.43 - consider removing default impl
+    default HttpServerBuilder transportConfig(TransportConfig transportConfig) {
+        throw new UnsupportedOperationException("Setting transport config is not yet supported by " +
+                getClass().getName());
+    }
+
+    /**
      * Adds a {@link SocketOption} that is applied to connected/accepted socket channels.
      *
      * @param <T> the type of the value.
      * @param option the option to apply.
      * @param value the value.
-     * @return this.
+     * @return {@code this}.
      * @see StandardSocketOptions
      * @see ServiceTalkSocketOptions
      */
@@ -129,7 +144,7 @@ public interface HttpServerBuilder {
      * @param <T> the type of the value.
      * @param option the option to apply.
      * @param value the value.
-     * @return this.
+     * @return {@code this}.
      * @see StandardSocketOptions
      * @see ServiceTalkSocketOptions
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfig.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ProxyConfig.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
  * Configuration for a proxy.
  *
  * @param <A> the type of address
+ * @see ProxyConfigBuilder
  */
 public interface ProxyConfig<A> {
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfig.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/RedirectConfig.java
@@ -22,6 +22,8 @@ import java.util.function.BiFunction;
 
 /**
  * Configuration options for <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4">redirection</a>.
+ *
+ * @see RedirectConfigBuilder
  */
 public interface RedirectConfig {
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -29,6 +29,8 @@ import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
+import io.servicetalk.transport.api.TransportConfig;
+import io.servicetalk.transport.api.TransportConfigBuilder;
 import io.servicetalk.transport.api.TransportObserver;
 
 import java.net.SocketOption;
@@ -401,4 +403,17 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * @return {@code this}
      */
     SingleAddressHttpClientBuilder<U, R> inferSniHostname(boolean shouldInfer);
+
+    /**
+     * Set the transport configuration.
+     *
+     * @param transportConfig {@link TransportConfig} to use
+     * @return {@code this}
+     * @see TransportConfigBuilder
+     */
+    // FIXME: 0.43 - consider removing default impl
+    default SingleAddressHttpClientBuilder<U, R> transportConfig(TransportConfig transportConfig) {
+        throw new UnsupportedOperationException("Setting transport config is not yet supported by " +
+                getClass().getName());
+    }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -233,7 +233,7 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
 
     @Override
     public HttpServerBuilder transportConfig(final TransportConfig transportConfig) {
-        this.config.tcpConfig().transportConfig(transportConfig);
+        config.tcpConfig().transportConfig(transportConfig);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -49,6 +49,7 @@ import io.servicetalk.transport.api.ExecutionStrategyInfluencer;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.api.LateConnectionAcceptor;
 import io.servicetalk.transport.api.ServerSslConfig;
+import io.servicetalk.transport.api.TransportConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.InfluencerConnectionAcceptor;
 
@@ -227,6 +228,12 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
     @Override
     public HttpServerBuilder sslConfig(final ServerSslConfig config, final boolean acceptInsecureConnections) {
         this.config.tcpConfig().sslConfig(config, acceptInsecureConnections);
+        return this;
+    }
+
+    @Override
+    public HttpServerBuilder transportConfig(final TransportConfig transportConfig) {
+        this.config.tcpConfig().transportConfig(transportConfig);
         return this;
     }
 

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -60,6 +60,7 @@ import io.servicetalk.transport.api.ClientSslConfig;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
+import io.servicetalk.transport.api.TransportConfig;
 
 import io.netty.handler.ssl.SslContext;
 import org.slf4j.Logger;
@@ -644,6 +645,12 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
     @Override
     public DefaultSingleAddressHttpClientBuilder<U, R> inferSniHostname(boolean shouldInfer) {
         config.inferSniHostname(shouldInfer);
+        return this;
+    }
+
+    @Override
+    public DefaultSingleAddressHttpClientBuilder<U, R> transportConfig(final TransportConfig transportConfig) {
+        config.tcpConfig().transportConfig(transportConfig);
         return this;
     }
 

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractReadOnlyTcpConfig.java
@@ -18,6 +18,7 @@ package io.servicetalk.tcp.netty.internal;
 import io.servicetalk.logging.api.UserDataLoggerConfig;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
 import io.servicetalk.transport.api.SslConfig;
+import io.servicetalk.transport.api.TransportConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 
 import io.netty.channel.ChannelOption;
@@ -40,12 +41,14 @@ abstract class AbstractReadOnlyTcpConfig {
     private final FlushStrategy flushStrategy;
     @Nullable
     private final UserDataLoggerConfig wireLoggerConfig;
+    private final TransportConfig transportConfig;
 
     protected AbstractReadOnlyTcpConfig(final AbstractTcpConfig from) {
         options = nonNullOptions(from.options());
         idleTimeoutMs = from.idleTimeoutMs();
         flushStrategy = from.flushStrategy();
         wireLoggerConfig = from.wireLoggerConfig();
+        transportConfig = from.transportConfig();
     }
 
     AbstractReadOnlyTcpConfig(final AbstractReadOnlyTcpConfig from) {
@@ -53,6 +56,7 @@ abstract class AbstractReadOnlyTcpConfig {
         idleTimeoutMs = from.idleTimeoutMs();
         flushStrategy = from.flushStrategy();
         wireLoggerConfig = from.wireLoggerConfig();
+        transportConfig = from.transportConfig();
     }
 
     @SuppressWarnings("rawtypes")
@@ -113,4 +117,13 @@ abstract class AbstractReadOnlyTcpConfig {
      */
     @Nullable
     public abstract SslConfig sslConfig();
+
+    /**
+     * Get the {@link TransportConfig}.
+     *
+     * @return {@link TransportConfig} to use
+     */
+    public final TransportConfig transportConfig() {
+        return transportConfig;
+    }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -19,6 +19,8 @@ import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.logging.api.UserDataLoggerConfig;
 import io.servicetalk.logging.slf4j.internal.DefaultUserDataLoggerConfig;
 import io.servicetalk.transport.api.ServiceTalkSocketOptions;
+import io.servicetalk.transport.api.TransportConfig;
+import io.servicetalk.transport.api.TransportConfigBuilder;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 
 import io.netty.channel.ChannelOption;
@@ -41,6 +43,8 @@ import static java.util.Objects.requireNonNull;
  */
 abstract class AbstractTcpConfig {
 
+    private static final TransportConfig DEFAULT_TRANSPORT_CONFIG = new TransportConfigBuilder().build();
+
     @Nullable
     @SuppressWarnings("rawtypes")
     private Map<ChannelOption, Object> options;
@@ -48,6 +52,7 @@ abstract class AbstractTcpConfig {
     private FlushStrategy flushStrategy = defaultFlushStrategy();
     @Nullable
     private UserDataLoggerConfig wireLoggerConfig;
+    private TransportConfig transportConfig = DEFAULT_TRANSPORT_CONFIG;
 
     protected AbstractTcpConfig() {
         socketOption(SO_KEEPALIVE, true);
@@ -58,6 +63,7 @@ abstract class AbstractTcpConfig {
         idleTimeoutMs = from.idleTimeoutMs;
         flushStrategy = from.flushStrategy;
         wireLoggerConfig = from.wireLoggerConfig;
+        transportConfig = from.transportConfig;
     }
 
     @Nullable
@@ -77,6 +83,10 @@ abstract class AbstractTcpConfig {
     @Nullable
     final UserDataLoggerConfig wireLoggerConfig() {
         return wireLoggerConfig;
+    }
+
+    final TransportConfig transportConfig() {
+        return transportConfig;
     }
 
     /**
@@ -124,5 +134,14 @@ abstract class AbstractTcpConfig {
                                         final LogLevel logLevel,
                                         final BooleanSupplier logUserData) {
         wireLoggerConfig = new DefaultUserDataLoggerConfig(loggerName, logLevel, logUserData);
+    }
+
+    /**
+     * Sets the transport configuration.
+     *
+     * @param transportConfig {@link TransportConfig} to use
+     */
+    public final void transportConfig(final TransportConfig transportConfig) {
+        this.transportConfig = requireNonNull(transportConfig);
     }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -86,6 +86,8 @@ public class TcpClientChannelInitializer implements ChannelInitializer {    // F
                                        final boolean deferSslHandler) {
         ChannelInitializer delegate = ChannelInitializer.defaultInitializer();
 
+        delegate = delegate.andThen(new TransportConfigInitializer(config.transportConfig()));
+
         final ClientSslConfig sslConfig = config.sslConfig();
         if (observer != NoopConnectionObserver.INSTANCE) {
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -68,6 +68,8 @@ public class TcpServerChannelInitializer implements ChannelInitializer {    // F
                                        final ExecutionContext<?> executionContext) {
         ChannelInitializer delegate = ChannelInitializer.defaultInitializer();
 
+        delegate = delegate.andThen(new TransportConfigInitializer(config.transportConfig()));
+
         if (observer != NoopConnectionObserver.INSTANCE) {
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
                     channel -> new TcpConnectionInfo(channel,

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TransportConfigInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TransportConfigInitializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.tcp.netty.internal;
+
+import io.servicetalk.transport.api.TransportConfig;
+import io.servicetalk.transport.netty.internal.ChannelInitializer;
+
+import io.netty.channel.AdaptiveRecvByteBufAllocator;
+import io.netty.channel.Channel;
+
+import static java.lang.Math.min;
+
+final class TransportConfigInitializer implements ChannelInitializer {
+
+    private final TransportConfig config;
+
+    TransportConfigInitializer(final TransportConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void init(final Channel channel) {
+        channel.config().setRecvByteBufAllocator(new AdaptiveRecvByteBufAllocator(
+                min(512, config.maxBytesPerRead()), min(32_768, config.maxBytesPerRead()), config.maxBytesPerRead())
+                .respectMaybeMoreData(false)
+                .maxMessagesPerRead(config.maxReadAttemptsPerSelect()));
+    }
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ClientSslConfig.java
@@ -22,6 +22,7 @@ import javax.net.ssl.SSLParameters;
 
 /**
  * Specifies the configuration for client side TLS/SSL.
+ *
  * @see ClientSslConfigBuilder
  */
 public interface ClientSslConfig extends SslConfig {

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSslConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ServerSslConfig.java
@@ -19,6 +19,7 @@ import javax.net.ssl.SSLParameters;
 
 /**
  * Specifies the configuration for server side TLS/SSL.
+ *
  * @see ServerSslConfigBuilder
  */
 public interface ServerSslConfig extends SslConfig {

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportConfig.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+/**
+ * Configuration for transport settings.
+ *
+ * @see TransportConfigBuilder
+ */
+public interface TransportConfig {
+
+    /**
+     * Maximum number of times the transport will attempt to read data when the selector notifies that there is
+     * read data pending.
+     * <p>
+     * The value must be positive. If this value is greater than {@code 1}, the transport might attempt to read multiple
+     * times to procure multiple messages.
+     *
+     * @return Maximum number of times the transport will attempt to read data when the selector notifies that there is
+     * read data pending
+     */
+    int maxReadAttemptsPerSelect();
+
+    /**
+     * Maximum number of bytes per read operation.
+     * <p>
+     * The transport may gradually increase the expected number of readable bytes up to this value if the previous read
+     * fully filled the allocated buffer. It may also gradually decrease the expected number of readable bytes if the
+     * read operation was not able to fill a predicted amount of the allocated bytes some number of times consecutively.
+     * <p>
+     * The value must be positive.
+     *
+     * @return Maximum number of bytes per read operation
+     */
+    int maxBytesPerRead();
+}

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportConfigBuilder.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportConfigBuilder.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
+
+/**
+ * Builder for {@link TransportConfig}.
+ */
+public final class TransportConfigBuilder {
+
+    private static final int DEFAULT_MAX_READ_ATTEMPTS_PER_SELECT = 4;
+    private static final int DEFAULT_MAX_BYTES_PER_READ = 65_536;
+
+    private int maxReadAttemptsPerSelect = DEFAULT_MAX_READ_ATTEMPTS_PER_SELECT;
+    private int maxBytesPerRead = DEFAULT_MAX_BYTES_PER_READ;
+
+    /**
+     * Sets maximum number of times the transport will attempt to read data when the selector notifies that there is
+     * read data pending.
+     * <p>
+     * The value must be positive. If this value is greater than {@code 1}, the transport might attempt to read multiple
+     * times to procure multiple messages.
+     *
+     * @param maxReadAttemptsPerSelect Maximum number of times the transport will attempt to read data when the selector
+     * notifies that there is read data pending
+     * @return {@code this}
+     * @see TransportConfig#maxReadAttemptsPerSelect()
+     */
+    public TransportConfigBuilder maxReadAttemptsPerSelect(final int maxReadAttemptsPerSelect) {
+        this.maxReadAttemptsPerSelect = ensurePositive(maxReadAttemptsPerSelect, "maxReadAttemptsPerSelect");
+        return this;
+    }
+
+    /**
+     * Sets maximum number of bytes per read operation.
+     * <p>
+     * The transport may gradually increase the expected number of readable bytes up to this value if the previous read
+     * fully filled the allocated buffer. It may also gradually decrease the expected number of readable bytes if the
+     * read operation was not able to fill a predicted amount of the allocated bytes some number of times consecutively.
+     * <p>
+     * The value must be positive.
+     *
+     * @param maxBytesPerRead Maximum number of bytes per read operation
+     * @return {@code this}
+     * @see TransportConfig#maxBytesPerRead()
+     */
+    public TransportConfigBuilder maxBytesPerRead(final int maxBytesPerRead) {
+        this.maxBytesPerRead = ensurePositive(maxBytesPerRead, "maxBytesPerRead");
+        return this;
+    }
+
+    /**
+     * Builds a new {@link TransportConfig}.
+     *
+     * @return a new {@link TransportConfig}
+     */
+    public TransportConfig build() {
+        return new DefaultTransportConfig(maxReadAttemptsPerSelect, maxBytesPerRead);
+    }
+
+    private static final class DefaultTransportConfig implements TransportConfig {
+
+        private final int maxReadAttemptsPerSelect;
+        private final int maxBytesPerRead;
+
+        private DefaultTransportConfig(final int maxReadAttemptsPerSelect, final int maxBytesPerRead) {
+            this.maxReadAttemptsPerSelect = maxReadAttemptsPerSelect;
+            this.maxBytesPerRead = maxBytesPerRead;
+        }
+
+        @Override
+        public int maxReadAttemptsPerSelect() {
+            return maxReadAttemptsPerSelect;
+        }
+
+        @Override
+        public int maxBytesPerRead() {
+            return maxBytesPerRead;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final DefaultTransportConfig that = (DefaultTransportConfig) o;
+            return maxReadAttemptsPerSelect == that.maxReadAttemptsPerSelect && maxBytesPerRead == that.maxBytesPerRead;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = maxReadAttemptsPerSelect;
+            result = 31 * result + maxBytesPerRead;
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() +
+                    "{maxReadAttemptsPerSelect=" + maxReadAttemptsPerSelect +
+                    ", maxBytesPerRead=" + maxBytesPerRead +
+                    '}';
+        }
+    }
+}

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ChannelInitializer.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.transport.netty.internal;
 
-import io.netty.channel.AdaptiveRecvByteBufAllocator;
 import io.netty.channel.Channel;
 
 /**
@@ -53,9 +52,6 @@ public interface ChannelInitializer {
      * @return Default initializer for ServiceTalk.
      */
     static ChannelInitializer defaultInitializer() {
-        return channel -> channel.config().setRecvByteBufAllocator(
-                new AdaptiveRecvByteBufAllocator(512, 32_768, 65_536)
-                        .respectMaybeMoreData(false)
-                        .maxMessagesPerRead(4));
+        return channel -> { /* noop */ };
     }
 }


### PR DESCRIPTION
Motivation:

Users need a way to change low-level Netty settings, like `AdaptiveRecvByteBufAllocator` parameters. In the future, we can use this interface for more similar settings without the need to change client/server builder.

Modifications:

- Add `TransportConfig` and `TransportConfigBuilder` in `transport-api` module;
- Add methods on `SingleAddressHttpClientBuilder` and `HttpServerBuilder` to let users pass `TransportConfig`;
- Wire it up to propagate to `Tcp[Client|Server]ChannelInitializer` as `TransportConfigInitializer`;

Result:

Users can control `AdaptiveRecvByteBufAllocator` settings.