### PR TITLE
Correct log4j dependencies

### DIFF
--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -70,7 +70,6 @@ dependencies {
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testFixturesRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }
 
 // We need testng for the reactive-streams-tck

--- a/servicetalk-opentracing-http/build.gradle
+++ b/servicetalk-opentracing-http/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation project(":servicetalk-opentracing-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
+  testImplementation enforcedPlatform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
@@ -45,6 +46,5 @@ dependencies {
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
-  testRuntimeOnly enforcedPlatform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl"
 }


### PR DESCRIPTION
Motivation:

1. `servicetalk-http-netty-test-fixtures` do not depend on `log4j`, `log4j-slf4j-impl` can be safely removed.
2. `servicetalk-opentracing-http` uses `log4j-core` as `testImplementation` dependency. Therefore, `log4j-bom` have to move from `testRuntimeOnly` to `testImplementation` scope.