### PR TITLE
Remove unnecessary suppressions for dependency-analysis plugin

### DIFF
--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -16,19 +16,6 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-afterEvaluate {
-  if (tasks.findByName("projectHealth")) {
-    dependencyAnalysis {
-      issues {
-        // False positives for testImplementation
-        onUnusedDependencies {
-          exclude("io.netty.incubator:netty-incubator-transport-native-io_uring")
-        }
-      }
-    }
-  }
-}
-
 dependencies {
   api project(":servicetalk-client-api")
   api project(":servicetalk-concurrent-api")
@@ -85,7 +72,6 @@ dependencies {
   testImplementation project(":servicetalk-transport-netty")
   testImplementation "com.fasterxml.jackson.core:jackson-core"
   testImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$nettyIoUringVersion"
-  testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.junit.platform:junit-platform-commons:$junitPlatformVersion"

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -16,19 +16,6 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-afterEvaluate {
-  if (tasks.findByName("projectHealth")) {
-    dependencyAnalysis {
-      issues {
-        // False positives for testFixturesImplementation
-        onUnusedDependencies {
-          exclude("org.junit.platform:junit-platform-suite")
-        }
-      }
-    }
-  }
-}
-
 def actualJerseyVersion = "${jerseyVersion}"
 def actualJavaxActivationVersion = "${javaxActivationVersion}"
 def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersion}"
@@ -106,7 +93,6 @@ dependencies {
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
-  testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 

--- a/servicetalk-http-router-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10/build.gradle
@@ -78,19 +78,6 @@ afterEvaluate {
   }
 }
 
-afterEvaluate {
-  if (tasks.findByName("projectHealth")) {
-    dependencyAnalysis {
-      issues {
-        // False positives for testFixturesImplementation
-        onUnusedDependencies {
-          exclude("org.junit.platform:junit-platform-suite")
-        }
-      }
-    }
-  }
-}
-
 def actualJerseyVersion = "${jersey3VersionEE10}"
 def actualJavaxActivationVersion = "${javaxActivationVersionEE10}"
 def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE10}"
@@ -168,7 +155,6 @@ dependencies {
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
-  testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 

--- a/servicetalk-http-router-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9/build.gradle
@@ -78,19 +78,6 @@ afterEvaluate {
   }
 }
 
-afterEvaluate {
-  if (tasks.findByName("projectHealth")) {
-    dependencyAnalysis {
-      issues {
-        // False positives for testFixturesImplementation
-        onUnusedDependencies {
-          exclude("org.junit.platform:junit-platform-suite")
-        }
-      }
-    }
-  }
-}
-
 def actualJerseyVersion = "${jersey3VersionEE9}"
 def actualJavaxActivationVersion = "${javaxActivationVersionEE9}"
 def actualJavaxAnnotationsApiVersion = "${javaxAnnotationsApiVersionEE9}"
@@ -168,7 +155,6 @@ dependencies {
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "net.javacrumbs.json-unit:json-unit:$jsonUnitVersion"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-params"
-  testFixturesImplementation "org.junit.platform:junit-platform-suite:$junitPlatformVersion"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
 

--- a/servicetalk-tcp-netty-internal/build.gradle
+++ b/servicetalk-tcp-netty-internal/build.gradle
@@ -16,20 +16,6 @@
 
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
-afterEvaluate {
-  if (tasks.findByName("projectHealth")) {
-    dependencyAnalysis {
-      issues {
-        // False positives for testFixturesImplementation
-        onUnusedDependencies {
-          exclude("io.netty:netty-transport-native-epoll")
-          exclude("io.netty:netty-transport-native-kqueue")
-        }
-      }
-    }
-  }
-}
-
 dependencies {
   api platform("io.netty:netty-bom:$nettyVersion")
   api project(":servicetalk-client-api")
@@ -76,8 +62,6 @@ dependencies {
   testFixturesImplementation "io.netty:netty-transport"
   testFixturesImplementation "io.netty:netty-transport-classes-epoll"
   testFixturesImplementation "io.netty:netty-transport-classes-kqueue"
-  testFixturesImplementation "io.netty:netty-transport-native-epoll"
-  testFixturesImplementation "io.netty:netty-transport-native-kqueue"
   testFixturesImplementation "io.netty:netty-transport-native-unix-common"
   testFixturesImplementation "org.junit.jupiter:junit-jupiter-api"
   testFixturesImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -18,19 +18,6 @@ apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 ext.isNettySnapshot = "$nettyVersion".endsWithAny("SNAPSHOT", "+")
 
-afterEvaluate {
-  if (tasks.findByName("projectHealth")) {
-    dependencyAnalysis {
-      issues {
-        // False positives for testFixturesImplementation
-        onUnusedDependencies {
-          exclude("io.netty.incubator:netty-incubator-transport-native-io_uring")
-        }
-      }
-    }
-  }
-}
-
 dependencies {
   api platform("io.netty:netty-bom:$nettyVersion")
   api project(":servicetalk-buffer-api")
@@ -98,7 +85,6 @@ dependencies {
 
   testFixturesImplementation project(":servicetalk-utils-internal")
   testFixturesImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$nettyIoUringVersion"
-  testFixturesImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
   testFixturesImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"


### PR DESCRIPTION
Motivation:

Previously identified "false positives" were actually not false. After fixing all other warnings, it's clear now that we can remove some of the suppressions and address those warnings too.

Modifications:

- Remove suppressions that can be addressed.

Result:

Less suppressions for dependency-analysis plugin checks.