### PR TITLE
traffic-resilience-http: discard events after cancel in TrafficManagement

### DIFF
--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
@@ -283,7 +283,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
                     return Single.succeeded(resp).shareContextOnSubscribe();
                 })
                 .liftSync(new BeforeFinallyHttpOperator(
-                        new SignalConsumer(this, ticket, ticketObserver, breaker, startTimeNs)));
+                        new SignalConsumer(this, ticket, ticketObserver, breaker, startTimeNs), true));
     }
 
     private Single<StreamingHttpResponse> dryRunHandleAllow(
@@ -308,7 +308,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
                     }
                     return resp;
                 })
-                .liftSync(new BeforeFinallyHttpOperator(signalConsumer));
+                .liftSync(new BeforeFinallyHttpOperator(signalConsumer, true));
     }
 
     private static final class SignalConsumer implements TerminalSignalConsumer {


### PR DESCRIPTION
Motivation:

We accidentially removed the discardEventsAfterCancel flag in PR #3085.

Modifications:

Add it back.