### PR TITLE
loadbalancer-experimental: javadoc cleanup and minor fixes

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -40,11 +40,11 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
     }
 
     protected abstract Single<C> selectConnection0(Predicate<C> selector, @Nullable ContextMap context,
-                                         boolean forceNewConnectionAndReserve);
+                                                   boolean forceNewConnectionAndReserve);
 
     @Override
     public final Single<C> selectConnection(Predicate<C> selector, @Nullable ContextMap context,
-                                      boolean forceNewConnectionAndReserve) {
+                                            boolean forceNewConnectionAndReserve) {
         return hosts.isEmpty() ? noHostsFailure() : selectConnection0(selector, context, forceNewConnectionAndReserve);
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -39,8 +39,8 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
         this.lbDescription = requireNonNull(lbDescription, "lbDescription");
     }
 
-    protected abstract Single<C> selectConnection0(Predicate<C> selector, @Nullable ContextMap context,
-                                                   boolean forceNewConnectionAndReserve);
+    abstract Single<C> selectConnection0(Predicate<C> selector, @Nullable ContextMap context,
+                                         boolean forceNewConnectionAndReserve);
 
     @Override
     public final Single<C> selectConnection(Predicate<C> selector, @Nullable ContextMap context,
@@ -60,15 +60,15 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
         return anyHealthy(hosts);
     }
 
-    protected final List<? extends Host<ResolvedAddress, C>> hosts() {
+    final List<? extends Host<ResolvedAddress, C>> hosts() {
         return hosts;
     }
 
-    protected final String lbDescription() {
+    final String lbDescription() {
         return lbDescription;
     }
 
-    protected final Single<C> noActiveHostsFailure(List<? extends Host<ResolvedAddress, C>> usedHosts) {
+    final Single<C> noActiveHostsFailure(List<? extends Host<ResolvedAddress, C>> usedHosts) {
         return failed(Exceptions.StacklessNoActiveHostException.newInstance(
                 lbDescription() + ": Failed to pick an active host. Either all are busy, expired, or unhealthy: " +
                         usedHosts, this.getClass(), "selectConnection(...)"));
@@ -76,7 +76,7 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
 
     // This method assumes the host is considered healthy.
     @Nullable
-    protected final Single<C> selectFromHost(Host<ResolvedAddress, C> host, Predicate<C> selector,
+    final Single<C> selectFromHost(Host<ResolvedAddress, C> host, Predicate<C> selector,
             boolean forceNewConnectionAndReserve, @Nullable ContextMap contextMap) {
         // First see if we can get an existing connection regardless of health status.
         if (!forceNewConnectionAndReserve) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolPolicies.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionPoolPolicies.java
@@ -17,6 +17,9 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
 
+/**
+ * A factory to create different {@link ConnectionPoolPolicy} variants.
+ */
 public final class ConnectionPoolPolicies {
     private static final int DEFAULT_MAX_EFFORT = 5;
     private static final int DEFAULT_LINEAR_SEARCH_SPACE = 16;
@@ -38,14 +41,15 @@ public final class ConnectionPoolPolicies {
      * If the core pool cannot satisfy the load traffic can spill over to extra connections which are selected in-order.
      * This has the property of minimizing traffic to the latest elements added outside the core pool size, thus let
      * them idle out of the pool once they're no longer necessary.
+     *
      * @param corePoolSize the size of the core pool.
      * @param forceCorePool whether to avoid selecting connections from the core pool until it has reached the
      *                      configured core pool size.
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
      * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C>
-    corePool(final int corePoolSize, final boolean forceCorePool) {
+    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> corePool(final int corePoolSize,
+                                                                                      final boolean forceCorePool) {
         return CorePoolConnectionSelector.factory(corePoolSize, forceCorePool);
     }
 
@@ -56,6 +60,7 @@ public final class ConnectionPoolPolicies {
      * traffic to connections in the order they were created in linear order up until a configured quantity. After
      * this linear pool is exhausted the remaining connections will be selected from at random. Prioritizing traffic
      * to the existing connections will let tailing connections be removed due to idleness.
+     *
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
      * @return the configured {@link ConnectionPoolPolicy}.
      */
@@ -70,12 +75,13 @@ public final class ConnectionPoolPolicies {
      * traffic to connections in the order they were created in linear order up until a configured quantity. After
      * this linear pool is exhausted the remaining connections will be selected from at random. Prioritizing traffic
      * to the existing connections will let tailing connections be removed due to idleness.
+     *
      * @param linearSearchSpace the space to search linearly before resorting to random selection for remaining
      *                          connections.
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
      * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> linearSearch(int linearSearchSpace) {
+    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> linearSearch(final int linearSearchSpace) {
         return LinearSearchConnectionSelector.factory(linearSearchSpace);
     }
 
@@ -83,19 +89,25 @@ public final class ConnectionPoolPolicies {
      * A {@link ConnectionPoolPolicy} that attempts to discern between the health of individual connections.
      * If individual connections have health data the P2C policy can be used to bias traffic toward the best
      * connections. This has the following algorithm:
-     * - Randomly select two connections from the 'core pool' (pick-two).
-     *   - Try to select the 'best' of the two connections.
-     *   - If we fail to select the best connection, try the other connection.
-     * - If both connections fail, repeat the pick-two operation for up to maxEffort attempts, begin linear iteration
-     *   through the remaining connections searching for an acceptable connection.
+     * <ol>
+     *     <li>Randomly select two connections from the 'core pool' (pick-two).
+     *         <ol>
+     *             <li>Try to select the 'best' of the two connections.</li>
+     *             <li>If we fail to select the best connection, try the other connection.</li>
+     *         </ol>
+     *     </li>
+     *     <li>If both connections fail, repeat the pick-two operation for up to maxEffort attempts, begin linear
+     *     iteration through the remaining connections searching for an acceptable connection.</li>
+     * </ol>
+     *
      * @param corePoolSize the size of the core pool.
      * @param forceCorePool whether to avoid selecting connections from the core pool until it has reached the
      *                      configured core pool size.
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
      * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C>
-    p2c(int corePoolSize, boolean forceCorePool) {
+    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> p2c(final int corePoolSize,
+                                                                                 final boolean forceCorePool) {
         return p2c(DEFAULT_MAX_EFFORT, corePoolSize, forceCorePool);
     }
 
@@ -103,11 +115,17 @@ public final class ConnectionPoolPolicies {
      * A {@link ConnectionPoolPolicy} that attempts to discern between the health of individual connections.
      * If individual connections have health data the P2C policy can be used to bias traffic toward the best
      * connections. This has the following algorithm:
-     * - Randomly select two connections from the 'core pool' (pick-two).
-     *   - Try to select the 'best' of the two connections.
-     *   - If we fail to select the best connection, try the other connection.
-     * - If both connections fail, repeat the pick-two operation for up to maxEffort attempts, begin linear iteration
-     *   through the remaining connections searching for an acceptable connection.
+     * <ol>
+     *     <li>Randomly select two connections from the 'core pool' (pick-two).
+     *         <ol>
+     *             <li>Try to select the 'best' of the two connections.</li>
+     *             <li>If we fail to select the best connection, try the other connection.</li>
+     *         </ol>
+     *     </li>
+     *     <li>If both connections fail, repeat the pick-two operation for up to maxEffort attempts, begin linear
+     *     iteration through the remaining connections searching for an acceptable connection.</li>
+     * </ol>
+     *
      * @param maxEffort the maximum number of attempts to pick a healthy connection from the core pool.
      * @param corePoolSize the size of the core pool.
      * @param forceCorePool whether to avoid selecting connections from the core pool until it has reached the
@@ -115,8 +133,9 @@ public final class ConnectionPoolPolicies {
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
      * @return the configured {@link ConnectionPoolPolicy}.
      */
-    public static <C extends LoadBalancedConnection>
-    ConnectionPoolPolicy<C> p2c(int maxEffort, int corePoolSize, boolean forceCorePool) {
+    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> p2c(final int maxEffort,
+                                                                                 final int corePoolSize,
+                                                                                 final boolean forceCorePool) {
         return P2CConnectionSelector.factory(maxEffort, corePoolSize, forceCorePool);
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultRequestTracker.java
@@ -69,7 +69,7 @@ abstract class DefaultRequestTracker implements RequestTracker, ScoreSupplier {
      * The current time in nanoseconds.
      * @return the current time in nanoseconds.
      */
-    protected abstract long currentTimeNanos();
+    abstract long currentTimeNanos();
 
     @Override
     public final long beforeRequestStart() {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -89,4 +89,9 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
     public LoadBalancerFactory<ResolvedAddress, C> build() {
         return delegate.build();
     }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "{delegate=" + delegate() + '}';
+    }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HealthIndicator.java
@@ -20,8 +20,7 @@ import io.servicetalk.client.api.ScoreSupplier;
 import io.servicetalk.concurrent.Cancellable;
 
 /**
- * An abstraction used by a {@link Host} to interact with the {@link OutlierDetector} currently monitoring
- * the host.
+ * An abstraction used by a {@link Host} to interact with the {@link OutlierDetector} currently monitoring the host.
  * <p>
  * This abstraction serves as a sort of two-way channel between a host and the health check system: the
  * health check system can give the host information about it's perceived health and the host can give the

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -42,7 +42,7 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
 
     /**
      * Select or establish a new connection from an existing Host.
-     *
+     * <p>
      * This method will be called concurrently with other selectConnection calls and
      * hostSetChanged calls and must be thread safe under those conditions.
      */

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -72,6 +72,7 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
 
     /**
      * The size of the host candidate pool for this host selector.
+     * <p>
      * Note that this is primarily for observability purposes.
      * @return the size of the host candidate pool for this host selector.
      */

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -64,6 +64,7 @@ import javax.annotation.Nullable;
 public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConnection> {
     /**
      * Set the {@code loadBalancingPolicy} to use with this load balancer.
+     *
      * @param loadBalancingPolicy the {@code loadBalancingPolicy} to use
      * @return {@code this}
      */
@@ -72,6 +73,7 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
 
     /**
      * Set the {@link LoadBalancerObserverFactory} to use with this load balancer.
+     *
      * @param loadBalancerObserverFactory the {@link LoadBalancerObserverFactory} to use, or {@code null} to not use an
      *                                    observer.
      * @return {code this}
@@ -81,9 +83,11 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
 
     /**
      * Set the {@link OutlierDetectorConfig} to use with this load balancer.
+     * <p>
      * The outlier detection system works in conjunction with the load balancing policy to attempt to avoid hosts
      * that have been determined to be unhealthy or slow. The details of the selection process are determined by the
      * {@link LoadBalancingPolicy} while the health status is determined by the outlier detection configuration.
+     *
      * @param outlierDetectorConfig the {@link OutlierDetectorConfig} to use, or {@code null} to use the default
      *                              outlier detection.
      * @return {code this}
@@ -93,6 +97,7 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
 
     /**
      * Set the {@link ConnectionPoolPolicy} to use with this load balancer.
+     *
      * @param connectionPoolPolicy the factory of connection pooling strategies to use.
      * @return {@code this}
      */

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilderProvider.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilderProvider.java
@@ -20,6 +20,7 @@ import io.servicetalk.client.api.LoadBalancedConnection;
 /**
  * Provider for {@link LoadBalancerBuilder} that can be registered using {@link java.util.ServiceLoader}.
  */
+@FunctionalInterface
 public interface LoadBalancerBuilderProvider {
 
     /**

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilderProvider.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilderProvider.java
@@ -18,7 +18,7 @@ package io.servicetalk.loadbalancer;
 import io.servicetalk.client.api.LoadBalancedConnection;
 
 /**
- * Provider for {@link LoadBalancerBuilder}.
+ * Provider for {@link LoadBalancerBuilder} that can be registered using {@link java.util.ServiceLoader}.
  */
 public interface LoadBalancerBuilderProvider {
 
@@ -28,10 +28,9 @@ public interface LoadBalancerBuilderProvider {
      * This method may return the pre-initialized {@code builder} as-is, or apply custom builder settings before
      * returning it, or wrap it ({@link DelegatingLoadBalancerBuilder} may be helpful).
      *
-     * @param id a (unique) identifier used to identify the underlying {@link io.servicetalk.client.api.LoadBalancer}.
+     * @param id a (unique) identifier used to identify the underlying {@link LoadBalancerBuilder}.
      * @param builder pre-initialized {@link LoadBalancerBuilder}.
-     * @return a {@link LoadBalancerBuilder} based on the pre-initialized
-     * {@link LoadBalancerBuilder}.
+     * @return a {@link LoadBalancerBuilder} based on the pre-initialized {@link LoadBalancerBuilder}.
      * @param <ResolvedAddress> The resolved address type.
      * @param <C> The type of connection.
      */

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -34,11 +34,6 @@ public interface LoadBalancerObserver {
     HostObserver hostObserver(Object resolvedAddress);
 
     /**
-     * Callback for when connection selection fails due to no hosts being available.
-     */
-    void onNoHostsAvailable();
-
-    /**
      * Callback for monitoring the changes due to a service discovery update.
      * @param events the collection of {@link ServiceDiscovererEvent}s received by the load balancer.
      * @param oldHostSetSize the size of the previous host set.
@@ -46,13 +41,6 @@ public interface LoadBalancerObserver {
      */
     void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events,
                                  int oldHostSetSize, int newHostSetSize);
-
-    /**
-     * Callback for when connection selection fails due to all hosts being inactive.
-     * @param hostSetSize the size of the current host set.
-     * @param exception an exception with more details about the failure.
-     */
-    void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exception);
 
     /**
      * Callback for when the set of hosts used by the load balancer has changed. This set may not
@@ -63,6 +51,18 @@ public interface LoadBalancerObserver {
      */
     default void onHostSetChanged(Collection<? extends Host> newHosts) {
     }
+
+    /**
+     * Callback for when connection selection fails due to no hosts being available.
+     */
+    void onNoHostsAvailable();
+
+    /**
+     * Callback for when connection selection fails due to all hosts being inactive.
+     * @param hostSetSize the size of the current host set.
+     * @param exception an exception with more details about the failure.
+     */
+    void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exception);
 
     /**
      * An observer for {@link io.servicetalk.loadbalancer.Host} events.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancers.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancers.java
@@ -16,6 +16,7 @@
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
+import io.servicetalk.client.api.LoadBalancer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +26,7 @@ import java.util.List;
 import static io.servicetalk.utils.internal.ServiceLoaderUtils.loadProviders;
 
 /**
- * A factory to create {@link DefaultLoadBalancer DefaultLoadBalancers}.
+ * A factory to create a {@link LoadBalancer} or a {@link LoadBalancerBuilder} to customize one.
  */
 public final class LoadBalancers {
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicies.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicies.java
@@ -16,7 +16,7 @@
 package io.servicetalk.loadbalancer;
 
 /**
- * A collections of factories for constructing a {@link LoadBalancingPolicy}.
+ * A factory to create different {@link LoadBalancingPolicy} variants.
  */
 public final class LoadBalancingPolicies {
 
@@ -26,9 +26,11 @@ public final class LoadBalancingPolicies {
 
     /**
      * Builder for the round-robin {@link LoadBalancingPolicy}.
+     * <p>
      * Round-robin load balancing is a strategy that maximizes fairness of the request distribution. This comes at the
      * cost of being unable to bias toward better performing hosts and can only leverage the course grained
      * healthy/unhealthy status of a host.
+     *
      * @return a builder for the round-robin {@link LoadBalancingPolicy}.
      */
     public static RoundRobinLoadBalancingPolicyBuilder roundRobin() {
@@ -37,9 +39,11 @@ public final class LoadBalancingPolicies {
 
     /**
      * Builder for the power of two choices (P2C) {@link LoadBalancingPolicy}.
+     * <p>
      * Power of Two Choices (P2C) leverages both course grained healthy/unhealthy status of a host plus additional
      * fine-grained scoring to prioritize hosts that are both healthy and better performing. See the
      * {@link P2CLoadBalancingPolicy} for more details.
+     *
      * @return a builder for the power of two choices (P2C) {@link LoadBalancingPolicy}.
      */
     public static P2CLoadBalancingPolicyBuilder p2c() {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
@@ -83,7 +83,7 @@ final class NoopOutlierDetector<ResolvedAddress, C extends LoadBalancedConnectio
         }
 
         @Override
-        protected long currentTimeNanos() {
+        long currentTimeNanos() {
             return executor.currentTime(TimeUnit.NANOSECONDS);
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetector.java
@@ -29,9 +29,11 @@ interface OutlierDetector<ResolvedAddress, C extends LoadBalancedConnection> ext
 
     /**
      * Construct a new {@link HealthIndicator}.
-     * @note The most common use case will be to use the indicator to track a newly constructed {@link Host} but
+     * <p>
+     * The most common use case will be to use the indicator to track a newly constructed {@link Host} but
      * it's possible that a currently live host may have its indicator replaced due to load balancing configuration
      * changes, so it's not safe to assume that the host that will use this tracker is exactly new.
+     *
      * @param address the resolved address of the destination.
      * @return new {@link HealthIndicator}.
      */
@@ -40,9 +42,12 @@ interface OutlierDetector<ResolvedAddress, C extends LoadBalancedConnection> ext
 
     /**
      * Stream of events that signal that the health status has changed for one or more of the hosts observed by the
-     * {@link OutlierDetector}. The events signal scenarios where hosts have transitioned from healthy to unhealthy and
-     * vise versa. The {@link OutlierDetector} may choose to send these events at regular intervals or immediately when
-     * a host has been detected unhealthy.
+     * {@link OutlierDetector}.
+     * <p>
+     * The events signal scenarios where hosts have transitioned from healthy to unhealthy and vise versa.
+     * The {@link OutlierDetector} may choose to send these events at regular intervals or immediately when a host has
+     * been detected unhealthy.
+     *
      * @return a {@link Publisher} that represents the stream of health status changes.
      */
     Publisher<Void> healthStatusChanged();

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -397,12 +397,14 @@ public final class OutlierDetectorConfig {
      */
     public static final class Builder {
 
-        // Default xDS outlier detector settings.
+        // ServiceTalk specific settings.
+        static final Duration DEFAULT_EWMA_HALF_LIFE = Duration.ofSeconds(10);
         static final int DEFAULT_CANCEL_PENALTY = 5;
         static final int DEFAULT_ERROR_PENALTY = 10;
         static final int DEFAULT_CONCURRENT_REQUEST_PENALTY = 1;
+        private boolean cancellationIsError = true;
 
-        private static final Duration DEFAULT_EWMA_HALF_LIFE = Duration.ofSeconds(10);
+        // Default xDS outlier detector settings.
         private static final int DEFAULT_CONSECUTIVE_5XX = 5;
         private static final Duration DEFAULT_FAILURE_DETECTOR_INTERVAL = ofSeconds(10);
         private static final Duration DEFAULT_BASE_EJECTION_TIME = ofSeconds(30);
@@ -422,7 +424,6 @@ public final class OutlierDetectorConfig {
         private Duration ewmaHalfLife = DEFAULT_EWMA_HALF_LIFE;
         private int ewmaCancellationPenalty = DEFAULT_CANCEL_PENALTY;
         private int ewmaErrorPenalty = DEFAULT_ERROR_PENALTY;
-        private boolean cancellationIsError = true;
         private int concurrentRequestPenalty = DEFAULT_CONCURRENT_REQUEST_PENALTY;
         private int failedConnectionsThreshold = DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
         private Duration intervalJitter = DEFAULT_HEALTH_CHECK_JITTER;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -17,6 +17,7 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
+import io.servicetalk.utils.internal.DurationUtils;
 
 import java.time.Duration;
 import java.util.concurrent.ThreadLocalRandom;
@@ -113,8 +114,10 @@ public final class OutlierDetectorConfig {
 
     /**
      * The Exponentially Weighted Moving Average (EWMA) half-life.
+     * <p>
      * In the context of an exponentially weighted moving average, the half-life means the time during which
      * historical data has the same weight as a new sample.
+     *
      * @return the Exponentially Weighted Moving Average (EWMA) half-life.
      */
     public Duration ewmaHalfLife() {
@@ -123,7 +126,9 @@ public final class OutlierDetectorConfig {
 
     /**
      * The penalty factor for local cancellation of requests.
+     * <p>
      * The latency of the cancelled request is multiplied by the provided penalty before incorporating it into the EWMA.
+     *
      * @return the penalty factor for local cancellation of requests.
      */
     public int ewmaCancellationPenalty() {
@@ -132,6 +137,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * Determines whether a cancellation is considered to be an error.
+     *
      * @return whether a cancellation is considered to be an error.
      */
     public boolean cancellationIsError() {
@@ -140,7 +146,9 @@ public final class OutlierDetectorConfig {
 
     /**
      * The penalty factor for requests that were classified as an error.
+     * <p>
      * The latency of the failed request is multiplied by the provided penalty before incorporating it into the EWMA.
+     *
      * @return the penalty factor for requests that were classified as an error.
      */
     public int ewmaErrorPenalty() {
@@ -149,8 +157,10 @@ public final class OutlierDetectorConfig {
 
     /**
      * The penalty factory to apply to concurrent requests.
+     * <p>
      * The EWMA penalty to apply to endpoints when there are concurrent requests. By penalizing endpoints with
      * concurrent load the traffic distribution will be smoother for algorithms that consider load metrics.
+     *
      * @return the penalty factory to use for concurrent load.
      */
     public int concurrentRequestPenalty() {
@@ -159,6 +169,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The threshold for consecutive connection failures to a host.
+     *
      * @return the threshold for consecutive connection failures to a host.
      * @see Builder#failedConnectionsThreshold(int)
      */
@@ -168,6 +179,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The jitter used along with the configured interval to determine duration between outlier detector checks.
+     *
      * @return the jitter used along with the configured interval to determine duration between outlier detector checks.
      * @see #failureDetectorInterval()
      * @see Builder#failureDetectorInterval(Duration, Duration)
@@ -178,6 +190,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The interval between service discovery resubscribes.
+     *
      * @return the interval between service discovery resubscribes.
      * @see #serviceDiscoveryResubscribeJitter()
      * @see Builder#serviceDiscoveryResubscribeInterval(Duration, Duration)
@@ -188,6 +201,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The jitter to use along with the service discovery resubscribe interval.
+     *
      * @return the jitter to use along with the service discovery resubscribe interval.
      * @see #serviceDiscoveryResubscribeInterval()
      * @see Builder#serviceDiscoveryResubscribeInterval(Duration, Duration)
@@ -198,6 +212,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The number of consecutive failures before the attempt to suspect the host.
+     *
      * @return the number of consecutive failures before the attempt to suspect the host.
      */
     public int consecutive5xx() {
@@ -206,9 +221,11 @@ public final class OutlierDetectorConfig {
 
     /**
      * The interval on which to run failure detectors.
+     * <p>
      * Failure percentage and success rate outlier detectors perform periodic scans to detect outliers. Active
      * revival mechanisms such as the layer-4 connectivity detector also use this interval to perform their periodic
      * health check to see if a host can be considered revived.
+     *
      * @return the interval on which to run failure percentage and success rate failure detectors.
      */
     public Duration failureDetectorInterval() {
@@ -217,8 +234,10 @@ public final class OutlierDetectorConfig {
 
     /**
      * The base ejection time.
+     * <p>
      * The base ejection time is multiplied by the number of consecutive times the host has been ejected to get the
      * total ejection time, capped by the {@link #maxEjectionTime()}.
+     *
      * @return the base ejection time.
      * @see #ejectionTimeJitter()
      */
@@ -228,6 +247,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The maximum percentage of hosts that can be ejected due to outlier detection.
+     *
      * @return the maximum percentage of hosts that can be ejected due to outlier detection.
      */
     public int maxEjectionPercentage() {
@@ -237,6 +257,7 @@ public final class OutlierDetectorConfig {
     /**
      * The probability in percentage that a host will be marked as unhealthy when a host reaches the
      * {@link #consecutive5xx()} threshold.
+     *
      * @return the probability with which the host should be marked as unhealthy.
      */
     public int enforcingConsecutive5xx() {
@@ -246,6 +267,7 @@ public final class OutlierDetectorConfig {
     /**
      * The probability in percentage that a host will be marked as unhealthy when a host exceeds the success rate
      * outlier detectors threshold.
+     *
      * @return the probability with which the host should be marked as unhealthy.
      */
     public int enforcingSuccessRate() {
@@ -254,6 +276,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The minimum number of hosts required to perform the success rate outlier detector analysis.
+     *
      * @return the minimum number of hosts required to perform the success rate outlier detector analysis.
      */
     public int successRateMinimumHosts() {
@@ -263,6 +286,7 @@ public final class OutlierDetectorConfig {
     /**
      * The minimum number of requests in an outlier detector interval required to include it in the success rate
      * outlier detector analysis.
+     *
      * @return the minimum number of request required.
      */
     public int successRateRequestVolume() {
@@ -272,6 +296,7 @@ public final class OutlierDetectorConfig {
     /**
      * The value divided by 1000 and then multiplied against the success rate standard deviation which sets the
      * threshold for ejection in the success rate outlier detector.
+     *
      * @return the stdev factor divided by 1000 used to determine the statistical outliers.
      */
     public int successRateStdevFactor() {
@@ -280,6 +305,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The failure threshold in percentage for ejecting a host.
+     *
      * @return the failure threshold in percentage for ejecting a host.
      */
     public int failurePercentageThreshold() {
@@ -289,6 +315,7 @@ public final class OutlierDetectorConfig {
     /**
      * The probability in percentage that a host will be marked as unhealthy when a host exceeds the failure percentage
      * outlier detectors threshold.
+     *
      * @return the probability with which the host should be marked as unhealthy.
      */
     public int enforcingFailurePercentage() {
@@ -297,6 +324,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The minimum number of hosts required to perform the failure percentage outlier detector analysis.
+     *
      * @return the minimum number of hosts required to perform the failure percentage outlier detector analysis.
      */
     public int failurePercentageMinimumHosts() {
@@ -306,6 +334,7 @@ public final class OutlierDetectorConfig {
     /**
      * The minimum number of requests in an outlier detector interval required to include it in the failure percentage
      * outlier detector analysis.
+     *
      * @return the minimum number of request required.
      */
     public int failurePercentageRequestVolume() {
@@ -314,6 +343,7 @@ public final class OutlierDetectorConfig {
 
     /**
      * The maximum amount of time a host can be ejected regardless of the number of consecutive ejections.
+     *
      * @return the maximum amount of time a host can be ejected.
      */
     public Duration maxEjectionTime() {
@@ -322,8 +352,10 @@ public final class OutlierDetectorConfig {
 
     /**
      * The amount of jitter to add to the ejection time.
+     * <p>
      * An additional amount of 'jitter' is added to the ejection time to prevent connection storms if multiple hosts
      * are ejected at the time.
+     *
      * @return the amount of jitter to add to the ejection time.
      * @see #baseEjectionTime()
      */
@@ -365,13 +397,12 @@ public final class OutlierDetectorConfig {
      */
     public static final class Builder {
 
-        static final Duration DEFAULT_EWMA_HALF_LIFE = Duration.ofSeconds(10);
+        // Default xDS outlier detector settings.
         static final int DEFAULT_CANCEL_PENALTY = 5;
         static final int DEFAULT_ERROR_PENALTY = 10;
         static final int DEFAULT_CONCURRENT_REQUEST_PENALTY = 1;
-        private boolean cancellationIsError = true;
 
-        // Default xDS outlier detector settings.
+        private static final Duration DEFAULT_EWMA_HALF_LIFE = Duration.ofSeconds(10);
         private static final int DEFAULT_CONSECUTIVE_5XX = 5;
         private static final Duration DEFAULT_FAILURE_DETECTOR_INTERVAL = ofSeconds(10);
         private static final Duration DEFAULT_BASE_EJECTION_TIME = ofSeconds(30);
@@ -391,6 +422,7 @@ public final class OutlierDetectorConfig {
         private Duration ewmaHalfLife = DEFAULT_EWMA_HALF_LIFE;
         private int ewmaCancellationPenalty = DEFAULT_CANCEL_PENALTY;
         private int ewmaErrorPenalty = DEFAULT_ERROR_PENALTY;
+        private boolean cancellationIsError = true;
         private int concurrentRequestPenalty = DEFAULT_CONCURRENT_REQUEST_PENALTY;
         private int failedConnectionsThreshold = DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
         private Duration intervalJitter = DEFAULT_HEALTH_CHECK_JITTER;
@@ -458,6 +490,7 @@ public final class OutlierDetectorConfig {
 
         /**
          * Build the OutlierDetectorConfig.
+         *
          * @return the OutlierDetectorConfig.
          */
         public OutlierDetectorConfig build() {
@@ -476,24 +509,28 @@ public final class OutlierDetectorConfig {
 
         /**
          * Set the Exponentially Weighted Moving Average (EWMA) half-life.
+         * <p>
          * In the context of an exponentially weighted moving average, the half-life means the time during which
          * historical data has the same weight as a new sample.
+         * <p>
          * Defaults to 10 seconds.
+         *
          * @param ewmaHalfLife the half-life for latency data.
          * @return {@code this}
          */
         public Builder ewmaHalfLife(final Duration ewmaHalfLife) {
-            requireNonNull(ewmaHalfLife, "ewmaHalfLife");
-            ensureNonNegative(ewmaHalfLife.toNanos(), "ewmaHalfLife");
-            this.ewmaHalfLife = ewmaHalfLife;
+            this.ewmaHalfLife = DurationUtils.ensureNonNegative(ewmaHalfLife, "ewmaHalfLife");
             return this;
         }
 
         /**
          * Set the penalty factor for local cancellation of requests.
+         * <p>
          * The latency of the cancelled request is multiplied by the provided penalty before incorporating it into the
          * EWMA.
+         * <p>
          * Defaults to {@value DEFAULT_CANCEL_PENALTY}.
+         *
          * @param ewmaCancellationPenalty the penalty factor for local cancellation of requests.
          * @return {@code this}
          */
@@ -504,12 +541,15 @@ public final class OutlierDetectorConfig {
 
         /**
          * Set the penalty factor for requests that were classified as an error.
+         * <p>
          * The latency of the failed request is multiplied by the provided penalty before incorporating it into the
          * EWMA.
+         * <p>
          * Defaults to {@value DEFAULT_ERROR_PENALTY}.
-         * See {@link OutlierDetectorConfig#ewmaErrorPenalty()}.
+         *
          * @param ewmaErrorPenalty the penalty factor for requests that were classified as an error.
          * @return {@code this}
+         * @see OutlierDetectorConfig#ewmaErrorPenalty()
          */
         public Builder ewmaErrorPenalty(final int ewmaErrorPenalty) {
             this.ewmaErrorPenalty = ensureNonNegative(ewmaErrorPenalty, "ewmaErrorPenalty");
@@ -518,6 +558,7 @@ public final class OutlierDetectorConfig {
 
         /**
          * Set whether a cancellation is considered to be an error by the outlier detector.
+         *
          * @param cancellationIsError whether a cancellation is considered to be an error by the outlier detector.
          * @return {@code this}
          */
@@ -528,12 +569,15 @@ public final class OutlierDetectorConfig {
 
         /**
          * Set the penalty factory to apply to concurrent requests.
+         * <p>
          * The EWMA penalty to apply to endpoints when there are concurrent requests. By penalizing endpoints with
          * concurrent load the traffic distribution will be more fair for algorithms that consider load metrics.
          * Larger penalties will favor a more even request distribution while lower penalties will bias traffic toward
          * endpoints with better performance. A value of 0 disables the penalty, 1 is an intermediate value, and larger
          * values such as 10 or more will strongly favor fairness over performance.
+         * <p>
          * Defaults to {@value DEFAULT_CONCURRENT_REQUEST_PENALTY}.
+         *
          * @param ewmaConcurrentRequestPenalty the penalty factory to apply for concurrent load.
          * @return {@code this}
          */
@@ -558,7 +602,7 @@ public final class OutlierDetectorConfig {
          * @param jitter the amount of jitter to apply to each re-subscribe {@code interval}.
          * @return {@code this}.
          */
-        public Builder serviceDiscoveryResubscribeInterval(Duration interval, Duration jitter) {
+        public Builder serviceDiscoveryResubscribeInterval(final Duration interval, final Duration jitter) {
             validateHealthCheckIntervals(interval, jitter);
             this.serviceDiscoveryResubscribeInterval = interval;
             this.serviceDiscoveryResubscribeJitter = jitter;
@@ -566,11 +610,13 @@ public final class OutlierDetectorConfig {
         }
 
         /**
-         * Configure a threshold for consecutive connection failures to a host. When the {@link LoadBalancer}
-         * consecutively fails to open connections in the amount greater or equal to the specified value,
-         * the host will be marked as unhealthy and connection establishment will take place in the background
-         * repeatedly on the {@link #failureDetectorInterval()} (with jitter {@link #failureDetectorIntervalJitter()}) until a connection is
-         * established. During that time, the host will not take part in load balancing selection.
+         * Configure a threshold for consecutive connection failures to a host.
+         * <p>
+         * When the {@link LoadBalancer} consecutively fails to open connections in the amount greater or equal to the
+         * specified value, the host will be marked as unhealthy and connection establishment will take place in the
+         * background repeatedly on the {@link #failureDetectorInterval()} (with jitter
+         * {@link #failureDetectorIntervalJitter()}) until a connection is established. During that time, the host will
+         * not take part in load balancing selection.
          * <p>
          * Use a negative value of the argument to disable health checking.
          *
@@ -582,14 +628,16 @@ public final class OutlierDetectorConfig {
         public Builder failedConnectionsThreshold(int failedConnectionsThreshold) {
             this.failedConnectionsThreshold = failedConnectionsThreshold;
             if (failedConnectionsThreshold == 0) {
-                throw new IllegalArgumentException("Not valid value: 0");
+                throw new IllegalArgumentException("Not valid value: 0 (expected: positive or negative)");
             }
             return this;
         }
 
         /**
          * Set the threshold for consecutive failures before a host is ejected.
+         * <p>
          * Defaults to {@value DEFAULT_CONSECUTIVE_5XX}.
+         *
          * @param consecutive5xx the threshold for consecutive failures before a host is ejected.
          * @return {@code this}
          */
@@ -601,22 +649,28 @@ public final class OutlierDetectorConfig {
 
         /**
          * Set the failure detector interval on which the outlier detector will perform periodic tasks.
+         * <p>
          * These tasks can include detection of outlier or the active revival checks.
+         * <p>
          * This method will also use either the default jitter or the provided interval, whichever is smaller.
+         * <p>
          * Defaults to 10 second interval with 3 second jitter.
+         *
          * @param interval the interval on which to run failure percentage and success rate failure detectors.
          * @return {@code this}
          */
         public Builder failureDetectorInterval(final Duration interval) {
-            this.failureDetectorInterval = requireNonNull(interval, "interval");
             return failureDetectorInterval(interval, interval.compareTo(DEFAULT_HEALTH_CHECK_INTERVAL) < 0 ?
                     interval.dividedBy(2) : DEFAULT_HEALTH_CHECK_JITTER);
         }
 
         /**
          * Set the interval on which to run failure percentage and success rate failure detectors.
+         * <p>
          * These tasks can include detection of outlier or the active revival checks.
+         * <p>
          * Defaults to 10 second interval with 3 second jitter.
+         *
          * @param interval the interval on which to run failure percentage and success rate failure detectors.
          * @param jitter the jitter of the time interval. The next interval will have a duration of
          *               [interval - jitter, interval + jitter].
@@ -624,42 +678,45 @@ public final class OutlierDetectorConfig {
          */
         public Builder failureDetectorInterval(final Duration interval, final Duration jitter) {
             validateHealthCheckIntervals(interval, jitter);
-            this.failureDetectorInterval = requireNonNull(interval, "interval");
+            this.failureDetectorInterval = interval;
             this.intervalJitter = jitter;
             return this;
         }
 
         /**
          * Set the base ejection time.
+         * <p>
          * Defaults to 30 seconds.
+         *
          * @param baseEjectionTime the base ejection time.
          * @return {@code this}.
          * @see #ejectionTimeJitter(Duration)
          */
         public Builder baseEjectionTime(final Duration baseEjectionTime) {
-            this.baseEjectionTime = requireNonNull(baseEjectionTime, "baseEjectionTime");
-            ensurePositive(baseEjectionTime.toNanos(), "baseEjectionTime");
+            this.baseEjectionTime = DurationUtils.ensurePositive(baseEjectionTime, "baseEjectionTime");
             return this;
         }
 
         /**
          * Set the ejection time jitter.
+         * <p>
          * Defaults to 3 seconds.
+         *
          * @param ejectionTimeJitter the jitter to add to the calculated ejection time.
          * @return {@code this}.
          * @see #baseEjectionTime(Duration)
          */
         public Builder ejectionTimeJitter(final Duration ejectionTimeJitter) {
-            ensureNonNegative(requireNonNull(ejectionTimeJitter, "ejectionTimeJitter").toNanos(),
-                    "ejectionTimeJitter");
-            this.ejectionTimeJitter = ejectionTimeJitter;
+            this.ejectionTimeJitter = DurationUtils.ensureNonNegative(ejectionTimeJitter, "ejectionTimeJitter");
             return this;
         }
 
         /**
          * Set the maximum percentage of hosts that can be ejected due to outlier detection.
+         * <p>
          * Defaults to {@value DEFAULT_MAX_EJECTION_PERCENTAGE} percent but at least one host will be allowed to be
          * ejected regardless of value.
+         *
          * @param maxEjectionPercentage the maximum percentage of hosts that can be ejected due to outlier detection.
          * @return {@code this}.
          */
@@ -672,7 +729,9 @@ public final class OutlierDetectorConfig {
         /**
          * Set the probability in percentage that a host will be marked as unhealthy when a host reaches the
          * {@link #consecutive5xx()} threshold.
+         * <p>
          * Defaults to {@value DEFAULT_ENFORCING_CONSECUTIVE_5XX} percent.
+         *
          * @param enforcingConsecutive5xx the probability the host will be marked as unhealthy.
          * @return {@code this}.
          */
@@ -685,7 +744,9 @@ public final class OutlierDetectorConfig {
         /**
          * Set the probability in percentage that a host will be marked as unhealthy when a host exceeds the success
          * rate outlier detectors threshold.
+         * <p>
          * Defaults to {@value DEFAULT_ENFORCING_SUCCESS_RATE} percent.
+         *
          * @param enforcingSuccessRate the probability the host will be marked as unhealthy.
          * @return {@code this}.
          */
@@ -698,6 +759,7 @@ public final class OutlierDetectorConfig {
         /**
          * Set the minimum number of hosts required to perform the success rate outlier detector analysis.
          * Defaults to {@value DEFAULT_SUCCESS_RATE_MINIMUM_HOSTS}.
+         *
          * @param successRateMinimumHosts the minimum number of hosts required to perform the success rate outlier
          *                                detector analysis.
          * @return {@code this}.
@@ -711,7 +773,9 @@ public final class OutlierDetectorConfig {
         /**
          * Set the minimum number of requests in an outlier detector interval required to include it in the success rate
          * outlier detector analysis.
+         * <p>
          * Defaults to {@value DEFAULT_SUCCESS_RATE_REQUEST_VOLUME}.
+         *
          * @param successRateRequestVolume the minimum number of requests in an outlier detector interval required to
          *                                 include it in the success rate outlier detector analysis.
          * @return {@code this}.
@@ -725,7 +789,9 @@ public final class OutlierDetectorConfig {
         /**
          * Set the value divided by 1000 and then multiplied against the success rate standard deviation which sets the
          * threshold for ejection in the success rate outlier detector.
+         * <p>
          * Defaults to {@value DEFAULT_SUCCESS_RATE_STDEV_FACTOR}.
+         *
          * @param successRateStdevFactor the value divided by 1000 and then multiplied against the success rate standard
          *                               deviation which sets the threshold for ejection in the success rate outlier
          *                               detector.
@@ -739,7 +805,9 @@ public final class OutlierDetectorConfig {
 
         /**
          * Set the failure threshold in percentage for ejecting a host.
+         * <p>
          * Defaults to {@value DEFAULT_FAILURE_PERCENTAGE_THRESHOLD} percent.
+         *
          * @param failurePercentageThreshold the failure threshold in percentage for ejecting a host.
          * @return {@code this}.
          */
@@ -752,7 +820,9 @@ public final class OutlierDetectorConfig {
         /**
          * Set the probability in percentage that a host will be marked as unhealthy when a host exceeds the failure
          * percentage outlier detectors threshold.
+         * <p>
          * Defaults to {@value DEFAULT_ENFORCING_FAILURE_PERCENTAGE} percent.
+         *
          * @param enforcingFailurePercentage the probability in percentage that a host will be marked as unhealthy when
          *                                   percentage outlier detectors threshold.
          * @return {@code this}.
@@ -765,7 +835,9 @@ public final class OutlierDetectorConfig {
 
         /**
          * Set the minimum number of hosts required to perform the failure percentage outlier detector analysis.
+         * <p>
          * Defaults to {@value DEFAULT_FAILURE_PERCENTAGE_MINIMUM_HOSTS}.
+         *
          * @param failurePercentageMinimumHosts the minimum number of hosts required to perform the failure percentage
          *                                      outlier detector analysis.
          * @return {@code this}.
@@ -779,7 +851,9 @@ public final class OutlierDetectorConfig {
         /**
          * Set the minimum number of requests in an outlier detector interval required to include it in the failure
          * percentage outlier detector analysis.
+         * <p>
          * Defaults to {@value DEFAULT_FAILURE_PERCENTAGE_REQUEST_VOLUME}.
+         *
          * @param failurePercentageRequestVolume the minimum number of requests in an outlier detector interval required
          *                                       to include it in the failure percentage outlier detector analysis.
          * @return {@code this}.
@@ -792,14 +866,15 @@ public final class OutlierDetectorConfig {
 
         /**
          * Set the maximum amount of time a host can be ejected regardless of the number of consecutive ejections.
+         * <p>
          * Defaults to a max ejection time of 300 seconds and 0 seconds jitter.
+         *
          * @param maxEjectionTime the maximum amount of time a host can be ejected regardless of the number of
          *                        consecutive ejections.
          * @return {@code this}.
          */
         public Builder maxEjectionTime(final Duration maxEjectionTime) {
-            ensureNonNegative(requireNonNull(maxEjectionTime, "maxEjectionTime").toNanos(), "maxEjectionTime");
-            this.maxEjectionTime = maxEjectionTime;
+            this.maxEjectionTime = DurationUtils.ensureNonNegative(maxEjectionTime, "maxEjectionTime");
             return this;
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionSelector.java
@@ -39,6 +39,7 @@ import static java.util.Objects.requireNonNull;
  *   - If we fail to select the best connection, try the other connection.
  * - If both connections fail, repeat the pick-two operation for up to maxEffort attempts, begin linear iteration
  *   through the remaining connections searching for an acceptable connection.
+ *
  * @param <C> the type of the load balanced connection.
  */
 final class P2CConnectionSelector<C extends LoadBalancedConnection> implements ConnectionSelector<C> {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -47,7 +47,7 @@ final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnec
     private final Random random;
 
     P2CLoadBalancingPolicy(final boolean ignoreWeights, final int maxEffort,
-                                   final boolean failOpen, @Nullable final Random random) {
+                           final boolean failOpen, @Nullable final Random random) {
         this.ignoreWeights = ignoreWeights;
         this.maxEffort = maxEffort;
         this.failOpen = failOpen;
@@ -55,8 +55,8 @@ final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnec
     }
 
     @Override
-    HostSelector<ResolvedAddress, C> buildSelector(
-            List<Host<ResolvedAddress, C>> hosts, String lbDescription) {
+    HostSelector<ResolvedAddress, C> buildSelector(final List<Host<ResolvedAddress, C>> hosts,
+                                                   final String lbDescription) {
         return new P2CSelector<>(hosts, lbDescription, ignoreWeights, maxEffort, failOpen, random);
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicyBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicyBuilder.java
@@ -23,7 +23,8 @@ import javax.annotation.Nullable;
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 
 /**
- * A builder for immutable {@link P2CLoadBalancingPolicy} instances.
+ * A builder for {@link P2CLoadBalancingPolicy} instances.
+ *
  * @see LoadBalancingPolicies#p2c()
  */
 public final class P2CLoadBalancingPolicyBuilder {
@@ -39,12 +40,12 @@ public final class P2CLoadBalancingPolicyBuilder {
     private Random random;
 
     P2CLoadBalancingPolicyBuilder() {
-    // package private
+        // package private
     }
 
     /**
-     * Set the maximum number of attempts that P2C will attempt to select a pair with at least one
-     * healthy host.
+     * Set the maximum number of attempts that P2C will attempt to select a pair with at least one healthy host.
+     * <p>
      * Defaults to {@value DEFAULT_MAX_EFFORT}.
      *
      * @param maxEffort the maximum number of attempts.
@@ -57,9 +58,10 @@ public final class P2CLoadBalancingPolicyBuilder {
 
     /**
      * Set whether the selector should fail-open in the event no healthy hosts are found.
+     * <p>
      * When a load balancing policy is configured to fail-open and is unable to find a healthy host, it will attempt
-     * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy
-     * session.
+     * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy session.
+     * <p>
      * Defaults to {@value DEFAULT_FAIL_OPEN_POLICY}.
      *
      * @param failOpen if true, will attempt  to select or establish a connection from an arbitrary host even if it
@@ -73,9 +75,11 @@ public final class P2CLoadBalancingPolicyBuilder {
 
     /**
      * Set whether the host selector should ignore {@link Host}s weight.
+     * <p>
      * Host weight influences the probability it will be selected to serve a request. The host weight can come
      * from many sources including known host capacity, priority groups, and others, so ignoring weight
      * information can lead to other features not working properly and should be used with care.
+     * <p>
      * Defaults to {@value DEFAULT_IGNORE_WEIGHTS}.
      *
      * @param ignoreWeights whether the host selector should ignore host weight information.
@@ -87,13 +91,13 @@ public final class P2CLoadBalancingPolicyBuilder {
     }
 
     // For testing purposes only.
-    P2CLoadBalancingPolicyBuilder random(Random random) {
+    P2CLoadBalancingPolicyBuilder random(final Random random) {
         this.random = random;
         return this;
     }
 
     /**
-     * Construct an immutable {@link P2CLoadBalancingPolicy}.
+     * Construct the {@link P2CLoadBalancingPolicy}.
      *
      * @param <ResolvedAddress> the type of the resolved address.
      * @param <C>               the refined type of the {@link LoadBalancedConnection}.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
@@ -49,9 +49,9 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
     private final int maxEffort;
     private final boolean failOpen;
 
-    P2CSelector(List<? extends Host<ResolvedAddress, C>> hosts, final String lbDescription,
-                       final boolean ignoreWeights, final int maxEffort, final boolean failOpen,
-                       @Nullable final Random random) {
+    P2CSelector(final List<? extends Host<ResolvedAddress, C>> hosts, final String lbDescription,
+                final boolean ignoreWeights, final int maxEffort, final boolean failOpen,
+                @Nullable final Random random) {
         super(hosts, lbDescription);
         this.ignoreWeights = ignoreWeights;
         this.entrySelector = ignoreWeights ? new EqualWeightEntrySelector(hosts.size()) : buildAliasTable(hosts);

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
@@ -66,8 +66,8 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
     }
 
     @Override
-    protected Single<C> selectConnection0(Predicate<C> selector, @Nullable ContextMap context,
-                                          boolean forceNewConnectionAndReserve) {
+    Single<C> selectConnection0(final Predicate<C> selector, @Nullable final ContextMap context,
+                                final boolean forceNewConnectionAndReserve) {
         final int size = hostSetSize();
         switch (size) {
             case 0:

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
@@ -21,10 +21,12 @@ import io.servicetalk.context.api.ContextMap;
  * A tracker of latency of an action over time.
  * <p>
  * The usage of the RequestTracker is intended to follow the simple workflow:
- * - At initiation of an action for which a request is must call {@link RequestTracker#beforeRequestStart()} and save
- *   the timestamp much like would be done when using a stamped lock.
- * - Once the request event is complete only one of the {@link RequestTracker#onRequestSuccess(long)} or
- *   {@link RequestTracker#onRequestError(long, ErrorClass)} methods must be called and called exactly once.
+ * <ul>
+ *     <li>At initiation of an action for which a request is must call {@link RequestTracker#beforeRequestStart()} and
+ *     save the timestamp much like would be done when using a stamped lock.</li>
+ *     <li>Once the request event is complete only one of the {@link RequestTracker#onRequestSuccess(long)} or
+ *     {@link RequestTracker#onRequestError(long, ErrorClass)} methods must be called and called exactly once</li>
+ * </ul>
  * In other words, every call to {@link RequestTracker#beforeRequestStart()} must be followed by exactly one call to
  * either of the completion methods {@link RequestTracker#onRequestSuccess(long)} or
  * {@link RequestTracker#onRequestError(long, ErrorClass)}. Failure to do so can cause state corruption in the
@@ -82,6 +84,7 @@ public interface RequestTracker {
         CANCELLED(true);
 
         private final boolean isLocal;
+
         ErrorClass(boolean isLocal) {
             this.isLocal = isLocal;
         }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
@@ -22,8 +22,9 @@ import io.servicetalk.context.api.ContextMap;
  * <p>
  * The usage of the RequestTracker is intended to follow the simple workflow:
  * <ul>
- *     <li>At initiation of an action for which a request is must call {@link RequestTracker#beforeRequestStart()} and
- *     save the timestamp much like would be done when using a stamped lock.</li>
+ *     <li>At initiation of an action that will be tracked the caller must call
+ *     {@link RequestTracker#beforeRequestStart()} and save the timestamp much like would be done when using a stamped
+ *     lock.</li>
  *     <li>Once the request event is complete only one of the {@link RequestTracker#onRequestSuccess(long)} or
  *     {@link RequestTracker#onRequestError(long, ErrorClass)} methods must be called and called exactly once</li>
  * </ul>

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RichServiceDiscovererEvent.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RichServiceDiscovererEvent.java
@@ -57,7 +57,7 @@ final class RichServiceDiscovererEvent<ResolvedAddress> implements ServiceDiscov
      * The relative weight this endpoint should be given for load balancing decisions.
      * @return the relative weight this endpoint should be given for load balancing decisions.
      */
-    public double loadBalancingWeight() {
+    double loadBalancingWeight() {
         return weight;
     }
 
@@ -65,7 +65,7 @@ final class RichServiceDiscovererEvent<ResolvedAddress> implements ServiceDiscov
      * Priority group this endpoint belongs to.
      * @return the priority group this endpoint belongs to.
      */
-    public int priority() {
+    int priority() {
         return priority;
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -21,10 +21,10 @@ import java.util.List;
 
 /**
  * A round-robin load balancing policy.
- *
- * This load balancing algorithm is the well known policy of selecting hosts sequentially
- * from an ordered set. If a host is considered unhealthy it is skipped the next host
- * is selected until a healthy host is found or the entire host set has been exhausted.
+ * <p>
+ * This load balancing algorithm is the well known policy of selecting hosts sequentially from an ordered set.
+ * If a host is considered unhealthy it is skipped the next host is selected until a healthy host is found or the entire
+ * host set has been exhausted.
  *
  * @param <ResolvedAddress> the type of the resolved address
  * @param <C> the type of the load balanced connection
@@ -41,8 +41,8 @@ final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     }
 
     @Override
-    HostSelector<ResolvedAddress, C>
-    buildSelector(final List<Host<ResolvedAddress, C>> hosts, final String lbDescription) {
+    HostSelector<ResolvedAddress, C> buildSelector(final List<Host<ResolvedAddress, C>> hosts,
+                                                   final String lbDescription) {
         return new RoundRobinSelector<>(hosts, lbDescription, failOpen, ignoreWeights);
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
@@ -75,8 +75,7 @@ public final class RoundRobinLoadBalancingPolicyBuilder {
      * @param <C>               the refined type of the {@link LoadBalancedConnection}.
      * @return the concrete {@link RoundRobinLoadBalancingPolicy}.
      */
-    public <ResolvedAddress, C extends LoadBalancedConnection> LoadBalancingPolicy<ResolvedAddress, C>
-    build() {
+    public <ResolvedAddress, C extends LoadBalancedConnection> LoadBalancingPolicy<ResolvedAddress, C> build() {
         return new RoundRobinLoadBalancingPolicy<>(failOpen, ignoreWeights);
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicyBuilder.java
@@ -18,7 +18,8 @@ package io.servicetalk.loadbalancer;
 import io.servicetalk.client.api.LoadBalancedConnection;
 
 /**
- * A builder for immutable {@link RoundRobinLoadBalancingPolicy} instances.
+ * A builder for {@link RoundRobinLoadBalancingPolicy} instances.
+ *
  * @see LoadBalancingPolicies#roundRobin()
  */
 public final class RoundRobinLoadBalancingPolicyBuilder {
@@ -35,9 +36,10 @@ public final class RoundRobinLoadBalancingPolicyBuilder {
 
     /**
      * Set whether the selector should fail-open in the event no healthy hosts are found.
+     * <p>
      * When a load balancing policy is configured to fail-open and is unable to find a healthy host, it will attempt
-     * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy
-     * session.
+     * to select or establish a connection from an arbitrary host even if it is unlikely to return a healthy session.
+     * <p>
      * Defaults to {@value DEFAULT_FAIL_OPEN_POLICY}.
      *
      * @param failOpen if true, will attempt  to select or establish a connection from an arbitrary host even if it
@@ -51,9 +53,11 @@ public final class RoundRobinLoadBalancingPolicyBuilder {
 
     /**
      * Set whether the host selector should ignore {@link Host}s weight.
+     * <p>
      * Host weight influences the probability it will be selected to serve a request. The host weight can come
      * from many sources including known host capacity, priority groups, and others, so ignoring weight
      * information can lead to other features not working properly and should be used with care.
+     * <p>
      * Defaults to {@value DEFAULT_IGNORE_WEIGHTS}.
      *
      * @param ignoreWeights whether the host selector should ignore host weight information.
@@ -65,7 +69,7 @@ public final class RoundRobinLoadBalancingPolicyBuilder {
     }
 
     /**
-     * Construct the immutable {@link RoundRobinLoadBalancingPolicy}.
+     * Construct the {@link RoundRobinLoadBalancingPolicy}.
      *
      * @param <ResolvedAddress> the type of the resolved address.
      * @param <C>               the refined type of the {@link LoadBalancedConnection}.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -71,9 +71,8 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
     }
 
     @Override
-    protected Single<C> selectConnection0(
-            final Predicate<C> selector, @Nullable final ContextMap context,
-            final boolean forceNewConnectionAndReserve) {
+    Single<C> selectConnection0(final Predicate<C> selector, @Nullable final ContextMap context,
+                                final boolean forceNewConnectionAndReserve) {
         // try one loop over hosts and if all are expired, give up
         final int cursor = scheduler.nextHost();
         Host<ResolvedAddress, C> failOpenHost = null;
@@ -141,7 +140,7 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
     private abstract static class Scheduler {
 
         private final AtomicInteger index;
-        protected final int hostsSize;
+        final int hostsSize;
 
         Scheduler(final AtomicInteger index, final int hostsSize) {
             this.index = index;
@@ -151,7 +150,7 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
         // Get the index of the next host
         abstract int nextHost();
 
-        protected final long nextIndex() {
+        final long nextIndex() {
             return Integer.toUnsignedLong(index.getAndIncrement());
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
@@ -32,6 +32,10 @@ import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK
 import static io.servicetalk.loadbalancer.HealthCheckConfig.validateHealthCheckIntervals;
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 
+/**
+ * A {@link RoundRobinLoadBalancerBuilderProvider} to automatically migrate from {@link RoundRobinLoadBalancerBuilder}
+ * to {@link LoadBalancerBuilder} implementation with compatible runtime behavior.
+ */
 public final class RoundRobinToDefaultLBMigrationProvider implements RoundRobinLoadBalancerBuilderProvider {
 
     static final String PROPERTY_NAME = "io.servicetalk.loadbalancer.roundRobinUsesDefaultLoadBalancer";

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
@@ -57,7 +57,7 @@ final class SequentialExecutor implements Executor {
         this.exceptionHandler = requireNonNull(exceptionHandler, "exceptionHandler");
     }
 
-    public boolean isCurrentThreadDraining() {
+    boolean isCurrentThreadDraining() {
         // Even though `currentDrainingThread` is not a volatile field this is thread safe:
         // the only way that `currentDrainingThread` will ever equal this thread, even if
         // we get a stale value, is if _this_ thread set it.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -86,26 +86,26 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
      * Get the current configuration.
      * @return the current configuration.
      */
-    protected abstract OutlierDetectorConfig currentConfig();
+    abstract OutlierDetectorConfig currentConfig();
 
     /**
      * Attempt to mark the host as ejected with the parent XDS health checker.
      * @return whether this host was successfully ejected.
      */
-    protected abstract boolean tryEjectHost();
+    abstract boolean tryEjectHost();
 
     /**
      * Alert the parent {@link XdsOutlierDetector} that this host has transitions from healthy to unhealthy.
      */
-    protected abstract void hostRevived();
+    abstract void hostRevived();
 
     /**
      * Alert the parent {@link XdsOutlierDetector} that this {@link HealthIndicator} is no longer being used.
      */
-    protected abstract void doCancel();
+    abstract void doCancel();
 
     @Override
-    protected final long currentTimeNanos() {
+    final long currentTimeNanos() {
         return executor.currentTime(TimeUnit.NANOSECONDS);
     }
 
@@ -197,14 +197,14 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
         }
     }
 
-    public final void forceRevival() {
+    final void forceRevival() {
         assert sequentialExecutor.isCurrentThreadDraining();
         if (!cancelled && evictedUntilNanos != null) {
             sequentialRevive();
         }
     }
 
-    public final boolean updateOutlierStatus(OutlierDetectorConfig config, boolean isOutlier) {
+    final boolean updateOutlierStatus(OutlierDetectorConfig config, boolean isOutlier) {
         assert sequentialExecutor.isCurrentThreadDraining();
         if (cancelled) {
             return false;
@@ -239,16 +239,16 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
         }
     }
 
-    public final void resetCounters() {
+    final void resetCounters() {
         successes.set(0);
         failures.set(0);
     }
 
-    public final long getSuccesses() {
+    final long getSuccesses() {
         return successes.get();
     }
 
-    public final long getFailures() {
+    final long getFailures() {
         return failures.get();
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -151,7 +151,7 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
         }
 
         @Override
-        protected OutlierDetectorConfig currentConfig() {
+        OutlierDetectorConfig currentConfig() {
             return kernel.config;
         }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProvider.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderProvider.java
@@ -18,7 +18,7 @@ package io.servicetalk.loadbalancer;
 import io.servicetalk.client.api.LoadBalancedConnection;
 
 /**
- * Provider for {@link RoundRobinLoadBalancerBuilder}.
+ * Provider for {@link RoundRobinLoadBalancerBuilder} that can be registered using {@link java.util.ServiceLoader}.
  */
 public interface RoundRobinLoadBalancerBuilderProvider {
 


### PR DESCRIPTION
Minor adjustments to indentation, validation, formatting, in code and javadoc.
Also reduced visibility where it was possible. Even if those methods are currently in pkg-private classes, it may help to start with minimal visibility on methods to avoid accidental API leaks when we make classes public in the future.