### PR TITLE
Remove unused `api` dependencies or move them to lower scope

### DIFF
--- a/servicetalk-data-protobuf/build.gradle
+++ b/servicetalk-data-protobuf/build.gradle
@@ -27,18 +27,18 @@ ideaModule.dependsOn "generateTestProto"
 
 dependencies {
   api platform("com.google.protobuf:protobuf-bom:$protobufVersion")
-  api project(":servicetalk-buffer-api")
-  api project(":servicetalk-concurrent-api")
   api project(":servicetalk-serialization-api")
   api project(":servicetalk-serializer-api")
   api "com.google.protobuf:protobuf-java"
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-serializer-utils")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation project(":servicetalk-test-resources")
   testImplementation project(":servicetalk-buffer-netty")
+  testImplementation project(":servicetalk-concurrent-api")
+  testImplementation project(":servicetalk-test-resources")
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-grpc-netty/build.gradle
+++ b/servicetalk-grpc-netty/build.gradle
@@ -44,7 +44,6 @@ afterEvaluate {
 dependencies {
   api project(":servicetalk-client-api")
   api project(":servicetalk-grpc-api")
-  api project(":servicetalk-grpc-utils")
   api project(":servicetalk-http-netty")
   api project(":servicetalk-transport-api")
 
@@ -79,6 +78,7 @@ dependencies {
   testImplementation project(":servicetalk-encoding-netty")
   testImplementation project(":servicetalk-grpc-protobuf")
   testImplementation project(":servicetalk-grpc-protoc")
+  testImplementation project(":servicetalk-grpc-utils")
   testImplementation project(":servicetalk-http-utils")
   testImplementation project(":servicetalk-logging-api")
   testImplementation project(":servicetalk-router-api")

--- a/servicetalk-grpc-protobuf/build.gradle
+++ b/servicetalk-grpc-protobuf/build.gradle
@@ -30,7 +30,6 @@ dependencies {
   api project(":servicetalk-encoding-api")
   api project(":servicetalk-grpc-api")
   api "com.google.protobuf:protobuf-java"
-  api "com.google.api.grpc:proto-google-common-protos:$protoGoogleCommonProtosVersion"
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-buffer-api")

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -21,9 +21,20 @@ plugins {
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
+afterEvaluate {
+  if (tasks.findByName("projectHealth")) {
+    dependencyAnalysis {
+      issues {
+        onIncorrectConfiguration {
+          exclude(":servicetalk-data-protobuf") // Needed for the generated classes
+        }
+      }
+    }
+  }
+}
+
 dependencies {
-  // Needed for the generated classes
-  api project(":servicetalk-data-protobuf")
+  api project(":servicetalk-data-protobuf") // Needed for the generated classes
 
   compileOnly "com.squareup:javapoet:$javaPoetVersion"
 

--- a/servicetalk-opentelemetry-asynccontext/build.gradle
+++ b/servicetalk-opentelemetry-asynccontext/build.gradle
@@ -18,7 +18,6 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
   api platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion")
-  api "io.opentelemetry:opentelemetry-api"
   api "io.opentelemetry:opentelemetry-context"
 
   implementation project(":servicetalk-annotations")

--- a/servicetalk-opentelemetry-asynccontext/gradle.lockfile
+++ b/servicetalk-opentelemetry-asynccontext/gradle.lockfile
@@ -2,7 +2,6 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
-io.opentelemetry:opentelemetry-api:1.38.0=compileClasspath,runtimeClasspath
 io.opentelemetry:opentelemetry-bom:1.38.0=compileClasspath,runtimeClasspath
 io.opentelemetry:opentelemetry-context:1.38.0=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath

--- a/servicetalk-opentracing-asynccontext/build.gradle
+++ b/servicetalk-opentracing-asynccontext/build.gradle
@@ -17,7 +17,6 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  api project(":servicetalk-opentracing-inmemory")
   api project(":servicetalk-opentracing-inmemory-api")
   api "io.opentracing:opentracing-api:$openTracingVersion"
 

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -32,9 +32,7 @@ afterEvaluate {
 
 dependencies {
   api platform("io.netty:netty-bom:$nettyVersion")
-  api project(":servicetalk-client-api")
   api project(":servicetalk-concurrent-api")
-  api project(":servicetalk-logging-api")
   api project(":servicetalk-transport-api")
   api project(":servicetalk-transport-netty-internal")
   api "io.netty:netty-common"
@@ -42,9 +40,11 @@ dependencies {
   api "io.netty:netty-transport"
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-client-api")
   implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-logging-api")
   implementation project(":servicetalk-logging-slf4j-internal")
   implementation project(":servicetalk-utils-internal")
   implementation "io.netty:netty-buffer"

--- a/servicetalk-traffic-resilience-http/build.gradle
+++ b/servicetalk-traffic-resilience-http/build.gradle
@@ -22,13 +22,13 @@ dependencies {
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-context-api")
   api project(":servicetalk-http-api")
-  api project(":servicetalk-http-utils")
   api project(":servicetalk-transport-api")
 
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-buffer-api")
   implementation project(":servicetalk-concurrent")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-utils-internal")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -34,7 +34,6 @@ afterEvaluate {
 dependencies {
   api platform("io.netty:netty-bom:$nettyVersion")
   api project(":servicetalk-buffer-api")
-  api project(":servicetalk-buffer-netty")
   api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
   api project(":servicetalk-concurrent-api-internal")
@@ -47,6 +46,7 @@ dependencies {
 
   implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-buffer-netty")
   implementation project(":servicetalk-concurrent-internal")
   implementation project(":servicetalk-context-api")
   implementation project(":servicetalk-logging-slf4j-internal")
@@ -96,6 +96,7 @@ dependencies {
   testFixturesApi "io.netty:netty-transport"
   testFixturesApi "org.junit.jupiter:junit-jupiter-api"
 
+  testFixturesImplementation project(":servicetalk-buffer-netty")
   testFixturesImplementation project(":servicetalk-utils-internal")
   testFixturesImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$nettyIoUringVersion"
   testFixturesImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"


### PR DESCRIPTION
Motivation:

Dependency-analysis plugin detected that some `api` dependencies are unused and can be either removed or downgraded to `implementation` / `testImplementation` scopes.

Modifications:

- Remove unused `api` dependencies.
- Downgrade some to `implementation` / `testImplementation` scopes.
- Regenerate lock files.

Result:

No more warnings from dependency-analysis plugin.

Risk for users:

Minimal. They can be broken only if they use some dependency at compile time without explicitly declaring it in their build, which is their mistake.

Highlights:
- Most changes are related to `servicetalk-*` dependencies, users likely have them anyway via other modules.
- It's safe to remove `opentelemetry-api` from `opentelemetry-asynccontext` module because in #3164 we added `opentelemetry-context`.
- Removal of `proto-google-common-protos` should not be an issue because it's already an `api` dependency for `grpc-api` module.