### PR TITLE
loadbalancer-experimental: remove random-subsetting API from LoadBala…

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -60,12 +60,6 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
     }
 
     @Override
-    public LoadBalancerBuilder<ResolvedAddress, C> randomSubsetSize(int randomSubsetSize) {
-        delegate = delegate.randomSubsetSize(randomSubsetSize);
-        return this;
-    }
-
-    @Override
     public LoadBalancerBuilder<ResolvedAddress, C> loadBalancerObserver(
             @Nullable LoadBalancerObserverFactory loadBalancerObserverFactory) {
         delegate = delegate.loadBalancerObserver(loadBalancerObserverFactory);

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -71,16 +71,6 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
             LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy);
 
     /**
-     * Set the random host subset size for the load balancer.
-     * This is valuable for limiting the number of outgoing connections when calling services that have
-     * a very high replica count. It does so by selecting the specified number of hosts randomly from the total host
-     * set and routing traffic only to these hosts.
-     * @param randomSubsetSize the maximum number of healthy hosts to establish connections to
-     * @return {@code this}
-     */
-    LoadBalancerBuilder<ResolvedAddress, C> randomSubsetSize(int randomSubsetSize);
-
-    /**
      * Set the {@link LoadBalancerObserverFactory} to use with this load balancer.
      * @param loadBalancerObserverFactory the {@link LoadBalancerObserverFactory} to use, or {@code null} to not use an
      *                                    observer.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/PrioritizedHost.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/PrioritizedHost.java
@@ -21,6 +21,12 @@ package io.servicetalk.loadbalancer;
 interface PrioritizedHost {
 
     /**
+     * A random seed given to a host on it's initial creation.
+     * @return a random seed given to a host on it's initial creation.
+     */
+    long randomSeed();
+
+    /**
      * The current priority of the host.
      * @return the current priority of the host.
      */

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RandomSubsetter.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RandomSubsetter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
+
+/**
+ * A {@link Subsetter} that takes a random subset of the provided hosts.
+ */
+final class RandomSubsetter implements Subsetter {
+
+    private final int randomSubsetSize;
+
+    RandomSubsetter(int randomSubsetSize) {
+        this.randomSubsetSize = ensurePositive(randomSubsetSize, "randomSubsetSize");
+    }
+
+    @Override
+    public <T extends PrioritizedHost> List<T> subset(List<T> nextHosts) {
+        if (nextHosts.size() <= randomSubsetSize) {
+            return nextHosts;
+        }
+
+        // We need to sort, and then return the list with the subsetSize number of healthy elements.
+        List<T> result = new ArrayList<>(nextHosts);
+        result.sort(Comparator.comparingLong(PrioritizedHost::randomSeed));
+
+        // We don't want to consider the unhealthy elements to be a part of our subset, so we're going to grow it
+        // to account for un-health endpoints. However, we need to know how many that is.
+        for (int i = 0, healthyCount = 0; i < result.size(); i++) {
+            if (result.get(i).isHealthy()) {
+                ++healthyCount;
+                if (healthyCount == randomSubsetSize) {
+                    // Trim elements after i to form the subset.
+                    while (result.size() > i + 1) {
+                        result.remove(result.size() - 1);
+                    }
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/Subsetter.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/Subsetter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import java.util.List;
+
+/**
+ * An abstraction for picking a subset of hosts to use for load balancing purposes.
+ */
+interface Subsetter {
+
+    /**
+     * Subset the provided host list into the list of hosts that will be used for load balancing.
+     * @param hosts the eligible list of hosts.
+     * @return the list of hosts that should be used for load balancing.
+     * @param <T> the type of the {@link PrioritizedHost}
+     */
+    <T extends PrioritizedHost> List<T> subset(List<T> hosts);
+}

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategyTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategyTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
@@ -280,6 +281,7 @@ class DefaultHostPriorityStrategyTest {
     private static class TestPrioritizedHost implements PrioritizedHost {
 
         private final String address;
+        private final long randomSeed = ThreadLocalRandom.current().nextLong();
 
         private boolean isHealthy = true;
         private int priority;
@@ -291,6 +293,11 @@ class DefaultHostPriorityStrategyTest {
 
         String address() {
             return address;
+        }
+
+        @Override
+        public long randomSeed() {
+            return randomSeed;
         }
 
         @Override

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RandomSubsetterTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RandomSubsetterTest.java
@@ -47,7 +47,7 @@ class RandomSubsetterTest {
         when(hosts.get(0).isHealthy()).thenReturn(false);
         List<PrioritizedHost> results = new RandomSubsetter(5).subset(hosts);
         long healthyCount = results.stream().filter(PrioritizedHost::isHealthy).count();
-        assertThat(healthyCount, equalTo(5l));
+        assertThat(healthyCount, equalTo(5L));
     }
 
     @Test
@@ -59,7 +59,7 @@ class RandomSubsetterTest {
         when(hosts.get(0).isHealthy()).thenReturn(false);
         List<PrioritizedHost> results = new RandomSubsetter(5).subset(hosts);
         long healthyCount = results.stream().filter(PrioritizedHost::isHealthy).count();
-        assertThat(healthyCount, equalTo(0l));
+        assertThat(healthyCount, equalTo(0L));
         assertThat(hosts, equalTo(results));
     }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RandomSubsetterTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RandomSubsetterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.loadbalancer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RandomSubsetterTest {
+
+    @Test
+    void desiredSubsetLargerThanHostList() {
+        List<PrioritizedHost> hosts = hosts(10);
+        List<PrioritizedHost> results = new RandomSubsetter(Integer.MAX_VALUE).subset(hosts);
+        assertThat(results, equalTo(hosts));
+    }
+
+    @Test
+    void desiredSubsetSmallerThanHostList() {
+        List<PrioritizedHost> hosts = hosts(10);
+        List<PrioritizedHost> results = new RandomSubsetter(5).subset(hosts);
+        assertThat(results.size(), equalTo(5));
+    }
+
+    @Test
+    void enoughHealthEndpoints() {
+        List<PrioritizedHost> hosts = hosts(10);
+        when(hosts.get(0).isHealthy()).thenReturn(false);
+        List<PrioritizedHost> results = new RandomSubsetter(5).subset(hosts);
+        long healthyCount = results.stream().filter(PrioritizedHost::isHealthy).count();
+        assertThat(healthyCount, equalTo(5l));
+    }
+
+    @Test
+    void notEnoughHealthEndpoints() {
+        List<PrioritizedHost> hosts = hosts(10);
+        for (PrioritizedHost host : hosts) {
+            when(host.isHealthy()).thenReturn(false);
+        }
+        when(hosts.get(0).isHealthy()).thenReturn(false);
+        List<PrioritizedHost> results = new RandomSubsetter(5).subset(hosts);
+        long healthyCount = results.stream().filter(PrioritizedHost::isHealthy).count();
+        assertThat(healthyCount, equalTo(0l));
+        assertThat(hosts, equalTo(results));
+    }
+
+    private static List<PrioritizedHost> hosts(int count) {
+        List<PrioritizedHost> hosts = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            PrioritizedHost host = mock(PrioritizedHost.class);
+            when(host.randomSeed()).thenReturn((long) i);
+            when(host.isHealthy()).thenReturn(true);
+            hosts.add(host);
+        }
+
+        return hosts;
+    }
+}

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -37,11 +37,6 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
     }
 
     @Override
-    public LoadBalancerBuilder<String, TestLoadBalancedConnection> randomSubsetSize(int randomSubsetSize) {
-        throw new UnsupportedOperationException("Cannot set subset size for old round robin");
-    }
-
-    @Override
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> loadBalancerObserver(
             @Nullable LoadBalancerObserverFactory loadBalancerObserverFactory) {
         throw new UnsupportedOperationException("Cannot set a load balancer observer for old round robin");


### PR DESCRIPTION
…ncerBuilder

Motivation:

There are many forms of subsetting and I don't think we have sorted out the best way to make that configurable from an API perspective. As we make the LoadBalancerBuilder API non-experimental, we don't want to yet commit to the existing API.

Modifications:

- Remove the configuration from LoadBalancerBuilder
- Extract the random subsetting logic into it's own abstraction to prep for future subsetting strategies
- Add some independent unit tests for RandomSubsetter

Result:

- Smaller API commitments
- More flexibility to experiment internally