### PR TITLE
http-netty: pass a useful id to the load-balancer construction process

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -140,7 +140,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         config = new HttpClientConfig();
         executionContextBuilder = new HttpExecutionContextBuilder();
         strategyComputation = new ClientStrategyInfluencerChainBuilder();
-        this.loadBalancerFactory = defaultLoadBalancer();
+        this.loadBalancerFactory = defaultLoadBalancer(address.toString());
         this.serviceDiscoverer = new CastedServiceDiscoverer<>(serviceDiscoverer);
         clientFilterFactory = appendFilter(clientFilterFactory, HttpMessageDiscardWatchdogClientFilter.CLIENT_CLEANER);
     }
@@ -825,10 +825,10 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
         }
     }
 
-    private static <ResolvedAddress> HttpLoadBalancerFactory<ResolvedAddress> defaultLoadBalancer() {
+    private static <ResolvedAddress> HttpLoadBalancerFactory<ResolvedAddress> defaultLoadBalancer(String id) {
         return new DefaultHttpLoadBalancerFactory<>(
                 RoundRobinLoadBalancers.<ResolvedAddress, FilterableStreamingHttpLoadBalancedConnection>builder(
-                                DefaultHttpLoadBalancerFactory.class.getSimpleName()).build());
+                                id).build());
     }
 
     // Because of the change in https://github.com/apple/servicetalk/pull/2379, we should constrain the type back to

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientsCompileTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientsCompileTest.java
@@ -27,7 +27,7 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 
 class HttpClientsCompileTest {
-    private static final String IGNORE_ADDRESS = "";
+    private static final String IGNORE_ADDRESS = "<ignored>";
 
     @Test
     void testHttpClientsAcceptsBaseServiceDiscovererEvents() {


### PR DESCRIPTION
Motivation:

When we create the default load balancer for our HttpClientBuilder we pass the class name of the DefaultHttpLoadBalancerFactory. This isn't helpful for distinguishing between different load balancers for different endpoints which makes it really hard for providers to operate on a single load balancers client, instead it can only operate on all clients.

Modifications:

Instead of passing in the class name as the ID, we pass in the address in string form.

Result:

Providers can operate on individual clients.