### PR TITLE
`DefaultNettyConnection`: share AsyncContext state on write

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -644,7 +644,9 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 WriteStreamSubscriber subscriber = new WriteStreamSubscriber(channel(), demandEstimatorSupplier.get(),
                         completableSubscriber, closeHandler, writeObserver, enrichProtocolError, isClient, shouldWait);
                 if (failIfWriteActive(subscriber, completableSubscriber)) {
-                    toSource(composeFlushes(channel(), write, flushStrategySupplier.get(), writeObserver))
+                    toSource(composeFlushes(channel(), write, flushStrategySupplier.get(), writeObserver)
+                            // AsyncContext state should be shared between publisher we write and returned completable
+                            .shareContextOnSubscribe())
                             .subscribe(subscriber);
                 }
             }


### PR DESCRIPTION
Motivation:

Even though we pass a `Publisher` to `NettyConnection.write(...)` as another async source, we always use it in a way that expects a shared AsyncContext state between what we write and returned `Completable`. However, we can not apply `shareContextOnSubscribe()` on the passed `Publisher` because internally `write(...)` operation also applies `FlushSubscriber`.

Modifications:

- Add `shareContextOnSubscribe()` before subscribing to the write `Publisher`.
- Add a test to assert expected context propagation.

Result:

`AsyncContext` state is shared between the `Publisher` we write and returned `Completable`.