### PR TITLE
http-utils: Fix bad logging when request and response are present

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
@@ -168,6 +168,11 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
 
         @Override
         public void onExchangeFinally() {
+            if (!logger.isEnabled()) {
+                // Logger isn't active so no need to pay for logging since it will go nowhere.
+                return;
+            }
+
             // request info always expected to be available:
             final HttpRequestMetaData requestMetaData = this.requestMetaData;
             assert requestMetaData != null;

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
@@ -23,11 +23,11 @@ import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.logging.slf4j.internal.FixedLevelLogger;
 import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.utils.internal.ThrowableUtils;
 
 import javax.annotation.Nullable;
 
 import static io.servicetalk.logging.slf4j.internal.Slf4jFixedLevelLoggers.newLogger;
-import static io.servicetalk.utils.internal.ThrowableUtils.combine;
 import static java.lang.System.nanoTime;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -178,26 +178,42 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
                 unwrappedRequestResult = Result.cancelled;
             }
             assert responseResult != null;
+            final Throwable maybeException = ThrowableUtils.combine(responseResult, requestResult);
             if (responseMetaData != null) {
-                logger.log("connection='{}' " +
-                "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} requestResult={} " +
-                "responseCode={} responseHeadersCount={} responseSize={} responseTrailersCount={} responseResult={} " +
-                "responseTime={}ms totalTime={}ms",
-                connInfo == null ? "unknown" : connInfo,
-                requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
-                responseMetaData.status().code(), responseMetaData.headers().size(), responseSize,
-                responseTrailersCount, unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
-                combine(responseResult, requestResult));
+                final String logMessage = "connection='{}' " +
+                        "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} " +
+                        "requestResult={} responseCode={} responseHeadersCount={} responseSize={} " +
+                        "responseTrailersCount={} responseResult={} responseTime={}ms totalTime={}ms";
+                if (maybeException == null) {
+                    logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
+                            requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
+                            requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
+                            responseMetaData.status().code(), responseMetaData.headers().size(), responseSize,
+                            responseTrailersCount, unwrapResult(responseResult), responseTimeMs, durationMs(startTime));
+                } else {
+                    logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
+                            requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
+                            requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
+                            responseMetaData.status().code(), responseMetaData.headers().size(), responseSize,
+                            responseTrailersCount, unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
+                            maybeException);
+                }
             } else {
-                logger.log("connection='{}' " +
-                "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} requestResult={} " +
-                "responseResult={} responseTime={}ms totalTime={}ms",
-                connInfo == null ? "unknown" : connInfo,
-                requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
-                unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
-                combine(responseResult, requestResult));
+                final String logMessage = "connection='{}' " +
+                        "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} " +
+                        "requestResult={} responseResult={} responseTime={}ms totalTime={}ms";
+                if (maybeException == null) {
+                    logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
+                            requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
+                            requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
+                            unwrapResult(responseResult), responseTimeMs, durationMs(startTime));
+                } else {
+                    logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
+                            requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
+                            requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
+                            unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
+                            maybeException);
+                }
             }
         }
 

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
@@ -93,7 +93,6 @@ class LoggingHttpLifecycleObserverTest {
     @Test
     void noErrorDoesntIncludeException() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
-        Throwable requestError = new DeliberateException();
         observer.onRequest(mockRequestMetadata);
         ((HttpLifecycleObserver.HttpRequestObserver) observer).onRequestComplete();
         observer.onResponse(mockResponseMetadata);

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
@@ -73,6 +73,48 @@ class LoggingHttpLifecycleObserverTest {
     }
 
     @Test
+    void noErrorResponseCancelDoesntIncludeException() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        observer.onRequest(mockRequestMetadata);
+        ((HttpLifecycleObserver.HttpRequestObserver) observer).onRequestComplete();
+        observer.onResponseCancel();
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                eq(0), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong()); // duration
+    }
+
+    @Test
+    void noErrorDoesntIncludeException() {
+        observer.onConnectionSelected(mock(ConnectionInfo.class));
+        Throwable requestError = new DeliberateException();
+        observer.onRequest(mockRequestMetadata);
+        ((HttpLifecycleObserver.HttpRequestObserver) observer).onRequestComplete();
+        observer.onResponse(mockResponseMetadata);
+        ((HttpLifecycleObserver.HttpResponseObserver) observer).onResponseComplete();
+        observer.onExchangeFinally();
+        verify(mockLogger).log(anyString(),
+                any(), // conn info
+                eq(HttpRequestMethod.GET), eq("/foo/bar"), eq(HttpProtocolVersion.HTTP_2_0), eq(0),
+                eq(0L), // request size
+                eq(0), // requestTrailersCount
+                any(), // unwrappedRequestResult
+                eq(HttpResponseStatus.OK.code()), // responseCode
+                eq(0), // response Header Size
+                eq(0L), // responseSize
+                eq(0), // responseTrailersCount
+                any(), // unwrappedResponseResult
+                anyLong(), // responseTimeMs
+                anyLong()); // duration
+    }
+
+    @Test
     void testOnRequestError() {
         observer.onConnectionSelected(mock(ConnectionInfo.class));
         Throwable requestError = new DeliberateException();

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserverTest.java
@@ -62,6 +62,7 @@ class LoggingHttpLifecycleObserverTest {
 
         mockLogger = mock(FixedLevelLogger.class);
         when(mockLogger.logLevel()).thenReturn(LogLevel.INFO);
+        when(mockLogger.isEnabled()).thenReturn(true);
 
         observer = new LoggingHttpLifecycleObserver(mockLogger).onNewExchange();
     }


### PR DESCRIPTION
Motivation:

We use the var-args logger in LoggingHttpLifecycleObserver and add the exception regardless of if one is generated which means when there is not an exception we put a `null` as the last argument. The logger can't tell this was supposed to be an exception so it gets angry because it found one more argument (a null) than it expected based on the format string.

Modifications:

Don't add the exception if it's null.