### PR TITLE
`RedirectSingle`: avoid extra operator for exception handling path

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectSingle.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/RedirectSingle.java
@@ -194,8 +194,8 @@ final class RedirectSingle extends SubscribableSingle<StreamingHttpResponse> {
                 if (!terminalDelivered) {
                     // Drain response payload body before propagating the cause
                     sequentialCancellable.nextCancellable(response.messageBody().ignoreElements()
-                            .whenOnError(suppressed -> safeOnError(target, addSuppressed(cause, suppressed)))
-                            .subscribe(() -> safeOnError(target, cause)));
+                            .subscribe(() -> safeOnError(target, cause),
+                                    suppressed -> safeOnError(target, addSuppressed(cause, suppressed))));
                 } else {
                     LOGGER.info("Ignoring exception from onSuccess of Subscriber {}.", target, cause);
                 }


### PR DESCRIPTION
Use new `Single.subscribe(...)` overload introduced in [#3112](https://github.com/apple/servicetalk/pull/3112) that takes `errorConsumer` to avoid using extra operator `whenOnError`. It will also help to avoid logging those exceptions by `SimpleSingleSubscriber` (hard to relate to a real request) and instead they will only bubble up on the caller path.