### PR TITLE
concurrent-api: Fix examples in CapturedContextProvider

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
@@ -30,18 +30,24 @@ public interface CapturedContextProvider {
      * <p>
      * An example provider may be implemented as follows:
      * <pre>{@code
-     *     private class CapturedContextImpl {
+     *     private class CapturedContextImpl implements CapturedContext {
      *         private final CapturedContext delegate;
      *         private final String state;
      *
-     *         Scope restoreContext() {
+     *         @Override
+     *         public Scope attachContext() {
      *             String old = getMyString();
      *             setMyString(state);
-     *             Scope outer = delegate.restoreContext();
+     *             Scope outer = delegate.attachContext();
      *             return () -> {
      *                 outer.close();
      *                 setMyString(old);
      *             };
+     *         }
+     *
+     *         @Override
+     *         public ContextMap captured() {
+     *             return delegate.captured();
      *         }
      *     }
      *

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
@@ -34,7 +34,6 @@ public interface CapturedContextProvider {
      *         private final CapturedContext delegate;
      *         private final String state;
      *
-     *         @Override
      *         public Scope attachContext() {
      *             String old = getMyString();
      *             setMyString(state);
@@ -45,7 +44,6 @@ public interface CapturedContextProvider {
      *             };
      *         }
      *
-     *         @Override
      *         public ContextMap captured() {
      *             return delegate.captured();
      *         }


### PR DESCRIPTION
Motivation:

The example became stale during method renames and had some other defects.

Modifications:

Fix it.

Result:

Example better aligns with reality.