### PR TITLE
traffic-resilience-http: Fix flaky testStopAcceptingConnections() test

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -559,7 +559,6 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
     private Single<C> selectConnection0(final Predicate<C> selector, @Nullable final ContextMap context,
                                         final boolean forceNewConnectionAndReserve) {
         final HostSelector<ResolvedAddress, C> currentHostSelector = hostSelector;
-        LOGGER.info("Selecting connection.");
         Single<C> result = currentHostSelector.selectConnection(selector, context, forceNewConnectionAndReserve);
         return result.beforeOnError(exn -> {
             if (exn instanceof NoActiveHostException) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -559,6 +559,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
     private Single<C> selectConnection0(final Predicate<C> selector, @Nullable final ContextMap context,
                                         final boolean forceNewConnectionAndReserve) {
         final HostSelector<ResolvedAddress, C> currentHostSelector = hostSelector;
+        LOGGER.info("Selecting connection.");
         Single<C> result = currentHostSelector.selectConnection(selector, context, forceNewConnectionAndReserve);
         return result.beforeOnError(exn -> {
             if (exn instanceof NoActiveHostException) {

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -248,8 +248,8 @@ class TrafficResilienceHttpServiceFilterTest {
                         .get();
 
                 // We expect up to a couple connections to succeed due to the intrinsic race between disabling accepts
-                // and new connect requests, as well as to account for kernel connect backlog. However, we do expect it
-                // to fail after a fairly short number of iterations.
+                // and new connect requests, as well as to account for kernel connect backlog (effectively 1 for all
+                // OS's). That means we can have up to two connects succeed, but expect it to fail by the 3rd attempt.
                 for (int i = 0; i < 3; i++) {
                     if (dryRun) {
                         client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/")).toFuture().get()

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.netty.util.internal.PlatformDependent.normalizedOs;

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -266,7 +266,8 @@ class TrafficResilienceHttpServiceFilterTest {
             assertThat(client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/"))
                     // This is the failing line.
                     // https://github.com/apple/servicetalk/actions/runs/12129341561/job/33817567364?pr=3125
-                    .toFuture().get(CI ? 4 : 2, SECONDS).asConnection(), instanceOf(HttpConnection.class));
+                    // This now fails to resolve.
+                    .toFuture().get(CI ? 10 : 2, SECONDS).asConnection(), instanceOf(HttpConnection.class));
         } catch (ExecutionException e) {
             if (dryRun) {
                 throw e;

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -202,7 +202,7 @@ class TrafficResilienceHttpServiceFilterTest {
     }
 
     @Test
-    @RepeatedTest(200)
+    @RepeatedTest(100)
     void repro() throws Exception {
         testStopAcceptingConnections(false, "h1");
     }
@@ -263,10 +263,7 @@ class TrafficResilienceHttpServiceFilterTest {
                 // This connection shall full-fil the BACKLOG=1 setting
                 try {
                     assertThat(client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/"))
-                            // This is the failing line.
-                            // https://github.com/apple/servicetalk/actions/runs/12129341561/job/33817567364?pr=3125
-                            // This now fails to resolve.
-                            .toFuture().get(CI ? 10 : 2, SECONDS).asConnection(), instanceOf(HttpConnection.class));
+                            .toFuture().get().asConnection(), instanceOf(HttpConnection.class));
                 } catch (ExecutionException e) {
                     if (dryRun) {
                         throw e;

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -44,7 +44,6 @@ import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.transport.api.ServerContext;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -199,12 +198,6 @@ class TrafficResilienceHttpServiceFilterTest {
         verifyNoMoreInteractions(limiter);
 
         assertThat(rejectedCount.get(), equalTo(1));
-    }
-
-    @Test
-    @RepeatedTest(100)
-    void repro() throws Exception {
-        testStopAcceptingConnections(false, "h1");
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] dryRun={0},protocol={1}")

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -260,8 +260,15 @@ class TrafficResilienceHttpServiceFilterTest {
                 .toFuture().get().asConnection(), instanceOf(HttpConnection.class));
 
         // This connection shall full-fil the BACKLOG=1 setting
-        assertThat(client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/"))
-                .toFuture().get().asConnection(), instanceOf(HttpConnection.class));
+        try {
+            assertThat(client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/"))
+                    .toFuture().get().asConnection(), instanceOf(HttpConnection.class)); // This is the failing line. https://github.com/apple/servicetalk/actions/runs/12129341561/job/33817567364?pr=3125
+        } catch (ExecutionException e) {
+            if (dryRun) {
+                throw e;
+            }
+            assertThat(e.getCause(), instanceOf(ConnectTimeoutException.class));
+        }
 
         // Any attempt to create a connection now, should time out if we're not in dry mode.
         if (dryRun) {

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -202,7 +202,7 @@ class TrafficResilienceHttpServiceFilterTest {
     }
 
     @Test
-    @RepeatedTest(100)
+    @RepeatedTest(200)
     void repro() throws Exception {
         testStopAcceptingConnections(false, "h1");
     }

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -262,7 +262,9 @@ class TrafficResilienceHttpServiceFilterTest {
         // This connection shall full-fil the BACKLOG=1 setting
         try {
             assertThat(client.reserveConnection(client.newRequest(HttpRequestMethod.GET, "/"))
-                    .toFuture().get().asConnection(), instanceOf(HttpConnection.class)); // This is the failing line. https://github.com/apple/servicetalk/actions/runs/12129341561/job/33817567364?pr=3125
+                    // This is the failing line.
+                    // https://github.com/apple/servicetalk/actions/runs/12129341561/job/33817567364?pr=3125
+                    .toFuture().get().asConnection(), instanceOf(HttpConnection.class));
         } catch (ExecutionException e) {
             if (dryRun) {
                 throw e;

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -44,6 +44,7 @@ import io.servicetalk.http.netty.HttpClients;
 import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.transport.api.ServerContext;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -198,6 +199,12 @@ class TrafficResilienceHttpServiceFilterTest {
         verifyNoMoreInteractions(limiter);
 
         assertThat(rejectedCount.get(), equalTo(1));
+    }
+
+    @Test
+    @RepeatedTest(100)
+    void repro() throws Exception {
+        testStopAcceptingConnections(false, "h1");
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] dryRun={0},protocol={1}")


### PR DESCRIPTION
Motivation:

The `TrafficResilienceHttpServiceFilterTest.testStopAcceptingConnections(..)` test is flaky and sometimes will find that a connection times out before it was expected to. These additional connections are made to account for intrinsic races as well as kernel connection backlog behavior which is really hard to control.

Modifications:

The timeout behavior is the desired result, it just happens before we expect it to. So, instead of trying to make exactly two connections that we expect to succeed followed by one that should fail, we instead can just perform a low iteration loop and demand that we eventually stop accepting connections, which is the desired behavior.

Closes #3076. 