### PR TITLE
Explicitly declare transitive dependencies that we use directly

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,25 +40,31 @@ slf4jVersion=1.7.36
 
 # Jersey 2
 javaxActivationVersion=1.2.2
+javaxAnnotationsApiVersion=1.3.5
 javaxJaxbApiVersion=2.3.3
 javaxJaxbCoreVersion=2.3.0.1
 javaxJaxbImplVersion=2.3.3
+javaxInjectVersion=2.6.1
 jaxRsVersion=2.1.6
 jerseyVersion=2.41
 
 #Jersey 3.0 - Jakarta EE 9
 javaxActivationVersionEE9=2.0.1
+javaxAnnotationsApiVersionEE9=2.0.0
 javaxJaxbApiVersionEE9=3.0.1
 javaxJaxbCoreVersionEE9=3.0.2
 javaxJaxbImplVersionEE9=3.0.2
+javaxInjectVersionEE9=2.0.1
 jaxRsVersionEE9=3.0.0
 jersey3VersionEE9=3.0.17
 
 #Jersey 3.1 - Jakarta EE 10
 javaxActivationVersionEE10=2.1.3
+javaxAnnotationsApiVersionEE10=2.1.1
 javaxJaxbApiVersionEE10=4.0.2
 javaxJaxbCoreVersionEE10=4.0.5
 javaxJaxbImplVersionEE10=4.0.5
+javaxInjectVersionEE10=2.0.1
 jaxRsVersionEE10=3.1.0
 jersey3VersionEE10=3.1.9
 
@@ -69,8 +75,9 @@ jacksonVersion=2.16.2
 
 openTracingVersion=0.33.0
 zipkinReporterVersion=2.17.2
+zipkinVersion=2.27.0
 opentelemetryVersion=1.38.0
-opentelemetryInstrumentationVersion=1.33.3-alpha
+opentelemetryInstrumentationVersion=1.33.3
 
 # gRPC
 protobufGradlePluginVersion=0.9.4

--- a/servicetalk-benchmarks/build.gradle
+++ b/servicetalk-benchmarks/build.gradle
@@ -22,18 +22,30 @@ plugins {
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  implementation platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-buffer-netty")
+  implementation project(":servicetalk-client-api")
+  implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-context-api")
+  implementation project(":servicetalk-data-jackson")
   implementation project(":servicetalk-http-api")
   implementation project(":servicetalk-http-netty")
-  implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-loadbalancer")
-  implementation project(":servicetalk-data-jackson")
+  implementation project(":servicetalk-serializer-api")
+  implementation project(":servicetalk-transport-api")
+  implementation project(":servicetalk-transport-netty-internal")
+  implementation "com.fasterxml.jackson.core:jackson-core"
+  implementation "com.fasterxml.jackson.core:jackson-databind"
+  implementation "io.netty:netty-buffer"
   implementation "io.netty:netty-codec-http"
+  implementation "io.netty:netty-common"
+  implementation "io.netty:netty-transport"
   implementation "org.openjdk.jmh:jmh-core:$jmhCoreVersion"
 }
 

--- a/servicetalk-circuit-breaker-resilience4j/build.gradle
+++ b/servicetalk-circuit-breaker-resilience4j/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   api "io.github.resilience4j:resilience4j-circuitbreaker:$resilience4jVersion"
 
   implementation project(":servicetalk-annotations")
+  implementation "io.github.resilience4j:resilience4j-core:$resilience4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/servicetalk-client-api-internal/build.gradle
+++ b/servicetalk-client-api-internal/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   api project(":servicetalk-concurrent-api")
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/servicetalk-client-api/build.gradle
+++ b/servicetalk-client-api/build.gradle
@@ -18,9 +18,11 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-context-api")
   api project(":servicetalk-transport-api")
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/servicetalk-concurrent-api-internal/build.gradle
+++ b/servicetalk-concurrent-api-internal/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-oio-api")
 
@@ -31,8 +32,9 @@ dependencies {
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-buffer-netty")
-  testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-concurrent-test-internal")
+  testImplementation project(":servicetalk-context-api")
+  testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-concurrent-api-test/build.gradle
+++ b/servicetalk-concurrent-api-test/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
 
   implementation project(":servicetalk-annotations")
@@ -27,6 +28,7 @@ dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
+  testImplementation project(":servicetalk-context-api")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -34,6 +34,8 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
+  testFixturesApi project(":servicetalk-concurrent")
+
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation project(":servicetalk-concurrent-internal")
   testFixturesImplementation project(":servicetalk-utils-internal")

--- a/servicetalk-concurrent-jdkflow/build.gradle
+++ b/servicetalk-concurrent-jdkflow/build.gradle
@@ -37,6 +37,7 @@ compileTestJava {
 }
 
 dependencies {
+    api project(":servicetalk-concurrent")
     api project(":servicetalk-concurrent-api")
 
     implementation project(":servicetalk-annotations")

--- a/servicetalk-concurrent-reactivestreams/build.gradle
+++ b/servicetalk-concurrent-reactivestreams/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
   api "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
 
@@ -28,12 +29,16 @@ dependencies {
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
+  testImplementation project(":servicetalk-buffer-api")
+  testImplementation project(":servicetalk-serializer-api")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.testng:testng:$testngVersion"
 
+  testFixturesApi project(":servicetalk-concurrent-api")
+  testFixturesApi "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
   testFixturesApi "org.reactivestreams:reactive-streams-tck:$reactiveStreamsVersion"
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
 }

--- a/servicetalk-data-jackson-jersey/build.gradle
+++ b/servicetalk-data-jackson-jersey/build.gradle
@@ -17,24 +17,36 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 def actualJerseyVersion = "${jerseyVersion}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersion}"
+def actualJavaxInjectVersion = "${javaxInjectVersion}"
 def actualJaxRsVersion = "${jaxRsVersion}"
 
 // Dependencies must remain consistent between servicetalk-data-jackson-jerseyX modules
 dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
+  api platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   api project(":servicetalk-data-jackson")
+  api "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion" // Priority
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion" // MediaType, Feature
+  api "com.fasterxml.jackson.core:jackson-databind" // ObjectMapper
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-buffer-netty")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-api")
   implementation project(":servicetalk-http-router-jersey")
   implementation project(":servicetalk-http-router-jersey-internal")
   implementation project(":servicetalk-http-utils")
+  implementation project(":servicetalk-serialization-api")
+  implementation project(":servicetalk-serializer-api")
+  implementation project(":servicetalk-transport-api")
   implementation project(":servicetalk-transport-netty")
+  implementation "com.fasterxml.jackson.core:jackson-core"
+  implementation "org.glassfish.hk2.external:jakarta.inject:$actualJavaxInjectVersion"
   implementation "org.glassfish.jersey.core:jersey-server"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-data-jackson-jersey3-jakarta10/build.gradle
+++ b/servicetalk-data-jackson-jersey3-jakarta10/build.gradle
@@ -77,24 +77,36 @@ afterEvaluate {
 }
 
 def actualJerseyVersion = "${jersey3VersionEE10}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE10}"
+def actualJavaxInjectVersion = "${javaxInjectVersionEE10}"
 def actualJaxRsVersion = "${jaxRsVersionEE10}"
 
 // Dependencies must remain consistent between servicetalk-data-jackson-jerseyX modules
 dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
+  api platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   api project(":servicetalk-data-jackson")
+  api "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion" // Priority
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion" // MediaType, Feature
+  api "com.fasterxml.jackson.core:jackson-databind" // ObjectMapper
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-buffer-netty")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-api")
   implementation project(":servicetalk-http-router-jersey3-jakarta10")
   implementation project(":servicetalk-http-router-jersey3-jakarta10-internal")
   implementation project(":servicetalk-http-utils")
+  implementation project(":servicetalk-serialization-api")
+  implementation project(":servicetalk-serializer-api")
+  implementation project(":servicetalk-transport-api")
   implementation project(":servicetalk-transport-netty")
+  implementation "com.fasterxml.jackson.core:jackson-core"
+  implementation "jakarta.inject:jakarta.inject-api:$actualJavaxInjectVersion"
   implementation "org.glassfish.jersey.core:jersey-server"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-data-jackson-jersey3-jakarta9/build.gradle
+++ b/servicetalk-data-jackson-jersey3-jakarta9/build.gradle
@@ -77,24 +77,36 @@ afterEvaluate {
 }
 
 def actualJerseyVersion = "${jersey3VersionEE9}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE9}"
+def actualJavaxInjectVersion = "${javaxInjectVersionEE9}"
 def actualJaxRsVersion = "${jaxRsVersionEE9}"
 
 // Dependencies must remain consistent between servicetalk-data-jackson-jerseyX modules
 dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
+  api platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   api project(":servicetalk-data-jackson")
+  api "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion" // Priority
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion" // MediaType, Feature
+  api "com.fasterxml.jackson.core:jackson-databind" // ObjectMapper
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-buffer-netty")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-api")
   implementation project(":servicetalk-http-router-jersey3-jakarta9")
   implementation project(":servicetalk-http-router-jersey3-jakarta9-internal")
   implementation project(":servicetalk-http-utils")
+  implementation project(":servicetalk-serialization-api")
+  implementation project(":servicetalk-serializer-api")
+  implementation project(":servicetalk-transport-api")
   implementation project(":servicetalk-transport-netty")
+  implementation "com.fasterxml.jackson.core:jackson-core"
+  implementation "jakarta.inject:jakarta.inject-api:$actualJavaxInjectVersion"
   implementation "org.glassfish.jersey.core:jersey-server"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-data-jackson/build.gradle
+++ b/servicetalk-data-jackson/build.gradle
@@ -18,11 +18,15 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
+  api project(":servicetalk-buffer-api")
   api project(":servicetalk-serialization-api")
   api project(":servicetalk-serializer-api")
+  api "com.fasterxml.jackson.core:jackson-core"
   api "com.fasterxml.jackson.core:jackson-databind"
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")

--- a/servicetalk-data-protobuf-jersey/build.gradle
+++ b/servicetalk-data-protobuf-jersey/build.gradle
@@ -24,17 +24,22 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 apply plugin: "com.google.protobuf"
 
 def actualJerseyVersion = "${jerseyVersion}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersion}"
+def actualJavaxInjectVersion = "${javaxInjectVersion}"
 def actualJaxRsVersion = "${jaxRsVersion}"
 
 // Dependencies must remain consistent between servicetalk-data-protobuf-jerseyX modules
 dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
+  api "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion" // Priority
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion" // MediaType, Feature
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation platform("com.google.protobuf:protobuf-bom:$protobufVersion")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-buffer-netty")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-data-protobuf")
@@ -42,8 +47,11 @@ dependencies {
   implementation project(":servicetalk-http-router-jersey")
   implementation project(":servicetalk-http-router-jersey-internal")
   implementation project(":servicetalk-http-utils")
+  implementation project(":servicetalk-serializer-api")
+  implementation project(":servicetalk-transport-api")
   implementation project(":servicetalk-transport-netty")
   implementation "com.google.protobuf:protobuf-java"
+  implementation "org.glassfish.hk2.external:jakarta.inject:$actualJavaxInjectVersion"
   implementation "org.glassfish.jersey.core:jersey-server"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-data-protobuf-jersey3-jakarta10/build.gradle
+++ b/servicetalk-data-protobuf-jersey3-jakarta10/build.gradle
@@ -85,17 +85,22 @@ afterEvaluate {
 }
 
 def actualJerseyVersion = "${jersey3VersionEE10}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE10}"
+def actualJavaxInjectVersion = "${javaxInjectVersionEE10}"
 def actualJaxRsVersion = "${jaxRsVersionEE10}"
 
 // Dependencies must remain consistent between servicetalk-data-protobuf-jerseyX modules
 dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
+  api "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion" // Priority
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion" // MediaType, Feature
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation platform("com.google.protobuf:protobuf-bom:$protobufVersion")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-buffer-netty")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-data-protobuf")
@@ -103,8 +108,11 @@ dependencies {
   implementation project(":servicetalk-http-router-jersey3-jakarta10")
   implementation project(":servicetalk-http-router-jersey3-jakarta10-internal")
   implementation project(":servicetalk-http-utils")
+  implementation project(":servicetalk-serializer-api")
+  implementation project(":servicetalk-transport-api")
   implementation project(":servicetalk-transport-netty")
   implementation "com.google.protobuf:protobuf-java"
+  implementation "jakarta.inject:jakarta.inject-api:$actualJavaxInjectVersion"
   implementation "org.glassfish.jersey.core:jersey-server"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-data-protobuf-jersey3-jakarta9/build.gradle
+++ b/servicetalk-data-protobuf-jersey3-jakarta9/build.gradle
@@ -85,22 +85,22 @@ afterEvaluate {
 }
 
 def actualJerseyVersion = "${jersey3VersionEE9}"
-def actualJavaxActivationVersion = "${javaxActivationVersionEE9}"
-def actualJavaxJaxbApiVersion = "${javaxJaxbApiVersionEE9}"
-def actualJavaxJaxbCoreVersion = "${javaxJaxbCoreVersionEE9}"
-def actualJavaxJaxbImplVersion = "${javaxJaxbImplVersionEE9}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE9}"
+def actualJavaxInjectVersion = "${javaxInjectVersionEE9}"
 def actualJaxRsVersion = "${jaxRsVersionEE9}"
-
 
 // Dependencies must remain consistent between servicetalk-data-protobuf-jerseyX modules
 dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
+  api "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion" // Priority
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion" // MediaType, Feature
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation platform("com.google.protobuf:protobuf-bom:$protobufVersion")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-buffer-netty")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-data-protobuf")
@@ -108,8 +108,11 @@ dependencies {
   implementation project(":servicetalk-http-router-jersey3-jakarta9")
   implementation project(":servicetalk-http-router-jersey3-jakarta9-internal")
   implementation project(":servicetalk-http-utils")
+  implementation project(":servicetalk-serializer-api")
+  implementation project(":servicetalk-transport-api")
   implementation project(":servicetalk-transport-netty")
   implementation "com.google.protobuf:protobuf-java"
+  implementation "jakarta.inject:jakarta.inject-api:$actualJavaxInjectVersion"
   implementation "org.glassfish.jersey.core:jersey-server"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -28,8 +28,10 @@ dependencies {
   api platform("com.google.protobuf:protobuf-bom:$protobufVersion")
   api platform("io.netty:netty-bom:$nettyVersion")
   api platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion")
-  api platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:" +
+  api platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:" +
       "$opentelemetryInstrumentationVersion")
+  api platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:" +
+      "$opentelemetryInstrumentationVersion-alpha")
   api platform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   api platform("org.glassfish.jersey:jersey-bom:$jerseyVersion")
 

--- a/servicetalk-dns-discovery-netty/build.gradle
+++ b/servicetalk-dns-discovery-netty/build.gradle
@@ -18,13 +18,31 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
 
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        // These are transitive dependencies of "org.apache.directory.server:apacheds-protocol-dns" and we don't want to
+        // manage them manually because they are only used by testImplementation scope.
+        onUsedTransitiveDependencies {
+          exclude("org.apache.directory.server:apacheds-protocol-shared")
+          exclude("org.apache.mina:mina-core")
+        }
+      }
+    }
+  }
+}
+
 dependencies {
   api project(":servicetalk-client-api")
+  api project(":servicetalk-transport-api")
 
   implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-concurrent")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
+  implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-transport-netty")
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-utils-internal")

--- a/servicetalk-encoding-api-internal/build.gradle
+++ b/servicetalk-encoding-api-internal/build.gradle
@@ -17,7 +17,10 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+    api project(":servicetalk-buffer-api")
     api project(":servicetalk-encoding-api")
+    api project(":servicetalk-serializer-api")
 
     implementation project(":servicetalk-annotations")
+    implementation project(":servicetalk-concurrent-api")
 }

--- a/servicetalk-encoding-api/build.gradle
+++ b/servicetalk-encoding-api/build.gradle
@@ -22,7 +22,9 @@ dependencies {
     api project(":servicetalk-serializer-api")
 
     implementation project(":servicetalk-annotations")
+    implementation project(":servicetalk-concurrent")
     implementation project(":servicetalk-concurrent-internal")
+    implementation project(":servicetalk-oio-api")
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")

--- a/servicetalk-encoding-netty/build.gradle
+++ b/servicetalk-encoding-netty/build.gradle
@@ -17,15 +17,20 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+    api project(":servicetalk-buffer-api")
     api project(":servicetalk-encoding-api")
+    api project(":servicetalk-serializer-api")
 
     implementation platform("io.netty:netty-bom:$nettyVersion")
     implementation project(":servicetalk-annotations")
     implementation project(":servicetalk-buffer-netty")
+    implementation project(":servicetalk-concurrent")
+    implementation project(":servicetalk-concurrent-api")
     implementation project(":servicetalk-concurrent-internal")
     implementation project(":servicetalk-utils-internal")
     implementation "io.netty:netty-buffer"
     implementation "io.netty:netty-codec"
+    implementation "io.netty:netty-common"
     implementation "io.netty:netty-transport"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-grpc-api/build.gradle
+++ b/servicetalk-grpc-api/build.gradle
@@ -17,15 +17,22 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-context-api")
+  api project(":servicetalk-encoding-api")
   api project(":servicetalk-http-api")
+  api project(":servicetalk-oio-api")
   api project(":servicetalk-router-api")
+  api project(":servicetalk-serializer-api")
+  api project(":servicetalk-transport-api")
   api ("com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion") {
     exclude group: "com.google.protobuf"
   }
 
   implementation platform("com.google.protobuf:protobuf-bom:$protobufVersion")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-encoding-api-internal")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")

--- a/servicetalk-grpc-health/build.gradle
+++ b/servicetalk-grpc-health/build.gradle
@@ -24,15 +24,25 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 apply plugin: "com.google.protobuf"
 
 dependencies {
-  api project(":servicetalk-grpc-api") // generated code is exposed
+  api platform("com.google.protobuf:protobuf-bom:$protobufVersion")
+  api project(":servicetalk-grpc-api")
+  api project(":servicetalk-concurrent")
+  api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-encoding-api")
+  api project(":servicetalk-router-api")
+  api "com.google.protobuf:protobuf-java"
+
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-data-protobuf")
   implementation project(":servicetalk-grpc-netty")
-  implementation project(":servicetalk-grpc-protoc")
   implementation project(":servicetalk-grpc-protobuf")
+  implementation project(":servicetalk-grpc-protoc")
+  implementation project(":servicetalk-serializer-api")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
+  testImplementation project(":servicetalk-transport-api")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/servicetalk-grpc-internal/build.gradle
+++ b/servicetalk-grpc-internal/build.gradle
@@ -17,9 +17,11 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api project(":servicetalk-context-api")
   api project(":servicetalk-http-api")
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-utils-internal")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -31,50 +31,73 @@ afterEvaluate {
         onUnusedDependencies {
           exclude(":servicetalk-http-utils")
         }
+        // This is a transitive dependency of "io.grpc:grpc-stub" and we don't want to manage it manually because
+        // it's only used by testImplementation scope.
+        onUsedTransitiveDependencies {
+          exclude("com.google.guava:guava")
+        }
       }
     }
   }
 }
 
 dependencies {
+  api project(":servicetalk-client-api")
   api project(":servicetalk-grpc-api")
   api project(":servicetalk-grpc-utils")
   api project(":servicetalk-http-netty")
+  api project(":servicetalk-transport-api")
 
   compileOnly project(":servicetalk-http-utils") // only for javadoc references
 
   implementation platform("com.google.protobuf:protobuf-bom:$protobufVersion")
-  implementation project(":servicetalk-grpc-internal")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
+  implementation project(":servicetalk-concurrent-api")
+  implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-context-api")
+  implementation project(":servicetalk-grpc-internal")
+  implementation project(":servicetalk-http-api")
   implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-utils-internal")
-  implementation project(":servicetalk-concurrent-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   implementation "com.google.protobuf:protobuf-java"
 
   testImplementation enforcedPlatform("io.grpc:grpc-bom:$grpcVersion")
+  testImplementation enforcedPlatform("io.netty:netty-bom:$nettyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-buffer-api"))
   testImplementation testFixtures(project(":servicetalk-http-netty"))
+  testImplementation project(":servicetalk-buffer-netty")
+  testImplementation project(":servicetalk-concurrent")
   testImplementation project(":servicetalk-concurrent-api-internal")
   testImplementation project(":servicetalk-concurrent-test-internal")
+  testImplementation project(":servicetalk-data-protobuf")
+  testImplementation project(":servicetalk-encoding-api")
   testImplementation project(":servicetalk-encoding-netty")
   testImplementation project(":servicetalk-grpc-protobuf")
-  testImplementation project(":servicetalk-http-utils")
-  testImplementation project(":servicetalk-data-protobuf")
   testImplementation project(":servicetalk-grpc-protoc")
+  testImplementation project(":servicetalk-http-utils")
+  testImplementation project(":servicetalk-logging-api")
+  testImplementation project(":servicetalk-router-api")
   testImplementation project(":servicetalk-router-utils-internal")
+  testImplementation project(":servicetalk-serializer-api")
+  testImplementation project(":servicetalk-serializer-utils")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-transport-netty")
-  testImplementation project(":servicetalk-serializer-utils")
+  testImplementation "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
+  testImplementation "io.grpc:grpc-api"
   testImplementation("io.grpc:grpc-netty") {
     exclude group: "io.netty"
   }
   testImplementation "io.grpc:grpc-protobuf"
   testImplementation "io.grpc:grpc-stub"
+  testImplementation "io.netty:netty-common"
+  testImplementation "io.netty:netty-handler"
+  testImplementation "io.netty:netty-transport"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-grpc-protobuf/build.gradle
+++ b/servicetalk-grpc-protobuf/build.gradle
@@ -27,14 +27,20 @@ ideaModule.dependsOn "generateTestProto"
 
 dependencies {
   api platform("com.google.protobuf:protobuf-bom:$protobufVersion")
+  api project(":servicetalk-encoding-api")
   api project(":servicetalk-grpc-api")
   api "com.google.protobuf:protobuf-java"
   api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-buffer-netty")
-  implementation project(":servicetalk-serializer-api")
+  implementation project(":servicetalk-concurrent")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-data-protobuf")
+  implementation project(":servicetalk-http-api")
+  implementation project(":servicetalk-serialization-api")
+  implementation project(":servicetalk-serializer-api")
   implementation project(":servicetalk-serializer-utils")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -27,11 +27,18 @@ dependencies {
 
   compileOnly "com.squareup:javapoet:$javaPoetVersion"
 
+  implementation platform("com.google.protobuf:protobuf-bom:$protobufVersion")
   implementation project(":servicetalk-annotations")
+  implementation "com.google.protobuf:protobuf-java"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testImplementation project(":servicetalk-concurrent")
+  testImplementation project(":servicetalk-concurrent-api")
+  testImplementation project(":servicetalk-encoding-api")
   testImplementation project(":servicetalk-grpc-api")
   testImplementation project(":servicetalk-grpc-protobuf")
+  testImplementation project(":servicetalk-router-api")
+  testImplementation project(":servicetalk-serializer-api")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 

--- a/servicetalk-grpc-utils/build.gradle
+++ b/servicetalk-grpc-utils/build.gradle
@@ -18,9 +18,13 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api project(":servicetalk-grpc-api")
+  api project(":servicetalk-logging-api")
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
+  implementation project(":servicetalk-http-api")
   implementation project(":servicetalk-logging-slf4j-internal")
+  implementation project(":servicetalk-transport-api")
   implementation project(":servicetalk-utils-internal")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")

--- a/servicetalk-http-api/build.gradle
+++ b/servicetalk-http-api/build.gradle
@@ -19,14 +19,15 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   api project(":servicetalk-buffer-api")
   api project(":servicetalk-client-api")
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-context-api")
+  api project(":servicetalk-encoding-api")
   api project(":servicetalk-logging-api")
+  api project(":servicetalk-oio-api")
   api project(":servicetalk-serialization-api")
   api project(":servicetalk-serializer-api")
   api project(":servicetalk-transport-api")
-  api project(":servicetalk-oio-api")
-  api project(":servicetalk-encoding-api")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")
@@ -37,6 +38,7 @@ dependencies {
   implementation project(":servicetalk-oio-api-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
+  testImplementation enforcedPlatform("io.netty:netty-bom:$nettyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-buffer-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
@@ -47,11 +49,17 @@ dependencies {
   testImplementation project(":servicetalk-encoding-netty")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-transport-netty-internal")
+  testImplementation "io.netty:netty-codec"
+  testImplementation "io.netty:netty-common"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
+
+  testFixturesApi project(":servicetalk-buffer-api")
+  testFixturesApi project(":servicetalk-concurrent-api")
+  testFixturesApi project(":servicetalk-transport-api")
 
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -30,15 +30,21 @@ afterEvaluate {
 }
 
 dependencies {
+  api project(":servicetalk-client-api")
   api project(":servicetalk-concurrent-api")
-  api project(":servicetalk-logging-api")
+  api project(":servicetalk-context-api")
   api project(":servicetalk-http-api")
+  api project(":servicetalk-logging-api")
+  api project(":servicetalk-transport-api")
 
   implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
+  implementation project(":servicetalk-buffer-netty")
   implementation project(":servicetalk-client-api-internal")
-  implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-api-internal")
+  implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-dns-discovery-netty")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-loadbalancer")
@@ -57,6 +63,7 @@ dependencies {
   implementation "io.netty:netty-transport"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
+  testImplementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-buffer-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
@@ -68,19 +75,31 @@ dependencies {
   testImplementation project(":servicetalk-concurrent-api-test")
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-data-jackson")
+  testImplementation project(":servicetalk-encoding-api")
   testImplementation project(":servicetalk-encoding-api-internal")
   testImplementation project(":servicetalk-encoding-netty")
+  testImplementation project(":servicetalk-oio-api")
+  testImplementation project(":servicetalk-serializer-api")
   testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-utils-internal")
+  testImplementation "com.fasterxml.jackson.core:jackson-core"
+  testImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$nettyIoUringVersion"
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
+  testImplementation "org.junit.platform:junit-platform-commons:$junitPlatformVersion"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
   testImplementation "org.testng:testng:$testngVersion"
 
+  testFixturesApi project(":servicetalk-context-api")
+  testFixturesApi project(":servicetalk-http-api")
+  testFixturesApi project(":servicetalk-transport-api")
+
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testFixturesImplementation project(":servicetalk-buffer-api")
+  testFixturesImplementation project(":servicetalk-concurrent")
   testFixturesImplementation project(":servicetalk-http-utils")
   testFixturesImplementation project(":servicetalk-test-resources")
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"

--- a/servicetalk-http-router-jersey-internal/build.gradle
+++ b/servicetalk-http-router-jersey-internal/build.gradle
@@ -21,6 +21,9 @@ def actualJaxRsVersion = "${jaxRsVersion}"
 
 // Dependencies must remain consistent between servicetalk-http-router-jerseyX-internal modules
 dependencies {
+  api project(":servicetalk-buffer-api")
+  api project(":servicetalk-concurrent")
+  api project(":servicetalk-concurrent-api")
   api project(":servicetalk-http-api")
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
 
@@ -29,5 +32,6 @@ dependencies {
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-utils")
+  implementation project(":servicetalk-transport-api")
   implementation "org.glassfish.jersey.core:jersey-common"
 }

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -31,9 +31,11 @@ afterEvaluate {
 
 def actualJerseyVersion = "${jerseyVersion}"
 def actualJavaxActivationVersion = "${javaxActivationVersion}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersion}"
 def actualJavaxJaxbApiVersion = "${javaxJaxbApiVersion}"
 def actualJavaxJaxbCoreVersion = "${javaxJaxbCoreVersion}"
 def actualJavaxJaxbImplVersion = "${javaxJaxbImplVersion}"
+def actualJavaxInjectVersion = "${javaxInjectVersion}"
 def actualJaxRsVersion = "${jaxRsVersion}"
 
 // Dependencies must remain consistent between servicetalk-http-router-jerseyX modules
@@ -41,10 +43,15 @@ dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   api project(":servicetalk-http-api")
   api project(":servicetalk-router-api")
+  api project(":servicetalk-transport-api")
+  api "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion" // Priority
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
+  implementation project(":servicetalk-concurrent")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-data-jackson")
@@ -55,6 +62,7 @@ dependencies {
   implementation "com.sun.activation:jakarta.activation:$actualJavaxActivationVersion"
   implementation "com.sun.xml.bind:jaxb-core:$actualJavaxJaxbCoreVersion"
   implementation "jakarta.xml.bind:jakarta.xml.bind-api:$actualJavaxJaxbApiVersion"
+  implementation "org.glassfish.hk2.external:jakarta.inject:$actualJavaxInjectVersion"
   implementation "org.glassfish.jersey.core:jersey-server"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
@@ -66,24 +74,40 @@ dependencies {
 
   testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson"
 
+  testFixturesApi project(":servicetalk-buffer-api")
+  testFixturesApi project(":servicetalk-concurrent-api")
+  testFixturesApi project(":servicetalk-http-api")
+  testFixturesApi project(":servicetalk-router-api")
+  testFixturesApi project(":servicetalk-transport-api")
+  testFixturesApi "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion"
+  testFixturesApi "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
+  testFixturesApi "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
+
+  testFixturesImplementation platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testFixturesImplementation testFixtures(project(":servicetalk-http-netty"))
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testFixturesImplementation project(":servicetalk-buffer-netty")
+  testFixturesImplementation project(":servicetalk-concurrent")
+  testFixturesImplementation project(":servicetalk-context-api")
   testFixturesImplementation project(":servicetalk-data-jackson")
   testFixturesImplementation project(":servicetalk-http-netty")
   testFixturesImplementation project(":servicetalk-http-router-predicate")
   testFixturesImplementation project(":servicetalk-router-utils-internal")
   testFixturesImplementation project(":servicetalk-test-resources")
   testFixturesImplementation project(":servicetalk-transport-netty-internal")
-  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
+  testFixturesImplementation project(":servicetalk-serializer-api")
+  testFixturesImplementation "com.fasterxml.jackson.core:jackson-core"
+  testFixturesImplementation "com.fasterxml.jackson.core:jackson-databind"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
+  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
+  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
   testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
-  testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 

--- a/servicetalk-http-router-jersey3-jakarta10-internal/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10-internal/build.gradle
@@ -76,6 +76,9 @@ def actualJaxRsVersion = "${jaxRsVersionEE10}"
 
 // Dependencies must remain consistent between servicetalk-http-router-jerseyX-internal modules
 dependencies {
+  api project(":servicetalk-buffer-api")
+  api project(":servicetalk-concurrent")
+  api project(":servicetalk-concurrent-api")
   api project(":servicetalk-http-api")
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
 
@@ -84,5 +87,6 @@ dependencies {
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-utils")
+  implementation project(":servicetalk-transport-api")
   implementation "org.glassfish.jersey.core:jersey-common"
 }

--- a/servicetalk-http-router-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10/build.gradle
@@ -93,9 +93,11 @@ afterEvaluate {
 
 def actualJerseyVersion = "${jersey3VersionEE10}"
 def actualJavaxActivationVersion = "${javaxActivationVersionEE10}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE10}"
 def actualJavaxJaxbApiVersion = "${javaxJaxbApiVersionEE10}"
 def actualJavaxJaxbCoreVersion = "${javaxJaxbCoreVersionEE10}"
 def actualJavaxJaxbImplVersion = "${javaxJaxbImplVersionEE10}"
+def actualJavaxInjectVersion = "${javaxInjectVersionEE10}"
 def actualJaxRsVersion = "${jaxRsVersionEE10}"
 
 // Dependencies must remain consistent between servicetalk-http-router-jerseyX modules
@@ -103,10 +105,15 @@ dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   api project(":servicetalk-http-api")
   api project(":servicetalk-router-api")
+  api project(":servicetalk-transport-api")
+  api "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion" // Priority
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
+  implementation project(":servicetalk-concurrent")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-data-jackson")
@@ -115,6 +122,7 @@ dependencies {
   implementation project(":servicetalk-router-utils-internal")
   implementation project(":servicetalk-utils-internal")
   implementation "jakarta.activation:jakarta.activation-api:$actualJavaxActivationVersion" // replacement for com.sun.activation:jakarta.activation
+  implementation "jakarta.inject:jakarta.inject-api:$actualJavaxInjectVersion" // replacement for org.glassfish.hk2.external:jakarta.inject
   implementation "org.glassfish.jaxb:jaxb-core:$actualJavaxJaxbCoreVersion" // replacement for com.sun.xml.bind:jaxb-core
   implementation "jakarta.xml.bind:jakarta.xml.bind-api:$actualJavaxJaxbApiVersion"
   implementation "org.glassfish.jersey.core:jersey-server"
@@ -128,24 +136,40 @@ dependencies {
 
   testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson"
 
+  testFixturesApi project(":servicetalk-buffer-api")
+  testFixturesApi project(":servicetalk-concurrent-api")
+  testFixturesApi project(":servicetalk-http-api")
+  testFixturesApi project(":servicetalk-router-api")
+  testFixturesApi project(":servicetalk-transport-api")
+  testFixturesApi "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion"
+  testFixturesApi "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
+  testFixturesApi "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
+
+  testFixturesImplementation platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testFixturesImplementation testFixtures(project(":servicetalk-http-netty"))
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testFixturesImplementation project(":servicetalk-buffer-netty")
+  testFixturesImplementation project(":servicetalk-concurrent")
+  testFixturesImplementation project(":servicetalk-context-api")
   testFixturesImplementation project(":servicetalk-data-jackson")
   testFixturesImplementation project(":servicetalk-http-netty")
   testFixturesImplementation project(":servicetalk-http-router-predicate")
   testFixturesImplementation project(":servicetalk-router-utils-internal")
+  testFixturesImplementation project(":servicetalk-serializer-api")
   testFixturesImplementation project(":servicetalk-test-resources")
   testFixturesImplementation project(":servicetalk-transport-netty-internal")
-  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
+  testFixturesImplementation "com.fasterxml.jackson.core:jackson-core"
+  testFixturesImplementation "com.fasterxml.jackson.core:jackson-databind"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
+  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
+  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
   testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
-  testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 

--- a/servicetalk-http-router-jersey3-jakarta9-internal/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9-internal/build.gradle
@@ -76,6 +76,9 @@ def actualJaxRsVersion = "${jaxRsVersionEE9}"
 
 // Dependencies must remain consistent between servicetalk-http-router-jerseyX-internal modules
 dependencies {
+  api project(":servicetalk-buffer-api")
+  api project(":servicetalk-concurrent")
+  api project(":servicetalk-concurrent-api")
   api project(":servicetalk-http-api")
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
 
@@ -84,5 +87,6 @@ dependencies {
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-utils")
+  implementation project(":servicetalk-transport-api")
   implementation "org.glassfish.jersey.core:jersey-common"
 }

--- a/servicetalk-http-router-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9/build.gradle
@@ -93,9 +93,11 @@ afterEvaluate {
 
 def actualJerseyVersion = "${jersey3VersionEE9}"
 def actualJavaxActivationVersion = "${javaxActivationVersionEE9}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE9}"
 def actualJavaxJaxbApiVersion = "${javaxJaxbApiVersionEE9}"
 def actualJavaxJaxbCoreVersion = "${javaxJaxbCoreVersionEE9}"
 def actualJavaxJaxbImplVersion = "${javaxJaxbImplVersionEE9}"
+def actualJavaxInjectVersion = "${javaxInjectVersionEE9}"
 def actualJaxRsVersion = "${jaxRsVersionEE9}"
 
 // Dependencies must remain consistent between servicetalk-http-router-jerseyX modules
@@ -103,10 +105,15 @@ dependencies {
   api platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   api project(":servicetalk-http-api")
   api project(":servicetalk-router-api")
+  api project(":servicetalk-transport-api")
+  api "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion" // Priority
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
   api "org.glassfish.jersey.core:jersey-common" // AutoDiscoverable
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
+  implementation project(":servicetalk-concurrent")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-data-jackson")
@@ -115,6 +122,7 @@ dependencies {
   implementation project(":servicetalk-router-utils-internal")
   implementation project(":servicetalk-utils-internal")
   implementation "com.sun.activation:jakarta.activation:$actualJavaxActivationVersion"
+  implementation "jakarta.inject:jakarta.inject-api:$actualJavaxInjectVersion" // replacement for org.glassfish.hk2.external:jakarta.inject
   implementation "org.glassfish.jaxb:jaxb-core:$actualJavaxJaxbCoreVersion" // replacement for com.sun.xml.bind:jaxb-core
   implementation "jakarta.xml.bind:jakarta.xml.bind-api:$actualJavaxJaxbApiVersion"
   implementation "org.glassfish.jersey.core:jersey-server"
@@ -128,24 +136,40 @@ dependencies {
 
   testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson"
 
+  testFixturesApi project(":servicetalk-buffer-api")
+  testFixturesApi project(":servicetalk-concurrent-api")
+  testFixturesApi project(":servicetalk-http-api")
+  testFixturesApi project(":servicetalk-router-api")
+  testFixturesApi project(":servicetalk-transport-api")
+  testFixturesApi "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion"
+  testFixturesApi "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
+  testFixturesApi "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
+
+  testFixturesImplementation platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testFixturesImplementation testFixtures(project(":servicetalk-http-netty"))
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testFixturesImplementation project(":servicetalk-buffer-netty")
+  testFixturesImplementation project(":servicetalk-concurrent")
+  testFixturesImplementation project(":servicetalk-context-api")
   testFixturesImplementation project(":servicetalk-data-jackson")
   testFixturesImplementation project(":servicetalk-http-netty")
   testFixturesImplementation project(":servicetalk-http-router-predicate")
   testFixturesImplementation project(":servicetalk-router-utils-internal")
+  testFixturesImplementation project(":servicetalk-serializer-api")
   testFixturesImplementation project(":servicetalk-test-resources")
   testFixturesImplementation project(":servicetalk-transport-netty-internal")
-  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
+  testFixturesImplementation "com.fasterxml.jackson.core:jackson-core"
+  testFixturesImplementation "com.fasterxml.jackson.core:jackson-databind"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
+  testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
+  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
+  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
   testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
-  testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 

--- a/servicetalk-http-router-predicate/build.gradle
+++ b/servicetalk-http-router-predicate/build.gradle
@@ -18,18 +18,22 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api project(":servicetalk-http-api")
+  api project(":servicetalk-transport-api")
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent-api")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-http-api"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testImplementation project(":servicetalk-buffer-api")
   testImplementation project(":servicetalk-buffer-netty")
+  testImplementation project(":servicetalk-concurrent")
   testImplementation project(":servicetalk-http-netty")
-  testImplementation project(":servicetalk-transport-netty")
   testImplementation project(":servicetalk-test-resources")
+  testImplementation project(":servicetalk-transport-netty")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-http-security-jersey/build.gradle
+++ b/servicetalk-http-security-jersey/build.gradle
@@ -17,22 +17,28 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 def actualJerseyVersion = "${jerseyVersion}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersion}"
 def actualJaxRsVersion = "${jaxRsVersion}"
 
 // Dependencies must remain consistent between servicetalk-http-security-jerseyX modules
 dependencies {
+  api project(":servicetalk-context-api")
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
 
   implementation platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
+  implementation "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion"
   implementation "org.glassfish.jersey.core:jersey-common"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testImplementation project(":servicetalk-buffer-api")
+  testImplementation project(":servicetalk-http-api")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-http-router-jersey")
   testImplementation project(":servicetalk-http-utils")
+  testImplementation project(":servicetalk-transport-api")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "net.javacrumbs.json-unit:json-unit-fluent:$jsonUnitVersion"

--- a/servicetalk-http-security-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-security-jersey3-jakarta10/build.gradle
@@ -78,22 +78,28 @@ afterEvaluate {
 }
 
 def actualJerseyVersion = "${jersey3VersionEE10}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE10}"
 def actualJaxRsVersion = "${jaxRsVersionEE10}"
 
 // Dependencies must remain consistent between servicetalk-http-security-jerseyX modules
 dependencies {
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
+  api project(":servicetalk-context-api")
 
   implementation platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
+  implementation "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion"
   implementation "org.glassfish.jersey.core:jersey-common"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testImplementation project(":servicetalk-buffer-api")
+  testImplementation project(":servicetalk-http-api")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-http-router-jersey3-jakarta10")
   testImplementation project(":servicetalk-http-utils")
+  testImplementation project(":servicetalk-transport-api")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "net.javacrumbs.json-unit:json-unit-fluent:$jsonUnitVersion"

--- a/servicetalk-http-security-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-security-jersey3-jakarta9/build.gradle
@@ -78,22 +78,28 @@ afterEvaluate {
 }
 
 def actualJerseyVersion = "${jersey3VersionEE9}"
+def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE9}"
 def actualJaxRsVersion = "${jaxRsVersionEE9}"
 
 // Dependencies must remain consistent between servicetalk-http-security-jerseyX modules
 dependencies {
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
+  api project(":servicetalk-context-api")
 
   implementation platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
+  implementation "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion"
   implementation "org.glassfish.jersey.core:jersey-common"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testImplementation project(":servicetalk-buffer-api")
+  testImplementation project(":servicetalk-http-api")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-http-router-jersey3-jakarta9")
   testImplementation project(":servicetalk-http-utils")
+  testImplementation project(":servicetalk-transport-api")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "net.javacrumbs.json-unit:json-unit-fluent:$jsonUnitVersion"

--- a/servicetalk-http-utils/build.gradle
+++ b/servicetalk-http-utils/build.gradle
@@ -17,10 +17,16 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api project(":servicetalk-client-api")
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-context-api")
   api project(":servicetalk-http-api")
+  api project(":servicetalk-logging-api")
+  api project(":servicetalk-transport-api")
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")

--- a/servicetalk-loadbalancer-experimental-provider/build.gradle
+++ b/servicetalk-loadbalancer-experimental-provider/build.gradle
@@ -20,6 +20,8 @@ dependencies {
   api project(":servicetalk-http-api")
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-client-api")
   implementation project(":servicetalk-loadbalancer")
+  implementation project(":servicetalk-transport-api")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/servicetalk-loadbalancer/build.gradle
+++ b/servicetalk-loadbalancer/build.gradle
@@ -19,10 +19,13 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   api project(":servicetalk-client-api")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-transport-api")
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-context-api")
   implementation project(":servicetalk-utils-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-log4j2-mdc-utils/build.gradle
+++ b/servicetalk-log4j2-mdc-utils/build.gradle
@@ -23,9 +23,11 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-context-api")
   implementation "org.apache.logging.log4j:log4j-core"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testImplementation project(":servicetalk-concurrent")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/servicetalk-log4j2-mdc/build.gradle
+++ b/servicetalk-log4j2-mdc/build.gradle
@@ -20,7 +20,9 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-log4j2-mdc-utils")
 
+  testImplementation enforcedPlatform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
+  testImplementation "org.apache.logging.log4j:log4j-api"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/servicetalk-opentelemetry-asynccontext/build.gradle
+++ b/servicetalk-opentelemetry-asynccontext/build.gradle
@@ -19,9 +19,11 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   api platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion")
   api "io.opentelemetry:opentelemetry-api"
+  api "io.opentelemetry:opentelemetry-context"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
+  implementation project(":servicetalk-context-api")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")

--- a/servicetalk-opentelemetry-http/build.gradle
+++ b/servicetalk-opentelemetry-http/build.gradle
@@ -21,18 +21,31 @@ dependencies {
   api project(":servicetalk-http-api")
   api "io.opentelemetry:opentelemetry-api"
 
-  implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:" +
+  implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:" +
       "$opentelemetryInstrumentationVersion")
+  implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:" +
+      "$opentelemetryInstrumentationVersion-alpha")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-http-utils")
-  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv")
+  implementation project(":servicetalk-transport-api")
+  implementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api"
+  implementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv"
+  implementation "io.opentelemetry.semconv:opentelemetry-semconv"
+  implementation "io.opentelemetry:opentelemetry-context"
 
+  testImplementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
+  testImplementation project(":servicetalk-concurrent")
   testImplementation project(":servicetalk-data-jackson")
   testImplementation project(":servicetalk-http-netty")
+  testImplementation project(":servicetalk-serializer-api")
   testImplementation project(":servicetalk-test-resources")
+  testImplementation "com.fasterxml.jackson.core:jackson-annotations"
+  testImplementation "com.fasterxml.jackson.core:jackson-databind"
+  testImplementation "io.opentelemetry:opentelemetry-sdk-trace"
   testImplementation "io.opentelemetry:opentelemetry-sdk-testing"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.assertj:assertj-core:$assertJCoreVersion"

--- a/servicetalk-opentracing-asynccontext/build.gradle
+++ b/servicetalk-opentracing-asynccontext/build.gradle
@@ -18,9 +18,12 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api project(":servicetalk-opentracing-inmemory")
+  api project(":servicetalk-opentracing-inmemory-api")
+  api "io.opentracing:opentracing-api:$openTracingVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
+  implementation project(":servicetalk-context-api")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation project(":servicetalk-test-resources")

--- a/servicetalk-opentracing-http/build.gradle
+++ b/servicetalk-opentracing-http/build.gradle
@@ -18,25 +18,31 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api project(":servicetalk-http-api")
+  api project(":servicetalk-transport-api")
   api "io.opentracing:opentracing-api:$openTracingVersion"
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent-api")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-opentracing-inmemory")
   implementation project(":servicetalk-opentracing-inmemory-api")
   implementation project(":servicetalk-opentracing-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
+  testImplementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   testImplementation enforcedPlatform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
   testImplementation testFixtures(project(":servicetalk-http-netty"))
+  testImplementation project(":servicetalk-concurrent")
   testImplementation project(":servicetalk-data-jackson")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-opentracing-asynccontext")
+  testImplementation project(":servicetalk-serializer-api")
   testImplementation project(":servicetalk-test-resources")
+  testImplementation "com.fasterxml.jackson.core:jackson-annotations"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-opentracing-inmemory/build.gradle
+++ b/servicetalk-opentracing-inmemory/build.gradle
@@ -19,6 +19,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   api project(":servicetalk-opentracing-inmemory-api")
   api project(":servicetalk-concurrent-api")
+  api "io.opentracing:opentracing-api:$openTracingVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-buffer-api")

--- a/servicetalk-opentracing-log4j2/build.gradle
+++ b/servicetalk-opentracing-log4j2/build.gradle
@@ -17,7 +17,9 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api platform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   api project(":servicetalk-log4j2-mdc-utils")
+  api "org.apache.logging.log4j:log4j-api"
 
   implementation platform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   implementation project(":servicetalk-annotations")
@@ -30,6 +32,8 @@ dependencies {
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
+  testImplementation project(":servicetalk-opentracing-inmemory")
+  testImplementation "io.opentracing:opentracing-api:$openTracingVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/servicetalk-opentracing-zipkin-publisher/build.gradle
+++ b/servicetalk-opentracing-zipkin-publisher/build.gradle
@@ -23,15 +23,21 @@ dependencies {
   api project(":servicetalk-http-api")
   api project(":servicetalk-transport-api")
   api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
+  api "io.zipkin.zipkin2:zipkin:$zipkinVersion"
 
   implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-transport-netty-internal")
+  implementation project(":servicetalk-buffer-api")
+  implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")
+  implementation project(":servicetalk-transport-netty-internal")
   implementation project(":servicetalk-utils-internal")
+  implementation "io.opentracing:opentracing-api:$openTracingVersion"
+  implementation "io.netty:netty-buffer"
   implementation "io.netty:netty-codec"
+  implementation "io.netty:netty-common"
   implementation "io.netty:netty-transport"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-serialization-api/build.gradle
+++ b/servicetalk-serialization-api/build.gradle
@@ -18,6 +18,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api project(":servicetalk-buffer-api")
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-serializer-api")
 

--- a/servicetalk-serializer-api/build.gradle
+++ b/servicetalk-serializer-api/build.gradle
@@ -18,6 +18,7 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api project(":servicetalk-buffer-api")
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-oio-api")
 

--- a/servicetalk-serializer-utils/build.gradle
+++ b/servicetalk-serializer-utils/build.gradle
@@ -17,8 +17,10 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  api project(":servicetalk-serializer-api")
   api project(":servicetalk-buffer-api")
+  api project(":servicetalk-concurrent")
+  api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-serializer-api")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -31,36 +31,55 @@ afterEvaluate {
 }
 
 dependencies {
+  api platform("io.netty:netty-bom:$nettyVersion")
   api project(":servicetalk-client-api")
+  api project(":servicetalk-concurrent-api")
   api project(":servicetalk-logging-api")
+  api project(":servicetalk-transport-api")
   api project(":servicetalk-transport-netty-internal")
+  api "io.netty:netty-common"
+  api "io.netty:netty-handler"
+  api "io.netty:netty-transport"
 
   implementation project(":servicetalk-buffer-netty")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-transport-netty")
   implementation project(":servicetalk-utils-internal")
+  implementation "io.netty:netty-buffer"
+  implementation "io.netty:netty-resolver"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testImplementation project(":servicetalk-buffer-api")
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
+  testFixturesApi project(":servicetalk-buffer-api")
+  testFixturesApi project(":servicetalk-transport-api")
+  testFixturesApi project(":servicetalk-transport-netty-internal")
+
   testFixturesImplementation platform("io.netty:netty-bom:$nettyVersion")
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testFixturesImplementation project(":servicetalk-concurrent")
+  testFixturesImplementation project(":servicetalk-concurrent-api")
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "io.netty:netty-transport"
+  testFixturesImplementation "io.netty:netty-transport-classes-epoll"
+  testFixturesImplementation "io.netty:netty-transport-classes-kqueue"
   testFixturesImplementation "io.netty:netty-transport-native-epoll"
   testFixturesImplementation "io.netty:netty-transport-native-kqueue"
+  testFixturesImplementation "io.netty:netty-transport-native-unix-common"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/servicetalk-traffic-resilience-http/build.gradle
+++ b/servicetalk-traffic-resilience-http/build.gradle
@@ -18,23 +18,32 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 dependencies {
   api project(":servicetalk-capacity-limiter-api")
   api project(":servicetalk-circuit-breaker-api")
+  api project(":servicetalk-client-api")
+  api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-context-api")
   api project(":servicetalk-http-api")
   api project(":servicetalk-http-utils")
+  api project(":servicetalk-transport-api")
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
+  implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
+  testImplementation enforcedPlatform("io.netty:netty-bom:$nettyVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation testFixtures(project(":servicetalk-http-netty"))
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testImplementation project(":servicetalk-buffer-netty")
   testImplementation project(":servicetalk-concurrent-api-test")
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-test-resources")
+  testImplementation "io.netty:netty-common"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-transport-api/build.gradle
+++ b/servicetalk-transport-api/build.gradle
@@ -18,7 +18,9 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api project(":servicetalk-buffer-api")
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-context-api")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-internal")

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -33,7 +33,9 @@ afterEvaluate {
 
 dependencies {
   api platform("io.netty:netty-bom:$nettyVersion")
+  api project(":servicetalk-buffer-api")
   api project(":servicetalk-buffer-netty")
+  api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-logging-api")
   api project(":servicetalk-transport-api")
@@ -42,21 +44,27 @@ dependencies {
   api "io.netty:netty-handler"
   api "io.netty:netty-transport"
 
+  implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-context-api")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-utils-internal")
   implementation "io.netty:netty-codec"
   implementation "io.netty:netty-transport-native-epoll"
   runtimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-x86_64")
   runtimeOnly( group:"io.netty", name:"netty-transport-native-epoll", classifier:"linux-aarch_64")
+  implementation "io.netty:netty-transport-classes-epoll"
+  implementation "io.netty:netty-transport-classes-kqueue"
   implementation "io.netty:netty-transport-native-kqueue"
   if (!project.ext.isNettySnapshot) {
     // Netty doesn't publish snapshots for macos artifacts
     runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-x86_64")
     runtimeOnly( group:"io.netty", name:"netty-transport-native-kqueue", classifier:"osx-aarch_64")
   }
+  implementation "io.netty:netty-transport-native-unix-common"
+  implementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$nettyIoUringVersion"
   implementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   runtimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", version:"$nettyIoUringVersion", classifier:"linux-x86_64")
   runtimeOnly( group:"io.netty.incubator", name:"netty-incubator-transport-native-io_uring", version:"$nettyIoUringVersion", classifier:"linux-aarch_64")
@@ -78,8 +86,16 @@ dependencies {
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
+  testFixturesApi platform("io.netty:netty-bom:$nettyVersion")
+  testFixturesApi project(":servicetalk-buffer-api")
+  testFixturesApi project(":servicetalk-concurrent-api")
+  testFixturesApi project(":servicetalk-transport-api")
+  testFixturesApi "io.netty:netty-common"
+  testFixturesApi "io.netty:netty-transport"
+
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation project(":servicetalk-utils-internal")
+  testFixturesImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$nettyIoUringVersion"
   testFixturesImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"


### PR DESCRIPTION
Motivation:

Dependency-analysis plugin detected that some dependencies that we use directly not declared in our build configuration.

Modifications:

1. This PR only adds missing dependencies. It does not remove anything. If you see a removed line, it only means I sorted existing dependencies in alphabetical order.
2. Adds `opentelemetry-instrumentation-bom` to `servicetalk-dependencies`.

Result:

Addresses "These transitive dependencies should be declared directly" warning from dependency-analysis plugin.

Risk:

Because we only add missed dependencies, there is no risk of breaking existing users.