### PR TITLE
Fix antora sed script to allow tags with single entry to work

### DIFF
--- a/scripts/manage-antora-remote-versions.sh
+++ b/scripts/manage-antora-remote-versions.sh
@@ -56,7 +56,7 @@ cat "$file" | while IFS='' read line; do
         if ( echo "$line" | grep -q "[[ ]${majorminor}.\d" ); then
             # If major.minor was already in this line, update the patch version
             echo "$line" |
-              sed "s/^      tags: \[\(.*[[ ]\)$majorminor\.[^,]*\(.*\)\]$/      tags: [\1$newversion\2]/" \
+              sed "s/^      tags: \[\(.*[[ ]\)*$majorminor\.[^,]*\(.*\)\]$/      tags: [\1$newversion\2]/" \
               >> "$file.tmp"
         elif ( echo "$line" | grep -q "^      tags: \[[ ]*\]$" ); then
             # If tags is empty


### PR DESCRIPTION
This changeset makes sure that tags in the form of [a.b.c] are properly recognized. Previously they would only work if either no or at least two elements are in the tags list.