### PR TITLE
Remove unused test dependencies and reduce scope to runtime if possible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ buildscript {
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-root"
 
 // Unfortunately, we can not make this validation part of our servicetalk-gradle-plugin-internal because it requires
-// JDK11 while we build and package out plugin with JDK8.
+// JDK11 while we build and package our plugin with JDK8.
 if (JavaVersion.current().isJava11Compatible()) {
   apply plugin: "com.autonomousapps.dependency-analysis"
 
@@ -67,6 +67,13 @@ if (JavaVersion.current().isJava11Compatible()) {
       all {
         onAny {
           severity("warn")  // FIXME: switch to "fail" when all issues are addressed
+        }
+        onUnusedDependencies {
+          // We use it for log4j2.xml configuration
+          exclude(":servicetalk-test-resources")
+        }
+        onUsedTransitiveDependencies {
+          // We import it as api dependency via :servicetalk-annotations
           exclude("com.google.code.findbugs:jsr305")
         }
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -98,7 +98,5 @@ spotbugsPluginVersion=5.0.13
 dependencyAnalysisPluginVersion=2.6.1
 
 apacheDirectoryServerVersion=1.5.7
-commonsLangVersion=2.6
 grpcVersion=1.69.0
-javaxAnnotationsApiVersion=1.3.5
 jsonUnitVersion=2.40.1

--- a/servicetalk-benchmarks/build.gradle
+++ b/servicetalk-benchmarks/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation project(":servicetalk-buffer-netty")
   implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
+  implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-api")
   implementation project(":servicetalk-http-netty")
   implementation project(":servicetalk-transport-netty-internal")
@@ -34,11 +35,6 @@ dependencies {
   implementation project(":servicetalk-data-jackson")
   implementation "io.netty:netty-codec-http"
   implementation "org.openjdk.jmh:jmh-core:$jmhCoreVersion"
-
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
-  testImplementation project(":servicetalk-concurrent-internal")
-  testImplementation project(":servicetalk-concurrent-api-internal")
-  testImplementation project(":servicetalk-test-resources")
 }
 
 jmh {

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/concurrent/ConnectableBufferOutputStreamBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/concurrent/ConnectableBufferOutputStreamBenchmark.java
@@ -37,6 +37,7 @@ import org.openjdk.jmh.annotations.Warmup;
 
 import java.io.IOException;
 import java.util.Random;
+import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_HEAP_ALLOCATOR;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
@@ -109,6 +110,7 @@ public class ConnectableBufferOutputStreamBenchmark {
     byte[] data;
     ConnectableBufferOutputStream cbos;
     Publisher<Buffer> publisher;
+    @Nullable
     Subscription subscription;
 
     @Setup(Level.Iteration)

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/concurrent/package-info.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/concurrent/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@ElementsAreNonnullByDefault
+package io.servicetalk.benchmark.concurrent;
 
-apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
-
-dependencies {
-  api project(":servicetalk-circuit-breaker-api")
-  api "io.github.resilience4j:resilience4j-circuitbreaker:$resilience4jVersion"
-
-  implementation project(":servicetalk-annotations")
-
-  testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation "org.junit.jupiter:junit-jupiter-api"
-}
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/http/package-info.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@ElementsAreNonnullByDefault
+package io.servicetalk.benchmark.http;
 
-apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
-
-dependencies {
-  api project(":servicetalk-circuit-breaker-api")
-  api "io.github.resilience4j:resilience4j-circuitbreaker:$resilience4jVersion"
-
-  implementation project(":servicetalk-annotations")
-
-  testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation "org.junit.jupiter:junit-jupiter-api"
-}
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/package-info.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/loadbalancer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@ElementsAreNonnullByDefault
+package io.servicetalk.benchmark.loadbalancer;
 
-apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
-
-dependencies {
-  api project(":servicetalk-circuit-breaker-api")
-  api "io.github.resilience4j:resilience4j-circuitbreaker:$resilience4jVersion"
-
-  implementation project(":servicetalk-annotations")
-
-  testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation "org.junit.jupiter:junit-jupiter-api"
-}
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/package-info.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/benchmark/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@ElementsAreNonnullByDefault
+package io.servicetalk.benchmark;
 
-apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
-
-dependencies {
-  api project(":servicetalk-circuit-breaker-api")
-  api "io.github.resilience4j:resilience4j-circuitbreaker:$resilience4jVersion"
-
-  implementation project(":servicetalk-annotations")
-
-  testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation "org.junit.jupiter:junit-jupiter-api"
-}
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-buffer-api/build.gradle
+++ b/servicetalk-buffer-api/build.gradle
@@ -23,7 +23,6 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
   testFixturesApi "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"

--- a/servicetalk-client-api-internal/build.gradle
+++ b/servicetalk-client-api-internal/build.gradle
@@ -27,10 +27,9 @@ dependencies {
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
 }

--- a/servicetalk-client-api/build.gradle
+++ b/servicetalk-client-api/build.gradle
@@ -26,12 +26,11 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+
+  testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
 }

--- a/servicetalk-concurrent-api-test/build.gradle
+++ b/servicetalk-concurrent-api-test/build.gradle
@@ -30,5 +30,4 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 }

--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -35,12 +35,11 @@ dependencies {
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
+  testFixturesImplementation project(":servicetalk-concurrent-internal")
   testFixturesImplementation project(":servicetalk-utils-internal")
   testFixturesImplementation project(":servicetalk-concurrent-test-internal")
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/servicetalk-concurrent-internal/build.gradle
+++ b/servicetalk-concurrent-internal/build.gradle
@@ -32,7 +32,6 @@ dependencies {
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation project(":servicetalk-annotations")
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/servicetalk-data-jackson-jersey/build.gradle
+++ b/servicetalk-data-jackson-jersey/build.gradle
@@ -39,20 +39,15 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
-  testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-http-router-jersey"))
-  testImplementation project(":servicetalk-http-netty")
-  testImplementation project(":servicetalk-http-router-predicate")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation project(":servicetalk-transport-netty-internal")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
-  testImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testImplementation "org.glassfish.jersey.inject:jersey-hk2"
-  testImplementation "org.glassfish.jersey.media:jersey-media-sse"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
+
+  testRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
+  testRuntimeOnly "org.glassfish.jersey.media:jersey-media-sse"
 }

--- a/servicetalk-data-jackson-jersey3-jakarta10/build.gradle
+++ b/servicetalk-data-jackson-jersey3-jakarta10/build.gradle
@@ -99,20 +99,15 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
-  testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-http-router-jersey3-jakarta10"))
-  testImplementation project(":servicetalk-http-netty")
-  testImplementation project(":servicetalk-http-router-predicate")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation project(":servicetalk-transport-netty-internal")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
-  testImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testImplementation "org.glassfish.jersey.inject:jersey-hk2"
-  testImplementation "org.glassfish.jersey.media:jersey-media-sse"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
+
+  testRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
+  testRuntimeOnly "org.glassfish.jersey.media:jersey-media-sse"
 }

--- a/servicetalk-data-jackson-jersey3-jakarta9/build.gradle
+++ b/servicetalk-data-jackson-jersey3-jakarta9/build.gradle
@@ -99,20 +99,15 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
-  testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-http-router-jersey3-jakarta9"))
-  testImplementation project(":servicetalk-http-netty")
-  testImplementation project(":servicetalk-http-router-predicate")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation project(":servicetalk-transport-netty-internal")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
-  testImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testImplementation "org.glassfish.jersey.inject:jersey-hk2"
-  testImplementation "org.glassfish.jersey.media:jersey-media-sse"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+  testImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
+
+  testRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
+  testRuntimeOnly "org.glassfish.jersey.media:jersey-media-sse"
 }

--- a/servicetalk-data-jackson/build.gradle
+++ b/servicetalk-data-jackson/build.gradle
@@ -29,12 +29,11 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
 }

--- a/servicetalk-data-protobuf-jersey/build.gradle
+++ b/servicetalk-data-protobuf-jersey/build.gradle
@@ -48,23 +48,18 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
-  testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-http-router-jersey"))
-  testImplementation project(":servicetalk-http-netty")
-  testImplementation project(":servicetalk-http-router-predicate")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation project(":servicetalk-transport-netty-internal")
-  // BaseJerseyRouterTestSuite assumes JSON serialization is supported.
-  testImplementation project(":servicetalk-data-jackson-jersey")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
-  testImplementation "org.glassfish.jersey.inject:jersey-hk2"
-  testImplementation "org.glassfish.jersey.media:jersey-media-sse"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  // BaseJerseyRouterTestSuite assumes JSON serialization is supported.
+  testRuntimeOnly project(":servicetalk-data-jackson-jersey")
+  testRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
+  testRuntimeOnly "org.glassfish.jersey.media:jersey-media-sse"
 }
 
 protobuf {

--- a/servicetalk-data-protobuf-jersey3-jakarta10/build.gradle
+++ b/servicetalk-data-protobuf-jersey3-jakarta10/build.gradle
@@ -109,23 +109,18 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
-  testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-http-router-jersey3-jakarta10"))
-  testImplementation project(":servicetalk-http-netty")
-  testImplementation project(":servicetalk-http-router-predicate")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation project(":servicetalk-transport-netty-internal")
-  // BaseJerseyRouterTestSuite assumes JSON serialization is supported.
-  testImplementation project(":servicetalk-data-jackson-jersey3-jakarta10")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
-  testImplementation "org.glassfish.jersey.inject:jersey-hk2"
-  testImplementation "org.glassfish.jersey.media:jersey-media-sse"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  // BaseJerseyRouterTestSuite assumes JSON serialization is supported.
+  testRuntimeOnly project(":servicetalk-data-jackson-jersey3-jakarta10")
+  testRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
+  testRuntimeOnly "org.glassfish.jersey.media:jersey-media-sse"
 }
 
 protobuf {

--- a/servicetalk-data-protobuf-jersey3-jakarta9/build.gradle
+++ b/servicetalk-data-protobuf-jersey3-jakarta9/build.gradle
@@ -114,23 +114,18 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
-  testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-http-router-jersey3-jakarta9"))
-  testImplementation project(":servicetalk-http-netty")
-  testImplementation project(":servicetalk-http-router-predicate")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation project(":servicetalk-transport-netty-internal")
-  // BaseJerseyRouterTestSuite assumes JSON serialization is supported.
-  testImplementation project(":servicetalk-data-jackson-jersey3-jakarta9")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
-  testImplementation "org.glassfish.jersey.inject:jersey-hk2"
-  testImplementation "org.glassfish.jersey.media:jersey-media-sse"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  // BaseJerseyRouterTestSuite assumes JSON serialization is supported.
+  testRuntimeOnly project(":servicetalk-data-jackson-jersey3-jakarta9")
+  testRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
+  testRuntimeOnly "org.glassfish.jersey.media:jersey-media-sse"
 }
 
 protobuf {

--- a/servicetalk-data-protobuf/build.gradle
+++ b/servicetalk-data-protobuf/build.gradle
@@ -39,14 +39,14 @@ dependencies {
   implementation project(":servicetalk-serializer-utils")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
 }
 
 protobuf {

--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -48,7 +48,6 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-concurrent-test-internal")
-  testImplementation "commons-lang:commons-lang:$commonsLangVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.apache.directory.server:apacheds-protocol-dns:$apacheDirectoryServerVersion"

--- a/servicetalk-encoding-api/build.gradle
+++ b/servicetalk-encoding-api/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.junit.jupiter:junit-jupiter-params"
     testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/servicetalk-encoding-netty/build.gradle
+++ b/servicetalk-encoding-netty/build.gradle
@@ -30,8 +30,9 @@ dependencies {
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-    testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.junit.jupiter:junit-jupiter-params"
     testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+
+    testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
 }

--- a/servicetalk-grpc-api/build.gradle
+++ b/servicetalk-grpc-api/build.gradle
@@ -41,6 +41,4 @@ dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 }

--- a/servicetalk-grpc-health/build.gradle
+++ b/servicetalk-grpc-health/build.gradle
@@ -31,7 +31,6 @@ dependencies {
   implementation project(":servicetalk-grpc-protobuf")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation project(":servicetalk-concurrent-api-test")
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-grpc-internal/build.gradle
+++ b/servicetalk-grpc-internal/build.gradle
@@ -26,5 +26,4 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -23,11 +23,15 @@ buildscript {
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 apply plugin: "com.google.protobuf"
 
-dependencyAnalysis {
-  issues {
-    // False positives for testImplementation
-    onUnusedDependencies {
-      exclude(":servicetalk-http-utils")
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        // False positives for testImplementation
+        onUnusedDependencies {
+          exclude(":servicetalk-http-utils")
+        }
+      }
     }
   }
 }

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -23,6 +23,15 @@ buildscript {
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 apply plugin: "com.google.protobuf"
 
+dependencyAnalysis {
+  issues {
+    // False positives for testImplementation
+    onUnusedDependencies {
+      exclude(":servicetalk-http-utils")
+    }
+  }
+}
+
 dependencies {
   api project(":servicetalk-grpc-api")
   api project(":servicetalk-grpc-utils")
@@ -48,7 +57,6 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-http-netty"))
   testImplementation project(":servicetalk-concurrent-api-internal")
   testImplementation project(":servicetalk-concurrent-test-internal")
-  testImplementation project(":servicetalk-encoding-api-internal")
   testImplementation project(":servicetalk-encoding-netty")
   testImplementation project(":servicetalk-grpc-protobuf")
   testImplementation project(":servicetalk-http-utils")
@@ -56,16 +64,13 @@ dependencies {
   testImplementation project(":servicetalk-grpc-protoc")
   testImplementation project(":servicetalk-router-utils-internal")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation project(":servicetalk-utils-internal")
   testImplementation project(":servicetalk-transport-netty")
   testImplementation project(":servicetalk-serializer-utils")
-  testImplementation "io.grpc:grpc-core"
   testImplementation("io.grpc:grpc-netty") {
     exclude group: "io.netty"
   }
   testImplementation "io.grpc:grpc-protobuf"
   testImplementation "io.grpc:grpc-stub"
-  testImplementation "jakarta.annotation:jakarta.annotation-api:$javaxAnnotationsApiVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-grpc-protobuf/build.gradle
+++ b/servicetalk-grpc-protobuf/build.gradle
@@ -42,7 +42,6 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 }
 
 protobuf {

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -32,7 +32,6 @@ dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation project(":servicetalk-grpc-api")
   testImplementation project(":servicetalk-grpc-protobuf")
-  testImplementation "com.squareup:javapoet:$javaPoetVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -34,6 +34,8 @@ dependencies {
   testImplementation project(":servicetalk-grpc-protobuf")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+
+  testRuntimeOnly "com.squareup:javapoet:$javaPoetVersion"
 }
 
 jar {

--- a/servicetalk-grpc-utils/build.gradle
+++ b/servicetalk-grpc-utils/build.gradle
@@ -29,5 +29,4 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
-  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 }

--- a/servicetalk-http-api/build.gradle
+++ b/servicetalk-http-api/build.gradle
@@ -54,7 +54,6 @@ dependencies {
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation project(":servicetalk-buffer-netty")
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -16,11 +16,15 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-dependencyAnalysis {
-  issues {
-    // False positives for testImplementation
-    onUnusedDependencies {
-      exclude("io.netty.incubator:netty-incubator-transport-native-io_uring")
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        // False positives for testImplementation
+        onUnusedDependencies {
+          exclude("io.netty.incubator:netty-incubator-transport-native-io_uring")
+        }
+      }
     }
   }
 }

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -16,6 +16,15 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
+dependencyAnalysis {
+  issues {
+    // False positives for testImplementation
+    onUnusedDependencies {
+      exclude("io.netty.incubator:netty-incubator-transport-native-io_uring")
+    }
+  }
+}
+
 dependencies {
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-logging-api")
@@ -59,8 +68,6 @@ dependencies {
   testImplementation project(":servicetalk-encoding-netty")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-utils-internal")
-  testImplementation project(":servicetalk-oio-api-internal")
-  testImplementation "io.netty:netty-transport-native-unix-common"
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -16,6 +16,15 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
+dependencyAnalysis {
+  issues {
+    // False positives for testFixturesImplementation
+    onUnusedDependencies {
+      exclude("org.junit.platform:junit-platform-suite")
+    }
+  }
+}
+
 def actualJerseyVersion = "${jerseyVersion}"
 def actualJavaxActivationVersion = "${javaxActivationVersion}"
 def actualJavaxJaxbApiVersion = "${javaxJaxbApiVersion}"
@@ -60,20 +69,20 @@ dependencies {
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation project(":servicetalk-data-jackson")
   testFixturesImplementation project(":servicetalk-http-netty")
-  testFixturesImplementation project(":servicetalk-http-utils")
   testFixturesImplementation project(":servicetalk-http-router-predicate")
   testFixturesImplementation project(":servicetalk-router-utils-internal")
   testFixturesImplementation project(":servicetalk-test-resources")
-  testFixturesImplementation project(":servicetalk-transport-netty")
   testFixturesImplementation project(":servicetalk-transport-netty-internal")
+  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
   testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
   testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testFixturesImplementation "org.glassfish.jersey.inject:jersey-hk2"
-  testFixturesImplementation "org.glassfish.jersey.media:jersey-media-sse"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testFixturesRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
+  testFixturesRuntimeOnly "org.glassfish.jersey.media:jersey-media-sse"
 }

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -16,11 +16,15 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-dependencyAnalysis {
-  issues {
-    // False positives for testFixturesImplementation
-    onUnusedDependencies {
-      exclude("org.junit.platform:junit-platform-suite")
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        // False positives for testFixturesImplementation
+        onUnusedDependencies {
+          exclude("org.junit.platform:junit-platform-suite")
+        }
+      }
     }
   }
 }

--- a/servicetalk-http-router-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10/build.gradle
@@ -78,11 +78,15 @@ afterEvaluate {
   }
 }
 
-dependencyAnalysis {
-  issues {
-    // False positives for testFixturesImplementation
-    onUnusedDependencies {
-      exclude("org.junit.platform:junit-platform-suite")
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        // False positives for testFixturesImplementation
+        onUnusedDependencies {
+          exclude("org.junit.platform:junit-platform-suite")
+        }
+      }
     }
   }
 }

--- a/servicetalk-http-router-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10/build.gradle
@@ -78,6 +78,15 @@ afterEvaluate {
   }
 }
 
+dependencyAnalysis {
+  issues {
+    // False positives for testFixturesImplementation
+    onUnusedDependencies {
+      exclude("org.junit.platform:junit-platform-suite")
+    }
+  }
+}
+
 def actualJerseyVersion = "${jersey3VersionEE10}"
 def actualJavaxActivationVersion = "${javaxActivationVersionEE10}"
 def actualJavaxJaxbApiVersion = "${javaxJaxbApiVersionEE10}"
@@ -122,20 +131,20 @@ dependencies {
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation project(":servicetalk-data-jackson")
   testFixturesImplementation project(":servicetalk-http-netty")
-  testFixturesImplementation project(":servicetalk-http-utils")
   testFixturesImplementation project(":servicetalk-http-router-predicate")
   testFixturesImplementation project(":servicetalk-router-utils-internal")
   testFixturesImplementation project(":servicetalk-test-resources")
-  testFixturesImplementation project(":servicetalk-transport-netty")
   testFixturesImplementation project(":servicetalk-transport-netty-internal")
+  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
   testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
   testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testFixturesImplementation "org.glassfish.jersey.inject:jersey-hk2"
-  testFixturesImplementation "org.glassfish.jersey.media:jersey-media-sse"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testFixturesRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
+  testFixturesRuntimeOnly "org.glassfish.jersey.media:jersey-media-sse"
 }

--- a/servicetalk-http-router-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9/build.gradle
@@ -78,6 +78,15 @@ afterEvaluate {
   }
 }
 
+dependencyAnalysis {
+  issues {
+    // False positives for testFixturesImplementation
+    onUnusedDependencies {
+      exclude("org.junit.platform:junit-platform-suite")
+    }
+  }
+}
+
 def actualJerseyVersion = "${jersey3VersionEE9}"
 def actualJavaxActivationVersion = "${javaxActivationVersionEE9}"
 def actualJavaxJaxbApiVersion = "${javaxJaxbApiVersionEE9}"
@@ -122,20 +131,20 @@ dependencies {
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation project(":servicetalk-data-jackson")
   testFixturesImplementation project(":servicetalk-http-netty")
-  testFixturesImplementation project(":servicetalk-http-utils")
   testFixturesImplementation project(":servicetalk-http-router-predicate")
   testFixturesImplementation project(":servicetalk-router-utils-internal")
   testFixturesImplementation project(":servicetalk-test-resources")
-  testFixturesImplementation project(":servicetalk-transport-netty")
   testFixturesImplementation project(":servicetalk-transport-netty-internal")
+  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
   testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
   testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testFixturesImplementation "org.glassfish.jersey.inject:jersey-hk2"
-  testFixturesImplementation "org.glassfish.jersey.media:jersey-media-sse"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testFixturesRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
+  testFixturesRuntimeOnly "org.glassfish.jersey.media:jersey-media-sse"
 }

--- a/servicetalk-http-router-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9/build.gradle
@@ -78,11 +78,15 @@ afterEvaluate {
   }
 }
 
-dependencyAnalysis {
-  issues {
-    // False positives for testFixturesImplementation
-    onUnusedDependencies {
-      exclude("org.junit.platform:junit-platform-suite")
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        // False positives for testFixturesImplementation
+        onUnusedDependencies {
+          exclude("org.junit.platform:junit-platform-suite")
+        }
+      }
     }
   }
 }

--- a/servicetalk-http-router-predicate/build.gradle
+++ b/servicetalk-http-router-predicate/build.gradle
@@ -26,7 +26,6 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-http-api"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
-  testImplementation project(":servicetalk-concurrent-internal")
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-transport-netty")

--- a/servicetalk-http-security-jersey/build.gradle
+++ b/servicetalk-http-security-jersey/build.gradle
@@ -29,9 +29,7 @@ dependencies {
   implementation "org.glassfish.jersey.core:jersey-common"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
-  testImplementation project(":servicetalk-data-jackson-jersey")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-http-router-jersey")
   testImplementation project(":servicetalk-http-utils")
@@ -39,9 +37,13 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "net.javacrumbs.json-unit:json-unit-fluent:$jsonUnitVersion"
   testImplementation "org.glassfish.jersey.core:jersey-server"
-  testImplementation "org.glassfish.jersey.inject:jersey-hk2"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
+  // BaseJerseyRouterTestSuite assumes JSON serialization is supported.
+  testRuntimeOnly project(":servicetalk-data-jackson-jersey")
   testRuntimeOnly project(":servicetalk-test-resources")
+  testRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
 }

--- a/servicetalk-http-security-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-security-jersey3-jakarta10/build.gradle
@@ -90,9 +90,7 @@ dependencies {
   implementation "org.glassfish.jersey.core:jersey-common"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
-  testImplementation project(":servicetalk-data-jackson-jersey3-jakarta10")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-http-router-jersey3-jakarta10")
   testImplementation project(":servicetalk-http-utils")
@@ -100,10 +98,13 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "net.javacrumbs.json-unit:json-unit-fluent:$jsonUnitVersion"
   testImplementation "org.glassfish.jersey.core:jersey-server"
-  testImplementation "org.glassfish.jersey.inject:jersey-hk2"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
+  testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
+  // BaseJerseyRouterTestSuite assumes JSON serialization is supported.
+  testRuntimeOnly project(":servicetalk-data-jackson-jersey3-jakarta10")
   testRuntimeOnly project(":servicetalk-test-resources")
+  testRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
 }

--- a/servicetalk-http-security-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-security-jersey3-jakarta9/build.gradle
@@ -90,9 +90,7 @@ dependencies {
   implementation "org.glassfish.jersey.core:jersey-common"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
-  testImplementation project(":servicetalk-data-jackson-jersey3-jakarta9")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-http-router-jersey3-jakarta9")
   testImplementation project(":servicetalk-http-utils")
@@ -100,9 +98,13 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "net.javacrumbs.json-unit:json-unit-fluent:$jsonUnitVersion"
   testImplementation "org.glassfish.jersey.core:jersey-server"
-  testImplementation "org.glassfish.jersey.inject:jersey-hk2"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
+  // BaseJerseyRouterTestSuite assumes JSON serialization is supported.
+  testRuntimeOnly project(":servicetalk-data-jackson-jersey3-jakarta9")
   testRuntimeOnly project(":servicetalk-test-resources")
+  testRuntimeOnly "org.glassfish.jersey.inject:jersey-hk2"
 }

--- a/servicetalk-http-utils/build.gradle
+++ b/servicetalk-http-utils/build.gradle
@@ -37,7 +37,6 @@ dependencies {
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-concurrent-api-test")
   testImplementation project(":servicetalk-transport-netty")
-  testImplementation project(":servicetalk-transport-netty-internal")
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-log4j2-mdc-utils/build.gradle
+++ b/servicetalk-log4j2-mdc-utils/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
-  testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 
   testFixturesImplementation "org.apache.logging.log4j:log4j-core"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-opentelemetry-asynccontext/build.gradle
+++ b/servicetalk-opentelemetry-asynccontext/build.gradle
@@ -27,5 +27,4 @@ dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
-  testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 }

--- a/servicetalk-opentelemetry-http/build.gradle
+++ b/servicetalk-opentelemetry-http/build.gradle
@@ -30,7 +30,6 @@ dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
-  testImplementation project(":servicetalk-opentelemetry-asynccontext")
   testImplementation project(":servicetalk-data-jackson")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-test-resources")
@@ -42,6 +41,7 @@ dependencies {
   testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testRuntimeOnly enforcedPlatform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
+  testRuntimeOnly project(":servicetalk-opentelemetry-asynccontext")
   testRuntimeOnly "io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.17-autoconfigure"
   testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl"
 }

--- a/servicetalk-opentracing-asynccontext/build.gradle
+++ b/servicetalk-opentracing-asynccontext/build.gradle
@@ -25,8 +25,6 @@ dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
-  testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 }

--- a/servicetalk-opentracing-http/build.gradle
+++ b/servicetalk-opentracing-http/build.gradle
@@ -29,22 +29,19 @@ dependencies {
 
   testImplementation enforcedPlatform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
   testImplementation testFixtures(project(":servicetalk-http-netty"))
-  testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-data-jackson")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-opentracing-asynccontext")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation project(":servicetalk-opentracing-log4j2")
-  testImplementation "org.apache.logging.log4j:log4j-core"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
+  testRuntimeOnly project(":servicetalk-opentracing-log4j2")
   testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl"
 }

--- a/servicetalk-opentracing-log4j2/build.gradle
+++ b/servicetalk-opentracing-log4j2/build.gradle
@@ -32,6 +32,4 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.apache.logging.log4j:log4j-core"
-  testImplementation "org.apache.logging.log4j:log4j-slf4j-impl"
 }

--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -36,17 +36,14 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
-  testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-opentracing-asynccontext")
   testImplementation project(":servicetalk-opentracing-inmemory")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-http-netty")
-  testImplementation project(":servicetalk-utils-internal")
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
 }

--- a/servicetalk-serializer-utils/build.gradle
+++ b/servicetalk-serializer-utils/build.gradle
@@ -26,13 +26,11 @@ dependencies {
 
   testImplementation enforcedPlatform("com.google.protobuf:protobuf-bom:$protobufVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
-  testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
-  testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-buffer-netty")
   testImplementation "com.google.protobuf:protobuf-java"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+
+  testRuntimeOnly testFixtures(project(":servicetalk-concurrent-internal"))
 }

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -16,12 +16,16 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-dependencyAnalysis {
-  issues {
-    // False positives for testFixturesImplementation
-    onUnusedDependencies {
-      exclude("io.netty:netty-transport-native-epoll")
-      exclude("io.netty:netty-transport-native-kqueue")
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        // False positives for testFixturesImplementation
+        onUnusedDependencies {
+          exclude("io.netty:netty-transport-native-epoll")
+          exclude("io.netty:netty-transport-native-kqueue")
+        }
+      }
     }
   }
 }

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -16,7 +16,15 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
+dependencyAnalysis {
+  issues {
+    // False positives for testFixturesImplementation
+    onUnusedDependencies {
+      exclude("io.netty:netty-transport-native-epoll")
+      exclude("io.netty:netty-transport-native-kqueue")
+    }
+  }
+}
 
 dependencies {
   api project(":servicetalk-client-api")
@@ -44,21 +52,12 @@ dependencies {
 
   testFixturesImplementation platform("io.netty:netty-bom:$nettyVersion")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "io.netty:netty-transport"
   testFixturesImplementation "io.netty:netty-transport-native-epoll"
-  testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-x86_64")
-  testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-aarch_64")
   testFixturesImplementation "io.netty:netty-transport-native-kqueue"
-  if (!project.ext.isNettySnapshot) {
-    // Netty doesn't publish snapshots for macos artifacts
-    testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-x86_64")
-    testFixturesRuntimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-aarch_64")
-  }
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/servicetalk-transport-api/build.gradle
+++ b/servicetalk-transport-api/build.gradle
@@ -26,12 +26,10 @@ dependencies {
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -67,10 +67,8 @@ dependencies {
 
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation project(":servicetalk-utils-internal")
-  testFixturesImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -18,6 +18,19 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
 
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        // False positives for testFixturesImplementation
+        onUnusedDependencies {
+          exclude("io.netty.incubator:netty-incubator-transport-native-io_uring")
+        }
+      }
+    }
+  }
+}
+
 dependencies {
   api platform("io.netty:netty-bom:$nettyVersion")
   api project(":servicetalk-buffer-netty")
@@ -67,6 +80,7 @@ dependencies {
 
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation project(":servicetalk-utils-internal")
+  testFixturesImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"


### PR DESCRIPTION
Motivation:

Reduce warnings produced by dependency-analysis-gradle-plugin for test dependencies.

Modifications:

- Remove unused test dependencies;
- Reduce scope to runtime-only for some test dependencies;
- Add exclude rules for false positives;
- Add missed `package-info.java` files for benchmarks module;

Result:

Less warnings for our dependencies.