### PR TITLE
traffic-resilience-http: extend connect timeout for CI even further

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -23,6 +23,7 @@ import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Executors;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.internal.TestTimeoutConstants;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
 import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpProtocolConfig;
@@ -83,7 +84,6 @@ import static io.servicetalk.transport.api.ConnectionAcceptor.ACCEPT_ALL;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
-import static java.lang.Boolean.parseBoolean;
 import static java.lang.Thread.NORM_PRIORITY;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
@@ -235,7 +235,7 @@ abstract class AbstractNettyHttpServerTest {
     }
 
     void ignoreTestWhen(ExecutorSupplier clientExecutorSupplier, ExecutorSupplier serverExecutorSupplier) {
-        assumeFalse(parseBoolean(System.getenv("CI")) &&
+        assumeFalse(TestTimeoutConstants.CI &&
                         this.clientExecutorSupplier == clientExecutorSupplier &&
                         this.serverExecutorSupplier == serverExecutorSupplier,
                    "Ignored flaky test");

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -49,6 +49,7 @@ import static io.netty.util.internal.PlatformDependent.normalizedOs;
 import static io.servicetalk.capacity.limiter.api.CapacityLimiters.fixedCapacity;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
@@ -57,7 +58,6 @@ import static io.servicetalk.transport.api.ServiceTalkSocketOptions.CONNECT_TIME
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.SO_BACKLOG;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static java.lang.Boolean.parseBoolean;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -74,8 +74,6 @@ import static org.mockito.Mockito.when;
 class TrafficResilienceHttpServiceFilterTest {
 
     private static final boolean IS_LINUX = "linux".equals(normalizedOs());
-
-    private static final boolean CI = parseBoolean(System.getenv("CI"));
 
     // There is an off-by-one behavior difference between macOS & Linux.
     // Linux has a greater-than check
@@ -172,7 +170,7 @@ class TrafficResilienceHttpServiceFilterTest {
 
         final StreamingHttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
                 .protocols(protocol.config)
-                .socketOption(CONNECT_TIMEOUT, (int) SECONDS.toMillis(CI ? 4 : 2))
+                .socketOption(CONNECT_TIMEOUT, (int) SECONDS.toMillis(CI ? 8 : 2))
                 .buildStreaming();
 
         // First request -> Pending 1


### PR DESCRIPTION
Motivation:

Even 4 seconds added in #3077 seems too low for CI. Trying higher value. Also, we can reuse already existing `CI` constant.