### PR TITLE
http-netty: Fix flaky FullDuplexAndSequentialModeTest

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -117,7 +117,7 @@ abstract class AbstractNettyHttpServerTest {
     private static IoExecutor clientIoExecutor;
     private static IoExecutor serverIoExecutor;
 
-    private Executor clientExecutor;
+    Executor clientExecutor;
     private Executor serverExecutor;
     private ExecutorSupplier clientExecutorSupplier;
     private ExecutorSupplier serverExecutorSupplier;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FullDuplexAndSequentialModeTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FullDuplexAndSequentialModeTest.java
@@ -90,10 +90,11 @@ class FullDuplexAndSequentialModeTest extends AbstractNettyHttpServerTest {
         return new BufferedInputStream(new ByteArrayInputStream(array));
     }
 
-    private static Future<StreamingHttpResponse> stallingSendRequest(StreamingHttpConnection connection,
+    private Future<StreamingHttpResponse> stallingSendRequest(StreamingHttpConnection connection,
                                                                      CountDownLatch continueRequest,
                                                                      InputStream payload) {
-        return connection.request(connection.post(SVC_ECHO).payloadBody(fromInputStream(payload, CHUNK_SIZE)
+        return connection.request(connection.post(SVC_ECHO).payloadBody(fromInputStream(payload, 1)
+                        .publishOn(clientExecutor)
                 .map(chunk -> {
                     try {
                         continueRequest.await();    // wait until the InputStream is closed


### PR DESCRIPTION
Motivation:

This test suite has been flaky for a while. As detailed in issue #1894, this is because under some conditions the test running thread ends up waiting on a latch that it is actually responsible to release.

Modifications:

Make sure the publishing of the InputStreamPublisher happens in on a different thread so we don't end up in deadlock.

Fixes #1894