### PR TITLE
Small internal fixes to build and javadoc

### DIFF
--- a/servicetalk-concurrent-api-internal/build.gradle
+++ b/servicetalk-concurrent-api-internal/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   api project(":servicetalk-buffer-api") // Buffer based Concurrent conversions
   api project(":servicetalk-concurrent")
   api project(":servicetalk-concurrent-api")
-  api project(":servicetalk-concurrent-api")
   api project(":servicetalk-concurrent-internal")
   api project(":servicetalk-oio-api")
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
@@ -17,13 +17,12 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.internal.RejectedSubscribeException;
-import io.servicetalk.context.api.ContextMap;
 
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
  * A {@link Publisher} that does not expect to receive a call to {@link #handleSubscribe(Subscriber)} since it overrides
- * {@link Publisher#handleSubscribe(Subscriber, ContextMap, AsyncContextProvider)}.
+ * {@link Publisher#handleSubscribe(Subscriber, CapturedContext, AsyncContextProvider)}.
  *
  * @param <T> Type of items emitted.
  */


### PR DESCRIPTION
1. `AbstractNoHandleSubscribePublisher` has incorrect reference in javadoc.
2. `servicetalk-concurrent-api-internal` had a duplicate line for `servicetalk-concurrent-api` dependency.