### PR TITLE
opentelemetry-http: make span status extraction conform to semconv

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -123,7 +123,7 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryF
                 HttpSpanNameExtractor.create(ServiceTalkHttpAttributesGetter.CLIENT_INSTANCE);
         InstrumenterBuilder<HttpRequestMetaData, HttpResponseMetaData> clientInstrumenterBuilder =
                 Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, clientSpanNameExtractor);
-        clientInstrumenterBuilder.setSpanStatusExtractor(ServicetalkSpanStatusExtractor.INSTANCE);
+        clientInstrumenterBuilder.setSpanStatusExtractor(ServicetalkSpanStatusExtractor.CLIENT_INSTANCE);
 
         clientInstrumenterBuilder
                 .addAttributesExtractor(

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
@@ -104,7 +104,7 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryFi
                 HttpSpanNameExtractor.create(ServiceTalkHttpAttributesGetter.SERVER_INSTANCE);
         InstrumenterBuilder<HttpRequestMetaData, HttpResponseMetaData> serverInstrumenterBuilder =
                 Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, serverSpanNameExtractor);
-        serverInstrumenterBuilder.setSpanStatusExtractor(ServicetalkSpanStatusExtractor.INSTANCE);
+        serverInstrumenterBuilder.setSpanStatusExtractor(ServicetalkSpanStatusExtractor.SERVER_INSTANCE);
 
         serverInstrumenterBuilder
                 .addAttributesExtractor(HttpServerAttributesExtractor

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/ServicetalkSpanStatusExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/ServicetalkSpanStatusExtractor.java
@@ -27,9 +27,13 @@ import javax.annotation.Nullable;
 
 final class ServicetalkSpanStatusExtractor implements SpanStatusExtractor<HttpRequestMetaData, HttpResponseMetaData> {
 
-    static final ServicetalkSpanStatusExtractor INSTANCE = new ServicetalkSpanStatusExtractor();
+    static final ServicetalkSpanStatusExtractor CLIENT_INSTANCE = new ServicetalkSpanStatusExtractor(true);
+    static final ServicetalkSpanStatusExtractor SERVER_INSTANCE = new ServicetalkSpanStatusExtractor(false);
 
-    private ServicetalkSpanStatusExtractor() {
+    private final boolean isClient;
+
+    private ServicetalkSpanStatusExtractor(final boolean isClient) {
+        this.isClient = isClient;
     }
 
     @Override
@@ -41,13 +45,29 @@ final class ServicetalkSpanStatusExtractor implements SpanStatusExtractor<HttpRe
         if (error != null) {
             spanStatusBuilder.setStatus(StatusCode.ERROR);
         } else if (status != null) {
+            // See https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status for the conventions.
             switch (status.status().statusClass()) {
+                case INFORMATIONAL_1XX:
+                case SUCCESSFUL_2XX:
+                case REDIRECTION_3XX:
+                    // "Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges, unless
+                    // there was another error (e.g., network error receiving the response body; or 3xx codes with max
+                    // redirects exceeded), in which case status MUST be set to Error."
+                    break;
                 case CLIENT_ERROR_4XX:
+                    // "For HTTP status codes in the 4xx range span status MUST be left unset in case of
+                    // SpanKind.SERVER and SHOULD be set to Error in case of SpanKind.CLIENT."
+                    if (isClient) {
+                        spanStatusBuilder.setStatus(StatusCode.ERROR);
+                    }
+                    break;
                 case SERVER_ERROR_5XX:
+                    // "For HTTP status codes in the 5xx range, as well as any other code the client failed to
+                    // interpret, span status SHOULD be set to Error."
                     spanStatusBuilder.setStatus(StatusCode.ERROR);
                     break;
                 default:
-                    spanStatusBuilder.setStatus(StatusCode.OK);
+                    // Unknown to ServiceTalk. The client or server may know what it means, so we leave it unset.
                     break;
             }
         } else {


### PR DESCRIPTION
Motivation:

Our span status extraction is out of sync with the OTEL semantic conventions. Specifically, we should leave the span status (different from the HTTP status) unset a lot more often.
See https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status for details.

Modifications:

- Leave status unset for 1xx-3xx.
- Leave status unset for 4xx on the server side.
- Leave status unset for 600+ since we don't know what it means.

Result:

Better conformance with the spec.