### PR TITLE
Add SslConfig to onSecurityHandshake

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -29,6 +29,7 @@ import io.servicetalk.transport.api.ConnectionObserver.MultiplexedObserver;
 import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopProxyConnectObserver;
@@ -206,7 +207,7 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             }
 
             @Override
-            public SecurityHandshakeObserver onSecurityHandshake() {
+            public SecurityHandshakeObserver onSecurityHandshake(final SslConfig config) {
                 // AsyncContext is unknown at this point because this event is triggered by network
                 return NoopSecurityHandshakeObserver.INSTANCE;
             }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -41,6 +41,7 @@ import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.RetryableException;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopDataObserver;
@@ -161,7 +162,8 @@ class HttpsProxyTest {
         securityHandshakeObserver = mock(SecurityHandshakeObserver.class, "securityHandshakeObserver");
         when(transportObserver.onNewConnection(any(), any())).thenReturn(connectionObserver);
         when(connectionObserver.onProxyConnect(any())).thenReturn(proxyConnectObserver);
-        lenient().when(connectionObserver.onSecurityHandshake()).thenReturn(securityHandshakeObserver);
+        lenient().when(connectionObserver.onSecurityHandshake(any(SslConfig.class)))
+                .thenReturn(securityHandshakeObserver);
         lenient().when(connectionObserver.connectionEstablished(any())).thenReturn(NoopDataObserver.INSTANCE);
         lenient().when(connectionObserver.multiplexedConnectionEstablished(any()))
                 .thenReturn(NoopMultiplexedObserver.INSTANCE);
@@ -230,7 +232,7 @@ class HttpsProxyTest {
         assertTargetAddress();
 
         verifyProxyConnectComplete();
-        order.verify(connectionObserver).onSecurityHandshake();
+        order.verify(connectionObserver).onSecurityHandshake(any(SslConfig.class));
         order.verify(securityHandshakeObserver).handshakeComplete(any());
         if (expectedVersion.major() > 1) {
             order.verify(connectionObserver).multiplexedConnectionEstablished(any());
@@ -398,7 +400,7 @@ class HttpsProxyTest {
         assertTargetAddress();
 
         verifyProxyConnectComplete();
-        order.verify(connectionObserver).onSecurityHandshake();
+        order.verify(connectionObserver).onSecurityHandshake(any(SslConfig.class));
         order.verify(securityHandshakeObserver).handshakeFailed(e);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -24,6 +24,7 @@ import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopDataObserver;
@@ -94,7 +95,8 @@ class SecurityHandshakeObserverTest {
         clientConnectionObserver = mock(ConnectionObserver.class, "clientConnectionObserver");
         clientSecurityHandshakeObserver = mock(SecurityHandshakeObserver.class, "clientSecurityHandshakeObserver");
         when(clientTransportObserver.onNewConnection(any(), any())).thenReturn(clientConnectionObserver);
-        when(clientConnectionObserver.onSecurityHandshake()).thenReturn(clientSecurityHandshakeObserver);
+        when(clientConnectionObserver.onSecurityHandshake(any(SslConfig.class)))
+                .thenReturn(clientSecurityHandshakeObserver);
         when(clientConnectionObserver.connectionEstablished(any(ConnectionInfo.class)))
                 .thenReturn(NoopDataObserver.INSTANCE);
         when(clientConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
@@ -107,7 +109,8 @@ class SecurityHandshakeObserverTest {
         serverConnectionObserver = mock(ConnectionObserver.class, "serverConnectionObserver");
         serverSecurityHandshakeObserver = mock(SecurityHandshakeObserver.class, "serverSecurityHandshakeObserver");
         when(serverTransportObserver.onNewConnection(any(), any())).thenReturn(serverConnectionObserver);
-        when(serverConnectionObserver.onSecurityHandshake()).thenReturn(serverSecurityHandshakeObserver);
+        when(serverConnectionObserver.onSecurityHandshake(any(SslConfig.class)))
+                .thenReturn(serverSecurityHandshakeObserver);
         when(serverConnectionObserver.connectionEstablished(any(ConnectionInfo.class)))
                 .thenReturn(NoopDataObserver.INSTANCE);
         when(serverConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
@@ -177,7 +180,7 @@ class SecurityHandshakeObserverTest {
             assertThat(client.request(client.get(SVC_ECHO)).status(), is(OK));
         }
 
-        verify(serverConnectionObserver, never()).onSecurityHandshake();
+        verify(serverConnectionObserver, never()).onSecurityHandshake(any(SslConfig.class));
         verifyNoMoreInteractions(serverSecurityHandshakeObserver);
     }
 
@@ -221,7 +224,7 @@ class SecurityHandshakeObserverTest {
             HttpProtocol expectedProtocol, boolean failHandshake) {
         order.verify(transportObserver).onNewConnection(any(), any());
         order.verify(connectionObserver).onTransportHandshakeComplete(any());
-        order.verify(connectionObserver).onSecurityHandshake();
+        order.verify(connectionObserver).onSecurityHandshake(any(SslConfig.class));
         if (failHandshake) {
             ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
             order.verify(securityHandshakeObserver).handshakeFailed(exceptionCaptor.capture());

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
@@ -28,6 +28,7 @@ import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.SslProvider;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver;
@@ -155,7 +156,7 @@ class SslCertificateCompressionTest {
                 }
 
                 @Override
-                public SecurityHandshakeObserver onSecurityHandshake() {
+                public SecurityHandshakeObserver onSecurityHandshake(final SslConfig config) {
                     inHandshake = true;
                     return new SecurityHandshakeObserver() {
                         @Override

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -95,7 +95,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {    // F
                             // ExecutionContext can be null if users used deprecated ctor
                             executionContext == null ? null : channelExecutionContext(channel, executionContext),
                             sslConfig, config.idleTimeoutMs()),
-                    sslConfig != null && !deferSslHandler, true));
+                    sslConfig != null && !deferSslHandler, true, sslConfig));
         }
 
         if (config.idleTimeoutMs() > 0L) {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -94,8 +94,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {    // F
                     channel -> new TcpConnectionInfo(channel,
                             // ExecutionContext can be null if users used deprecated ctor
                             executionContext == null ? null : channelExecutionContext(channel, executionContext),
-                            sslConfig, config.idleTimeoutMs()),
-                    sslConfig != null && !deferSslHandler, true, sslConfig));
+                            sslConfig, config.idleTimeoutMs()), true, !deferSslHandler ? sslConfig : null));
         }
 
         if (config.idleTimeoutMs() > 0L) {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -94,7 +94,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {    // F
                     channel -> new TcpConnectionInfo(channel,
                             // ExecutionContext can be null if users used deprecated ctor
                             executionContext == null ? null : channelExecutionContext(channel, executionContext),
-                            sslConfig, config.idleTimeoutMs()), true, !deferSslHandler ? sslConfig : null));
+                            sslConfig, config.idleTimeoutMs()), true, deferSslHandler ? null : sslConfig));
         }
 
         if (config.idleTimeoutMs() > 0L) {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -77,8 +77,7 @@ public class TcpServerChannelInitializer implements ChannelInitializer {    // F
                     channel -> new TcpConnectionInfo(channel,
                             // ExecutionContext can be null if users used deprecated ctor
                             executionContext == null ? null : channelExecutionContext(channel, executionContext),
-                            sslConfig, config.idleTimeoutMs()),
-                    sslConfig != null, false, sslConfig));
+                            sslConfig, config.idleTimeoutMs()), false, sslConfig));
         }
 
         if (config.idleTimeoutMs() > 0L) {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -19,6 +19,7 @@ import io.servicetalk.logging.api.UserDataLoggerConfig;
 import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ExecutionContext;
+import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.ConnectionObserverInitializer;
 import io.servicetalk.transport.netty.internal.IdleTimeoutInitializer;
@@ -71,12 +72,13 @@ public class TcpServerChannelInitializer implements ChannelInitializer {    // F
         delegate = delegate.andThen(new TransportConfigInitializer(config.transportConfig()));
 
         if (observer != NoopConnectionObserver.INSTANCE) {
+            final ServerSslConfig sslConfig = config.sslConfig();
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
                     channel -> new TcpConnectionInfo(channel,
                             // ExecutionContext can be null if users used deprecated ctor
                             executionContext == null ? null : channelExecutionContext(channel, executionContext),
-                            config.sslConfig(), config.idleTimeoutMs()),
-                    config.sslConfig() != null, false));
+                            sslConfig, config.idleTimeoutMs()),
+                    sslConfig != null, false, sslConfig));
         }
 
         if (config.idleTimeoutMs() > 0L) {

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/AbstractTransportObserverTest.java
@@ -26,6 +26,7 @@ import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 import io.servicetalk.transport.api.ServerSslConfig;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.SslProvider;
 import io.servicetalk.transport.api.TransportObserver;
 
@@ -68,7 +69,8 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         clientReadObserver = mock(ReadObserver.class, "clientReadObserver");
         clientWriteObserver = mock(WriteObserver.class, "clientWriteObserver");
         when(clientTransportObserver.onNewConnection(any(), any())).thenReturn(clientConnectionObserver);
-        when(clientConnectionObserver.onSecurityHandshake()).thenReturn(clientSecurityHandshakeObserver);
+        when(clientConnectionObserver.onSecurityHandshake(any(SslConfig.class)))
+                .thenReturn(clientSecurityHandshakeObserver);
         when(clientConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(clientDataObserver);
         when(clientDataObserver.onNewRead()).thenReturn(clientReadObserver);
         when(clientDataObserver.onNewWrite()).thenReturn(clientWriteObserver);
@@ -80,7 +82,8 @@ public class AbstractTransportObserverTest extends AbstractTcpServerTest {
         serverReadObserver = mock(ReadObserver.class, "serverReadObserver");
         serverWriteObserver = mock(WriteObserver.class, "serverWriteObserver");
         when(serverTransportObserver.onNewConnection(any(), any())).thenReturn(serverConnectionObserver);
-        when(serverConnectionObserver.onSecurityHandshake()).thenReturn(serverSecurityHandshakeObserver);
+        when(serverConnectionObserver.onSecurityHandshake(any(SslConfig.class)))
+                .thenReturn(serverSecurityHandshakeObserver);
         when(serverConnectionObserver.connectionEstablished(any(ConnectionInfo.class))).thenReturn(serverDataObserver);
         when(serverDataObserver.onNewRead()).thenReturn(serverReadObserver);
         when(serverDataObserver.onNewWrite()).thenReturn(serverWriteObserver);

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverErrorsTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.ServerSslConfigBuilder;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.SslProvider;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 
@@ -178,7 +179,7 @@ final class SecureTcpTransportObserverErrorsTest extends AbstractTransportObserv
         verify(serverConnectionObserver, await()).onTransportHandshakeComplete(any());
         switch (errorReason) {
             case SECURE_CLIENT_TO_PLAIN_SERVER:
-                verify(clientConnectionObserver, await()).onSecurityHandshake();
+                verify(clientConnectionObserver, await()).onSecurityHandshake(any(SslConfig.class));
                 if (clientProvider == JDK) {
                     verify(clientSecurityHandshakeObserver, await()).handshakeFailed(any(SSLProtocolException.class));
                     verify(clientConnectionObserver, await()).connectionClosed(any(SSLProtocolException.class));
@@ -189,7 +190,7 @@ final class SecureTcpTransportObserverErrorsTest extends AbstractTransportObserv
                 serverConnectionClosed.await();
                 break;
             case PLAIN_CLIENT_TO_SECURE_SERVER:
-                verify(serverConnectionObserver, await()).onSecurityHandshake();
+                verify(serverConnectionObserver, await()).onSecurityHandshake(any(SslConfig.class));
                 clientConnected.await();
                 connection.get().write(from(DEFAULT_ALLOCATOR.fromAscii("Hello"))).toFuture().get();
                 verify(serverSecurityHandshakeObserver, await()).handshakeFailed(any(NotSslRecordException.class));
@@ -202,8 +203,8 @@ final class SecureTcpTransportObserverErrorsTest extends AbstractTransportObserv
             case MISSED_CLIENT_CERTIFICATE:
             case NOT_MATCHING_PROTOCOLS:
             case NOT_MATCHING_CIPHERS:
-                verify(clientConnectionObserver, await()).onSecurityHandshake();
-                verify(serverConnectionObserver, await()).onSecurityHandshake();
+                verify(clientConnectionObserver, await()).onSecurityHandshake(any(SslConfig.class));
+                verify(serverConnectionObserver, await()).onSecurityHandshake(any(SslConfig.class));
                 verify(clientSecurityHandshakeObserver, await()).handshakeFailed(any(SSLException.class));
                 verify(clientConnectionObserver, await()).connectionClosed(any(SSLException.class));
                 verify(serverSecurityHandshakeObserver, await()).handshakeFailed(any(SSLException.class));

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/SecureTcpTransportObserverTest.java
@@ -17,6 +17,7 @@ package io.servicetalk.tcp.netty.internal;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.SslProvider;
 import io.servicetalk.transport.netty.internal.NettyConnection;
 
@@ -82,8 +83,8 @@ class SecureTcpTransportObserverTest extends AbstractTransportObserverTest {
         verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
 
         // handshake starts
-        verify(clientConnectionObserver).onSecurityHandshake();
-        verify(serverConnectionObserver).onSecurityHandshake();
+        verify(clientConnectionObserver).onSecurityHandshake(any(SslConfig.class));
+        verify(serverConnectionObserver).onSecurityHandshake(any(SslConfig.class));
         // handshake progress
         verify(clientConnectionObserver, atLeastOnce()).onDataRead(anyInt());
         verify(clientConnectionObserver, atLeastOnce()).onDataWrite(anyInt());

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -84,8 +84,15 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public SecurityHandshakeObserver onSecurityHandshake() {
             return new BiSecurityHandshakeObserver(first.onSecurityHandshake(), second.onSecurityHandshake());
+        }
+
+        @Override
+        public SecurityHandshakeObserver onSecurityHandshake(final SslConfig sslConfig) {
+            return new BiSecurityHandshakeObserver(first.onSecurityHandshake(sslConfig),
+                    second.onSecurityHandshake(sslConfig));
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -96,8 +96,15 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public SecurityHandshakeObserver onSecurityHandshake() {
             return safeReport(observer::onSecurityHandshake, observer, "security handshake",
+                    CatchAllSecurityHandshakeObserver::new, NoopSecurityHandshakeObserver.INSTANCE);
+        }
+
+        @Override
+        public SecurityHandshakeObserver onSecurityHandshake(final SslConfig sslConfig) {
+            return safeReport(() -> observer.onSecurityHandshake(sslConfig), observer, "security handshake",
                     CatchAllSecurityHandshakeObserver::new, NoopSecurityHandshakeObserver.INSTANCE);
         }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -93,7 +93,7 @@ public interface ConnectionObserver {
      * Callback when a security handshake is initiated.
      * <p>
      * For a typical connection, this callback is invoked after {@link #onTransportHandshakeComplete(ConnectionInfo)}.
-     * There are may be exceptions:
+     * There are exceptions:
      * <ol>
      *     <li>For a TCP connection, when {@link ServiceTalkSocketOptions#TCP_FASTOPEN_CONNECT} option is configured and
      *     the Fast Open feature is supported by the OS, this callback may be invoked earlier. Note, even if the Fast
@@ -106,8 +106,35 @@ public interface ConnectionObserver {
      *
      * @return a new {@link SecurityHandshakeObserver} that provides visibility into security handshake events
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc7413">RFC7413: TCP Fast Open</a>
+     * @deprecated use {@link #onSecurityHandshake(ConnectionInfo)}
      */
-    SecurityHandshakeObserver onSecurityHandshake();
+    @Deprecated
+    default SecurityHandshakeObserver onSecurityHandshake() {  // FIXME: 0.43 - remove deprecated method
+        return NoopTransportObserver.NoopSecurityHandshakeObserver.INSTANCE;
+    }
+
+    /**
+     * Callback when a security handshake is initiated.
+     * <p>
+     * For a typical connection, this callback is invoked after {@link #onTransportHandshakeComplete(ConnectionInfo)}.
+     * There are exceptions:
+     * <ol>
+     *     <li>For a TCP connection, when {@link ServiceTalkSocketOptions#TCP_FASTOPEN_CONNECT} option is configured and
+     *     the Fast Open feature is supported by the OS, this callback may be invoked earlier. Note, even if the Fast
+     *     Open is available and configured, it may not actually happen if the
+     *     <a href="https://datatracker.ietf.org/doc/html/rfc7413#section-4.1">Fast Open Cookie</a> is {@code null} or
+     *     rejected by the server.</li>
+     *     <li>For a proxy connections, the handshake may happen after an observer returned by
+     *     {@link #onProxyConnect(Object)} completes successfully.</li>
+     * </ol>
+     *
+     * @param info the {@link ConnectionInfo} or null if {@code TCP_FASTOPEN} is used.
+     * @return a new {@link SecurityHandshakeObserver} that provides visibility into security handshake events
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7413">RFC7413: TCP Fast Open</a>
+     */
+    default SecurityHandshakeObserver onSecurityHandshake(@Nullable ConnectionInfo info) {
+        return onSecurityHandshake();
+    }
 
     /**
      * Callback when a non-multiplexed connection is established and ready.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -68,10 +68,10 @@ public interface ConnectionObserver {
      *
      * @param info {@link ConnectionInfo} for the connection after transport handshake completes. Note that the
      * {@link ConnectionInfo#sslSession()} will always return {@code null} since it is called before the
-     * {@link ConnectionObserver#onSecurityHandshake() security handshake} is performed (and as a result no SSL session
-     * has been established). Also, {@link ConnectionInfo#protocol()} will return L4 (transport) protocol.
-     * Finalized {@link ConnectionInfo} will be available via {@link #connectionEstablished(ConnectionInfo)} or
-     * {@link #multiplexedConnectionEstablished(ConnectionInfo)} callbacks.
+     * {@link ConnectionObserver#onSecurityHandshake(SslConfig)}  security handshake} is performed (and as a result
+     * no SSL session has been established). Also, {@link ConnectionInfo#protocol()} will return L4 (transport)
+     * protocol. Finalized {@link ConnectionInfo} will be available via {@link #connectionEstablished(ConnectionInfo)}
+     * or {@link #multiplexedConnectionEstablished(ConnectionInfo)} callbacks.
      */
     default void onTransportHandshakeComplete(ConnectionInfo info) {
         onTransportHandshakeComplete();
@@ -106,7 +106,7 @@ public interface ConnectionObserver {
      *
      * @return a new {@link SecurityHandshakeObserver} that provides visibility into security handshake events
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc7413">RFC7413: TCP Fast Open</a>
-     * @deprecated use {@link #onSecurityHandshake(ConnectionInfo)}
+     * @deprecated use {@link #onSecurityHandshake(SslConfig)}
      */
     @Deprecated
     default SecurityHandshakeObserver onSecurityHandshake() {  // FIXME: 0.43 - remove deprecated method
@@ -128,11 +128,11 @@ public interface ConnectionObserver {
      *     {@link #onProxyConnect(Object)} completes successfully.</li>
      * </ol>
      *
-     * @param info the {@link ConnectionInfo} or null if {@code TCP_FASTOPEN} is used.
+     * @param sslConfig the {@link SslConfig} used when performing the security handshake.
      * @return a new {@link SecurityHandshakeObserver} that provides visibility into security handshake events
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc7413">RFC7413: TCP Fast Open</a>
      */
-    default SecurityHandshakeObserver onSecurityHandshake(@Nullable ConnectionInfo info) {
+    default SecurityHandshakeObserver onSecurityHandshake(SslConfig sslConfig) {
         return onSecurityHandshake();
     }
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -74,6 +74,11 @@ final class NoopTransportObserver implements TransportObserver {
         }
 
         @Override
+        public SecurityHandshakeObserver onSecurityHandshake(final SslConfig sslConfig) {
+            return NoopSecurityHandshakeObserver.INSTANCE;
+        }
+
+        @Override
         public DataObserver connectionEstablished(final ConnectionInfo info) {
             return NoopDataObserver.INSTANCE;
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -86,7 +86,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
                                          final Function<Channel, ConnectionInfo> connectionInfoFactory,
                                          final boolean handshakeOnActive,
                                          final boolean client) {
-        this(observer, connectionInfoFactory, handshakeOnActive, client, null);
+        this(observer, connectionInfoFactory, client, null);
     }
 
     /**
@@ -95,18 +95,16 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
      * @param observer {@link ConnectionObserver} to report network events
      * @param connectionInfoFactory {@link Function} that creates {@link ConnectionInfo} from the provided
      * {@link Channel} to report {@link ConnectionObserver#onTransportHandshakeComplete(ConnectionInfo)}
-     * @param handshakeOnActive {@code true} if the observed connection is secure
      * @param client {@code true} if this initializer is used on the client-side
      * @param sslConfig the {@link SslConfig} to supply to the observer on handshake.
      */
     public ConnectionObserverInitializer(final ConnectionObserver observer,
                                          final Function<Channel, ConnectionInfo> connectionInfoFactory,
-                                         final boolean handshakeOnActive,
                                          final boolean client,
                                          @Nullable final SslConfig sslConfig) {
         this.observer = requireNonNull(observer);
         this.connectionInfoFactory = requireNonNull(connectionInfoFactory);
-        this.handshakeOnActive = handshakeOnActive;
+        this.handshakeOnActive = sslConfig != null;
         this.client = client;
         this.sslConfig = sslConfig;
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -76,7 +76,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
      * @param observer {@link ConnectionObserver} to report network events
      * @param connectionInfoFactory {@link Function} that creates {@link ConnectionInfo} from the provided
      * {@link Channel} to report {@link ConnectionObserver#onTransportHandshakeComplete(ConnectionInfo)}
-     * @param handshakeOnActive {@code true} if the observed connection is secure
+     * @param ignored ignored parameter.
      * @param client {@code true} if this initializer is used on the client-side
      * @deprecated Use {@link #ConnectionObserverInitializer(ConnectionObserver, Function, boolean, SslConfig)}
      * instead
@@ -84,7 +84,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public ConnectionObserverInitializer(final ConnectionObserver observer,
                                          final Function<Channel, ConnectionInfo> connectionInfoFactory,
-                                         final boolean handshakeOnActive,
+                                         final boolean ignored,
                                          final boolean client) {
         this(observer, connectionInfoFactory, client, null);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -49,7 +49,6 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
     private final ConnectionObserver observer;
     private final Function<Channel, ConnectionInfo> connectionInfoFactory;
-    private final boolean handshakeOnActive;
     private final boolean client;
     @Nullable
     private final SslConfig sslConfig;
@@ -104,7 +103,6 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
                                          @Nullable final SslConfig sslConfig) {
         this.observer = requireNonNull(observer);
         this.connectionInfoFactory = requireNonNull(connectionInfoFactory);
-        this.handshakeOnActive = sslConfig != null;
         this.client = client;
         this.sslConfig = sslConfig;
     }
@@ -120,11 +118,11 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
             }
         });
         channel.pipeline().addLast(new ConnectionObserverHandler(observer, connectionInfoFactory,
-                handshakeOnActive, isFastOpen(channel), sslConfig));
+                sslConfig != null, isFastOpen(channel), sslConfig));
     }
 
     private boolean isFastOpen(final Channel channel) {
-        return client && handshakeOnActive && Boolean.TRUE.equals(channel.config().getOption(TCP_FASTOPEN_CONNECT)) &&
+        return client && sslConfig != null && Boolean.TRUE.equals(channel.config().getOption(TCP_FASTOPEN_CONNECT)) &&
                 (Epoll.isTcpFastOpenClientSideAvailable() || KQueue.isTcpFastOpenClientSideAvailable());
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -60,7 +60,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
      * @param observer {@link ConnectionObserver} to report network events.
      * @param handshakeOnActive {@code true} if the observed connection is secure
      * @param client {@code true} if this initializer is used on the client-side
-     * @deprecated Use {@link #ConnectionObserverInitializer(ConnectionObserver, Function, boolean, boolean, SslConfig)}
+     * @deprecated Use {@link #ConnectionObserverInitializer(ConnectionObserver, Function, boolean, SslConfig)}
      * instead
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
@@ -78,7 +78,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
      * {@link Channel} to report {@link ConnectionObserver#onTransportHandshakeComplete(ConnectionInfo)}
      * @param handshakeOnActive {@code true} if the observed connection is secure
      * @param client {@code true} if this initializer is used on the client-side
-     * @deprecated Use {@link #ConnectionObserverInitializer(ConnectionObserver, Function, boolean, boolean, SslConfig)}
+     * @deprecated Use {@link #ConnectionObserverInitializer(ConnectionObserver, Function, boolean, SslConfig)}
      * instead
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DeferSslHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DeferSslHandler.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.transport.netty.internal;
 
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.ConnectionObserverInitializer.ConnectionObserverHandler;
 
 import io.netty.channel.Channel;
@@ -29,10 +30,12 @@ import io.netty.handler.ssl.SslHandler;
 public class DeferSslHandler extends ChannelDuplexHandler {
     private final Channel channel;
     private final SslHandler handler;
+    private final SslConfig sslConfig;
 
-    DeferSslHandler(final Channel channel, final SslHandler handler) {
+    DeferSslHandler(final Channel channel, final SslHandler handler, final SslConfig sslConfig) {
         this.channel = channel;
         this.handler = handler;
+        this.sslConfig = sslConfig;
     }
 
     /**
@@ -42,7 +45,7 @@ public class DeferSslHandler extends ChannelDuplexHandler {
         final ChannelPipeline pipeline = channel.pipeline();
         final ConnectionObserverHandler observerHandler = pipeline.get(ConnectionObserverHandler.class);
         if (observerHandler != null) {
-            observerHandler.reportSecurityHandshakeStarting();
+            observerHandler.reportSecurityHandshakeStarting(sslConfig);
         }
         pipeline.replace(this, null, handler);
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NoopTransportObserver.java
@@ -24,6 +24,7 @@ import io.servicetalk.transport.api.ConnectionObserver.ReadObserver;
 import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
 import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
+import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 
 import javax.annotation.Nullable;
@@ -84,6 +85,11 @@ public final class NoopTransportObserver implements TransportObserver {
 
         @Override
         public SecurityHandshakeObserver onSecurityHandshake() {
+            return NoopSecurityHandshakeObserver.INSTANCE;
+        }
+
+        @Override
+        public SecurityHandshakeObserver onSecurityHandshake(final SslConfig sslConfig) {
             return NoopSecurityHandshakeObserver.INSTANCE;
         }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
@@ -47,6 +47,6 @@ public class SslClientChannelInitializer implements ChannelInitializer {
     @Override
     public void init(Channel channel) {
         final SslHandler sslHandler = newClientSslHandler(sslContext, sslConfig, channel);
-        channel.pipeline().addLast(deferSslHandler ? new DeferSslHandler(channel, sslHandler) : sslHandler);
+        channel.pipeline().addLast(deferSslHandler ? new DeferSslHandler(channel, sslHandler, sslConfig) : sslHandler);
     }
 }


### PR DESCRIPTION
Motivation
----------
This changeset adds the `SslConfig` if available to the `onSecurityHandshake`, similar to a change made to
`onTransportHandshakeComplete` where the full `ConnectionInfo` gets passed in. This allows to get
information about the config from the argument itself, without having to get it as an instance variable
from `onTransportHandshakeComplete`.