### PR TITLE
http-netty: Extract draining out of NettyHttpServer and into a filter

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -357,6 +357,9 @@ class DefaultHttpServerBuilder implements HttpServerBuilder {
             @Nullable final HttpLifecycleObserver lifecycleObserver) {
         final List<StreamingHttpServiceFilterFactory> filters = new ArrayList<>();
         // Append internal filters:
+        if (drainRequestPayloadBody) {
+            appendNonOffloadingServiceFilter(filters, HttpRequestAutoDrainingServiceFilter.INSTANCE);
+        }
         if (lifecycleObserver != null) {
             appendNonOffloadingServiceFilter(filters, new HttpLifecycleObserverServiceFilter(lifecycleObserver));
         }
@@ -460,20 +463,20 @@ class DefaultHttpServerBuilder implements HttpServerBuilder {
             }
             ReadOnlyHttpServerConfig roConfigWithoutSsl = configWithoutSsl.asReadOnly();
             return OptionalSslNegotiator.bind(executionContext, roConfig, roConfigWithoutSsl, address,
-                    connectionAcceptor, filteredService, drainRequestPayloadBody, earlyConnectionAcceptor,
+                    connectionAcceptor, filteredService, earlyConnectionAcceptor,
                     lateConnectionAcceptor);
         } else if (roConfig.tcpConfig().isAlpnConfigured()) {
             return DeferredServerChannelBinder.bind(executionContext, roConfig, address, connectionAcceptor,
-                    filteredService, drainRequestPayloadBody, false, earlyConnectionAcceptor, lateConnectionAcceptor);
+                    filteredService, false, earlyConnectionAcceptor, lateConnectionAcceptor);
         } else if (roConfig.tcpConfig().sniMapping() != null) {
             return DeferredServerChannelBinder.bind(executionContext, roConfig, address, connectionAcceptor,
-                    filteredService, drainRequestPayloadBody, true, earlyConnectionAcceptor, lateConnectionAcceptor);
+                    filteredService, true, earlyConnectionAcceptor, lateConnectionAcceptor);
         } else if (roConfig.isH2PriorKnowledge()) {
             return H2ServerParentConnectionContext.bind(executionContext, roConfig, address, connectionAcceptor,
-                    filteredService, drainRequestPayloadBody, earlyConnectionAcceptor, lateConnectionAcceptor);
+                    filteredService, earlyConnectionAcceptor, lateConnectionAcceptor);
         }
         return NettyHttpServer.bind(executionContext, roConfig, address, connectionAcceptor,
-                filteredService, drainRequestPayloadBody, earlyConnectionAcceptor, lateConnectionAcceptor);
+                filteredService, earlyConnectionAcceptor, lateConnectionAcceptor);
     }
 
     private static <T extends HttpExecutionStrategyInfluencer> HttpExecutionStrategy computeServiceStrategy(

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentConnectionContext.java
@@ -92,7 +92,6 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
                                           final SocketAddress listenAddress,
                                           @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
                                           final StreamingHttpService service,
-                                          final boolean drainRequestPayloadBody,
                                           @Nullable final EarlyConnectionAcceptor earlyConnectionAcceptor,
                                           @Nullable final LateConnectionAcceptor lateConnectionAcceptor) {
         if (config.h2Config() == null) {
@@ -102,7 +101,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
         return TcpServerBinder.bind(listenAddress, tcpServerConfig, executionContext, connectionAcceptor,
                 (channel, connectionObserver) -> initChannel(listenAddress, channel, executionContext, config,
                         new TcpServerChannelInitializer(tcpServerConfig, connectionObserver, executionContext), service,
-                        drainRequestPayloadBody, connectionObserver),
+                        connectionObserver),
                 serverConnection -> { /* nothing to do as h2 uses auto read on the parent channel */ },
                         earlyConnectionAcceptor, lateConnectionAcceptor)
                 .map(delegate -> {
@@ -120,7 +119,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
     static Single<H2ServerParentConnectionContext> initChannel(final SocketAddress listenAddress,
                 final Channel channel, final HttpExecutionContext httpExecutionContext,
                 final ReadOnlyHttpServerConfig config, final ChannelInitializer initializer,
-                final StreamingHttpService service, final boolean drainRequestPayloadBody,
+                final StreamingHttpService service,
                 final ConnectionObserver observer) {
         final H2ProtocolConfig h2ServerConfig = config.h2Config();
         if (h2ServerConfig == null) {
@@ -190,7 +189,7 @@ final class H2ServerParentConnectionContext extends H2ParentConnectionContext im
 
                                 // ServiceTalk HTTP service handler
                                 new NettyHttpServerConnection(streamConnection, service, HTTP_2_0,
-                                        h2ServerConfig.headersFactory(), drainRequestPayloadBody,
+                                        h2ServerConfig.headersFactory(),
                                         config.allowDropTrailersReadFromTransport()).process(false);
                             }
                     }).init(channel);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestAutoDrainingServiceFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestAutoDrainingServiceFilter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.concurrent.api.TerminalSignalConsumer;
+import io.servicetalk.concurrent.internal.CancelImmediatelySubscriber;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+import io.servicetalk.http.utils.BeforeFinallyHttpOperator;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.servicetalk.concurrent.api.Single.defer;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+
+public final class HttpRequestAutoDrainingServiceFilter implements StreamingHttpServiceFilterFactory {
+
+    static final StreamingHttpServiceFilterFactory INSTANCE = new HttpRequestAutoDrainingServiceFilter();
+
+    private HttpRequestAutoDrainingServiceFilter() {
+        // singleton
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return offloadNone();
+    }
+
+    @Override
+    public StreamingHttpServiceFilter create(StreamingHttpService service) {
+        return new DrainingStreamingHttpServiceFilter(service);
+    }
+
+    private static final class DrainingStreamingHttpServiceFilter extends StreamingHttpServiceFilter {
+
+        DrainingStreamingHttpServiceFilter(StreamingHttpService service) {
+            super(service);
+        }
+
+        @Override
+        public Single<StreamingHttpResponse> handle(HttpServiceContext ctx, StreamingHttpRequest request,
+                                                    StreamingHttpResponseFactory responseFactory) {
+            return defer(() -> doHandle(ctx, request, responseFactory).shareContextOnSubscribe());
+        }
+
+        private Single<StreamingHttpResponse> doHandle(HttpServiceContext ctx, StreamingHttpRequest request,
+                                                    StreamingHttpResponseFactory responseFactory) {
+            final AtomicBoolean payloadSubscribed = new AtomicBoolean();
+            request.transformMessageBody(body ->
+                    body.beforeSubscriber(() -> {
+                        payloadSubscribed.set(true);
+                        return HttpMessageDiscardWatchdogServiceFilter.NoopSubscriber.INSTANCE;
+                    }));
+            return delegate().handle(ctx, request, responseFactory)
+                    .liftSync(new BeforeFinallyHttpOperator(new TerminalSignalConsumer() {
+                @Override
+                public void onComplete() {
+                    request.payloadBody().ignoreElements().shareContextOnSubscribe().subscribe();
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    cancel(); // same behavior as cancel()
+                }
+
+                @Override
+                public void cancel() {
+                    maybeCancelMessageBody(payloadSubscribed, request.messageBody());
+                }
+            }, true));
+        }
+
+        private void maybeCancelMessageBody(AtomicBoolean payloadSubscribed, Publisher<?> messageBody) {
+            if (payloadSubscribed.compareAndSet(false, true)) {
+                cancelMessageBody(messageBody);
+            }
+        }
+
+        private void cancelMessageBody(Publisher<?> messageBody) {
+            toSource(messageBody.shareContextOnSubscribe()).subscribe(CancelImmediatelySubscriber.INSTANCE);
+        }
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptionalSslNegotiator.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptionalSslNegotiator.java
@@ -54,7 +54,6 @@ final class OptionalSslNegotiator {
                                           final SocketAddress listenAddress,
                                           @Nullable final InfluencerConnectionAcceptor connectionAcceptor,
                                           final StreamingHttpService service,
-                                          final boolean drainRequestPayloadBody,
                                           @Nullable final EarlyConnectionAcceptor earlyConnectionAcceptor,
                                           @Nullable final LateConnectionAcceptor lateConnectionAcceptor) {
         final BiFunction<Channel, ConnectionObserver, Single<NettyConnectionContext>> channelInit =
@@ -68,22 +67,22 @@ final class OptionalSslNegotiator {
                         if (roTcpConfig.isAlpnConfigured()) {
                             return DeferredServerChannelBinder.alpnInitChannel(listenAddress, channel,
                                     roConfig, executionContext,
-                                    service, drainRequestPayloadBody, connectionObserver);
+                                    service, connectionObserver);
                         } else if (roTcpConfig.sniMapping() != null) {
                             return DeferredServerChannelBinder.sniInitChannel(listenAddress, channel,
                                     roConfig, executionContext,
-                                    service, drainRequestPayloadBody, connectionObserver);
+                                    service, connectionObserver);
                         } else if (roConfig.isH2PriorKnowledge()) {
                             return H2ServerParentConnectionContext.initChannel(listenAddress, channel,
                                     executionContext, roConfig,
                                     new TcpServerChannelInitializer(roTcpConfig, connectionObserver,
                                             executionContext), service,
-                                    drainRequestPayloadBody, connectionObserver);
+                                    connectionObserver);
                         } else {
                             return NettyHttpServer.initChannel(channel, executionContext, roConfig,
                                     new TcpServerChannelInitializer(roTcpConfig, connectionObserver,
                                             executionContext), service,
-                                    drainRequestPayloadBody, connectionObserver);
+                                    connectionObserver);
                         }
                     } else {
                         if (roConfigWithoutSsl.h2Config() != null) {
@@ -91,12 +90,12 @@ final class OptionalSslNegotiator {
                                     executionContext, roConfigWithoutSsl,
                                     new TcpServerChannelInitializer(roConfigWithoutSsl.tcpConfig(),
                                             connectionObserver, executionContext), service,
-                                    drainRequestPayloadBody, connectionObserver);
+                                    connectionObserver);
                         } else {
                             return NettyHttpServer.initChannel(channel, executionContext, roConfigWithoutSsl,
                                     new TcpServerChannelInitializer(roConfigWithoutSsl.tcpConfig(),
                                             connectionObserver, executionContext), service,
-                                    drainRequestPayloadBody, connectionObserver);
+                                    connectionObserver);
                         }
                     }
                 });

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -88,7 +88,7 @@ class ServerRespondsOnClosingTest {
         };
         serverConnection = initChannel(channel, httpExecutionContext, config, new TcpServerChannelInitializer(
                 config.tcpConfig(), connectionObserver, httpExecutionContext),
-                toStreamingHttpService(offloadNone(), service), true,
+                toStreamingHttpService(offloadNone(), service),
                 connectionObserver).toFuture().get();
     }
 

--- a/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
+++ b/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
@@ -55,6 +55,10 @@ public final class TestUtils {
             return;
         }
 
+        if (true) {
+            throw new AssertionError(errors.poll());
+        }
+
         final AssertionError error = null != message ? new AssertionError(message) : new AssertionError();
         Throwable t;
         while ((t = errors.poll()) != null) {


### PR DESCRIPTION
Motivation:

The server shouldn't have to concern itself with draining and it should be handy to put draining behavior after other things such as the OpenTelemetry filters.

Modifications:

Extract draining into a filter.