### PR TITLE
Log runtime values for `NativeTransportUtils`

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -112,7 +112,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
             LOGGER.debug("Default TTL poll jitter seconds: {}", DEFAULT_TTL_POLL_JITTER_SECONDS);
             LOGGER.debug("Default TTL cache boundaries in seconds: [{}, {}]",
                     DEFAULT_MIN_TTL_CACHE_SECONDS, DEFAULT_MAX_TTL_CACHE_SECONDS);
-            LOGGER.debug("-D{}={}", NEGATIVE_TTL_CACHE_SECONDS_PROPERTY, negativeCacheTtlValue);
+            LOGGER.debug("-D{}: {}", NEGATIVE_TTL_CACHE_SECONDS_PROPERTY, negativeCacheTtlValue);
             LOGGER.debug("Default negative TTL cache in seconds: {}", DEFAULT_NEGATIVE_TTL_CACHE_SECONDS);
             LOGGER.debug("Default missing records status: {}", DEFAULT_MISSING_RECOREDS_STATUS);
             LOGGER.debug("-D{}: {}", NX_DOMAIN_INVALIDATES_PROPERTY, DEFAULT_NX_DOMAIN_INVALIDATES);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptimizedHttp2FrameCodecBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptimizedHttp2FrameCodecBuilder.java
@@ -201,7 +201,7 @@ final class OptimizedHttp2FrameCodecBuilder extends Http2FrameCodecBuilder {
                 return defaultValue;
             }
         }
-        LOGGER.debug("-D{}={}", name, intValue);
+        LOGGER.debug("-D{}: {}", name, intValue);
         return intValue;
     }
 }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NativeTransportUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NativeTransportUtils.java
@@ -45,19 +45,25 @@ final class NativeTransportUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NativeTransportUtils.class);
     private static final String REQUIRE_NATIVE_LIBS_NAME = "io.servicetalk.transport.netty.requireNativeLibs";
+    // FIXME: 0.43 - consider requiring native libs by default
     private static final boolean REQUIRE_NATIVE_LIBS = getBoolean(REQUIRE_NATIVE_LIBS_NAME);
     private static final String NETTY_NO_NATIVE_NAME = "io.netty.transport.noNative";
     private static final boolean NETTY_NO_NATIVE = getBoolean(NETTY_NO_NATIVE_NAME);
-
+    private static final String TRY_IO_URING_NAME = "io.servicetalk.transport.netty.tryIoUring";
+    private static final AtomicBoolean TRY_IO_URING;    // non-primitive boolean to allow overrides in tests
     private static final boolean IS_LINUX;
     private static final boolean IS_OSX_OR_BSD;
-    private static final AtomicBoolean TRY_IO_URING;
 
     static {
         final String os = PlatformDependent.normalizedOs();
         IS_LINUX = "linux".equals(os);
         IS_OSX_OR_BSD = "osx".equals(os) || os.contains("bsd");
-        TRY_IO_URING = new AtomicBoolean(getBoolean("io.servicetalk.transport.netty.tryIoUring"));
+        TRY_IO_URING = new AtomicBoolean(getBoolean(TRY_IO_URING_NAME));
+
+        LOGGER.debug("-D{}: {}", REQUIRE_NATIVE_LIBS_NAME, REQUIRE_NATIVE_LIBS);
+        LOGGER.debug("-D{}: {}", NETTY_NO_NATIVE_NAME, NETTY_NO_NATIVE);
+        LOGGER.debug("-D{}: {}", TRY_IO_URING_NAME, TRY_IO_URING.get());
+        LOGGER.debug("Operating system: {}", os);
 
         if (IS_LINUX && !Epoll.isAvailable()) {
             reactOnUnavailability("epoll", os, Epoll.unavailabilityCause());


### PR DESCRIPTION
Motivation:

Help users to debug what were the supplied values for system properties supported by `NativeTransportUtils`.

Modifications:

- Log every system property value that we read in `NativeTransportUtils`;
- Align logging format for system properties in other places;

Result:

Easier to see what values were loaded after `NativeTransportUtils` class initialization.