### PR TITLE
`servicetalk-grpc-protoc`: add `servicetalk-grpc-protobuf` transitively

### DIFF
--- a/servicetalk-examples/grpc/compression/build.gradle
+++ b/servicetalk-examples/grpc/compression/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   implementation project(":servicetalk-encoding-netty")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
 
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/grpc/deadline/build.gradle
+++ b/servicetalk-examples/grpc/deadline/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
 
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-examples/grpc/debugging/build.gradle
+++ b/servicetalk-examples/grpc/debugging/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
 
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/grpc/errors/build.gradle
+++ b/servicetalk-examples/grpc/errors/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
 
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/grpc/execution-strategy/build.gradle
+++ b/servicetalk-examples/grpc/execution-strategy/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
 
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/grpc/health/build.gradle
+++ b/servicetalk-examples/grpc/health/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
   implementation project(":servicetalk-grpc-health")
 
   implementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/servicetalk-examples/grpc/helloworld/build.gradle
+++ b/servicetalk-examples/grpc/helloworld/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
 
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/grpc/keepalive/build.gradle
+++ b/servicetalk-examples/grpc/keepalive/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
 
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/grpc/observer/build.gradle
+++ b/servicetalk-examples/grpc/observer/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
   implementation project(":servicetalk-grpc-utils")
 
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/grpc/protoc-options/build.gradle
+++ b/servicetalk-examples/grpc/protoc-options/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
 
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/servicetalk-examples/grpc/request-response-context/build.gradle
+++ b/servicetalk-examples/grpc/request-response-context/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
 
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/servicetalk-examples/grpc/routeguide/build.gradle
+++ b/servicetalk-examples/grpc/routeguide/build.gradle
@@ -27,9 +27,9 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-grpc-netty")
   implementation project(":servicetalk-grpc-protoc")
-  implementation project(":servicetalk-grpc-protobuf")
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
   implementation "com.google.protobuf:protobuf-java-util:$protobufVersion"
+
   runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }
 

--- a/servicetalk-grpc-protoc/README.adoc
+++ b/servicetalk-grpc-protoc/README.adoc
@@ -10,7 +10,9 @@ endif::[]
 
 This module implements the
 link:https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/plugin.proto[Protoc Plugin Interface]
-and generates ServiceTalk code for service definitions contained in `.proto` files.
+to generate ServiceTalk code for service definitions contained in `.proto` files. It's also a convenient way of adding
+all required transitive dependencies for the generated code by simply adding `io.servicetalk:servicetalk-grpc-protobuf`
+as a dependency to your classpath.
 
 It is recommended to automate the usage of this plugin in your build via
 link:https://github.com/google/protobuf-gradle-plugin[protobuf-gradle-plugin] or

--- a/servicetalk-grpc-protoc/build.gradle
+++ b/servicetalk-grpc-protoc/build.gradle
@@ -26,7 +26,10 @@ afterEvaluate {
     dependencyAnalysis {
       issues {
         onIncorrectConfiguration {
-          exclude(":servicetalk-data-protobuf") // Needed for the generated classes
+          exclude(":servicetalk-data-protobuf")
+        }
+        onUnusedDependencies {
+          exclude(":servicetalk-grpc-protobuf")
         }
       }
     }
@@ -34,7 +37,9 @@ afterEvaluate {
 }
 
 dependencies {
-  api project(":servicetalk-data-protobuf") // Needed for the generated classes
+  // The following api dependencies are required to compile generated classes:
+  api project(":servicetalk-data-protobuf")
+  api project(":servicetalk-grpc-protobuf")
 
   compileOnly "com.squareup:javapoet:$javaPoetVersion"
 

--- a/servicetalk-grpc-protoc/gradle.lockfile
+++ b/servicetalk-grpc-protoc/gradle.lockfile
@@ -1,10 +1,14 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.google.api.grpc:proto-google-common-protos:2.29.0=compileClasspath,runtimeClasspath
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
 com.google.protobuf:protobuf-bom:3.25.5=compileClasspath,runtimeClasspath
 com.google.protobuf:protobuf-java:3.25.5=compileClasspath,runtimeClasspath
 com.squareup:javapoet:1.13.0=compileClasspath
+io.netty:netty-bom:4.1.119.Final=runtimeClasspath
+io.netty:netty-buffer:4.1.119.Final=runtimeClasspath
+io.netty:netty-common:4.1.119.Final=runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
 org.slf4j:slf4j-api:1.7.36=runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,protobuf,shadow,spotbugsPlugins,testAnnotationProcessor,testProtobuf


### PR DESCRIPTION
Motivation:

`servicetalk-grpc-protoc` generates stubs, and the generated code requires 2 dependencies to make it compilable:
`servicetalk-data-protobuf` and `servicetalk-grpc-protobuf`. `servicetalk-grpc-protoc` already adds the first one transitively, but not the second one. In our examples, it's used as a way to add required transitive dependencies for generated code and should have all required dependencies.

Modifications:

- Add `servicetalk-grpc-protobuf` as a transitive `api` dependency for `servicetalk-grpc-protoc`.
- Remove `servicetalk-grpc-protobuf` from all examples.

Result:

Users don't need to guess what dependencies they need for the generated code, they can simply add `servicetalk-grpc-protoc` as their dependency to bring everything that they need transitively.