### PR TITLE
SourceAdapters should convert back and forth without allocation

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeCompletable.java
@@ -27,7 +27,11 @@ abstract class AbstractNoHandleSubscribeCompletable extends SubscribableCompleta
 
     @Override
     protected final void handleSubscribe(final Subscriber subscriber) {
-        deliverErrorFromSource(subscriber, new UnsupportedOperationException("Subscribe with no " +
-                CapturedContext.class.getSimpleName() + " is not supported for " + getClass()));
+        deliverErrorFromSource(subscriber, newUnsupportedOperationException(getClass()));
+    }
+
+    static UnsupportedOperationException newUnsupportedOperationException(final Class<?> clazz) {
+        return new UnsupportedOperationException(
+                "Subscribe with no " + CapturedContext.class.getSimpleName() + " is not supported for " + clazz);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribePublisher.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.SubscribableSources.SubscribablePublisher;
 
+import static io.servicetalk.concurrent.api.AbstractNoHandleSubscribeCompletable.newUnsupportedOperationException;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
@@ -29,7 +30,6 @@ abstract class AbstractNoHandleSubscribePublisher<T> extends SubscribablePublish
 
     @Override
     protected final void handleSubscribe(final Subscriber<? super T> subscriber) {
-        deliverErrorFromSource(subscriber, new UnsupportedOperationException("Subscribe with no " +
-                CapturedContext.class.getSimpleName() + " is not supported for " + getClass()));
+        deliverErrorFromSource(subscriber, newUnsupportedOperationException(getClass()));
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AbstractNoHandleSubscribeSingle.java
@@ -17,6 +17,7 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.api.SubscribableSources.SubscribableSingle;
 
+import static io.servicetalk.concurrent.api.AbstractNoHandleSubscribeCompletable.newUnsupportedOperationException;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 
 /**
@@ -29,7 +30,6 @@ abstract class AbstractNoHandleSubscribeSingle<T> extends SubscribableSingle<T> 
 
     @Override
     protected final void handleSubscribe(final Subscriber<? super T> subscriber) {
-        deliverErrorFromSource(subscriber, new UnsupportedOperationException("Subscribe with no " +
-                CapturedContext.class.getSimpleName() + " is not supported for " + getClass()));
+        deliverErrorFromSource(subscriber, newUnsupportedOperationException(getClass()));
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableSetContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableSetContextOnSubscribe.java
@@ -39,6 +39,6 @@ final class CompletableSetContextOnSubscribe extends AbstractNoHandleSubscribeCo
         // This operator currently only targets the subscribe method. Given this limitation if we try to change the
         // ContextMap now it is possible that operators downstream in the subscribe call stack may have modified
         // the ContextMap and we don't want to discard those changes by using a different ContextMap.
-        original.handleSubscribe(subscriber, capturedContext, contextProvider);
+        original.delegateSubscribe(subscriber, capturedContext, contextProvider);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableShareContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CompletableShareContextOnSubscribe.java
@@ -33,6 +33,6 @@ final class CompletableShareContextOnSubscribe extends AbstractNoHandleSubscribe
         // This operator currently only targets the subscribe method. Given this limitation if we try to change the
         // ContextMap now it is possible that operators downstream in the subscribe call stack may have modified
         // the ContextMap and we don't want to discard those changes by using a different ContextMap.
-        original.handleSubscribe(subscriber, capturedContext, contextProvider);
+        original.delegateSubscribe(subscriber, capturedContext, contextProvider);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSetContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherSetContextOnSubscribe.java
@@ -39,6 +39,6 @@ final class PublisherSetContextOnSubscribe<T> extends AbstractNoHandleSubscribeP
         // This operator currently only targets the subscribe method. Given this limitation if we try to change the
         // ContextMap now it is possible that operators downstream in the subscribe call stack may have modified
         // the ContextMap and we don't want to discard those changes by using a different ContextMap.
-        original.handleSubscribe(singleSubscriber, capturedContext, contextProvider);
+        original.delegateSubscribe(singleSubscriber, capturedContext, contextProvider);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherShareContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherShareContextOnSubscribe.java
@@ -33,6 +33,6 @@ final class PublisherShareContextOnSubscribe<T> extends AbstractNoHandleSubscrib
         // This operator currently only targets the subscribe method. Given this limitation if we try to change the
         // ContextMap now it is possible that operators downstream in the subscribe call stack may have modified
         // the ContextMap and we don't want to discard those changes by using a different ContextMap.
-        original.handleSubscribe(singleSubscriber, capturedContext, contextProvider);
+        original.delegateSubscribe(singleSubscriber, capturedContext, contextProvider);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleSetContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleSetContextOnSubscribe.java
@@ -39,6 +39,6 @@ final class SingleSetContextOnSubscribe<T> extends AbstractNoHandleSubscribeSing
         // This operator currently only targets the subscribe method. Given this limitation if we try to change the
         // ContextMap now it is possible that operators downstream in the subscribe call stack may have modified
         // the ContextMap and we don't want to discard those changes by using a different ContextMap.
-        original.handleSubscribe(singleSubscriber, capturedContext, contextProvider);
+        original.delegateSubscribe(singleSubscriber, capturedContext, contextProvider);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleShareContextOnSubscribe.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SingleShareContextOnSubscribe.java
@@ -33,6 +33,6 @@ final class SingleShareContextOnSubscribe<T> extends AbstractNoHandleSubscribeSi
         // This operator currently only targets the subscribe method. Given this limitation if we try to change the
         // ContextMap now it is possible that operators downstream in the subscribe call stack may have modified
         // the ContextMap and we don't want to discard those changes by using a different ContextMap.
-        original.handleSubscribe(singleSubscriber, capturedContext, contextProvider);
+        original.delegateSubscribe(singleSubscriber, capturedContext, contextProvider);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SourceAdapters.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/SourceAdapters.java
@@ -151,7 +151,7 @@ public final class SourceAdapters {
         @Override
         void handleSubscribe(final Subscriber<? super T> subscriber,
                              final CapturedContext capturedContext, final AsyncContextProvider contextProvider) {
-            publisher.handleSubscribe(subscriber, capturedContext, contextProvider);
+            publisher.delegateSubscribe(subscriber, capturedContext, contextProvider);
         }
 
         @Override
@@ -176,7 +176,7 @@ public final class SourceAdapters {
         @Override
         void handleSubscribe(final Subscriber<? super T> subscriber,
                              final CapturedContext capturedContext, final AsyncContextProvider contextProvider) {
-            single.handleSubscribe(subscriber, capturedContext, contextProvider);
+            single.delegateSubscribe(subscriber, capturedContext, contextProvider);
         }
 
         @Override
@@ -201,7 +201,7 @@ public final class SourceAdapters {
         @Override
         void handleSubscribe(final Subscriber subscriber,
                              final CapturedContext capturedContext, final AsyncContextProvider contextProvider) {
-            completable.handleSubscribe(subscriber, capturedContext, contextProvider);
+            completable.delegateSubscribe(subscriber, capturedContext, contextProvider);
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SourceAdaptersTest.java
@@ -20,24 +20,26 @@ import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.SourceAdapters.CompletableToCompletableSource;
+import io.servicetalk.concurrent.api.SourceAdapters.PublisherToPublisherSource;
+import io.servicetalk.concurrent.api.SourceAdapters.SingleToSingleSource;
 import io.servicetalk.concurrent.internal.ScalarValueSubscription;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
-import static io.servicetalk.concurrent.api.Completable.completed;
-import static io.servicetalk.concurrent.api.Publisher.from;
-import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.concurrent.internal.EmptySubscriptions.EMPTY_SUBSCRIPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentCaptor.forClass;
@@ -48,25 +50,29 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class SourceAdaptersTest {
 
-    @Test
-    void publisherToSourceSuccess() {
-        PublisherSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(from(1));
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void publisherToSourceSuccess(boolean same) {
+        PublisherSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(Publisher.from(1), same);
         verify(subscriber).onNext(1);
         verify(subscriber).onComplete();
         verifyNoMoreInteractions(subscriber);
     }
 
-    @Test
-    void publisherToSourceError() {
-        PublisherSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(Publisher.failed(DELIBERATE_EXCEPTION));
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void publisherToSourceError(boolean same) {
+        PublisherSource.Subscriber<Integer> subscriber =
+                toSourceAndSubscribe(Publisher.failed(DELIBERATE_EXCEPTION), same);
         verify(subscriber).onError(DELIBERATE_EXCEPTION);
         verifyNoMoreInteractions(subscriber);
     }
 
-    @Test
-    void publisherToSourceCancel() {
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void publisherToSourceCancel(boolean same) {
         TestPublisher<Integer> stPublisher = new TestPublisher<>();
-        PublisherSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(stPublisher);
+        PublisherSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(stPublisher, same);
         TestSubscription subscription = new TestSubscription();
         stPublisher.onSubscribe(subscription);
         assertThat("Source not subscribed.", stPublisher.isSubscribed(), is(true));
@@ -76,155 +82,342 @@ class SourceAdaptersTest {
         assertThat("Subscription not cancelled.", subscription.isCancelled(), is(true));
     }
 
-    @Test
-    void singleToSourceSuccess() {
-        SingleSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(succeeded(1));
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void singleToSourceSuccess(boolean same) {
+        SingleSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(Single.succeeded(1), same);
         verify(subscriber).onSuccess(1);
         verifyNoMoreInteractions(subscriber);
     }
 
-    @Test
-    void singleToSourceError() {
-        SingleSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(Single.failed(DELIBERATE_EXCEPTION));
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void singleToSourceError(boolean same) {
+        SingleSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(Single.failed(DELIBERATE_EXCEPTION), same);
         verify(subscriber).onError(DELIBERATE_EXCEPTION);
         verifyNoMoreInteractions(subscriber);
     }
 
-    @Test
-    void singleToSourceCancel() {
-        LegacyTestSingle<Integer> stSingle = new LegacyTestSingle<>();
-        SingleSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(stSingle);
-        stSingle.verifyListenCalled();
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void singleToSourceCancel(boolean same) {
+        TestSingle<Integer> stSingle = new TestSingle<>();
+        SingleSource.Subscriber<Integer> subscriber = toSourceAndSubscribe(stSingle, same);
+        TestCancellable cancellable = new TestCancellable();
+        stSingle.onSubscribe(cancellable);
+        assertThat("Source not subscribed.", stSingle.isSubscribed(), is(true));
         ArgumentCaptor<Cancellable> cancellableCaptor = forClass(Cancellable.class);
         verify(subscriber).onSubscribe(cancellableCaptor.capture());
         cancellableCaptor.getValue().cancel();
-        stSingle.verifyCancelled();
+        assertThat("Cancellable not cancelled.", cancellable.isCancelled(), is(true));
     }
 
-    @Test
-    void completableToSourceSuccess() {
-        CompletableSource.Subscriber subscriber = toSourceAndSubscribe(completed());
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void completableToSourceSuccess(boolean same) {
+        CompletableSource.Subscriber subscriber = toSourceAndSubscribe(Completable.completed(), same);
         verify(subscriber).onComplete();
         verifyNoMoreInteractions(subscriber);
     }
 
-    @Test
-    void completableToSourceError() {
-        CompletableSource.Subscriber subscriber = toSourceAndSubscribe(Completable.failed(DELIBERATE_EXCEPTION));
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void completableToSourceError(boolean same) {
+        CompletableSource.Subscriber subscriber = toSourceAndSubscribe(Completable.failed(DELIBERATE_EXCEPTION), same);
         verify(subscriber).onError(DELIBERATE_EXCEPTION);
         verifyNoMoreInteractions(subscriber);
     }
 
-    @Test
-    void completableToSourceCancel() {
-        LegacyTestCompletable stCompletable = new LegacyTestCompletable();
-        CompletableSource.Subscriber subscriber = toSourceAndSubscribe(stCompletable);
-        stCompletable.verifyListenCalled();
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void completableToSourceCancel(boolean same) {
+        TestCompletable stCompletable = new TestCompletable();
+        CompletableSource.Subscriber subscriber = toSourceAndSubscribe(stCompletable, same);
+        TestCancellable cancellable = new TestCancellable();
+        stCompletable.onSubscribe(cancellable);
+        assertThat("Source not subscribed.", stCompletable.isSubscribed(), is(true));
         ArgumentCaptor<Cancellable> cancellableCaptor = forClass(Cancellable.class);
         verify(subscriber).onSubscribe(cancellableCaptor.capture());
         cancellableCaptor.getValue().cancel();
-        stCompletable.verifyCancelled();
+        assertThat("Cancellable not cancelled.", cancellable.isCancelled(), is(true));
     }
 
-    @Test
-    void publisherFromSourceSuccess() throws Exception {
-        PublisherSource<Integer> src = s -> s.onSubscribe(new ScalarValueSubscription<>(1, s));
-        Integer result = fromSource(src).firstOrElse(() -> null).toFuture().get();
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void publisherFromSourceSuccess(boolean same) throws Exception {
+        PublisherSource<Integer> src = same ? uncheckedCast(Publisher.from(1)) :
+                s -> s.onSubscribe(new ScalarValueSubscription<>(1, s));
+        Integer result = fromSourceAndSubscribe(src, same).get();
         assertThat("Unexpected result.", result, is(1));
     }
 
-    @Test
-    void publisherFromSourceError() {
-        PublisherSource<Integer> src = s -> {
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void publisherFromSourceError(boolean same) {
+        PublisherSource<Integer> src = same ? uncheckedCast(Publisher.failed(DELIBERATE_EXCEPTION)) : s -> {
             s.onSubscribe(EMPTY_SUBSCRIPTION);
             s.onError(DELIBERATE_EXCEPTION);
         };
 
-        Future<Integer> future = fromSource(src).firstOrElse(() -> null).toFuture();
-        Exception e = assertThrows(ExecutionException.class, () -> future.get());
+        Future<Integer> future = fromSourceAndSubscribe(src, same);
+        Exception e = assertThrows(ExecutionException.class, future::get);
         assertThat(e.getCause(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
-    @Test
-    void publisherFromSourceCancel() {
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void publisherFromSourceCancel(boolean same) {
         PublisherSource.Subscription srcSubscription = mock(PublisherSource.Subscription.class);
-        PublisherSource<Integer> source = s -> s.onSubscribe(srcSubscription);
+        TestPublisher<Integer> testPublisher = new TestPublisher<>();
+        PublisherSource<Integer> src = same ? uncheckedCast(testPublisher) : s -> s.onSubscribe(srcSubscription);
 
-        fromSource(source).firstOrElse(() -> null).toFuture().cancel(true);
+        Future<Integer> future = fromSourceAndSubscribe(src, same);
+        if (same) {
+            testPublisher.onSubscribe(srcSubscription);
+        }
+        future.cancel(true);
         verify(srcSubscription).cancel();
     }
 
-    @Test
-    void singleFromSourceSuccess() throws Exception {
-        SingleSource<Integer> src = s -> {
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void singleFromSourceSuccess(boolean same) throws Exception {
+        SingleSource<Integer> src = same ? uncheckedCast(Single.succeeded(1)) : s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onSuccess(1);
         };
-        Integer result = fromSource(src).toFuture().get();
+        Integer result = fromSourceAndSubscribe(src, same).get();
         assertThat("Unexpected result.", result, is(1));
     }
 
-    @Test
-    void singleFromSourceError() {
-        SingleSource<Integer> src = s -> {
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void singleFromSourceError(boolean same) {
+        SingleSource<Integer> src = same ? uncheckedCast(Single.failed(DELIBERATE_EXCEPTION)) : s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onError(DELIBERATE_EXCEPTION);
         };
 
-        Future<Integer> future = fromSource(src).toFuture();
-        Exception e = assertThrows(ExecutionException.class, () -> future.get());
+        Future<Integer> future = fromSourceAndSubscribe(src, same);
+        Exception e = assertThrows(ExecutionException.class, future::get);
         assertThat(e.getCause(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
-    @Test
-    void singleFromSourceCancel() {
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void singleFromSourceCancel(boolean same) {
         Cancellable srcCancellable = mock(Cancellable.class);
-        SingleSource<Integer> source = s -> s.onSubscribe(srcCancellable);
+        TestSingle<Integer> testSingle = new TestSingle<>();
+        SingleSource<Integer> src = same ? uncheckedCast(testSingle) : s -> s.onSubscribe(srcCancellable);
 
-        fromSource(source).toFuture().cancel(true);
+        Future<Integer> future = fromSourceAndSubscribe(src, same);
+        if (same) {
+            testSingle.onSubscribe(srcCancellable);
+        }
+        future.cancel(true);
         verify(srcCancellable).cancel();
     }
 
-    @Test
-    void completableFromSourceSuccess() throws Exception {
-        CompletableSource src = s -> {
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void completableFromSourceSuccess(boolean same) throws Exception {
+        CompletableSource src = same ? (CompletableSource) Completable.completed() : s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onComplete();
         };
-        fromSource(src).toFuture().get();
+        fromSourceAndSubscribe(src, same).get();
     }
 
-    @Test
-    void completableFromSourceError() {
-        CompletableSource src = s -> {
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void completableFromSourceError(boolean same) {
+        CompletableSource src = same ? (CompletableSource) Completable.failed(DELIBERATE_EXCEPTION) : s -> {
             s.onSubscribe(IGNORE_CANCEL);
             s.onError(DELIBERATE_EXCEPTION);
         };
 
-        Future<Void> future = fromSource(src).toFuture();
-        Exception e = assertThrows(ExecutionException.class, () -> future.get());
+        Future<Void> future = fromSourceAndSubscribe(src, same);
+        Exception e = assertThrows(ExecutionException.class, future::get);
         assertThat(e.getCause(), sameInstance(DELIBERATE_EXCEPTION));
     }
 
-    @Test
-    void completableFromSourceCancel() {
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void completableFromSourceCancel(boolean same) {
         Cancellable srcCancellable = mock(Cancellable.class);
-        CompletableSource source = s -> s.onSubscribe(srcCancellable);
+        TestCompletable testCompletable = new TestCompletable();
+        CompletableSource src = same ? testCompletable : s -> s.onSubscribe(srcCancellable);
 
-        fromSource(source).toFuture().cancel(true);
+        Future<Void> future = fromSourceAndSubscribe(src, same);
+        if (same) {
+            testCompletable.onSubscribe(srcCancellable);
+        }
+        future.cancel(true);
         verify(srcCancellable).cancel();
     }
 
-    private CompletableSource.Subscriber toSourceAndSubscribe(Completable completable) {
-        CompletableSource src = toSource(completable);
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void publisherBackAndForthConversions(boolean same) {
+        if (same) {
+            Publisher<Integer> original = new TestPublisher<>();
+            PublisherSource<Integer> src = toSource(original);
+            assertThat(src, is(sameInstance(original)));
+            Publisher<Integer> back = fromSource(src);
+            assertThat(back, is(sameInstance(src)));
+        } else {
+            Publisher<Integer> original = new Publisher<Integer>() {
+
+                @Override
+                protected void handleSubscribe(PublisherSource.Subscriber<? super Integer> s) {
+                    s.onSubscribe(EMPTY_SUBSCRIPTION);
+                    s.onComplete();
+                }
+            };
+            PublisherSource<Integer> src = toSource(original);
+            assertThat(src, is(not(sameInstance(original))));
+            Publisher<Integer> back = fromSource(src);
+            assertThat(back, is(sameInstance(src)));
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void publisherSourceBackAndForthConversions(boolean same) {
+        if (same) {
+            PublisherSource<Integer> original = new TestPublisher<>();
+            Publisher<Integer> publisher = fromSource(original);
+            assertThat(publisher, is(sameInstance(original)));
+            PublisherSource<Integer> back = toSource(publisher);
+            assertThat(back, is(sameInstance(publisher)));
+        } else {
+            PublisherSource<Integer> original = s -> {
+                s.onSubscribe(EMPTY_SUBSCRIPTION);
+                s.onError(DELIBERATE_EXCEPTION);
+            };
+            Publisher<Integer> publisher = fromSource(original);
+            assertThat(publisher, is(not(sameInstance(original))));
+            PublisherSource<Integer> back = toSource(publisher);
+            assertThat(back, is(sameInstance(publisher)));
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void singleBackAndForthConversions(boolean same) {
+        if (same) {
+            Single<Integer> original = new TestSingle<>();
+            SingleSource<Integer> src = toSource(original);
+            assertThat(src, is(sameInstance(original)));
+            Single<Integer> back = fromSource(src);
+            assertThat(back, is(sameInstance(src)));
+        } else {
+            Single<Integer> original = new Single<Integer>() {
+
+                @Override
+                protected void handleSubscribe(SingleSource.Subscriber<? super Integer> s) {
+                    s.onSubscribe(EMPTY_SUBSCRIPTION);
+                    s.onSuccess(null);
+                }
+            };
+            SingleSource<Integer> src = toSource(original);
+            assertThat(src, is(not(sameInstance(original))));
+            Single<Integer> back = fromSource(src);
+            assertThat(back, is(sameInstance(src)));
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void singleSourceBackAndForthConversions(boolean same) {
+        if (same) {
+            SingleSource<Integer> original = new TestSingle<>();
+            Single<Integer> single = fromSource(original);
+            assertThat(single, is(sameInstance(original)));
+            SingleSource<Integer> back = toSource(single);
+            assertThat(back, is(sameInstance(single)));
+        } else {
+            SingleSource<Integer> original = s -> {
+                s.onSubscribe(EMPTY_SUBSCRIPTION);
+                s.onSuccess(null);
+            };
+            Single<Integer> single = fromSource(original);
+            assertThat(single, is(not(sameInstance(original))));
+            SingleSource<Integer> back = toSource(single);
+            assertThat(back, is(sameInstance(single)));
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void completableBackAndForthConversions(boolean same) {
+        if (same) {
+            Completable original = new TestCompletable();
+            CompletableSource src = toSource(original);
+            assertThat(src, is(sameInstance(original)));
+            Completable back = fromSource(src);
+            assertThat(back, is(sameInstance(src)));
+        } else {
+            Completable original = new Completable() {
+
+                @Override
+                protected void handleSubscribe(CompletableSource.Subscriber s) {
+                    s.onSubscribe(EMPTY_SUBSCRIPTION);
+                    s.onComplete();
+                }
+            };
+            CompletableSource src = toSource(original);
+            assertThat(src, is(not(sameInstance(original))));
+            Completable back = fromSource(src);
+            assertThat(back, is(sameInstance(src)));
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] same={0}")
+    @ValueSource(booleans = {false, true})
+    void completableSourceBackAndForthConversions(boolean same) {
+        if (same) {
+            CompletableSource original = new TestCompletable();
+            Completable completable = fromSource(original);
+            assertThat(completable, is(sameInstance(original)));
+            CompletableSource back = toSource(completable);
+            assertThat(back, is(sameInstance(completable)));
+        } else {
+            CompletableSource original = s -> {
+                s.onSubscribe(EMPTY_SUBSCRIPTION);
+                s.onComplete();
+            };
+            Completable completable = fromSource(original);
+            assertThat(completable, is(not(sameInstance(original))));
+            CompletableSource back = toSource(completable);
+            assertThat(back, is(sameInstance(completable)));
+        }
+    }
+
+    private CompletableSource.Subscriber toSourceAndSubscribe(Completable completable, boolean same) {
+        CompletableSource src;
+        if (same) {
+            src = toSource(completable);
+            assertThat(src, is(sameInstance(completable)));
+        } else {
+            src = new CompletableToCompletableSource(completable);
+            assertThat(src, is(not(sameInstance(completable))));
+        }
         CompletableSource.Subscriber subscriber = mock(CompletableSource.Subscriber.class);
         src.subscribe(subscriber);
         verify(subscriber).onSubscribe(any());
         return subscriber;
     }
 
-    private SingleSource.Subscriber<Integer> toSourceAndSubscribe(Single<Integer> single) {
-        SingleSource<Integer> src = toSource(single);
+    private SingleSource.Subscriber<Integer> toSourceAndSubscribe(Single<Integer> single, boolean same) {
+        SingleSource<Integer> src;
+        if (same) {
+            src = toSource(single);
+            assertThat(src, is(sameInstance(single)));
+        } else {
+            src = new SingleToSingleSource<>(single);
+            assertThat(src, is(not(sameInstance(single))));
+        }
         @SuppressWarnings("unchecked")
         SingleSource.Subscriber<Integer> subscriber = mock(SingleSource.Subscriber.class);
         src.subscribe(subscriber);
@@ -232,8 +425,15 @@ class SourceAdaptersTest {
         return subscriber;
     }
 
-    private PublisherSource.Subscriber<Integer> toSourceAndSubscribe(final Publisher<Integer> publisher) {
-        PublisherSource<Integer> src = toSource(publisher);
+    private PublisherSource.Subscriber<Integer> toSourceAndSubscribe(Publisher<Integer> publisher, boolean same) {
+        PublisherSource<Integer> src;
+        if (same) {
+            src = toSource(publisher);
+            assertThat(src, is(sameInstance(publisher)));
+        } else {
+            src = new PublisherToPublisherSource<>(publisher);
+            assertThat(src, is(not(sameInstance(publisher))));
+        }
         @SuppressWarnings("unchecked")
         PublisherSource.Subscriber<Integer> subscriber = mock(PublisherSource.Subscriber.class);
         src.subscribe(subscriber);
@@ -241,5 +441,33 @@ class SourceAdaptersTest {
         verify(subscriber).onSubscribe(subscriptionCaptor.capture());
         subscriptionCaptor.getValue().request(1);
         return subscriber;
+    }
+
+    private static Future<Void> fromSourceAndSubscribe(CompletableSource src, boolean same) {
+        final Completable completable = fromSource(src);
+        assertThat(completable, is(same ? sameInstance(src) : not(sameInstance(src))));
+        return completable.toFuture();
+    }
+
+    private static Future<Integer> fromSourceAndSubscribe(SingleSource<Integer> src, boolean same) {
+        final Single<Integer> single = fromSource(src);
+        assertThat(single, is(same ? sameInstance(src) : not(sameInstance(src))));
+        return single.toFuture();
+    }
+
+    private static Future<Integer> fromSourceAndSubscribe(PublisherSource<Integer> src, boolean same) {
+        final Publisher<Integer> publisher = fromSource(src);
+        assertThat(publisher, is(same ? sameInstance(src) : not(sameInstance(src))));
+        return publisher.firstOrElse(() -> null).toFuture();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> PublisherSource<T> uncheckedCast(final Publisher<T> publisher) {
+        return (PublisherSource<T>) publisher;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> SingleSource<T> uncheckedCast(final Single<T> single) {
+        return (SingleSource<T>) single;
     }
 }


### PR DESCRIPTION
Motivation:

`SourceAdapters.toSource(...)` currently returns a source without implementing the original type. In result, operation like `fromSource(toSource(notSource))` returns double wrapped object instead of wrapping only once.

Modifications:

- `PublisherToPublisherSource` extends `Publisher`;
- `SingleToSingleSource` extends `Single`;
- `CompletableToCompletableSource` extends `Completable`;
- Enhance `SourceAdaptersTest` to cover all transformations (via cast and via wrapping).

Result:

Less wrapping layers for back and forth conversions and better test coverage for `SourceAdapters`.