### PR TITLE
loadbalancer-experimental: rename ConnectionPoolConfig -> ConnectionPoolPolicy

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolPolicy.java
@@ -20,19 +20,19 @@ import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 /**
  * Configuration of the strategy for selecting connections from a pool to the same endpoint.
  */
-public abstract class ConnectionPoolConfig {
+public abstract class ConnectionPoolPolicy {
 
     static final int DEFAULT_MAX_EFFORT = 5;
     static final int DEFAULT_LINEAR_SEARCH_SPACE = 16;
 
-    private ConnectionPoolConfig() {
+    private ConnectionPoolPolicy() {
         // only instances are in this class.
     }
 
     /**
      * A connection selection strategy that prioritizes a configurable "core" pool.
      * <p>
-     * This {@link ConnectionPoolStrategy} attempts to emulate the pooling behavior often seen in thread pools.
+     * This {@link ConnectionPoolPolicy} attempts to emulate the pooling behavior often seen in thread pools.
      * Specifically it allows for the configuration of a "core pool" size which are intended to be long-lived.
      * Iteration starts in the core pool at a random position and then iterates through the entire core pool before
      * moving to an overflow pool. Because iteration of this core pool starts at a random position the core connections
@@ -46,42 +46,42 @@ public abstract class ConnectionPoolConfig {
      * @param corePoolSize the size of the core pool.
      * @param forceCorePool whether to avoid selecting connections from the core pool until it has reached the
      *                      configured core pool size.
-     * @return the configured {@link ConnectionPoolConfig}.
+     * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static ConnectionPoolConfig corePool(final int corePoolSize, final boolean forceCorePool) {
+    public static ConnectionPoolPolicy corePool(final int corePoolSize, final boolean forceCorePool) {
         return new CorePoolStrategy(corePoolSize, forceCorePool);
     }
 
     /**
      * A connection selection strategy that prioritizes connection reuse.
      * <p>
-     * This {@link ConnectionPoolStrategy} attempts to minimize the number of connections by attempting to direct
+     * This {@link ConnectionPoolPolicy} attempts to minimize the number of connections by attempting to direct
      * traffic to connections in the order they were created in linear order up until a configured quantity. After
      * this linear pool is exhausted the remaining connections will be selected from at random. Prioritizing traffic
      * to the existing connections will let tailing connections be removed due to idleness.
-     * @return the configured {@link ConnectionPoolConfig}.
+     * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static ConnectionPoolConfig linearSearch() {
+    public static ConnectionPoolPolicy linearSearch() {
         return linearSearch(DEFAULT_LINEAR_SEARCH_SPACE);
     }
 
     /**
      * A connection selection strategy that prioritizes connection reuse.
      * <p>
-     * This {@link ConnectionPoolStrategy} attempts to minimize the number of connections by attempting to direct
+     * This {@link ConnectionPoolPolicy} attempts to minimize the number of connections by attempting to direct
      * traffic to connections in the order they were created in linear order up until a configured quantity. After
      * this linear pool is exhausted the remaining connections will be selected from at random. Prioritizing traffic
      * to the existing connections will let tailing connections be removed due to idleness.
      * @param linearSearchSpace the space to search linearly before resorting to random selection for remaining
      *                          connections.
-     * @return the configured {@link ConnectionPoolConfig}.
+     * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static ConnectionPoolConfig linearSearch(int linearSearchSpace) {
+    public static ConnectionPoolPolicy linearSearch(int linearSearchSpace) {
         return new LinearSearchStrategy(linearSearchSpace);
     }
 
     /**
-     * A {@link ConnectionPoolStrategy} that attempts to discern between the health of individual connections.
+     * A {@link ConnectionPoolPolicy} that attempts to discern between the health of individual connections.
      * If individual connections have health data the P2C strategy can be used to bias traffic toward the best
      * connections. This has the following algorithm:
      * - Randomly select two connections from the 'core pool' (pick-two).
@@ -92,14 +92,14 @@ public abstract class ConnectionPoolConfig {
      * @param corePoolSize the size of the core pool.
      * @param forceCorePool whether to avoid selecting connections from the core pool until it has reached the
      *                      configured core pool size.
-     * @return the configured {@link ConnectionPoolConfig}.
+     * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static ConnectionPoolConfig p2c(int corePoolSize, boolean forceCorePool) {
+    public static ConnectionPoolPolicy p2c(int corePoolSize, boolean forceCorePool) {
         return p2c(DEFAULT_MAX_EFFORT, corePoolSize, forceCorePool);
     }
 
     /**
-     * A {@link ConnectionPoolStrategy} that attempts to discern between the health of individual connections.
+     * A {@link ConnectionPoolPolicy} that attempts to discern between the health of individual connections.
      * If individual connections have health data the P2C strategy can be used to bias traffic toward the best
      * connections. This has the following algorithm:
      * - Randomly select two connections from the 'core pool' (pick-two).
@@ -111,14 +111,14 @@ public abstract class ConnectionPoolConfig {
      * @param corePoolSize the size of the core pool.
      * @param forceCorePool whether to avoid selecting connections from the core pool until it has reached the
      *                      configured core pool size.
-     * @return the configured {@link ConnectionPoolConfig}.
+     * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static ConnectionPoolConfig p2c(int maxEffort, int corePoolSize, boolean forceCorePool) {
+    public static ConnectionPoolPolicy p2c(int maxEffort, int corePoolSize, boolean forceCorePool) {
         return new P2CStrategy(maxEffort, corePoolSize, forceCorePool);
     }
 
     // instance types
-    static final class CorePoolStrategy extends ConnectionPoolConfig {
+    static final class CorePoolStrategy extends ConnectionPoolPolicy {
         final int corePoolSize;
         final boolean forceCorePool;
 
@@ -128,7 +128,7 @@ public abstract class ConnectionPoolConfig {
         }
     }
 
-    static final class P2CStrategy extends ConnectionPoolConfig {
+    static final class P2CStrategy extends ConnectionPoolPolicy {
         final int maxEffort;
         final int corePoolSize;
         final boolean forceCorePool;
@@ -140,7 +140,7 @@ public abstract class ConnectionPoolConfig {
         }
     }
 
-    static final class LinearSearchStrategy extends ConnectionPoolConfig {
+    static final class LinearSearchStrategy extends ConnectionPoolPolicy {
         final int linearSearchSpace;
 
         LinearSearchStrategy(int linearSearchSpace) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -78,10 +78,10 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     }
 
     @Override
-    public LoadBalancerBuilder<ResolvedAddress, C> connectionPoolConfig(
-            ConnectionPoolConfig connectionPoolConfig) {
-        this.connectionPoolStrategyFactory = convertPoolStrategy(requireNonNull(connectionPoolConfig,
-                "connectionPoolConfig"));
+    public LoadBalancerBuilder<ResolvedAddress, C> connectionPoolPolicy(
+            ConnectionPoolPolicy connectionPoolPolicy) {
+        this.connectionPoolStrategyFactory = convertPoolStrategy(requireNonNull(connectionPoolPolicy,
+                "connectionPoolPolicy"));
         return this;
     }
 
@@ -197,17 +197,17 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     }
 
     private static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C> convertPoolStrategy(
-            ConnectionPoolConfig connectionPoolStrategyConfig) {
-        if (connectionPoolStrategyConfig instanceof ConnectionPoolConfig.P2CStrategy) {
-            ConnectionPoolConfig.P2CStrategy strategy = (ConnectionPoolConfig.P2CStrategy) connectionPoolStrategyConfig;
+            ConnectionPoolPolicy connectionPoolStrategyConfig) {
+        if (connectionPoolStrategyConfig instanceof ConnectionPoolPolicy.P2CStrategy) {
+            ConnectionPoolPolicy.P2CStrategy strategy = (ConnectionPoolPolicy.P2CStrategy) connectionPoolStrategyConfig;
             return P2CConnectionPoolStrategy.factory(strategy.maxEffort, strategy.corePoolSize, strategy.forceCorePool);
-        } else if (connectionPoolStrategyConfig instanceof ConnectionPoolConfig.CorePoolStrategy) {
-            ConnectionPoolConfig.CorePoolStrategy strategy =
-                    (ConnectionPoolConfig.CorePoolStrategy) connectionPoolStrategyConfig;
+        } else if (connectionPoolStrategyConfig instanceof ConnectionPoolPolicy.CorePoolStrategy) {
+            ConnectionPoolPolicy.CorePoolStrategy strategy =
+                    (ConnectionPoolPolicy.CorePoolStrategy) connectionPoolStrategyConfig;
             return CorePoolConnectionPoolStrategy.factory(strategy.corePoolSize, strategy.forceCorePool);
-        } else if (connectionPoolStrategyConfig instanceof ConnectionPoolConfig.LinearSearchStrategy) {
-            ConnectionPoolConfig.LinearSearchStrategy strategy =
-                    (ConnectionPoolConfig.LinearSearchStrategy) connectionPoolStrategyConfig;
+        } else if (connectionPoolStrategyConfig instanceof ConnectionPoolPolicy.LinearSearchStrategy) {
+            ConnectionPoolPolicy.LinearSearchStrategy strategy =
+                    (ConnectionPoolPolicy.LinearSearchStrategy) connectionPoolStrategyConfig;
             return LinearSearchConnectionPoolStrategy.factory(strategy.linearSearchSpace);
         } else {
             throw new IllegalStateException("Unexpected ConnectionPoolConfig: " +
@@ -222,6 +222,6 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     private static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C>
     defaultConnectionPoolStrategyFactory() {
-        return convertPoolStrategy(ConnectionPoolConfig.linearSearch());
+        return convertPoolStrategy(ConnectionPoolPolicy.linearSearch());
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -85,9 +85,9 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
     }
 
     @Override
-    public LoadBalancerBuilder<ResolvedAddress, C> connectionPoolConfig(
-            ConnectionPoolConfig connectionPoolConfig) {
-        delegate = delegate.connectionPoolConfig(connectionPoolConfig);
+    public LoadBalancerBuilder<ResolvedAddress, C> connectionPoolPolicy(
+            ConnectionPoolPolicy connectionPoolPolicy) {
+        delegate = delegate.connectionPoolPolicy(connectionPoolPolicy);
         return this;
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -102,11 +102,11 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
     LoadBalancerBuilder<ResolvedAddress, C> outlierDetectorConfig(OutlierDetectorConfig outlierDetectorConfig);
 
     /**
-     * Set the {@link ConnectionPoolStrategy} to use with this load balancer.
-     * @param connectionPoolConfig the factory of connection pooling strategies to use.
+     * Set the {@link ConnectionPoolPolicy} to use with this load balancer.
+     * @param connectionPoolPolicy the factory of connection pooling strategies to use.
      * @return {@code this}
      */
-    LoadBalancerBuilder<ResolvedAddress, C> connectionPoolConfig(ConnectionPoolConfig connectionPoolConfig);
+    LoadBalancerBuilder<ResolvedAddress, C> connectionPoolPolicy(ConnectionPoolPolicy connectionPoolPolicy);
 
     /**
      * Set the background {@link Executor} to use for determining time and scheduling background tasks such

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
@@ -138,7 +138,7 @@ public final class RoundRobinToDefaultLBMigrationProvider implements RoundRobinL
             }
             return builder.outlierDetectorConfig(outlierDetectorConfig)
                     .loadBalancingPolicy(loadBalancingPolicy)
-                    .connectionPoolConfig(ConnectionPoolConfig.linearSearch(linearSearchSpace))
+                    .connectionPoolPolicy(ConnectionPoolPolicy.linearSearch(linearSearchSpace))
                     .build();
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
-import static io.servicetalk.loadbalancer.ConnectionPoolConfig.DEFAULT_LINEAR_SEARCH_SPACE;
+import static io.servicetalk.loadbalancer.ConnectionPoolPolicy.DEFAULT_LINEAR_SEARCH_SPACE;
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
 import static io.servicetalk.loadbalancer.UnhealthyHostConnectionFactory.UNHEALTHY_HOST_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -41,7 +41,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
-import static io.servicetalk.loadbalancer.ConnectionPoolConfig.DEFAULT_LINEAR_SEARCH_SPACE;
+import static io.servicetalk.loadbalancer.ConnectionPoolPolicy.DEFAULT_LINEAR_SEARCH_SPACE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -48,8 +48,8 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
     }
 
     @Override
-    public LoadBalancerBuilder<String, TestLoadBalancedConnection> connectionPoolConfig(
-            ConnectionPoolConfig connectionPoolConfig) {
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> connectionPoolPolicy(
+            ConnectionPoolPolicy connectionPoolPolicy) {
         throw new UnsupportedOperationException("Cannot set a connection pool strategy for old round robin");
     }
 


### PR DESCRIPTION
Motivation:

We commonly use the term 'policy' in our API's but ConnectionPoolConfig is an outlier.

Modifications:

Rename `ConnectionPoolConfig` to `ConnectionPoolPolicy`.

Result:

More consistency.