### PR TITLE
Add JDK 24 to the CI matrix and fix the build

### DIFF
--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       # Matrix should be coordinated with ci-prb.yml.
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 21, 24 ]
         os: [ ubuntu-latest ]
     steps:
       - name: Download Artifacts

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 21, 24 ]
         os: [ ubuntu-latest ]
         include:
           - java: 11

--- a/.github/workflows/ci-prq-reports.yml
+++ b/.github/workflows/ci-prq-reports.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 21, 24 ]
     steps:
       - name: Download Artifacts
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 21, 24 ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,9 +1,13 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
 
 jobs:
   validation:
+    name: "Validation"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3.5.0
+      - uses: gradle/actions/wrapper-validation@v4

--- a/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/BufferAllocatorsTest.java
+++ b/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/BufferAllocatorsTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.buffer.api.BufferAllocator;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -240,7 +241,10 @@ class BufferAllocatorsTest {
     }
 
     private void assertBuffer(BufferAllocator allocator, Buffer buffer) {
-        assertBuffer(buffer, allocator != PREFER_HEAP_ALLOCATOR);
+        // JDK24+ disables unsafe by default, which means allocators like PREFER_DIRECT will also fall back to
+        // heap allocations if unsafe is not explicitly enabled via a JVM arg.
+        final boolean direct = allocator != PREFER_HEAP_ALLOCATOR && PlatformDependent.hasUnsafe();
+        assertBuffer(buffer, direct);
     }
 
     private static void assertBuffer(Buffer buffer, boolean direct) {

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Processors.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Processors.java
@@ -38,7 +38,7 @@ public final class Processors {
 
     /**
      * Create a new {@link CompletableSource.Processor} that allows for multiple
-     * {@link CompletableSource.Subscriber#subscribe(CompletableSource.Subscriber) subscribes}. The returned
+     * {@link CompletableSource#subscribe(CompletableSource.Subscriber) subscribes}. The returned
      * {@link CompletableSource.Processor} provides all the expected API guarantees when used as a
      * {@link CompletableSource} but does not expect the same guarantees when used as a
      * {@link CompletableSource.Subscriber}. As an example, users are not expected to call
@@ -46,7 +46,7 @@ public final class Processors {
      * {@link CompletableSource.Subscriber} methods concurrently and/or multiple times.
      *
      * @return a new {@link CompletableSource.Processor} that allows for multiple
-     * {@link CompletableSource.Subscriber#subscribe(CompletableSource.Subscriber) subscribes}.
+     * {@link CompletableSource#subscribe(CompletableSource.Subscriber) subscribes}.
      */
     public static CompletableSource.Processor newCompletableProcessor() {
         return new CompletableProcessor();
@@ -54,7 +54,7 @@ public final class Processors {
 
     /**
      * Create a new {@link SingleSource.Processor} that allows for multiple
-     * {@link SingleSource.Subscriber#subscribe(SingleSource.Subscriber) subscribes}. The returned
+     * {@link SingleSource#subscribe(SingleSource.Subscriber) subscribes}. The returned
      * {@link SingleSource.Processor} provides all the expected API guarantees when used as a
      * {@link SingleSource} but does not expect the same guarantees when used as a
      * {@link SingleSource.Subscriber}. As an example, users are not expected to call
@@ -64,7 +64,7 @@ public final class Processors {
      * @param <T> The {@link SingleSource} type and {@link SingleSource.Subscriber} type of the
      * {@link SingleSource.Processor}.
      * @return a new {@link SingleSource.Processor} that allows for multiple
-     * {@link SingleSource.Subscriber#subscribe(SingleSource.Subscriber) subscribes}.
+     * {@link SingleSource#subscribe(SingleSource.Subscriber) subscribes}.
      */
     public static <T> SingleSource.Processor<T, T> newSingleProcessor() {
         return new SingleProcessor<>();
@@ -72,7 +72,7 @@ public final class Processors {
 
     /**
      * Create a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}. The returned
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}. The returned
      * {@link PublisherSource.Processor} provides all the expected API guarantees when used as a
      * {@link PublisherSource} but does not expect the same guarantees when used as a
      * {@link PublisherSource.Subscriber}. As an example, users are not expected to call
@@ -86,7 +86,7 @@ public final class Processors {
      * @param <T> The {@link PublisherSource} type and {@link PublisherSource.Subscriber} type of the
      * {@link PublisherSource.Processor}.
      * @return a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}.
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}.
      * @see #newPublisherProcessor(int)
      * @see #newPublisherProcessor(PublisherProcessorSignalsHolder)
      */
@@ -96,7 +96,7 @@ public final class Processors {
 
     /**
      * Create a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}. The returned
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}. The returned
      * {@link PublisherSource.Processor} provides all the expected API guarantees when used as a
      * {@link PublisherSource} but does not expect the same guarantees when used as a
      * {@link PublisherSource.Subscriber}. As an example, users are not expected to call
@@ -112,7 +112,7 @@ public final class Processors {
      * @param <T> The {@link PublisherSource} type and {@link PublisherSource.Subscriber} type of the
      * {@link PublisherSource.Processor}.
      * @return a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}.
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}.
      */
     public static <T> PublisherSource.Processor<T, T> newPublisherProcessor(final int maxBuffer) {
         return newPublisherProcessor(fixedSize(maxBuffer));
@@ -120,7 +120,7 @@ public final class Processors {
 
     /**
      * Create a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}. The returned
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}. The returned
      * {@link PublisherSource.Processor} provides all the expected API guarantees when used as a
      * {@link PublisherSource} but does not expect the same guarantees when used as a
      * {@link PublisherSource.Subscriber}. As an example, users are not expected to call
@@ -136,7 +136,7 @@ public final class Processors {
      * @param <T> The {@link PublisherSource} type and {@link PublisherSource.Subscriber} type of the
      * {@link PublisherSource.Processor}.
      * @return a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}.
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}.
      */
     public static <T> PublisherSource.Processor<T, T> newPublisherProcessorDropHeadOnOverflow(final int maxBuffer) {
         return newPublisherProcessor(fixedSizeDropHead(maxBuffer));
@@ -144,7 +144,7 @@ public final class Processors {
 
     /**
      * Create a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}. The returned
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}. The returned
      * {@link PublisherSource.Processor} provides all the expected API guarantees when used as a
      * {@link PublisherSource} but does not expect the same guarantees when used as a
      * {@link PublisherSource.Subscriber}. As an example, users are not expected to call
@@ -160,7 +160,7 @@ public final class Processors {
      * @param <T> The {@link PublisherSource} type and {@link PublisherSource.Subscriber} type of the
      * {@link PublisherSource.Processor}.
      * @return a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}.
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}.
      */
     public static <T> PublisherSource.Processor<T, T> newPublisherProcessorDropTailOnOverflow(final int maxBuffer) {
         return newPublisherProcessor(fixedSizeDropTail(maxBuffer));
@@ -168,7 +168,7 @@ public final class Processors {
 
     /**
      * Create a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}. The returned
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}. The returned
      * {@link PublisherSource.Processor} provides all the expected API guarantees when used as a
      * {@link PublisherSource}. Users are expected to provide same API guarantees from the passed
      * {@link PublisherProcessorSignalsHolder} as they use the returned {@link PublisherSource.Processor} as a
@@ -181,7 +181,7 @@ public final class Processors {
      * @param <T> The {@link PublisherSource} type and {@link PublisherSource.Subscriber} type of the
      * {@link PublisherSource.Processor}.
      * @return a new {@link PublisherSource.Processor} that allows for a single
-     * {@link PublisherSource.Subscriber#subscribe(PublisherSource.Subscriber) subscribe}.
+     * {@link PublisherSource#subscribe(PublisherSource.Subscriber) subscribe}.
      */
     public static <T> PublisherSource.Processor<T, T> newPublisherProcessor(
             final PublisherProcessorSignalsHolder<T> holder) {

--- a/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleUrlClient.java
+++ b/servicetalk-examples/http/debugging/src/main/java/io/servicetalk/examples/http/debugging/DebuggingExampleUrlClient.java
@@ -156,6 +156,7 @@ import static io.servicetalk.logging.api.LogLevel.TRACE;
  * 2023-08-29 18:02:12,535 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xc0b781e2, L:/127.0.0.1:63690 - R:localhost/127.0.0.1:8080] CLOSE
  * 2023-08-29 18:02:12,536 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xc0b781e2, L:/127.0.0.1:63690 ! R:localhost/127.0.0.1:8080] INACTIVE
  * 2023-08-29 18:02:12,537 servicetalk-global-io-executor-1-2 [TRACE] servicetalk-examples-wire-logger - [id: 0xc0b781e2, L:/127.0.0.1:63690 ! R:localhost/127.0.0.1:8080] UNREGISTERED
+ * </pre>
  */
 public class DebuggingExampleUrlClient {
 

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
@@ -111,7 +111,8 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
 
     /**
      * Default rejection observer for dropped requests from an external sourced due to service unavailability.
-     * see. {@link Builder#peerBreakerRejection(HttpResponseMetaData, CircuitBreaker, Function)}.
+     * see. {@link TrafficResilienceHttpClientFilter#peerBreakerRejection(HttpResponseMetaData,
+     * CircuitBreaker, Function)}.
      * <p>
      * The default predicate matches the following HTTP response codes:
      * <ul>


### PR DESCRIPTION
One of our tests did not take into account that on jdk24
no unsafe is present, in which case the PREFER_DIRECT allocator
would also fall back to heap allocations.

Also, some javadocs are now errors so those had to be fixed
as well.