### PR TITLE
traffic-resilience-http: Add dry-run mode for resilience filters

### DIFF
--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
@@ -88,6 +88,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
     private final Supplier<Function<HttpRequestMetaData, CircuitBreaker>> circuitBreakerPartitionsSupplier;
 
     private final TrafficResiliencyObserver observer;
+    private final boolean dryRunMode;
 
     AbstractTrafficResilienceHttpFilter(
             final Supplier<Function<HttpRequestMetaData, CapacityLimiter>> capacityPartitionsSupplier,
@@ -99,7 +100,9 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             final Consumer<Ticket> onCancellationTicketTerminal,
             final BiConsumer<Ticket, Throwable> onErrorTicketTerminal,
             final Supplier<Function<HttpRequestMetaData, CircuitBreaker>> circuitBreakerPartitionsSupplier,
-            final TrafficResiliencyObserver observer) {
+            final TrafficResiliencyObserver observer,
+            final boolean dryRunMode
+            ) {
         this.capacityPartitionsSupplier = requireNonNull(capacityPartitionsSupplier, "capacityPartitionsSupplier");
         this.rejectWhenNotMatchedCapacityPartition = rejectWhenNotMatchedCapacityPartition;
         this.capacityRejectionPredicate = requireNonNull(capacityRejectionPredicate, "capacityRejectionPredicate");
@@ -112,6 +115,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
         this.circuitBreakerPartitionsSupplier = requireNonNull(circuitBreakerPartitionsSupplier,
                 "circuitBreakerPartitionsSupplier");
         this.observer = requireNonNull(observer, "observer");
+        this.dryRunMode = dryRunMode;
     }
 
     @Override
@@ -136,7 +140,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
         return __ -> Duration.ZERO;
     }
 
-    Single<StreamingHttpResponse> applyCapacityControl(
+    protected final Single<StreamingHttpResponse> applyCapacityControl(
             final Function<HttpRequestMetaData, CapacityLimiter> capacityPartitions,
             final Function<HttpRequestMetaData, CircuitBreaker> circuitBreakerPartitions,
             final Function<HttpRequestMetaData, Classification> classifier,
@@ -151,7 +155,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             if (partition == null) {
                 observer.onRejectedUnmatchedPartition(request);
                 return rejectWhenNotMatchedCapacityPartition ?
-                        handleLocalCapacityRejection(null, request, responseFactory)
+                        doHandleLocalCapacityRejection(delegate, null, request, responseFactory)
                                 .shareContextOnSubscribe() :
                         handlePassthrough(delegate, request)
                                 .shareContextOnSubscribe();
@@ -166,7 +170,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
 
             if (ticket == null) {
                 observer.onRejectedLimit(request, partition.name(), meta, classification);
-                return handleLocalCapacityRejection(serverListenContext, request, responseFactory)
+                return doHandleLocalCapacityRejection(delegate, serverListenContext, request, responseFactory)
                         .shareContextOnSubscribe();
             }
             final CircuitBreaker breaker = circuitBreakerPartitions.apply(request);
@@ -174,14 +178,15 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
                 observer.onRejectedOpenCircuit(request, breaker.name(), meta, classification);
                 // Ignore the acquired ticket if breaker was open.
                 ticket.ignored();
-                return handleLocalBreakerRejection(request, responseFactory, breaker).shareContextOnSubscribe();
+                return doHandleLocalBreakerRejection(delegate, request, responseFactory, breaker)
+                        .shareContextOnSubscribe();
             }
 
             // Ticket lifetime must be completed at all points now, try/catch to ensure if anything throws (e.g.
             // reactive flow isn't followed) we still complete ticket lifetime.
             try {
                 final TicketObserver ticketObserver = observer.onAllowedThrough(request, ticket.state());
-                return handleAllow(delegate, delayProvider, request, wrapTicket(serverListenContext, ticket),
+                return doHandleAllow(delegate, delayProvider, request, wrapTicket(serverListenContext, ticket),
                         ticketObserver, breaker, startTime).shareContextOnSubscribe();
             } catch (Throwable cause) {
                 onError(cause, breaker, startTime, ticket);
@@ -194,10 +199,28 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
         return ticket;
     }
 
+    private Single<StreamingHttpResponse> doHandleLocalCapacityRejection(
+            Function<StreamingHttpRequest, Single<StreamingHttpResponse>> delegate,
+            @Nullable ServerListenContext serverListenContext,
+            StreamingHttpRequest request,
+            @Nullable StreamingHttpResponseFactory responseFactory) {
+        return dryRunMode ? handlePassthrough(delegate, request) :
+                handleLocalCapacityRejection(serverListenContext, request, responseFactory);
+    }
+
     abstract Single<StreamingHttpResponse> handleLocalCapacityRejection(
             @Nullable ServerListenContext serverListenContext,
             StreamingHttpRequest request,
             @Nullable StreamingHttpResponseFactory responseFactory);
+
+    private Single<StreamingHttpResponse> doHandleLocalBreakerRejection(
+            Function<StreamingHttpRequest, Single<StreamingHttpResponse>> delegate,
+            StreamingHttpRequest request,
+            @Nullable StreamingHttpResponseFactory responseFactory,
+            CircuitBreaker breaker) {
+        return dryRunMode ? handlePassthrough(delegate, request) :
+                handleLocalBreakerRejection(request, responseFactory, breaker);
+    }
 
     abstract Single<StreamingHttpResponse> handleLocalBreakerRejection(
             StreamingHttpRequest request,
@@ -217,6 +240,16 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             final Function<StreamingHttpRequest, Single<StreamingHttpResponse>> delegate,
             final StreamingHttpRequest request) {
         return delegate.apply(request);
+    }
+
+    private Single<StreamingHttpResponse> doHandleAllow(
+            final Function<StreamingHttpRequest, Single<StreamingHttpResponse>> delegate,
+            final Function<HttpResponseMetaData, Duration> delayProvider, final StreamingHttpRequest request,
+            final Ticket ticket, final TicketObserver ticketObserver, @Nullable final CircuitBreaker breaker,
+            final long startTimeNs) {
+        return dryRunMode ? dryRunHandleAllow(
+                delayProvider, ticket, ticketObserver, breaker, startTimeNs, delegate.apply(request)) :
+                handleAllow(delegate, delayProvider, request, ticket, ticketObserver, breaker, startTimeNs);
     }
 
     private Single<StreamingHttpResponse> handleAllow(
@@ -249,37 +282,76 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
                     }
                     return Single.succeeded(resp).shareContextOnSubscribe();
                 })
-                .liftSync(new BeforeFinallyHttpOperator(new TerminalSignalConsumer() {
-                    @Override
-                    public void onComplete() {
-                        try {
-                            if (breaker != null) {
-                                breaker.onSuccess(nanoTime() - startTimeNs, NANOSECONDS);
-                            }
-                        } finally {
-                            onSuccessTicketTerminal.accept(ticket);
-                            ticketObserver.onComplete();
-                        }
-                    }
+                .liftSync(beforeFinally(ticket, ticketObserver, breaker, startTimeNs));
+    }
 
-                    @Override
-                    public void onError(final Throwable throwable) {
-                        AbstractTrafficResilienceHttpFilter.this.onError(throwable, breaker, startTimeNs, ticket);
-                        ticketObserver.onError(throwable);
-                    }
+    private Single<StreamingHttpResponse> dryRunHandleAllow(
+            final Function<HttpResponseMetaData, Duration> delayProvider, final Ticket ticket,
+            final TicketObserver ticketObserver, @Nullable final CircuitBreaker breaker, final long startTimeNs,
+            final Single<StreamingHttpResponse> responseSingle) {
+        // The map is issuing an exception that will be propagated to the downstream BeforeFinallyHttpOperator
+        // in order to invoke the appropriate callbacks to release resources.
+        // If the BeforeFinallyHttpOperator comes earlier, the Single will succeed and only downstream will
+        // see the exception, preventing callbacks to release permits; which results in the limiter eventually
+        // throttling ALL future requests.
+        // Before returning an error, we have to drain the response payload body to properly release resources
+        // and avoid leaking a connection, except for the PassthroughRequestDroppedException case.
+        return responseSingle.onErrorMap(throwable -> {
+            onError(throwable, breaker, startTimeNs, ticket);
+            ticketObserver.onError(throwable);
+            return throwable;
+        }).flatMap(resp -> {
+            if (breaker != null && breakerRejectionPredicate.test(resp)) {
+                Exception rejection = peerBreakerRejection(resp, breaker, delayProvider);
+                onError(rejection, breaker, startTimeNs, ticket);
+                ticketObserver.onError(rejection);
+                return Single.succeeded(resp).shareContextOnSubscribe();
+            }
+            if (capacityRejectionPredicate.test(resp)) {
+                final RuntimeException rejection = peerRejection(resp);
+                onError(rejection, breaker, startTimeNs, ticket);
+                ticketObserver.onError(rejection);
+                return Single.succeeded(resp).shareContextOnSubscribe();
+            }
+            return Single.succeeded(resp).shareContextOnSubscribe()
+                    .liftSync(beforeFinally(ticket, ticketObserver, breaker, startTimeNs));
+        });
+    }
 
-                    @Override
-                    public void cancel() {
-                        try {
-                            if (breaker != null) {
-                                breaker.ignorePermit();
-                            }
-                        } finally {
-                            onCancellationTicketTerminal.accept(ticket);
-                            ticketObserver.onCancel();
-                        }
+    private BeforeFinallyHttpOperator beforeFinally(
+            final Ticket ticket, final TicketObserver ticketObserver, @Nullable final CircuitBreaker breaker,
+            final long startTimeNs) {
+        return new BeforeFinallyHttpOperator(new TerminalSignalConsumer() {
+            @Override
+            public void onComplete() {
+                try {
+                    if (breaker != null) {
+                        breaker.onSuccess(nanoTime() - startTimeNs, NANOSECONDS);
                     }
-                }, true));
+                } finally {
+                    onSuccessTicketTerminal.accept(ticket);
+                    ticketObserver.onComplete();
+                }
+            }
+
+            @Override
+            public void onError(final Throwable throwable) {
+                AbstractTrafficResilienceHttpFilter.this.onError(throwable, breaker, startTimeNs, ticket);
+                ticketObserver.onError(throwable);
+            }
+
+            @Override
+            public void cancel() {
+                try {
+                    if (breaker != null) {
+                        breaker.ignorePermit();
+                    }
+                } finally {
+                    onCancellationTicketTerminal.accept(ticket);
+                    ticketObserver.onCancel();
+                }
+            }
+        }, true);
     }
 
     private void onError(final Throwable throwable, @Nullable final CircuitBreaker breaker,

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
@@ -88,7 +88,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
     private final Supplier<Function<HttpRequestMetaData, CircuitBreaker>> circuitBreakerPartitionsSupplier;
 
     private final TrafficResiliencyObserver observer;
-    private final boolean dryRunMode;
+    private final boolean dryRun;
 
     AbstractTrafficResilienceHttpFilter(
             final Supplier<Function<HttpRequestMetaData, CapacityLimiter>> capacityPartitionsSupplier,
@@ -101,7 +101,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             final BiConsumer<Ticket, Throwable> onErrorTicketTerminal,
             final Supplier<Function<HttpRequestMetaData, CircuitBreaker>> circuitBreakerPartitionsSupplier,
             final TrafficResiliencyObserver observer,
-            final boolean dryRunMode
+            final boolean dryRun
             ) {
         this.capacityPartitionsSupplier = requireNonNull(capacityPartitionsSupplier, "capacityPartitionsSupplier");
         this.rejectWhenNotMatchedCapacityPartition = rejectWhenNotMatchedCapacityPartition;
@@ -115,7 +115,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
         this.circuitBreakerPartitionsSupplier = requireNonNull(circuitBreakerPartitionsSupplier,
                 "circuitBreakerPartitionsSupplier");
         this.observer = requireNonNull(observer, "observer");
-        this.dryRunMode = dryRunMode;
+        this.dryRun = dryRun;
     }
 
     @Override
@@ -204,7 +204,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             @Nullable ServerListenContext serverListenContext,
             StreamingHttpRequest request,
             @Nullable StreamingHttpResponseFactory responseFactory) {
-        return dryRunMode ? handlePassthrough(delegate, request) :
+        return dryRun ? handlePassthrough(delegate, request) :
                 handleLocalCapacityRejection(serverListenContext, request, responseFactory);
     }
 
@@ -218,7 +218,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             StreamingHttpRequest request,
             @Nullable StreamingHttpResponseFactory responseFactory,
             CircuitBreaker breaker) {
-        return dryRunMode ? handlePassthrough(delegate, request) :
+        return dryRun ? handlePassthrough(delegate, request) :
                 handleLocalBreakerRejection(request, responseFactory, breaker);
     }
 
@@ -247,7 +247,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             final Function<HttpResponseMetaData, Duration> delayProvider, final StreamingHttpRequest request,
             final Ticket ticket, final TicketObserver ticketObserver, @Nullable final CircuitBreaker breaker,
             final long startTimeNs) {
-        return dryRunMode ? dryRunHandleAllow(
+        return dryRun ? dryRunHandleAllow(
                 delayProvider, ticket, ticketObserver, breaker, startTimeNs, delegate.apply(request)) :
                 handleAllow(delegate, delayProvider, request, ticket, ticketObserver, breaker, startTimeNs);
     }

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
@@ -144,10 +144,11 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
                                               @Nullable final Supplier<Function<HttpResponseMetaData, Duration>>
                                                       focreOpenCircuitOnPeerCircuitRejectionsDelayProvider,
                                               @Nullable final Executor circuitBreakerResetExecutor,
-                                              final TrafficResiliencyObserver observer) {
+                                              final TrafficResiliencyObserver observer,
+                                              final boolean dryRunMode) {
         super(capacityPartitionsSupplier, rejectWhenNotMatchedCapacityPartition, classifier,
                 clientPeerRejectionPolicy.predicate(), breakerRejectionPredicate, onCompletion, onCancellation,
-                onError, circuitBreakerPartitionsSupplier, observer);
+                onError, circuitBreakerPartitionsSupplier, observer, dryRunMode);
         this.clientPeerRejectionPolicy = clientPeerRejectionPolicy;
         this.forceOpenCircuitOnPeerCircuitRejections = forceOpenCircuitOnPeerCircuitRejections;
         this.focreOpenCircuitOnPeerCircuitRejectionsDelayProvider =
@@ -256,6 +257,7 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
         @Nullable
         private Executor circuitBreakerResetExecutor;
         private TrafficResiliencyObserver observer = NoOpTrafficResiliencyObserver.INSTANCE;
+        private boolean dryRunMode;
 
         /**
          * A {@link TrafficResilienceHttpClientFilter} with no partitioning schemes.
@@ -527,6 +529,18 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
         }
 
         /**
+         * Use the resilience filter in dry-run mode.
+         * In dry-run mode the capacity limiter will track requests and log their results but request which would
+         * have been rejected will instead pass through to the underlying client.
+         * @param dryRunMode whether to use the resilience filter in dry-run mode.
+         * @return {@code this}
+         */
+        public Builder dryRunMode(final boolean dryRunMode) {
+            this.dryRunMode = dryRunMode;
+            return this;
+        }
+
+        /**
          * Invoke to build an instance of {@link TrafficResilienceHttpClientFilter} filter to be used inside the
          * HttpClientBuilder.
          *
@@ -539,7 +553,8 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
                     circuitBreakerPartitionsSupplier, classifier, clientPeerRejectionPolicy,
                     peerUnavailableRejectionPredicate, onCompletionTicketTerminal, onCancellationTicketTerminal,
                     onErrorTicketTerminal, forceOpenCircuitOnPeerCircuitRejections,
-                    focreOpenCircuitOnPeerCircuitRejectionsDelayProvider, circuitBreakerResetExecutor, observer);
+                    focreOpenCircuitOnPeerCircuitRejectionsDelayProvider, circuitBreakerResetExecutor, observer,
+                    dryRunMode);
         }
     }
 }

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
@@ -145,10 +145,10 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
                                                       focreOpenCircuitOnPeerCircuitRejectionsDelayProvider,
                                               @Nullable final Executor circuitBreakerResetExecutor,
                                               final TrafficResiliencyObserver observer,
-                                              final boolean dryRunMode) {
+                                              final boolean dryRun) {
         super(capacityPartitionsSupplier, rejectWhenNotMatchedCapacityPartition, classifier,
                 clientPeerRejectionPolicy.predicate(), breakerRejectionPredicate, onCompletion, onCancellation,
-                onError, circuitBreakerPartitionsSupplier, observer, dryRunMode);
+                onError, circuitBreakerPartitionsSupplier, observer, dryRun);
         this.clientPeerRejectionPolicy = clientPeerRejectionPolicy;
         this.forceOpenCircuitOnPeerCircuitRejections = forceOpenCircuitOnPeerCircuitRejections;
         this.focreOpenCircuitOnPeerCircuitRejectionsDelayProvider =
@@ -257,7 +257,7 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
         @Nullable
         private Executor circuitBreakerResetExecutor;
         private TrafficResiliencyObserver observer = NoOpTrafficResiliencyObserver.INSTANCE;
-        private boolean dryRunMode;
+        private boolean dryRun;
 
         /**
          * A {@link TrafficResilienceHttpClientFilter} with no partitioning schemes.
@@ -532,11 +532,11 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
          * Use the resilience filter in dry-run mode.
          * In dry-run mode the capacity limiter will track requests and log their results but request which would
          * have been rejected will instead pass through to the underlying client.
-         * @param dryRunMode whether to use the resilience filter in dry-run mode.
+         * @param dryRun whether to use the resilience filter in dry-run mode.
          * @return {@code this}
          */
-        public Builder dryRunMode(final boolean dryRunMode) {
-            this.dryRunMode = dryRunMode;
+        public Builder dryRun(final boolean dryRun) {
+            this.dryRun = dryRun;
             return this;
         }
 
@@ -554,7 +554,7 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
                     peerUnavailableRejectionPredicate, onCompletionTicketTerminal, onCancellationTicketTerminal,
                     onErrorTicketTerminal, forceOpenCircuitOnPeerCircuitRejections,
                     focreOpenCircuitOnPeerCircuitRejectionsDelayProvider, circuitBreakerResetExecutor, observer,
-                    dryRunMode);
+                    dryRun);
         }
     }
 }

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilter.java
@@ -93,9 +93,10 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
                                                final Supplier<Function<HttpRequestMetaData, CircuitBreaker>>
                                                        circuitBreakerPartitionsSupplier,
                                                final ServiceRejectionPolicy onServiceRejectionPolicy,
-                                               final TrafficResiliencyObserver observer) {
+                                               final TrafficResiliencyObserver observer,
+                                               final boolean dryRunMode) {
         super(capacityPartitionsSupplier, rejectNotMatched, classifier, __ -> false, __ -> false,
-                onCompletion, onCancellation, onError, circuitBreakerPartitionsSupplier, observer);
+                onCompletion, onCancellation, onError, circuitBreakerPartitionsSupplier, observer, dryRunMode);
         this.serviceRejectionPolicy = onServiceRejectionPolicy;
     }
 
@@ -191,6 +192,7 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
             }
         };
         private TrafficResiliencyObserver observer = NoOpTrafficResiliencyObserver.INSTANCE;
+        private boolean dryRunMode;
 
         /**
          * A {@link TrafficResilienceHttpServiceFilter} with no partitioning schemes.
@@ -378,6 +380,18 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
         }
 
         /**
+         * Use the resilience filter in dry-run mode.
+         * In dry-run mode the capacity limiter will track requests and log their results but request which would
+         * have been rejected will instead pass through to the underlying client.
+         * @param dryRunMode whether to use the resilience filter in dry-run mode.
+         * @return {@code this}
+         */
+        public Builder dryRunMode(final boolean dryRunMode) {
+            this.dryRunMode = dryRunMode;
+            return this;
+        }
+
+        /**
          * Invoke to build an instance of {@link TrafficResilienceHttpServiceFilter} filter to be used inside the
          * {@link HttpServerBuilder}.
          * @return An instance of {@link TrafficResilienceHttpServiceFilter} with the characteristics
@@ -386,7 +400,8 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
         public TrafficResilienceHttpServiceFilter build() {
             return new TrafficResilienceHttpServiceFilter(capacityPartitionsSupplier, rejectNotMatched,
                     classifier, onCompletionTicketTerminal, onCancellationTicketTerminal,
-                    onErrorTicketTerminal, circuitBreakerPartitionsSupplier, onServiceRejectionPolicy, observer);
+                    onErrorTicketTerminal, circuitBreakerPartitionsSupplier, onServiceRejectionPolicy, observer,
+                    dryRunMode);
         }
     }
 

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilter.java
@@ -94,9 +94,9 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
                                                        circuitBreakerPartitionsSupplier,
                                                final ServiceRejectionPolicy onServiceRejectionPolicy,
                                                final TrafficResiliencyObserver observer,
-                                               final boolean dryRunMode) {
+                                               final boolean dryRun) {
         super(capacityPartitionsSupplier, rejectNotMatched, classifier, __ -> false, __ -> false,
-                onCompletion, onCancellation, onError, circuitBreakerPartitionsSupplier, observer, dryRunMode);
+                onCompletion, onCancellation, onError, circuitBreakerPartitionsSupplier, observer, dryRun);
         this.serviceRejectionPolicy = onServiceRejectionPolicy;
     }
 
@@ -192,7 +192,7 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
             }
         };
         private TrafficResiliencyObserver observer = NoOpTrafficResiliencyObserver.INSTANCE;
-        private boolean dryRunMode;
+        private boolean dryRun;
 
         /**
          * A {@link TrafficResilienceHttpServiceFilter} with no partitioning schemes.
@@ -383,11 +383,11 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
          * Use the resilience filter in dry-run mode.
          * In dry-run mode the capacity limiter will track requests and log their results but request which would
          * have been rejected will instead pass through to the underlying client.
-         * @param dryRunMode whether to use the resilience filter in dry-run mode.
+         * @param dryRun whether to use the resilience filter in dry-run mode.
          * @return {@code this}
          */
-        public Builder dryRunMode(final boolean dryRunMode) {
-            this.dryRunMode = dryRunMode;
+        public Builder dryRun(final boolean dryRun) {
+            this.dryRun = dryRun;
             return this;
         }
 
@@ -401,7 +401,7 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
             return new TrafficResilienceHttpServiceFilter(capacityPartitionsSupplier, rejectNotMatched,
                     classifier, onCompletionTicketTerminal, onCancellationTicketTerminal,
                     onErrorTicketTerminal, circuitBreakerPartitionsSupplier, onServiceRejectionPolicy, observer,
-                    dryRunMode);
+                    dryRun);
         }
     }
 

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
@@ -65,7 +65,7 @@ class TrafficResilienceHttpClientFilterTest {
 
     private static final StreamingHttpRequest REQUEST = REQ_RES_FACTORY.newRequest(HttpRequestMethod.GET, "");
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] dryRun={0}")
     @ValueSource(booleans = {false, true})
     void verifyPeerRetryableRejection(boolean dryRun) throws Exception {
         final TrafficResilienceHttpClientFilter trafficResilienceHttpClientFilter =
@@ -93,7 +93,7 @@ class TrafficResilienceHttpClientFilterTest {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] dryRun={0}")
     @ValueSource(booleans = {false, true})
     void verifyPeerRejection(boolean dryRun) throws Exception {
         final TrafficResilienceHttpClientFilter trafficResilienceHttpClientFilter =
@@ -127,7 +127,7 @@ class TrafficResilienceHttpClientFilterTest {
         assertThat(payloadDrained.get(), is(true));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] dryRun={0}")
     @ValueSource(booleans = {false, true})
     void verifyPeerRejectionPassthrough(boolean dryRun) throws Exception {
         final TrafficResilienceHttpClientFilter trafficResilienceHttpClientFilter =
@@ -150,7 +150,7 @@ class TrafficResilienceHttpClientFilterTest {
         assertThat(response.payloadBody().toString(UTF_8), is(equalTo("content")));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] dryRun={0}")
     @ValueSource(booleans = {false, true})
     void releaseCapacityIfDelegateThrows(boolean dryRun) {
         CapacityLimiter limiter = mock(CapacityLimiter.class);

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
@@ -33,7 +33,8 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayInputStream;
 import java.util.concurrent.ExecutionException;
@@ -64,31 +65,42 @@ class TrafficResilienceHttpClientFilterTest {
 
     private static final StreamingHttpRequest REQUEST = REQ_RES_FACTORY.newRequest(HttpRequestMethod.GET, "");
 
-    @Test
-    void verifyPeerRetryableRejection() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void verifyPeerRetryableRejection(boolean dryRun) throws Exception {
         final TrafficResilienceHttpClientFilter trafficResilienceHttpClientFilter =
                 new TrafficResilienceHttpClientFilter.Builder(
-                        () -> CapacityLimiters.fixedCapacity(1).build()).build();
+                        () -> CapacityLimiters.fixedCapacity(1).build())
+                        .dryRunMode(dryRun)
+                        .build();
 
         FilterableStreamingHttpClient client = mock(FilterableStreamingHttpClient.class);
         when(client.request(any())).thenReturn(Single.succeeded(REQ_RES_FACTORY.newResponse(BAD_GATEWAY)));
 
         final StreamingHttpClientFilter clientWithFilter = trafficResilienceHttpClientFilter.create(client);
-        assertThrows(DelayedRetryRequestDroppedException.class, () -> {
-            try {
-                clientWithFilter.request(REQUEST).toFuture().get();
-            } catch (ExecutionException e) {
-                throw e.getCause();
-            }
-        });
+        if (dryRun) {
+            StreamingHttpResponse response = clientWithFilter.request(REQUEST).toFuture().get();
+            response.messageBody().ignoreElements().toFuture().get();
+            assertThat(response.status(), equalTo(BAD_GATEWAY));
+        } else {
+            assertThrows(DelayedRetryRequestDroppedException.class, () -> {
+                try {
+                    clientWithFilter.request(REQUEST).toFuture().get();
+                } catch (ExecutionException e) {
+                    throw e.getCause();
+                }
+            });
+        }
     }
 
-    @Test
-    void verifyPeerRejection() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void verifyPeerRejection(boolean dryRun) throws Exception {
         final TrafficResilienceHttpClientFilter trafficResilienceHttpClientFilter =
                 new TrafficResilienceHttpClientFilter.Builder(
                         () -> CapacityLimiters.fixedCapacity(1).build())
                         .rejectionPolicy(ofRejection(resp -> BAD_GATEWAY.equals(resp.status())))
+                        .dryRunMode(dryRun)
                         .build();
 
         FilterableStreamingHttpClient client = mock(FilterableStreamingHttpClient.class);
@@ -99,22 +111,30 @@ class TrafficResilienceHttpClientFilterTest {
                         .map(DEFAULT_ALLOCATOR::wrap).whenOnComplete(() -> payloadDrained.set(true)))));
 
         final StreamingHttpClientFilter clientWithFilter = trafficResilienceHttpClientFilter.create(client);
-        assertThrows(RequestDroppedException.class, () -> {
-            try {
-                clientWithFilter.request(REQUEST).toFuture().get();
-            } catch (ExecutionException e) {
-                throw e.getCause();
-            }
-        });
+        if (dryRun) {
+            StreamingHttpResponse response = clientWithFilter.request(REQUEST).toFuture().get();
+            assertThat(response.status(), equalTo(BAD_GATEWAY));
+            response.messageBody().ignoreElements().toFuture().get();
+        } else {
+            assertThrows(RequestDroppedException.class, () -> {
+                try {
+                    clientWithFilter.request(REQUEST).toFuture().get();
+                } catch (ExecutionException e) {
+                    throw e.getCause();
+                }
+            });
+        }
         assertThat(payloadDrained.get(), is(true));
     }
 
-    @Test
-    void verifyPeerRejectionPassthrough() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void verifyPeerRejectionPassthrough(boolean dryRun) throws Exception {
         final TrafficResilienceHttpClientFilter trafficResilienceHttpClientFilter =
                 new TrafficResilienceHttpClientFilter.Builder(
                         () -> CapacityLimiters.fixedCapacity(1).build())
                         .rejectionPolicy(ofPassthrough(resp -> BAD_GATEWAY.equals(resp.status())))
+                        .dryRunMode(dryRun)
                         .build();
 
         FilterableStreamingHttpClient client = mock(FilterableStreamingHttpClient.class);
@@ -130,14 +150,17 @@ class TrafficResilienceHttpClientFilterTest {
         assertThat(response.payloadBody().toString(UTF_8), is(equalTo("content")));
     }
 
-    @Test
-    void releaseCapacityIfDelegateThrows() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void releaseCapacityIfDelegateThrows(boolean dryRun) {
         CapacityLimiter limiter = mock(CapacityLimiter.class);
         Ticket ticket = mock(Ticket.class);
         when(limiter.tryAcquire(any(), any())).thenReturn(ticket);
 
         TrafficResilienceHttpClientFilter filter =
-                new TrafficResilienceHttpClientFilter.Builder(() -> limiter).build();
+                new TrafficResilienceHttpClientFilter.Builder(() -> limiter)
+                        .dryRunMode(dryRun)
+                        .build();
 
         FilterableStreamingHttpClient client = mock(FilterableStreamingHttpClient.class);
         when(client.request(any())).thenThrow(DELIBERATE_EXCEPTION);

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
@@ -71,7 +71,7 @@ class TrafficResilienceHttpClientFilterTest {
         final TrafficResilienceHttpClientFilter trafficResilienceHttpClientFilter =
                 new TrafficResilienceHttpClientFilter.Builder(
                         () -> CapacityLimiters.fixedCapacity(1).build())
-                        .dryRunMode(dryRun)
+                        .dryRun(dryRun)
                         .build();
 
         FilterableStreamingHttpClient client = mock(FilterableStreamingHttpClient.class);
@@ -100,7 +100,7 @@ class TrafficResilienceHttpClientFilterTest {
                 new TrafficResilienceHttpClientFilter.Builder(
                         () -> CapacityLimiters.fixedCapacity(1).build())
                         .rejectionPolicy(ofRejection(resp -> BAD_GATEWAY.equals(resp.status())))
-                        .dryRunMode(dryRun)
+                        .dryRun(dryRun)
                         .build();
 
         FilterableStreamingHttpClient client = mock(FilterableStreamingHttpClient.class);
@@ -134,7 +134,7 @@ class TrafficResilienceHttpClientFilterTest {
                 new TrafficResilienceHttpClientFilter.Builder(
                         () -> CapacityLimiters.fixedCapacity(1).build())
                         .rejectionPolicy(ofPassthrough(resp -> BAD_GATEWAY.equals(resp.status())))
-                        .dryRunMode(dryRun)
+                        .dryRun(dryRun)
                         .build();
 
         FilterableStreamingHttpClient client = mock(FilterableStreamingHttpClient.class);
@@ -159,7 +159,7 @@ class TrafficResilienceHttpClientFilterTest {
 
         TrafficResilienceHttpClientFilter filter =
                 new TrafficResilienceHttpClientFilter.Builder(() -> limiter)
-                        .dryRunMode(dryRun)
+                        .dryRun(dryRun)
                         .build();
 
         FilterableStreamingHttpClient client = mock(FilterableStreamingHttpClient.class);

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -182,7 +182,7 @@ class TrafficResilienceHttpServiceFilterTest {
         TrafficResilienceHttpServiceFilter filter =
                 new TrafficResilienceHttpServiceFilter.Builder(() -> limiter)
                         .observer(observer)
-                        .dryRunMode(true)
+                        .dryRun(true)
                         .build();
 
         StreamingHttpResponse response = StreamingHttpResponses.newResponse(HttpResponseStatus.OK,
@@ -223,7 +223,7 @@ class TrafficResilienceHttpServiceFilterTest {
         TrafficResilienceHttpServiceFilter filter = new TrafficResilienceHttpServiceFilter
                 .Builder(() -> limiter)
                 .rejectionPolicy(serviceRejectionPolicy)
-                .dryRunMode(dryRun)
+                .dryRun(dryRun)
                 .build();
 
         final HttpServerContext serverContext = forAddress(localAddress(0))

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -15,23 +15,30 @@
  */
 package io.servicetalk.traffic.resilience.http;
 
+import io.servicetalk.buffer.netty.BufferAllocators;
 import io.servicetalk.capacity.limiter.api.CapacityLimiter;
 import io.servicetalk.capacity.limiter.api.CapacityLimiters;
+import io.servicetalk.capacity.limiter.api.Classification;
 import io.servicetalk.client.api.ConnectTimeoutException;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.test.StepVerifiers;
 import io.servicetalk.concurrent.internal.DeliberateException;
+import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpConnection;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.HttpServerContext;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpResponses;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.http.netty.HttpServers;
@@ -39,7 +46,7 @@ import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -49,10 +56,12 @@ import static io.netty.util.internal.PlatformDependent.normalizedOs;
 import static io.servicetalk.capacity.limiter.api.CapacityLimiters.fixedCapacity;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
 import static io.servicetalk.http.netty.HttpServers.forAddress;
+import static io.servicetalk.traffic.resilience.http.NoOpTrafficResiliencyObserver.NO_OP_TICKET_OBSERVER;
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.CONNECT_TIMEOUT;
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.SO_BACKLOG;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -60,6 +69,7 @@ import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAnd
 import static java.lang.Boolean.parseBoolean;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -139,19 +149,71 @@ class TrafficResilienceHttpServiceFilterTest {
         verifyNoMoreInteractions(limiter, ticket);
     }
 
-    enum Protocol {
-        H1(h1Default()),
-        H2(h2Default());
+    @Test
+    void dryRunWillContinueToSendRequestsToDelegate() {
+        CapacityLimiter limiter = mock(CapacityLimiter.class);
+        when(limiter.tryAcquire(any(), any())).thenReturn(null);
 
-        private final HttpProtocolConfig config;
-        Protocol(HttpProtocolConfig config) {
-            this.config = config;
-        }
+        AtomicInteger rejectedCount = new AtomicInteger();
+        TrafficResiliencyObserver observer = new TrafficResiliencyObserver() {
+            @Override
+            public void onRejectedUnmatchedPartition(StreamingHttpRequest request) {
+                // noop
+            }
+
+            @Override
+            public void onRejectedLimit(StreamingHttpRequest request, String capacityLimiter, ContextMap meta,
+                                        Classification classification) {
+                rejectedCount.incrementAndGet();
+            }
+
+            @Override
+            public void onRejectedOpenCircuit(StreamingHttpRequest request, String circuitBreaker, ContextMap meta,
+                                              Classification classification) {
+                // noop
+            }
+
+            @Override
+            public TicketObserver onAllowedThrough(StreamingHttpRequest request, CapacityLimiter.LimiterState state) {
+                return NO_OP_TICKET_OBSERVER;
+            }
+        };
+
+        TrafficResilienceHttpServiceFilter filter =
+                new TrafficResilienceHttpServiceFilter.Builder(() -> limiter)
+                        .observer(observer)
+                        .dryRunMode(true)
+                        .build();
+
+        StreamingHttpResponse response = StreamingHttpResponses.newResponse(HttpResponseStatus.OK,
+                HTTP_1_1, DefaultHttpHeadersFactory.INSTANCE.newHeaders(), BufferAllocators.DEFAULT_ALLOCATOR,
+                DefaultHttpHeadersFactory.INSTANCE);
+        StreamingHttpServiceFilter service = mock(StreamingHttpServiceFilter.class);
+        when(service.handle(any(), any(), any())).thenReturn(Single.succeeded(response));
+
+        StreamingHttpServiceFilter serviceWithFilter = filter.create(service);
+        StepVerifiers.create(serviceWithFilter.handle(mock(HttpServiceContext.class), mock(StreamingHttpRequest.class),
+                        mock(StreamingHttpResponseFactory.class)))
+                .expectSuccess()
+                .verify();
+        verify(limiter).tryAcquire(any(), any());
+        verify(limiter).name(); // called when going through the rejection pathway.
+        verifyNoMoreInteractions(limiter);
+
+        assertThat(rejectedCount.get(), equalTo(1));
     }
 
     @ParameterizedTest
-    @EnumSource(Protocol.class)
-    void testStopAcceptingConnections(final Protocol protocol) throws Exception {
+    @CsvSource({"true, h1", "true, h2", "false, h1", "false, h2"})
+    void testStopAcceptingConnections(final boolean dryRun, final String protocol) throws Exception {
+        final HttpProtocolConfig protocolConfig;
+        if ("h1".equalsIgnoreCase(protocol)) {
+            protocolConfig = h1Default();
+        } else if ("h2".equalsIgnoreCase(protocol)) {
+            protocolConfig = h2Default();
+        } else {
+            throw new IllegalStateException("Unexpected protocol argument: " + protocol);
+        }
         final CapacityLimiter limiter = fixedCapacity(1).build();
         final ServiceRejectionPolicy serviceRejectionPolicy = new ServiceRejectionPolicy.Builder()
                 .onLimitStopAcceptingConnections(true)
@@ -161,17 +223,18 @@ class TrafficResilienceHttpServiceFilterTest {
         TrafficResilienceHttpServiceFilter filter = new TrafficResilienceHttpServiceFilter
                 .Builder(() -> limiter)
                 .rejectionPolicy(serviceRejectionPolicy)
+                .dryRunMode(dryRun)
                 .build();
 
         final HttpServerContext serverContext = forAddress(localAddress(0))
-                .protocols(protocol.config)
+                .protocols(protocolConfig)
                 .listenSocketOption(SO_BACKLOG, TCP_BACKLOG)
                 .appendNonOffloadingServiceFilter(filter)
                 .listenStreamingAndAwait((ctx, request, responseFactory) ->
                         succeeded(responseFactory.ok().payloadBody(Publisher.never())));
 
         final StreamingHttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
-                .protocols(protocol.config)
+                .protocols(protocolConfig)
                 .socketOption(CONNECT_TIMEOUT, (int) SECONDS.toMillis(CI ? 4 : 2))
                 .buildStreaming();
 
@@ -196,12 +259,17 @@ class TrafficResilienceHttpServiceFilterTest {
         assertThat(client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/"))
                 .toFuture().get().asConnection(), instanceOf(HttpConnection.class));
 
-        // Any attempt to create a connection now, should time out
-        try {
-            client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/")).toFuture().get();
-            fail("Expected a connection timeout");
-        } catch (ExecutionException e) {
-            assertThat(e.getCause(), instanceOf(ConnectTimeoutException.class));
+        // Any attempt to create a connection now, should time out if we're not in dry mode.
+        if (dryRun) {
+            client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/")).toFuture().get()
+                    .releaseAsync().toFuture().get();
+        } else {
+            try {
+                client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/")).toFuture().get();
+                fail("Expected a connection timeout");
+            } catch (ExecutionException e) {
+                assertThat(e.getCause(), instanceOf(ConnectTimeoutException.class));
+            }
         }
     }
 }

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -203,7 +203,7 @@ class TrafficResilienceHttpServiceFilterTest {
         assertThat(rejectedCount.get(), equalTo(1));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] dryRun={0},protocol={1}")
     @CsvSource({"true, h1", "true, h2", "false, h1", "false, h2"})
     void testStopAcceptingConnections(final boolean dryRun, final String protocol) throws Exception {
         final HttpProtocolConfig protocolConfig;


### PR DESCRIPTION
Motivation:

Sometimes people will want to test out the capacity limiters without
actually rejecting any traffic. This can help them tune their system
and generally just feel more confident.

Modifications:

Add dry-run mode.