### PR TITLE
Make all async sources subscribable

### DIFF
--- a/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriter.java
+++ b/servicetalk-concurrent-api-internal/src/main/java/io/servicetalk/concurrent/api/internal/ConnectablePayloadWriter.java
@@ -16,7 +16,6 @@
 package io.servicetalk.concurrent.api.internal;
 
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
-import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
 import io.servicetalk.concurrent.internal.TerminalNotification;
@@ -273,7 +272,7 @@ public final class ConnectablePayloadWriter<T> implements PayloadWriter<T> {
         }
     }
 
-    private static final class ConnectedPublisher<T> extends Publisher<T> {
+    private static final class ConnectedPublisher<T> extends SubscribablePublisher<T> {
         private static final Logger LOGGER = LoggerFactory.getLogger(ConnectedPublisher.class);
         private final ConnectablePayloadWriter<T> outer;
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeCompletable.java
@@ -15,25 +15,19 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.CompletableSource;
-import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableCompletable;
 
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
  * A {@link Completable} that does not expect to receive a call to {@link #handleSubscribe(Subscriber)} since it
- * overrides {@link Completable#handleSubscribe(Subscriber, ContextMap, AsyncContextProvider)}.
+ * overrides {@link Completable#handleSubscribe(Subscriber, CapturedContext, AsyncContextProvider)}.
  */
-abstract class AbstractNoHandleSubscribeCompletable extends Completable implements CompletableSource {
+abstract class AbstractNoHandleSubscribeCompletable extends SubscribableCompletable {
 
     @Override
     protected final void handleSubscribe(Subscriber subscriber) {
         deliverErrorFromSource(subscriber,
                 new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
-    }
-
-    @Override
-    public final void subscribe(final Subscriber subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribablePublisher;
 import io.servicetalk.concurrent.internal.RejectedSubscribeException;
 
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
@@ -26,16 +26,11 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFro
  *
  * @param <T> Type of items emitted.
  */
-abstract class AbstractNoHandleSubscribePublisher<T> extends Publisher<T> implements PublisherSource<T> {
+abstract class AbstractNoHandleSubscribePublisher<T> extends SubscribablePublisher<T> {
 
     @Override
     protected final void handleSubscribe(Subscriber<? super T> subscriber) {
         deliverErrorFromSource(subscriber,
                 new RejectedSubscribeException("Subscribe with no executor is not supported for " + getClass()));
-    }
-
-    @Override
-    public final void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeSingle.java
@@ -15,27 +15,21 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.SingleSource;
-import io.servicetalk.context.api.ContextMap;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
  * A {@link Single} that does not expect to receive a call to {@link #handleSubscribe(Subscriber)} since it overrides
- * {@link Single#handleSubscribe(Subscriber, ContextMap, AsyncContextProvider)}.
+ * {@link Single#handleSubscribe(Subscriber, CapturedContext, AsyncContextProvider)}.
  *
  * @param <T> Type of the result of the single.
  */
-abstract class AbstractNoHandleSubscribeSingle<T> extends Single<T> implements SingleSource<T> {
+abstract class AbstractNoHandleSubscribeSingle<T> extends SubscribableSingle<T> {
 
     @Override
     protected final void handleSubscribe(Subscriber<? super T> subscriber) {
         deliverErrorFromSource(subscriber,
                 new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
-    }
-
-    @Override
-    public final void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractPublisherGroupBy.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.internal.ConcurrentSubscription;
 import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
 
@@ -211,8 +210,7 @@ abstract class AbstractPublisherGroupBy<Key, T> extends AbstractNoHandleSubscrib
         }
     }
 
-    private static final class DefaultGroupedPublisher<Key, T> extends GroupedPublisher<Key, T>
-            implements PublisherSource<T> {
+    private static final class DefaultGroupedPublisher<Key, T> extends GroupedPublisher<Key, T> {
         private final GroupMulticastSubscriber<Key, T> groupSink;
         private final CapturedContext capturedContext;
         private final AsyncContextProvider contextProvider;
@@ -223,11 +221,6 @@ abstract class AbstractPublisherGroupBy<Key, T> extends AbstractNoHandleSubscrib
             this.groupSink = groupSink;
             this.capturedContext = capturedContext;
             this.contextProvider = contextProvider;
-        }
-
-        @Override
-        public void subscribe(final Subscriber<? super T> subscriber) {
-            subscribeInternal(subscriber);
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSubmitCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSubmitCompletable.java
@@ -17,12 +17,13 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableCompletable;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static java.util.Objects.requireNonNull;
 
-abstract class AbstractSubmitCompletable extends Completable implements CompletableSource {
+abstract class AbstractSubmitCompletable extends SubscribableCompletable {
     private final Executor runExecutor;
 
     AbstractSubmitCompletable(final Executor runExecutor) {
@@ -58,10 +59,5 @@ abstract class AbstractSubmitCompletable extends Completable implements Completa
             return;
         }
         cancellable.delayedCancellable(eCancellable);
-    }
-
-    @Override
-    public final void subscribe(final Subscriber subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSubmitSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractSubmitSingle.java
@@ -16,7 +16,7 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
-import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 
 import java.util.concurrent.Callable;
@@ -24,7 +24,7 @@ import java.util.concurrent.Callable;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static java.util.Objects.requireNonNull;
 
-abstract class AbstractSubmitSingle<T> extends Single<T> implements SingleSource<T> {
+abstract class AbstractSubmitSingle<T> extends SubscribableSingle<T> {
     private final Executor runExecutor;
 
     AbstractSubmitSingle(final Executor runExecutor) {
@@ -61,10 +61,5 @@ abstract class AbstractSubmitSingle<T> extends Single<T> implements SingleSource
             return;
         }
         cancellable.delayedCancellable(eCancellable);
-    }
-
-    @Override
-    public final void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AmbSingles.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AmbSingles.java
@@ -16,7 +16,7 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
-import io.servicetalk.concurrent.SingleSource.Subscriber;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.handleException
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
-final class AmbSingles<T> extends Single<T> {
+final class AmbSingles<T> extends SubscribableSingle<T> {
     private final Single<? extends T>[] singles;
 
     @SafeVarargs

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncCloseables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncCloseables.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableCompletable;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -238,14 +238,6 @@ public final class AsyncCloseables {
         @Override
         public Completable onClosing() {
             return onClosing;
-        }
-    }
-
-    private abstract static class SubscribableCompletable extends Completable implements CompletableSource {
-
-        @Override
-        public final void subscribe(final Subscriber subscriber) {
-            subscribeInternal(subscriber);
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategies.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/BufferStrategies.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.api.BufferStrategy.Accumulator;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableCompletable;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -143,7 +144,7 @@ public final class BufferStrategies {
                     CountingAccumulator<T, B> firstAccum =
                             new CountingAccumulator<>(state, accumulatorSupplier.get(), count);
                     state.beforeNewAccumulatorEmitted(firstAccum);
-                    return Single.succeeded(firstAccum).concat(new Completable() {
+                    return Single.succeeded(firstAccum).concat(new SubscribableCompletable() {
                         @Override
                         protected void handleSubscribe(final Subscriber subscriber) {
                             // We ignore cancel and expect ambWith to ignore if we delay emit

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableDefer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableDefer.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableCompletable;
 
 import java.util.function.Supplier;
 
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * As returned by {@link Completable#defer(Supplier)}.
  */
-final class CompletableDefer extends Completable implements CompletableSource {
+final class CompletableDefer extends SubscribableCompletable {
     private final Supplier<? extends Completable> completableFactory;
 
     CompletableDefer(Supplier<? extends Completable> completableFactory) {
@@ -46,10 +46,5 @@ final class CompletableDefer extends Completable implements CompletableSource {
         // Since, we are invoking user code (completableFactory) we need this method to be run using an Executor
         // and also use the configured Executor for subscribing to the Completable returned from completableFactory.
         completable.subscribeInternal(subscriber);
-    }
-
-    @Override
-    public void subscribe(final Subscriber subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableProcessor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableProcessor.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.CompletableSource.Processor;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableCompletable;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 import io.servicetalk.concurrent.internal.TerminalNotification;
 
@@ -27,12 +28,12 @@ import static io.servicetalk.concurrent.internal.TerminalNotification.complete;
  * A {@link Completable} which is also a {@link Subscriber}. State of this {@link Completable} can be modified by using
  * the {@link Subscriber} methods which is forwarded to all existing or subsequent {@link Subscriber}s.
  */
-final class CompletableProcessor extends Completable implements Processor {
+final class CompletableProcessor extends SubscribableCompletable implements Processor {
     private final ClosableConcurrentStack<Subscriber> stack = new ClosableConcurrentStack<>();
 
     @Override
     protected void handleSubscribe(Subscriber subscriber) {
-        // We must subscribe before adding subscriber the the queue. Otherwise it is possible that this
+        // We must subscribe before adding subscriber the queue. Otherwise, it is possible that this
         // Completable has been terminated and the subscriber may be notified before onSubscribe is called.
         // We used a DelayedCancellable to avoid the case where the Subscriber will synchronously cancel and then
         // we would add the subscriber to the queue and possibly never (until termination) dereference the subscriber.
@@ -69,10 +70,5 @@ final class CompletableProcessor extends Completable implements Processor {
 
     private void terminate(TerminalNotification terminalSignal) {
         stack.close(terminalSignal::terminate);
-    }
-
-    @Override
-    public void subscribe(final Subscriber subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletionStageToSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletionStageToSingle.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +29,7 @@ import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static java.util.Objects.requireNonNull;
 
-final class CompletionStageToSingle<T> extends Single<T> implements SingleSource<T> {
+final class CompletionStageToSingle<T> extends SubscribableSingle<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CompletionStageToSingle.class);
     private final CompletionStage<? extends T> stage;
 
@@ -86,10 +86,5 @@ final class CompletionStageToSingle<T> extends Single<T> implements SingleSource
         } catch (Throwable cause) {
             return null;
         }
-    }
-
-    @Override
-    public void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FirstAndTailToPackedSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FirstAndTailToPackedSingle.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource.Subscriber;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribablePublisher;
 import io.servicetalk.concurrent.internal.DelayedSubscription;
 import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
 
@@ -219,9 +220,9 @@ final class FirstAndTailToPackedSingle<Packed, T> implements PublisherToSingleOp
 
         @Nonnull
         private Publisher<T> newTailPublisher() {
-            return new AbstractSynchronousPublisher<T>() {
+            return new SubscribablePublisher<T>() {
                 @Override
-                protected void doSubscribe(PublisherSource.Subscriber<? super T> newSubscriber) {
+                protected void handleSubscribe(PublisherSource.Subscriber<? super T> newSubscriber) {
                     final DelayedSubscription delayedSubscription = new DelayedSubscription();
                     // newSubscriber.onSubscribe MUST be called before making newSubscriber visible below with the CAS
                     // on maybeTailSubUpdater. Otherwise there is a potential for concurrent invocation on the

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
@@ -16,6 +16,7 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribablePublisher;
 import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
 
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @param <T> Type of items emitted to the {@link PublisherSource.Subscriber}.
  */
-final class FromInputStreamPublisher<T> extends Publisher<T> implements PublisherSource<T> {
+final class FromInputStreamPublisher<T> extends SubscribablePublisher<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(FromInputStreamPublisher.class);
     // While sun.nio.ch.FileChannelImpl and java.io.InputStream.transferTo(...) use 8Kb chunks,
     // we use 16Kb-32B because 16Kb is:
@@ -87,11 +88,6 @@ final class FromInputStreamPublisher<T> extends Publisher<T> implements Publishe
     FromInputStreamPublisher(final InputStream stream, final ByteArrayMapper<T> mapper) {
         this.stream = requireNonNull(stream);
         this.mapper = requireNonNull(mapper);
-    }
-
-    @Override
-    public void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FutureToSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FutureToSingle.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +25,7 @@ import java.util.concurrent.Future;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static java.util.Objects.requireNonNull;
 
-final class FutureToSingle<T> extends Single<T> implements SingleSource<T> {
+final class FutureToSingle<T> extends SubscribableSingle<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(FutureToSingle.class);
     private final Future<? extends T> future;
 
@@ -54,10 +54,5 @@ final class FutureToSingle<T> extends Single<T> implements SingleSource<T> {
         } catch (Throwable t) {
             LOGGER.info("Ignoring exception from onSuccess of Subscriber {}.", subscriber, t);
         }
-    }
-
-    @Override
-    public void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GroupedPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GroupedPublisher.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.concurrent.api;
 
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribablePublisher;
+
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
@@ -25,7 +27,7 @@ import static java.util.Objects.requireNonNull;
  * @param <Key> Key for the group.
  * @param <T> Items emitted by this {@link Publisher}.
  */
-public abstract class GroupedPublisher<Key, T> extends Publisher<T> {
+public abstract class GroupedPublisher<Key, T> extends SubscribablePublisher<T> {
     private final Key key;
 
     GroupedPublisher(Key key) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LiftSynchronousPublisherToSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LiftSynchronousPublisherToSingle.java
@@ -16,12 +16,11 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.SingleSource;
-import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
-final class LiftSynchronousPublisherToSingle<T, R> extends SubscribableSingle<R> {
+final class LiftSynchronousPublisherToSingle<T, R> extends Single<R> implements SingleSource<R> {
     private final Publisher<T> original;
     private final PublisherToSingleOperator<? super T, ? extends R> customOperator;
 
@@ -35,6 +34,11 @@ final class LiftSynchronousPublisherToSingle<T, R> extends SubscribableSingle<R>
     protected void handleSubscribe(final SingleSource.Subscriber<? super R> subscriber) {
         deliverErrorFromSource(subscriber,
                 new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
+    }
+
+    @Override
+    public void subscribe(final SingleSource.Subscriber<? super R> subscriber) {
+        subscribeInternal(subscriber);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LiftSynchronousPublisherToSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/LiftSynchronousPublisherToSingle.java
@@ -16,11 +16,12 @@
 package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static java.util.Objects.requireNonNull;
 
-final class LiftSynchronousPublisherToSingle<T, R> extends Single<R> implements SingleSource<R> {
+final class LiftSynchronousPublisherToSingle<T, R> extends SubscribableSingle<R> {
     private final Publisher<T> original;
     private final PublisherToSingleOperator<? super T, ? extends R> customOperator;
 
@@ -34,11 +35,6 @@ final class LiftSynchronousPublisherToSingle<T, R> extends Single<R> implements 
     protected void handleSubscribe(final SingleSource.Subscriber<? super R> subscriber) {
         deliverErrorFromSource(subscriber,
                 new UnsupportedOperationException("Subscribe with no executor is not supported for " + getClass()));
-    }
-
-    @Override
-    public void subscribe(final SingleSource.Subscriber<? super R> subscriber) {
-        subscribeInternal(subscriber);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherDefer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherDefer.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribablePublisher;
 
 import java.util.function.Supplier;
 
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @param <T> Type of items emitted by this {@link Publisher}.
  */
-final class PublisherDefer<T> extends Publisher<T> implements PublisherSource<T> {
+final class PublisherDefer<T> extends SubscribablePublisher<T> {
     private final Supplier<? extends Publisher<? extends T>> publisherFactory;
 
     PublisherDefer(Supplier<? extends Publisher<? extends T>> publisherFactory) {
@@ -47,10 +47,5 @@ final class PublisherDefer<T> extends Publisher<T> implements PublisherSource<T>
         // Since, we are invoking user code (publisherFactory) we need this method to be run using an Executor
         // and also use the configured Executor for subscribing to the Publisher returned from publisherFactory.
         publisher.subscribeInternal(subscriber);
-    }
-
-    @Override
-    public void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherFlatMapConcatUtils.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -86,7 +87,7 @@ final class PublisherFlatMapConcatUtils {
             final Single<? extends R> single = mapper.apply(t);
             final Item<R> item = new Item<>();
             results.add(item);
-            return new Single<R>() {
+            return new SubscribableSingle<R>() {
                 @Override
                 protected void handleSubscribe(final SingleSource.Subscriber<? super R> subscriber) {
                     assert item.subscriber == null; // flatMapMergeSingle only does a single subscribe.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherProcessor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherProcessor.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.PublisherSource.Processor;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribablePublisher;
 import io.servicetalk.concurrent.internal.ConcurrentSubscription;
 import io.servicetalk.concurrent.internal.DelayedSubscription;
 import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
@@ -40,7 +41,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
-final class PublisherProcessor<T> extends Publisher<T> implements Processor<T, T>, Subscription {
+final class PublisherProcessor<T> extends SubscribablePublisher<T> implements Processor<T, T>, Subscription {
     private static final Logger LOGGER = LoggerFactory.getLogger(PublisherProcessor.class);
     @SuppressWarnings("rawtypes")
     private static final ProcessorSignalsConsumer CANCELLED = new NoopProcessorSignalsConsumer();
@@ -120,11 +121,6 @@ final class PublisherProcessor<T> extends Publisher<T> implements Processor<T, T
                             ((SubscriberProcessorSignalsConsumer<T>) existingConsumer).subscriber : null;
             safeOnError(subscriber, new DuplicateSubscribeException(existingSubscriber, subscriber));
         }
-    }
-
-    @Override
-    public void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleDefer.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleDefer.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 
 import java.util.function.Supplier;
 
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @param <T> Type of result of this {@link Single}.
  */
-final class SingleDefer<T> extends Single<T> implements SingleSource<T> {
+final class SingleDefer<T> extends SubscribableSingle<T> {
     private final Supplier<? extends Single<? extends T>> singleFactory;
 
     SingleDefer(Supplier<? extends Single<? extends T>> singleFactory) {
@@ -47,10 +47,5 @@ final class SingleDefer<T> extends Single<T> implements SingleSource<T> {
         // Since, we are invoking user code (singleFactory) we need this method to be run using an Executor
         // and also use the configured Executor for subscribing to the Single returned from singleFactory.
         single.subscribeInternal(subscriber);
-    }
-
-    @Override
-    public void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleProcessor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleProcessor.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.SingleSource.Processor;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 
 import java.util.function.Consumer;
@@ -29,7 +30,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.handleException
  * {@link Subscriber} methods which is forwarded to all existing or subsequent {@link Subscriber}s.
  * @param <T> The type of result of the {@link Single}.
  */
-final class SingleProcessor<T> extends Single<T> implements Processor<T, T> {
+final class SingleProcessor<T> extends SubscribableSingle<T> implements Processor<T, T> {
     private final ClosableConcurrentStack<Subscriber<? super T>> stack = new ClosableConcurrentStack<>();
 
     @Override
@@ -71,10 +72,5 @@ final class SingleProcessor<T> extends Single<T> implements Processor<T, T> {
 
     private void terminate(Consumer<Subscriber<? super T>> terminalSignal) {
         stack.close(terminalSignal);
-    }
-
-    @Override
-    public void subscribe(final Subscriber<? super T> subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SubscribableSources.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SubscribableSources.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.PublisherSource;
+import io.servicetalk.concurrent.SingleSource;
+
+final class SubscribableSources {
+
+    private SubscribableSources() {
+        // No instances
+    }
+
+    /**
+     * A {@link Completable} that is also a {@link CompletableSource} and hence can be subscribed.
+     * <p>
+     * Typically, this will be used to implement a {@link Completable} that does not require an additional allocation
+     * when converting to a {@link CompletableSource} via {@link SourceAdapters#toSource(Completable)}.
+     */
+    abstract static class SubscribableCompletable extends Completable implements CompletableSource {
+
+        @Override
+        public final void subscribe(final Subscriber subscriber) {
+            subscribeInternal(subscriber);
+        }
+    }
+
+    /**
+     * A {@link Single} that is also a {@link SingleSource} and hence can be subscribed.
+     * <p>
+     * Typically, this will be used to implement a {@link Single} that does not require an additional allocation
+     * when converting to a {@link SingleSource} via {@link SourceAdapters#toSource(Single)}.
+     *
+     * @param <T> Type of result of this {@link SubscribableSingle}.
+     */
+    abstract static class SubscribableSingle<T> extends Single<T> implements SingleSource<T> {
+
+        @Override
+        public final void subscribe(final Subscriber<? super T> subscriber) {
+            subscribeInternal(subscriber);
+        }
+    }
+
+    /**
+     * A {@link Publisher} that is also a {@link PublisherSource} and hence can be subscribed.
+     * <p>
+     * Typically, this will be used to implement a {@link Publisher} that does not require an additional allocation
+     * when converting to a {@link PublisherSource} via {@link SourceAdapters#toSource(Publisher)}.
+     *
+     * @param <T> Type of the items emitted by this {@link SubscribablePublisher}.
+     */
+    abstract static class SubscribablePublisher<T> extends Publisher<T> implements PublisherSource<T> {
+
+        @Override
+        public final void subscribe(final Subscriber<? super T> subscriber) {
+            subscribeInternal(subscriber);
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimerCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TimerCompletable.java
@@ -15,7 +15,7 @@
  */
 package io.servicetalk.concurrent.api;
 
-import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.api.SubscribableSources.SubscribableCompletable;
 import io.servicetalk.concurrent.internal.DelayedCancellable;
 
 import java.time.Duration;
@@ -25,7 +25,7 @@ import static io.servicetalk.concurrent.internal.SubscriberUtils.handleException
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
-final class TimerCompletable extends Completable implements CompletableSource {
+final class TimerCompletable extends SubscribableCompletable {
     private final Executor timeoutExecutor;
     private final long delayNs;
 
@@ -57,10 +57,5 @@ final class TimerCompletable extends Completable implements CompletableSource {
         } catch (Throwable cause) {
             subscriber.onError(cause);
         }
-    }
-
-    @Override
-    public void subscribe(final Subscriber subscriber) {
-        subscribeInternal(subscriber);
     }
 }

--- a/servicetalk-concurrent-jdkflow/build.gradle
+++ b/servicetalk-concurrent-jdkflow/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     api project(":servicetalk-concurrent-api")
 
     implementation project(":servicetalk-annotations")
+    implementation project(":servicetalk-concurrent-api-internal")
 
     testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
     testImplementation testFixtures(project(":servicetalk-concurrent-api"))

--- a/servicetalk-concurrent-jdkflow/src/main/java/io/servicetalk/concurrent/jdkflow/JdkFlowAdapters.java
+++ b/servicetalk-concurrent-jdkflow/src/main/java/io/servicetalk/concurrent/jdkflow/JdkFlowAdapters.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.jdkflow;
 
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.internal.SubscribablePublisher;
 
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
@@ -126,7 +127,7 @@ public final class JdkFlowAdapters {
         }
     }
 
-    private static final class FlowToStPublisher<T> extends Publisher<T> {
+    private static final class FlowToStPublisher<T> extends SubscribablePublisher<T> {
         private final java.util.concurrent.Flow.Publisher<T> source;
 
         FlowToStPublisher(final java.util.concurrent.Flow.Publisher<T> source) {

--- a/servicetalk-concurrent-reactivestreams/build.gradle
+++ b/servicetalk-concurrent-reactivestreams/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   api "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
 
   implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent-api-internal")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-concurrent-api"))

--- a/servicetalk-concurrent-reactivestreams/src/main/java/io/servicetalk/concurrent/reactivestreams/ReactiveStreamsAdapters.java
+++ b/servicetalk-concurrent-reactivestreams/src/main/java/io/servicetalk/concurrent/reactivestreams/ReactiveStreamsAdapters.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.SingleSource;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.internal.SubscribablePublisher;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -179,7 +180,7 @@ public final class ReactiveStreamsAdapters {
         }
     }
 
-    private static final class RsToStPublisher<T> extends Publisher<T> {
+    private static final class RsToStPublisher<T> extends SubscribablePublisher<T> {
         private final org.reactivestreams.Publisher<T> source;
 
         RsToStPublisher(final org.reactivestreams.Publisher<T> source) {

--- a/servicetalk-grpc-api/build.gradle
+++ b/servicetalk-grpc-api/build.gradle
@@ -33,13 +33,14 @@ dependencies {
   implementation platform("com.google.protobuf:protobuf-bom:$protobufVersion")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-buffer-api")
-  implementation project(":servicetalk-encoding-api-internal")
+  implementation project(":servicetalk-concurrent-api-internal")
   implementation project(":servicetalk-concurrent-internal")
+  implementation project(":servicetalk-encoding-api-internal")
+  implementation project(":servicetalk-grpc-internal")
   implementation project(":servicetalk-http-utils")
   implementation project(":servicetalk-router-utils-internal")
-  implementation project(":servicetalk-utils-internal")
-  implementation project(":servicetalk-grpc-internal")
   implementation project(":servicetalk-serializer-utils")
+  implementation project(":servicetalk-utils-internal")
   implementation "com.google.protobuf:protobuf-java"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -27,6 +27,7 @@ import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
 import io.servicetalk.context.api.ContextMap;
 import io.servicetalk.encoding.api.BufferDecoder;
 import io.servicetalk.encoding.api.BufferDecoderGroup;
@@ -992,7 +993,7 @@ final class GrpcRouter {
         }
 
         private static AsyncCloseable toAsyncCloseable(final GracefulAutoCloseable original) {
-            return AsyncCloseables.toAsyncCloseable(graceful -> new Completable() {
+            return AsyncCloseables.toAsyncCloseable(graceful -> new SubscribableCompletable() {
                 @Override
                 protected void handleSubscribe(final CompletableSource.Subscriber subscriber) {
                     try {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -16,14 +16,14 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.Buffer;
-import io.servicetalk.concurrent.CompletableSource.Processor;
+import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
-import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.ScanMapper;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.ConnectablePayloadWriter;
+import io.servicetalk.concurrent.api.internal.SubscribableSingle;
 import io.servicetalk.concurrent.internal.ThreadInterruptingCancellable;
 
 import java.io.IOException;
@@ -63,7 +63,7 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                 final StreamingHttpRequest request,
                                                 final StreamingHttpResponseFactory responseFactory) {
-        return new Single<StreamingHttpResponse>() {
+        return new SubscribableSingle<StreamingHttpResponse>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
                 final ThreadInterruptingCancellable tiCancellable = new ThreadInterruptingCancellable(currentThread());
@@ -77,7 +77,7 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
                 // This exists to help users with error propagation. If the user closes the payloadWriter and they throw
                 // (e.g. try-with-resources) this processor is merged with the payloadWriter Publisher so the error will
                 // still be propagated.
-                final Processor exceptionProcessor = newCompletableProcessor();
+                final CompletableSource.Processor exceptionProcessor = newCompletableProcessor();
                 final BufferHttpPayloadWriter payloadWriter = new BufferHttpPayloadWriter(
                         () -> ctx.headersFactory().newTrailers());
                 DefaultBlockingStreamingHttpServerResponse response = null;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -25,12 +25,12 @@ import io.servicetalk.client.api.LoadBalancer;
 import io.servicetalk.client.api.ServiceDiscoverer;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.CompletableSource;
-import io.servicetalk.concurrent.CompletableSource.Subscriber;
 import io.servicetalk.concurrent.api.BiIntFunction;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.CompositeCloseable;
 import io.servicetalk.concurrent.api.Executor;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
 import io.servicetalk.http.api.DefaultHttpLoadBalancerFactory;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.DelegatingHttpExecutionContext;
@@ -709,7 +709,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         }
     }
 
-    private static final class SdStatusCompletable extends Completable {
+    private static final class SdStatusCompletable extends SubscribableCompletable {
         private volatile CompletableSource.Processor processor = newCompletableProcessor();
         private boolean seenError;  //  this is only accessed from nextError and resetError which are not concurrent
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelinedConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelinedConnection.java
@@ -21,6 +21,7 @@ import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.internal.SubscribablePublisher;
 import io.servicetalk.concurrent.internal.ConcurrentUtils;
 import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
@@ -103,7 +104,7 @@ public final class NettyPipelinedConnection<Req, Resp> implements NettyConnectio
                           final Supplier<FlushStrategy> flushStrategySupplier,
                           final Supplier<WriteDemandEstimator> writeDemandEstimatorSupplier) {
         // Lazy modification of local state required (e.g. nodes, delayed subscriber, queue modifications)
-        return new Publisher<Resp>() {
+        return new SubscribablePublisher<Resp>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super Resp> subscriber) {
                 final WriteTask nextWriteTask;
@@ -248,7 +249,7 @@ public final class NettyPipelinedConnection<Req, Resp> implements NettyConnectio
                         // the most straightforward way to propagate an error through the APIs is through the read async
                         // source. This has a side effect that the read async source isn't strictly full-duplex (data
                         // will be full-duplex, but completion will be delayed until the write completes).
-                        .mergeDelayError(new Publisher<Resp>() {
+                        .mergeDelayError(new SubscribablePublisher<Resp>() {
                             @Override
                             protected void handleSubscribe(final Subscriber<? super Resp> rSubscriber) {
                                 final Subscriber<? super Resp> nextReadSubscriber;


### PR DESCRIPTION
Motivation:

If all sources also implement their corresponding `*Source` interface, they can be converted using `SourceAdapters` without allocating a wrapper.

Modifications:

- Introduce internal `SubscribableSources` in `concurrent-api`.
- Use `SubscribableSources` as a base class for all operators.
- Use `SubscribableSources` equivalent from `concurrent-api-internal` in all other modules where we missed `*Source` interface.

Result:

`SourceAdapters.toSource(...)` don't require allocations for our async primitives.