### PR TITLE
Mark `Publisher.subscribeInternal(Subscriber)` method as final

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -4400,7 +4400,7 @@ Kotlin flatMapLatest</a>
      *
      * @param subscriber {@link Subscriber} to subscribe for the result.
      */
-    protected void subscribeInternal(Subscriber<? super T> subscriber) {
+    protected final void subscribeInternal(Subscriber<? super T> subscriber) {
         requireNonNull(subscriber);
         AsyncContextProvider provider = AsyncContext.provider();
         CapturedContext capturedContext = contextForSubscribe(provider);


### PR DESCRIPTION
Motivation:

This method was accidentally made non-final in #1639. See diff for easier view:
https://patch-diff.githubusercontent.com/raw/apple/servicetalk/pull/1639.diff

Modifications:

- Add `final` modifier for `Publisher.subscribeInternal(Subscriber)`.

Result:

`subscribeInternal` definition is consistent across `Publisher`, `Single`, and `Completable`.

Risk:

Because this is very specific internal API, I don't expect anyone to depend on it. Users should operate with `subscribe` and/or `handleSubscribe` methods. At least, I could not find any use-case visible to me.
The risk of breaking anyone is quite low. If anyone reports it as a breaking change, we can change it back and re-release, notifying them that it will be marked as `final` anyway in the future major release.