### PR TITLE
Increase visibility for unexpected HTTP/2 errors on the server-side

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -194,11 +194,11 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 h2HeadersToH1HeadersClient(ctx, h2Headers, httpStatus, true, streamId)));
     }
 
-    private NettyH2HeadersToHttpHeaders h2HeadersToH1HeadersClient(final ChannelHandlerContext ctx,
-                                                                   final Http2Headers h2Headers,
-                                                                   @Nullable final HttpResponseStatus httpStatus,
-                                                                   final boolean fullResponse,
-                                                                   final int streamId) throws Http2Exception {
+    private HttpHeaders h2HeadersToH1HeadersClient(final ChannelHandlerContext ctx,
+                                                   final Http2Headers h2Headers,
+                                                   @Nullable final HttpResponseStatus httpStatus,
+                                                   final boolean fullResponse,
+                                                   final int streamId) throws Http2Exception {
         assert method != null;
         h2HeadersSanitizeForH1(h2Headers);
         if (httpStatus != null) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -139,11 +139,11 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                 h2HeadersToH1HeadersServer(ctx, h2Headers, httpMethod, true, streamId)));
     }
 
-    private NettyH2HeadersToHttpHeaders h2HeadersToH1HeadersServer(final ChannelHandlerContext ctx,
-                                                                   final Http2Headers h2Headers,
-                                                                   @Nullable final HttpRequestMethod httpMethod,
-                                                                   final boolean fullRequest,
-                                                                   final int streamId) throws Http2Exception {
+    private HttpHeaders h2HeadersToH1HeadersServer(final ChannelHandlerContext ctx,
+                                                   final Http2Headers h2Headers,
+                                                   @Nullable final HttpRequestMethod httpMethod,
+                                                   final boolean fullRequest,
+                                                   final int streamId) throws Http2Exception {
         CharSequence value = h2Headers.getAndRemove(AUTHORITY.value());
         if (value != null) {
             h2Headers.set(HOST, value);
@@ -165,7 +165,7 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
                 headersFactory.validateValues());
     }
 
-    private NettyH2HeadersToHttpHeaders h2TrailersToH1TrailersServer(Http2Headers h2Headers) {
+    private HttpHeaders h2TrailersToH1TrailersServer(Http2Headers h2Headers) {
         return new NettyH2HeadersToHttpHeaders(h2Headers, headersFactory.validateCookies(),
                 headersFactory.validateValues());
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -665,23 +665,25 @@ final class NettyHttpServer {
 
         private static void logHttp2Exception(final Http2Exception e, final NettyHttpServerConnection connection) {
             final Http2ErrorCode errorCode = e.errorCode();
-            if (errorCode == CANCEL) {
+            if (CANCEL.equals(errorCode)) {
                 LOGGER.debug(
                         "{} HTTP/2 stream was cancelled by a remote peer, most likely due to timeout or lost interest",
                         connection, e);
-            } else if (errorCode == NO_ERROR) {
+            } else if (NO_ERROR.equals(errorCode)) {
                 LOGGER.debug("{} HTTP/2 stream was closed because underlying connection closed due to GO_AWAY",
                         connection, e);
-            } else if (errorCode == SETTINGS_TIMEOUT) {
+            } else if (SETTINGS_TIMEOUT.equals(errorCode)) {
                 LOGGER.warn("{} HTTP/2 stream was closed because underlying connection did not receive SETTINGS " +
                         "acknowledgement on time", connection, e);
-            } else if (errorCode == PROTOCOL_ERROR || errorCode == INTERNAL_ERROR || errorCode == FLOW_CONTROL_ERROR ||
-                    errorCode == STREAM_CLOSED || errorCode == FRAME_SIZE_ERROR || errorCode == COMPRESSION_ERROR ||
-                    errorCode == INADEQUATE_SECURITY || errorCode == HTTP_1_1_REQUIRED) {
+            } else if (PROTOCOL_ERROR.equals(errorCode) || INTERNAL_ERROR.equals(errorCode) ||
+                    FLOW_CONTROL_ERROR.equals(errorCode) || STREAM_CLOSED.equals(errorCode) ||
+                    FRAME_SIZE_ERROR.equals(errorCode) || COMPRESSION_ERROR.equals(errorCode) ||
+                    INADEQUATE_SECURITY.equals(errorCode) || HTTP_1_1_REQUIRED.equals(errorCode)) {
                 LOGGER.warn("{} HTTP/2 stream failed with an error indicating client misbehavior", connection, e);
             } else {
                 // REFUSED_STREAM & ENHANCE_YOUR_CALM - we don't support ServerPush, should only happen on client side
                 // CONNECT_ERROR - expected to happen only on client side
+                // Any other non-standard error code - we don't know how to handle it
                 LOGGER.warn("{} HTTP/2 stream failed with an error unexpected for the server-side", connection, e);
             }
             if (connection.nettyChannel().isOpen()) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -669,16 +669,19 @@ final class NettyHttpServer {
                 LOGGER.debug(
                         "{} HTTP/2 stream was cancelled by a remote peer, most likely due to timeout or lost interest",
                         connection, e);
+            } else if (STREAM_CLOSED.equals(errorCode)) {
+                LOGGER.debug("{} HTTP/2 stream was closed, most likely because regular frames sent raced with " +
+                        "cancellation received from a remote peer", connection, e);
             } else if (NO_ERROR.equals(errorCode)) {
-                LOGGER.debug("{} HTTP/2 stream was closed because underlying connection closed due to GO_AWAY",
+                LOGGER.debug("{} HTTP/2 stream was interrupted because underlying connection closed due to GO_AWAY",
                         connection, e);
             } else if (SETTINGS_TIMEOUT.equals(errorCode)) {
-                LOGGER.warn("{} HTTP/2 stream was closed because underlying connection did not receive SETTINGS " +
+                LOGGER.warn("{} HTTP/2 stream was interrupted because underlying connection did not receive SETTINGS " +
                         "acknowledgement on time", connection, e);
             } else if (PROTOCOL_ERROR.equals(errorCode) || INTERNAL_ERROR.equals(errorCode) ||
-                    FLOW_CONTROL_ERROR.equals(errorCode) || STREAM_CLOSED.equals(errorCode) ||
-                    FRAME_SIZE_ERROR.equals(errorCode) || COMPRESSION_ERROR.equals(errorCode) ||
-                    INADEQUATE_SECURITY.equals(errorCode) || HTTP_1_1_REQUIRED.equals(errorCode)) {
+                    FLOW_CONTROL_ERROR.equals(errorCode) || FRAME_SIZE_ERROR.equals(errorCode) ||
+                    COMPRESSION_ERROR.equals(errorCode) || INADEQUATE_SECURITY.equals(errorCode) ||
+                    HTTP_1_1_REQUIRED.equals(errorCode)) {
                 LOGGER.warn("{} HTTP/2 stream failed with an error indicating client misbehavior", connection, e);
             } else {
                 // REFUSED_STREAM & ENHANCE_YOUR_CALM - we don't support ServerPush, should only happen on client side


### PR DESCRIPTION
Motivation:

HTTP/2 protocol defines a set of error codes for its exceptions. Some of those are expected and can be logged at debug level, but others could be concerning. Giving higher visibility to users may help them identify problems earlier and identify misbehaving clients.

Modifications:

- Add special rule in `ErrorLoggingHttpSubscriber` to handle `Http2Exception`s;

Result:

Users have better visibility for unexpected HTTP/2 errors.