### PR TITLE
loadbalancer-experimental: Add support for randomly subsetting hosts

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -36,7 +36,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         implements LoadBalancerBuilder<ResolvedAddress, C> {
 
     private final String id;
-    private int subsetSize = Integer.MAX_VALUE;
+    private int randomSubsetSize = Integer.MAX_VALUE;
     private LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy = defaultLoadBalancingPolicy();
 
     @Nullable
@@ -59,8 +59,8 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     }
 
     @Override
-    public LoadBalancerBuilder<ResolvedAddress, C> subsetSize(int subsetSize) {
-        this.subsetSize = ensurePositive(subsetSize, "subsetSize");
+    public LoadBalancerBuilder<ResolvedAddress, C> randomSubsetSize(int randomSubsetSize) {
+        this.randomSubsetSize = ensurePositive(randomSubsetSize, "randomSubsetSize");
         return this;
     }
 
@@ -93,7 +93,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     @Override
     public LoadBalancerFactory<ResolvedAddress, C> build() {
-        return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, subsetSize, loadBalancerObserverFactory,
+        return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, randomSubsetSize, loadBalancerObserverFactory,
                 connectionPoolStrategyFactory, outlierDetectorConfig, getExecutor());
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -29,12 +29,14 @@ import java.util.Collection;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 
 final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection>
         implements LoadBalancerBuilder<ResolvedAddress, C> {
 
     private final String id;
+    private int subsetSize = Integer.MAX_VALUE;
     private LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy = defaultLoadBalancingPolicy();
 
     @Nullable
@@ -53,6 +55,12 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     public LoadBalancerBuilder<ResolvedAddress, C> loadBalancingPolicy(
             LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy) {
         this.loadBalancingPolicy = requireNonNull(loadBalancingPolicy, "loadBalancingPolicy");
+        return this;
+    }
+
+    @Override
+    public LoadBalancerBuilder<ResolvedAddress, C> subsetSize(int subsetSize) {
+        this.subsetSize = ensurePositive(subsetSize, "subsetSize");
         return this;
     }
 
@@ -85,7 +93,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     @Override
     public LoadBalancerFactory<ResolvedAddress, C> build() {
-        return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, loadBalancerObserverFactory,
+        return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, subsetSize, loadBalancerObserverFactory,
                 connectionPoolStrategyFactory, outlierDetectorConfig, getExecutor());
     }
 
@@ -94,6 +102,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
         private final String id;
         private final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy;
+        private final int subsetSize;
         @Nullable
         private final LoadBalancerObserverFactory loadBalancerObserverFactory;
         private final ConnectionPoolStrategyFactory<C> connectionPoolStrategyFactory;
@@ -101,12 +110,14 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         private final Executor executor;
 
         DefaultLoadBalancerFactory(final String id, final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy,
+                                   final int subsetSize,
                                    @Nullable final LoadBalancerObserverFactory loadBalancerObserverFactory,
                                    final ConnectionPoolStrategyFactory<C> connectionPoolStrategyFactory,
                                    final OutlierDetectorConfig outlierDetectorConfig,
                                    final Executor executor) {
             this.id = requireNonNull(id, "id");
             this.loadBalancingPolicy = requireNonNull(loadBalancingPolicy, "loadBalancingPolicy");
+            this.subsetSize = ensurePositive(subsetSize, "subsetSize");
             this.loadBalancerObserverFactory = loadBalancerObserverFactory;
             this.outlierDetectorConfig = requireNonNull(outlierDetectorConfig, "outlierDetectorConfig");
             this.connectionPoolStrategyFactory = requireNonNull(
@@ -156,7 +167,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
                     new XdsOutlierDetector<>(executor, outlierDetectorConfig, lbDescription);
             }
             return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
-                    DefaultHostPriorityStrategy::new, loadBalancingPolicy,
+                    DefaultHostPriorityStrategy::new, loadBalancingPolicy, subsetSize,
                     connectionPoolStrategyFactory, connectionFactory,
                     loadBalancerObserverFactory, healthCheckConfig, outlierDetectorFactory);
         }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -60,8 +60,8 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
     }
 
     @Override
-    public LoadBalancerBuilder<ResolvedAddress, C> subsetSize(int subsetSize) {
-        delegate = delegate.subsetSize(subsetSize);
+    public LoadBalancerBuilder<ResolvedAddress, C> randomSubsetSize(int randomSubsetSize) {
+        delegate = delegate.randomSubsetSize(randomSubsetSize);
         return this;
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -60,6 +60,12 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
     }
 
     @Override
+    public LoadBalancerBuilder<ResolvedAddress, C> subsetSize(int subsetSize) {
+        delegate = delegate.subsetSize(subsetSize);
+        return this;
+    }
+
+    @Override
     public LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(
             @Nullable LoadBalancerObserverFactory loadBalancerObserverFactory) {
         delegate = delegate.loadBalancerObserver(loadBalancerObserverFactory);

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -71,13 +71,14 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
             LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy);
 
     /**
-     * Set the host subset size for the load balancer.
+     * Set the random host subset size for the load balancer.
      * This is valuable for limiting the number of outgoing connections when calling services that have
-     * a very high replica count.
-     * @param subsetSize the maximum number of healthy hosts to establish connections to
+     * a very high replica count. It does so by selecting the specified number of hosts randomly from the total host
+     * set and routing traffic only to these hosts.
+     * @param randomSubsetSize the maximum number of healthy hosts to establish connections to
      * @return {@code this}
      */
-    LoadBalancerBuilder<ResolvedAddress, C> subsetSize(int subsetSize);
+    LoadBalancerBuilder<ResolvedAddress, C> randomSubsetSize(int randomSubsetSize);
 
     /**
      * Set the {@link LoadBalancerObserverFactory} to use with this load balancer.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -71,6 +71,15 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
             LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy);
 
     /**
+     * Set the host subset size for the load balancer.
+     * This is valuable for limiting the number of outgoing connections when calling services that have
+     * a very high replica count.
+     * @param subsetSize the maximum number of healthy hosts to establish connections to
+     * @return {@code this}
+     */
+    LoadBalancerBuilder<ResolvedAddress, C> subsetSize(int subsetSize);
+
+    /**
      * Set the {@link LoadBalancerObserverFactory} to use with this load balancer.
      * @param loadBalancerObserverFactory the {@link LoadBalancerObserverFactory} to use, or {@code null} to not use an
      *                                    observer.

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -33,19 +33,24 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
     @Override
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> loadBalancingPolicy(
             LoadBalancingPolicy<String, TestLoadBalancedConnection> loadBalancingPolicy) {
-        throw new IllegalStateException("Cannot set new policy for old round robin");
+        throw new UnsupportedOperationException("Cannot set new policy for old round robin");
+    }
+
+    @Override
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> subsetSize(int subsetSize) {
+        throw new UnsupportedOperationException("Cannot set subset size for old round robin");
     }
 
     @Override
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> loadBalancerObserver(
             @Nullable LoadBalancerObserverFactory loadBalancerObserverFactory) {
-        throw new IllegalStateException("Cannot set a load balancer observer for old round robin");
+        throw new UnsupportedOperationException("Cannot set a load balancer observer for old round robin");
     }
 
     @Override
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> connectionPoolConfig(
             ConnectionPoolConfig connectionPoolConfig) {
-        throw new IllegalStateException("Cannot set a connection pool strategy for old round robin");
+        throw new UnsupportedOperationException("Cannot set a connection pool strategy for old round robin");
     }
 
     @Override

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -37,7 +37,7 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
     }
 
     @Override
-    public LoadBalancerBuilder<String, TestLoadBalancedConnection> subsetSize(int subsetSize) {
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> randomSubsetSize(int randomSubsetSize) {
         throw new UnsupportedOperationException("Cannot set subset size for old round robin");
     }
 


### PR DESCRIPTION
Motivation:
When a client is talking to a very large cluster we may want to limit the number of hosts it talks to in order to reduce connection load.

Modifications:
Introduce the notion of random subsetting. The algorithm works by giving endpoints a random number, ordering the endpoint set by that number, and finally taking the first `subsetSize` health instances.