### PR TITLE
http-utils: cleanup the BeforeFinallyHttpOperator state

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -147,6 +147,13 @@ public final class BeforeFinallyHttpOperator implements SingleOperator<Streaming
         public void onSubscribe(final Cancellable cancellable) {
             subscriber.onSubscribe(() -> {
                 try {
+                    // TODO: We may also need to complete the `beforeFinally()` if we're in the PROCESSING state.
+                    //  and also audit something else?
+                    //  Investigate if rdar://105295860 (BeforeFinallyHttpOperator: callbacks will be invoked more
+                    //  than once if users re-subscribe to response payload body) could be another source of
+                    //  misaligned limiter counters. Note that it does not affect iCloud because we guarantee we
+                    //  never re-subscribe inside http-client-servicetalk, but could be an issue for other users
+                    //  of ServiceTalk.
                     if (stateUpdater.compareAndSet(this, IDLE, TERMINATED)) {
                         beforeFinally.cancel();
                     }

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -155,7 +155,7 @@ public final class BeforeFinallyHttpOperator implements SingleOperator<Streaming
             subscriber.onSubscribe(() -> {
                 try {
                     final int previous = stateUpdater.getAndSet(this, RESPONSE_COMPLETE);
-                    if ((previous == IDLE || previous == PROCESSING_PAYLOAD)) {
+                    if (previous == IDLE || previous == PROCESSING_PAYLOAD) {
                         beforeFinally.cancel();
                     }
                 } finally {

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -366,6 +366,7 @@ public final class BeforeFinallyHttpOperator implements SingleOperator<Streaming
             }
         }
 
+        @Override
         public void onError(final Throwable t) {
             if (!discardEventsAfterCancel) {
                 try {

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/BeforeFinallyHttpOperatorTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/BeforeFinallyHttpOperatorTest.java
@@ -564,14 +564,8 @@ class BeforeFinallyHttpOperatorTest {
         assertThat("Payload was not cancelled", payloadSubscription.isCancelled(), is(true));
 
         assertThat("Unexpected payload body items", receivedPayload, contains(EMPTY_BUFFER));
-        if (!fromOnNext) {
-            // We are discarding events after cancel, so if we cancel from onNext we won't be fed the terminal events.
-            assertThat("Unexpected payload body termination", subscriberTerminal.get(),
-                    equalTo(payloadTerminal));
-        }
-        if (fromOnNext) {
-            verify(beforeFinally).cancel();
-        } else if (payloadTerminal.cause() == null) {
+        assertThat("Unexpected payload body termination", subscriberTerminal.get(), equalTo(payloadTerminal));
+        if (payloadTerminal.cause() == null) {
             verify(beforeFinally).onComplete();
         } else {
             verify(beforeFinally).onError(payloadTerminal.cause());

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/BeforeFinallyHttpOperatorTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/BeforeFinallyHttpOperatorTest.java
@@ -315,8 +315,10 @@ class BeforeFinallyHttpOperatorTest {
             payload.onError(payloadTerminal.cause());
         }
         if (discardEventsAfterCancel) {
-            // TODO: these are failing because cancellation happened before subscribing to the message body and now
-            //  we're skipping events.
+            // TODO: this branch is failing because cancellation happened before we subscribed to the payload body
+            //  so we didn't wrap it with anything. What should happen? If we don't do anything then we break
+            //  the RS pattern because the request payload stream wasn't cancelled, so if we must send something
+            //  or it is a hung stream.
             assertThat("Unexpected payload body items", payloadSubscriber.pollAllOnNext(), empty());
             assertThat("Payload body terminated unexpectedly",
                     payloadSubscriber.pollTerminal(100, MILLISECONDS), is(nullValue()));

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/BeforeFinallyHttpOperatorTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/BeforeFinallyHttpOperatorTest.java
@@ -77,7 +77,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;


### PR DESCRIPTION
Motivation:

The BeforeFinallyHttpOperator has a few shortcomings
- It doesn't honor the contract of calling the callbacks only once in the case of multiple subscribes.
- It won't honor a cancel if in the `PROCESSING_PAYLOAD` state, which has some weird callback lifetime questions.

Modifications:

- If we receive a cancellation on the Single<StreamingHttpResponse> before the message body has been subscribed, that counts as a cancel. Once the message body is subscribed ownership of the callbacks are fully transferred to it.
- Only the first body subscribe gets ownership of the callbacks.