### PR TITLE
concurrent-api: Makethe CapturedContext API's public

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContext.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContext.java
@@ -25,7 +25,7 @@ import io.servicetalk.context.api.ContextMap;
  * thread via the {@link CapturedContext#attachContext()} method which will return a {@link Scope} used to detach this
  * state, restoring any context information that existed beforehand.
  */
-interface CapturedContext {
+public interface CapturedContext {
 
     /**
      * The {@link ContextMap} that was captured.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
@@ -19,7 +19,7 @@ package io.servicetalk.concurrent.api;
  * Functionality related to capturing thread-local like context for later restoration across async boundaries.
  */
 @FunctionalInterface
-interface CapturedContextProvider {
+public interface CapturedContextProvider {
 
     /**
      * Capture existing context in preparation for an asynchronous thread jump.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Scope.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Scope.java
@@ -22,7 +22,7 @@ package io.servicetalk.concurrent.api;
  * {@link CapturedContext#attachContext()} to be undone. In practice, this may look like restoring a {@link ThreadLocal}
  * to the state it had before the call to {@link CapturedContext#attachContext()}.
  */
-interface Scope extends AutoCloseable {
+public interface Scope extends AutoCloseable {
 
     /**
      * No-op {@link Scope}.


### PR DESCRIPTION
Motivation:

The CapturedContext API's seem to do what we want them to but they're not yet public.

Modifications:

Make them public.