### PR TITLE
Deprecate `DelegatingFlushStrategy`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DelegatingFlushStrategy.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DelegatingFlushStrategy.java
@@ -19,8 +19,12 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link FlushStrategy} implementation that delegates all calls to another {@link FlushStrategy}.
+ *
+ * @deprecated this class will be made package-private in the future releases. If you depend on this code, consider
+ * copying it into your codebase.
  */
-public class DelegatingFlushStrategy implements FlushStrategy {
+@Deprecated
+public class DelegatingFlushStrategy implements FlushStrategy { // FIXME: 0.43 - make this class pkg-private and final
 
     private final FlushStrategy delegate;
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/FlushStrategyHolder.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/FlushStrategyHolder.java
@@ -38,6 +38,7 @@ public final class FlushStrategyHolder {
      *
      * @param flushStrategy Initial {@link FlushStrategy} to use.
      */
+    @SuppressWarnings("deprecation")
     public FlushStrategyHolder(final FlushStrategy flushStrategy) {
         // Wrap the strategy so that we can do reference equality to check if the strategy has been modified.
         originalFlushStrategy = new DelegatingFlushStrategy(flushStrategy);


### PR DESCRIPTION
Motivation:

This class is used only internally, no need to be public in the future releases.