### PR TITLE
Remove unused dependencies from `servicetalk-transport-netty`

### DIFF
--- a/servicetalk-transport-netty/build.gradle
+++ b/servicetalk-transport-netty/build.gradle
@@ -17,11 +17,9 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  api project(":servicetalk-concurrent-api")
   api project(":servicetalk-transport-api")
 
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-transport-netty-internal")
   implementation "io.netty:netty-common"
 }


### PR DESCRIPTION
Motivation:

`servicetalk-transport-netty` does not depend on `concurrent-api` or `concurrent-internal`.