### PR TITLE
concurrent-api: defer logging during CapturedContextProviders initialization

### DIFF
--- a/servicetalk-concurrent-api/gradle/checkstyle/suppressions.xml
+++ b/servicetalk-concurrent-api/gradle/checkstyle/suppressions.xml
@@ -32,4 +32,7 @@
   <!-- Extra whitespace makes it easier to read doNotFailOnInputStreamWithBrokenAvailableCall() stream inputs -->
   <suppress checks="SingleSpaceSeparator"
             files="io[\\/]servicetalk[\\/]concurrent[\\/]api[\\/]FromInputStreamPublisherTest.java"/>
+  <!--  We can't log at this point, so we must surface errors through the console-->
+  <suppress id="ConsolePrint"
+            files="io[\\/]servicetalk[\\/]concurrent[\\/]api[\\/]DefaultAsyncContextProvider.java"/>
 </suppressions>

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProviders.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProviders.java
@@ -26,13 +26,11 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
 final class CapturedContextProviders {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(CapturedContextProviders.class);
     private static final List<CapturedContextProvider> PROVIDERS;
 
     static {
         final ClassLoader classLoader = CapturedContextProviders.class.getClassLoader();
-        PROVIDERS = loadProviders(CapturedContextProvider.class, classLoader, LOGGER);
+        PROVIDERS = loadProviders(CapturedContextProvider.class, classLoader);
     }
 
     private CapturedContextProviders() {
@@ -46,16 +44,16 @@ final class CapturedContextProviders {
     // This was copied from `ServiceLoaderUtils` because the implementation there logs the result, which normally
     // wouldn't be a problem but as it turns out things like the MDC logging utils depend on the AsyncContext which
     // may result in a cyclical dependency in class initialization.
-    private static <T> List<T> loadProviders(final Class<T> clazz, final ClassLoader classLoader, final Logger logger) {
+    private static <T> List<T> loadProviders(final Class<T> clazz, final ClassLoader classLoader) {
         final List<T> list = new ArrayList<>(0);
         for (T provider : ServiceLoader.load(clazz, classLoader)) {
             list.add(provider);
         }
         if (list.isEmpty()) {
-            runLater(() -> logger.debug("ServiceLoader {}(s) registered: []", clazz.getSimpleName()));
+            runLater(() -> getLogger().debug("ServiceLoader {}(s) registered: []", clazz.getSimpleName()));
             return emptyList();
         }
-        runLater(() -> logger.info("ServiceLoader {}(s) registered: {}", clazz.getSimpleName(), list));
+        runLater(() -> getLogger().info("ServiceLoader {}(s) registered: {}", clazz.getSimpleName(), list));
         return unmodifiableList(list);
     }
 
@@ -66,5 +64,9 @@ final class CapturedContextProviders {
         t.setDaemon(true);
         t.setName(CapturedContextProviders.class.getSimpleName() + "-logging");
         t.start();
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(CapturedContextProviders.class);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProviders.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProviders.java
@@ -30,7 +30,14 @@ final class CapturedContextProviders {
 
     static {
         final ClassLoader classLoader = CapturedContextProviders.class.getClassLoader();
-        PROVIDERS = loadProviders(CapturedContextProvider.class, classLoader);
+        List<CapturedContextProvider> providers = emptyList();
+        try {
+            providers = loadProviders(CapturedContextProvider.class, classLoader);
+        } catch (Throwable ex) {
+            runLater(() ->
+                    getLogger().error("Failed to load {} instances", CapturedContextProvider.class.getName(), ex));
+        }
+        PROVIDERS = providers;
     }
 
     private CapturedContextProviders() {
@@ -59,7 +66,7 @@ final class CapturedContextProviders {
 
     // We have to run logging code 'later' because of cyclical dependency issues that can arise if logging depends
     // on the AsyncContext.
-    private static void runLater(Runnable runnable) {
+    static void runLater(Runnable runnable) {
         Thread t = new Thread(runnable);
         t.setDaemon(true);
         t.setName(CapturedContextProviders.class.getSimpleName() + "-logging");

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
@@ -41,9 +41,19 @@ class DefaultAsyncContextProvider implements AsyncContextProvider {
             withInitial(DefaultAsyncContextProvider::newContextMap);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAsyncContextProvider.class);
-    private static final boolean NO_DEBUG_LOGGING = !LOGGER.isDebugEnabled();
-
     static final AsyncContextProvider INSTANCE = new DefaultAsyncContextProvider();
+    private static final boolean NO_DEBUG_LOGGING;
+
+
+    static {
+        boolean noDebugLogging = true;
+        try {
+            noDebugLogging = !LOGGER.isDebugEnabled();
+        } catch (Exception ex) {
+            System.err.println("Couldn't evaluate debug logging: defaulting to false. Cause:\n" + ex);
+        }
+        NO_DEBUG_LOGGING = noDebugLogging;
+    }
 
     protected DefaultAsyncContextProvider() {
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
@@ -42,18 +42,7 @@ class DefaultAsyncContextProvider implements AsyncContextProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAsyncContextProvider.class);
     static final AsyncContextProvider INSTANCE = new DefaultAsyncContextProvider();
-    private static final boolean NO_DEBUG_LOGGING;
-
-
-    static {
-        boolean noDebugLogging = true;
-        try {
-            noDebugLogging = !LOGGER.isDebugEnabled();
-        } catch (Exception ex) {
-            System.err.println("Couldn't evaluate debug logging: defaulting to false. Cause:\n" + ex);
-        }
-        NO_DEBUG_LOGGING = noDebugLogging;
-    }
+    private static final boolean NO_DEBUG_LOGGING = isNoDebugLogging();
 
     protected DefaultAsyncContextProvider() {
     }
@@ -388,5 +377,16 @@ class DefaultAsyncContextProvider implements AsyncContextProvider {
 
     private static ContextMap newContextMap() {
         return new CopyOnWriteContextMap();
+    }
+
+    @SuppressWarnings("PMD.SystemPrintln")
+    private static boolean isNoDebugLogging() {
+        try {
+            return !LOGGER.isDebugEnabled();
+        } catch (Exception ex) {
+            // Logger isn't initialized, so we have to send it to a console.
+            System.err.println("Couldn't evaluate debug logging: defaulting to false. Cause:\n" + ex);
+            return true;
+        }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
@@ -385,7 +385,9 @@ class DefaultAsyncContextProvider implements AsyncContextProvider {
             return !LOGGER.isDebugEnabled();
         } catch (Exception ex) {
             // Logger isn't initialized, so we have to send it to a console.
-            System.err.println("Couldn't evaluate debug logging: defaulting to false. Cause:\n" + ex);
+            System.err.println("Could not evaluate logging level, considering debug level is disabled by default. " +
+                    "Cause:" + System.lineSeparator() + ex);
+            ex.printStackTrace(System.err);
             return true;
         }
     }

--- a/servicetalk-log4j2-mdc-utils/src/test/java/io/servicetalk/log4j2/mdc/utils/ServiceTalkThreadContextMapTest.java
+++ b/servicetalk-log4j2-mdc-utils/src/test/java/io/servicetalk/log4j2/mdc/utils/ServiceTalkThreadContextMapTest.java
@@ -44,6 +44,7 @@ class ServiceTalkThreadContextMapTest {
 
     @BeforeEach
     void verifyMDCSetup() {
+        logger.info("Attempting to log");
         assumeTrue(ThreadContext.getThreadContextMap() instanceof ServiceTalkThreadContextMap);
     }
 

--- a/servicetalk-log4j2-mdc-utils/src/test/resources/log4j2-test.xml
+++ b/servicetalk-log4j2-mdc-utils/src/test/resources/log4j2-test.xml
@@ -20,6 +20,13 @@
       <PatternLayout pattern="%d %30t a=%X{a} b=%X{b} c=%X{c} [%-5level] %-30logger{1} - %msg%n"/>
     </Console>
   </Appenders>
+
+<!--  We add the DynamicThresholdFilter to surface cyclical dependencies between MDC logging and the AsyncContext -->
+  <DynamicThresholdFilter key="USER_ROLE" defaultThreshold="ERROR" onMatch="ACCEPT" onMismatch="DENY">
+    <KeyValuePair key="ADMIN" value="INFO"/>
+    <KeyValuePair key="GUEST" value="DEBUG"/>
+  </DynamicThresholdFilter>
+
   <Loggers>
     <Logger name="io.netty" level="info"/>
     <Root level="debug">


### PR DESCRIPTION
Motivation:

The MDC utilities depend on the AsyncContext for storing properties. This can create a cyclical dependency since we try to log the loaded providers as part of the initialization.

Modifications:

Submit the logging to a different thread so that it will happen 'later' after the class initialization is complete.