### PR TITLE
`ConnectablePayloadWriter`: avoid static exception that may leak memory

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TerminalNotification.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/TerminalNotification.java
@@ -60,6 +60,7 @@ public final class TerminalNotification {
         if (this == COMPLETE) {
             subscriber.onComplete();
         } else {
+            assert cause != null;
             subscriber.onError(cause);
         }
     }


### PR DESCRIPTION
Motivation:

`ConnectablePayloadWriter` uses a static `IOException` instance as a state and can propagate it to `Subscriber`. This opens a possibility for a memory leak if `Subscriber` or intermediate operators attach a suppressed exception to this static instance.

Modifications:
- Create `StacklessCancelledIOException` and always use a new instance in case of cancellation;
- Keep `cancel()` noop if `outer.closed != null`;

Result:

`ConnectablePayloadWriter` can not leak memory via static exception instance.