### PR TITLE
Promote dependencies to `api` where necessary

### DIFF
--- a/servicetalk-concurrent-api-internal/build.gradle
+++ b/servicetalk-concurrent-api-internal/build.gradle
@@ -17,18 +17,18 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api project(":servicetalk-buffer-api") // Buffer based Concurrent conversions
   api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-concurrent-internal")
   api project(":servicetalk-oio-api")
 
-  testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-buffer-api") // Buffer based Concurrent conversions
-  implementation project(":servicetalk-concurrent-api")
-  implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-utils-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
+  testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))
   testImplementation testFixtures(project(":servicetalk-concurrent-internal"))
   testImplementation project(":servicetalk-buffer-netty")

--- a/servicetalk-concurrent-api-test/gradle.lockfile
+++ b/servicetalk-concurrent-api-test/gradle.lockfile
@@ -3,5 +3,5 @@
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
-org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-concurrent-test-internal/gradle.lockfile
+++ b/servicetalk-concurrent-test-internal/gradle.lockfile
@@ -3,5 +3,5 @@
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
-org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-data-protobuf/build.gradle
+++ b/servicetalk-data-protobuf/build.gradle
@@ -29,13 +29,13 @@ dependencies {
   api platform("com.google.protobuf:protobuf-bom:$protobufVersion")
   api project(":servicetalk-buffer-api")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-serialization-api")
   api project(":servicetalk-serializer-api")
   api "com.google.protobuf:protobuf-java"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
-  implementation project(":servicetalk-serialization-api")
   implementation project(":servicetalk-serializer-utils")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")

--- a/servicetalk-grpc-internal/gradle.lockfile
+++ b/servicetalk-grpc-internal/gradle.lockfile
@@ -3,5 +3,5 @@
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
-org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-grpc-utils/gradle.lockfile
+++ b/servicetalk-grpc-utils/gradle.lockfile
@@ -6,5 +6,5 @@ com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
 com.google.protobuf:protobuf-bom:3.25.3=runtimeClasspath
 com.google.protobuf:protobuf-java:3.25.3=runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
-org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-http-router-jersey-internal/build.gradle
+++ b/servicetalk-http-router-jersey-internal/build.gradle
@@ -24,12 +24,12 @@ dependencies {
   api project(":servicetalk-buffer-api")
   api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-concurrent-api-internal")
   api project(":servicetalk-http-api")
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
 
   implementation platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-transport-api")

--- a/servicetalk-http-router-jersey3-jakarta10-internal/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10-internal/build.gradle
@@ -79,12 +79,12 @@ dependencies {
   api project(":servicetalk-buffer-api")
   api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-concurrent-api-internal")
   api project(":servicetalk-http-api")
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
 
   implementation platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-transport-api")

--- a/servicetalk-http-router-jersey3-jakarta9-internal/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9-internal/build.gradle
@@ -79,12 +79,12 @@ dependencies {
   api project(":servicetalk-buffer-api")
   api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-concurrent-api-internal")
   api project(":servicetalk-http-api")
   api "jakarta.ws.rs:jakarta.ws.rs-api:$actualJaxRsVersion"
 
   implementation platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-transport-api")

--- a/servicetalk-log4j2-mdc/build.gradle
+++ b/servicetalk-log4j2-mdc/build.gradle
@@ -17,8 +17,9 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api project(":servicetalk-log4j2-mdc-utils")
+
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-log4j2-mdc-utils")
 
   testImplementation enforcedPlatform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")

--- a/servicetalk-router-utils-internal/build.gradle
+++ b/servicetalk-router-utils-internal/build.gradle
@@ -17,8 +17,9 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+  api project(":servicetalk-router-api")
+  api project(":servicetalk-transport-api")
+
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-concurrent-api")
-  implementation project(":servicetalk-router-api")
-  implementation project(":servicetalk-transport-api")
 }

--- a/servicetalk-serialization-api/gradle.lockfile
+++ b/servicetalk-serialization-api/gradle.lockfile
@@ -3,5 +3,5 @@
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
-org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-serializer-utils/gradle.lockfile
+++ b/servicetalk-serializer-utils/gradle.lockfile
@@ -3,5 +3,5 @@
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
-org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-test-resources/gradle.lockfile
+++ b/servicetalk-test-resources/gradle.lockfile
@@ -4,5 +4,5 @@
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
 org.hamcrest:hamcrest:2.2=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
-org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   api project(":servicetalk-buffer-netty")
   api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
+  api project(":servicetalk-concurrent-api-internal")
   api project(":servicetalk-logging-api")
   api project(":servicetalk-transport-api")
   api "io.netty:netty-buffer"
@@ -46,7 +47,6 @@ dependencies {
 
   implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
-  implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-context-api")
   implementation project(":servicetalk-logging-slf4j-internal")

--- a/servicetalk-utils-internal/build.gradle
+++ b/servicetalk-utils-internal/build.gradle
@@ -17,10 +17,11 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
+    api "org.slf4j:slf4j-api:$slf4jVersion"
+
     implementation project(":servicetalk-annotations")
     implementation project(":servicetalk-buffer-api")
     implementation "org.jctools:jctools-core:$jcToolsVersion"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
     testImplementation "org.junit.jupiter:junit-jupiter-api"


### PR DESCRIPTION
Motivation:

Dependency-analysis plugin detected that some dependencies must be declared as `api` while they have more restrictive scope today.

Modifications:

- Update scope of dependencies to `api` as recommended by the plugin.
- Regenerate lock files.

Result:

Addresses warning from dependency-analysis plugin that recommend different scope for main dependencies.

Risk for users:

None, promotion to `api` is a safe change for users. It only brings more dependencies to their compile classpath rather than runtime but can not break the build. 