### PR TITLE
loadbalancer: surface random subsetting behavior in the LoadBalancerBuilder API

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -112,7 +112,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
             this.loadBalancerObserverFactory = loadBalancerBuilder.loadBalancerObserverFactory;
             this.outlierDetectorConfig = requireNonNull(
                     loadBalancerBuilder.outlierDetectorConfig, "outlierDetectorConfig");
-            this.subsetter = loadBalancerBuilder.subsetter;
+            this.subsetter = requireNonNull(loadBalancerBuilder.subsetter, "subsetter");
             this.connectionSelectorPolicy = requireNonNull(
                     loadBalancerBuilder.connectionSelectorPolicy, "connectionSelectorPolicy");
             this.executor = requireNonNull(loadBalancerBuilder.getExecutor(), "executor");

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -91,8 +91,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
 
     @Override
     public LoadBalancerFactory<ResolvedAddress, C> build() {
-        return new DefaultLoadBalancerFactory<>(id, loadBalancingPolicy, loadBalancerObserverFactory,
-                connectionSelectorPolicy, outlierDetectorConfig, subsetter, getExecutor());
+        return new DefaultLoadBalancerFactory<>(this);
     }
 
     static final class DefaultLoadBalancerFactory<ResolvedAddress, C extends LoadBalancedConnection>
@@ -107,19 +106,16 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         private final LoadBalancerObserverFactory loadBalancerObserverFactory;
         private final Executor executor;
 
-        DefaultLoadBalancerFactory(final String id, final LoadBalancingPolicy<ResolvedAddress, C> loadBalancingPolicy,
-                                   @Nullable final LoadBalancerObserverFactory loadBalancerObserverFactory,
-                                   final ConnectionSelectorPolicy<C> connectionSelectorPolicy,
-                                   final OutlierDetectorConfig outlierDetectorConfig,
-                                   final Subsetter subsetter,
-                                   final Executor executor) {
-            this.id = requireNonNull(id, "id");
-            this.loadBalancingPolicy = requireNonNull(loadBalancingPolicy, "loadBalancingPolicy");
-            this.loadBalancerObserverFactory = loadBalancerObserverFactory;
-            this.outlierDetectorConfig = requireNonNull(outlierDetectorConfig, "outlierDetectorConfig");
-            this.subsetter = subsetter;
-            this.connectionSelectorPolicy = requireNonNull(connectionSelectorPolicy, "connectionSelectorPolicy");
-            this.executor = requireNonNull(executor, "executor");
+        DefaultLoadBalancerFactory(DefaultLoadBalancerBuilder<ResolvedAddress, C> loadBalancerBuilder) {
+            this.id = requireNonNull(loadBalancerBuilder.id, "id");
+            this.loadBalancingPolicy = requireNonNull(loadBalancerBuilder.loadBalancingPolicy, "loadBalancingPolicy");
+            this.loadBalancerObserverFactory = loadBalancerBuilder.loadBalancerObserverFactory;
+            this.outlierDetectorConfig = requireNonNull(
+                    loadBalancerBuilder.outlierDetectorConfig, "outlierDetectorConfig");
+            this.subsetter = loadBalancerBuilder.subsetter;
+            this.connectionSelectorPolicy = requireNonNull(
+                    loadBalancerBuilder.connectionSelectorPolicy, "connectionSelectorPolicy");
+            this.executor = requireNonNull(loadBalancerBuilder.getExecutor(), "executor");
         }
 
         @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DelegatingLoadBalancerBuilder.java
@@ -73,6 +73,12 @@ public class DelegatingLoadBalancerBuilder<ResolvedAddress, C extends LoadBalanc
     }
 
     @Override
+    public LoadBalancerBuilder<ResolvedAddress, C> maxRandomSubsetSize(int maxUsed) {
+        delegate = delegate.maxRandomSubsetSize(maxUsed);
+        return this;
+    }
+
+    @Override
     public LoadBalancerBuilder<ResolvedAddress, C> backgroundExecutor(Executor backgroundExecutor) {
         delegate = delegate.backgroundExecutor(backgroundExecutor);
         return this;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -114,6 +114,7 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
      * @return {@code this}
      */
     default LoadBalancerBuilder<ResolvedAddress, C> maxRandomSubsetSize(int maxUsed) {
+        // FIXME: 0.43 - remove default impl
         throw new UnsupportedOperationException("maxRandomSubsetSize is not implemented");
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -105,6 +105,19 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
             ConnectionSelectorPolicy<C> connectionSelectorPolicy);
 
     /**
+     * Set the maximum number of healthy backends to load balance against using a random-subsetting strategy.
+     *
+     * Note: If a backend within the subset is found to be unhealthy, another endpoint will be added until the unhealthy
+     * backend recovers, after which the subset will return to its original state.
+     *
+     * @param maxUsed the maximum number of healthy backends to use.
+     * @return {@code this}
+     */
+    default LoadBalancerBuilder<ResolvedAddress, C> maxRandomSubsetSize(int maxUsed) {
+        throw new UnsupportedOperationException("maxRandomSubsetSize is not implemented");
+    }
+
+    /**
      * Set the background {@link Executor} to use for determining time and scheduling background tasks such
      * as those associated with outlier detection.
      *

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RandomSubsetter.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RandomSubsetter.java
@@ -58,4 +58,11 @@ final class RandomSubsetter implements Subsetter {
         }
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "RandomSubsetter{" +
+                "randomSubsetSize=" + randomSubsetSize +
+                '}';
+    }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilderAdapter.java
@@ -37,6 +37,11 @@ final class RoundRobinLoadBalancerBuilderAdapter implements LoadBalancerBuilder<
     }
 
     @Override
+    public LoadBalancerBuilder<String, TestLoadBalancedConnection> maxRandomSubsetSize(int maxUsed) {
+        throw new UnsupportedOperationException("Cannot set subset size for old round robin");
+    }
+
+    @Override
     public LoadBalancerBuilder<String, TestLoadBalancedConnection> loadBalancerObserver(
             @Nullable LoadBalancerObserverFactory loadBalancerObserverFactory) {
         throw new UnsupportedOperationException("Cannot set a load balancer observer for old round robin");


### PR DESCRIPTION
Motivation:

We want to let users specify a random subset size so they can limit
the maximum number of backends they'll talk to. This feature is
already implemented, but not yet surfaced for users to configure.

Modifications:

Add a method to the LoadBalancerBuilder api.