### PR TITLE
`Single`/`Completable` `subscribe` overloads to handle failures

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1772,6 +1772,21 @@ public abstract class Completable {
     }
 
     /**
+     * Subscribe to this {@link Completable}, invoke passed {@link Runnable} when this {@link Completable} terminates
+     * successfully or emit an error to {@link Consumer} when it fails.
+     *
+     * @param onComplete {@link Runnable} to invoke when this {@link Completable} terminates successfully.
+     * @param errorConsumer {@link Consumer} to accept the error when this {@link Completable} fails.
+     * @return {@link Cancellable} used to invoke {@link Cancellable#cancel()} on the parameter of
+     * {@link Subscriber#onSubscribe(Cancellable)} for this {@link Completable}.
+     */
+    public final Cancellable subscribe(Runnable onComplete, Consumer<? super Throwable> errorConsumer) {
+        SimpleCompletableSubscriber subscriber = new SimpleCompletableSubscriber(onComplete, errorConsumer);
+        subscribeInternal(subscriber);
+        return subscriber;
+    }
+
+    /**
      * Handles a subscriber to this {@code Completable}.
      * <p>
      * This method is invoked internally by {@link Completable} for every call to the

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SimpleCompletableSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SimpleCompletableSubscriber.java
@@ -40,13 +40,14 @@ final class SimpleCompletableSubscriber extends SequentialCancellable implements
     }
 
     SimpleCompletableSubscriber(final Runnable onComplete) {
-        this(onComplete, null);
+        this.onComplete = requireNonNull(onComplete);
+        this.errorConsumer = null;
     }
 
     SimpleCompletableSubscriber(final Runnable onComplete,
-                                @Nullable final Consumer<? super Throwable> errorConsumer) {
+                                final Consumer<? super Throwable> errorConsumer) {
         this.onComplete = requireNonNull(onComplete);
-        this.errorConsumer = errorConsumer;
+        this.errorConsumer = requireNonNull(errorConsumer);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SimpleSingleSubscriber.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SimpleSingleSubscriber.java
@@ -36,13 +36,14 @@ final class SimpleSingleSubscriber<T> extends SequentialCancellable implements S
     private final Consumer<? super Throwable> errorConsumer;
 
     SimpleSingleSubscriber(final Consumer<? super T> resultConsumer) {
-        this(resultConsumer, null);
+        this.resultConsumer = requireNonNull(resultConsumer);
+        this.errorConsumer = null;
     }
 
     SimpleSingleSubscriber(final Consumer<? super T> resultConsumer,
-                           @Nullable final Consumer<? super Throwable> errorConsumer) {
+                           final Consumer<? super Throwable> errorConsumer) {
         this.resultConsumer = requireNonNull(resultConsumer);
-        this.errorConsumer = errorConsumer;
+        this.errorConsumer = requireNonNull(errorConsumer);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -1879,16 +1879,30 @@ public abstract class Single<T> {
     }
 
     /**
-     * Subscribe to this {@link Single}, emits the result to the passed {@link Consumer} and log any
-     * {@link Subscriber#onError(Throwable)}.
+     * Subscribe to this {@link Single}, emit the result to the passed {@link Consumer} and log any
+     * {@link Subscriber#onError(Throwable)} at debug level.
      *
-     * @param resultConsumer {@link Consumer} to accept the result of this {@link Single}.
-     *
+     * @param resultConsumer {@link Consumer} to accept the result of this {@link Single} if it succeeds.
      * @return {@link Cancellable} used to invoke {@link Cancellable#cancel()} on the parameter of
      * {@link Subscriber#onSubscribe(Cancellable)} for this {@link Single}.
      */
     public final Cancellable subscribe(Consumer<? super T> resultConsumer) {
         SimpleSingleSubscriber<T> subscriber = new SimpleSingleSubscriber<>(resultConsumer);
+        subscribeInternal(subscriber);
+        return subscriber;
+    }
+
+    /**
+     * Subscribe to this {@link Single}, emit the result or error to one of the passed {@link Consumer}s.
+     *
+     * @param resultConsumer {@link Consumer} to accept the result of this {@link Single} if it succeeds.
+     * @param errorConsumer {@link Consumer} to accept the error of this {@link Single} if it fails.
+     * @return {@link Cancellable} used to invoke {@link Cancellable#cancel()} on the parameter of
+     * {@link Subscriber#onSubscribe(Cancellable)} for this {@link Single}.
+     */
+    public final Cancellable subscribe(Consumer<? super T> resultConsumer,
+                                       Consumer<? super Throwable> errorConsumer) {
+        SimpleSingleSubscriber<T> subscriber = new SimpleSingleSubscriber<>(resultConsumer, errorConsumer);
         subscribeInternal(subscriber);
         return subscriber;
     }


### PR DESCRIPTION
Motivation:

Currently, users can consume the result or execute a `Runnable` for successful termination of a `Single`/`Completable`. Failures will be logged at debug level. Users can only use `whenOnError` operator to intercept the error, but it may result in duplicated logging or users simply forget to handle the error case.

Modifications:

- Add `Single.subscribe(Consumer<? super T>, Consumer<? super Throwable>)`;
- Add `Completable.subscribe(Runnable, Consumer<? super Throwable>)`;
- Modify `SimpleSingleSubscriber/SimpleCompletableSubscriber` to handle error when `errorConsumer` is provided.

Result:

Users can easily handle error cases when they subscribe to `Single` or `Completable`.