### PR TITLE
`DelegatingExecutor`: drop `abstract` class modifier

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * An {@link Executor} that simply delegates all calls to another {@link Executor}.
  */
-public abstract class DelegatingExecutor implements Executor {
+public class DelegatingExecutor implements Executor {
 
     private final Executor delegate;
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingHttpServiceContext.java
@@ -47,7 +47,7 @@ public class DelegatingHttpServiceContext extends HttpServiceContext {
      *
      * @return the delegate {@link HttpServiceContext}.
      */
-    public HttpServiceContext delegate() {
+    public HttpServiceContext delegate() {  // FIXME: 0.43 - consider making this method protected
         return delegate;
     }
 


### PR DESCRIPTION
Motivation:

All other `Delegating*` classes are non-abstract.

Modifications:

- Drop `abstract` class modifier from `DelegatingExecutor`.

Result:

`DelegatingExecutor` is consistent with all other `Delegating*` classes.