### PR TITLE
Update OpenTelemetry 1.28.0 -> 1.38.0, instrumentation 1.28.0 -> 1.33.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,8 +69,8 @@ jacksonVersion=2.16.2
 
 openTracingVersion=0.33.0
 zipkinReporterVersion=2.17.2
-opentelemetryVersion=1.41.0
-opentelemetryInstrumentationVersion=1.33.6-alpha
+opentelemetryVersion=1.38.0
+opentelemetryInstrumentationVersion=1.33.3-alpha
 
 # gRPC
 protobufGradlePluginVersion=0.9.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -69,8 +69,8 @@ jacksonVersion=2.16.2
 
 openTracingVersion=0.33.0
 zipkinReporterVersion=2.17.2
-opentelemetryVersion=1.28.0
-opentelemetryInstrumentationVersion=1.28.0-alpha
+opentelemetryVersion=1.41.0
+opentelemetryInstrumentationVersion=1.33.6-alpha
 
 # gRPC
 protobufGradlePluginVersion=0.9.4

--- a/servicetalk-opentelemetry-asynccontext/gradle.lockfile
+++ b/servicetalk-opentelemetry-asynccontext/gradle.lockfile
@@ -2,9 +2,9 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-api:1.41.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-bom:1.41.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-context:1.41.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-api:1.38.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-bom:1.38.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-context:1.38.0=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
 org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-opentelemetry-asynccontext/gradle.lockfile
+++ b/servicetalk-opentelemetry-asynccontext/gradle.lockfile
@@ -2,9 +2,9 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-api:1.28.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-bom:1.28.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-context:1.28.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-api:1.41.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-bom:1.41.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-context:1.41.0=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
 org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-opentelemetry-http/gradle.lockfile
+++ b/servicetalk-opentelemetry-http/gradle.lockfile
@@ -2,16 +2,16 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
-io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:1.33.6-alpha=compileClasspath,runtimeClasspath
-io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.33.6=compileClasspath,runtimeClasspath
-io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.33.6-alpha=compileClasspath,runtimeClasspath
-io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:1.33.6=compileClasspath,runtimeClasspath
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:1.33.3-alpha=compileClasspath,runtimeClasspath
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.33.3=compileClasspath,runtimeClasspath
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.33.3-alpha=compileClasspath,runtimeClasspath
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:1.33.3=compileClasspath,runtimeClasspath
 io.opentelemetry.semconv:opentelemetry-semconv:1.23.1-alpha=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-api-incubator:1.41.0-alpha=runtimeClasspath
-io.opentelemetry:opentelemetry-api:1.41.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-bom-alpha:1.41.0-alpha=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-bom:1.41.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-context:1.41.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-api-incubator:1.38.0-alpha=runtimeClasspath
+io.opentelemetry:opentelemetry-api:1.38.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-bom-alpha:1.38.0-alpha=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-bom:1.38.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-context:1.38.0=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
 org.slf4j:slf4j-api:1.7.36=runtimeClasspath
 empty=annotationProcessor,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-opentelemetry-http/gradle.lockfile
+++ b/servicetalk-opentelemetry-http/gradle.lockfile
@@ -2,16 +2,16 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
-io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:1.28.0-alpha=compileClasspath,runtimeClasspath
-io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.28.0=compileClasspath,runtimeClasspath
-io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.28.0-alpha=compileClasspath,runtimeClasspath
-io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:1.28.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-api:1.28.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-bom-alpha:1.28.0-alpha=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-bom:1.28.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-context:1.28.0=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-extension-incubator:1.28.0-alpha=runtimeClasspath
-io.opentelemetry:opentelemetry-semconv:1.28.0-alpha=compileClasspath,runtimeClasspath
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:1.33.6-alpha=compileClasspath,runtimeClasspath
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.33.6=compileClasspath,runtimeClasspath
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.33.6-alpha=compileClasspath,runtimeClasspath
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:1.33.6=compileClasspath,runtimeClasspath
+io.opentelemetry.semconv:opentelemetry-semconv:1.23.1-alpha=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-api-incubator:1.41.0-alpha=runtimeClasspath
+io.opentelemetry:opentelemetry-api:1.41.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-bom-alpha:1.41.0-alpha=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-bom:1.41.0=compileClasspath,runtimeClasspath
+io.opentelemetry:opentelemetry-context:1.41.0=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
 org.slf4j:slf4j-api:1.7.36=runtimeClasspath
 empty=annotationProcessor,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -44,10 +44,10 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttribut
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.semconv.SemanticAttributes;
 
 import java.util.function.UnaryOperator;
 
-import static io.opentelemetry.semconv.SemanticAttributes.PEER_SERVICE;
 
 /**
  * An HTTP filter that supports <a href="https://opentelemetry.io/docs/instrumentation/java/">open telemetry</a>.
@@ -142,7 +142,7 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryF
         componentName = componentName.trim();
         if (!componentName.isEmpty()) {
             clientInstrumenterBuilder.addAttributesExtractor(
-                    AttributesExtractor.constant(PEER_SERVICE, componentName));
+                    AttributesExtractor.constant(SemanticAttributes.PEER_SERVICE, componentName));
         }
         instrumenter =
                 clientInstrumenterBuilder.buildClientInstrumenter(RequestHeadersPropagatorSetter.INSTANCE);

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -119,10 +119,10 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryF
     OpenTelemetryHttpRequestFilter(final OpenTelemetry openTelemetry, String componentName,
                                    final OpenTelemetryOptions opentelemetryOptions) {
         super(openTelemetry);
-        SpanNameExtractor<HttpRequestMetaData> serverSpanNameExtractor =
-                HttpSpanNameExtractor.create(ServiceTalkHttpAttributesGetter.SERVER_INSTANCE);
+        SpanNameExtractor<HttpRequestMetaData> clientSpanNameExtractor =
+                HttpSpanNameExtractor.create(ServiceTalkHttpAttributesGetter.CLIENT_INSTANCE);
         InstrumenterBuilder<HttpRequestMetaData, HttpResponseMetaData> clientInstrumenterBuilder =
-                Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, serverSpanNameExtractor);
+                Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, clientSpanNameExtractor);
         clientInstrumenterBuilder.setSpanStatusExtractor(ServicetalkSpanStatusExtractor.INSTANCE);
 
         clientInstrumenterBuilder

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -48,7 +48,6 @@ import io.opentelemetry.semconv.SemanticAttributes;
 
 import java.util.function.UnaryOperator;
 
-
 /**
  * An HTTP filter that supports <a href="https://opentelemetry.io/docs/instrumentation/java/">open telemetry</a>.
  * <p>

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
@@ -96,18 +96,20 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryFi
     OpenTelemetryHttpServerFilter(final OpenTelemetry openTelemetry, final OpenTelemetryOptions opentelemetryOptions) {
         super(openTelemetry);
         SpanNameExtractor<HttpRequestMetaData> serverSpanNameExtractor =
-                HttpSpanNameExtractor.create(ServiceTalkHttpAttributesGetter.INSTANCE);
+                HttpSpanNameExtractor.create(ServiceTalkHttpAttributesGetter.SERVER_INSTANCE);
         InstrumenterBuilder<HttpRequestMetaData, HttpResponseMetaData> serverInstrumenterBuilder =
                 Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, serverSpanNameExtractor);
         serverInstrumenterBuilder.setSpanStatusExtractor(ServicetalkSpanStatusExtractor.INSTANCE);
 
         serverInstrumenterBuilder
                 .addAttributesExtractor(HttpServerAttributesExtractor
-                        .builder(ServiceTalkHttpAttributesGetter.INSTANCE, ServiceTalkNetAttributesGetter.INSTANCE)
+                        .builder(ServiceTalkHttpAttributesGetter.SERVER_INSTANCE,
+                                ServiceTalkNetAttributesGetter.SERVER_INSTANCE)
                         .setCapturedRequestHeaders(opentelemetryOptions.capturedRequestHeaders())
                         .setCapturedResponseHeaders(opentelemetryOptions.capturedResponseHeaders())
                         .build())
-                .addAttributesExtractor(NetServerAttributesExtractor.create(ServiceTalkNetAttributesGetter.INSTANCE));
+                .addAttributesExtractor(NetServerAttributesExtractor.create(
+                        ServiceTalkNetAttributesGetter.SERVER_INSTANCE));
         if (opentelemetryOptions.enableMetrics()) {
             serverInstrumenterBuilder.addOperationMetrics(HttpServerMetrics.get());
         }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/ServiceTalkHttpAttributesGetter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/ServiceTalkHttpAttributesGetter.java
@@ -33,33 +33,31 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 
-final class ServiceTalkHttpAttributesGetter implements
-            HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData>,
-            HttpServerAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> {
+abstract class ServiceTalkHttpAttributesGetter {
 
-    static final ServiceTalkHttpAttributesGetter INSTANCE = new ServiceTalkHttpAttributesGetter();
+    static final HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> CLIENT_INSTANCE =
+            new ClientGetter();
+
+    static final HttpServerAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> SERVER_INSTANCE =
+            new ServerGetter();
 
     private ServiceTalkHttpAttributesGetter() {
     }
 
-    @Override
     public String getHttpRequestMethod(final HttpRequestMetaData httpRequestMetaData) {
         return httpRequestMetaData.method().name();
     }
 
-    @Override
     public List<String> getHttpRequestHeader(final HttpRequestMetaData httpRequestMetaData, final String name) {
         return getHeaderValues(httpRequestMetaData.headers(), name);
     }
 
-    @Override
     public Integer getHttpResponseStatusCode(final HttpRequestMetaData httpRequestMetaData,
                                              final HttpResponseMetaData httpResponseMetaData,
                                              @Nullable final Throwable error) {
         return httpResponseMetaData.status().code();
     }
 
-    @Override
     public List<String> getHttpResponseHeader(final HttpRequestMetaData httpRequestMetaData,
                                               final HttpResponseMetaData httpResponseMetaData,
                                               final String name) {
@@ -67,7 +65,6 @@ final class ServiceTalkHttpAttributesGetter implements
     }
 
     @Nullable
-    @Override
     public String getUrlFull(final HttpRequestMetaData request) {
         HostAndPort effectiveHostAndPort = request.effectiveHostAndPort();
         if (effectiveHostAndPort == null) {
@@ -78,18 +75,16 @@ final class ServiceTalkHttpAttributesGetter implements
         return requestScheme + "://" + hostAndPort + '/' + request.requestTarget();
     }
 
-    @Override
     public String getUrlScheme(final HttpRequestMetaData httpRequestMetaData) {
         final String scheme = httpRequestMetaData.scheme();
         return scheme == null ? "http" : scheme;
     }
 
-    @Override
     public String getUrlPath(final HttpRequestMetaData httpRequestMetaData) {
         return httpRequestMetaData.path();
     }
 
-    @Override
+    @Nullable
     public String getUrlQuery(final HttpRequestMetaData httpRequestMetaData) {
         return httpRequestMetaData.query();
     }
@@ -110,5 +105,24 @@ final class ServiceTalkHttpAttributesGetter implements
             result.add(iterator.next().toString());
         }
         return unmodifiableList(result);
+    }
+
+    private static final class ClientGetter extends ServiceTalkHttpAttributesGetter
+            implements HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> {
+        @Nullable
+        @Override
+        public String getServerAddress(HttpRequestMetaData metaData) {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Integer getServerPort(HttpRequestMetaData metaData) {
+            return null;
+        }
+    }
+
+    private static final class ServerGetter extends ServiceTalkHttpAttributesGetter
+            implements HttpServerAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> {
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/ServiceTalkNetAttributesGetter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/ServiceTalkNetAttributesGetter.java
@@ -25,22 +25,21 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributes
 
 import javax.annotation.Nullable;
 
-final class ServiceTalkNetAttributesGetter implements
-            NetClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData>,
-            NetServerAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> {
+abstract class ServiceTalkNetAttributesGetter {
 
-    static final ServiceTalkNetAttributesGetter INSTANCE = new ServiceTalkNetAttributesGetter();
+    static final NetClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> CLIENT_INSTANCE =
+            new ClientGetter();
+    static final NetServerAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> SERVER_INSTANCE =
+            new ServerGetter();
 
     private ServiceTalkNetAttributesGetter() {
     }
 
-    @Override
     public String getNetworkProtocolName(final HttpRequestMetaData request,
                                          @Nullable final HttpResponseMetaData response) {
         return "http";
     }
 
-    @Override
     public String getNetworkProtocolVersion(final HttpRequestMetaData request,
                                             @Nullable final HttpResponseMetaData response) {
         if (response == null) {
@@ -49,7 +48,6 @@ final class ServiceTalkNetAttributesGetter implements
         return response.version().fullVersion();
     }
 
-    @Override
     @Nullable
     public String getServerAddress(final HttpRequestMetaData request) {
         final HostAndPort effectiveHostAndPort = request.effectiveHostAndPort();
@@ -57,16 +55,16 @@ final class ServiceTalkNetAttributesGetter implements
     }
 
     @Nullable
-    @Override
     public Integer getServerPort(final HttpRequestMetaData request) {
         final HostAndPort effectiveHostAndPort = request.effectiveHostAndPort();
         return effectiveHostAndPort != null ? effectiveHostAndPort.port() : null;
     }
 
-    @Nullable
-    @Override
-    public String getNetworkType(final HttpRequestMetaData requestMetaData,
-                                 @Nullable final HttpResponseMetaData metaData) {
-        return NetServerAttributesGetter.super.getNetworkType(requestMetaData, metaData);
+    private static final class ClientGetter extends ServiceTalkNetAttributesGetter implements
+            NetClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> {
+    }
+
+    private static final class ServerGetter extends ServiceTalkNetAttributesGetter implements
+            NetServerAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> {
     }
 }

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilterTest.java
@@ -32,7 +32,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilterTest.java
@@ -34,7 +34,7 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Motivation:

We're experiencing some degree of incompatibility with otel. This is happening because we're using otels alpha API's for the semconv package and they have walked on us.

Modifications:

Upgrade the dependency versions. Note that it seems like the 1.33.3-alpha boms are using the 1.38.0 non-alpha packages, which is odd but that is why the versions for alpha and non-alpha are different.