### PR TITLE
Use `delegate` instead of `super` when calling the next filter

### DIFF
--- a/servicetalk-examples/http/service-composition/src/main/java/io/servicetalk/examples/http/service/composition/HttpResponseExceptionHandlingServiceFilter.java
+++ b/servicetalk-examples/http/service-composition/src/main/java/io/servicetalk/examples/http/service/composition/HttpResponseExceptionHandlingServiceFilter.java
@@ -39,7 +39,7 @@ final class HttpResponseExceptionHandlingServiceFilter implements StreamingHttpS
             @Override
             public Single<StreamingHttpResponse> handle(HttpServiceContext ctx, StreamingHttpRequest request,
                                                         StreamingHttpResponseFactory responseFactory) {
-                return super.handle(ctx, request, responseFactory).onErrorResume(cause -> {
+                return delegate().handle(ctx, request, responseFactory).onErrorResume(cause -> {
                     if (cause instanceof HttpResponseException) {
                         // It's useful to include the exception message in the payload for demonstration purposes, but
                         // this is not recommended in production as it may leak internal information.

--- a/servicetalk-examples/http/service-composition/src/main/java/io/servicetalk/examples/http/service/composition/backends/ErrorResponseGeneratingServiceFilter.java
+++ b/servicetalk-examples/http/service-composition/src/main/java/io/servicetalk/examples/http/service/composition/backends/ErrorResponseGeneratingServiceFilter.java
@@ -48,7 +48,7 @@ public final class ErrorResponseGeneratingServiceFilter implements StreamingHttp
                 if (request.hasQueryParameter(SIMULATE_ERROR_QP_NAME, serviceName)) {
                     return succeeded(responseFactory.internalServerError());
                 }
-                return super.handle(ctx, request, responseFactory);
+                return delegate().handle(ctx, request, responseFactory);
             }
         };
     }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/TrailersOnlyErrorTest.java
@@ -288,7 +288,7 @@ class TrailersOnlyErrorTest {
                     @Override
                     protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                                     final StreamingHttpRequest request) {
-                        return super.request(delegate, request)
+                        return delegate.request(request)
                                 .map(response -> {
                                     assertGrpcStatusInHeaders(response, errors);
                                     return response;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
@@ -112,7 +112,7 @@ public final class ContentCodingHttpServiceFilter implements StreamingHttpServic
                             request.transformPayloadBody(bufferPublisher -> coding.decode(bufferPublisher, allocator));
                         }
 
-                        return super.handle(ctx, request, responseFactory).map(response -> {
+                        return delegate().handle(ctx, request, responseFactory).map(response -> {
                             encodePayloadContentIfAvailable(request.headers(), request.method(), responseCodings,
                                     response, allocator);
                             return response;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
@@ -108,7 +108,7 @@ public final class ContentEncodingHttpServiceFilter implements StreamingHttpServ
                         requestDecompressed = request;
                     }
 
-                    return super.handle(ctx, requestDecompressed, responseFactory).map(response -> {
+                    return delegate().handle(ctx, requestDecompressed, responseFactory).map(response -> {
                         final CharSequence reqAcceptEncoding;
                         if (isPassThrough(request.method(), response) ||
                                 (reqAcceptEncoding = request.headers().get(ACCEPT_ENCODING)) == null) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BasicAuthHttpServiceFilterTest.java
@@ -67,7 +67,7 @@ class BasicAuthHttpServiceFilterTest {
                                     final HttpServiceContext ctx, final StreamingHttpRequest request,
                                     final StreamingHttpResponseFactory responseFactory) {
                                 request.headers().set(AUTHORIZATION, "Basic " + userPassBase64());
-                                return super.handle(ctx, request, responseFactory);
+                                return delegate().handle(ctx, request, responseFactory);
                             }
                         };
                     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConditionalHttpServiceFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConditionalHttpServiceFilterTest.java
@@ -49,7 +49,7 @@ public class ConditionalHttpServiceFilterTest extends AbstractConditionalHttpFil
                         public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                                     final StreamingHttpRequest req,
                                                                     final StreamingHttpResponseFactory resFactory) {
-                            return super.handle(ctx, markFiltered(req), resFactory);
+                            return delegate().handle(ctx, markFiltered(req), resFactory);
                         }
 
                         @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -314,7 +314,7 @@ class H2PriorKnowledgeFeatureParityTest {
                                                         final StreamingHttpResponseFactory responseFactory) {
                 return request.queryParameter(qpName) == null ?
                         succeeded(responseFactory.badRequest()) :
-                        super.handle(ctx, request, responseFactory);
+                        delegate().handle(ctx, request, responseFactory);
             }
         }, null);
         String responseBody = "hello world";

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/MalformedDataAfterHttpMessageTest.java
@@ -138,7 +138,7 @@ class MalformedDataAfterHttpMessageTest {
                     @Override
                     public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
                         contextQueue.add(connectionContext());
-                        return super.request(request);
+                        return delegate().request(request);
                     }
                 })
                 .buildBlocking()) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentCodingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentCodingTest.java
@@ -119,7 +119,7 @@ class ServiceTalkContentCodingTest extends BaseContentCodingTest {
                             assertThat(actualReqAcceptedEncodings, equalTo(expectedReqAcceptedEncodings));
                         }
 
-                        return super.handle(ctx, request, responseFactory);
+                        return delegate().handle(ctx, request, responseFactory);
                     } catch (Throwable t) {
                         errors.add(t);
                         return failed(t);
@@ -137,7 +137,7 @@ class ServiceTalkContentCodingTest extends BaseContentCodingTest {
                 @Override
                 protected Single<StreamingHttpResponse> request(final StreamingHttpRequester delegate,
                                                                 final StreamingHttpRequest request) {
-                    return super.request(delegate, request).map(response -> {
+                    return delegate.request(request).map(response -> {
                         if (INTERNAL_SERVER_ERROR.equals(response.status())) {
                             // Ignore any further validations
                             return response;

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/PayloadSizeLimitingHttpServiceFilter.java
@@ -52,7 +52,7 @@ public final class PayloadSizeLimitingHttpServiceFilter implements StreamingHttp
             public Single<StreamingHttpResponse> handle(
                     final HttpServiceContext ctx, final StreamingHttpRequest request,
                     final StreamingHttpResponseFactory responseFactory) {
-                return super.handle(ctx,
+                return delegate().handle(ctx,
                         // We could use transformPayloadBody to convert into Buffers, but transformMessageBody has
                         // slightly less overhead. Since this implementation is internal to ServiceTalk we take the more
                         // advanced route.


### PR DESCRIPTION
Motivation:

It's recommended to use `delegate` for invoking the next filter in the chain rather than `super`. In the past, we had cases when the `super` implementation changed and it affected filter behavior.

Modifications:

- Replace all calls to `super.handle(...)` with `delegate().handle(...)` and `super.request(...)` with `delegate.request(...)`.

Result:

All filters consistently use `delegate`.