### PR TITLE
HttpRequestMetaData#hasQueryParameter(String) default implementation fix

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequestMetaData.java
@@ -287,8 +287,7 @@ public interface HttpRequestMetaData extends HttpMetaData {
      */
     default boolean hasQueryParameter(final String key) {
         // FIXME: 0.43 - remove default, force implementations to implement.
-        //  null value support was added and this method is now incorrect as default
-        return queryParameter(key) != null;
+        return queryParametersKeys().contains(key);
     }
 
     /**


### PR DESCRIPTION
Motivation:
Null key support was added for query parameters but the default method implementation was not updated, and so it returns incorrect results if a key has a null value.

Modifications:
- Use queryParametersKeys() to determine if key is present.