### PR TITLE
loadbalancer-experimental: change host set update events

### DIFF
--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -45,7 +45,7 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
 
     @Override
     public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events) {
-        LOGGER.debug("{}- onServiceDiscoveryEvent(events: {})", lbDescription, events);
+        LOGGER.debug("{}- onServiceDiscoveryEvent(events: {}, size {})", lbDescription, events, events.size());
     }
 
     @Override
@@ -57,8 +57,9 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
                     healthyCount++;
                 }
             }
-            LOGGER.debug("{}- onHostsUpdate(old hosts: {}, new hosts: {}), new healthy count: {}",
-                    lbDescription, oldHosts, newHosts, healthyCount);
+            LOGGER.debug("{}- onHostsUpdate(old hosts: {}, new hosts: {}), old hosts size: {}, new hosts size: {}, " +
+                            "new healthy count: {}",
+                    lbDescription, oldHosts, newHosts, oldHosts.size(), newHosts.size(), healthyCount);
         }
     }
 

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -45,7 +45,7 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
 
     @Override
     public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events) {
-        LOGGER.debug("{}- onServiceDiscoveryEvent(events: {}, size {})", lbDescription, events, events.size());
+        LOGGER.debug("{}- onServiceDiscoveryEvent(events: {}, count {})", lbDescription, events, events.size());
     }
 
     @Override
@@ -57,7 +57,7 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
                     healthyCount++;
                 }
             }
-            LOGGER.debug("{}- onHostsUpdate(old hosts: {}, new hosts: {}), old hosts size: {}, new hosts size: {}, " +
+            LOGGER.debug("{}- onHostsUpdate(old hosts: {}, new hosts: {}), old host count: {}, new host count: {}, " +
                             "new healthy count: {}",
                     lbDescription, oldHosts, newHosts, oldHosts.size(), newHosts.size(), healthyCount);
         }
@@ -70,7 +70,8 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
 
     @Override
     public void onNoActiveHostException(Collection<? extends Host> hosts, NoActiveHostException exception) {
-        LOGGER.debug("{}- onNoActiveHostException(hosts: {})", lbDescription, hosts, exception);
+        LOGGER.debug("{}- onNoActiveHostException(hosts: {}, host count: {})", lbDescription, hosts, hosts.size(),
+                exception);
     }
 
     private final class HostObserverImpl implements HostObserver {

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -68,8 +68,8 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
     }
 
     @Override
-    public void onNoActiveHostException(int hostsCount, NoActiveHostException exception) {
-        LOGGER.debug("{}- onNoActiveHostException(hostSetSize: {})", lbDescription, hostsCount, exception);
+    public void onNoActiveHostException(Collection<? extends Host> hosts, NoActiveHostException exception) {
+        LOGGER.debug("{}- onNoActiveHostException(hosts: {})", lbDescription, hosts, exception);
     }
 
     private final class HostObserverImpl implements HostObserver {

--- a/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental-provider/src/main/java/io/servicetalk/loadbalancer/experimental/DefaultLoadBalancerObserver.java
@@ -44,14 +44,12 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
     }
 
     @Override
-    public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events, int oldHostSetSize,
-                                        int newHostSetSize) {
-        LOGGER.debug("{}- onServiceDiscoveryEvent(events: {}, oldHostSetSize: {}, newHostSetSize: {})",
-                lbDescription, events, oldHostSetSize, newHostSetSize);
+    public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events) {
+        LOGGER.debug("{}- onServiceDiscoveryEvent(events: {})", lbDescription, events);
     }
 
     @Override
-    public void onHostSetChanged(Collection<? extends Host> newHosts) {
+    public void onHostsUpdate(Collection<? extends Host> oldHosts, Collection<? extends Host> newHosts) {
         if (LOGGER.isDebugEnabled()) {
             int healthyCount = 0;
             for (Host host : newHosts) {
@@ -59,8 +57,8 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
                     healthyCount++;
                 }
             }
-            LOGGER.debug("{}- onHostSetChanged(host set size: {}, healthy: {}). New hosts: {}", lbDescription,
-                    newHosts.size(), healthyCount, newHosts);
+            LOGGER.debug("{}- onHostsUpdate(old hosts: {}, new hosts: {}), new healthy count: {}",
+                    lbDescription, oldHosts, newHosts, healthyCount);
         }
     }
 
@@ -70,8 +68,8 @@ final class DefaultLoadBalancerObserver implements LoadBalancerObserver {
     }
 
     @Override
-    public void onNoActiveHostException(int hostSetSize, NoActiveHostException exception) {
-        LOGGER.debug("{}- onNoActiveHostException(hostSetSize: {})", lbDescription, hostSetSize, exception);
+    public void onNoActiveHostException(int hostsCount, NoActiveHostException exception) {
+        LOGGER.debug("{}- onNoActiveHostException(hostSetSize: {})", lbDescription, hostsCount, exception);
     }
 
     private final class HostObserverImpl implements HostObserver {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -49,18 +49,14 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
     }
 
     @Override
-    public final int hostSetSize() {
-        return hosts.size();
-    }
-
-    @Override
     public final boolean isHealthy() {
         // TODO: in the future we may want to make this more of a "are at least X hosts available" question
         //  so that we can compose a group of selectors into a priority set.
         return anyHealthy(hosts);
     }
 
-    final List<? extends Host<ResolvedAddress, C>> hosts() {
+    @Override
+    public final List<? extends Host<ResolvedAddress, C>> hosts() {
         return hosts;
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
@@ -117,6 +117,11 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     }
 
     @Override
+    public double loadBalancingWeight() {
+        return 1;
+    }
+
+    @Override
     public boolean markActiveIfNotClosed() {
         final ConnState oldState = connStateUpdater.getAndUpdate(this, oldConnState -> {
             if (oldConnState.state == State.EXPIRED) {

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -516,7 +516,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         } else {
             newHostSelector = oldHostSelector;
         }
-        final Collection<? extends Host<ResolvedAddress, C>> newHosts = newHostSelector.hosts();
+        final Collection<? extends LoadBalancerObserver.Host> newHosts = newHostSelector.hosts();
         loadBalancerObserver.onHostsUpdate(Collections.unmodifiableCollection(oldHostSelector.hosts()),
                 Collections.unmodifiableCollection(newHosts));
         LOGGER.debug("{}: Using addresses (size={}): {}.", this, newHosts.size(), newHosts);
@@ -632,7 +632,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         }
 
         @Override
-        public List<? extends Host<ResolvedAddress, C>> hosts() {
+        public Collection<? extends LoadBalancerObserver.Host> hosts() {
             return emptyList();
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/Host.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/Host.java
@@ -29,7 +29,8 @@ import javax.annotation.Nullable;
  * @param <ResolvedAddress> the type of resolved address.
  * @param <C> the concrete type of returned connections.
  */
-interface Host<ResolvedAddress, C extends LoadBalancedConnection> extends ListenableAsyncCloseable, ScoreSupplier {
+interface Host<ResolvedAddress, C extends LoadBalancedConnection> extends ListenableAsyncCloseable, ScoreSupplier,
+        LoadBalancerObserver.Host {
     /**
      * Select an existing connection from the host.
      * @return the selected host, or null if a suitable host couldn't be found.
@@ -49,14 +50,8 @@ interface Host<ResolvedAddress, C extends LoadBalancedConnection> extends Listen
      * The address of the host
      * @return the address of the host
      */
+    @Override
     ResolvedAddress address();
-
-    /**
-     * Determine the health status of this host.
-     * @return whether the host considers itself healthy enough to serve traffic. This is best effort and does not
-     *         guarantee that the request will succeed.
-     */
-    boolean isHealthy();
 
     /**
      * Determine whether the host is in a state where it can make new connections.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -78,5 +78,5 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
      * due to various filtering mechanisms.
      * @return the set of hosts this selector will pick from.
      */
-    Collection<? extends Host<ResolvedAddress, C>> hosts();
+    Collection<? extends LoadBalancerObserver.Host> hosts();
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/HostSelector.java
@@ -19,6 +19,7 @@ import io.servicetalk.client.api.LoadBalancedConnection;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.context.api.ContextMap;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
@@ -71,10 +72,11 @@ interface HostSelector<ResolvedAddress, C extends LoadBalancedConnection> {
     boolean isHealthy();
 
     /**
-     * The size of the host candidate pool for this host selector.
+     * The set of hosts this selector will pick from.
      * <p>
-     * Note that this is primarily for observability purposes.
-     * @return the size of the host candidate pool for this host selector.
+     * Note that this may differ from the hosts advertised by the {@link io.servicetalk.client.api.ServiceDiscoverer}
+     * due to various filtering mechanisms.
+     * @return the set of hosts this selector will pick from.
      */
-    int hostSetSize();
+    Collection<? extends Host<ResolvedAddress, C>> hosts();
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -37,20 +37,18 @@ public interface LoadBalancerObserver {
     /**
      * Callback for monitoring the changes due to a service discovery update.
      * @param events the collection of {@link ServiceDiscovererEvent}s received by the load balancer.
-     * @param oldHostSetSize the size of the previous host set.
-     * @param newHostSetSize the new size of  the host set.
      */
-    void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events,
-                                 int oldHostSetSize, int newHostSetSize);
+    void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events);
 
     /**
      * Callback for when the set of hosts used by the load balancer has changed. This set may not
      * exactly reflect the state of the service discovery system due to filtering of zero-weight
      * hosts and forms of sub-setting and thus may only represent the hosts that the selection
      * algorithm may use.
+     * @param oldHosts the old set of hosts used by the selection algorithm.
      * @param newHosts the new set of hosts used by the selection algorithm.
      */
-    void onHostSetChanged(Collection<? extends Host> newHosts);
+    void onHostsUpdate(Collection<? extends Host> oldHosts, Collection<? extends Host> newHosts);
 
     /**
      * Callback for when connection selection fails due to no hosts being available.
@@ -60,10 +58,10 @@ public interface LoadBalancerObserver {
 
     /**
      * Callback for when connection selection fails due to all hosts being inactive.
-     * @param hostSetSize the size of the current host set where all hosts are inactive.
+     * @param hostsCount the size of the current host set where all hosts are inactive.
      * @param exception an exception with more details about the failure.
      */
-    void onNoActiveHostException(int hostSetSize, NoActiveHostException exception);
+    void onNoActiveHostException(int hostsCount, NoActiveHostException exception);
 
     /**
      * An observer for {@link io.servicetalk.loadbalancer.Host} events.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -58,10 +58,10 @@ public interface LoadBalancerObserver {
 
     /**
      * Callback for when connection selection fails due to all hosts being inactive.
-     * @param hostsCount the size of the current host set where all hosts are inactive.
+     * @param hosts the set of hosts that is eligible for selection.
      * @param exception an exception with more details about the failure.
      */
-    void onNoActiveHostException(int hostsCount, NoActiveHostException exception);
+    void onNoActiveHostException(Collection<? extends Host> hosts, NoActiveHostException exception);
 
     /**
      * An observer for {@link io.servicetalk.loadbalancer.Host} events.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
@@ -52,7 +52,7 @@ final class NoopLoadBalancerObserver implements LoadBalancerObserver {
     }
 
     @Override
-    public void onNoActiveHostException(int hostsCount, NoActiveHostException exn) {
+    public void onNoActiveHostException(Collection<? extends Host> hosts, NoActiveHostException exn) {
         // noop
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/NoopLoadBalancerObserver.java
@@ -37,13 +37,12 @@ final class NoopLoadBalancerObserver implements LoadBalancerObserver {
     }
 
     @Override
-    public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events,
-                                        int oldHostSetSize, int newHostSetSize) {
+    public void onServiceDiscoveryEvent(Collection<? extends ServiceDiscovererEvent<?>> events) {
         // noop
     }
 
     @Override
-    public void onHostSetChanged(Collection<? extends Host> newHosts) {
+    public void onHostsUpdate(Collection<? extends Host> oldHosts, Collection<? extends Host> newHosts) {
         // noop
     }
 
@@ -53,7 +52,7 @@ final class NoopLoadBalancerObserver implements LoadBalancerObserver {
     }
 
     @Override
-    public void onNoActiveHostException(int hostSetSize, NoActiveHostException exn) {
+    public void onNoActiveHostException(int hostsCount, NoActiveHostException exn) {
         // noop
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
@@ -68,7 +68,7 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
     @Override
     Single<C> selectConnection0(final Predicate<C> selector, @Nullable final ContextMap context,
                                 final boolean forceNewConnectionAndReserve) {
-        final int size = hostSetSize();
+        final int size = hosts().size();
         switch (size) {
             case 0:
                 // We shouldn't get called if the load balancer doesn't have any hosts.

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -486,8 +486,8 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
             }
 
             @Override
-            public int hostSetSize() {
-                return hosts.size();
+            public List<? extends Host<String, TestLoadBalancedConnection>> hosts() {
+                return hosts;
             }
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -486,7 +486,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
             }
 
             @Override
-            public List<? extends Host<String, TestLoadBalancedConnection>> hosts() {
+            public Collection<? extends LoadBalancerObserver.Host> hosts() {
                 return hosts;
             }
         }


### PR DESCRIPTION
Motivation:

As discussed in #3140, we need to adjust some of the LoadBalancerObserver callbacks to make the events more clear and also preserve important order characteristics.

Modifications:

- Remove the size parameters from the `onServiceDiscoveryEvent` method as that required us to either precompute the size change or emit the event later than host observer creation events.
- Change the `onHostSetChanged` method to take two collections: one reflecting the previous set and the new set, both after manipulations where done such as prioritization and subsetting.