### PR TITLE
Use Netty 4.2.0.RC+ snapshots instead of 4.2.0.Beta+

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         java: [ 8 ]
         os: [ ubuntu-latest ]
-        netty: [ 4.1+, 4.2.0.Beta+ ]
+        netty: [ 4.1+, 4.2.0.RC+ ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Netty 4.2 transitioned to RC state.