### PR TITLE
Allow to configure the maxChunkSize for H1 chunk decoding

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
@@ -88,7 +88,7 @@ public class HttpResponseDecoderBenchmark {
 
         channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(), new PollLikePeakArrayDeque<>(),
                 getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192,
-                false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+                false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, 8192));
     }
 
     @Benchmark

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfig.java
@@ -55,6 +55,18 @@ public interface H1ProtocolConfig extends HttpProtocolConfig {
     int maxStartLineLength();
 
     /**
+     * Maximum allowed length of an HTTP <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-4.1">chunk</a>
+     * for an HTTP message.
+     * <p>
+     * If the chunk received is larger than the {@code maxChunkSize} configured, it will be split up into multiple
+     * smaller chunk so that they fit inside the configured boundaries.
+     *
+     * @return the maximum allowed length of an HTTP
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-4.1">chunk</a> for an HTTP message.
+     */
+    int maxChunkSize();
+
+    /**
      * Maximum length of the HTTP <a href="https://tools.ietf.org/html/rfc7230#section-3.2">header fields</a> and
      * <a href="https://tools.ietf.org/html/rfc7230#section-4.1.2trailers">trailer fields</a> to parse.
      * <p>

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
@@ -35,6 +35,7 @@ public final class H1ProtocolConfigBuilder {
     private int maxPipelinedRequests = 1;
     private int maxStartLineLength = 4096;
     private int maxHeaderFieldLength = 8192;
+    private int maxChunkSize = 8192;
     private HttpHeadersFactory headersFactory = DefaultHttpHeadersFactory.INSTANCE;
     private int headersEncodedSizeEstimate = 256;
     private int trailersEncodedSizeEstimate = 256;
@@ -106,6 +107,18 @@ public final class H1ProtocolConfigBuilder {
     }
 
     /**
+     * Sets the maximum allowed length of an HTTP
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-4.1">chunk</a> for an HTTP message.
+     *
+     * @param maxChunkSize maximum size in bytes per chunk.
+     * @return {@code this}
+     */
+    public H1ProtocolConfigBuilder maxChunkSize(final int maxChunkSize) {
+        this.maxChunkSize = ensurePositive(maxChunkSize, "maxChunkSize");
+        return this;
+    }
+
+    /**
      * Sets the value used to calculate an exponential moving average of the encoded size of the HTTP
      * <a href="https://tools.ietf.org/html/rfc7230#section-3.1">start line</a> and
      * <a href="https://tools.ietf.org/html/rfc7230#section-3.2">header fields</a> for a guess for future buffer
@@ -153,7 +166,8 @@ public final class H1ProtocolConfigBuilder {
      */
     public H1ProtocolConfig build() {
         return new DefaultH1ProtocolConfig(headersFactory, maxPipelinedRequests, maxStartLineLength,
-                maxHeaderFieldLength, headersEncodedSizeEstimate, trailersEncodedSizeEstimate, specExceptions);
+                maxHeaderFieldLength, headersEncodedSizeEstimate, trailersEncodedSizeEstimate, specExceptions,
+                maxChunkSize);
     }
 
     private static final class DefaultH1ProtocolConfig implements H1ProtocolConfig {
@@ -162,6 +176,7 @@ public final class H1ProtocolConfigBuilder {
         private final int maxPipelinedRequests;
         private final int maxStartLineLength;
         private final int maxHeaderFieldLength;
+        private final int maxChunkSize;
         private final int headersEncodedSizeEstimate;
         private final int trailersEncodedSizeEstimate;
         private final H1SpecExceptions specExceptions;
@@ -169,7 +184,7 @@ public final class H1ProtocolConfigBuilder {
         DefaultH1ProtocolConfig(final HttpHeadersFactory headersFactory, final int maxPipelinedRequests,
                                 final int maxStartLineLength, final int maxHeaderFieldLength,
                                 final int headersEncodedSizeEstimate, final int trailersEncodedSizeEstimate,
-                                final H1SpecExceptions specExceptions) {
+                                final H1SpecExceptions specExceptions, final int maxChunkSize) {
             this.headersFactory = headersFactory;
             this.maxPipelinedRequests = maxPipelinedRequests;
             this.maxStartLineLength = maxStartLineLength;
@@ -177,6 +192,7 @@ public final class H1ProtocolConfigBuilder {
             this.headersEncodedSizeEstimate = headersEncodedSizeEstimate;
             this.trailersEncodedSizeEstimate = trailersEncodedSizeEstimate;
             this.specExceptions = specExceptions;
+            this.maxChunkSize = maxChunkSize;
         }
 
         @Override
@@ -197,6 +213,11 @@ public final class H1ProtocolConfigBuilder {
         @Override
         public int maxHeaderFieldLength() {
             return maxHeaderFieldLength;
+        }
+
+        @Override
+        public int maxChunkSize() {
+            return maxChunkSize;
         }
 
         @Override
@@ -222,6 +243,7 @@ public final class H1ProtocolConfigBuilder {
                     ", maxPipelinedRequests=" + maxPipelinedRequests +
                     ", maxStartLineLength=" + maxStartLineLength +
                     ", maxHeaderFieldLength=" + maxHeaderFieldLength +
+                    ", maxChunkSize=" + maxChunkSize +
                     ", headersEncodedSizeEstimate=" + headersEncodedSizeEstimate +
                     ", trailersEncodedSizeEstimate=" + trailersEncodedSizeEstimate +
                     ", specExceptions=" + specExceptions +

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
@@ -58,7 +58,7 @@ final class HttpClientChannelInitializer implements ChannelInitializer {
             pipeline.addLast(new HttpResponseDecoder(methodQueue, signalsQueue, alloc, config.headersFactory(),
                     config.maxStartLineLength(), config.maxHeaderFieldLength(),
                     config.specExceptions().allowPrematureClosureBeforePayloadBody(),
-                    config.specExceptions().allowLFWithoutCR(), closeHandler));
+                    config.specExceptions().allowLFWithoutCR(), closeHandler, config.maxChunkSize()));
             pipeline.addLast(new HttpRequestEncoder(methodQueue, signalsQueue,
                     config.headersEncodedSizeEstimate(), config.trailersEncodedSizeEstimate(), closeHandler));
         });

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
@@ -56,9 +56,9 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> im
     HttpRequestDecoder(final Queue<HttpRequestMethod> methodQueue, final ByteBufAllocator alloc,
                        final HttpHeadersFactory headersFactory, final int maxStartLineLength,
                        final int maxHeaderFieldLength, final boolean allowPrematureClosureBeforePayloadBody,
-                       final boolean allowLFWithoutCR, final CloseHandler closeHandler) {
+                       final boolean allowLFWithoutCR, final CloseHandler closeHandler, final int maxChunkSize) {
         super(alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength, allowPrematureClosureBeforePayloadBody,
-                allowLFWithoutCR, closeHandler);
+                allowLFWithoutCR, closeHandler, maxChunkSize);
         this.methodQueue = requireNonNull(methodQueue);
         this.closeHandler = closeHandler;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
@@ -49,6 +49,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATION
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
 import static io.servicetalk.http.netty.HttpResponseDecoder.Signal.REQUEST_SIGNAL;
 import static io.servicetalk.http.netty.HttpResponseDecoder.Signal.REQUEST_WITH_EXPECT_CONTINUE_SIGNAL;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
@@ -77,9 +78,9 @@ final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> 
                         final ByteBufAllocator alloc,
                         final HttpHeadersFactory headersFactory, final int maxStartLineLength, int maxHeaderFieldLength,
                         final boolean allowPrematureClosureBeforePayloadBody, final boolean allowLFWithoutCR,
-                        final CloseHandler closeHandler) {
+                        final CloseHandler closeHandler, final int maxChunkSize) {
         super(alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength, allowPrematureClosureBeforePayloadBody,
-                allowLFWithoutCR, closeHandler);
+                allowLFWithoutCR, closeHandler, maxChunkSize);
         this.methodQueue = requireNonNull(methodQueue);
         this.signalsQueue = requireNonNull(signalsQueue);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
@@ -49,7 +49,6 @@ import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATION
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
 import static io.servicetalk.http.netty.HttpResponseDecoder.Signal.REQUEST_SIGNAL;
 import static io.servicetalk.http.netty.HttpResponseDecoder.Signal.REQUEST_WITH_EXPECT_CONTINUE_SIGNAL;
-import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -192,7 +192,7 @@ final class NettyHttpServer {
             final HttpRequestDecoder decoder = new HttpRequestDecoder(methodQueue, alloc, config.headersFactory(),
                     config.maxStartLineLength(), config.maxHeaderFieldLength(),
                     config.specExceptions().allowPrematureClosureBeforePayloadBody(),
-                    config.specExceptions().allowLFWithoutCR(), closeHandler);
+                    config.specExceptions().allowLFWithoutCR(), closeHandler, config.maxChunkSize());
             pipeline.addLast(decoder);
             pipeline.addLast(new HttpResponseEncoder(methodQueue, config.headersEncodedSizeEstimate(),
                     config.trailersEncodedSizeEstimate(), closeHandler, decoder));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -37,7 +37,6 @@ import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.api.HttpRequestMethod.Properties.NONE;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
-import static java.lang.Integer.max;
 import static java.lang.Integer.toHexString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -37,6 +37,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.api.HttpRequestMethod.Properties.NONE;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
+import static java.lang.Integer.max;
 import static java.lang.Integer.toHexString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -49,18 +50,23 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class HttpRequestDecoderTest extends HttpObjectDecoderTest {
 
-    private final EmbeddedChannel channel = newChannel(false);
-    private final EmbeddedChannel channelSpecException = newChannel(true);
+    private final EmbeddedChannel channel = newChannel(false, 8192);
+    private final EmbeddedChannel channelSpecException = newChannel(true, 8192);
 
-    private static EmbeddedChannel newChannel(boolean allowLFWithoutCR) {
+    private static EmbeddedChannel newChannel(boolean allowLFWithoutCR, final int maxChunkSize) {
         return new EmbeddedChannel(new HttpRequestDecoder(new ArrayDeque<>(), getByteBufAllocator(DEFAULT_ALLOCATOR),
                 DefaultHttpHeadersFactory.INSTANCE, 8192, 8192, false, allowLFWithoutCR,
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER, maxChunkSize));
     }
 
     @Override
     EmbeddedChannel channel() {
         return channel;
+    }
+
+    @Override
+    EmbeddedChannel channel(final boolean crlf, final int maxChunkSize) {
+        return newChannel(!crlf, maxChunkSize);
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -64,7 +64,6 @@ import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.netty.HttpResponseDecoder.Signal.REQUEST_SIGNAL;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
-import static java.lang.Integer.max;
 import static java.lang.Integer.toHexString;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
Before this change it was not possible to configure a maxChunkSize when decoding a HTTP chunked encoding payload. With this change, it defaults to ~8k which is also the default in netty, and aligns its implementation with the netty decoder on how the maxChunkSize is applied.

Tests have been added on both request and response decoding to make sure that even if the maxChunkSize is smaller than the arriving chunk, the code will continue to work. It is expected that there is no user impact, since it will just keep on decoding small chunks until the full payload has been read.