### PR TITLE
Update scope of test-fixtures dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,10 @@ if (JavaVersion.current().isJava11Compatible()) {
           // We import it as api dependency via :servicetalk-annotations
           exclude("com.google.code.findbugs:jsr305")
         }
+        onIncorrectConfiguration {
+          // We import it as api dependency via :servicetalk-annotations
+          exclude("com.google.code.findbugs:jsr305")
+        }
       }
     }
   }

--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -35,13 +35,13 @@ dependencies {
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
   testFixturesApi project(":servicetalk-concurrent")
+  testFixturesApi project(":servicetalk-concurrent-internal")
+  testFixturesApi "org.junit.jupiter:junit-jupiter-api"
+  testFixturesApi "org.hamcrest:hamcrest:$hamcrestVersion"
 
   testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation project(":servicetalk-concurrent-internal")
   testFixturesImplementation project(":servicetalk-utils-internal")
   testFixturesImplementation project(":servicetalk-concurrent-test-internal")
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/servicetalk-concurrent-internal/build.gradle
+++ b/servicetalk-concurrent-internal/build.gradle
@@ -31,7 +31,8 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
-  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
-  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
+  testFixturesApi platform("org.junit:junit-bom:$junit5Version")
+  testFixturesApi "org.junit.jupiter:junit-jupiter-api"
+
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/servicetalk-concurrent-reactivestreams/build.gradle
+++ b/servicetalk-concurrent-reactivestreams/build.gradle
@@ -16,6 +16,19 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        // False positives for testFixturesApi
+        onIncorrectConfiguration {
+          exclude("org.reactivestreams:reactive-streams-tck")
+        }
+      }
+    }
+  }
+}
+
 dependencies {
   api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")

--- a/servicetalk-dependencies/build.gradle
+++ b/servicetalk-dependencies/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     api "io.zipkin.reporter2:zipkin-reporter:$zipkinReporterVersion"
     api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxRsVersion"
     api "jakarta.xml.bind:jakarta.xml.bind-api:$javaxJaxbApiVersion"
-    api "org.hamcrest:hamcrest:$hamcrestVersion"  // Matchers are exposed by test-resources & buffer-api
+    api "org.hamcrest:hamcrest:$hamcrestVersion"  // Matchers are exposed by test-resources & some test-fixtures
     api "org.jctools:jctools-core:$jcToolsVersion"
     api "org.openjdk.jmh:jmh-core:$jmhCoreVersion"
     api "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"

--- a/servicetalk-http-api/build.gradle
+++ b/servicetalk-http-api/build.gradle
@@ -57,19 +57,18 @@ dependencies {
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
+  testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-buffer-api")
   testFixturesApi project(":servicetalk-concurrent-api")
   testFixturesApi project(":servicetalk-transport-api")
+  testFixturesApi "org.junit.jupiter:junit-jupiter-api"
+  testFixturesApi "org.junit.jupiter:junit-jupiter-params"
+  testFixturesApi "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
-  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testFixturesImplementation project(":servicetalk-buffer-netty")
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
-  testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
-  testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 }
 
 sourceSets {

--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -81,7 +81,6 @@ dependencies {
   testImplementation project(":servicetalk-oio-api")
   testImplementation project(":servicetalk-serializer-api")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation project(":servicetalk-utils-internal")
   testImplementation "com.fasterxml.jackson.core:jackson-core"
   testImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$nettyIoUringVersion"
   testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -74,6 +74,7 @@ dependencies {
 
   testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson"
 
+  testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-buffer-api")
   testFixturesApi project(":servicetalk-concurrent-api")
   testFixturesApi project(":servicetalk-http-api")
@@ -81,10 +82,12 @@ dependencies {
   testFixturesApi project(":servicetalk-transport-api")
   testFixturesApi "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion"
   testFixturesApi "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
+  testFixturesApi "org.glassfish.jersey.core:jersey-server"
+  testFixturesApi "org.hamcrest:hamcrest:$hamcrestVersion"
+  testFixturesApi "org.junit.jupiter:junit-jupiter-api"
   testFixturesApi "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
 
   testFixturesImplementation platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
-  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testFixturesImplementation testFixtures(project(":servicetalk-http-netty"))
@@ -103,9 +106,6 @@ dependencies {
   testFixturesImplementation "com.fasterxml.jackson.core:jackson-databind"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
   testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-http-router-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10/build.gradle
@@ -136,6 +136,7 @@ dependencies {
 
   testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson"
 
+  testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-buffer-api")
   testFixturesApi project(":servicetalk-concurrent-api")
   testFixturesApi project(":servicetalk-http-api")
@@ -143,10 +144,12 @@ dependencies {
   testFixturesApi project(":servicetalk-transport-api")
   testFixturesApi "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion"
   testFixturesApi "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
+  testFixturesApi "org.glassfish.jersey.core:jersey-server"
+  testFixturesApi "org.hamcrest:hamcrest:$hamcrestVersion"
+  testFixturesApi "org.junit.jupiter:junit-jupiter-api"
   testFixturesApi "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
 
   testFixturesImplementation platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
-  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testFixturesImplementation testFixtures(project(":servicetalk-http-netty"))
@@ -165,9 +168,6 @@ dependencies {
   testFixturesImplementation "com.fasterxml.jackson.core:jackson-databind"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
   testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-http-router-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9/build.gradle
@@ -136,6 +136,7 @@ dependencies {
 
   testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson"
 
+  testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-buffer-api")
   testFixturesApi project(":servicetalk-concurrent-api")
   testFixturesApi project(":servicetalk-http-api")
@@ -143,10 +144,12 @@ dependencies {
   testFixturesApi project(":servicetalk-transport-api")
   testFixturesApi "jakarta.annotation:jakarta.annotation-api:$actualJavaxAnnotationsApiVersion"
   testFixturesApi "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
+  testFixturesApi "org.glassfish.jersey.core:jersey-server"
+  testFixturesApi "org.hamcrest:hamcrest:$hamcrestVersion"
+  testFixturesApi "org.junit.jupiter:junit-jupiter-api"
   testFixturesApi "org.junit.platform:junit-platform-suite-api:$junitPlatformVersion"
 
   testFixturesImplementation platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
-  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testFixturesImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testFixturesImplementation testFixtures(project(":servicetalk-http-netty"))
@@ -165,9 +168,6 @@ dependencies {
   testFixturesImplementation "com.fasterxml.jackson.core:jackson-databind"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
-  testFixturesImplementation "org.glassfish.jersey.core:jersey-server"
-  testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
   testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -87,18 +87,18 @@ dependencies {
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 
   testFixturesApi platform("io.netty:netty-bom:$nettyVersion")
+  testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-buffer-api")
   testFixturesApi project(":servicetalk-concurrent-api")
   testFixturesApi project(":servicetalk-transport-api")
   testFixturesApi "io.netty:netty-common"
   testFixturesApi "io.netty:netty-transport"
+  testFixturesApi "org.junit.jupiter:junit-jupiter-api"
 
-  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation project(":servicetalk-utils-internal")
   testFixturesImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$nettyIoUringVersion"
   testFixturesImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
-  testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 }


### PR DESCRIPTION
Motivation:

Dependency-analysis plugin detected that some dependencies declared under incorrect scope. In this PR we only focus on test-fixtures dependencies.

Modifications:

- Update scope of dependencies as recommended by the plugin. Typically, it recommends to promote some `testFixturesImplementation` dependencies to `testFixturesApi`.
- Add exclusion rule for `com.google.code.findbugs:jsr305` for `onIncorrectConfiguration` rule as we don't want to promote it explicitly, it's handled by `servicetalk-annotations`.
- Exclude some false positives when the plugin recommends reducing scope, but `testFixturesApi` is actually required.

Result:

Addresses warning from dependency-analysis plugin that recommends different scope for test dependencies.

Risk for users:

None, because changes were made only for test-fixures dependencies to expand their scope, not reduce.