### PR TITLE
loadbalancer-experimental: Unify the Host.weight() methods

### DIFF
--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
@@ -117,7 +117,7 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
     }
 
     @Override
-    public double loadBalancingWeight() {
+    public double weight() {
         return 1;
     }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
@@ -133,14 +133,14 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
                 // instead to all receive an equal portion of the groups weight.
                 double weight = ((double) groupProbability) / hosts.size();
                 for (H host : hosts) {
-                    host.loadBalancingWeight(weight);
+                    host.weight(weight);
                     results.add(host);
                 }
             } else {
                 double scalingFactor = groupProbability / groupTotalWeight;
                 for (H host : hosts) {
-                    double hostWeight = host.loadBalancingWeight() * scalingFactor;
-                    host.loadBalancingWeight(hostWeight);
+                    double hostWeight = host.weight() * scalingFactor;
+                    host.weight(hostWeight);
                     if (hostWeight > 0) {
                         results.add(host);
                     }
@@ -152,7 +152,7 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
     private static double totalWeight(Iterable<? extends PrioritizedHost> hosts) {
         double sum = 0;
         for (PrioritizedHost host : hosts) {
-            sum += host.loadBalancingWeight();
+            sum += host.weight();
         }
         return sum;
     }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -508,7 +508,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             // We need to reset the load balancing weights before we run the host set through the rest
             // of the operations that will transform and consume the load balancing weight.
             for (PrioritizedHostImpl<?, ?> host : nextHosts) {
-                host.loadBalancingWeight(host.serviceDiscoveryWeight());
+                host.weight(host.serviceDiscoveryWeight());
             }
             nextHosts = priorityStrategy.prioritize(nextHosts);
             nextHosts = subsetter.subset(nextHosts);
@@ -706,12 +706,12 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         // Set the weight to use in load balancing. This includes derived weight information such as prioritization
         // and is what the host selectors will use when picking hosts.
         @Override
-        public void loadBalancingWeight(final double weight) {
+        public void weight(final double weight) {
             this.loadBalancingWeight = weight;
         }
 
         @Override
-        public double loadBalancingWeight() {
+        public double weight() {
             return loadBalancingWeight;
         }
 

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/Host.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/Host.java
@@ -73,12 +73,4 @@ interface Host<ResolvedAddress, C extends LoadBalancedConnection> extends Listen
      * @return true if the host is now in the closed state, false otherwise.
      */
     boolean markExpired();
-
-    /**
-     * The weight of the host, relative to the weights of associated hosts.
-     * @return the relative weight of the host.
-     */
-    default double weight() {
-        return 1.0;
-    }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/LoadBalancerObserver.java
@@ -125,6 +125,6 @@ public interface LoadBalancerObserver {
          * The weight of the host, relative to the weights of associated hosts as used for load balancing.
          * @return the relative weight of the host.
          */
-        double loadBalancingWeight();
+        double weight();
     }
 }

--- a/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/PrioritizedHost.java
+++ b/servicetalk-loadbalancer-experimental/src/main/java/io/servicetalk/loadbalancer/PrioritizedHost.java
@@ -42,11 +42,11 @@ interface PrioritizedHost {
      * The weight of the host to use for load balancing.
      * @return the weight of the host to use for load balancing.
      */
-    double loadBalancingWeight();
+    double weight();
 
     /**
      * Set the weight of the host to use during load balancing.
      * @param weight the weight of the host to use during load balancing.
      */
-    void loadBalancingWeight(double weight);
+    void weight(double weight);
 }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategyTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategyTest.java
@@ -47,7 +47,7 @@ class DefaultHostPriorityStrategyTest {
     void noPrioritiesWithWeights() {
         List<TestPrioritizedHost> hosts = makeHosts(4);
         for (int i = 0; i < hosts.size(); i++) {
-            hosts.get(i).loadBalancingWeight(i + 1d);
+            hosts.get(i).weight(i + 1d);
         }
         List<TestPrioritizedHost> result = hostPriorityStrategy.prioritize(hosts);
         assertThat(result.size(), equalTo(hosts.size()));
@@ -79,7 +79,7 @@ class DefaultHostPriorityStrategyTest {
     void twoPrioritiesWithWeights() {
         List<TestPrioritizedHost> hosts = makeHosts(6);
         for (int i = 0; i < hosts.size(); i++) {
-            hosts.get(i).loadBalancingWeight(i + 1d);
+            hosts.get(i).weight(i + 1d);
             if (i >= 3) {
                 hosts.get(i).priority(1);
             }
@@ -99,7 +99,7 @@ class DefaultHostPriorityStrategyTest {
     void twoPrioritiesWithWeightsButSkipNumbers() {
         List<TestPrioritizedHost> hosts = makeHosts(6);
         for (int i = 0; i < hosts.size(); i++) {
-            hosts.get(i).loadBalancingWeight(i + 1d);
+            hosts.get(i).weight(i + 1d);
             if (i >= 3) {
                 hosts.get(i).priority(2);
             }
@@ -119,7 +119,7 @@ class DefaultHostPriorityStrategyTest {
     void noHealthyNodesDoesntFilterOutElements() {
         List<TestPrioritizedHost> hosts = makeHosts(6);
         for (int i = 0; i < hosts.size(); i++) {
-            hosts.get(i).loadBalancingWeight(i + 1d);
+            hosts.get(i).weight(i + 1d);
             hosts.get(i).isHealthy = false;
             if (i >= 3) {
                 hosts.get(i).priority(1);
@@ -206,10 +206,10 @@ class DefaultHostPriorityStrategyTest {
         hosts.get(0).isHealthy(false);
         for (int i = 0; i < hosts.size(); i++) {
             if (i >= 3) {
-                hosts.get(i).loadBalancingWeight(i - 3 + 1d);
+                hosts.get(i).weight(i - 3 + 1d);
                 hosts.get(i).priority(1);
             } else {
-                hosts.get(i).loadBalancingWeight(i + 1d);
+                hosts.get(i).weight(i + 1d);
             }
         }
         List<TestPrioritizedHost> result = hostPriorityStrategy.prioritize(hosts);
@@ -241,10 +241,10 @@ class DefaultHostPriorityStrategyTest {
         List<TestPrioritizedHost> hosts = makeHosts(6);
         for (int i = 0; i < hosts.size(); i++) {
             if (i >= 3) {
-                hosts.get(i).loadBalancingWeight(0);
+                hosts.get(i).weight(0);
                 hosts.get(i).priority(1);
             } else {
-                hosts.get(i).loadBalancingWeight(1);
+                hosts.get(i).weight(1);
                 hosts.get(i).isHealthy = false;
             }
         }
@@ -312,7 +312,7 @@ class DefaultHostPriorityStrategyTest {
         // Set the weight to use in load balancing. This includes derived weight information such as prioritization
         // and is what the host selectors will use when picking endpoints.
         @Override
-        public void loadBalancingWeight(final double weight) {
+        public void weight(final double weight) {
             this.loadBalancedWeight = weight;
         }
 
@@ -330,7 +330,7 @@ class DefaultHostPriorityStrategyTest {
         }
 
         @Override
-        public double loadBalancingWeight() {
+        public double weight() {
             return loadBalancedWeight;
         }
     }

--- a/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer-experimental/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -185,10 +185,10 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
             public <T extends PrioritizedHost> List<T> prioritize(List<T> hosts) {
                 assert hosts.size() == 1;
                 T host = hosts.get(0);
-                value.set(host.loadBalancingWeight());
+                value.set(host.weight());
                 // We want to adjust the weight here so that if the `loadBalancingWeight()` fails to be
                 // reset then the test will fail.
-                host.loadBalancingWeight(0.5 * host.loadBalancingWeight());
+                host.weight(0.5 * host.weight());
                 return hosts;
             }
         };
@@ -201,7 +201,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         List<? extends DefaultLoadBalancer.PrioritizedHostImpl<?, ?>> curentHosts = refinedLb.hosts();
         assertThat(curentHosts, hasSize(1));
         assertThat(curentHosts.get(0).priority(), equalTo(0));
-        assertThat(curentHosts.get(0).loadBalancingWeight(), equalTo(0.5));
+        assertThat(curentHosts.get(0).weight(), equalTo(0.5));
         assertThat(value.getAndSet(null), equalTo(1.0));
 
         // send a new event with a different priority group. This should trigger another build.
@@ -209,7 +209,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         curentHosts = refinedLb.hosts();
         assertThat(curentHosts, hasSize(1));
         assertThat(curentHosts.get(0).priority(), equalTo(1));
-        assertThat(curentHosts.get(0).loadBalancingWeight(), equalTo(0.5));
+        assertThat(curentHosts.get(0).weight(), equalTo(0.5));
         assertThat(value.getAndSet(null), equalTo(1.0));
 
         // send a new event with a different weight. This should trigger yet another build.
@@ -217,7 +217,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         curentHosts = refinedLb.hosts();
         assertThat(curentHosts, hasSize(1));
         assertThat(curentHosts.get(0).priority(), equalTo(1));
-        assertThat(curentHosts.get(0).loadBalancingWeight(), equalTo(1.0));
+        assertThat(curentHosts.get(0).weight(), equalTo(1.0));
         assertThat(value.getAndSet(null), equalTo(2.0));
     }
 


### PR DESCRIPTION
Motivation:

We have a few Host related weight methods, but they have slightly different names. Worse yet, we don't use them properly when adjusting weights.

Modifications:

Rename the LoadBalancerObserver.Host.loadBalancingWeight() to simply .weight()