### PR TITLE
Fix `AsyncContext` visibility for OTEL filters

### DIFF
--- a/servicetalk-opentelemetry-http/build.gradle
+++ b/servicetalk-opentelemetry-http/build.gradle
@@ -37,8 +37,9 @@ dependencies {
 
   testImplementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
-  testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
+  testImplementation testFixtures(project(":servicetalk-http-netty"))
   testImplementation testFixtures(project(":servicetalk-log4j2-mdc-utils"))
+  testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))
   testImplementation project(":servicetalk-data-jackson")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-serializer-api")

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryFilter.java
@@ -45,8 +45,9 @@ abstract class AbstractOpenTelemetryFilter implements HttpExecutionStrategyInflu
             @Override
             protected void handleSubscribe(SingleSource.Subscriber<? super StreamingHttpResponse> subscriber) {
                 try (Scope ignored = context.makeCurrent()) {
-                    SourceAdapters.toSource(responseSingle.map(resp ->
-                                    resp.transformMessageBody(body -> transformBody(body, context))))
+                    SourceAdapters.toSource(responseSingle
+                                    .map(resp -> resp.transformMessageBody(body -> transformBody(body, context)))
+                                    .shareContextOnSubscribe())
                             .subscribe(subscriber);
                 }
             }
@@ -58,7 +59,7 @@ abstract class AbstractOpenTelemetryFilter implements HttpExecutionStrategyInflu
             @Override
             protected void handleSubscribe(PublisherSource.Subscriber<? super T> subscriber) {
                 try (Scope ignored = context.makeCurrent()) {
-                    SourceAdapters.toSource(body).subscribe(subscriber);
+                    SourceAdapters.toSource(body.shareContextOnSubscribe()).subscribe(subscriber);
                 }
             }
         };

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilterTest.java
@@ -45,6 +45,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.opentelemetry.http.OpenTelemetryHttpRequestFilterTest.verifyTraceIdPresentInLogs;
 import static io.servicetalk.opentelemetry.http.TestUtils.SPAN_STATE_SERIALIZER;
@@ -233,6 +234,11 @@ class OpenTelemetryHttpServerFilterTest {
                     });
             }
         }
+    }
+
+    @Test
+    void verifyAsyncContextVisibility() throws Exception {
+        verifyServerFilterAsyncContextVisibility(new OpenTelemetryHttpServerFilter());
     }
 
     private static ServerContext buildServer(OpenTelemetry givenOpentelemetry,


### PR DESCRIPTION
Motivation:

`AbstractOpenTelemetryFilter` manually subscribes to response and its payload body but does not share context on subscribe. In result, `AsyncContext` propagation is incorrect when OTEL filters are in place.

Modifications:

- Add `shareContextOnSubscribe()` before subscribing response single and its payload Publisher.
- Add a test that uses our utility to verify correct AsyncContext propagation.

Result:

`AsyncContext` state is correctly propagated through stages of response processing when OTEL filters are in place.