### PR TITLE
`CloseableIteratorBufferAsInputStream`: fix `CLOSED` marker instance

### DIFF
--- a/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/CloseableIteratorBufferAsInputStream.java
+++ b/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/CloseableIteratorBufferAsInputStream.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.internal.AbstractCloseableIteratorAsInputStream
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
@@ -29,7 +30,8 @@ import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLO
  * Conversion from a {@link CloseableIterator} of {@link Buffer}s to a {@link InputStream}.
  */
 public final class CloseableIteratorBufferAsInputStream extends AbstractCloseableIteratorAsInputStream<Buffer> {
-    private static final Buffer CLOSED = DEFAULT_RO_ALLOCATOR.fromAscii("");
+    // Use `wrap` instead of `fromAscii("")` to avoid getting a reference to EmptyBuffer constant
+    private static final Buffer CLOSED = DEFAULT_RO_ALLOCATOR.wrap(ByteBuffer.allocate(0).asReadOnlyBuffer());
     @Nullable
     private Buffer leftover;
 

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/AbstractCloseableIteratorAsInputStream.java
@@ -111,7 +111,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
                     len -= toRead;
                 } else { // toRead == len, i.e. we filled the buffer.
                     leftOverCheckReset();
-                    return initialLen - (len - toRead);
+                    return initialLen;
                 }
             }
             // Avoid fetching a new element if we have no more space to read to. This prevents serializing and
@@ -120,8 +120,7 @@ public abstract class AbstractCloseableIteratorAsInputStream<T> extends InputStr
                 return initialLen;
             }
             if (!iterator.hasNext()) {
-                final int bytesRead = initialLen - len;
-                return bytesRead == 0 ? -1 : bytesRead;
+                return initialLen == len ? -1 : (initialLen - len);
             }
             nextLeftOver(iterator);
         }


### PR DESCRIPTION
Motivation:

`CloseableIteratorBufferAsInputStream` uses `CLOSED` as a marker for `isClosed()`. However, `fromAscii("")` returns a static reference to `EmptyBuffer`, which opens a risk of getting such `Buffer` via underlying iterator.

Modifications:
- Use `wrap` method that guarantees allocation of a new unique instance of a `Buffer`;

Result:

`CLOSED` marker is guaranteed to be a unique instance.

Additional cleanup of `AbstractCloseableIteratorAsInputStream`:
- Remove `len - toRead` that always results in `0`;
- Avoid arithmetic if `initialLen == len`;