### PR TITLE
loadbalancer-experimental: fix some raw types usages

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -80,7 +80,7 @@ class DefaultHostTest {
         }
     }
 
-    private void buildHost(@Nullable HealthIndicator healthIndicator) {
+    private void buildHost(@Nullable HealthIndicator<String, TestLoadBalancedConnection> healthIndicator) {
         host = new DefaultHost<>("lbDescription", DEFAULT_ADDRESS,
                 LinearSearchConnectionSelector.<TestLoadBalancedConnection>factory(DEFAULT_LINEAR_SEARCH_SPACE)
                         .buildConnectionSelector("resource"),
@@ -206,7 +206,7 @@ class DefaultHostTest {
 
     @Test
     void healthIndicatorInfluencesHealthStatus() {
-        HealthIndicator healthIndicator = mock(HealthIndicator.class);
+        HealthIndicator<String, TestLoadBalancedConnection> healthIndicator = mock(HealthIndicator.class);
         when(healthIndicator.isHealthy()).thenReturn(true);
         buildHost(healthIndicator);
         assertThat(host.isHealthy(), is(true));
@@ -216,7 +216,7 @@ class DefaultHostTest {
 
     @Test
     void forwardsHealthIndicatorScore() {
-        HealthIndicator healthIndicator = mock(HealthIndicator.class);
+        HealthIndicator<String, TestLoadBalancedConnection> healthIndicator = mock(HealthIndicator.class);
         when(healthIndicator.score()).thenReturn(10);
         buildHost(healthIndicator);
         assertThat(host.score(), is(10));
@@ -226,7 +226,7 @@ class DefaultHostTest {
     @Test
     void connectFailuresAreForwardedToHealthIndicator() {
         connectionFactory = new TestConnectionFactory(address -> failed(DELIBERATE_EXCEPTION));
-        HealthIndicator healthIndicator = mock(HealthIndicator.class);
+        HealthIndicator<String, TestLoadBalancedConnection> healthIndicator = mock(HealthIndicator.class);
         buildHost(healthIndicator);
         Throwable underlying = assertThrows(ExecutionException.class, () ->
                 host.newConnection(cxn -> true, false, null).toFuture().get()).getCause();

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/SelectorTestHelpers.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/SelectorTestHelpers.java
@@ -58,7 +58,8 @@ final class SelectorTestHelpers {
         return results;
     }
 
-    private static Host mockHost(String addr, TestLoadBalancedConnection connection) {
+    private static Host<String, TestLoadBalancedConnection> mockHost(
+            String addr, TestLoadBalancedConnection connection) {
         Host<String, TestLoadBalancedConnection> host = mock(Host.class);
         when(host.address()).thenReturn(addr);
         when(host.isHealthy()).thenReturn(true);

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithmTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithmTest.java
@@ -80,8 +80,10 @@ class XdsOutlierDetectorAlgorithmTest {
     void cancellation() {
         config = withAllEnforcing().maxEjectionPercentage(100).build();
         outlierDetector = buildOutlierDetector();
-        HealthIndicator indicator1 = outlierDetector.newHealthIndicator("address-1", observer());
-        HealthIndicator indicator2 = outlierDetector.newHealthIndicator("address-2", observer());
+        HealthIndicator<String, TestLoadBalancedConnection> indicator1 =
+                outlierDetector.newHealthIndicator("address-1", observer());
+        HealthIndicator<String, TestLoadBalancedConnection> indicator2 =
+                outlierDetector.newHealthIndicator("address-2", observer());
         eject(indicator1);
         eject(indicator2);
         assertFalse(indicator1.isHealthy());
@@ -110,7 +112,8 @@ class XdsOutlierDetectorAlgorithmTest {
                 .build();
         outlierDetector = buildOutlierDetector();
 
-        HealthIndicator indicator1 = outlierDetector.newHealthIndicator("address-1", observer());
+        HealthIndicator<String, TestLoadBalancedConnection> indicator1 =
+                outlierDetector.newHealthIndicator("address-1", observer());
         eject(indicator1);
         assertFalse(indicator1.isHealthy());
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
@@ -133,12 +136,12 @@ class XdsOutlierDetectorAlgorithmTest {
     private void testEjectPercentage(int maxEjectPercentage) {
         config = withAllEnforcing().maxEjectionPercentage(maxEjectPercentage).build();
         outlierDetector = buildOutlierDetector();
-        List<HealthIndicator> healthIndicators = new ArrayList<>(4);
+        List<HealthIndicator<String, TestLoadBalancedConnection>> healthIndicators = new ArrayList<>(4);
         for (int i = 0; i < 4; i++) {
             healthIndicators.add(outlierDetector.newHealthIndicator("address-" + i, observer()));
         }
 
-        for (HealthIndicator indicator : healthIndicators) {
+        for (HealthIndicator<String, TestLoadBalancedConnection> indicator : healthIndicators) {
             eject(indicator);
         }
 
@@ -147,7 +150,7 @@ class XdsOutlierDetectorAlgorithmTest {
                 .filter(indicator -> !indicator.isHealthy()).collect(Collectors.toList()), hasSize(expectedFailed));
     }
 
-    private void eject(HealthIndicator indicator) {
+    private void eject(HealthIndicator<String, TestLoadBalancedConnection> indicator) {
         for (int i = 0; i < config.consecutive5xx(); i++) {
             if (!indicator.isHealthy()) {
                 break;


### PR DESCRIPTION
Motivation:

We have a few raw types usages in loadbalancer-experimental tests.

Modifications:

Add the types.