### PR TITLE
loadbalancer-experimental: make DefaultLoadBalancer the default RR implementation

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
@@ -55,7 +55,7 @@ public final class RoundRobinToDefaultLBMigrationProvider implements RoundRobinL
     private static boolean isEnabled() {
         // Enabled by default.
         String propValue = System.getProperty(PROPERTY_NAME);
-        return propValue == null ? true : Boolean.parseBoolean(propValue);
+        return propValue == null || Boolean.parseBoolean(propValue);
     }
 
     private static final class DefaultLoadBalancerRoundRobinBuilder<ResolvedAddress, C extends LoadBalancedConnection>

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
@@ -53,7 +53,9 @@ public final class RoundRobinToDefaultLBMigrationProvider implements RoundRobinL
     }
 
     private static boolean isEnabled() {
-        return Boolean.getBoolean(PROPERTY_NAME);
+        // Enabled by default.
+        String propValue = System.getProperty(PROPERTY_NAME);
+        return propValue == null ? true : Boolean.parseBoolean(propValue);
     }
 
     private static final class DefaultLoadBalancerRoundRobinBuilder<ResolvedAddress, C extends LoadBalancedConnection>

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProviderTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProviderTest.java
@@ -61,7 +61,7 @@ final class RoundRobinToDefaultLBMigrationProviderTest {
                 new RoundRobinLoadBalancerFactory.Builder<>();
         RoundRobinLoadBalancerBuilder<String, TestLoadBalancedConnection> result = provider.newBuilder(
                 "builder", builder);
-        assertThat(result, sameInstance(builder));
+        assertThat(result.build(), instanceOf(DefaultLoadBalancerBuilder.DefaultLoadBalancerFactory.class));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

It's been out a while now and DefaultLoadBalancer can exactly behave as the old RoundRobinLoadBalancer. That means we can insert it in place of RoundRobinLoadBalancer.

Modifications:

Default to building a DefaultLoadBalancer in round-robin compatibility mode via the RoundRobinToDefaultLBMigrationProvider. We retain the flag for safety for a few releases but will eventually remove it and RoundRobinLoadBalancer.