### PR TITLE
loadbalancer-experimental: rename ConnectionPoolStrategy -> ConnectionSelector

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolPolicy.java
@@ -18,7 +18,7 @@ package io.servicetalk.loadbalancer;
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 
 /**
- * Configuration of the strategy for selecting connections from a pool to the same endpoint.
+ * Configuration of the policy for selecting connections from a pool to the same endpoint.
  */
 public abstract class ConnectionPoolPolicy {
 
@@ -30,7 +30,7 @@ public abstract class ConnectionPoolPolicy {
     }
 
     /**
-     * A connection selection strategy that prioritizes a configurable "core" pool.
+     * A connection selection policy that prioritizes a configurable "core" pool.
      * <p>
      * This {@link ConnectionPoolPolicy} attempts to emulate the pooling behavior often seen in thread pools.
      * Specifically it allows for the configuration of a "core pool" size which are intended to be long-lived.
@@ -49,11 +49,11 @@ public abstract class ConnectionPoolPolicy {
      * @return the configured {@link ConnectionPoolPolicy}.
      */
     public static ConnectionPoolPolicy corePool(final int corePoolSize, final boolean forceCorePool) {
-        return new CorePoolStrategy(corePoolSize, forceCorePool);
+        return new CorePoolPolicy(corePoolSize, forceCorePool);
     }
 
     /**
-     * A connection selection strategy that prioritizes connection reuse.
+     * A connection selection policy that prioritizes connection reuse.
      * <p>
      * This {@link ConnectionPoolPolicy} attempts to minimize the number of connections by attempting to direct
      * traffic to connections in the order they were created in linear order up until a configured quantity. After
@@ -66,7 +66,7 @@ public abstract class ConnectionPoolPolicy {
     }
 
     /**
-     * A connection selection strategy that prioritizes connection reuse.
+     * A connection selection policy that prioritizes connection reuse.
      * <p>
      * This {@link ConnectionPoolPolicy} attempts to minimize the number of connections by attempting to direct
      * traffic to connections in the order they were created in linear order up until a configured quantity. After
@@ -77,12 +77,12 @@ public abstract class ConnectionPoolPolicy {
      * @return the configured {@link ConnectionPoolPolicy}.
      */
     public static ConnectionPoolPolicy linearSearch(int linearSearchSpace) {
-        return new LinearSearchStrategy(linearSearchSpace);
+        return new LinearSearchPolicy(linearSearchSpace);
     }
 
     /**
      * A {@link ConnectionPoolPolicy} that attempts to discern between the health of individual connections.
-     * If individual connections have health data the P2C strategy can be used to bias traffic toward the best
+     * If individual connections have health data the P2C policy can be used to bias traffic toward the best
      * connections. This has the following algorithm:
      * - Randomly select two connections from the 'core pool' (pick-two).
      *   - Try to select the 'best' of the two connections.
@@ -100,7 +100,7 @@ public abstract class ConnectionPoolPolicy {
 
     /**
      * A {@link ConnectionPoolPolicy} that attempts to discern between the health of individual connections.
-     * If individual connections have health data the P2C strategy can be used to bias traffic toward the best
+     * If individual connections have health data the P2C policy can be used to bias traffic toward the best
      * connections. This has the following algorithm:
      * - Randomly select two connections from the 'core pool' (pick-two).
      *   - Try to select the 'best' of the two connections.
@@ -114,36 +114,36 @@ public abstract class ConnectionPoolPolicy {
      * @return the configured {@link ConnectionPoolPolicy}.
      */
     public static ConnectionPoolPolicy p2c(int maxEffort, int corePoolSize, boolean forceCorePool) {
-        return new P2CStrategy(maxEffort, corePoolSize, forceCorePool);
+        return new P2CPolicy(maxEffort, corePoolSize, forceCorePool);
     }
 
     // instance types
-    static final class CorePoolStrategy extends ConnectionPoolPolicy {
+    static final class CorePoolPolicy extends ConnectionPoolPolicy {
         final int corePoolSize;
         final boolean forceCorePool;
 
-        CorePoolStrategy(final int corePoolSize, final boolean forceCorePool) {
+        CorePoolPolicy(final int corePoolSize, final boolean forceCorePool) {
             this.corePoolSize = ensurePositive(corePoolSize, "corePoolSize");
             this.forceCorePool = forceCorePool;
         }
     }
 
-    static final class P2CStrategy extends ConnectionPoolPolicy {
+    static final class P2CPolicy extends ConnectionPoolPolicy {
         final int maxEffort;
         final int corePoolSize;
         final boolean forceCorePool;
 
-        P2CStrategy(final int maxEffort, final int corePoolSize, final boolean forceCorePool) {
+        P2CPolicy(final int maxEffort, final int corePoolSize, final boolean forceCorePool) {
             this.maxEffort = ensurePositive(maxEffort, "maxEffort");
             this.corePoolSize = ensurePositive(corePoolSize, "corePoolSize");
             this.forceCorePool = forceCorePool;
         }
     }
 
-    static final class LinearSearchStrategy extends ConnectionPoolPolicy {
+    static final class LinearSearchPolicy extends ConnectionPoolPolicy {
         final int linearSearchSpace;
 
-        LinearSearchStrategy(int linearSearchSpace) {
+        LinearSearchPolicy(int linearSearchSpace) {
             this.linearSearchSpace = ensurePositive(linearSearchSpace, "linearSearchSpace");
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionSelector.java
@@ -22,10 +22,10 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 /**
- * A strategy for selecting connections at the {@link Host} level connection pool.
+ * An abstraction for selecting connections at the {@link Host} level connection pool.
  * @param <C> the concrete type of the connection.
  */
-interface ConnectionPoolStrategy<C extends LoadBalancedConnection> {
+interface ConnectionSelector<C extends LoadBalancedConnection> {
 
     /**
      * Select a connection from the ordered list of connections.
@@ -37,18 +37,18 @@ interface ConnectionPoolStrategy<C extends LoadBalancedConnection> {
     C select(List<C> connections, Predicate<C> selector);
 
     /**
-     * The factory of {@link ConnectionPoolStrategy} instances.
-     * @param <C> the least specific connection type necessary for properly implementing the strategy.
-     * @see ConnectionPoolStrategy for available strategies.
+     * The factory of {@link ConnectionSelector} instances.
+     * @param <C> the least specific connection type necessary for properly implementing the selector.
+     * @see ConnectionSelector for available strategies.
      */
 
-    interface ConnectionPoolStrategyFactory<C extends LoadBalancedConnection> {
+    interface ConnectionSelectorFactory<C extends LoadBalancedConnection> {
 
         /**
-         * Provide an instance of the {@link ConnectionPoolStrategy} to use with a {@link Host}.
+         * Provide an instance of the {@link ConnectionSelector} to use with a {@link Host}.
          * @param lbDescription description of the resource, used for logging purposes.
-         * @return an instance of the {@link ConnectionPoolStrategy} to use with a {@link Host}.
+         * @return an instance of the {@link ConnectionSelector} to use with a {@link Host}.
          */
-        ConnectionPoolStrategy<C> buildStrategy(String lbDescription);
+        ConnectionSelector<C> buildConnectionSelector(String lbDescription);
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionSelector.java
@@ -28,7 +28,7 @@ import static java.lang.Math.min;
 /**
  * A connection selection strategy that prioritizes a configurable "core" pool.
  * <p>
- * This {@link ConnectionPoolStrategy} attempts to emulate the pooling behavior often seen in thread pools.
+ * This {@link ConnectionSelector} attempts to emulate the pooling behavior often seen in thread pools.
  * Specifically it allows for the configuration of a "core pool" size which are intended to be long-lived.
  * Iteration starts in the core pool at a random position and then iterates through the entire core pool before
  * moving to an overflow pool. Because iteration of this core pool starts at a random position the core connections
@@ -40,13 +40,13 @@ import static java.lang.Math.min;
  *
  * @param <C> the concrete type of the {@link LoadBalancedConnection}.
  */
-final class CorePoolConnectionPoolStrategy<C extends LoadBalancedConnection>
-        implements ConnectionPoolStrategy<C> {
+final class CorePoolConnectionSelector<C extends LoadBalancedConnection>
+        implements ConnectionSelector<C> {
 
     private final int corePoolSize;
     private final boolean forceCorePool;
 
-    private CorePoolConnectionPoolStrategy(final int corePoolSize, final boolean forceCorePool) {
+    private CorePoolConnectionSelector(final int corePoolSize, final boolean forceCorePool) {
         this.corePoolSize = ensurePositive(corePoolSize, "corePoolSize");
         this.forceCorePool = forceCorePool;
     }
@@ -83,30 +83,30 @@ final class CorePoolConnectionPoolStrategy<C extends LoadBalancedConnection>
         return null;
     }
 
-    static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C> factory(
+    static <C extends LoadBalancedConnection> ConnectionSelectorFactory<C> factory(
             int corePoolSize, boolean forceCorePool) {
-        return new CorePoolConnectionPoolStrategyFactory<>(corePoolSize, forceCorePool);
+        return new CorePoolConnectionSelectorFactory<>(corePoolSize, forceCorePool);
     }
 
-    private static final class CorePoolConnectionPoolStrategyFactory<C extends LoadBalancedConnection>
-            implements ConnectionPoolStrategyFactory<C> {
+    private static final class CorePoolConnectionSelectorFactory<C extends LoadBalancedConnection>
+            implements ConnectionSelectorFactory<C> {
 
         private final int corePoolSize;
         private final boolean forceCorePool;
 
-        CorePoolConnectionPoolStrategyFactory(int corePoolSize, boolean forceCorePool) {
+        CorePoolConnectionSelectorFactory(int corePoolSize, boolean forceCorePool) {
             this.corePoolSize = ensurePositive(corePoolSize, "corePoolSize");
             this.forceCorePool = forceCorePool;
         }
 
         @Override
-        public ConnectionPoolStrategy<C> buildStrategy(String lbDescription) {
-            return new CorePoolConnectionPoolStrategy<>(corePoolSize, forceCorePool);
+        public ConnectionSelector<C> buildConnectionSelector(String lbDescription) {
+            return new CorePoolConnectionSelector<>(corePoolSize, forceCorePool);
         }
 
         @Override
         public String toString() {
-            return "CorePoolConnectionPoolStrategyFactory{" +
+            return CorePoolConnectionSelectorFactory.class.getSimpleName() + "{" +
                     "corePoolSize=" + corePoolSize +
                     ", forceCorePool=" + forceCorePool +
                     '}';

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
@@ -85,7 +85,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     private final Addr address;
     @Nullable
     private final HealthCheckConfig healthCheckConfig;
-    private final ConnectionPoolStrategy<C> connectionPoolStrategy;
+    private final ConnectionSelector<C> connectionSelector;
     @Nullable
     private final HealthIndicator<Addr, C> healthIndicator;
     private final LoadBalancerObserver.HostObserver hostObserver;
@@ -94,14 +94,14 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     private volatile ConnState connState = new ConnState(emptyList(), State.ACTIVE, 0, null);
 
     DefaultHost(final String lbDescription, final Addr address,
-                final ConnectionPoolStrategy<C> connectionPoolStrategy,
+                final ConnectionSelector<C> connectionSelector,
                 final ConnectionFactory<Addr, ? extends C> connectionFactory,
                 final HostObserver hostObserver, @Nullable final HealthCheckConfig healthCheckConfig,
                 @Nullable final HealthIndicator<Addr, C> healthIndicator) {
         this.lbDescription = requireNonNull(lbDescription, "lbDescription");
         this.address = requireNonNull(address, "address");
         this.healthIndicator = healthIndicator;
-        this.connectionPoolStrategy = requireNonNull(connectionPoolStrategy, "connectionPoolStrategy");
+        this.connectionSelector = requireNonNull(connectionSelector, "connectionSelector");
         requireNonNull(connectionFactory, "connectionFactory");
         this.connectionFactory = healthIndicator == null ? connectionFactory :
                 new InstrumentedConnectionFactory<>(connectionFactory, healthIndicator);
@@ -181,7 +181,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     @Nullable
     public C pickConnection(Predicate<C> selector, @Nullable final ContextMap context) {
         final List<C> connections = connState.connections;
-        return connectionPoolStrategy.select(connections, selector);
+        return connectionSelector.select(connections, selector);
     }
 
     @Override

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -109,7 +109,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
     private final Processor<Object, Object> eventStreamProcessor = newPublisherProcessorDropHeadOnOverflow(32);
     private final Publisher<Object> eventStream;
     private final SequentialCancellable discoveryCancellable = new SequentialCancellable();
-    private final ConnectionPoolStrategy<C> connectionPoolStrategy;
+    private final ConnectionSelector<C> connectionSelector;
     private final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory;
     private final int randomSubsetSize;
     @Nullable
@@ -130,7 +130,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
      * @param priorityStrategyFactory a builder of the {@link HostPriorityStrategy} to use with the load balancer.
      * @param loadBalancingPolicy a factory of the initial host selector to use with this load balancer.
      * @param randomSubsetSize the maximum number of health hosts to use when load balancing.
-     * @param connectionPoolStrategyFactory factory of the connection pool strategy to use with this load balancer.
+     * @param connectionSelectorFactory factory of the connection pool strategy to use with this load balancer.
      * @param connectionFactory a function which creates new connections.
      * @param loadBalancerObserverFactory factory used to build a {@link LoadBalancerObserver} to use with this
      *                                    load balancer.
@@ -146,7 +146,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final Function<String, HostPriorityStrategy> priorityStrategyFactory,
             final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy,
             final int randomSubsetSize,
-            final ConnectionPoolStrategy.ConnectionPoolStrategyFactory<C> connectionPoolStrategyFactory,
+            final ConnectionSelector.ConnectionSelectorFactory<C> connectionSelectorFactory,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
             final LoadBalancerObserverFactory loadBalancerObserverFactory,
             @Nullable final HealthCheckConfig healthCheckConfig,
@@ -157,8 +157,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                 .buildSelector(Collections.emptyList(), lbDescription);
         this.priorityStrategy = requireNonNull(
                 priorityStrategyFactory, "priorityStrategyFactory").apply(lbDescription);
-        this.connectionPoolStrategy = requireNonNull(connectionPoolStrategyFactory,
-                "connectionPoolStrategyFactory").buildStrategy(lbDescription);
+        this.connectionSelector = requireNonNull(connectionSelectorFactory,
+                "connectionSelectorFactory").buildConnectionSelector(lbDescription);
         this.eventPublisher = requireNonNull(eventPublisher);
         this.eventStream = fromSource(eventStreamProcessor)
                 .replay(1); // Allow for multiple subscribers and provide new subscribers with last signal.
@@ -427,7 +427,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final HealthCheckConfig hostHealthCheckConfig =
                     healthCheckConfig == null || healthCheckConfig.failedThreshold < 0 ? null : healthCheckConfig;
             final PrioritizedHostImpl<ResolvedAddress, C> host = new PrioritizedHostImpl<>(
-                    new DefaultHost<>(lbDescription, addr, connectionPoolStrategy,
+                    new DefaultHost<>(lbDescription, addr, connectionSelector,
                     connectionFactory, hostObserver, hostHealthCheckConfig, indicator),
                     eventWeight(event), eventPriority(event));
             if (indicator != null) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionSelector.java
@@ -28,14 +28,14 @@ import static java.lang.Math.min;
 /**
  * A connection selection strategy that prioritizes connection reuse.
  * <p>
- * This {@link ConnectionPoolStrategy} attempts to minimize the number of connections by attempting to direct
+ * This {@link ConnectionSelector} attempts to minimize the number of connections by attempting to direct
  * traffic to connections in the order they were created in linear order up until a configured quantity. After
  * this linear pool is exhausted the remaining connections will be selected from at random. Prioritizing traffic
  * to the existing connections will let tailing connections be removed due to idleness.
  *
  * @param <C> the concrete type of the {@link LoadBalancedConnection}.
  */
-final class LinearSearchConnectionPoolStrategy<C extends LoadBalancedConnection> implements ConnectionPoolStrategy<C> {
+final class LinearSearchConnectionSelector<C extends LoadBalancedConnection> implements ConnectionSelector<C> {
 
     /**
      * With a relatively small number of connections we can minimize connection creation under moderate concurrency by
@@ -56,7 +56,7 @@ final class LinearSearchConnectionPoolStrategy<C extends LoadBalancedConnection>
 
     private final int linearSearchSpace;
 
-    private LinearSearchConnectionPoolStrategy(final int linearSearchSpace) {
+    private LinearSearchConnectionSelector(final int linearSearchSpace) {
         this.linearSearchSpace = ensureNonNegative(linearSearchSpace, "linearSearchSpace");
     }
 
@@ -90,27 +90,27 @@ final class LinearSearchConnectionPoolStrategy<C extends LoadBalancedConnection>
         return null;
     }
 
-    static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C> factory(final int linearSearchSpace) {
-        return new LinearSearchConnectionPoolStrategyFactory<>(linearSearchSpace);
+    static <C extends LoadBalancedConnection> ConnectionSelectorFactory<C> factory(final int linearSearchSpace) {
+        return new LinearSearchConnectionSelectorFactory<>(linearSearchSpace);
     }
 
-    private static final class LinearSearchConnectionPoolStrategyFactory<C extends LoadBalancedConnection>
-            implements ConnectionPoolStrategyFactory<C> {
+    private static final class LinearSearchConnectionSelectorFactory<C extends LoadBalancedConnection>
+            implements ConnectionSelectorFactory<C> {
 
         private final int linearSearchSpace;
 
-        LinearSearchConnectionPoolStrategyFactory(final int linearSearchSpace) {
+        LinearSearchConnectionSelectorFactory(final int linearSearchSpace) {
             this.linearSearchSpace = ensureNonNegative(linearSearchSpace, "linearSearchSpace");
         }
 
         @Override
-        public ConnectionPoolStrategy<C> buildStrategy(String lbDescription) {
-            return new LinearSearchConnectionPoolStrategy<>(linearSearchSpace);
+        public ConnectionSelector<C> buildConnectionSelector(String lbDescription) {
+            return new LinearSearchConnectionSelector<>(linearSearchSpace);
         }
 
         @Override
         public String toString() {
-            return "LinearSearchConnectionPoolStrategyFactory{" +
+            return LinearSearchConnectionSelectorFactory.class.getSimpleName() + "{" +
                     "linearSearchSpace=" + linearSearchSpace +
                     '}';
         }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionSelector.java
@@ -31,7 +31,7 @@ import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A {@link ConnectionPoolStrategy} that attempts to discern between the health of individual connections.
+ * A {@link ConnectionSelector} that attempts to discern between the health of individual connections.
  * If individual connections have health data the P2C strategy can be used to bias traffic toward the best
  * connections. This has the following algorithm:
  * - Randomly select two connections from the 'core pool' (pick-two).
@@ -41,17 +41,17 @@ import static java.util.Objects.requireNonNull;
  *   through the remaining connections searching for an acceptable connection.
  * @param <C> the type of the load balanced connection.
  */
-final class P2CConnectionPoolStrategy<C extends LoadBalancedConnection> implements ConnectionPoolStrategy<C> {
+final class P2CConnectionSelector<C extends LoadBalancedConnection> implements ConnectionSelector<C> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(P2CConnectionPoolStrategy.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(P2CConnectionSelector.class);
 
     private final String lbDescription;
     private final int maxEffort;
     private final int corePoolSize;
     private final boolean forceCorePool;
 
-    private P2CConnectionPoolStrategy(final String lbDescription, final int maxEffort, final int corePoolSize,
-                              final boolean forceCorePool) {
+    private P2CConnectionSelector(final String lbDescription, final int maxEffort, final int corePoolSize,
+                                  final boolean forceCorePool) {
         this.lbDescription = requireNonNull(lbDescription, "lbDescription");
         this.maxEffort = ensureNonNegative(maxEffort, "maxEffort");
         this.corePoolSize = ensureNonNegative(corePoolSize, "corePoolSize");
@@ -139,19 +139,19 @@ final class P2CConnectionPoolStrategy<C extends LoadBalancedConnection> implemen
         return null;
     }
 
-    static <C extends LoadBalancedConnection> ConnectionPoolStrategyFactory<C> factory(
+    static <C extends LoadBalancedConnection> ConnectionSelectorFactory<C> factory(
             final int maxEffort, final int corePoolSize, final boolean forceCorePool) {
-        return new P2CConnectionPoolStrategyFactory<>(maxEffort, corePoolSize, forceCorePool);
+        return new P2CConnectionSelectorFactory<>(maxEffort, corePoolSize, forceCorePool);
     }
 
-    private static final class P2CConnectionPoolStrategyFactory<C extends LoadBalancedConnection>
-            implements ConnectionPoolStrategyFactory<C> {
+    private static final class P2CConnectionSelectorFactory<C extends LoadBalancedConnection>
+            implements ConnectionSelectorFactory<C> {
 
         private final int maxEffort;
         private final int corePoolSize;
         private final boolean forceCorePool;
 
-        P2CConnectionPoolStrategyFactory(
+        P2CConnectionSelectorFactory(
                 final int maxEffort, final int corePoolSize, final boolean forceCorePool) {
             this.maxEffort = ensurePositive(maxEffort, " maxEffort");
             this.corePoolSize = ensureNonNegative(corePoolSize, "corePoolSize");
@@ -159,13 +159,13 @@ final class P2CConnectionPoolStrategy<C extends LoadBalancedConnection> implemen
         }
 
         @Override
-        public ConnectionPoolStrategy<C> buildStrategy(String lbDescription) {
-            return new P2CConnectionPoolStrategy<>(lbDescription, maxEffort, corePoolSize, forceCorePool);
+        public ConnectionSelector<C> buildConnectionSelector(String lbDescription) {
+            return new P2CConnectionSelector<>(lbDescription, maxEffort, corePoolSize, forceCorePool);
         }
 
         @Override
         public String toString() {
-            return "P2CConnectionPoolStrategyFactory{" +
+            return P2CConnectionSelectorFactory.class.getSimpleName() + "{" +
                     "maxEffort=" + maxEffort +
                     ", corePoolSize=" + corePoolSize +
                     ", forceCorePool=" + forceCorePool +

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/ConnectionSelectorHelpers.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/ConnectionSelectorHelpers.java
@@ -18,9 +18,9 @@ package io.servicetalk.loadbalancer;
 import java.util.ArrayList;
 import java.util.List;
 
-public final class ConnectionPoolStrategyHelpers {
+public final class ConnectionSelectorHelpers {
 
-    private ConnectionPoolStrategyHelpers() {
+    private ConnectionSelectorHelpers() {
         // no instances
     }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/ConnectionSelectorHelpers.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/ConnectionSelectorHelpers.java
@@ -18,7 +18,7 @@ package io.servicetalk.loadbalancer;
 import java.util.ArrayList;
 import java.util.List;
 
-public final class ConnectionSelectorHelpers {
+final class ConnectionSelectorHelpers {
 
     private ConnectionSelectorHelpers() {
         // no instances

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -82,8 +82,8 @@ class DefaultHostTest {
 
     private void buildHost(@Nullable HealthIndicator healthIndicator) {
         host = new DefaultHost<>("lbDescription", DEFAULT_ADDRESS,
-                LinearSearchConnectionPoolStrategy.<TestLoadBalancedConnection>factory(DEFAULT_LINEAR_SEARCH_SPACE)
-                        .buildStrategy("resource"),
+                LinearSearchConnectionSelector.<TestLoadBalancedConnection>factory(DEFAULT_LINEAR_SEARCH_SPACE)
+                        .buildConnectionSelector("resource"),
                 connectionFactory, mockHostObserver, healthCheckConfig, healthIndicator);
     }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -317,7 +317,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 hostPriorityStrategyFactory,
                 loadBalancingPolicy,
                 subsetSize,
-                LinearSearchConnectionPoolStrategy.factory(DEFAULT_LINEAR_SEARCH_SPACE),
+                LinearSearchConnectionSelector.factory(DEFAULT_LINEAR_SEARCH_SPACE),
                 connectionFactory,
                 NoopLoadBalancerObserver.factory(),
                 null,

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LinearSearchConnectionSelectorTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/LinearSearchConnectionSelectorTest.java
@@ -21,15 +21,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static io.servicetalk.loadbalancer.ConnectionPoolStrategyHelpers.makeConnections;
+import static io.servicetalk.loadbalancer.ConnectionSelectorHelpers.makeConnections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-class LinearSearchConnectionPoolStrategyTest {
+class LinearSearchConnectionSelectorTest {
 
-    ConnectionPoolStrategy<TestLoadBalancedConnection> strategy(int linearSearchSpace) {
-        return LinearSearchConnectionPoolStrategy.<TestLoadBalancedConnection>factory(linearSearchSpace)
-                .buildStrategy("resource");
+    ConnectionSelector<TestLoadBalancedConnection> strategy(int linearSearchSpace) {
+        return LinearSearchConnectionSelector.<TestLoadBalancedConnection>factory(linearSearchSpace)
+                .buildConnectionSelector("resource");
     }
 
     @Test
@@ -37,7 +37,7 @@ class LinearSearchConnectionPoolStrategyTest {
         // Ensure we can successfully select hosts for most sized pools
         for (int i = 1; i < 10; i++) {
             List<TestLoadBalancedConnection> connections = makeConnections(i);
-            ConnectionPoolStrategy<TestLoadBalancedConnection> strategy = strategy(5);
+            ConnectionSelector<TestLoadBalancedConnection> strategy = strategy(5);
             assertEquals(connections.get(0), strategy.select(connections, c -> true));
         }
     }
@@ -45,7 +45,7 @@ class LinearSearchConnectionPoolStrategyTest {
     @Test
     void picksHostsLinearlyUpToLinearSearchSpace() {
         List<TestLoadBalancedConnection> connections = makeConnections(10);
-        ConnectionPoolStrategy<TestLoadBalancedConnection> strategy = strategy(10);
+        ConnectionSelector<TestLoadBalancedConnection> strategy = strategy(10);
         Set<TestLoadBalancedConnection> selected = new HashSet<>();
         for (int i = 0; i < 10; i++) {
             TestLoadBalancedConnection cxn = strategy.select(connections, c -> !selected.contains(c));
@@ -57,7 +57,7 @@ class LinearSearchConnectionPoolStrategyTest {
     @Test
     void canRandomlySearchAfterLinearSpace() {
         List<TestLoadBalancedConnection> connections = makeConnections(5);
-        ConnectionPoolStrategy<TestLoadBalancedConnection> strategy = strategy(1);
+        ConnectionSelector<TestLoadBalancedConnection> strategy = strategy(1);
         for (int i = 0; i < 100; i++) {
             assertNotNull(strategy.select(connections, c -> c != connections.get(0)));
         }


### PR DESCRIPTION
Motivation:

The ConnectionPoolStrategy carries a lot of parallels with the HostSelector abstraction, in that it's goal is to select a connection. However, the names are dissimilar and 'Strategy' doesn't have as strong an implication of being capable of action and may suggest it's configuration.

Modifications:

Rename ConnectionPoolStrategy to ConnectionSelector to make its role more clear.