### PR TITLE
loadbalancer-experimental: make RichServiceDiscovererEvent package private

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RichServiceDiscovererEvent.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RichServiceDiscovererEvent.java
@@ -26,14 +26,14 @@ import static java.util.Objects.requireNonNull;
  * A richer {@link ServiceDiscovererEvent} that can carry weight and priority information.
  * @param <ResolvedAddress> the type of the resolved address.
  */
-public final class RichServiceDiscovererEvent<ResolvedAddress> implements ServiceDiscovererEvent<ResolvedAddress> {
+final class RichServiceDiscovererEvent<ResolvedAddress> implements ServiceDiscovererEvent<ResolvedAddress> {
 
     private final ResolvedAddress address;
     private final Status status;
     private final double weight;
     private final int priority;
 
-    public RichServiceDiscovererEvent(ResolvedAddress address, Status status, double weight, int priority) {
+    RichServiceDiscovererEvent(ResolvedAddress address, Status status, double weight, int priority) {
         if (weight < 0d) {
             throw new IllegalArgumentException("Illegal weight: " + weight);
         }


### PR DESCRIPTION
Motivation:

As we prepare to move the DefaultLoadBalancer out of experimental we need to scrutinize the API we expose as it effectively becomes permanent. RichServiceDiscovererEvent is one of those API's I don't think we want to commit to just yet.

Modifications:

Make RichServiceDiscovererEvent package private.