### PR TITLE
log4j-mdc: use getDeclaredField to reflectively access Provider.CURRENT_VERSION

### DIFF
--- a/servicetalk-log4j2-mdc/src/main/java/io/servicetalk/log4j2/mdc/DefaultServiceTalkThreadContextMapProvider.java
+++ b/servicetalk-log4j2-mdc/src/main/java/io/servicetalk/log4j2/mdc/DefaultServiceTalkThreadContextMapProvider.java
@@ -42,7 +42,7 @@ public final class DefaultServiceTalkThreadContextMapProvider extends Provider {
     private static String getCurrentVersion() {
         // The CURRENT_VERSION field is only available as of 2.24.0. Once we upgrade to 2.24+ we can drop this.
         try {
-            Field field = Provider.class.getField("CURRENT_VERSION");
+            Field field = Provider.class.getDeclaredField("CURRENT_VERSION");
             return (String) field.get(null /* static field */);
         } catch (Exception ex) {
             return DEFAULT_CURRENT_VERSION;


### PR DESCRIPTION
Motivation:

The static field CURRENT_VERSION is protected, so we can't get it via Class.getField, but need to use Class.getDeclaredField.

Modifications:

Use getDeclaredField. This was verified by walking through with the debugger.