### PR TITLE
`HelloWorldJaxRsResource`: fix method name

### DIFF
--- a/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsResource.java
+++ b/servicetalk-examples/http/jaxrs/src/main/java/io/servicetalk/examples/http/jaxrs/HelloWorldJaxRsResource.java
@@ -238,7 +238,7 @@ public class HelloWorldJaxRsResource {
     @GET
     @Path("file-hello")
     @Produces(TEXT_PLAIN)
-    public Publisher<Buffer> multipartHello(@Context final ConnectionContext ctx) {
+    public Publisher<Buffer> fileHello(@Context final ConnectionContext ctx) {
         final InputStream responseStream = HelloWorldJaxRsResource.class.getClassLoader()
                 .getResourceAsStream("response_payload.txt");
         final BufferAllocator allocator = ctx.executionContext().bufferAllocator();


### PR DESCRIPTION
Likely bcz of a copy-paste approach we currently have 2 endpoints with `multipartHello` name. The 2nd one should be named as `fileHello`.