### PR TITLE
ci-netty-snapshot.yml: add Regenerate Lock Files step

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -30,6 +30,8 @@ jobs:
         run: java -version
       - name: Make gradlew Executable
         run: chmod +x gradlew
+      - name: Regenerate Lock Files
+        run: ./gradlew resolveAndLockAll --write-locks
       - name: Print Netty Version
         run: ./gradlew :servicetalk-grpc-netty:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-codec-http2 | head -n 50
       - name: Clean Gradle project


### PR DESCRIPTION
Motivation:

After we added lock files, Netty Snapshot pipeline started to fail because Netty version does not match the one in the lock file anymore.

Modifications:

- Add a step to Regenerate Lock Files;

Result:

Netty Snapshot pipeline should start working again.