### PR TITLE
capacity-limiter-api: observer all gradient limit changes

### DIFF
--- a/servicetalk-capacity-limiter-api/build.gradle
+++ b/servicetalk-capacity-limiter-api/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 }

--- a/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiter.java
+++ b/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiter.java
@@ -218,7 +218,8 @@ final class GradientCapacityLimiter implements CapacityLimiter {
 
         if (oldLimit != newLimit) {
             // latencies and gradient were not involved in the calculations
-            observer.onLimitChange(0.0 /*longLatencyMillis*/, 0.0 /*shortLatencyMillis*/, -1.0 /*gradient*/, oldLimit, newLimit);
+            observer.onLimitChange(
+                    -1.0 /*longLatencyMillis*/, -1.0 /*shortLatencyMillis*/, -1.0 /*gradient*/, oldLimit, newLimit);
         }
         observer.onActiveRequestsDecr();
         return (int) (newLimit - newPending);

--- a/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterBuilder.java
+++ b/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterBuilder.java
@@ -329,6 +329,9 @@ public final class GradientCapacityLimiterBuilder {
 
     /**
      * A state observer for Gradient {@link CapacityLimiter} to monitor internal state changes.
+     *
+     * Note: callbacks are not guaranteed to be executed sequentially or in exactly the same order that state changes
+     * occurred.
      */
     public interface Observer {
 

--- a/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterBuilder.java
+++ b/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterBuilder.java
@@ -348,10 +348,13 @@ public final class GradientCapacityLimiterBuilder {
          * <p>
          * The rate of reporting to the observer is based on the rate of change to this
          * {@link CapacityLimiter} and the {@link #limitUpdateInterval(Duration) sampling interval}.
-         * @param longRtt The exponential moving average stat of request response times.
-         * @param shortRtt The sampled response time that triggered the limit change.
+         * @param longRtt The exponential moving average stat of request response times. A negative value means
+         *                response times were not used in the calculation.
+         * @param shortRtt The sampled response time that triggered the limit change. A negative value means
+         *          *                response times were not used in the calculation.
          * @param gradient The response time gradient (delta) between the long exposed stat (see. longRtt)
-         * and the sampled response time (see. shortRtt).
+         * and the sampled response time (see. shortRtt). A negative value means the gradient was not used in the
+         * calculation.
          * @param oldLimit The previous limit of the limiter.
          * @param newLimit The current limit of the limiter.
          */

--- a/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterTest.java
+++ b/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterTest.java
@@ -77,13 +77,12 @@ class GradientCapacityLimiterTest {
     void capacityCanDepleteToTheMinLimit() {
         for (;;) {
             CapacityLimiter.Ticket ticket = capacityLimiter.tryAcquire(DEFAULT, null);
-            currentTime += Duration.ofMillis(50).toNanos();
+            currentTime += Duration.ofMillis(10).toNanos();
             int capacity = ticket.failed(SAD_EXCEPTION);
             if (capacity == DEFAULT_MIN_LIMIT) {
                 break;
             }
         }
-
     }
 
     @Test

--- a/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterTest.java
+++ b/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterTest.java
@@ -114,12 +114,12 @@ class GradientCapacityLimiterTest {
         ticket.failed(SAD_EXCEPTION);
 
         // ticket failure will not use gradient
-        verify(observer).onLimitChange(eq(0.0), eq(0.0), eq(-1.0), eq(100.0), eq(50.0));
+        verify(observer).onLimitChange(eq(-1.0), eq(-1.0), eq(-1.0), eq(100.0), eq(50.0));
 
         ticket = capacityLimiter.tryAcquire(DEFAULT, null);
         currentTime += Duration.ofMillis(50).toNanos();
         // Ticket success should adjust observation upward.
         ticket.completed();
-        verify(observer).onLimitChange(not(eq(0.0)), not(eq(0.0)), not(eq(-1.0)), anyDouble(), anyDouble());
+        verify(observer).onLimitChange(not(eq(-1.0)), not(eq(-1.0)), not(eq(-1.0)), anyDouble(), anyDouble());
     }
 }


### PR DESCRIPTION
Motivation:

We currently see callbacks to Observer.onLimitChange(..) only for the successful case, but it's perhaps even more important for the limit decrease case.

Modifications:

- Call the callbacks whenever the limit changes.
- Also call them on the failure case. Since we don't use the gradient and RTT params, we pass in -1.0. This also requires a change in the javadoc.
- Add some tests to make sure the observers are called.