### PR TITLE
loadbalancer-experimental: Add default policies

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolPolicies.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolPolicies.java
@@ -26,6 +26,15 @@ public final class ConnectionPoolPolicies {
     }
 
     /**
+     * Get the recommended default {@link ConnectionPoolPolicy}.
+     * @param <C> the concrete type of the {@link LoadBalancedConnection}
+     * @return the recommended default {@link ConnectionPoolPolicy}.
+     */
+    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> defaultPolicy() {
+        return linearSearch();
+    }
+
+    /**
      * A connection selection policy that prioritizes a configurable "core" pool.
      * <p>
      * This {@link ConnectionPoolPolicy} attempts to emulate the pooling behavior often seen in thread pools.
@@ -44,8 +53,8 @@ public final class ConnectionPoolPolicies {
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
      * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C>
-    corePool(final int corePoolSize, final boolean forceCorePool) {
+    public static <C extends LoadBalancedConnection>
+    ConnectionPoolPolicy<C> corePool(final int corePoolSize, final boolean forceCorePool) {
         return CorePoolConnectionSelector.factory(corePoolSize, forceCorePool);
     }
 
@@ -94,8 +103,8 @@ public final class ConnectionPoolPolicies {
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
      * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C>
-    p2c(int corePoolSize, boolean forceCorePool) {
+    public static <C extends LoadBalancedConnection>
+    ConnectionPoolPolicy<C> p2c(int corePoolSize, boolean forceCorePool) {
         return p2c(DEFAULT_MAX_EFFORT, corePoolSize, forceCorePool);
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -39,8 +39,8 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     private Executor backgroundExecutor;
     @Nullable
     private LoadBalancerObserverFactory loadBalancerObserverFactory;
-    private LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy = defaultLoadBalancingPolicy();
-    private ConnectionPoolPolicy<C> connectionPoolPolicy = defaultConnectionSelectorFactory();
+    private LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy = LoadBalancingPolicies.defaultPolicy();
+    private ConnectionPoolPolicy<C> connectionPoolPolicy = ConnectionPoolPolicies.defaultPolicy();
     private OutlierDetectorConfig outlierDetectorConfig = OutlierDetectorConfig.DEFAULT_CONFIG;
 
     // package private constructor so users must funnel through providers in `LoadBalancers`
@@ -180,15 +180,5 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     private Executor getExecutor() {
         return backgroundExecutor ==
                 null ? RoundRobinLoadBalancerFactory.SharedExecutor.getInstance() : backgroundExecutor;
-    }
-
-    private static <ResolvedAddress, C extends LoadBalancedConnection>
-    LoadBalancingPolicy<ResolvedAddress, C> defaultLoadBalancingPolicy() {
-        return LoadBalancingPolicies.roundRobin().build();
-    }
-
-    private static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C>
-    defaultConnectionSelectorFactory() {
-        return ConnectionPoolPolicies.linearSearch();
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicies.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicies.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.loadbalancer;
 
+import io.servicetalk.client.api.LoadBalancedConnection;
+
 /**
  * A collections of factories for constructing a {@link LoadBalancingPolicy}.
  */
@@ -22,6 +24,15 @@ public final class LoadBalancingPolicies {
 
     private LoadBalancingPolicies() {
         // no instances.
+    }
+
+    /**
+     * Get the recommended default {@link LoadBalancingPolicy}.
+     * @return the recommended default {@link LoadBalancingPolicy}.
+     */
+    public static <ResolvedAddress, C extends LoadBalancedConnection>
+    LoadBalancingPolicy<ResolvedAddress, C> defaultPolicy() {
+        return LoadBalancingPolicies.roundRobin().build();
     }
 
     /**

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicies.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicies.java
@@ -28,6 +28,8 @@ public final class LoadBalancingPolicies {
 
     /**
      * Get the recommended default {@link LoadBalancingPolicy}.
+     * @param <ResolvedAddress> the type of the resolved address.
+     * @param <C> the type of the {@link LoadBalancedConnection}
      * @return the recommended default {@link LoadBalancingPolicy}.
      */
     public static <ResolvedAddress, C extends LoadBalancedConnection>


### PR DESCRIPTION
Motivation:

Users currently need to understand a lot about the different policies in order to make a good decision.

Modifications:

Add default connection pool and load balancing policies. This makes it easy for users to pick the recommended default. This also gives us as maintainers a place to change the recommended default.