### PR TITLE
loadbalancer-experimental: adjust `LoadBalancerObserver` API

### DIFF
--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -16,6 +16,7 @@
 package io.servicetalk.loadbalancer.experimental;
 
 import io.servicetalk.client.api.NoActiveHostException;
+import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.loadbalancer.LoadBalancerObserver;
 
@@ -43,20 +44,10 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
     }
 
     @Override
-    public void onNoHostsAvailable() {
-        LOGGER.debug("{}- onNoHostsAvailable()", lbDescription);
-    }
-
-    @Override
     public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events, int oldHostSetSize,
                                         int newHostSetSize) {
         LOGGER.debug("{}- onServiceDiscoveryEvent(events: {}, oldHostSetSize: {}, newHostSetSize: {})",
                 lbDescription, events, oldHostSetSize, newHostSetSize);
-    }
-
-    @Override
-    public void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exception) {
-        LOGGER.debug("{}- No active hosts available. Host set size: {}.", lbDescription, hostSetSize, exception);
     }
 
     @Override
@@ -71,6 +62,16 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
             LOGGER.debug("{}- onHostSetChanged(host set size: {}, healthy: {}). New hosts: {}", lbDescription,
                     newHosts.size(), healthyCount, newHosts);
         }
+    }
+
+    @Override
+    public void onNoAvailableHostException(final NoAvailableHostException exception) {
+        LOGGER.debug("{}- onNoAvailableHostException()", lbDescription, exception);
+    }
+
+    @Override
+    public void onNoActiveHostException(int hostSetSize, NoActiveHostException exception) {
+        LOGGER.debug("{}- onNoActiveHostException(hostSetSize: {})", lbDescription, hostSetSize, exception);
     }
 
     private final class HostObserverImpl implements HostObserver {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -541,10 +541,10 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                         subscribeToEvents(true);
                     }
                 }
-                loadBalancerObserver.onNoActiveHostsAvailable(
+                loadBalancerObserver.onNoActiveHostException(
                         currentHostSelector.hostSetSize(), (NoActiveHostException) exn);
             } else if (exn instanceof NoAvailableHostException) {
-                loadBalancerObserver.onNoHostsAvailable();
+                loadBalancerObserver.onNoAvailableHostException((NoAvailableHostException) exn);
             }
         });
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -16,6 +16,7 @@
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.NoActiveHostException;
+import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 
 import java.util.Collection;
@@ -49,20 +50,20 @@ public interface LoadBalancerObserver {
      * algorithm may use.
      * @param newHosts the new set of hosts used by the selection algorithm.
      */
-    default void onHostSetChanged(Collection<? extends Host> newHosts) {
-    }
+    void onHostSetChanged(Collection<? extends Host> newHosts);
 
     /**
      * Callback for when connection selection fails due to no hosts being available.
+     * @param exception an exception with more details about the failure.
      */
-    void onNoHostsAvailable();
+    void onNoAvailableHostException(NoAvailableHostException exception);
 
     /**
      * Callback for when connection selection fails due to all hosts being inactive.
-     * @param hostSetSize the size of the current host set.
+     * @param hostSetSize the size of the current host set where all hosts are inactive.
      * @param exception an exception with more details about the failure.
      */
-    void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exception);
+    void onNoActiveHostException(int hostSetSize, NoActiveHostException exception);
 
     /**
      * An observer for {@link io.servicetalk.loadbalancer.Host} events.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
@@ -16,6 +16,7 @@
 package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.NoActiveHostException;
+import io.servicetalk.client.api.NoAvailableHostException;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 
 import java.util.Collection;
@@ -36,16 +37,6 @@ final class NoopLoadBalancerObserver implements LoadBalancerObserver {
     }
 
     @Override
-    public void onNoHostsAvailable() {
-        // noop
-    }
-
-    @Override
-    public void onNoActiveHostsAvailable(int hostSetSize, NoActiveHostException exn) {
-        // noop
-    }
-
-    @Override
     public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events,
                                         int oldHostSetSize, int newHostSetSize) {
         // noop
@@ -53,6 +44,16 @@ final class NoopLoadBalancerObserver implements LoadBalancerObserver {
 
     @Override
     public void onHostSetChanged(Collection<? extends Host> newHosts) {
+        // noop
+    }
+
+    @Override
+    public void onNoAvailableHostException(NoAvailableHostException exception) {
+        // noop
+    }
+
+    @Override
+    public void onNoActiveHostException(int hostSetSize, NoActiveHostException exn) {
         // noop
     }
 


### PR DESCRIPTION
Modifications:

- Remove default implementation for `onHostSetChanged(Collection)`;
- Change `onNoHostsAvailable()` to `onNoAvailableHostException(NoAvailableHostException)`;
- Rename `onNoActiveHostsAvailable` to `onNoActiveHostException`;