### PR TITLE
More flexibility for AbstractCloseableIteratorAsInputStream subclasses

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
@@ -91,7 +91,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
     protected abstract boolean isClosed();
 
     @Override
-    public final int read(final byte[] b, int off, int len) throws IOException {
+    public int read(final byte[] b, int off, int len) throws IOException {
         checkAlreadyClosed();
         requireNonNull(b);
         if (off < 0 || len < 0 || len > b.length - off) {
@@ -145,7 +145,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
     }
 
     @Override
-    public final int read() throws IOException {
+    public int read() throws IOException {
         checkAlreadyClosed();
         if (hasLeftOver()) {
             return leftOverReadSingleByte() & 0xff;
@@ -164,7 +164,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
         }
     }
 
-    private void checkAlreadyClosed() throws IOException {
+    protected void checkAlreadyClosed() throws IOException {
         if (isClosed()) {
             throw new IOException("Stream is already closed.");
         }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
@@ -119,7 +119,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
             if (len == 0) {
                 return initialLen;
             }
-            if (!hasNext(iterator)) {
+            if (!hasNext()) {
                 final int bytesRead = initialLen - len;
                 return bytesRead == 0 ? -1 : bytesRead;
             }
@@ -151,7 +151,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
             return leftOverReadSingleByte() & 0xff;
         }
         for (;;) {
-            if (!hasNext(iterator)) {
+            if (!hasNext()) {
                 return -1;
             }
             nextLeftOver(iterator);
@@ -170,7 +170,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
         }
     }
 
-    protected boolean hasNext(final CloseableIterator<T> iterator) {
+    protected boolean hasNext() {
         return iterator.hasNext();
     }
 }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
@@ -119,7 +119,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
             if (len == 0) {
                 return initialLen;
             }
-            if (!iterator.hasNext()) {
+            if (!hasNext(iterator)) {
                 final int bytesRead = initialLen - len;
                 return bytesRead == 0 ? -1 : bytesRead;
             }
@@ -151,7 +151,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
             return leftOverReadSingleByte() & 0xff;
         }
         for (;;) {
-            if (!iterator.hasNext()) {
+            if (!hasNext(iterator)) {
                 return -1;
             }
             nextLeftOver(iterator);
@@ -168,5 +168,9 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
         if (isClosed()) {
             throw new IOException("Stream is already closed.");
         }
+    }
+
+    protected boolean hasNext(final CloseableIterator<T> iterator) {
+        return iterator.hasNext();
     }
 }


### PR DESCRIPTION
This changeset removes the final modifier for the two read methods as well as makes one method protected (from private) in order to allow any subclass more flexibility if they want to perform additional logic on read and/or decide what to do if the class has been closed already.