### PR TITLE
`BeforeFinallyHttpOperator`: restore binary compatibility

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AfterFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/AfterFinallyHttpOperator.java
@@ -53,7 +53,7 @@ import io.servicetalk.http.api.StreamingHttpResponse;
  *
  * @see BeforeFinallyHttpOperator
  */
-public final class AfterFinallyHttpOperator extends WhenFinallyHttpOperator {
+public final class AfterFinallyHttpOperator extends AbstractWhenFinallyHttpOperator {
 
     /**
      * Create a new instance.

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/BeforeFinallyHttpOperator.java
@@ -53,7 +53,7 @@ import io.servicetalk.http.api.StreamingHttpResponse;
  *
  * @see AfterFinallyHttpOperator
  */
-public final class BeforeFinallyHttpOperator extends WhenFinallyHttpOperator {
+public final class BeforeFinallyHttpOperator extends AbstractWhenFinallyHttpOperator {
 
     /**
      * Create a new instance.


### PR DESCRIPTION
Motivation:

Its binary compatibility was broken in #3231.

Modifications:

- Remove `final` modifier from `apply` method of the super class.
- Make its super class `abstract`.

Result:

`japicmp` is happy.