### PR TITLE
http-netty: Add phantom reference version of watchdog filters

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
@@ -35,12 +35,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.servicetalk.http.netty.HttpMessageDiscardWatchdogFilter.USE_PHANTOM_REFERENCE;
 import static io.servicetalk.http.netty.HttpMessageDiscardWatchdogServiceFilter.generifyAtomicReference;
 
 /**
  * Filter which tracks message bodies and warns if they are not discarded properly.
  */
-final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConnectionFilterFactory {
+final class HttpMessageDiscardWatchdogClientFilter {
 
     private static final ContextMap.Key<AtomicReference<Publisher<?>>> MESSAGE_PUBLISHER_KEY = ContextMap.Key
             .newKey(HttpMessageDiscardWatchdogClientFilter.class.getName() + ".messagePublisher",
@@ -51,51 +52,76 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConne
     /**
      * Instance of {@link HttpMessageDiscardWatchdogClientFilter}.
      */
-    static final HttpMessageDiscardWatchdogClientFilter INSTANCE = new HttpMessageDiscardWatchdogClientFilter();
+    static final StreamingHttpConnectionFilterFactory INSTANCE = USE_PHANTOM_REFERENCE ?
+            new PhantomReferenceConnectionFilterFactory() : new AtomicRefFilter();
 
     /**
      * Instance of {@link StreamingHttpClientFilterFactory} with the cleaner implementation.
      */
-    static final StreamingHttpClientFilterFactory CLIENT_CLEANER = new CleanerStreamingHttpClientFilterFactory();
+    static final StreamingHttpClientFilterFactory CLIENT_CLEANER = USE_PHANTOM_REFERENCE ?
+            new NoopCleanerFilterFactory() : new CleanerStreamingHttpClientFilterFactory();
 
     private HttpMessageDiscardWatchdogClientFilter() {
-        // Singleton
+        // no instances
     }
 
-    @Override
-    public StreamingHttpConnectionFilter create(final FilterableStreamingHttpConnection connection) {
-        return new StreamingHttpConnectionFilter(connection) {
-            @Override
-            public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-                return delegate().request(request).map(response -> {
-                    // always write the buffer publisher into the request context. When a downstream subscriber
-                    // arrives, mark the message as subscribed explicitly (having a message present and no
-                    // subscription is an indicator that it must be freed later on).
-                    final AtomicReference<Publisher<?>> reference = request.context()
-                            .computeIfAbsent(MESSAGE_PUBLISHER_KEY, key -> new AtomicReference<>());
-                    assert reference != null;
-                    if (reference.getAndSet(response.messageBody()) != null) {
-                        // If a previous message exists, the Single<StreamingHttpResponse> got resubscribed to
-                        // (i.e. during a retry) and so previous message body needs to be cleaned up by the
-                        // user.
-                        LOGGER.warn("Discovered un-drained HTTP response message body which has " +
-                                "been dropped by user code - this is a strong indication of a bug " +
-                                "in a user-defined filter. Response payload (message) body must " +
-                                "be fully consumed before retrying.");
-                    }
+    // This implementation uses an atomic reference stored on the context to track when requests have been leaked.
+    // It is efficient and doesn't depend on GC, but may be prone to false positives since its possible that the
+    // message body was going to be drained later in the program.
+    private static final class AtomicRefFilter implements StreamingHttpConnectionFilterFactory {
+        @Override
+        public StreamingHttpConnectionFilter create(final FilterableStreamingHttpConnection connection) {
+            return new StreamingHttpConnectionFilter(connection) {
+                @Override
+                public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                    return delegate().request(request).map(response -> {
+                        // always write the buffer publisher into the request context. When a downstream subscriber
+                        // arrives, mark the message as subscribed explicitly (having a message present and no
+                        // subscription is an indicator that it must be freed later on).
+                        final AtomicReference<Publisher<?>> reference = request.context()
+                                .computeIfAbsent(MESSAGE_PUBLISHER_KEY, key -> new AtomicReference<>());
+                        assert reference != null;
+                        if (reference.getAndSet(response.messageBody()) != null) {
+                            // If a previous message exists, the Single<StreamingHttpResponse> got resubscribed to
+                            // (i.e. during a retry) and so previous message body needs to be cleaned up by the
+                            // user.
+                            LOGGER.warn(HttpMessageDiscardWatchdogFilter.WARN_MESSAGE);
+                        }
 
-                    return response.transformMessageBody(msgPublisher -> msgPublisher.beforeSubscriber(() -> {
-                        reference.set(null);
-                        return HttpMessageDiscardWatchdogServiceFilter.NoopSubscriber.INSTANCE;
-                    }));
-                });
-            }
-        };
+                        return response.transformMessageBody(msgPublisher -> msgPublisher.beforeSubscriber(() -> {
+                            reference.set(null);
+                            return HttpMessageDiscardWatchdogServiceFilter.NoopSubscriber.INSTANCE;
+                        }));
+                    });
+                }
+            };
+        }
     }
 
-    @Override
-    public HttpExecutionStrategy requiredOffloads() {
-        return HttpExecutionStrategies.offloadNone();
+    // A PhantomReference based version of the watchdog filter. This implementation doesn't suffer from the false
+    // positives that can happen with the AtomicReference based system which allows it to drain the response, plugging
+    // the leak. However, it does rely on GC and thus comes with all the caveats associated with that.
+    private static final class PhantomReferenceConnectionFilterFactory implements StreamingHttpConnectionFilterFactory {
+
+        private PhantomReferenceConnectionFilterFactory() {
+            // singleton.
+        }
+
+        @Override
+        public StreamingHttpConnectionFilter create(FilterableStreamingHttpConnection connection) {
+            return new StreamingHttpConnectionFilter(connection) {
+                @Override
+                public Single<StreamingHttpResponse> request(StreamingHttpRequest request) {
+                    return delegate().request(request).map(response ->
+                            HttpMessageDiscardWatchdogFilterCleaner.instrument(LOGGER, response));
+                }
+            };
+        }
+
+        @Override
+        public HttpExecutionStrategy requiredOffloads() {
+            return HttpExecutionStrategies.offloadNone();
+        }
     }
 
     private static final class CleanerStreamingHttpClientFilterFactory implements StreamingHttpClientFilterFactory {
@@ -112,15 +138,24 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConne
                                 if (maybePublisher != null && maybePublisher.getAndSet(null) != null) {
                                     // No-one subscribed to the message (or there is none), so if there is a message
                                     // tell the user to clean it up.
-                                    LOGGER.warn("Discovered un-drained HTTP response message body which has " +
-                                            "been dropped by user code - this is a strong indication of a bug " +
-                                            "in a user-defined filter. Response payload (message) body must " +
-                                            "be fully consumed before discarding.");
+                                    LOGGER.warn(HttpMessageDiscardWatchdogFilter.WARN_MESSAGE);
                                 }
                                 return Single.<StreamingHttpResponse>failed(cause).shareContextOnSubscribe();
                             });
                 }
             };
+        }
+
+        @Override
+        public HttpExecutionStrategy requiredOffloads() {
+            return HttpExecutionStrategies.offloadNone();
+        }
+    }
+
+    private static final class NoopCleanerFilterFactory implements StreamingHttpClientFilterFactory {
+        @Override
+        public StreamingHttpClientFilter create(FilterableStreamingHttpClient client) {
+            return new StreamingHttpClientFilter(client) { };
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+final class HttpMessageDiscardWatchdogFilter {
+
+    static final String PROPERTY_KEY = "io.servicetalk.http.netty.watchdog.usegc";
+
+    static final boolean USE_PHANTOM_REFERENCE = Boolean.getBoolean(PROPERTY_KEY);
+
+    static final String WARN_MESSAGE = "Discovered un-drained HTTP response message body which has " +
+            "been dropped by user code - this is a strong indication of a bug " +
+            "in a user-defined filter. Response payload (message) body must " +
+            "be fully consumed before retrying.";
+
+    private HttpMessageDiscardWatchdogFilter() {
+        // no instances.
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogFilterCleaner.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogFilterCleaner.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.internal.CancelImmediatelySubscriber;
+import io.servicetalk.http.api.StreamingHttpResponse;
+
+import org.slf4j.Logger;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Supplier;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+
+final class HttpMessageDiscardWatchdogFilterCleaner {
+
+    private static final ReferenceQueue<Object> REFERENCE_QUEUE = new ReferenceQueue<>();
+
+    // We need something to keep our phantom references from being GC'd prematurely.
+    private static final Map<Reference<Object>, Cleanable> LIVE_SET = new ConcurrentHashMap<>();
+
+    static {
+        Thread t = new Thread(() -> watchdogQueueRunLoop(), "watchdog-cleaner");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    private static final class Cleanable implements Supplier<PublisherSource.Subscriber<Object>> {
+
+        private static final AtomicIntegerFieldUpdater<Cleanable> UPDATER =
+                AtomicIntegerFieldUpdater.newUpdater(Cleanable.class, "value");
+
+        private final Logger logger;
+        private final Publisher<?> msgPublisher;
+        private volatile int value;
+
+        private Cleanable(Logger logger, Publisher<?> msgPublisher) {
+            this.logger = logger;
+            this.msgPublisher = msgPublisher;
+        }
+
+        @Override
+        public PublisherSource.Subscriber<Object> get() {
+            signalDisposed();
+            return HttpMessageDiscardWatchdogServiceFilter.NoopSubscriber.INSTANCE;
+        }
+
+        private boolean signalDisposed() {
+            return UPDATER.getAndSet(this, 1) == 0;
+        }
+
+        private void dispose() {
+            if (signalDisposed()) {
+                logger.warn(HttpMessageDiscardWatchdogFilter.WARN_MESSAGE);
+                toSource(msgPublisher).subscribe(CancelImmediatelySubscriber.INSTANCE);
+            }
+        }
+    }
+
+    private HttpMessageDiscardWatchdogFilterCleaner() {
+        // no instances.
+    }
+
+    static StreamingHttpResponse instrument(Logger logger, StreamingHttpResponse response) {
+        return response.transformMessageBody(msgPublisher -> {
+            Cleanable cleanable = new Cleanable(logger, msgPublisher);
+            Publisher<?> result = msgPublisher.beforeSubscriber(cleanable);
+            PhantomReference<Object> w = new PhantomReference<>(result, REFERENCE_QUEUE);
+            LIVE_SET.put(w, cleanable);
+            return result;
+        });
+    }
+
+    private static void watchdogQueueRunLoop() {
+        while (true) {
+            try {
+                Reference<?> wrapper = REFERENCE_QUEUE.remove();
+                Cleanable cleanable = LIVE_SET.remove(wrapper);
+                assert cleanable != null;
+                cleanable.dispose();
+            } catch (InterruptedException ex) {
+                Thread.interrupted();
+            } catch (Throwable ex) {
+                // swallow.
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation

The current watchdog filters are not exact: they don't account for responses that get drained later than the cleaner expects which can result in false positives. Because of this they can't proactively drain the responses.

Modifications

Add a PhantomReference variant of the watchdog filters. This filter uses a PhantomReference based implementation to be certain the response has been abandoned. Because we can now be certain, we can also proactively drain the response.