### PR TITLE
Ignore GitHub Actions for non-relevant files

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -2,6 +2,15 @@ name: PR Builder
 on:
   pull_request:
     branches: [ main, '0.41', '0.42' ]
+    paths-ignore:
+      - 'docs/**'
+      - 'scripts/**'
+      - '.git.commit.template'
+      - '.gitignore'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - '**.adoc'
+      - '**.txt'
 jobs:
   build:
     name: JDK ${{ matrix.java }} ${{ matrix.os }}

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -2,6 +2,14 @@ name: PR Quality
 on:
   pull_request:
     branches: [ main, '0.41', '0.42' ]
+    paths-ignore:
+      - 'scripts/**'
+      - '.git.commit.template'
+      - '.gitignore'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - '*.adoc'
+      - '*.txt'
 jobs:
   quality:
     name: JDK ${{ matrix.java }}

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -5,6 +5,15 @@ on:
     tags-ignore:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+.[0-9]+"
+    paths-ignore:
+      - 'docs/**'
+      - 'scripts/**'
+      - '.git.commit.template'
+      - '.gitignore'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - '**.adoc'
+      - '*.txt'
 jobs:
   build:
     name: Snapshot JDK ${{ matrix.java }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,23 @@ name: CodeQL
 on:
   push:
     branches: [ main, '0.41', '0.42' ]
+    paths-ignore:
+      - 'docs/**'
+      - 'scripts/**'
+      - '.git.commit.template'
+      - '.gitignore'
+      - '**.adoc'
+      - '**.txt'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main, '0.41' ]
+    paths-ignore:
+      - 'docs/**'
+      - 'scripts/**'
+      - '.git.commit.template'
+      - '.gitignore'
+      - '**.adoc'
+      - '**.txt'
   schedule:
     - cron: '0 13 * * 1'
 


### PR DESCRIPTION
Motivation:

Currently, GitHub Actions workflows run on every change in the PR, even if it's known the file won't affect the output.

Modifications:
- For each workflow, ignore files that won't affect its result.

Result:

Less workflows to run for small PRs.