### PR TITLE
loadbalancer-experimental: remove/hide unused public API

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancingPolicy.java
@@ -39,7 +39,7 @@ public abstract class LoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
      * The name of the load balancing policy.
      * @return the name of the load balancing policy
      */
-    public abstract String name();
+    abstract String name();
 
     @Override
     public abstract String toString();

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CLoadBalancingPolicy.java
@@ -61,7 +61,7 @@ final class P2CLoadBalancingPolicy<ResolvedAddress, C extends LoadBalancedConnec
     }
 
     @Override
-    public String name() {
+    String name() {
         return "P2C";
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RequestTracker.java
@@ -67,31 +67,21 @@ public interface RequestTracker {
         /**
          * Failures caused locally, these would be things that failed due to an exception locally.
          */
-        LOCAL_ORIGIN_REQUEST_FAILED(true),
+        LOCAL_ORIGIN_REQUEST_FAILED,
 
         /**
          * Failures related to locally enforced timeouts waiting for responses from the peer.
          */
-        EXT_ORIGIN_TIMEOUT(false),
+        EXT_ORIGIN_TIMEOUT,
 
         /**
          * Failures returned from the remote peer. This will be things like 5xx responses.
          */
-        EXT_ORIGIN_REQUEST_FAILED(false),
+        EXT_ORIGIN_REQUEST_FAILED,
 
         /**
          * Failure due to cancellation.
          */
-        CANCELLED(true);
-
-        private final boolean isLocal;
-
-        ErrorClass(boolean isLocal) {
-            this.isLocal = isLocal;
-        }
-
-        public boolean isLocal() {
-            return isLocal;
-        }
+        CANCELLED
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancingPolicy.java
@@ -47,7 +47,7 @@ final class RoundRobinLoadBalancingPolicy<ResolvedAddress, C extends LoadBalance
     }
 
     @Override
-    public String name() {
+    String name() {
         return "RoundRobin";
     }
 

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -442,7 +442,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         int rebuilds;
 
         @Override
-        public String name() {
+        String name() {
             return "TestPolicy";
         }
 


### PR DESCRIPTION
Motivation:

Reduce public API that is not currently used.

Modifications:

- Make `LoadBalancingPolicy.name()` visibility pkg-private;
- Remove `RequestTracker.ErrorClass.isLocal()`;