### PR TITLE
Run snapshot tests with Netty 4.2.0 Beta versions

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         java: [ 8 ]
         os: [ ubuntu-latest ]
-        netty: [ 4.1+, 4.2.0.Alpha+ ]
+        netty: [ 4.1+, 4.2.0.Beta+ ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Netty 4.2 has moved on to the beta phase and we no longer release alpha versions.
https://netty.io/news/2024/11/04/4-2-0-Beta1.html