### PR TITLE
Don't use `discardEventsAfterCancel` when not necessary

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/HttpRequestAutoDrainingServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/HttpRequestAutoDrainingServiceFilter.java
@@ -83,7 +83,7 @@ public final class HttpRequestAutoDrainingServiceFilter implements StreamingHttp
             final DrainTerminalSignalConsumer terminalSignalConsumer = new DrainTerminalSignalConsumer(request);
             request.transformMessageBody(body -> body.beforeSubscriber(terminalSignalConsumer));
             return delegate().handle(ctx, request, responseFactory)
-                    .liftSync(new AfterFinallyHttpOperator(terminalSignalConsumer, true));
+                    .liftSync(new AfterFinallyHttpOperator(terminalSignalConsumer));
         }
     }
 

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrackPendingRequestsHttpFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrackPendingRequestsHttpFilter.java
@@ -113,7 +113,7 @@ final class TrackPendingRequestsHttpFilter implements StreamingHttpClientFilterF
                             private void decrement() {
                                 pendingUpdater.decrementAndGet(TrackPendingRequestsHttpClientFilter.this);
                             }
-                        }, true))
+                        }))
                         .shareContextOnSubscribe();
             });
         }
@@ -166,7 +166,7 @@ final class TrackPendingRequestsHttpFilter implements StreamingHttpClientFilterF
                             private void decrement() {
                                 pendingUpdater.decrementAndGet(TrackPendingRequestsHttpServiceFilter.this);
                             }
-                        }, true))
+                        }))
                         .shareContextOnSubscribe();
             });
         }


### PR DESCRIPTION
Motivation:

`discardEventsAfterCancel` flag for `[Before|After]FinallyHttpOperator` is useful only for cases when we don't want downstream users to see response `onComplete/onError` after cancellation to make sure output matches with callbacks (observability).
However, for `HttpRequestAutoDrainingServiceFilter` and `TrackPendingRequestsHttpFilter` we only need to track termination, influencing what users see for returned response is not necessary.

Modifications:

- Remove `discardEventsAfterCancel` flag from `HttpRequestAutoDrainingServiceFilter` and
`TrackPendingRequestsHttpFilter`;

Result:

`HttpRequestAutoDrainingServiceFilter` and
`TrackPendingRequestsHttpFilter` don't influence response output that users see.