### PR TITLE
http-netty: fix flaky ExpectContinueTest.retryExpectationFailed

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ExpectContinueTest.java
@@ -521,10 +521,9 @@ class ExpectContinueTest {
             TestPublisher<Buffer> payload = new TestPublisher.Builder<Buffer>().singleSubscriber().build();
             client.request(newRequest(client, withCL, true, payload)).subscribe(responses::add);
             requestReceived.await();
-            returnResponse.countDown();
-
             assertThat("Unexpected subscribe to payload body before 100 (Continue)",
                     payload.isSubscribed(), is(false));
+            returnResponse.countDown();
             sendContinue.countDown();
             sendRequestPayload(payload, client.executionContext().bufferAllocator());
             assertResponse(OK, PAYLOAD + PAYLOAD);


### PR DESCRIPTION
Motivation:

This test is flaky because of a race condition where we let the retry potentially happen before we assert that the request body hasn't been subscribed to. On the retry the entire request is sent without the expect: continue header so it should all be sent, and thus we expect the body to be subscribed to.

Modifications:

Don't let the first response continue until after the assertion. This should still test that the first `expect: continue` request doesn't subscribe to the body until it knows it's safe to proceed.

Result:

One less flaky test.

Fixes #2638