### PR TITLE
http-netty: Disable the ClientEffectiveStrategyTest suite

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -56,13 +56,13 @@ import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.testng.annotations.Ignore;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -228,7 +228,7 @@ class ClientEffectiveStrategyTest {
         return arguments.stream();
     }
 
-    @Ignore // Disabled due to continued flakiness. See issue #2245 for more details.
+    @Disabled // Disabled due to continued flakiness. See issue #2245 for more details.
     @ParameterizedTest(name = "Type={0} builder={1} filter={2} LB={3} CF={4}")
     @MethodSource("casesSupplier")
     void clientStrategy(final BuilderType builderType,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -62,6 +62,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.testng.annotations.Ignore;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -227,6 +228,7 @@ class ClientEffectiveStrategyTest {
         return arguments.stream();
     }
 
+    @Ignore // Disabled due to continued flakiness. See issue #2245 for more details.
     @ParameterizedTest(name = "Type={0} builder={1} filter={2} LB={3} CF={4}")
     @MethodSource("casesSupplier")
     void clientStrategy(final BuilderType builderType,


### PR DESCRIPTION
Motivation:

The ClientEffectiveStrategyTest suite has been flaky for a long time and multiple engineers have looked at it, without making progress. In the meantime, this suite causes a substantial fraction of the failed runs.

Modifications:

Mark the flaky test as `@Disabled`.

Result:

CI should be significantly less flaky.

Related to #2245.