### PR TITLE
Prevent concurrent execution of the same mutable request object

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ConcurrentGrpcRequestTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/ConcurrentGrpcRequestTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorExtension;
+import io.servicetalk.concurrent.api.Processors;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.SourceAdapters;
+import io.servicetalk.concurrent.internal.RejectedSubscribeException;
+import io.servicetalk.grpc.api.DefaultGrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.grpc.netty.TesterProto.TestRequest;
+import io.servicetalk.grpc.netty.TesterProto.TestResponse;
+import io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterClient;
+import io.servicetalk.grpc.netty.TesterProto.Tester.TesterService;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ConcurrentGrpcRequestTest {
+
+    private enum AsyncVariant {
+        TEST,
+        TEST_REQUEST_STREAM,
+        TEST_RESPONSE_STREAM,
+        TEST_BI_DI_STREAM,
+        BLOCKING_TEST,
+        BLOCKING_TEST_REQUEST_STREAM,
+        BLOCKING_TEST_RESPONSE_STREAM,
+        BLOCKING_TEST_BI_DI_STREAM
+    }
+
+    @RegisterExtension
+    static final ExecutorExtension<Executor> executorExtension = withCachedExecutor().setClassLevel(true);
+
+    private final CountDownLatch receivedFirstRequest = new CountDownLatch(1);
+    private final AtomicInteger receivedRequests = new AtomicInteger();
+    private final CompletableSource.Processor responseProcessor = Processors.newCompletableProcessor();
+    private final ServerContext serverCtx;
+
+    ConcurrentGrpcRequestTest() throws Exception {
+        serverCtx = GrpcServers.forAddress(localAddress(0)).listenAndAwait(new TesterService() {
+            @Override
+            public Single<TestResponse> test(GrpcServiceContext ctx, TestRequest request) {
+                return testSingle(Publisher.from(request));
+            }
+
+            @Override
+            public Single<TestResponse> testRequestStream(GrpcServiceContext ctx, Publisher<TestRequest> request) {
+                return testSingle(request);
+            }
+
+            @Override
+            public Publisher<TestResponse> testResponseStream(GrpcServiceContext ctx, TestRequest request) {
+                return testSingle(Publisher.from(request)).toPublisher();
+            }
+
+            @Override
+            public Publisher<TestResponse> testBiDiStream(GrpcServiceContext ctx, Publisher<TestRequest> request) {
+                return testSingle(request).toPublisher();
+            }
+
+            private Single<TestResponse> testSingle(Publisher<TestRequest> request) {
+                receivedFirstRequest.countDown();
+                if (receivedRequests.incrementAndGet() == 1) {
+                    return SourceAdapters.fromSource(responseProcessor)
+                            .concat(request.ignoreElements())
+                            .concat(Single.succeeded(TestResponse.newBuilder().setMessage("first").build()));
+                }
+                return Single.succeeded(TestResponse.newBuilder().setMessage("other").build());
+            }
+        });
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        serverCtx.close();
+    }
+
+    private static List<Arguments> asyncVariants() {
+        List<Arguments> arguments = new ArrayList<>();
+        for (AsyncVariant variant : AsyncVariant.values()) {
+            arguments.add(Arguments.of(true, variant));
+            // Blocking calls without metadata always create a new underlying request, there is no risk
+            if (!variant.name().startsWith("BLOCKING")) {
+                arguments.add(Arguments.of(false, variant));
+            }
+        }
+        return arguments;
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] withMetadata={0} variant={1}")
+    @MethodSource("asyncVariants")
+    void test(boolean withMetadata, AsyncVariant variant) throws Exception {
+        GrpcClientMetadata metadata = withMetadata ? new DefaultGrpcClientMetadata() : null;
+        try (TesterClient client = GrpcClients.forAddress(serverHostAndPort(serverCtx)).build(new ClientFactory())) {
+            Single<TestResponse> firstSingle = newSingle(variant, client, metadata);
+            Future<TestResponse> first = firstSingle.toFuture();
+            receivedFirstRequest.await();
+            Future<TestResponse> firstConcurrent = firstSingle.toFuture();
+            Future<TestResponse> secondConcurrent = newSingle(variant, client, metadata).toFuture();
+
+            responseProcessor.onComplete();
+            assertThat(first.get().getMessage(), is("first"));
+            assertRejected(firstConcurrent);
+            if (metadata != null) {
+                assertRejected(secondConcurrent);
+            } else {
+                // Requests are independent when metadata is not shared between them
+                assertThat(secondConcurrent.get().getMessage(), is("other"));
+            }
+
+            Future<TestResponse> firstSequential = firstSingle.toFuture();
+            assertThat(firstSequential.get().getMessage(), is("other"));
+            Future<TestResponse> thirdSequential = newSingle(variant, client, metadata).toFuture();
+            assertThat(thirdSequential.get().getMessage(), is("other"));
+        }
+        assertThat(receivedRequests.get(), is(metadata != null ? 3 : 4));
+    }
+
+    private static Single<TestResponse> newSingle(AsyncVariant variant, TesterClient client,
+                                                  @Nullable GrpcClientMetadata metadata) {
+        switch (variant) {
+            case TEST:
+                return metadata == null ?
+                        client.test(newRequest()) :
+                        client.test(metadata, newRequest());
+            case TEST_REQUEST_STREAM:
+                return metadata == null ?
+                        client.testRequestStream(newStreamingRequest()) :
+                        client.testRequestStream(metadata, newStreamingRequest());
+            case TEST_RESPONSE_STREAM:
+                return (metadata == null ?
+                        client.testResponseStream(newRequest()) :
+                        client.testResponseStream(metadata, newRequest()))
+                        .firstOrError();
+            case TEST_BI_DI_STREAM:
+                return (metadata == null ?
+                        client.testBiDiStream(newStreamingRequest()) :
+                        client.testBiDiStream(metadata, newStreamingRequest()))
+                        .firstOrError();
+            case BLOCKING_TEST:
+                return executorExtension.executor().submit(() -> metadata == null ?
+                        client.asBlockingClient().test(newRequest()) :
+                        client.asBlockingClient().test(metadata, newRequest()));
+            case BLOCKING_TEST_REQUEST_STREAM:
+                return executorExtension.executor().submit(() -> metadata == null ?
+                        client.asBlockingClient().testRequestStream(newIterableRequest()) :
+                        client.asBlockingClient().testRequestStream(metadata, newIterableRequest()));
+            case BLOCKING_TEST_RESPONSE_STREAM:
+                return executorExtension.executor().submit(() -> (metadata == null ?
+                        client.asBlockingClient().testResponseStream(newRequest()) :
+                        client.asBlockingClient().testResponseStream(metadata, newRequest()))
+                        .iterator().next());
+            case BLOCKING_TEST_BI_DI_STREAM:
+                return executorExtension.executor().submit(() -> (metadata == null ?
+                        client.asBlockingClient().testBiDiStream(newIterableRequest()) :
+                        client.asBlockingClient().testBiDiStream(metadata, newIterableRequest()))
+                        .iterator().next());
+            default:
+                throw new AssertionError("Unexpected variant: " + variant);
+        }
+    }
+
+    private static TestRequest newRequest() {
+        return TestRequest.newBuilder().setName("foo").build();
+    }
+
+    private static Publisher<TestRequest> newStreamingRequest() {
+        return Publisher.from(newRequest());
+    }
+
+    private static Iterable<TestRequest> newIterableRequest() {
+        return Collections.singletonList(newRequest());
+    }
+
+    private static void assertRejected(Future<?> future) {
+        ExecutionException ee = assertThrows(ExecutionException.class, future::get);
+        assertThat(ee.getCause(), is(instanceOf(GrpcStatusException.class)));
+        GrpcStatusException gse = (GrpcStatusException) ee.getCause();
+        assertThat(gse.getCause(), is(instanceOf(RejectedSubscribeException.class)));
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractHttpMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractHttpMetaData.java
@@ -84,6 +84,8 @@ abstract class AbstractHttpMetaData implements HttpMetaData {
     @Override
     public final ContextMap context() {
         if (context == null) {
+            // If this implementation ever changes to a concurrent one, remove external synchronization from
+            // FilterableClientToClient.executeRequest(...) and make it consistent with DefaultGrpcMetadata.
             context = new DefaultContextMap();
         }
         return context;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
@@ -221,6 +221,11 @@ final class FilterableClientToClient implements StreamingHttpClient {
             // chain and accidentally subscribed to the same request concurrently. This protection helps them avoid
             // ambiguous runtime behavior caused by a corrupted mutable request state.
             final Object inFlight;
+            // Note that because request.context() lazily allocates a new ContextMap, there is a risk that
+            // synchronization will happen on two different contexts. However, this is acceptable compromise because:
+            //  - Most likely users subscribe 2+ times to the same request from the same thread.
+            //  - This is the best effort protection, giving users at least one rejection should be enough to let them
+            //    know their code is incorrect and should be rewritten.
             synchronized (context) {
                 // We do not override lock because other layers may already set their own one.
                 inFlight = context.putIfAbsent(HTTP_IN_FLIGHT_REQUEST, lock);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractNettyHttpServerTest.java
@@ -319,14 +319,14 @@ abstract class AbstractNettyHttpServerTest {
         return awaitIndefinitelyNonNull(httpConnection.request(request));
     }
 
-    void assertResponse(final HttpResponseMetaData response, final HttpProtocolVersion version,
-                        final HttpResponseStatus status) {
+    static void assertResponse(final HttpResponseMetaData response, final HttpProtocolVersion version,
+                               final HttpResponseStatus status) {
         assertEquals(status, response.status());
         assertEquals(version, response.version());
     }
 
-    void assertResponse(final StreamingHttpResponse response, final HttpProtocolVersion version,
-                        final HttpResponseStatus status, final int expectedSize)
+    static void assertResponse(final StreamingHttpResponse response, final HttpProtocolVersion version,
+                               final HttpResponseStatus status, final int expectedSize)
             throws ExecutionException, InterruptedException {
         assertResponse(response, version, status);
         final int size = awaitIndefinitelyNonNull(
@@ -334,8 +334,8 @@ abstract class AbstractNettyHttpServerTest {
         assertEquals(expectedSize, size);
     }
 
-    void assertResponse(final StreamingHttpResponse response, final HttpProtocolVersion version,
-                        final HttpResponseStatus status, final String expectedPayload)
+    static void assertResponse(final StreamingHttpResponse response, final HttpProtocolVersion version,
+                               final HttpResponseStatus status, final String expectedPayload)
             throws ExecutionException, InterruptedException {
         assertResponse(response, version, status);
         String actualPayload = response.payloadBody().collect(StringBuilder::new, (sb, chunk) -> {
@@ -345,8 +345,8 @@ abstract class AbstractNettyHttpServerTest {
         assertThat(actualPayload, is(expectedPayload));
     }
 
-    void assertSerializedResponse(final StreamingHttpResponse response, final HttpProtocolVersion version,
-                                  final HttpResponseStatus status, final String expectedPayload)
+    static void assertSerializedResponse(final StreamingHttpResponse response, final HttpProtocolVersion version,
+                                         final HttpResponseStatus status, final String expectedPayload)
             throws ExecutionException, InterruptedException {
         assertResponse(response, version, status);
         String actualPayload = response.payloadBody(appSerializerUtf8FixLen())

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentHttpRequestTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentHttpRequestTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorExtension;
+import io.servicetalk.concurrent.api.Processors;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.SourceAdapters;
+import io.servicetalk.concurrent.internal.RejectedSubscribeException;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.BlockingHttpRequester;
+import io.servicetalk.http.api.BlockingStreamingHttpClient;
+import io.servicetalk.http.api.BlockingStreamingHttpRequest;
+import io.servicetalk.http.api.BlockingStreamingHttpRequester;
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.HttpRequester;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.http.api.HttpResponseStatus;
+import io.servicetalk.http.api.ReservedBlockingHttpConnection;
+import io.servicetalk.http.api.ReservedBlockingStreamingHttpConnection;
+import io.servicetalk.http.api.ReservedHttpConnection;
+import io.servicetalk.http.api.ReservedStreamingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.servicetalk.buffer.api.EmptyBuffer.EMPTY_BUFFER;
+import static io.servicetalk.concurrent.api.ExecutorExtension.withCachedExecutor;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.AbstractNettyHttpServerTest.assertResponse;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ConcurrentHttpRequestTest {
+
+    @RegisterExtension
+    static final ExecutorExtension<Executor> executorExtension = withCachedExecutor().setClassLevel(true);
+
+    private final CountDownLatch receivedFirstRequest = new CountDownLatch(1);
+    private final AtomicInteger receivedRequests = new AtomicInteger();
+    private final CompletableSource.Processor responseProcessor = Processors.newCompletableProcessor();
+    private final ServerContext serverCtx;
+
+    ConcurrentHttpRequestTest() throws Exception {
+        serverCtx = HttpServers.forAddress(localAddress(0))
+                .listenAndAwait((ctx, request, responseFactory) -> {
+                    receivedFirstRequest.countDown();
+                    if (receivedRequests.incrementAndGet() == 1) {
+                        return SourceAdapters.fromSource(responseProcessor)
+                                .concat(Single.succeeded(responseFactory.ok()));
+                    }
+                    return Single.succeeded(responseFactory.noContent());
+                });
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        serverCtx.close();
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] multiAddressClient={0}")
+    @ValueSource(booleans = {false, true})
+    void asyncStreamingClient(boolean multiAddressClient) throws Exception {
+        try (StreamingHttpClient client = newClient(multiAddressClient)) {
+            asyncStreamingRequester(client, multiAddressClient);
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] multiAddressClient={0}")
+    @ValueSource(booleans = {false, true})
+    void asyncStreamingConnection(boolean multiAddressClient) throws Exception {
+        try (StreamingHttpClient client = newClient(multiAddressClient)) {
+            try (ReservedStreamingHttpConnection connection = client.reserveConnection(
+                    client.get(requestTarget(multiAddressClient))).toFuture().get()) {
+
+                asyncStreamingRequester(connection, multiAddressClient);
+            }
+        }
+    }
+
+    void asyncStreamingRequester(StreamingHttpRequester requester, boolean multiAddressClient) throws Exception {
+        StreamingHttpRequest request = requester.get(requestTarget(multiAddressClient));
+        Single<StreamingHttpResponse> firstSingle = requester.request(request);
+        Future<StreamingHttpResponse> first = firstSingle.toFuture();
+        receivedFirstRequest.await();
+        Future<StreamingHttpResponse> firstConcurrent = firstSingle.toFuture();
+        Future<StreamingHttpResponse> secondConcurrent = requester.request(request).toFuture();
+
+        responseProcessor.onComplete();
+        assertResponse(first.get(), HTTP_1_1, OK, 0);
+        assertRejected(firstConcurrent);
+        assertRejected(secondConcurrent);
+
+        assertSequential(multiAddressClient, request, firstSingle);
+        assertSequential(multiAddressClient, request, requester.request(request));
+
+        assertThat(receivedRequests.get(), is(3));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] multiAddressClient={0}")
+    @ValueSource(booleans = {false, true})
+    void asyncAggregatedClient(boolean multiAddressClient) throws Exception {
+        try (HttpClient client = newClient(multiAddressClient).asClient()) {
+            asyncAggregatedRequester(client, multiAddressClient);
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] multiAddressClient={0}")
+    @ValueSource(booleans = {false, true})
+    void asyncAggregatedConnection(boolean multiAddressClient) throws Exception {
+        try (HttpClient client = newClient(multiAddressClient).asClient()) {
+            try (ReservedHttpConnection connection = client.reserveConnection(
+                    client.get(requestTarget(multiAddressClient))).toFuture().get()) {
+
+                asyncAggregatedRequester(connection, multiAddressClient);
+            }
+        }
+    }
+
+    void asyncAggregatedRequester(HttpRequester requester, boolean multiAddressClient) throws Exception {
+        HttpRequest request = requester.get(requestTarget(multiAddressClient));
+        Single<HttpResponse> firstSingle = requester.request(request);
+        Future<HttpResponse> first = firstSingle.toFuture();
+        receivedFirstRequest.await();
+        Future<HttpResponse> firstConcurrent = firstSingle.toFuture();
+        Future<HttpResponse> secondConcurrent = requester.request(request).toFuture();
+
+        responseProcessor.onComplete();
+        assertAggregatedResponse(first.get(), OK);
+        assertRejected(firstConcurrent);
+        assertRejected(secondConcurrent);
+
+        assertSequential(multiAddressClient, request, firstSingle);
+        assertSequential(multiAddressClient, request, requester.request(request));
+
+        assertThat(receivedRequests.get(), is(3));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] multiAddressClient={0}")
+    @ValueSource(booleans = {false, true})
+    void blockingStreamingClient(boolean multiAddressClient) throws Exception {
+        try (BlockingStreamingHttpClient client = newClient(multiAddressClient).asBlockingStreamingClient()) {
+            blockingStreamingRequester(client, multiAddressClient);
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] multiAddressClient={0}")
+    @ValueSource(booleans = {false, true})
+    void blockingStreamingConnection(boolean multiAddressClient) throws Exception {
+        try (BlockingStreamingHttpClient client = newClient(multiAddressClient).asBlockingStreamingClient()) {
+            try (ReservedBlockingStreamingHttpConnection connection = client.reserveConnection(
+                    client.get(requestTarget(multiAddressClient)))) {
+
+                blockingStreamingRequester(connection, multiAddressClient);
+            }
+        }
+    }
+
+    void blockingStreamingRequester(BlockingStreamingHttpRequester requester,
+                                    boolean multiAddressClient) throws Exception {
+        BlockingStreamingHttpRequest request = requester.get(requestTarget(multiAddressClient));
+        Single<StreamingHttpResponse> firstSingle =
+                executorExtension.executor().submit(() -> requester.request(request).toStreamingResponse());
+        Future<StreamingHttpResponse> first = firstSingle.toFuture();
+        receivedFirstRequest.await();
+        Future<StreamingHttpResponse> firstConcurrent = firstSingle.toFuture();
+        Future<StreamingHttpResponse> secondConcurrent =
+                executorExtension.executor().submit(() -> requester.request(request).toStreamingResponse()).toFuture();
+
+        responseProcessor.onComplete();
+        assertResponse(first.get(), HTTP_1_1, OK, 0);
+        assertRejected(firstConcurrent);
+        assertRejected(secondConcurrent);
+
+        assertSequential(multiAddressClient, request, firstSingle);
+        assertSequential(multiAddressClient, request,
+                executorExtension.executor().submit(() -> requester.request(request).toStreamingResponse()));
+
+        assertThat(receivedRequests.get(), is(3));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] multiAddressClient={0}")
+    @ValueSource(booleans = {false, true})
+    void blockingAggregatedClient(boolean multiAddressClient) throws Exception {
+        try (BlockingHttpClient client = newClient(multiAddressClient).asBlockingClient()) {
+            blockingAggregatedRequester(client, multiAddressClient);
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] multiAddressClient={0}")
+    @ValueSource(booleans = {false, true})
+    void blockingAggregatedConnection(boolean multiAddressClient) throws Exception {
+        try (BlockingHttpClient client = newClient(multiAddressClient).asBlockingClient()) {
+            try (ReservedBlockingHttpConnection connection = client.reserveConnection(
+                    client.get(requestTarget(multiAddressClient)))) {
+
+                blockingAggregatedRequester(connection, multiAddressClient);
+            }
+        }
+    }
+
+    void blockingAggregatedRequester(BlockingHttpRequester requester, boolean multiAddressClient) throws Exception {
+        HttpRequest request = requester.get(requestTarget(multiAddressClient));
+        Single<HttpResponse> firstSingle = executorExtension.executor().submit(() -> requester.request(request));
+        Future<HttpResponse> first = firstSingle.toFuture();
+        receivedFirstRequest.await();
+        Future<HttpResponse> firstConcurrent = firstSingle.toFuture();
+        Future<HttpResponse> secondConcurrent = executorExtension.executor().submit(() -> requester.request(request))
+                .toFuture();
+
+        responseProcessor.onComplete();
+        assertAggregatedResponse(first.get(), OK);
+        assertRejected(firstConcurrent);
+        assertRejected(secondConcurrent);
+
+        assertSequential(multiAddressClient, request, firstSingle);
+        assertSequential(multiAddressClient, request,
+                executorExtension.executor().submit(() -> requester.request(request)));
+
+        assertThat(receivedRequests.get(), is(3));
+    }
+
+    private StreamingHttpClient newClient(boolean multiAddressClient) {
+        return multiAddressClient ?
+                HttpClients.forMultiAddressUrl(getClass().getSimpleName()).buildStreaming() :
+                HttpClients.forSingleAddress(serverHostAndPort(serverCtx)).buildStreaming();
+    }
+
+    private String requestTarget(boolean multiAddressClient) {
+        return multiAddressClient ? "http://" + serverHostAndPort(serverCtx) + "/" : "/";
+    }
+
+    private static void assertRejected(Future<? extends HttpResponseMetaData> future) {
+        ExecutionException e = assertThrows(ExecutionException.class, future::get);
+        assertThat(e.getCause(), is(instanceOf(RejectedSubscribeException.class)));
+    }
+
+    private void assertSequential(boolean multiAddressClient, HttpRequestMetaData request,
+                                  Single<? extends HttpResponseMetaData> responseSingle) throws Exception {
+        // We need to reset requestTarget for MultiAddress client because it changed from absolute to relative format.
+        request.requestTarget(requestTarget(multiAddressClient));
+        Future<? extends HttpResponseMetaData> future = responseSingle.toFuture();
+        HttpResponseMetaData response = future.get();
+        if (response instanceof StreamingHttpResponse) {
+            assertResponse((StreamingHttpResponse) response, HTTP_1_1, NO_CONTENT, 0);
+        } else if (response instanceof HttpResponse) {
+            assertAggregatedResponse((HttpResponse) response, NO_CONTENT);
+        } else {
+            throw new AssertionError("Unexpected response type: " + response.getClass());
+        }
+    }
+
+    private static void assertAggregatedResponse(HttpResponse response, HttpResponseStatus status) {
+        assertResponse(response, HTTP_1_1, status);
+        assertThat(response.payloadBody(), is(EMPTY_BUFFER));
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentHttpRequestTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentHttpRequestTest.java
@@ -122,10 +122,10 @@ class ConcurrentHttpRequestTest {
         Future<StreamingHttpResponse> firstConcurrent = firstSingle.toFuture();
         Future<StreamingHttpResponse> secondConcurrent = requester.request(request).toFuture();
 
-        responseProcessor.onComplete();
-        assertResponse(first.get(), HTTP_1_1, OK, 0);
         assertRejected(firstConcurrent);
         assertRejected(secondConcurrent);
+        responseProcessor.onComplete();
+        assertResponse(first.get(), HTTP_1_1, OK, 0);
 
         assertSequential(multiAddressClient, request, firstSingle);
         assertSequential(multiAddressClient, request, requester.request(request));
@@ -161,10 +161,10 @@ class ConcurrentHttpRequestTest {
         Future<HttpResponse> firstConcurrent = firstSingle.toFuture();
         Future<HttpResponse> secondConcurrent = requester.request(request).toFuture();
 
-        responseProcessor.onComplete();
-        assertAggregatedResponse(first.get(), OK);
         assertRejected(firstConcurrent);
         assertRejected(secondConcurrent);
+        responseProcessor.onComplete();
+        assertAggregatedResponse(first.get(), OK);
 
         assertSequential(multiAddressClient, request, firstSingle);
         assertSequential(multiAddressClient, request, requester.request(request));
@@ -203,10 +203,10 @@ class ConcurrentHttpRequestTest {
         Future<StreamingHttpResponse> secondConcurrent =
                 executorExtension.executor().submit(() -> requester.request(request).toStreamingResponse()).toFuture();
 
-        responseProcessor.onComplete();
-        assertResponse(first.get(), HTTP_1_1, OK, 0);
         assertRejected(firstConcurrent);
         assertRejected(secondConcurrent);
+        responseProcessor.onComplete();
+        assertResponse(first.get(), HTTP_1_1, OK, 0);
 
         assertSequential(multiAddressClient, request, firstSingle);
         assertSequential(multiAddressClient, request,
@@ -244,10 +244,10 @@ class ConcurrentHttpRequestTest {
         Future<HttpResponse> secondConcurrent = executorExtension.executor().submit(() -> requester.request(request))
                 .toFuture();
 
-        responseProcessor.onComplete();
-        assertAggregatedResponse(first.get(), OK);
         assertRejected(firstConcurrent);
         assertRejected(secondConcurrent);
+        responseProcessor.onComplete();
+        assertAggregatedResponse(first.get(), OK);
 
         assertSequential(multiAddressClient, request, firstSingle);
         assertSequential(multiAddressClient, request,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentHttpRequestTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConcurrentHttpRequestTest.java
@@ -164,7 +164,7 @@ class ConcurrentHttpRequestTest {
         assertRejected(firstConcurrent);
         assertRejected(secondConcurrent);
         responseProcessor.onComplete();
-        assertAggregatedResponse(first.get(), OK);
+        assertAggregatedEmptyResponse(first.get(), OK);
 
         assertSequential(multiAddressClient, request, firstSingle);
         assertSequential(multiAddressClient, request, requester.request(request));
@@ -247,7 +247,7 @@ class ConcurrentHttpRequestTest {
         assertRejected(firstConcurrent);
         assertRejected(secondConcurrent);
         responseProcessor.onComplete();
-        assertAggregatedResponse(first.get(), OK);
+        assertAggregatedEmptyResponse(first.get(), OK);
 
         assertSequential(multiAddressClient, request, firstSingle);
         assertSequential(multiAddressClient, request,
@@ -280,13 +280,13 @@ class ConcurrentHttpRequestTest {
         if (response instanceof StreamingHttpResponse) {
             assertResponse((StreamingHttpResponse) response, HTTP_1_1, NO_CONTENT, 0);
         } else if (response instanceof HttpResponse) {
-            assertAggregatedResponse((HttpResponse) response, NO_CONTENT);
+            assertAggregatedEmptyResponse((HttpResponse) response, NO_CONTENT);
         } else {
             throw new AssertionError("Unexpected response type: " + response.getClass());
         }
     }
 
-    private static void assertAggregatedResponse(HttpResponse response, HttpResponseStatus status) {
+    private static void assertAggregatedEmptyResponse(HttpResponse response, HttpResponseStatus status) {
         assertResponse(response, HTTP_1_1, status);
         assertThat(response.payloadBody(), is(EMPTY_BUFFER));
     }


### PR DESCRIPTION
Motivation:

Our `HttpRequestMetaData` object is mutable, and we expect users to create a new request every time they need to make a new call. Sequential retries are acceptable, but concurrent execution can corrupt internal state. While these expectations are more clear for HTTP users, with gRPC it gets less obvious that they can not subscribe to the same returned `Single<Message>` concurrently.

Modifications:
- Enhance `FilterableClientToClient` to protect users from concurrent execution of the same request, while still allowing sequential retries.
- Verify concurrent execution is not allowed for HTTP and gRPC.

Result:

Users get `RejectedSubscribeException` if they subscribe to the same Single that shares underlying meta-data object concurrently. This is the best effort to let users know they misused the client.

Risk:

The change may unexpectedly break existing use-cases. To give users some time to adjust their code, we temporarily introduce a system property to opt-out from this new behavior: `-Dio.servicetalk.http.netty.skipConcurrentRequestCheck=true`.