### PR TITLE
loadbalancer: add some logging to RandomSubsetter

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -151,7 +151,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final Function<String, OutlierDetector<ResolvedAddress, C>> outlierDetectorFactory) {
         this.lbDescription = makeDescription(
                 requireNonNull(id, "id"), requireNonNull(targetResource, "targetResource"));
-        this.subsetter = subsetterFactory.build(lbDescription);
+        this.subsetter = subsetterFactory.newSubsetter(lbDescription);
         this.hostSelector = requireNonNull(loadBalancingPolicy, "loadBalancingPolicy")
                 .buildSelector(Collections.emptyList(), lbDescription);
         this.priorityStrategy = requireNonNull(

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RandomSubsetter.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RandomSubsetter.java
@@ -44,7 +44,7 @@ final class RandomSubsetter implements Subsetter {
     public <T extends PrioritizedHost> List<T> subset(List<T> allHosts) {
         if (allHosts.size() <= randomSubsetSize) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("{}: Host set size of {} is less than designated subset ({})",
+                LOGGER.debug("{}: Host set size of {} is less than designated subset size of {}, returning all hosts",
                         lbDescription, allHosts.size(), randomSubsetSize);
             }
             return allHosts;
@@ -69,8 +69,8 @@ final class RandomSubsetter implements Subsetter {
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("{}: Using {} hosts out of a total {}. ({} considered unhealthy)", lbDescription,
-                    result.size(), allHosts.size(), result.size() - allHosts.size());
+            LOGGER.debug("{}: Using {} out of a total {} hosts ({} considered unhealthy). Used hosts: {}",
+                    lbDescription, result.size(), allHosts.size(), result.size() - allHosts.size(), result);
         }
         return result;
     }
@@ -91,7 +91,7 @@ final class RandomSubsetter implements Subsetter {
         }
 
         @Override
-        public Subsetter build(String lbDescription) {
+        public Subsetter newSubsetter(String lbDescription) {
             return new RandomSubsetter(randomSubsetSize, lbDescription);
         }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/Subsetter.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/Subsetter.java
@@ -40,6 +40,6 @@ interface Subsetter {
          * @param lbDescription the string based description of the load balancer, useful for observability.
          * @return the constructed {@link Subsetter}.
          */
-        Subsetter build(String lbDescription);
+        Subsetter newSubsetter(String lbDescription);
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/Subsetter.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/Subsetter.java
@@ -29,4 +29,17 @@ interface Subsetter {
      * @param <T> the type of the {@link PrioritizedHost}
      */
     <T extends PrioritizedHost> List<T> subset(List<T> hosts);
+
+    /**
+     * Build {@link Subsetter} instances using the provided load balancer description.
+     */
+    interface SubsetterFactory {
+
+        /**
+         * Build {@link Subsetter} instances using the provided load balancer description.
+         * @param lbDescription the string based description of the load balancer, useful for observability.
+         * @return the constructed {@link Subsetter}.
+         */
+        Subsetter build(String lbDescription);
+    }
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultLoadBalancerTest.java
@@ -57,7 +57,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
     private LoadBalancingPolicy<String, TestLoadBalancedConnection> loadBalancingPolicy =
             LoadBalancingPolicies.p2c().build();
 
-    private Subsetter subsetter = new RandomSubsetter(Integer.MAX_VALUE);
+    private Subsetter.SubsetterFactory subsetterFactory = new RandomSubsetter.RandomSubsetterFactory(Integer.MAX_VALUE);
 
     private Function<String, HostPriorityStrategy> hostPriorityStrategyFactory = DefaultHostPriorityStrategy::new;
 
@@ -236,7 +236,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
     @ValueSource(ints = {1, 2, Integer.MAX_VALUE})
     void subsetting(final int subsetSize) throws Exception {
         serviceDiscoveryPublisher.onComplete();
-        this.subsetter = new RandomSubsetter(subsetSize);
+        this.subsetterFactory = new RandomSubsetter.RandomSubsetterFactory(subsetSize);
         // rr so we can test that each endpoint gets used deterministically.
         this.loadBalancingPolicy = LoadBalancingPolicies.roundRobin().build();
         lb = newTestLoadBalancer();
@@ -252,7 +252,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
         serviceDiscoveryPublisher.onComplete();
         final TestOutlierDetectorFactory factory = new TestOutlierDetectorFactory();
         outlierDetectorFactory = factory;
-        this.subsetter = new RandomSubsetter(2);
+        this.subsetterFactory = new RandomSubsetter.RandomSubsetterFactory(2);
         // rr so we can test that each endpoint gets used deterministically.
         this.loadBalancingPolicy = LoadBalancingPolicies.roundRobin().build();
         lb = newTestLoadBalancer();
@@ -316,7 +316,7 @@ class DefaultLoadBalancerTest extends LoadBalancerTestScaffold {
                 serviceDiscoveryPublisher,
                 hostPriorityStrategyFactory,
                 loadBalancingPolicy,
-                subsetter,
+                subsetterFactory,
                 ConnectionSelectorPolicies.linearSearch(),
                 connectionFactory,
                 NoopLoadBalancerObserver.factory(),

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RandomSubsetterTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RandomSubsetterTest.java
@@ -33,7 +33,8 @@ class RandomSubsetterTest {
     @Test
     void desiredSubsetLargerThanHostList() {
         List<PrioritizedHost> hosts = hosts(10);
-        List<PrioritizedHost> results = new RandomSubsetter(Integer.MAX_VALUE).subset(hosts);
+        List<PrioritizedHost> results = new RandomSubsetter.RandomSubsetterFactory(Integer.MAX_VALUE)
+                .build("").subset(hosts);
         assertThat(results, sameInstance(hosts));
     }
 
@@ -71,7 +72,7 @@ class RandomSubsetterTest {
     }
 
     private static List<PrioritizedHost> subset(int randomSubsetSize, List<PrioritizedHost> hosts) {
-        return new RandomSubsetter(randomSubsetSize).subset(hosts);
+        return new RandomSubsetter.RandomSubsetterFactory(randomSubsetSize).build("").subset(hosts);
     }
 
     private static List<PrioritizedHost> hosts(int count) {

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RandomSubsetterTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/RandomSubsetterTest.java
@@ -34,7 +34,7 @@ class RandomSubsetterTest {
     void desiredSubsetLargerThanHostList() {
         List<PrioritizedHost> hosts = hosts(10);
         List<PrioritizedHost> results = new RandomSubsetter.RandomSubsetterFactory(Integer.MAX_VALUE)
-                .build("").subset(hosts);
+                .newSubsetter("").subset(hosts);
         assertThat(results, sameInstance(hosts));
     }
 
@@ -72,7 +72,7 @@ class RandomSubsetterTest {
     }
 
     private static List<PrioritizedHost> subset(int randomSubsetSize, List<PrioritizedHost> hosts) {
-        return new RandomSubsetter.RandomSubsetterFactory(randomSubsetSize).build("").subset(hosts);
+        return new RandomSubsetter.RandomSubsetterFactory(randomSubsetSize).newSubsetter("").subset(hosts);
     }
 
     private static List<PrioritizedHost> hosts(int count) {


### PR DESCRIPTION
Motivation:

It could be helpful for people to know what happened during subsetting.

Modifications:

Add some logging to RandomSubsetter. This required some extra changes so that we could pass in the load balancer description so it's easier to know which subsetter we're actually talking about.

Result:

Better observability.