### PR TITLE
servicetalk-concurrent-api: add CapturedContextProvider.captureContextCopy() method

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncContextExecutorPlugin.EXECUTOR_PLUGIN;
 import static io.servicetalk.concurrent.api.Executors.EXECUTOR_PLUGINS;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Presents a static interface to retain state in an asynchronous environment.
@@ -584,8 +585,8 @@ public final class AsyncContext {
         private final CapturedContextProvider second;
 
         CapturedContextProviderUnion(CapturedContextProvider first, CapturedContextProvider second) {
-            this.first = first;
-            this.second = second;
+            this.first = requireNonNull(first, "first");
+            this.second = requireNonNull(second, "second");
         }
 
         @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContext.java
@@ -578,7 +578,7 @@ public final class AsyncContext {
         LOGGER.info("Disabled. Features that depend on AsyncContext will stop working.");
     }
 
-    private static class CapturedContextProviderUnion implements CapturedContextProvider {
+    private static final class CapturedContextProviderUnion implements CapturedContextProvider {
 
         private final CapturedContextProvider first;
         private final CapturedContextProvider second;

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
@@ -66,17 +66,27 @@ interface AsyncContextProvider {
     Scope attachContextMap(ContextMap contextMap);
 
     /**
-     * Capture the current context with the provided {@link ContextMap} as the captured {@link AsyncContext} state.
+     * Capture the current context with the provided {@link ContextMap} as the captured {@link AsyncContext} state
+     * using sharing semantics, if applicable.
      * @return the captured context to be restored across async boundaries.
+     * @deprecated this should be removed once we remove the `*SetContextOnSubscribe` operators.
      */
-    CapturedContext captureContext(ContextMap contextMap);
+    @Deprecated
+    CapturedContext captureContext(ContextMap context);
 
     /**
-     * Capture the current context. This is expected to provide identical results as calling
-     * {@code captureContext(context());}.
+     * Capture the current context with the provided {@link ContextMap} as the captured {@link AsyncContext} state
+     * using sharing semantics, if applicable.
      * @return the captured context to be restored across async boundaries.
      */
     CapturedContext captureContext();
+
+    /**
+     * Capture the current context with the provided {@link ContextMap} as the captured {@link AsyncContext} state
+     * using copy or snapshot semantics.
+     * @return the captured context to be restored across async boundaries.
+     */
+    CapturedContext captureContextCopy();
 
     /**
      * Wrap the {@link Cancellable} to ensure it is able to track {@link AsyncContext} correctly.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/AsyncContextProvider.java
@@ -71,7 +71,7 @@ interface AsyncContextProvider {
      * @return the captured context to be restored across async boundaries.
      * @deprecated this should be removed once we remove the `*SetContextOnSubscribe` operators.
      */
-    @Deprecated
+    @Deprecated // FIXME: 0.43
     CapturedContext captureContext(ContextMap context);
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
@@ -17,53 +17,68 @@ package io.servicetalk.concurrent.api;
 
 /**
  * Functionality related to capturing thread-local like context for later restoration across async boundaries.
+ *
+ * If you want to capture any external state you can create a wrapper {@link CapturedContext} to add additional
+ * state capturing to the context pathway. This state can then be restored by wrapping the {@link CapturedContext}
+ * with the additional functionality to restore and finally revert the context state.
+ * <p>
+ * An example provider may be implemented as follows:
+ * <pre>{@code
+ *     private class CapturedContextImpl implements CapturedContext {
+ *         private final CapturedContext delegate;
+ *         private final String state;
+ *
+ *         public Scope attachContext() {
+ *             String old = getMyString();
+ *             setMyString(state);
+ *             Scope outer = delegate.attachContext();
+ *             return () -> {
+ *                 outer.close();
+ *                 setMyString(old);
+ *             };
+ *         }
+ *
+ *         public ContextMap captured() {
+ *             return delegate.captured();
+ *         }
+ *     }
+ *
+ *     private MyState getMyState() {
+ *         // capture context state from the local environment
+ *     }
+ *
+ *     private void setMyState(MyState myState) {
+ *         // set the context state in the local environment
+ *     }
+ *
+ *     CapturedContext captureContext(CapturedContext underlying) {
+ *          return new CapturedContextImpl(delegate, getMyState());
+ *     }
+ *
+ *     CapturedContext captureContextCopy(CapturedContext underlying) {
+ *          return new CapturedContextImpl(delegate, getMyState().copy());
+ *     }
+ * }</pre>
+ *
+ * <b>Note:</b> If the MyState type is immutable then there is no distinction between
+ * captureContext(..) and captureContextCopy(..)
  */
-@FunctionalInterface
+
 public interface CapturedContextProvider {
 
     /**
-     * Capture existing context in preparation for an asynchronous thread jump.
-     *
-     * If you want to capture any external state you can create a wrapper {@link CapturedContext} to add additional
-     * state capturing to the context pathway. This state can then be restored by wrapping the {@link CapturedContext}
-     * with the additional functionality to restore and finally revert the context state.
-     * <p>
-     * An example provider may be implemented as follows:
-     * <pre>{@code
-     *     private class CapturedContextImpl implements CapturedContext {
-     *         private final CapturedContext delegate;
-     *         private final String state;
-     *
-     *         public Scope attachContext() {
-     *             String old = getMyString();
-     *             setMyString(state);
-     *             Scope outer = delegate.attachContext();
-     *             return () -> {
-     *                 outer.close();
-     *                 setMyString(old);
-     *             };
-     *         }
-     *
-     *         public ContextMap captured() {
-     *             return delegate.captured();
-     *         }
-     *     }
-     *
-     *     private String getMyString() {
-     *         // capture context state from the local environment
-     *     }
-     *
-     *     private void setMyString(String string) {
-     *         // set the context state in the local environment
-     *     }
-     *
-     *     CapturedContext captureContext(CapturedContext underlying) {
-     *          return new CapturedContextImpl(delegate, getMyString());
-     *     }
-     * }</pre>
+     * Capture a reference to existing context in preparation for an asynchronous thread jump.
      * @param underlying additional context that <i><b>must</b></i> be utilized as part of the returned
      * {@link CapturedContext}, usually wrapped as described above.
-     * @return the wrapped {@link CapturedContext}, or the original if there was no additional state captured.
+     * @return the wrapped {@link CapturedContext}.
      */
     CapturedContext captureContext(CapturedContext underlying);
+
+    /**
+     * Capture a copy of existing context in preparation for an asynchronous thread jump.
+     * @param underlying additional context that <i><b>must</b></i> be utilized as part of the returned
+     * {@link CapturedContext}, usually wrapped as described above.
+     * @return the wrapped {@link CapturedContext}.
+     */
+    CapturedContext captureContextCopy(CapturedContext underlying);
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CapturedContextProvider.java
@@ -17,7 +17,7 @@ package io.servicetalk.concurrent.api;
 
 /**
  * Functionality related to capturing thread-local like context for later restoration across async boundaries.
- *
+ * <p>
  * If you want to capture any external state you can create a wrapper {@link CapturedContext} to add additional
  * state capturing to the context pathway. This state can then be restored by wrapping the {@link CapturedContext}
  * with the additional functionality to restore and finally revert the context state.
@@ -67,7 +67,7 @@ package io.servicetalk.concurrent.api;
 public interface CapturedContextProvider {
 
     /**
-     * Capture a reference to existing context in preparation for an asynchronous thread jump.
+     * Capture a reference to existing context in preparation for an asynchronous boundary jump.
      * @param underlying additional context that <i><b>must</b></i> be utilized as part of the returned
      * {@link CapturedContext}, usually wrapped as described above.
      * @return the wrapped {@link CapturedContext}.
@@ -75,7 +75,7 @@ public interface CapturedContextProvider {
     CapturedContext captureContext(CapturedContext underlying);
 
     /**
-     * Capture a copy of existing context in preparation for an asynchronous thread jump.
+     * Capture a copy of existing context in preparation for an asynchronous boundary jump.
      * @param underlying additional context that <i><b>must</b></i> be utilized as part of the returned
      * {@link CapturedContext}, usually wrapped as described above.
      * @return the wrapped {@link CapturedContext}.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -1730,7 +1730,7 @@ public abstract class Completable {
      */
     CapturedContext contextForSubscribe(AsyncContextProvider provider) {
         // the default behavior is to copy the map. Some operators may want to use shared map
-        return provider.captureContext(provider.context().copy());
+        return provider.captureContextCopy();
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CustomCaptureAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CustomCaptureAsyncContextProvider.java
@@ -31,4 +31,9 @@ final class CustomCaptureAsyncContextProvider extends DefaultAsyncContextProvide
     public CapturedContext captureContext(ContextMap contextMap) {
         return delegate.captureContext(super.captureContext(contextMap));
     }
+
+    @Override
+    public CapturedContext captureContextCopy() {
+        return delegate.captureContextCopy(super.captureContextCopy());
+    }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DefaultAsyncContextProvider.java
@@ -80,14 +80,23 @@ class DefaultAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
-    public CapturedContext captureContext(ContextMap contextMap) {
-        return contextMap instanceof CapturedContext ?
-                (CapturedContext) contextMap : new CapturedContextImpl(contextMap);
+    public final CapturedContext captureContext() {
+        return captureContext(context());
     }
 
     @Override
-    public final CapturedContext captureContext() {
-        return captureContext(context());
+    public CapturedContext captureContext(ContextMap contextMap) {
+        return convertToCapturedContext(contextMap);
+    }
+
+    @Override
+    public CapturedContext captureContextCopy() {
+        return convertToCapturedContext(context().copy());
+    }
+
+    private CapturedContext convertToCapturedContext(ContextMap contextMap) {
+        return contextMap instanceof CapturedContext ?
+                (CapturedContext) contextMap : new CapturedContextImpl(contextMap);
     }
 
     @Override

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NoopAsyncContextProvider.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NoopAsyncContextProvider.java
@@ -52,6 +52,11 @@ final class NoopAsyncContextProvider implements AsyncContextProvider {
     }
 
     @Override
+    public CapturedContext captureContextCopy() {
+        return NoopContextMap.INSTANCE;
+    }
+
+    @Override
     public CapturedContext captureContext(ContextMap contextMap) {
         return NoopContextMap.INSTANCE;
     }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -4391,7 +4391,7 @@ Kotlin flatMapLatest</a>
      */
     CapturedContext contextForSubscribe(AsyncContextProvider provider) {
         // the default behavior is to copy the map. Some operators may want to use shared map
-        return provider.captureContext(provider.context().copy());
+        return provider.captureContextCopy();
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -2673,7 +2673,7 @@ public abstract class Single<T> {
      */
     CapturedContext contextForSubscribe(AsyncContextProvider provider) {
         // the default behavior is to copy the map. Some operators may want to use shared map
-        return provider.captureContext(provider.context().copy());
+        return provider.captureContextCopy();
     }
 
     /**

--- a/servicetalk-opentelemetry-asynccontext/src/main/java/io/servicetalk/opentelemetry/asynccontext/OtelCapturedContextProvider.java
+++ b/servicetalk-opentelemetry-asynccontext/src/main/java/io/servicetalk/opentelemetry/asynccontext/OtelCapturedContextProvider.java
@@ -35,6 +35,12 @@ public final class OtelCapturedContextProvider implements CapturedContextProvide
 
     @Override
     public CapturedContext captureContext(CapturedContext underlying) {
+        // OTEL state is immutable so everything is a copy.
+        return captureContextCopy(underlying);
+    }
+
+    @Override
+    public CapturedContext captureContextCopy(CapturedContext underlying) {
         return new WithOtelCapturedContext(Context.current(), underlying);
     }
 


### PR DESCRIPTION
Motivation:

Certain types of context is mutable. Examples include our own AsyncContext, MDC context, etc. For those situations we don't have a way to isolate the captured context boundaries from one another and it will ultimately bleed together.

Modifications:

Add a `captureContextCopy()` method to `CapturedContextProvider`. This will let the capture system know which type of context we're trying to acquire.

Result:

More consistent context capture system.