### PR TITLE
Add `macos-latest` to the `ci-prb-reports.yaml`

### DIFF
--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         java: [ 8, 11, 17, 21, 24 ]
         os: [ ubuntu-latest ]
+        include:
+          - java: 11
+            os: macos-latest
     steps:
       - name: Download Artifacts
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295


### PR DESCRIPTION
Motivation:

#3234 added `macos-latest` to `ci-prb.yaml`, but forgot to add it to `ci-prb-reports.yaml` too.