### PR TITLE
loadbalancer-experimental: include reason DefaultHost is unhealthy

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
@@ -456,10 +456,13 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     @Override
     public String toString() {
         final ConnState connState = this.connState;
-        return "Host{" +
+        String stateString = connState.isUnhealthy() ? State.UNHEALTHY + "(" + connState.healthCheck + ")" :
+                connState.state.toString();
+        return "DefaultHost{" +
                 "lbDescription=" + lbDescription +
                 ", address=" + address +
-                ", state=" + connState.state +
+                ", state=" + stateString +
+                ", healthIndicator=" + healthIndicator +
                 ", #connections=" + connState.connections.size() +
                 '}';
     }
@@ -514,7 +517,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
 
         @Override
         public String toString() {
-            return "UNHEALTHY(" + lastError + ')';
+            return "HealthCheck(" + lastError + ')';
         }
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -257,6 +257,16 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
         sequentialExecutor.execute(this::sequentialCancel);
     }
 
+    @Override
+    public String toString() {
+        return "XdsHealthIndicator{" +
+                ", consecutive5xx=" + consecutive5xx.get() +
+                ", successes=" + successes.get() +
+                ", failures=" + failures.get() +
+                ", evictedUntilNanos=" + evictedUntilNanos +
+                '}';
+    }
+
     void sequentialCancel() {
         assert sequentialExecutor.isCurrentThreadDraining();
         if (cancelled) {

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -35,6 +35,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static io.servicetalk.loadbalancer.HealthCheckConfig.DEFAULT_HEALTH_CHECK_FAILED_CONNECTIONS_THRESHOLD;
 import static io.servicetalk.loadbalancer.UnhealthyHostConnectionFactory.UNHEALTHY_HOST_EXCEPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -182,6 +183,9 @@ class DefaultHostTest {
             assertThrows(ExecutionException.class,
                     () -> host.newConnection(any(), false, null).toFuture().get());
         }
+        assertThat(host.toString(), containsString("UNHEALTHY"));
+        assertThat(host.toString(), containsString("DeliberateException"));
+
         verify(mockHostObserver, times(1)).onHostMarkedUnhealthy(UNHEALTHY_HOST_EXCEPTION);
         assertThat(host.isHealthy(), is(false));
         assertThat(host.canMakeNewConnections(), is(true));


### PR DESCRIPTION
Motivation:

We store the reason that a host enters the unhealthy/healthchecking state but we never use it.

Modifications:

- Include that info when we're creating the `DefaultHost.toString()` implementation.