### PR TITLE
Subscribable sources: try-catch `onSubscribe` and cleanup state if any

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -149,7 +149,13 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
                     deliverErrorFromSource(subscriber, cause);
                     return;
                 }
-                subscriber.onSubscribe(delayedCancellable);
+                try {
+                    subscriber.onSubscribe(delayedCancellable);
+                } catch (Throwable cause) {
+                    close(channel, cause);
+                    handleExceptionFromOnSubscribe(subscriber, cause);
+                    return;
+                }
                 // We have to add to the pipeline AFTER we call onSubscribe, because adding to the pipeline may invoke
                 // callbacks that interact with the subscriber.
                 pipeline.addLast(parentChannelInitializer);


### PR DESCRIPTION
Motivation:

All original sources that implement `handleSubscribe` method should protect from a buggy `Subscriber` that may unexpectedly throw from `onSubscribe`. If they have any state or resource, it should be cleaned up.

Modifications:
- Find all `Publisher`/`Single`/`Completable` that implement `handleSubscribe` and use `handleExceptionFromOnSubscribe` utility;

The following sources clean up their state on exception:
- `FromInputStreamPublisher` closes `InputStream`;
- `SpliceFlatStreamToMetaSingle` cancels upstream `Subscription`;
- `TcpConnector` signals `ConnectionObserver.connectionClosed(t)`;
- `TcpServerBinder` cancels bind `Future` and closes `Channel` if necessary;
- `NettyChannelPublisher` registers `fatalError` and closes `Channel`;
- `DefaultNettyConnection`, `ChannelInitSingle`, `H2ClientParentConnectionContext`, `H2ServerParentConnectionContext` close `Channel`;

Results:

1. Best effort to propagate exception via reactive flow.
2. Cleaning up resources.