### PR TITLE
Align `HttpRequester`/`StreamingHttpRequester` with blocking variants

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpClient.java
@@ -15,16 +15,13 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.concurrent.api.Single;
-
-import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
 /**
  * Provides a means to issue requests against HTTP service. The implementation is free to maintain a collection of
  * {@link HttpConnection} instances and distribute calls to {@link #request(HttpRequest)} amongst this collection.
  */
-public interface HttpClient extends HttpRequester, GracefulAutoCloseable {
+public interface HttpClient extends HttpRequester {
     /**
      * Reserve an {@link HttpConnection} based on provided {@link HttpRequestMetaData}.
      * <p>
@@ -62,15 +59,5 @@ public interface HttpClient extends HttpRequester, GracefulAutoCloseable {
      */
     default BlockingHttpClient asBlockingClient() {
         return asStreamingClient().asBlockingClient();
-    }
-
-    @Override
-    default void close() throws Exception {
-        awaitTermination(closeAsync().toFuture());
-    }
-
-    @Override
-    default void closeGracefully() throws Exception {
-        awaitTermination(closeAsyncGracefully().toFuture());
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpConnection.java
@@ -15,16 +15,13 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.concurrent.PublisherSource;
 import io.servicetalk.concurrent.api.Publisher;
-
-import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
 /**
  * Represents a single fixed connection to a HTTP server.
  */
-public interface HttpConnection extends HttpRequester, GracefulAutoCloseable {
+public interface HttpConnection extends HttpRequester {
     /**
      * Get the {@link HttpConnectionContext}.
      *
@@ -68,15 +65,5 @@ public interface HttpConnection extends HttpRequester, GracefulAutoCloseable {
      */
     default BlockingHttpConnection asBlockingConnection() {
         return asStreamingConnection().asBlockingConnection();
-    }
-
-    @Override
-    default void close() throws Exception {
-        awaitTermination(closeAsync().toFuture());
-    }
-
-    @Override
-    default void closeGracefully() throws Exception {
-        awaitTermination(closeAsyncGracefully().toFuture());
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpRequester.java
@@ -15,13 +15,16 @@
  */
 package io.servicetalk.http.api;
 
+import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
 /**
  * Provides a means to make a HTTP request.
  */
-public interface HttpRequester extends HttpRequestFactory, ListenableAsyncCloseable {
+public interface HttpRequester extends HttpRequestFactory, ListenableAsyncCloseable, GracefulAutoCloseable {
     /**
      * Send a {@code request}.
      *
@@ -46,4 +49,14 @@ public interface HttpRequester extends HttpRequestFactory, ListenableAsyncClosea
      * @return a {@link HttpResponseFactory}.
      */
     HttpResponseFactory httpResponseFactory();
+
+    @Override
+    default void close() throws Exception {
+        awaitTermination(closeAsync().toFuture());
+    }
+
+    @Override
+    default void closeGracefully() throws Exception {
+        awaitTermination(closeAsyncGracefully().toFuture());
+    }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpClient.java
@@ -15,16 +15,13 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.concurrent.api.Single;
-
-import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
 /**
  * The equivalent of {@link HttpClient} but that accepts {@link StreamingHttpRequest} and returns
  * {@link StreamingHttpResponse}.
  */
-public interface StreamingHttpClient extends FilterableStreamingHttpClient, GracefulAutoCloseable {
+public interface StreamingHttpClient extends FilterableStreamingHttpClient {
     /**
      * Reserve a {@link StreamingHttpConnection} based on provided {@link HttpRequestMetaData}.
      * <p>
@@ -66,14 +63,4 @@ public interface StreamingHttpClient extends FilterableStreamingHttpClient, Grac
      * @return a {@link BlockingHttpClient} representation of this {@link StreamingHttpClient}.
      */
     BlockingHttpClient asBlockingClient();
-
-    @Override
-    default void close() throws Exception {
-        awaitTermination(closeAsync().toFuture());
-    }
-
-    @Override
-    default void closeGracefully() throws Exception {
-        awaitTermination(closeAsyncGracefully().toFuture());
-    }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpConnection.java
@@ -15,15 +15,11 @@
  */
 package io.servicetalk.http.api;
 
-import io.servicetalk.concurrent.GracefulAutoCloseable;
-
-import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
-
 /**
  * The equivalent of {@link HttpConnection} but that accepts {@link StreamingHttpRequest} and returns
  * {@link StreamingHttpResponse}.
  */
-public interface StreamingHttpConnection extends FilterableStreamingHttpConnection, GracefulAutoCloseable {
+public interface StreamingHttpConnection extends FilterableStreamingHttpConnection {
     /**
      * Convert this {@link StreamingHttpConnection} to the {@link HttpConnection} API.
      * <p>
@@ -50,14 +46,4 @@ public interface StreamingHttpConnection extends FilterableStreamingHttpConnecti
      * @return a {@link BlockingHttpConnection} representation of this {@link StreamingHttpConnection}.
      */
     BlockingHttpConnection asBlockingConnection();
-
-    @Override
-    default void close() throws Exception {
-        awaitTermination(closeAsync().toFuture());
-    }
-
-    @Override
-    default void closeGracefully() throws Exception {
-        awaitTermination(closeAsyncGracefully().toFuture());
-    }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequester.java
@@ -15,14 +15,18 @@
  */
 package io.servicetalk.http.api;
 
+import io.servicetalk.concurrent.GracefulAutoCloseable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Single;
+
+import static io.servicetalk.concurrent.internal.FutureUtils.awaitTermination;
 
 /**
  * The equivalent of {@link HttpRequester} but that accepts {@link StreamingHttpRequest} and returns
  * {@link StreamingHttpResponse}.
  */
-public interface StreamingHttpRequester extends StreamingHttpRequestFactory, ListenableAsyncCloseable {
+public interface StreamingHttpRequester extends StreamingHttpRequestFactory, ListenableAsyncCloseable,
+                                                GracefulAutoCloseable {
     /**
      * Send a {@code request}.
      *
@@ -47,4 +51,14 @@ public interface StreamingHttpRequester extends StreamingHttpRequestFactory, Lis
      * @return a {@link StreamingHttpResponseFactory}.
      */
     StreamingHttpResponseFactory httpResponseFactory();
+
+    @Override
+    default void close() throws Exception {
+        awaitTermination(closeAsync().toFuture());
+    }
+
+    @Override
+    default void closeGracefully() throws Exception {
+        awaitTermination(closeAsyncGracefully().toFuture());
+    }
 }


### PR DESCRIPTION
Motivation:

`BlockingHttpRequester` and `BlockingStreamingHttpRequester` implement `GracefulAutoCloseable` interface and in result can be used in try-with-resources. For some reason, our `HttpRequester` and `StreamingHttpRequester` don't but their client and connection interfaces do.

Modifications:

- Promote `GracefulAutoCloseable` interface from `HttpClient` and `HttpConnection` to `HttpRequester`.
- Promote `GracefulAutoCloseable` interface from `StreamingHttpClient` and `StreamingHttpConnection` to `StreamingHttpRequester`.

Result:

All requester/client/connection interfaces are consistent across all 4 API variants.

Risk:

Minimal, `japicmp.sh` output:
```
Comparing binary compatibility of servicetalk-http-api-0.42.55-SNAPSHOT.jar against servicetalk-http-api-0.42.54.jar
No changes.
```
However, use-cases that have a static import of a method with name `close` on a requester implementation won't compile. See changes in `H2ClientParentConnectionContext`. Error:
```
servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java:394: error: method close in interface StreamingHttpRequester cannot be applied to given types;
                              close(streamChannel, cause);
                              ^
    required: no arguments
    found: Http2StreamChannel,Throwable
    reason: actual and formal argument lists differ in length
```
I consider that as a minimal risk, and ready to revert this change in future releases if any users find it problematic.