### PR TITLE
`BlockingStreamingHttpService`: drop trailers if users didn't create any

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -29,7 +29,6 @@ import io.servicetalk.concurrent.internal.ThreadInterruptingCancellable;
 import java.io.IOException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpRequest.java
@@ -245,7 +245,7 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
     public HttpHeaders trailers() {
         if (trailers == null) {
             trailers = original.payloadHolder().headersFactory().newTrailers();
-            original.transform(this);
+            original.transform(this);   // Invoke "transform" to set PayloadInfo.mayHaveTrailers() flag
         }
         return trailers;
     }
@@ -277,6 +277,9 @@ final class DefaultHttpRequest extends AbstractDelegatingHttpRequest
         @Nullable
         final Publisher<Object> payload;
         if (trailers != null) {
+            // We can not drop empty Trailers here bcz users could do type conversion intermediately, while still
+            // referencing the original HttpHeaders object from an aggregated type and keep using it to add trailers
+            // before sending the message or converting it back to an aggregated one.
             payload = emptyPayloadBody ? from(trailers) : from(payloadBody, trailers);
         } else {
             payload = emptyPayloadBody ? null : from(payloadBody);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpDataSourceTransformations.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpDataSourceTransformations.java
@@ -341,6 +341,9 @@ final class HttpDataSourceTransformations {
             if (isAlwaysEmpty(pair.payload)) {
                 payloadInfo.setEmpty(true);
             }
+            // We can not drop empty Trailers here bcz users could do type conversion intermediately multiple times,
+            // while still referencing the original HttpHeaders object from an aggregated type and keep using it to add
+            // trailers before sending the message or converting it back to an aggregated one.
             if (pair.trailers == null) {
                 payloadInfo.setMayHaveTrailersAndGenericTypeBuffer(false);
             }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpPayloadWriter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpPayloadWriter.java
@@ -28,16 +28,12 @@ import java.io.OutputStream;
 public interface HttpPayloadWriter<T> extends PayloadWriter<T>, TrailersHolder {
 
     /**
-     * {@inheritDoc}
-     * <p>
      * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
      */
     @Override
     HttpHeaders trailers();
 
     /**
-     * {@inheritDoc}
-     * <p>
      * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
      */
     @Override
@@ -47,8 +43,6 @@ public interface HttpPayloadWriter<T> extends PayloadWriter<T>, TrailersHolder {
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
      * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
      */
     @Override
@@ -58,8 +52,6 @@ public interface HttpPayloadWriter<T> extends PayloadWriter<T>, TrailersHolder {
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
      * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
      */
     @Override
@@ -69,8 +61,6 @@ public interface HttpPayloadWriter<T> extends PayloadWriter<T>, TrailersHolder {
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
      * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
      */
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpPayloadWriter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpPayloadWriter.java
@@ -27,6 +27,8 @@ import java.io.OutputStream;
  */
 public interface HttpPayloadWriter<T> extends PayloadWriter<T>, TrailersHolder {
 
+    // TODO: clarify in javadoc that trailers can not be modified after the writer is closed
+
     @Override
     default HttpPayloadWriter<T> addTrailer(final CharSequence name, final CharSequence value) {
         TrailersHolder.super.addTrailer(name, value);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpPayloadWriter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpPayloadWriter.java
@@ -27,26 +27,52 @@ import java.io.OutputStream;
  */
 public interface HttpPayloadWriter<T> extends PayloadWriter<T>, TrailersHolder {
 
-    // TODO: clarify in javadoc that trailers can not be modified after the writer is closed
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
+     */
+    @Override
+    HttpHeaders trailers();
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
+     */
     @Override
     default HttpPayloadWriter<T> addTrailer(final CharSequence name, final CharSequence value) {
         TrailersHolder.super.addTrailer(name, value);
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
+     */
     @Override
     default HttpPayloadWriter<T> addTrailers(final HttpHeaders trailers) {
         TrailersHolder.super.addTrailers(trailers);
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
+     */
     @Override
     default HttpPayloadWriter<T> setTrailer(final CharSequence name, final CharSequence value) {
         TrailersHolder.super.setTrailer(name, value);
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>Note:</b> modifying trailers after the payload writer is {@link #close() closed} is not allowed.
+     */
     @Override
     default HttpPayloadWriter<T> setTrailers(final HttpHeaders trailers) {
         TrailersHolder.super.setTrailers(trailers);


### PR DESCRIPTION
Motivation:

Behavior was discovered as part of debugging #3148.
Currently, `BlockingStreamingHttpService` allocates trailers upfront and concatenates them after the payload body when protocol allows. In result, aggregation of `BlockingStreamingHttpResponse` does not lead to a single HTTP/2 frame because we always expect to receive trailers. However, adding trailers after users close payload writer is race. There are no guarantees that new trailers will be written to the network after close. Therefore, we can inspect the state after close and decide if we need to append trailers or not.

Modifications:

- Use `scanWithMapper` inside `BlockingStreamingHttpService` instead of always concatenating payload body with trailers;
- Create trailers on demand inside `BufferHttpPayloadWriter`, only when users touch them;
- Clarify behavior in `HttpPayloadWriter`'s javadoc for trailers-related methods;
- Enhance `BlockingStreamingToStreamingServiceTest` to assert new expectations;

Result:

In `BlockingStreamingHttpService`, trailers are allocated and attached only if users touch trailers before closing `HttpPayloadWriter`.