### PR TITLE
CacheConnectionHttpLoadBalanceFactoryTest: Avoid using deprecated LB API

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/CacheConnectionHttpLoadBalanceFactoryTest.java
@@ -25,7 +25,7 @@ import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.utils.CacheConnectionHttpLoadBalanceFactory;
-import io.servicetalk.loadbalancer.RoundRobinLoadBalancers;
+import io.servicetalk.loadbalancer.LoadBalancers;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
@@ -91,9 +91,9 @@ final class CacheConnectionHttpLoadBalanceFactoryTest {
                      .enableWireLogging("servicetalk-tests-h2-frame-logger", LogLevel.TRACE, () -> false)
                      .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(connectionObserver))
                      .loadBalancerFactory(new CacheConnectionHttpLoadBalanceFactory<>(
-                             new DefaultHttpLoadBalancerFactory<>(RoundRobinLoadBalancers.<InetSocketAddress,
-                                     FilterableStreamingHttpLoadBalancedConnection>builder(getClass().getSimpleName())
-                                     .build()),
+                             new DefaultHttpLoadBalancerFactory<>(LoadBalancers.<InetSocketAddress,
+                                     FilterableStreamingHttpLoadBalancedConnection>builder(
+                                             "default-lb-with-cached-connections").build()),
                              a -> maxConcurrency))
                      // The accounting for connection caching and the ConcurrencyController are done at different layers
                      // so it is possible the connection caching will give a connection to the load balancer that fails


### PR DESCRIPTION
Use `LoadBalancers` instead of deprecated `RoundRobinLoadBalancers`.