### PR TITLE
HttpRequestMetaData#hasQueryParameter(String) implementaiton fix

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequestMetaData.java
@@ -307,6 +307,11 @@ class DefaultHttpRequestMetaData extends AbstractHttpMetaData implements HttpReq
     }
 
     @Override
+    public boolean hasQueryParameter(final String key) {
+        return lazyParseQueryString().contains(key);
+    }
+
+    @Override
     public boolean hasQueryParameter(final String key, final String value) {
         return lazyParseQueryString().contains(key, value);
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpQuery.java
@@ -141,6 +141,10 @@ final class HttpQuery implements Iterable<Map.Entry<String, String>> {
         return this;
     }
 
+    boolean contains(final String key) {
+        return params.get(key) != null;
+    }
+
     public boolean contains(final String key, final String value) {
         final Iterator<String> values = valuesIterator(key);
         while (values.hasNext()) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
@@ -286,6 +286,8 @@ public interface HttpRequestMetaData extends HttpMetaData {
      * @return {@code true} if {@code key} exists.
      */
     default boolean hasQueryParameter(final String key) {
+        // FIXME: 0.43 - remove default, force implementations to implement.
+        //  null value support was added and this method is now incorrect as default
         return queryParameter(key) != null;
     }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/AbstractHttpRequestMetaDataTest.java
@@ -656,7 +656,9 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals("/foo?bar", fixture.requestTarget());
         assertEquals("bar", fixture.rawQuery());
         assertNull(fixture.queryParameter("bar"));
+        assertTrue(fixture.hasQueryParameter("bar"));
         assertNull(fixture.queryParameter("nothing"));
+        assertFalse(fixture.hasQueryParameter("nothing"));
 
         assertEquals(singletonList("bar"), iteratorAsList(fixture.queryParametersKeys().iterator()));
         Iterator<Entry<String, String>> itr = fixture.queryParameters().iterator();
@@ -682,8 +684,11 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals(requestTarget, fixture.requestTarget());
         assertEquals(rawQuery, fixture.rawQuery());
         assertEquals(v1, fixture.queryParameter("bar"));
+        assertTrue(fixture.hasQueryParameter("bar"));
         assertEquals(v2, fixture.queryParameter("baz"));
+        assertTrue(fixture.hasQueryParameter("baz"));
         assertNull(fixture.queryParameter("nothing"));
+        assertFalse(fixture.hasQueryParameter("nothing"));
 
         assertEquals(asList("bar", "baz"), iteratorAsList(fixture.queryParametersKeys().iterator()));
         Iterator<Entry<String, String>> itr = fixture.queryParameters().iterator();
@@ -716,9 +721,13 @@ public abstract class AbstractHttpRequestMetaDataTest<T extends HttpRequestMetaD
         assertEquals(requestTarget, fixture.requestTarget());
         assertEquals(rawQuery, fixture.rawQuery());
         assertEquals(v1, fixture.queryParameter("bar"));
+        assertTrue(fixture.hasQueryParameter("bar"));
         assertEquals(v2, fixture.queryParameter("baz"));
+        assertTrue(fixture.hasQueryParameter("baz"));
         assertEquals(v3, fixture.queryParameter("zap"));
+        assertTrue(fixture.hasQueryParameter("zap"));
         assertNull(fixture.queryParameter("nothing"));
+        assertFalse(fixture.hasQueryParameter("nothing"));
 
         assertEquals(asList("bar", "baz", "zap"), iteratorAsList(fixture.queryParametersKeys().iterator()));
         Iterator<Entry<String, String>> itr = fixture.queryParameters().iterator();


### PR DESCRIPTION
Motivation:
HttpRequestMetaData#hasQueryParameter(String) returns false when there is a query parameter with no value. This is incorrect and it should return true.