### PR TITLE
Test all service filters propagate `AsyncContext` correctly

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcEnforceTrailersOnlyResponseServiceFilterTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcEnforceTrailersOnlyResponseServiceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
-
-import io.servicetalk.http.api.ContentCodingHttpServiceFilter;
+package io.servicetalk.grpc.netty;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
-import static java.util.Collections.singletonList;
 
-class ContentCodingHttpServiceFilterTest {
+class GrpcEnforceTrailersOnlyResponseServiceFilterTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     void verifyAsyncContext() throws Exception {
-        verifyServerFilterAsyncContextVisibility(new ContentCodingHttpServiceFilter(singletonList(identity())));
+        verifyServerFilterAsyncContextVisibility(GrpcEnforceTrailersOnlyResponseServiceFilter.INSTANCE);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -530,7 +530,7 @@ final class DefaultHttpServerBuilder implements HttpServerBuilder {
      * Internal filter that correctly sets {@link HttpHeaderNames#CONNECTION} header value based on the requested
      * keep-alive policy.
      */
-    private static final class KeepAliveServiceFilter implements StreamingHttpServiceFilterFactory {
+    static final class KeepAliveServiceFilter implements StreamingHttpServiceFilterFactory {
 
         static final StreamingHttpServiceFilterFactory INSTANCE = new KeepAliveServiceFilter();
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentEncodingHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentEncodingHttpServiceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,19 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.http.api.ContentCodingHttpServiceFilter;
+import io.servicetalk.http.api.ContentEncodingHttpServiceFilter;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.encoding.api.Identity.identity;
+import static io.servicetalk.encoding.api.Identity.identityEncoder;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static java.util.Collections.singletonList;
 
-class ContentCodingHttpServiceFilterTest {
+class ContentEncodingHttpServiceFilterTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     void verifyAsyncContext() throws Exception {
-        verifyServerFilterAsyncContextVisibility(new ContentCodingHttpServiceFilter(singletonList(identity())));
+        verifyServerFilterAsyncContextVisibility(
+                new ContentEncodingHttpServiceFilter(singletonList(identityEncoder())));
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpExceptionMapperServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpExceptionMapperServiceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,16 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.http.api.ContentCodingHttpServiceFilter;
+import io.servicetalk.http.api.HttpExceptionMapperServiceFilter;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
-import static java.util.Collections.singletonList;
 
-class ContentCodingHttpServiceFilterTest {
+class HttpExceptionMapperServiceFilterTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     void verifyAsyncContext() throws Exception {
-        verifyServerFilterAsyncContextVisibility(new ContentCodingHttpServiceFilter(singletonList(identity())));
+        verifyServerFilterAsyncContextVisibility(HttpExceptionMapperServiceFilter.INSTANCE);
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpLifecycleObserverServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpLifecycleObserverServiceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,15 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.http.api.ContentCodingHttpServiceFilter;
-
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
-import static java.util.Collections.singletonList;
 
-class ContentCodingHttpServiceFilterTest {
+class HttpLifecycleObserverServiceFilterTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     void verifyAsyncContext() throws Exception {
-        verifyServerFilterAsyncContextVisibility(new ContentCodingHttpServiceFilter(singletonList(identity())));
+        verifyServerFilterAsyncContextVisibility(
+                new HttpLifecycleObserverServiceFilter(NoopHttpLifecycleObserver.INSTANCE));
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilterTest.java
@@ -33,6 +33,7 @@ import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -45,11 +46,11 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
+import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
 import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("https://github.com/apple/servicetalk/issues/2756")
 final class HttpMessageDiscardWatchdogServiceFilterTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpMessageDiscardWatchdogServiceFilterTest.class);
@@ -81,6 +82,7 @@ final class HttpMessageDiscardWatchdogServiceFilterTest {
         loggerStringWriter.remove();
     }
 
+    @Disabled("https://github.com/apple/servicetalk/issues/2756")
     @ParameterizedTest(name = "{displayName} [{index}] transformer={0}")
     @MethodSource("responseTransformers")
     void warnsIfDiscarded(final ResponseTransformer transformer) throws Exception {
@@ -112,6 +114,11 @@ final class HttpMessageDiscardWatchdogServiceFilterTest {
                         + output + "\n-- END OUTPUT --");
             }
         }
+    }
+
+    @Test
+    void verifyAsyncContext() throws Exception {
+        verifyServerFilterAsyncContextVisibility(HttpMessageDiscardWatchdogServiceFilter.INSTANCE);
     }
 
     private static Stream<Arguments> responseTransformers() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/KeepAliveServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/KeepAliveServiceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,14 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.http.api.ContentCodingHttpServiceFilter;
-
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
-import static java.util.Collections.singletonList;
 
-class ContentCodingHttpServiceFilterTest {
+class KeepAliveServiceFilterTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     void verifyAsyncContext() throws Exception {
-        verifyServerFilterAsyncContextVisibility(new ContentCodingHttpServiceFilter(singletonList(identity())));
+        verifyServerFilterAsyncContextVisibility(DefaultHttpServerBuilder.KeepAliveServiceFilter.INSTANCE);
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/OffloadingFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/OffloadingFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,15 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.http.api.ContentCodingHttpServiceFilter;
-
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.encoding.api.Identity.identity;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadAll;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
-import static java.util.Collections.singletonList;
 
-class ContentCodingHttpServiceFilterTest {
+class OffloadingFilterTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     void verifyAsyncContext() throws Exception {
-        verifyServerFilterAsyncContextVisibility(new ContentCodingHttpServiceFilter(singletonList(identity())));
+        verifyServerFilterAsyncContextVisibility(new OffloadingFilter(offloadAll(), Boolean.TRUE::booleanValue));
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PayloadSizeLimitingHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/PayloadSizeLimitingHttpServiceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,16 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.http.api.ContentCodingHttpServiceFilter;
+import io.servicetalk.http.utils.PayloadSizeLimitingHttpServiceFilter;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
-import static java.util.Collections.singletonList;
 
-class ContentCodingHttpServiceFilterTest {
+class PayloadSizeLimitingHttpServiceFilterTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     void verifyAsyncContext() throws Exception {
-        verifyServerFilterAsyncContextVisibility(new ContentCodingHttpServiceFilter(singletonList(identity())));
+        verifyServerFilterAsyncContextVisibility(new PayloadSizeLimitingHttpServiceFilter(Integer.MAX_VALUE));
     }
 }

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrackPendingRequestsHttpFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrackPendingRequestsHttpFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.servicetalk.http.netty;
-
-import io.servicetalk.http.api.ContentCodingHttpServiceFilter;
+package io.servicetalk.traffic.resilience.http;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
-import static java.util.Collections.singletonList;
 
-class ContentCodingHttpServiceFilterTest {
+class TrackPendingRequestsHttpFilterTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     void verifyAsyncContext() throws Exception {
-        verifyServerFilterAsyncContextVisibility(new ContentCodingHttpServiceFilter(singletonList(identity())));
+        verifyServerFilterAsyncContextVisibility(TrackPendingRequestsHttpFilter.BEFORE);
     }
 }


### PR DESCRIPTION
Motivation:

We have `AsyncContextHttpFilterVerifier` test fixture to validate that a `StreamingHttpServiceFilterFactory` does not break `AsyncContext` propagation. It's used to validate some of our service filters, but not all.

Modifications:

- Use `AsyncContextHttpFilterVerifier` to test: `GrpcEnforceTrailersOnlyResponseServiceFilter`,
`ContentEncodingHttpServiceFilter`, `HttpExceptionMapperServiceFilter`, `HttpLifecycleObserverServiceFilter`,
`HttpMessageDiscardWatchdogServiceFilter`, `KeepAliveServiceFilter`, `OffloadingFilter`, `PayloadSizeLimitingHttpServiceFilter`, `TrackPendingRequestsHttpFilter`.

Result:

All service filters are tested with `AsyncContextHttpFilterVerifier`.