### PR TITLE
Minor fixes for `DefaultServiceTalkProvider`

### DIFF
--- a/servicetalk-log4j2-mdc/src/main/java/io/servicetalk/log4j2/mdc/DefaultServiceTalkThreadContextMapProvider.java
+++ b/servicetalk-log4j2-mdc/src/main/java/io/servicetalk/log4j2/mdc/DefaultServiceTalkThreadContextMapProvider.java
@@ -21,21 +21,21 @@ import org.apache.logging.log4j.spi.Provider;
 import java.lang.reflect.Field;
 
 /**
- * Service loaded MDC thread context map implementation.
- *
+ * Provider for {@link java.util.ServiceLoader} to initialize {@link DefaultServiceTalkThreadContextMap}.
+ * <p>
  * This class is service loaded by log4j2 and is used to provide an MDC context map implementation that will work
  * with ServiceTalks reactive primitives.
  */
-public final class DefaultServiceTalkProvider extends Provider {
+public final class DefaultServiceTalkThreadContextMapProvider extends Provider {
 
     private static final String DEFAULT_CURRENT_VERSION = "2.6.0";
 
     /**
-     * Create a new DefaultServiceTalkProvider.
-     *
-     * The zero-argument constructor is required by the service loading mechanism.
+     * Creates a new instance.
+     * <p>
+     * The zero-argument constructor is required by {@link java.util.ServiceLoader}.
      */
-    public DefaultServiceTalkProvider() {
+    public DefaultServiceTalkThreadContextMapProvider() {
         super(20, getCurrentVersion(), Log4jContextFactory.class, DefaultServiceTalkThreadContextMap.class);
     }
 

--- a/servicetalk-log4j2-mdc/src/main/resources/META-INF/services/org.apache.logging.log4j.spi.Provider
+++ b/servicetalk-log4j2-mdc/src/main/resources/META-INF/services/org.apache.logging.log4j.spi.Provider
@@ -1,1 +1,1 @@
-io.servicetalk.log4j2.mdc.DefaultServiceTalkProvider
+io.servicetalk.log4j2.mdc.DefaultServiceTalkThreadContextMapProvider


### PR DESCRIPTION
Follow-up for #3204 to align name with `ThreadContextMap` implementation it loads, and adjust javadoc.