### PR TITLE
Use `DelegatingListenableAsyncCloseable` where possible

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingServiceDiscoverer.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingServiceDiscoverer.java
@@ -15,12 +15,10 @@
  */
 package io.servicetalk.client.api;
 
-import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.DelegatingListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 
 import java.util.Collection;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link ServiceDiscoverer} that delegates all methods to another {@link ServiceDiscoverer}.
@@ -30,7 +28,7 @@ import static java.util.Objects.requireNonNull;
  * @param <E> Type of {@link ServiceDiscovererEvent}s published from {@link #discover(Object)}.
  */
 public class DelegatingServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
-        E extends ServiceDiscovererEvent<ResolvedAddress>>
+        E extends ServiceDiscovererEvent<ResolvedAddress>> extends DelegatingListenableAsyncCloseable
         implements ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> {
     private final ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> delegate;
 
@@ -40,7 +38,8 @@ public class DelegatingServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
      * @param delegate {@link ServiceDiscoverer} to which all methods are delegated.
      */
     public DelegatingServiceDiscoverer(final ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> delegate) {
-        this.delegate = requireNonNull(delegate);
+        super(delegate);
+        this.delegate = delegate;
     }
 
     /**
@@ -48,6 +47,7 @@ public class DelegatingServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
      *
      * @return Delegate {@link ServiceDiscoverer}.
      */
+    @Override
     protected final ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> delegate() {
         return delegate;
     }
@@ -55,30 +55,5 @@ public class DelegatingServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
     @Override
     public Publisher<Collection<E>> discover(final UnresolvedAddress address) {
         return delegate.discover(address);
-    }
-
-    @Override
-    public Completable onClose() {
-        return delegate.onClose();
-    }
-
-    @Override
-    public Completable onClosing() {
-        return delegate.onClosing();
-    }
-
-    @Override
-    public Completable closeAsync() {
-        return delegate.closeAsync();
-    }
-
-    @Override
-    public Completable closeAsyncGracefully() {
-        return delegate.closeAsyncGracefully();
-    }
-
-    @Override
-    public String toString() {
-        return this.getClass().getSimpleName() + "{delegate=" + delegate() + '}';
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
@@ -23,12 +23,10 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * An {@link Executor} that simply delegates all calls to another {@link Executor}.
  */
-public class DelegatingExecutor implements Executor {
+public class DelegatingExecutor extends DelegatingListenableAsyncCloseable implements Executor {
 
     private final Executor delegate;
 
@@ -38,12 +36,8 @@ public class DelegatingExecutor implements Executor {
      * @param delegate {@link Executor} to delegate all calls to.
      */
     protected DelegatingExecutor(final Executor delegate) {
-        this.delegate = requireNonNull(delegate);
-    }
-
-    @Override
-    public String toString() {
-        return this.getClass().getSimpleName() + "{delegate=" + delegate() + "}";
+        super(delegate);
+        this.delegate = delegate;
     }
 
     /**
@@ -51,6 +45,7 @@ public class DelegatingExecutor implements Executor {
      *
      * @return The delegate {@link Executor} used.
      */
+    @Override
     protected Executor delegate() {
         return delegate;
     }
@@ -104,25 +99,5 @@ public class DelegatingExecutor implements Executor {
     @Override
     public long currentTime(TimeUnit unit) {
         return delegate.currentTime(unit);
-    }
-
-    @Override
-    public Completable onClose() {
-        return delegate.onClose();
-    }
-
-    @Override
-    public Completable onClosing() {
-        return delegate.onClosing();
-    }
-
-    @Override
-    public Completable closeAsync() {
-        return delegate.closeAsync();
-    }
-
-    @Override
-    public Completable closeAsyncGracefully() {
-        return delegate.closeAsyncGracefully();
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpLoadBalancedConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpLoadBalancedConnection.java
@@ -16,15 +16,14 @@
 package io.servicetalk.http.api;
 
 import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.DelegatingListenableAsyncCloseable;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of {@link FilterableStreamingHttpLoadBalancedConnection} that delegates all methods.
  */
-public class DelegatingFilterableStreamingHttpLoadBalancedConnection
+public class DelegatingFilterableStreamingHttpLoadBalancedConnection extends DelegatingListenableAsyncCloseable
         implements FilterableStreamingHttpLoadBalancedConnection {
     private final FilterableStreamingHttpLoadBalancedConnection delegate;
 
@@ -34,7 +33,13 @@ public class DelegatingFilterableStreamingHttpLoadBalancedConnection
      */
     public DelegatingFilterableStreamingHttpLoadBalancedConnection(
             final FilterableStreamingHttpLoadBalancedConnection delegate) {
-        this.delegate = requireNonNull(delegate);
+        super(delegate);
+        this.delegate = delegate;
+    }
+
+    @Override
+    protected FilterableStreamingHttpLoadBalancedConnection delegate() {
+        return delegate;
     }
 
     @Override
@@ -55,26 +60,6 @@ public class DelegatingFilterableStreamingHttpLoadBalancedConnection
     @Override
     public int score() {
         return delegate.score();
-    }
-
-    @Override
-    public Completable closeAsync() {
-        return delegate.closeAsync();
-    }
-
-    @Override
-    public Completable closeAsyncGracefully() {
-        return delegate.closeAsyncGracefully();
-    }
-
-    @Override
-    public Completable onClose() {
-        return delegate.onClose();
-    }
-
-    @Override
-    public Completable onClosing() {
-        return delegate.onClosing();
     }
 
     @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
@@ -15,20 +15,18 @@
  */
 package io.servicetalk.transport.api;
 
-import io.servicetalk.concurrent.api.Completable;
+import io.servicetalk.concurrent.api.DelegatingListenableAsyncCloseable;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A {@link ConnectionContext} implementation that delegates all calls to a provided {@link ConnectionContext}. Any of
  * the methods can be overridden by implementations to change the behavior.
  */
-public class DelegatingConnectionContext implements ConnectionContext {
+public class DelegatingConnectionContext extends DelegatingListenableAsyncCloseable implements ConnectionContext {
 
     private final ConnectionContext delegate;
 
@@ -38,7 +36,8 @@ public class DelegatingConnectionContext implements ConnectionContext {
      * @param delegate {@link ConnectionContext} to delegate all calls.
      */
     public DelegatingConnectionContext(final ConnectionContext delegate) {
-        this.delegate = requireNonNull(delegate);
+        super(delegate);
+        this.delegate = delegate;
     }
 
     /**
@@ -46,6 +45,7 @@ public class DelegatingConnectionContext implements ConnectionContext {
      *
      * @return the {@link ConnectionContext} that this class delegates to.
      */
+    @Override
     protected ConnectionContext delegate() {
         return delegate;
     }
@@ -91,26 +91,6 @@ public class DelegatingConnectionContext implements ConnectionContext {
     @Override
     public ConnectionContext parent() {
         return delegate.parent();
-    }
-
-    @Override
-    public Completable onClose() {
-        return delegate.onClose();
-    }
-
-    @Override
-    public Completable onClosing() {
-        return delegate.onClosing();
-    }
-
-    @Override
-    public Completable closeAsync() {
-        return delegate.closeAsync();
-    }
-
-    @Override
-    public Completable closeAsyncGracefully() {
-        return delegate.closeAsyncGracefully();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

#3239 added new `DelegatingListenableAsyncCloseable` class, but I was not able to use it because of some false positives from japicmp. Now I figured what was the problem and we can remove some boilerplate code.

Modifications:

- Use `DelegatingListenableAsyncCloseable` to simplify `DelegatingExecutor`, `DelegatingConnectionFactory`, `DelegatingServiceDiscoverer`, `DelegatingConnectionContext`, and `DelegatingFilterableStreamingHttpLoadBalancedConnection` implementations.

Result:

Less code to maintain delegating classes that implement `ListenableAsyncCloseable` interface.

Binary compatibility:

If you run `./gradlew assemble && ./scripts/japicmp.sh 0.42.55 local`, it won't report anything for `DelegatingExecutor`, but will report false positives for all other classes. This happens because `japicmp` compares jar-to-jar and does not see changes in other dependencies. I tested that by copying `DelegatingListenableAsyncCloseable` and `DelegatingAsyncCloseable` classes to `servicetalk-client-api` module and then warnings disappear. So, as long as users have all ServiceTalk libraries of the same version, their binary compatibility won't be broken.