### PR TITLE
Detect unexpected response leaks for multi-address client instances

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -135,6 +135,9 @@ final class DefaultMultiAddressUrlHttpClientBuilder
             urlClient = redirectConfig == null ? urlClient :
                     new RedirectingHttpRequesterFilter(redirectConfig).create(urlClient);
 
+            // Detect leaks that can be caused by unexpected exceptions
+            urlClient = HttpMessageDiscardWatchdogClientFilter.CLIENT_CLEANER.create(urlClient);
+
             LOGGER.debug("Multi-address client created with base strategy {}", executionContext.executionStrategy());
             return new FilterableClientToClient(urlClient, executionContext);
         } catch (final Throwable t) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
@@ -115,7 +115,7 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConne
                                     LOGGER.warn("Discovered un-drained HTTP response message body which has " +
                                             "been dropped by user code - this is a strong indication of a bug " +
                                             "in a user-defined filter. Response payload (message) body must " +
-                                            "be fully consumed before discarding.");
+                                            "be fully consumed before discarding.", cause);
                                 }
                                 return Single.<StreamingHttpResponse>failed(cause).shareContextOnSubscribe();
                             });

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
@@ -107,7 +107,7 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConne
                                                                 final StreamingHttpRequest request) {
                     return delegate
                             .request(request)
-                            .whenOnError(cause -> {
+                            .beforeOnError(cause -> {
                                 final AtomicReference<?> maybePublisher = request.context().get(MESSAGE_PUBLISHER_KEY);
                                 if (maybePublisher != null && maybePublisher.getAndSet(null) != null) {
                                     // No-one subscribed to the message (or there is none), so if there is a message

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogClientFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023-2024 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConne
                                                                 final StreamingHttpRequest request) {
                     return delegate
                             .request(request)
-                            .onErrorResume(cause -> {
+                            .whenOnError(cause -> {
                                 final AtomicReference<?> maybePublisher = request.context().get(MESSAGE_PUBLISHER_KEY);
                                 if (maybePublisher != null && maybePublisher.getAndSet(null) != null) {
                                     // No-one subscribed to the message (or there is none), so if there is a message
@@ -117,7 +117,6 @@ final class HttpMessageDiscardWatchdogClientFilter implements StreamingHttpConne
                                             "in a user-defined filter. Response payload (message) body must " +
                                             "be fully consumed before discarding.", cause);
                                 }
-                                return Single.<StreamingHttpResponse>failed(cause).shareContextOnSubscribe();
                             });
                 }
             };


### PR DESCRIPTION
Motivation:

We already apply `HttpMessageDiscardWatchdogClientFilter` to single-address clients to detect response leaks that could be caused by unhandled exceptions in the filter chain. Multi-address client adds more logic around a client group and therefore also could leak responses if case on unexpected exceptions.

Modifications:

- Apply `HttpMessageDiscardWatchdogClientFilter` to multi-address client instances;
- Enhance `HttpMessageDiscardWatchdogClientFilter` to include unhandled exception in the logs to help narrow down the leak cause;
- `CleanerStreamingHttpClientFilterFactory`: replace `onErrorResume` with `whenOnError` to reduce RS overhead (avoids subscribe sequence for returned failed single);

Result:

Users will see warn message if their multi-address client leaks responses.