### PR TITLE
loadbalancer-experimental: Rename ConnectionPool* types to ConnectionSelector*

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionSelectorPolicies.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionSelectorPolicies.java
@@ -18,20 +18,20 @@ package io.servicetalk.loadbalancer;
 import io.servicetalk.client.api.LoadBalancedConnection;
 
 /**
- * A factory to create different {@link ConnectionPoolPolicy} variants.
+ * A factory to create different {@link ConnectionSelectorPolicy} variants.
  */
-public final class ConnectionPoolPolicies {
+public final class ConnectionSelectorPolicies {
     private static final int DEFAULT_MAX_EFFORT = 5;
     private static final int DEFAULT_LINEAR_SEARCH_SPACE = 16;
 
-    private ConnectionPoolPolicies() {
+    private ConnectionSelectorPolicies() {
         // no instances
     }
 
     /**
      * A connection selection policy that prioritizes a configurable "core" pool.
      * <p>
-     * This {@link ConnectionPoolPolicy} attempts to emulate the pooling behavior often seen in thread pools.
+     * This {@link ConnectionSelectorPolicy} attempts to emulate the pooling behavior often seen in thread pools.
      * Specifically it allows for the configuration of a "core pool" size which are intended to be long-lived.
      * Iteration starts in the core pool at a random position and then iterates through the entire core pool before
      * moving to an overflow pool. Because iteration of this core pool starts at a random position the core connections
@@ -46,32 +46,32 @@ public final class ConnectionPoolPolicies {
      * @param forceCorePool whether to avoid selecting connections from the core pool until it has reached the
      *                      configured core pool size.
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
-     * @return the configured {@link ConnectionPoolPolicy}.
+     * @return the configured {@link ConnectionSelectorPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> corePool(final int corePoolSize,
-                                                                                      final boolean forceCorePool) {
+    public static <C extends LoadBalancedConnection> ConnectionSelectorPolicy<C> corePool(final int corePoolSize,
+                                                                                          final boolean forceCorePool) {
         return CorePoolConnectionSelector.factory(corePoolSize, forceCorePool);
     }
 
     /**
      * A connection selection policy that prioritizes connection reuse.
      * <p>
-     * This {@link ConnectionPoolPolicy} attempts to minimize the number of connections by attempting to direct
+     * This {@link ConnectionSelectorPolicy} attempts to minimize the number of connections by attempting to direct
      * traffic to connections in the order they were created in linear order up until a configured quantity. After
      * this linear pool is exhausted the remaining connections will be selected from at random. Prioritizing traffic
      * to the existing connections will let tailing connections be removed due to idleness.
      *
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
-     * @return the configured {@link ConnectionPoolPolicy}.
+     * @return the configured {@link ConnectionSelectorPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> linearSearch() {
+    public static <C extends LoadBalancedConnection> ConnectionSelectorPolicy<C> linearSearch() {
         return linearSearch(DEFAULT_LINEAR_SEARCH_SPACE);
     }
 
     /**
      * A connection selection policy that prioritizes connection reuse.
      * <p>
-     * This {@link ConnectionPoolPolicy} attempts to minimize the number of connections by attempting to direct
+     * This {@link ConnectionSelectorPolicy} attempts to minimize the number of connections by attempting to direct
      * traffic to connections in the order they were created in linear order up until a configured quantity. After
      * this linear pool is exhausted the remaining connections will be selected from at random. Prioritizing traffic
      * to the existing connections will let tailing connections be removed due to idleness.
@@ -79,14 +79,15 @@ public final class ConnectionPoolPolicies {
      * @param linearSearchSpace the space to search linearly before resorting to random selection for remaining
      *                          connections.
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
-     * @return the configured {@link ConnectionPoolPolicy}.
+     * @return the configured {@link ConnectionSelectorPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> linearSearch(final int linearSearchSpace) {
+    public static <C extends LoadBalancedConnection>
+    ConnectionSelectorPolicy<C> linearSearch(final int linearSearchSpace) {
         return LinearSearchConnectionSelector.factory(linearSearchSpace);
     }
 
     /**
-     * A {@link ConnectionPoolPolicy} that attempts to discern between the health of individual connections.
+     * A {@link ConnectionSelectorPolicy} that attempts to discern between the health of individual connections.
      * If individual connections have health data the P2C policy can be used to bias traffic toward the best
      * connections. This has the following algorithm:
      * <ol>
@@ -104,15 +105,15 @@ public final class ConnectionPoolPolicies {
      * @param forceCorePool whether to avoid selecting connections from the core pool until it has reached the
      *                      configured core pool size.
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
-     * @return the configured {@link ConnectionPoolPolicy}.
+     * @return the configured {@link ConnectionSelectorPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> p2c(final int corePoolSize,
-                                                                                 final boolean forceCorePool) {
+    public static <C extends LoadBalancedConnection> ConnectionSelectorPolicy<C> p2c(final int corePoolSize,
+                                                                                     final boolean forceCorePool) {
         return p2c(DEFAULT_MAX_EFFORT, corePoolSize, forceCorePool);
     }
 
     /**
-     * A {@link ConnectionPoolPolicy} that attempts to discern between the health of individual connections.
+     * A {@link ConnectionSelectorPolicy} that attempts to discern between the health of individual connections.
      * If individual connections have health data the P2C policy can be used to bias traffic toward the best
      * connections. This has the following algorithm:
      * <ol>
@@ -131,11 +132,11 @@ public final class ConnectionPoolPolicies {
      * @param forceCorePool whether to avoid selecting connections from the core pool until it has reached the
      *                      configured core pool size.
      * @param <C> the concrete type of the {@link LoadBalancedConnection}
-     * @return the configured {@link ConnectionPoolPolicy}.
+     * @return the configured {@link ConnectionSelectorPolicy}.
      */
-    public static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> p2c(final int maxEffort,
-                                                                                 final int corePoolSize,
-                                                                                 final boolean forceCorePool) {
+    public static <C extends LoadBalancedConnection> ConnectionSelectorPolicy<C> p2c(final int maxEffort,
+                                                                                     final int corePoolSize,
+                                                                                     final boolean forceCorePool) {
         return P2CConnectionSelector.factory(maxEffort, corePoolSize, forceCorePool);
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionSelectorPolicy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/ConnectionSelectorPolicy.java
@@ -21,9 +21,9 @@ import io.servicetalk.client.api.LoadBalancedConnection;
  * Configuration of the policy for selecting connections from a pool to the same endpoint.
  * @param <C> the concrete type of the {@link LoadBalancedConnection}
  */
-public abstract class ConnectionPoolPolicy<C extends LoadBalancedConnection> {
+public abstract class ConnectionSelectorPolicy<C extends LoadBalancedConnection> {
 
-    ConnectionPoolPolicy() {
+    ConnectionSelectorPolicy() {
         // package private constructor to control proliferation
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/CorePoolConnectionSelector.java
@@ -83,13 +83,13 @@ final class CorePoolConnectionSelector<C extends LoadBalancedConnection>
         return null;
     }
 
-    static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> factory(
+    static <C extends LoadBalancedConnection> ConnectionSelectorPolicy<C> factory(
             int corePoolSize, boolean forceCorePool) {
         return new CorePoolConnectionSelectorFactory<>(corePoolSize, forceCorePool);
     }
 
     private static final class CorePoolConnectionSelectorFactory<C extends LoadBalancedConnection>
-            extends ConnectionPoolPolicy<C> {
+            extends ConnectionSelectorPolicy<C> {
 
         private final int corePoolSize;
         private final boolean forceCorePool;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -128,7 +128,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
      * @param priorityStrategyFactory a builder of the {@link HostPriorityStrategy} to use with the load balancer.
      * @param loadBalancingPolicy a factory of the initial host selector to use with this load balancer.
      * @param subsetter a subset builder.
-     * @param connectionPoolPolicy factory of the connection pool strategy to use with this load balancer.
+     * @param connectionSelectorPolicy factory of the connection pool strategy to use with this load balancer.
      * @param connectionFactory a function which creates new connections.
      * @param loadBalancerObserverFactory factory used to build a {@link LoadBalancerObserver} to use with this
      *                                    load balancer.
@@ -144,7 +144,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final Function<String, HostPriorityStrategy> priorityStrategyFactory,
             final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy,
             final Subsetter subsetter,
-            final ConnectionPoolPolicy<C> connectionPoolPolicy,
+            final ConnectionSelectorPolicy<C> connectionSelectorPolicy,
             final ConnectionFactory<ResolvedAddress, ? extends C> connectionFactory,
             final LoadBalancerObserverFactory loadBalancerObserverFactory,
             @Nullable final HealthCheckConfig healthCheckConfig,
@@ -155,8 +155,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                 .buildSelector(Collections.emptyList(), lbDescription);
         this.priorityStrategy = requireNonNull(
                 priorityStrategyFactory, "priorityStrategyFactory").apply(lbDescription);
-        this.connectionSelector = requireNonNull(connectionPoolPolicy,
-                "connectionPoolPolicy").buildConnectionSelector(lbDescription);
+        this.connectionSelector = requireNonNull(connectionSelectorPolicy,
+                "connectionSelectorPolicy").buildConnectionSelector(lbDescription);
         this.eventPublisher = requireNonNull(eventPublisher);
         this.eventStream = fromSource(eventStreamProcessor)
                 .replay(1); // Allow for multiple subscribers and provide new subscribers with last signal.

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -40,7 +40,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     @Nullable
     private LoadBalancerObserverFactory loadBalancerObserverFactory;
     private LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy = defaultLoadBalancingPolicy();
-    private ConnectionSelectorPolicy<C> connectionSelectorPolicy = defaultConnectionSelectorFactory();
+    private ConnectionSelectorPolicy<C> connectionSelectorPolicy = defaultConnectionSelectorPolicy();
     private OutlierDetectorConfig outlierDetectorConfig = OutlierDetectorConfig.DEFAULT_CONFIG;
 
     // package private constructor so users must funnel through providers in `LoadBalancers`
@@ -188,7 +188,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     }
 
     private static <C extends LoadBalancedConnection>
-    ConnectionSelectorPolicy<C> defaultConnectionSelectorFactory() {
+    ConnectionSelectorPolicy<C> defaultConnectionSelectorPolicy() {
         return ConnectionSelectorPolicies.linearSearch();
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -40,7 +40,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     @Nullable
     private LoadBalancerObserverFactory loadBalancerObserverFactory;
     private LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy = defaultLoadBalancingPolicy();
-    private ConnectionPoolPolicy<C> connectionPoolPolicy = defaultConnectionSelectorFactory();
+    private ConnectionSelectorPolicy<C> connectionSelectorPolicy = defaultConnectionSelectorFactory();
     private OutlierDetectorConfig outlierDetectorConfig = OutlierDetectorConfig.DEFAULT_CONFIG;
 
     // package private constructor so users must funnel through providers in `LoadBalancers`
@@ -69,9 +69,9 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     }
 
     @Override
-    public LoadBalancerBuilder<ResolvedAddress, C> connectionPoolPolicy(
-            ConnectionPoolPolicy<C> connectionPoolPolicy) {
-        this.connectionPoolPolicy = requireNonNull(connectionPoolPolicy, "connectionPoolPolicy");
+    public LoadBalancerBuilder<ResolvedAddress, C> connectionSelectorPolicy(
+            ConnectionSelectorPolicy<C> connectionSelectorPolicy) {
+        this.connectionSelectorPolicy = requireNonNull(connectionSelectorPolicy, "connectionSelectorPolicy");
         return this;
     }
 
@@ -84,7 +84,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
     @Override
     public LoadBalancerFactory<ResolvedAddress, C> build() {
         return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, loadBalancerObserverFactory,
-                connectionPoolPolicy, outlierDetectorConfig, getExecutor());
+                connectionSelectorPolicy, outlierDetectorConfig, getExecutor());
     }
 
     static final class DefaultLoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConnection>
@@ -92,7 +92,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
         private final String id;
         private final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy;
-        private final ConnectionPoolPolicy<C> connectionPoolPolicy;
+        private final ConnectionSelectorPolicy<C> connectionSelectorPolicy;
         private final OutlierDetectorConfig outlierDetectorConfig;
         @Nullable
         private final LoadBalancerObserverFactory loadBalancerObserverFactory;
@@ -100,14 +100,14 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
         DefaultLoadBalancerFactory(final String id, final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy,
                                    @Nullable final LoadBalancerObserverFactory loadBalancerObserverFactory,
-                                   final ConnectionPoolPolicy<C> connectionPoolPolicy,
+                                   final ConnectionSelectorPolicy<C> connectionSelectorPolicy,
                                    final OutlierDetectorConfig outlierDetectorConfig,
                                    final Executor executor) {
             this.id = requireNonNull(id, "id");
             this.loadBalancingPolicy = requireNonNull(loadBalancingPolicy, "loadBalancingPolicy");
             this.loadBalancerObserverFactory = loadBalancerObserverFactory;
             this.outlierDetectorConfig = requireNonNull(outlierDetectorConfig, "outlierDetectorConfig");
-            this.connectionPoolPolicy = requireNonNull(connectionPoolPolicy, "connectionPoolPolicy");
+            this.connectionSelectorPolicy = requireNonNull(connectionSelectorPolicy, "connectionSelectorPolicy");
             this.executor = requireNonNull(executor, "executor");
         }
 
@@ -154,7 +154,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
             }
             return new DefaultLoadBalancer<>(id, targetResource, eventPublisher,
                     DefaultHostPriorityStrategy::new, loadBalancingPolicy, new RandomSubsetter(Integer.MAX_VALUE),
-                    connectionPoolPolicy, connectionFactory,
+                    connectionSelectorPolicy, connectionFactory,
                     loadBalancerObserverFactory, healthCheckConfig, outlierDetectorFactory);
         }
 
@@ -169,7 +169,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
             return "DefaultLoadBalancerFactory{" +
                     "id='" + id + '\'' +
                     ", loadBalancingPolicy=" + loadBalancingPolicy +
-                    ", connectionPoolPolicy=" + connectionPoolPolicy +
+                    ", connectionSelectorPolicy=" + connectionSelectorPolicy +
                     ", outlierDetectorConfig=" + outlierDetectorConfig +
                     ", loadBalancerObserverFactory=" + loadBalancerObserverFactory +
                     ", executor=" + executor +
@@ -187,8 +187,8 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         return LoadBalancingPolicies.roundRobin().build();
     }
 
-    private static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C>
-    defaultConnectionSelectorFactory() {
-        return ConnectionPoolPolicies.linearSearch();
+    private static <C extends LoadBalancedConnection>
+    ConnectionSelectorPolicy<C> defaultConnectionSelectorFactory() {
+        return ConnectionSelectorPolicies.linearSearch();
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -79,9 +79,9 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
     }
 
     @Override
-    public LoadBalancerBuilder<ResolvedAddress, C> connectionPoolPolicy(
-            ConnectionPoolPolicy<C> connectionPoolPolicy) {
-        delegate = delegate.connectionPoolPolicy(connectionPoolPolicy);
+    public LoadBalancerBuilder<ResolvedAddress, C> connectionSelectorPolicy(
+            ConnectionSelectorPolicy<C> connectionSelectorPolicy) {
+        delegate = delegate.connectionSelectorPolicy(connectionSelectorPolicy);
         return this;
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LinearSearchConnectionSelector.java
@@ -90,12 +90,12 @@ final class LinearSearchConnectionSelector<C extends LoadBalancedConnection> imp
         return null;
     }
 
-    static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> factory(final int linearSearchSpace) {
+    static <C extends LoadBalancedConnection> ConnectionSelectorPolicy<C> factory(final int linearSearchSpace) {
         return new LinearSearchConnectionSelectorFactory<>(linearSearchSpace);
     }
 
     private static final class LinearSearchConnectionSelectorFactory<C extends LoadBalancedConnection>
-            extends ConnectionPoolPolicy<C> {
+            extends ConnectionSelectorPolicy<C> {
 
         private final int linearSearchSpace;
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -96,12 +96,13 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
     LoadBalancerBuilder<ResolvedAddress, C> outlierDetectorConfig(OutlierDetectorConfig outlierDetectorConfig);
 
     /**
-     * Set the {@link ConnectionPoolPolicy} to use with this load balancer.
+     * Set the {@link ConnectionSelectorPolicy} to use with this load balancer.
      *
-     * @param connectionPoolPolicy the factory of connection pooling strategies to use.
+     * @param connectionSelectorPolicy the factory of connection selection strategies to use.
      * @return {@code this}
      */
-    LoadBalancerBuilder<ResolvedAddress, C> connectionPoolPolicy(ConnectionPoolPolicy<C> connectionPoolPolicy);
+    LoadBalancerBuilder<ResolvedAddress, C> connectionSelectorPolicy(
+            ConnectionSelectorPolicy<C> connectionSelectorPolicy);
 
     /**
      * Set the background {@link Executor} to use for determining time and scheduling background tasks such

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionSelector.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/P2CConnectionSelector.java
@@ -140,13 +140,13 @@ final class P2CConnectionSelector<C extends LoadBalancedConnection> implements C
         return null;
     }
 
-    static <C extends LoadBalancedConnection> ConnectionPoolPolicy<C> factory(
+    static <C extends LoadBalancedConnection> ConnectionSelectorPolicy<C> factory(
             final int maxEffort, final int corePoolSize, final boolean forceCorePool) {
         return new P2CConnectionSelectorFactory<>(maxEffort, corePoolSize, forceCorePool);
     }
 
     private static final class P2CConnectionSelectorFactory<C extends LoadBalancedConnection>
-            extends ConnectionPoolPolicy<C> {
+            extends ConnectionSelectorPolicy<C> {
 
         private final int maxEffort;
         private final int corePoolSize;

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/RoundRobinToDefaultLBMigrationProvider.java
@@ -142,7 +142,7 @@ public final class RoundRobinToDefaultLBMigrationProvider implements RoundRobinL
             }
             return builder.outlierDetectorConfig(outlierDetectorConfig)
                     .loadBalancingPolicy(loadBalancingPolicy)
-                    .connectionPoolPolicy(ConnectionPoolPolicies.linearSearch(linearSearchSpace))
+                    .connectionSelectorPolicy(ConnectionSelectorPolicies.linearSearch(linearSearchSpace))
                     .build();
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -82,7 +82,7 @@ class DefaultHostTest {
 
     private void buildHost(@Nullable HealthIndicator<String, TestLoadBalancedConnection> healthIndicator) {
         host = new DefaultHost<>("lbDescription", DEFAULT_ADDRESS,
-                ConnectionPoolPolicies.<TestLoadBalancedConnection>linearSearch()
+                ConnectionSelectorPolicies.<TestLoadBalancedConnection>linearSearch()
                         .buildConnectionSelector("resource"),
                 connectionFactory, mockHostObserver, healthCheckConfig, healthIndicator);
     }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -316,7 +316,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 hostPriorityStrategyFactory,
                 loadBalancingPolicy,
                 subsetter,
-                ConnectionPoolPolicies.linearSearch(),
+                ConnectionSelectorPolicies.linearSearch(),
                 connectionFactory,
                 NoopLoadBalancerObserver.factory(),
                 null,

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -43,8 +43,8 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
     }
 
     @Override
-    public LoadBalancerBuilder<String, TestLoadBalancedConnection> connectionPoolPolicy(
-            ConnectionPoolPolicy connectionPoolPolicy) {
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> connectionSelectorPolicy(
+            ConnectionSelectorPolicy connectionSelectorPolicy) {
         throw new UnsupportedOperationException("Cannot set a connection pool strategy for old round robin");
     }
 


### PR DESCRIPTION
Motivation:

A ConnectionPoolPolicy doesn't actually control pooling, but selection from that pool. The name is also inconsistent with the thing it generates: a ConnectionSelector.

Modifications:

Rename the types to ConnectionSelector* for more consistincy.