### PR TITLE
Server-side `AsyncContext` initialized in lifecycle observer is lost

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToOffloadedStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToOffloadedStreamingHttpService.java
@@ -54,7 +54,7 @@ public class StreamingHttpServiceToOffloadedStreamingHttpService implements Stre
         // this ExecutionStrategy to understand if we need to offload more than we already offloaded:
         final HttpExecutionStrategy additionalOffloads = ctx.executionContext().executionStrategy().missing(strategy);
 
-        Executor useExecutor = null != executor ? executor : ctx.executionContext().executor();
+        final Executor useExecutor = executor != null ? executor : ctx.executionContext().executor();
 
         // The service should see this ExecutionStrategy and Executor inside the ExecutionContext:
         final HttpServiceContext wrappedCtx =
@@ -136,12 +136,12 @@ public class StreamingHttpServiceToOffloadedStreamingHttpService implements Stre
                 new StreamingHttpService() {
                     @Override
                     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
-                                                                StreamingHttpRequest request,
+                                                                final StreamingHttpRequest request,
                                                                 final StreamingHttpResponseFactory responseFactory) {
-                        Executor useExecutor = null != executor ? executor : ctx.executionContext().executor();
+                        final Executor useExecutor = executor != null ? executor : ctx.executionContext().executor();
 
                         // The service should see this ExecutionStrategy and Executor inside the ExecutionContext:
-                        HttpServiceContext wrappedCtx =
+                        final HttpServiceContext wrappedCtx =
                                 new ExecutionContextOverridingServiceContext(ctx, strategy, useExecutor);
 
                         return service.handle(wrappedCtx, request, responseFactory);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClearAsyncContextHttpServiceFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ClearAsyncContextHttpServiceFilter.java
@@ -32,8 +32,7 @@ import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
  */
 final class ClearAsyncContextHttpServiceFilter implements StreamingHttpServiceFilterFactory {
 
-    static final ClearAsyncContextHttpServiceFilter CLEAR_ASYNC_CONTEXT_HTTP_SERVICE_FILTER =
-            new ClearAsyncContextHttpServiceFilter();
+    static final ClearAsyncContextHttpServiceFilter INSTANCE = new ClearAsyncContextHttpServiceFilter();
 
     private ClearAsyncContextHttpServiceFilter() {
         // singleton

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OffloadingFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OffloadingFilter.java
@@ -30,25 +30,23 @@ import java.util.function.BooleanSupplier;
 final class OffloadingFilter implements StreamingHttpServiceFilterFactory {
 
     private final HttpExecutionStrategy strategy;
-    private final StreamingHttpServiceFilterFactory offloaded;
     private final BooleanSupplier shouldOffload;
 
     /**
+     * Creates a new instance.
+     *
      * @param strategy Execution strategy for the offloaded filters
-     * @param offloaded Filters to be offloaded
      * @param shouldOffload returns true if offloading is appropriate for the current execution context.
      */
-    OffloadingFilter(HttpExecutionStrategy strategy, StreamingHttpServiceFilterFactory offloaded,
-                     BooleanSupplier shouldOffload) {
+    OffloadingFilter(final HttpExecutionStrategy strategy, final BooleanSupplier shouldOffload) {
         this.strategy = strategy;
-        this.offloaded = offloaded;
         this.shouldOffload = shouldOffload;
     }
 
     @Override
-    public StreamingHttpServiceFilter create(StreamingHttpService service) {
+    public StreamingHttpServiceFilter create(final StreamingHttpService service) {
         StreamingHttpService offloadedService = StreamingHttpServiceToOffloadedStreamingHttpService.offloadService(
-                strategy, null, shouldOffload, offloaded.create(service));
+                strategy, null, shouldOffload, service);
         return new StreamingHttpServiceFilter(offloadedService);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractAsyncHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractAsyncHttpServiceAsyncContextTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+abstract class AbstractAsyncHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncContextTest {
+
+    @Test
+    void newRequestsGetFreshContextImmediate() throws Exception {
+        newRequestsGetFreshContext(true);
+    }
+
+    private static List<Arguments> params() {
+        List<Arguments> params = new ArrayList<>();
+        for (boolean useImmediate : Arrays.asList(false, true)) {
+            for (InitContextKeyPlace place : InitContextKeyPlace.values()) {
+                for (boolean asyncService : Arrays.asList(false, true)) {
+                    if (!useImmediate && !asyncService) {
+                        continue;
+                    }
+                    params.add(Arguments.of(useImmediate, place, asyncService));
+                }
+            }
+        }
+        return params;
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: useImmediate={0} initContextKeyPlace={1} asyncService={2}")
+    @MethodSource("params")
+    void contextPreservedOverFilterBoundariesAsync(boolean useImmediate, InitContextKeyPlace place,
+                                                   boolean asyncService) throws Exception {
+        contextPreservedOverFilterBoundaries(useImmediate, place, asyncService);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: connectionAcceptorType={0}")
+    @EnumSource(ConnectionAcceptorType.class)
+    void connectionAcceptorContextDoesNotLeakImmediate(ConnectionAcceptorType type) throws Exception {
+        connectionAcceptorContextDoesNotLeak(type, true);
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -15,32 +15,44 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.AsyncContext;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.BlockingHttpConnection;
+import io.servicetalk.http.api.HttpExecutionStrategies;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpHeaders;
+import io.servicetalk.http.api.HttpLifecycleObserver;
+import io.servicetalk.http.api.HttpLifecycleObserver.HttpExchangeObserver;
+import io.servicetalk.http.api.HttpLifecycleObserver.HttpRequestObserver;
+import io.servicetalk.http.api.HttpLifecycleObserver.HttpResponseObserver;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServiceContext;
-import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
-import io.servicetalk.http.api.StreamingHttpClient;
-import io.servicetalk.http.api.StreamingHttpConnection;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.DelegatingConnectionAcceptor;
-import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
-import java.net.InetSocketAddress;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
@@ -52,10 +64,8 @@ import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.context.api.ContextMap.Key.newKey;
-import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.assertAsyncContext;
-import static io.servicetalk.http.netty.HttpClients.forResolvedAddress;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
 import static io.servicetalk.test.resources.TestUtils.assertNoAsyncErrors;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -66,6 +76,21 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 abstract class AbstractHttpServiceAsyncContextTest {
+    enum InitContextKeyPlace {
+        LIFECYCLE_OBSERVER,
+        NON_OFFLOADING_LIFECYCLE_OBSERVER_FILTER,
+        NON_OFFLOADING_FILTER,
+        NON_OFFLOADING_ASYNC_FILTER,
+        LIFECYCLE_OBSERVER_FILTER,
+        FILTER,
+        ASYNC_FILTER
+    }
+
+    enum ConnectionAcceptorType {
+        EARLY,
+        LATE,
+        DEPRECATED
+    }
 
     protected static final ContextMap.Key<CharSequence> K1 = newKey("k1", CharSequence.class);
     protected static final CharSequence REQUEST_ID_HEADER = newAsciiString("request-id");
@@ -101,13 +126,9 @@ abstract class AbstractHttpServiceAsyncContextTest {
             for (int i = 0; i < concurrency; ++i) {
                 final int finalI = i;
                 executorService.execute(() -> {
-                    SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder =
-                            forResolvedAddress(serverHostAndPort(ctx))
-                                    .protocols(h1().maxPipelinedRequests(numRequests).build());
-                    try (StreamingHttpClient client = (!useImmediate ? clientBuilder :
-                            clientBuilder.executionStrategy(offloadNone())).buildStreaming()) {
-                        try (StreamingHttpConnection connection = client.reserveConnection(client.get("/"))
-                                .toFuture().get()) {
+                    try (BlockingHttpClient client = HttpClients.forResolvedAddress(serverHostAndPort(ctx))
+                            .protocols(h1().maxPipelinedRequests(numRequests).build()).buildBlocking()) {
+                        try (BlockingHttpConnection connection = client.reserveConnection(client.get("/"))) {
                             barrier.await();
                             for (int x = 0; x < numRequests; ++x) {
                                 makeClientRequestWithId(connection, "thread=" + finalI + " request=" + x);
@@ -128,27 +149,46 @@ abstract class AbstractHttpServiceAsyncContextTest {
         }
     }
 
-    @Test
-    void contextPreservedOverFilterBoundariesOffloaded() throws Exception {
-        contextPreservedOverFilterBoundaries(false, false, false);
+    @ParameterizedTest(name = "{displayName} [{index}]: useImmediate=false initContextKeyPlace={0} asyncService=false")
+    @EnumSource(InitContextKeyPlace.class)
+    void contextPreservedOverFilterBoundariesOffloaded(InitContextKeyPlace place) throws Exception {
+        contextPreservedOverFilterBoundaries(false, place, false);
     }
 
-    @Test
-    void contextPreservedOverFilterBoundariesOffloadedAsyncFilter() throws Exception {
-        contextPreservedOverFilterBoundaries(false, true, false);
-    }
-
-    final void contextPreservedOverFilterBoundaries(boolean useImmediate, boolean asyncFilter,
+    final void contextPreservedOverFilterBoundaries(boolean useImmediate, InitContextKeyPlace place,
                                                     boolean asyncService) throws Exception {
         Queue<Throwable> errorQueue = new ConcurrentLinkedQueue<>();
-
-        try (ServerContext ctx = serverWithService(HttpServers.forAddress(localAddress(0))
-                .appendServiceFilter(filterFactory(useImmediate, asyncFilter, errorQueue)),
-                useImmediate, asyncService);
-
-             StreamingHttpClient client = HttpClients.forResolvedAddress(serverHostAndPort(ctx)).buildStreaming();
-
-             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+        HttpServerBuilder builder = HttpServers.forAddress(localAddress(0));
+        switch (place) {
+            case LIFECYCLE_OBSERVER:
+                builder.lifecycleObserver(new AsyncContextLifecycleObserver(errorQueue));
+                break;
+            case NON_OFFLOADING_LIFECYCLE_OBSERVER_FILTER:
+                builder.appendNonOffloadingServiceFilter(new HttpLifecycleObserverServiceFilter(
+                        new AsyncContextLifecycleObserver(errorQueue)));
+                break;
+            case NON_OFFLOADING_FILTER:
+                builder.appendNonOffloadingServiceFilter(filterFactory(useImmediate, false, errorQueue));
+                break;
+            case NON_OFFLOADING_ASYNC_FILTER:
+                builder.appendNonOffloadingServiceFilter(filterFactory(useImmediate, true, errorQueue));
+                break;
+            case LIFECYCLE_OBSERVER_FILTER:
+                builder.appendServiceFilter(new HttpLifecycleObserverServiceFilter(
+                        new AsyncContextLifecycleObserver(errorQueue)));
+                break;
+            case FILTER:
+                builder.appendServiceFilter(filterFactory(useImmediate, false, errorQueue));
+                break;
+            case ASYNC_FILTER:
+                builder.appendServiceFilter(filterFactory(useImmediate, true, errorQueue));
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown InitContextKeyPlace: " + place);
+        }
+        try (ServerContext ctx = serverWithService(builder, useImmediate, asyncService);
+             BlockingHttpClient client = HttpClients.forResolvedAddress(serverHostAndPort(ctx)).buildBlocking();
+             BlockingHttpConnection connection = client.reserveConnection(client.get("/"))) {
 
             makeClientRequestWithId(connection, "1");
             assertNoAsyncErrors(errorQueue);
@@ -158,34 +198,44 @@ abstract class AbstractHttpServiceAsyncContextTest {
     private StreamingHttpServiceFilterFactory filterFactory(final boolean useImmediate,
                                                             final boolean asyncFilter,
                                                             final Queue<Throwable> errorQueue) {
-        return service -> new StreamingHttpServiceFilter(service) {
+        return new StreamingHttpServiceFilterFactory() {
             @Override
-            public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
-                                                        final StreamingHttpRequest request,
-                                                        final StreamingHttpResponseFactory factory) {
-                return asyncFilter ? defer(() -> doHandle(ctx, request, factory).shareContextOnSubscribe()) :
-                        doHandle(ctx, request, factory);
+            public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+                return new StreamingHttpServiceFilter(service) {
+                    @Override
+                    public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                                final StreamingHttpRequest request,
+                                                                final StreamingHttpResponseFactory factory) {
+                        return asyncFilter ? defer(() -> doHandle(ctx, request, factory).shareContextOnSubscribe()) :
+                                doHandle(ctx, request, factory);
+                    }
+
+                    private Single<StreamingHttpResponse> doHandle(final HttpServiceContext ctx,
+                                                                   final StreamingHttpRequest request,
+                                                                   final StreamingHttpResponseFactory factory) {
+                        if (useImmediate && !currentThread().getName().startsWith(IO_THREAD_PREFIX)) {
+                            // verify that if we expect to be offloaded, that we actually are
+                            return succeeded(factory.internalServerError());
+                        }
+                        CharSequence requestId = request.headers().getAndRemove(REQUEST_ID_HEADER);
+                        if (requestId != null) {
+                            AsyncContext.put(K1, requestId);
+                        }
+                        final StreamingHttpRequest filteredRequest = request.transformMessageBody(pub ->
+                                pub.afterSubscriber(assertAsyncContextSubscriber(requestId, errorQueue)));
+                        return delegate().handle(ctx, filteredRequest, factory).map(resp -> {
+                                    assertAsyncContext(K1, requestId, errorQueue);
+                                    return resp.transformMessageBody(pub ->
+                                            pub.afterSubscriber(assertAsyncContextSubscriber(requestId, errorQueue)));
+                                }
+                        );
+                    }
+                };
             }
 
-            private Single<StreamingHttpResponse> doHandle(final HttpServiceContext ctx,
-                                                           final StreamingHttpRequest request,
-                                                           final StreamingHttpResponseFactory factory) {
-                if (useImmediate && !currentThread().getName().startsWith(IO_THREAD_PREFIX)) {
-                    // verify that if we expect to be offloaded, that we actually are
-                    return succeeded(factory.internalServerError());
-                }
-                CharSequence requestId = request.headers().getAndRemove(REQUEST_ID_HEADER);
-                if (requestId != null) {
-                    AsyncContext.put(K1, requestId);
-                }
-                final StreamingHttpRequest filteredRequest = request.transformMessageBody(pub ->
-                        pub.afterSubscriber(assertAsyncContextSubscriber(requestId, errorQueue)));
-                return delegate().handle(ctx, filteredRequest, factory).map(resp -> {
-                            assertAsyncContext(K1, requestId, errorQueue);
-                            return resp.transformMessageBody(pub ->
-                                    pub.afterSubscriber(assertAsyncContextSubscriber(requestId, errorQueue)));
-                        }
-                );
+            @Override
+            public HttpExecutionStrategy requiredOffloads() {
+                return HttpExecutionStrategies.offloadNone();
             }
         };
     }
@@ -216,34 +266,151 @@ abstract class AbstractHttpServiceAsyncContextTest {
         };
     }
 
-    @Test
-    void connectionAcceptorContextDoesNotLeakOffload() throws Exception {
-        connectionAcceptorContextDoesNotLeak(false);
+    @ParameterizedTest(name = "{displayName} [{index}]: connectionAcceptorType={0}")
+    @EnumSource(ConnectionAcceptorType.class)
+    void connectionAcceptorContextDoesNotLeakOffloaded(ConnectionAcceptorType type) throws Exception {
+        connectionAcceptorContextDoesNotLeak(type, false);
     }
 
-    final void connectionAcceptorContextDoesNotLeak(boolean serverUseImmediate) throws Exception {
-        try (ServerContext ctx = serverWithEmptyAsyncContextService(HttpServers.forAddress(localAddress(0))
-                .appendConnectionAcceptorFilter(original -> new DelegatingConnectionAcceptor(context -> {
+    @SuppressWarnings("deprecation")
+    final void connectionAcceptorContextDoesNotLeak(ConnectionAcceptorType connectionAcceptorType,
+                                                    boolean serverUseImmediate) throws Exception {
+        HttpServerBuilder builder = HttpServers.forAddress(localAddress(0));
+        switch (connectionAcceptorType) {
+            case EARLY:
+                builder.appendEarlyConnectionAcceptor(conn -> {
                     AsyncContext.put(K1, "v1");
                     return completed();
-                })), serverUseImmediate);
-
-             StreamingHttpClient client = HttpClients.forResolvedAddress(serverHostAndPort(ctx)).buildStreaming();
-
-             StreamingHttpConnection connection = client.reserveConnection(client.get("/")).toFuture().get()) {
+                });
+                break;
+            case LATE:
+                builder.appendLateConnectionAcceptor(conn -> {
+                    AsyncContext.put(K1, "v1");
+                    return completed();
+                });
+                break;
+            case DEPRECATED:
+                builder.appendConnectionAcceptorFilter(original -> new DelegatingConnectionAcceptor(context -> {
+                    AsyncContext.put(K1, "v1");
+                    return completed();
+                }));
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown ConnectionAcceptorType: " + connectionAcceptorType);
+        }
+        try (ServerContext ctx = serverWithEmptyAsyncContextService(builder, serverUseImmediate);
+             BlockingHttpClient client = HttpClients.forResolvedAddress(serverHostAndPort(ctx)).buildBlocking();
+             BlockingHttpConnection connection = client.reserveConnection(client.get("/"))) {
 
             makeClientRequestWithId(connection, "1");
             makeClientRequestWithId(connection, "2");
         }
     }
 
-    private static void makeClientRequestWithId(StreamingHttpConnection connection, String requestId)
-            throws ExecutionException, InterruptedException {
-        StreamingHttpRequest request = connection.get("/");
+    private static void makeClientRequestWithId(BlockingHttpConnection connection, String requestId) throws Exception {
+        HttpRequest request = connection.get("/");
         request.headers().set(REQUEST_ID_HEADER, requestId);
-        StreamingHttpResponse response = connection.request(request).toFuture().get();
+        HttpResponse response = connection.request(request);
         assertEquals(OK, response.status());
         assertTrue(request.headers().contains(REQUEST_ID_HEADER, requestId));
-        response.messageBody().ignoreElements().toFuture().get();
+    }
+
+    private static final class AsyncContextLifecycleObserver implements HttpLifecycleObserver, HttpExchangeObserver,
+                                                                        HttpRequestObserver, HttpResponseObserver {
+
+        private final Queue<Throwable> errorQueue;
+        @Nullable
+        private CharSequence requestId;
+
+        AsyncContextLifecycleObserver(Queue<Throwable> errorQueue) {
+            this.errorQueue = errorQueue;
+        }
+
+        @Override
+        public HttpExchangeObserver onNewExchange() {
+            return this;
+        }
+
+        @Override
+        public void onConnectionSelected(ConnectionInfo info) {
+        }
+
+        @Override
+        public HttpRequestObserver onRequest(HttpRequestMetaData requestMetaData) {
+            requestId = requestMetaData.headers().getAndRemove(REQUEST_ID_HEADER);
+            if (requestId != null) {
+                AsyncContext.put(K1, requestId);
+            }
+            return this;
+        }
+
+        @Override
+        public void onRequestData(Buffer data) {
+            assertAsyncContext();
+        }
+
+        @Override
+        public void onRequestTrailers(HttpHeaders trailers) {
+            assertAsyncContext();
+        }
+
+        @Override
+        public void onRequestComplete() {
+            assertAsyncContext();
+        }
+
+        @Override
+        public void onRequestError(Throwable cause) {
+            errorQueue.add(new AssertionError("Unexpected onRequestError", cause));
+        }
+
+        @Override
+        public void onRequestCancel() {
+            errorQueue.add(new AssertionError("Unexpected onRequestCancel"));
+        }
+
+        @Override
+        public HttpResponseObserver onResponse(HttpResponseMetaData responseMetaData) {
+            assertAsyncContext();
+            return this;
+        }
+
+        @Override
+        public void onResponseData(final Buffer data) {
+            assertAsyncContext();
+        }
+
+        @Override
+        public void onResponseTrailers(final HttpHeaders trailers) {
+            assertAsyncContext();
+        }
+
+        @Override
+        public void onResponseComplete() {
+            assertAsyncContext();
+        }
+
+        @Override
+        public void onResponseError(Throwable cause) {
+            errorQueue.add(new AssertionError("Unexpected onResponseError", cause));
+        }
+
+        @Override
+        public void onResponseCancel() {
+            errorQueue.add(new AssertionError("Unexpected onResponseCancel"));
+        }
+
+        @Override
+        public void onExchangeFinally() {
+            assertAsyncContext();
+        }
+
+        private void assertAsyncContext() {
+            if (requestId == null) {
+                errorQueue.add(new AssertionError("Unexpected requestId == null"));
+                return;
+            }
+            AsyncContextHttpFilterVerifier.assertAsyncContext(K1, requestId, errorQueue);
+        }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingHttpServiceAsyncContextTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2019, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.http.api.BlockingHttpService;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.transport.api.ServerContext;
+
+import static java.lang.Thread.currentThread;
+
+class BlockingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncContextTest {
+
+    @Override
+    protected ServerContext serverWithEmptyAsyncContextService(HttpServerBuilder serverBuilder,
+                                                               boolean useImmediate) throws Exception {
+        // Ignore "useImmediate"
+        return serverBuilder.listenBlockingAndAwait(newEmptyAsyncContextService());
+    }
+
+    private static BlockingHttpService newEmptyAsyncContextService() {
+        return (ctx, request, factory) -> {
+            if (!AsyncContext.isEmpty()) {
+                BufferAllocator alloc = ctx.executionContext().bufferAllocator();
+                return factory.internalServerError()
+                        .payloadBody(alloc.fromAscii(AsyncContext.context().toString()));
+            }
+            CharSequence requestId = request.headers().getAndRemove(REQUEST_ID_HEADER);
+            if (requestId != null) {
+                AsyncContext.put(K1, requestId);
+                return factory.ok().setHeader(REQUEST_ID_HEADER, requestId);
+            } else {
+                return factory.badRequest();
+            }
+        };
+    }
+
+    @Override
+    protected ServerContext serverWithService(HttpServerBuilder serverBuilder,
+                                              boolean useImmediate, boolean asyncService) throws Exception {
+        // Ignore "useImmediate" and "asyncService"
+        return serverBuilder.listenBlockingAndAwait(service());
+    }
+
+    private static BlockingHttpService service() {
+        return (ctx, request, responseFactory) -> {
+            CharSequence requestId = AsyncContext.get(K1);
+
+            if (currentThread().getName().startsWith(IO_THREAD_PREFIX)) {
+                // verify that we are not offloaded
+                return responseFactory.badGateway();
+            }
+
+            if (requestId != null) {
+                return responseFactory.ok().setHeader(REQUEST_ID_HEADER, requestId);
+            } else {
+                return responseFactory.internalServerError()
+                        .setHeader(REQUEST_ID_HEADER, "null");
+            }
+        };
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingStreamingHttpServiceAsyncContextTest.java
@@ -23,6 +23,7 @@ import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.transport.api.ServerContext;
 
+import static io.servicetalk.http.api.HttpResponseStatus.BAD_GATEWAY;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_REQUEST;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static java.lang.Thread.currentThread;
@@ -79,8 +80,8 @@ class BlockingStreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAs
                 request.payloadBody().forEach(__ -> { });
 
                 if (currentThread().getName().startsWith(IO_THREAD_PREFIX)) {
-                    // verify that we actually are offloaded
-                    response.status(INTERNAL_SERVER_ERROR).sendMetaData().close();
+                    // verify that we are not offloaded
+                    response.status(BAD_GATEWAY).sendMetaData().close();
                     return;
                 }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpServiceAsyncContextTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2018-2019, 2021 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.AsyncContext;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseFactory;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpService;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.transport.api.ServerContext;
+
+import static io.servicetalk.concurrent.api.Single.defer;
+import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static java.lang.Thread.currentThread;
+
+class HttpServiceAsyncContextTest extends AbstractAsyncHttpServiceAsyncContextTest {
+
+    @Override
+    protected ServerContext serverWithEmptyAsyncContextService(HttpServerBuilder serverBuilder,
+                                                               boolean useImmediate) throws Exception {
+        if (useImmediate) {
+            serverBuilder.executionStrategy(offloadNone());
+        }
+        return serverBuilder.listenAndAwait(newEmptyAsyncContextService());
+    }
+
+    private HttpService newEmptyAsyncContextService() {
+        return (ctx, request, factory) -> {
+            if (!AsyncContext.isEmpty()) {
+                BufferAllocator alloc = ctx.executionContext().bufferAllocator();
+                return succeeded(factory.internalServerError()
+                        .payloadBody(alloc.fromAscii(AsyncContext.context().toString())));
+            }
+            CharSequence requestId = request.headers().getAndRemove(REQUEST_ID_HEADER);
+            if (requestId != null) {
+                AsyncContext.put(K1, requestId);
+                return succeeded(factory.ok().setHeader(REQUEST_ID_HEADER, requestId));
+            } else {
+                return succeeded(factory.badRequest());
+            }
+        };
+    }
+
+    @Override
+    protected ServerContext serverWithService(HttpServerBuilder serverBuilder, boolean useImmediate,
+                                              boolean asyncService) throws Exception {
+        if (useImmediate) {
+            serverBuilder.executionStrategy(offloadNone());
+        }
+        return serverBuilder.listenAndAwait(service(useImmediate, asyncService));
+    }
+
+    private HttpService service(boolean useImmediate, boolean asyncService) {
+        return new HttpService() {
+            @Override
+            public Single<HttpResponse> handle(HttpServiceContext ctx,
+                                               HttpRequest request,
+                                               HttpResponseFactory responseFactory) {
+                return asyncService ? defer(() -> doHandle(responseFactory).shareContextOnSubscribe()) :
+                        doHandle(responseFactory);
+            }
+
+            private Single<HttpResponse> doHandle(HttpResponseFactory factory) {
+                CharSequence requestId = AsyncContext.get(K1);
+                if (useImmediate && !currentThread().getName().startsWith(IO_THREAD_PREFIX)) {
+                    // verify that if we expect to be offloaded, that we actually are
+                    return succeeded(factory.badGateway());
+                }
+                if (requestId != null) {
+                    return succeeded(factory.ok().setHeader(REQUEST_ID_HEADER, requestId));
+                } else {
+                    return succeeded(factory.internalServerError().setHeader(REQUEST_ID_HEADER, "null"));
+                }
+            }
+        };
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingHttpServiceAsyncContextTest.java
@@ -25,8 +25,6 @@ import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.transport.api.ServerContext;
 
-import org.junit.jupiter.api.Test;
-
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -34,51 +32,11 @@ import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
 import static java.lang.Thread.currentThread;
 
-class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncContextTest {
-
-    @Test
-    void newRequestsGetFreshContextImmediate() throws Exception {
-        newRequestsGetFreshContext(true);
-    }
-
-    @Test
-    void contextPreservedOverFilterBoundariesOffloadedAsyncService() throws Exception {
-        contextPreservedOverFilterBoundaries(false, false, true);
-    }
-
-    @Test
-    void contextPreservedOverFilterBoundariesOffloadedAsyncFilterAsyncService() throws Exception {
-        contextPreservedOverFilterBoundaries(false, true, true);
-    }
-
-    @Test
-    void contextPreservedOverFilterBoundariesNoOffload() throws Exception {
-        contextPreservedOverFilterBoundaries(true, false, false);
-    }
-
-    @Test
-    void contextPreservedOverFilterBoundariesNoOffloadAsyncService() throws Exception {
-        contextPreservedOverFilterBoundaries(true, false, true);
-    }
-
-    @Test
-    void contextPreservedOverFilterBoundariesNoOffloadAsyncFilter() throws Exception {
-        contextPreservedOverFilterBoundaries(true, true, false);
-    }
-
-    @Test
-    void contextPreservedOverFilterBoundariesNoOffloadAsyncFilterAsyncService() throws Exception {
-        contextPreservedOverFilterBoundaries(true, true, true);
-    }
-
-    @Test
-    void connectionAcceptorContextDoesNotLeakImmediate() throws Exception {
-        connectionAcceptorContextDoesNotLeak(true);
-    }
+class StreamingHttpServiceAsyncContextTest extends AbstractAsyncHttpServiceAsyncContextTest {
 
     @Override
     protected ServerContext serverWithEmptyAsyncContextService(HttpServerBuilder serverBuilder,
-                                                     boolean useImmediate) throws Exception {
+                                                               boolean useImmediate) throws Exception {
         if (useImmediate) {
             serverBuilder.executionStrategy(offloadNone());
         }
@@ -105,8 +63,8 @@ class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncConte
     }
 
     @Override
-    protected ServerContext serverWithService(HttpServerBuilder serverBuilder,
-                                    boolean useImmediate, boolean asyncService) throws Exception {
+    protected ServerContext serverWithService(HttpServerBuilder serverBuilder, boolean useImmediate,
+                                              boolean asyncService) throws Exception {
         if (useImmediate) {
             serverBuilder.executionStrategy(offloadNone());
         }
@@ -133,7 +91,7 @@ class StreamingHttpServiceAsyncContextTest extends AbstractHttpServiceAsyncConte
                         .concat(defer(() -> {
                             if (useImmediate && !currentThread().getName().startsWith(IO_THREAD_PREFIX)) {
                                 // verify that if we expect to be offloaded, that we actually are
-                                return succeeded(factory.internalServerError());
+                                return succeeded(factory.badGateway());
                             }
                             CharSequence requestId2 = AsyncContext.get(K1);
                             if (requestId2 == requestId && requestId2 != null) {


### PR DESCRIPTION
Motivation:

If users put any data into `AsyncContext` inside `HttpLifecycleObserver` configured via `HttpServerBuilder.lifecycleObserver(...)` it won't be visible for filters and service because
`ClearAsyncContextHttpServiceFilter` is appended after `HttpLifecycleObserverServiceFilter` inside `applyInternalFilters`.

Modifications:
1. Move `ClearAsyncContextHttpServiceFilter` from the beginning of `noOffloadServiceFilters` to `applyInternalFilters`. However, this move discovered another bug in path that handles
`noOffloadServiceFilters.isEmpty()` case because it never adds `OffloadingFilter`.
2. Refactor `listenForService` method to always make a copy of filters lists, then prepend/append internal filters to those copies in easy to read/understand way, and construct a single filters `Stream` for `buildService` method.
3. Refactor `OffloadingFilter` to act as a regular filter factory instead of taking all further `serviceFilters` as pre-built factory.
4. Rename `ClearAsyncContextHttpServiceFilter` singleton instance.
5. Fix another bug when `OptionalSslNegotiator` binder takes a raw service instead of `filteredService` (user-defined filters were never applied for this path).
6. Modify `AbstractHttpServiceAsyncContextTest` to test `AsyncContext` propagation from lifecycle observer and non-offloading filters.
7. Modify `AbstractHttpServiceAsyncContextTest` to test `AsyncContext` initialized by early/late connection acceptor is not visible at request path.
8. Add `BlockingHttpServiceAsyncContextTest` and `HttpServiceAsyncContextTest` to make sure `AsyncContext` propagation for blocking/async aggregated services is also tested.
9. Use `ParameterizedTest` where possible.

Results:

1. `AsyncContext` initialized inside server's lifecycle observer is visible through filter chain and services.
2. Construction of server-side filter chain is consistent and sequential.
3. Filters are applied for servers with optional TLS.