### PR TITLE
scripts/release.sh: ensure tree is clean before releasing

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -53,8 +53,8 @@ if [ "$#" -ne "2" ]; then
     exit 1
 fi
 
-if ! git diff --quiet; then
-  echo "Branch is dirty. Commit or revert any changes before releasing."
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Branch has uncommitted changes. Commit or revert any changes before releasing."
   exit 1
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -53,6 +53,11 @@ if [ "$#" -ne "2" ]; then
     exit 1
 fi
 
+if ! git diff --quiet; then
+  echo "Branch is dirty. Commit or revert any changes before releasing."
+  exit 1
+fi
+
 # Enforce JDK17 to get latest LTS javadoc format/features (search, etc.):
 java_version=$(./gradlew --no-daemon -version | grep 'Launcher JVM:' | \
    awk -F\. '{gsub(/Launcher JVM:[ \t]*/,"",$1); print $1"."$2}')


### PR DESCRIPTION
Motivation:

As part of the release process our script makes some changes to versions etc and then everything in the branch is committed. This is dangerous if there are uncommitted changes present.

Modifications:

As part of the release.sh script check if the tree is dirty and error out if so.

This was tested by running the release script before and after committing the change and it worked as expected.