### PR TITLE
Correct netty dependencies

### DIFF
--- a/servicetalk-buffer-netty/build.gradle
+++ b/servicetalk-buffer-netty/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-utils-internal")
+  implementation "io.netty:netty-common"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")

--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -21,13 +21,19 @@ ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
 dependencies {
   api project(":servicetalk-client-api")
 
+  implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-transport-netty")
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-utils-internal")
+  implementation "io.netty:netty-buffer"
+  implementation "io.netty:netty-common"
+  implementation "io.netty:netty-codec-dns"
+  implementation "io.netty:netty-resolver"
   implementation "io.netty:netty-resolver-dns"
+  implementation "io.netty:netty-transport"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   if (!project.ext.isNettySnapshot) {

--- a/servicetalk-encoding-netty/build.gradle
+++ b/servicetalk-encoding-netty/build.gradle
@@ -19,11 +19,14 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
     api project(":servicetalk-encoding-api")
 
+    implementation platform("io.netty:netty-bom:$nettyVersion")
     implementation project(":servicetalk-annotations")
     implementation project(":servicetalk-buffer-netty")
     implementation project(":servicetalk-concurrent-internal")
     implementation project(":servicetalk-utils-internal")
+    implementation "io.netty:netty-buffer"
     implementation "io.netty:netty-codec"
+    implementation "io.netty:netty-transport"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   api project(":servicetalk-logging-api")
   api project(":servicetalk-http-api")
 
+  implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-client-api-internal")
   implementation project(":servicetalk-concurrent-internal")
@@ -35,8 +36,13 @@ dependencies {
   implementation project(":servicetalk-transport-netty")
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-utils-internal")
+  implementation "io.netty:netty-buffer"
+  implementation "io.netty:netty-codec"
   implementation "io.netty:netty-codec-http"
   implementation "io.netty:netty-codec-http2"
+  implementation "io.netty:netty-common"
+  implementation "io.netty:netty-handler"
+  implementation "io.netty:netty-transport"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -42,10 +42,12 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
+  testFixturesImplementation platform("io.netty:netty-bom:$nettyVersion")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  testFixturesImplementation "io.netty:netty-transport"
   testFixturesImplementation "io.netty:netty-transport-native-epoll"
   testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-x86_64")
   testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-aarch_64")

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -19,17 +19,22 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
 
 dependencies {
+  api platform("io.netty:netty-bom:$nettyVersion")
   api project(":servicetalk-buffer-netty")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-logging-api")
   api project(":servicetalk-transport-api")
+  api "io.netty:netty-buffer"
+  api "io.netty:netty-common"
   api "io.netty:netty-handler"
+  api "io.netty:netty-transport"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-utils-internal")
+  implementation "io.netty:netty-codec"
   implementation "io.netty:netty-transport-native-epoll"
   runtimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-x86_64")
   runtimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-aarch_64")

--- a/servicetalk-transport-netty/build.gradle
+++ b/servicetalk-transport-netty/build.gradle
@@ -23,5 +23,4 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-transport-netty-internal")
-  implementation "io.netty:netty-common"
 }


### PR DESCRIPTION
Motivation:

Maven helped to identify that after #3055 generated pom.xml files are invalid. We forgot to include `netty-bom` in some modules that depend on `io.netty` without specifying netty version.
Also, noticed that some of our modules that use `io.netty` do not list all used netty dependencies as needed.

Modifications:

- For all modules that contain `-netty` in their names add missed `netty-bom` and some other netty dependencies that are used explicitly;
- `servicetalk-buffer-netty`: add missed `netty-common` dependency;
- `servicetalk-transport-netty`: remove unused `netty-common` dependency;

Result:

Gradle generates valid pom.xml files.