### PR TITLE
Parametrize `Delegating[Listenable]AsyncCloseable`

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingConnectionFactory.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingConnectionFactory.java
@@ -33,9 +33,8 @@ import static io.servicetalk.client.api.DeprecatedToNewConnectionFactoryFilter.C
  * @param <C> The type of connections created by this factory.
  */
 public class DelegatingConnectionFactory<ResolvedAddress, C extends ListenableAsyncCloseable>
-        extends DelegatingListenableAsyncCloseable implements ConnectionFactory<ResolvedAddress, C> {
-
-    private final ConnectionFactory<ResolvedAddress, C> delegate;
+        extends DelegatingListenableAsyncCloseable<ConnectionFactory<ResolvedAddress, C>>
+        implements ConnectionFactory<ResolvedAddress, C> {
 
     /**
      * Create a new instance.
@@ -44,23 +43,22 @@ public class DelegatingConnectionFactory<ResolvedAddress, C extends ListenableAs
      */
     public DelegatingConnectionFactory(final ConnectionFactory<ResolvedAddress, C> delegate) {
         super(delegate);
-        this.delegate = delegate;
     }
 
     /**
-     * Returns the {@link ConnectionFactory} delegate.
+     * Get the {@link ConnectionFactory} that this class delegates to.
      *
-     * @return Delegate {@link ConnectionFactory}.
+     * @return the {@link ConnectionFactory} that this class delegates to.
      */
     @Override
     protected final ConnectionFactory<ResolvedAddress, C> delegate() {
-        return delegate;
+        return super.delegate();
     }
 
     @Deprecated
     @Override
     public Single<C> newConnection(final ResolvedAddress resolvedAddress, @Nullable final TransportObserver observer) {
-        return delegate.newConnection(resolvedAddress, observer);
+        return delegate().newConnection(resolvedAddress, observer);
     }
 
     @Override

--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingServiceDiscoverer.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DelegatingServiceDiscoverer.java
@@ -28,9 +28,9 @@ import java.util.Collection;
  * @param <E> Type of {@link ServiceDiscovererEvent}s published from {@link #discover(Object)}.
  */
 public class DelegatingServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
-        E extends ServiceDiscovererEvent<ResolvedAddress>> extends DelegatingListenableAsyncCloseable
+        E extends ServiceDiscovererEvent<ResolvedAddress>>
+        extends DelegatingListenableAsyncCloseable<ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E>>
         implements ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> {
-    private final ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> delegate;
 
     /**
      * Creates a new instance.
@@ -39,21 +39,20 @@ public class DelegatingServiceDiscoverer<UnresolvedAddress, ResolvedAddress,
      */
     public DelegatingServiceDiscoverer(final ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> delegate) {
         super(delegate);
-        this.delegate = delegate;
     }
 
     /**
-     * Returns the {@link ServiceDiscoverer} delegate.
+     * Get the {@link ServiceDiscoverer} that this class delegates to.
      *
-     * @return Delegate {@link ServiceDiscoverer}.
+     * @return the {@link ServiceDiscoverer} that this class delegates to.
      */
     @Override
     protected final ServiceDiscoverer<UnresolvedAddress, ResolvedAddress, E> delegate() {
-        return delegate;
+        return super.delegate();
     }
 
     @Override
     public Publisher<Collection<E>> discover(final UnresolvedAddress address) {
-        return delegate.discover(address);
+        return delegate().discover(address);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingAsyncCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingAsyncCloseable.java
@@ -40,7 +40,7 @@ public class DelegatingAsyncCloseable<T extends AsyncCloseable> implements Async
      *
      * @return the {@link T} subtype of {@link AsyncCloseable} that this class delegates to.
      */
-    protected T delegate() {
+    protected T delegate() {    // FIXME: 0.43 - consider making this method `final`
         return delegate;
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingAsyncCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingAsyncCloseable.java
@@ -19,26 +19,28 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * {@link AsyncCloseable} that delegates all calls to another {@link AsyncCloseable}.
+ *
+ * @param <T> The type of {@link AsyncCloseable} to delegate to.
  */
-public class DelegatingAsyncCloseable implements AsyncCloseable {
+public class DelegatingAsyncCloseable<T extends AsyncCloseable> implements AsyncCloseable {
 
-    private final AsyncCloseable delegate;
+    private final T delegate;
 
     /**
      * New instance.
      *
-     * @param delegate {@link AsyncCloseable} to delegate all calls to.
+     * @param delegate {@link T} subtype of {@link AsyncCloseable} to delegate all calls to.
      */
-    public DelegatingAsyncCloseable(final AsyncCloseable delegate) {
+    public DelegatingAsyncCloseable(final T delegate) {
         this.delegate = requireNonNull(delegate);
     }
 
     /**
-     * Get the {@link AsyncCloseable} that this class delegates to.
+     * Get the {@link T} subtype of {@link AsyncCloseable} that this class delegates to.
      *
-     * @return the {@link AsyncCloseable} that this class delegates to.
+     * @return the {@link T} subtype of {@link AsyncCloseable} that this class delegates to.
      */
-    protected AsyncCloseable delegate() {
+    protected T delegate() {
         return delegate;
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingExecutor.java
@@ -26,9 +26,7 @@ import java.util.function.Supplier;
 /**
  * An {@link Executor} that simply delegates all calls to another {@link Executor}.
  */
-public class DelegatingExecutor extends DelegatingListenableAsyncCloseable implements Executor {
-
-    private final Executor delegate;
+public class DelegatingExecutor extends DelegatingListenableAsyncCloseable<Executor> implements Executor {
 
     /**
      * New instance.
@@ -37,67 +35,67 @@ public class DelegatingExecutor extends DelegatingListenableAsyncCloseable imple
      */
     protected DelegatingExecutor(final Executor delegate) {
         super(delegate);
-        this.delegate = delegate;
     }
 
     /**
-     * Returns the delegate {@link Executor} used.
+     * Get the {@link Executor} that this class delegates to.
      *
-     * @return The delegate {@link Executor} used.
+     * @return the {@link Executor} that this class delegates to.
      */
     @Override
+    @SuppressWarnings("PMD.UselessOverridingMethod") // Method is overridden to preserve binary compatibility
     protected Executor delegate() {
-        return delegate;
+        return super.delegate();
     }
 
     @Override
     public Cancellable execute(final Runnable task) throws RejectedExecutionException {
-        return delegate.execute(task);
+        return delegate().execute(task);
     }
 
     @Override
     public Cancellable schedule(final Runnable task, final long delay, final TimeUnit unit)
             throws RejectedExecutionException {
-        return delegate.schedule(task, delay, unit);
+        return delegate().schedule(task, delay, unit);
     }
 
     @Override
     public Cancellable schedule(final Runnable task, final Duration delay) throws RejectedExecutionException {
-        return delegate.schedule(task, delay);
+        return delegate().schedule(task, delay);
     }
 
     @Override
     public Completable timer(final long delay, final TimeUnit unit) {
-        return delegate.timer(delay, unit);
+        return delegate().timer(delay, unit);
     }
 
     @Override
     public Completable timer(final Duration delay) {
-        return delegate.timer(delay);
+        return delegate().timer(delay);
     }
 
     @Override
     public Completable submit(final Runnable runnable) {
-        return delegate.submit(runnable);
+        return delegate().submit(runnable);
     }
 
     @Override
     public Completable submitRunnable(final Supplier<Runnable> runnableSupplier) {
-        return delegate.submitRunnable(runnableSupplier);
+        return delegate().submitRunnable(runnableSupplier);
     }
 
     @Override
     public <T> Single<T> submit(final Callable<? extends T> callable) {
-        return delegate.submit(callable);
+        return delegate().submit(callable);
     }
 
     @Override
     public <T> Single<T> submitCallable(final Supplier<? extends Callable<? extends T>> callableSupplier) {
-        return delegate.submitCallable(callableSupplier);
+        return delegate().submitCallable(callableSupplier);
     }
 
     @Override
     public long currentTime(TimeUnit unit) {
-        return delegate.currentTime(unit);
+        return delegate().currentTime(unit);
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingListenableAsyncCloseable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/DelegatingListenableAsyncCloseable.java
@@ -17,38 +17,39 @@ package io.servicetalk.concurrent.api;
 
 /**
  * {@link ListenableAsyncCloseable} that delegates all calls to another {@link ListenableAsyncCloseable}.
+ *
+ * @param <T> The type of {@link ListenableAsyncCloseable} to delegate to.
  */
-public class DelegatingListenableAsyncCloseable extends DelegatingAsyncCloseable implements ListenableAsyncCloseable {
-
-    private final ListenableAsyncCloseable delegate;
+public class DelegatingListenableAsyncCloseable<T extends ListenableAsyncCloseable> extends DelegatingAsyncCloseable<T>
+        implements ListenableAsyncCloseable {
 
     /**
      * New instance.
      *
-     * @param delegate {@link ListenableAsyncCloseable} to delegate all calls to.
+     * @param delegate {@link T} subtype of {@link ListenableAsyncCloseable} to delegate all calls to.
      */
-    public DelegatingListenableAsyncCloseable(final ListenableAsyncCloseable delegate) {
+    public DelegatingListenableAsyncCloseable(final T delegate) {
         super(delegate);
-        this.delegate = delegate;
     }
 
     /**
-     * Get the {@link ListenableAsyncCloseable} that this class delegates to.
+     * Get the {@link T} subtype of {@link ListenableAsyncCloseable} that this class delegates to.
      *
-     * @return the {@link ListenableAsyncCloseable} that this class delegates to.
+     * @return the {@link T} subtype of {@link ListenableAsyncCloseable} that this class delegates to.
      */
     @Override
-    protected ListenableAsyncCloseable delegate() {
-        return delegate;
+    @SuppressWarnings("PMD.UselessOverridingMethod") // Method is overridden for consistency w/ other delegating classes
+    protected T delegate() {
+        return super.delegate();
     }
 
     @Override
     public Completable onClose() {
-        return delegate.onClose();
+        return delegate().onClose();
     }
 
     @Override
     public Completable onClosing() {
-        return delegate.onClosing();
+        return delegate().onClosing();
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/GlobalExecutor.java
@@ -37,11 +37,6 @@ final class GlobalExecutor extends DelegatingExecutor {
     }
 
     @Override
-    public String toString() {
-        return this.getClass().getSimpleName() + "{delegate=" + delegate() + "}";
-    }
-
-    @Override
     public Completable closeAsync() {
         return delegate().closeAsync()
                 .beforeOnSubscribe(__ -> log(LOGGER, NAME_PREFIX, "closeAsync()"));

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpLoadBalancedConnection.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DelegatingFilterableStreamingHttpLoadBalancedConnection.java
@@ -23,9 +23,9 @@ import io.servicetalk.concurrent.api.Single;
 /**
  * Implementation of {@link FilterableStreamingHttpLoadBalancedConnection} that delegates all methods.
  */
-public class DelegatingFilterableStreamingHttpLoadBalancedConnection extends DelegatingListenableAsyncCloseable
+public class DelegatingFilterableStreamingHttpLoadBalancedConnection
+        extends DelegatingListenableAsyncCloseable<FilterableStreamingHttpLoadBalancedConnection>
         implements FilterableStreamingHttpLoadBalancedConnection {
-    private final FilterableStreamingHttpLoadBalancedConnection delegate;
 
     /**
      * Create a new instance.
@@ -34,126 +34,130 @@ public class DelegatingFilterableStreamingHttpLoadBalancedConnection extends Del
     public DelegatingFilterableStreamingHttpLoadBalancedConnection(
             final FilterableStreamingHttpLoadBalancedConnection delegate) {
         super(delegate);
-        this.delegate = delegate;
     }
 
+    /**
+     * Get the {@link FilterableStreamingHttpLoadBalancedConnection} that this class delegates to.
+     *
+     * @return the {@link FilterableStreamingHttpLoadBalancedConnection} that this class delegates to.
+     */
     @Override
     protected FilterableStreamingHttpLoadBalancedConnection delegate() {
-        return delegate;
+        return super.delegate();
     }
 
     @Override
     public Result tryRequest() {
-        return delegate.tryRequest();
+        return delegate().tryRequest();
     }
 
     @Override
     public void requestFinished() {
-        delegate.requestFinished();
+        delegate().requestFinished();
     }
 
     @Override
     public boolean tryReserve() {
-        return delegate.tryReserve();
+        return delegate().tryReserve();
     }
 
     @Override
     public int score() {
-        return delegate.score();
+        return delegate().score();
     }
 
     @Override
     public HttpConnectionContext connectionContext() {
-        return delegate.connectionContext();
+        return delegate().connectionContext();
     }
 
     @Override
     public <T> Publisher<? extends T> transportEventStream(final HttpEventKey<T> eventKey) {
-        return delegate.transportEventStream(eventKey);
+        return delegate().transportEventStream(eventKey);
     }
 
     @Override
     public void close() throws Exception {
-        delegate.close();
+        delegate().close();
     }
 
     @Override
     public void closeGracefully() throws Exception {
-        delegate.closeGracefully();
+        delegate().closeGracefully();
     }
 
     @Override
     public Completable releaseAsync() {
-        return delegate.releaseAsync();
+        return delegate().releaseAsync();
     }
 
     @Override
     public StreamingHttpRequest newRequest(final HttpRequestMethod method, final String requestTarget) {
-        return delegate.newRequest(method, requestTarget);
+        return delegate().newRequest(method, requestTarget);
     }
 
     @Override
     public StreamingHttpRequest get(final String requestTarget) {
-        return delegate.get(requestTarget);
+        return delegate().get(requestTarget);
     }
 
     @Override
     public StreamingHttpRequest post(final String requestTarget) {
-        return delegate.post(requestTarget);
+        return delegate().post(requestTarget);
     }
 
     @Override
     public StreamingHttpRequest put(final String requestTarget) {
-        return delegate.put(requestTarget);
+        return delegate().put(requestTarget);
     }
 
     @Override
     public StreamingHttpRequest options(final String requestTarget) {
-        return delegate.options(requestTarget);
+        return delegate().options(requestTarget);
     }
 
     @Override
     public StreamingHttpRequest head(final String requestTarget) {
-        return delegate.head(requestTarget);
+        return delegate().head(requestTarget);
     }
 
     @Override
     public StreamingHttpRequest trace(final String requestTarget) {
-        return delegate.trace(requestTarget);
+        return delegate().trace(requestTarget);
     }
 
     @Override
     public StreamingHttpRequest delete(final String requestTarget) {
-        return delegate.delete(requestTarget);
+        return delegate().delete(requestTarget);
     }
 
     @Override
     public StreamingHttpRequest patch(final String requestTarget) {
-        return delegate.patch(requestTarget);
+        return delegate().patch(requestTarget);
     }
 
     @Override
     public StreamingHttpRequest connect(final String requestTarget) {
-        return delegate.connect(requestTarget);
+        return delegate().connect(requestTarget);
     }
 
     @Override
     public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
-        return delegate.request(request);
+        return delegate().request(request);
     }
 
     @Override
     public HttpExecutionContext executionContext() {
-        return delegate.executionContext();
+        return delegate().executionContext();
     }
 
     @Override
     public StreamingHttpResponseFactory httpResponseFactory() {
-        return delegate.httpResponseFactory();
+        return delegate().httpResponseFactory();
     }
 
     @Override
     public String toString() {
-        return delegate.toString();
+        return delegate().toString();
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DelegatingConnectionContext.java
@@ -26,9 +26,8 @@ import javax.net.ssl.SSLSession;
  * A {@link ConnectionContext} implementation that delegates all calls to a provided {@link ConnectionContext}. Any of
  * the methods can be overridden by implementations to change the behavior.
  */
-public class DelegatingConnectionContext extends DelegatingListenableAsyncCloseable implements ConnectionContext {
-
-    private final ConnectionContext delegate;
+public class DelegatingConnectionContext extends DelegatingListenableAsyncCloseable<ConnectionContext>
+        implements ConnectionContext {
 
     /**
      * New instance.
@@ -37,7 +36,6 @@ public class DelegatingConnectionContext extends DelegatingListenableAsyncClosea
      */
     public DelegatingConnectionContext(final ConnectionContext delegate) {
         super(delegate);
-        this.delegate = delegate;
     }
 
     /**
@@ -47,54 +45,54 @@ public class DelegatingConnectionContext extends DelegatingListenableAsyncClosea
      */
     @Override
     protected ConnectionContext delegate() {
-        return delegate;
+        return super.delegate();
     }
 
     @Override
     public SocketAddress localAddress() {
-        return delegate.localAddress();
+        return delegate().localAddress();
     }
 
     @Override
     public SocketAddress remoteAddress() {
-        return delegate.remoteAddress();
+        return delegate().remoteAddress();
     }
 
     @Nullable
     @Override
     public SslConfig sslConfig() {
-        return delegate.sslConfig();
+        return delegate().sslConfig();
     }
 
     @Nullable
     @Override
     public SSLSession sslSession() {
-        return delegate.sslSession();
+        return delegate().sslSession();
     }
 
     @Override
     public ExecutionContext<?> executionContext() {
-        return delegate.executionContext();
+        return delegate().executionContext();
     }
 
     @Override
     public <T> T socketOption(final SocketOption<T> option) {
-        return delegate.socketOption(option);
+        return delegate().socketOption(option);
     }
 
     @Override
     public Protocol protocol() {
-        return delegate.protocol();
+        return delegate().protocol();
     }
 
     @Nullable
     @Override
     public ConnectionContext parent() {
-        return delegate.parent();
+        return delegate().parent();
     }
 
     @Override
     public String toString() {
-        return delegate.toString();
+        return delegate().toString();
     }
 }


### PR DESCRIPTION
Motivation:

They typically serve a role of a base interface for specific closeable contracts. Having a parametrized `delegate()` method helps to avoid additional class variables in its subtypes.

Modifications:

- Add `T` parameter for `DelegatingAsyncCloseable` and `DelegatingListenableAsyncCloseable`.

Result:

Classes that extend `Delegating[Listenable]AsyncCloseable` don't need additional class variable to delegate its methods.