### PR TITLE
Share context inside `Publisher.onErrorReturn` / `Single.onErrorReturn`

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -613,7 +613,7 @@ public abstract class Publisher<T> {
     public final Publisher<T> onErrorReturn(Predicate<? super Throwable> predicate,
                                             Function<? super Throwable, ? extends T> itemSupplier) {
         requireNonNull(itemSupplier);
-        return onErrorResume(predicate, t -> Publisher.from(itemSupplier.apply(t)));
+        return onErrorResume(predicate, t -> Publisher.from(itemSupplier.apply(t)).shareContextOnSubscribe());
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -200,7 +200,7 @@ public abstract class Single<T> {
     public final Single<T> onErrorReturn(Predicate<? super Throwable> predicate,
                                          Function<? super Throwable, ? extends T> itemSupplier) {
         requireNonNull(itemSupplier);
-        return onErrorResume(predicate, t -> succeeded(itemSupplier.apply(t)));
+        return onErrorResume(predicate, t -> succeeded(itemSupplier.apply(t)).shareContextOnSubscribe());
     }
 
     /**

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/OnErrorCompletableTest.java
@@ -17,9 +17,15 @@ package io.servicetalk.concurrent.api;
 
 import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.concurrent.test.internal.TestCompletableSubscriber;
+import io.servicetalk.context.api.ContextMap;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 
 import static io.servicetalk.concurrent.api.Completable.completed;
 import static io.servicetalk.concurrent.api.Completable.failed;
@@ -79,6 +85,23 @@ class OnErrorCompletableTest {
     }
 
     @Test
+    void onErrorReturnContextPropagation() {
+        Set<ContextMap> contextMapSet = Collections.newSetFromMap(new IdentityHashMap<>());
+        toSource(first
+                .whenOnError(t -> contextMapSet.add(AsyncContext.context()))
+                .onErrorComplete(t -> {   // predicate
+                    contextMapSet.add(AsyncContext.context());
+                    return true;
+                })
+                .whenOnComplete(() -> contextMapSet.add(AsyncContext.context())))
+                .subscribe(subscriber);
+        subscriber.awaitSubscription();
+        first.onError(DELIBERATE_EXCEPTION);
+        subscriber.awaitOnComplete();
+        assertThat("Unexpected number of different contexts", contextMapSet, Matchers.hasSize(1));
+    }
+
+    @Test
     void onErrorMapMatch() {
         toSource(first.onErrorMap(t -> DELIBERATE_EXCEPTION)).subscribe(subscriber);
         subscriber.awaitSubscription();
@@ -131,6 +154,34 @@ class OnErrorCompletableTest {
     }
 
     @Test
+    void onErrorMapContextPropagation() {
+        Set<ContextMap> contextMapSet = Collections.newSetFromMap(new IdentityHashMap<>());
+        toSource(first
+                .whenOnError(t -> contextMapSet.add(AsyncContext.context()))
+                .onErrorMap(t -> {   // predicate
+                    contextMapSet.add(AsyncContext.context());
+                    return true;
+                }, t -> {   // item supplier
+                    contextMapSet.add(AsyncContext.context());
+                    return DELIBERATE_EXCEPTION;
+                })
+                .whenOnError(t -> contextMapSet.add(AsyncContext.context())))
+                .subscribe(subscriber);
+        subscriber.awaitSubscription();
+        first.onError(new DeliberateException());
+        assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+        assertThat("Unexpected number of different contexts", contextMapSet, Matchers.hasSize(1));
+    }
+
+    @Test
+    void onErrorResume() {
+        toSource(first.onErrorResume(t -> Completable.completed())).subscribe(subscriber);
+        subscriber.awaitSubscription();
+        first.onError(DELIBERATE_EXCEPTION);
+        subscriber.awaitOnComplete();
+    }
+
+    @Test
     void onErrorResumeClassMatch() {
         toSource(first.onErrorResume(DeliberateException.class, t -> failed(DELIBERATE_EXCEPTION)))
                 .subscribe(subscriber);
@@ -162,5 +213,25 @@ class OnErrorCompletableTest {
         subscriber.awaitSubscription();
         first.onError(DELIBERATE_EXCEPTION);
         assertThat(subscriber.awaitOnError(), is(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    void onErrorResumeContextPropagation() {
+        Set<ContextMap> contextMapSet = Collections.newSetFromMap(new IdentityHashMap<>());
+        toSource(first
+                .whenOnError(t -> contextMapSet.add(AsyncContext.context()))
+                .onErrorResume(t -> {   // predicate
+                    contextMapSet.add(AsyncContext.context());
+                    return true;
+                }, t -> {   // item supplier
+                    contextMapSet.add(AsyncContext.context());
+                    return Completable.completed();
+                })
+                .whenOnComplete(() -> contextMapSet.add(AsyncContext.context())))
+                .subscribe(subscriber);
+        subscriber.awaitSubscription();
+        first.onError(DELIBERATE_EXCEPTION);
+        subscriber.awaitOnComplete();
+        assertThat("Unexpected number of different contexts", contextMapSet, Matchers.hasSize(1));
     }
 }


### PR DESCRIPTION
Motivation:

`Publisher.onErrorReturn` and `Single.onErrorReturn` are using an async `onErrorResume` operator internally, which item supplier returns an async source. Even though it doesn't change the behavior of `AsyncContext` propagation because the returned async source is already complete/succeeded, it's worth using `shareContextOnSubscribe()` operator to avoid unnecessary copy of the `ContextMap`.

Modifications:
- Add `shareContextOnSubscribe()` inside item supplier for `Publisher.onErrorReturn` and `Single.onErrorReturn`.
- Add tests to demonstrate that `AsyncContext` is propagated synchronously between previous and subsequent operators around `onError*` mappings.

Result:

Less allocations when using `Publisher.onErrorReturn` and `Single.onErrorReturn` operators.