### PR TITLE
Change dependency-analysis plugin to `fail` mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ if (JavaVersion.current().isJava11Compatible()) {
     issues {
       all {
         onAny {
-          severity("warn")  // FIXME: switch to "fail" when all issues are addressed
+          severity("fail")
         }
         onUnusedDependencies {
           // We use it for log4j2.xml configuration


### PR DESCRIPTION
Motivation:

All warnings from dependency-analysis plugin were addressed in prior PRs. We can enable the `fail` mode now.

Modifications:

- Change dependency-analysis plugin mode from `warn` to `fail`.

Result:

PRQ pipeline will fail if a new PR introduces warnings for dependencies.