### PR TITLE
Use invoke for `SslContextBuilder#endpointIdentificationAlgorithm(String)`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslContextFactory.java
@@ -85,7 +85,7 @@ public final class SslContextFactory {
 
         MethodHandle endpointIdentificationAlgorithm;
         try {
-            // Find a new method that exists only in Netty starting from 4.2.0.Final:
+            // Find a new method that exists only in Netty starting from 4.1.112.Final:
             endpointIdentificationAlgorithm = MethodHandles.publicLookup().findVirtual(SslContextBuilder.class,
                     "endpointIdentificationAlgorithm", methodType(SslContextBuilder.class, String.class));
             // Verify the method is working as expected:
@@ -93,7 +93,7 @@ public final class SslContextFactory {
                     SslContextBuilder.forClient(), "HTTPS");
         } catch (Throwable cause) {
             LOGGER.debug("SslContextBuilder#endpointIdentificationAlgorithm(String) is available only " +
-                            "starting from Netty 4.2.0.Final. Detected Netty version: {}",
+                            "starting from Netty 4.1.112.Final. Detected Netty version: {}",
                     SslContextBuilder.class.getPackage().getImplementationVersion(), cause);
             endpointIdentificationAlgorithm = null;
         }
@@ -115,18 +115,16 @@ public final class SslContextFactory {
         }
     }
 
-    private static SslContextBuilder setEndpointIdentificationAlgorithm(@Nullable final MethodHandle methodHandle,
-                                                                        final SslContextBuilder builderInstance,
-                                                                        @Nullable final String algorithm) {
+    private static void setEndpointIdentificationAlgorithm(@Nullable final MethodHandle methodHandle,
+                                                           final SslContextBuilder builderInstance,
+                                                           @Nullable final String algorithm) {
         if (methodHandle == null) {
-            return builderInstance;
+            return;
         }
         try {
-            // invokeExact requires return type cast to match the type signature
-            return (SslContextBuilder) methodHandle.invokeExact(builderInstance, algorithm == null ? "" : algorithm);
+            methodHandle.invoke(builderInstance, algorithm == null ? "" : algorithm);
         } catch (Throwable t) {
             throwException(t);
-            return builderInstance;
         }
     }
 


### PR DESCRIPTION
Motivation:

Users reported that they can see:
```
io.servicetalk.transport.netty.internal.SslContextFactory - SslContextBuilder#endpointIdentificationAlgorithm(String) is available only starting from Netty 4.2.0.Final. Detected Netty version: 4.1.113.Final
java.lang.invoke.WrongMethodTypeException: expected (SslContextBuilder,String)SslContextBuilder but found (SslContextBuilder,Object)SslContextBuilder
        at java.base/java.lang.invoke.Invokers.newWrongMethodTypeException(Invokers.java:523) ~[?:?]
        at java.base/java.lang.invoke.Invokers.checkExactType(Invokers.java:532) ~[?:?]
        at io.servicetalk.transport.netty.internal.SslContextFactory.setEndpointIdentificationAlgorithm(SslContextFactory.java:126) ~[servicetalk-transport-netty-internal-0.42.48.jar:0.42.48]
        at io.servicetalk.transport.netty.internal.SslContextFactory.<clinit>(SslContextFactory.java:92) ~[servicetalk-transport-netty-internal-0.42.48.jar:0.42.48]
```

However, this method was backported to Netty 4.1.112. See release notes: https://netty.io/news/2024/07/19/4-1-112-Final.html

For some reason, `invokeExact` does not work as expected.

Modifications:

- Replaced `invokeExact` with `invoke`;

Result:

Method `SslContextBuilder#endpointIdentificationAlgorithm(String)` is detected for Netty 4.1.112.