### PR TITLE
Reduce PR quality matrix to just JDK 8 and 11

### DIFF
--- a/.github/workflows/ci-prq-reports.yml
+++ b/.github/workflows/ci-prq-reports.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21, 24 ]
+        java: [ 8, 11 ] # These are the JDK's we publish artifacts with.
     steps:
       - name: Download Artifacts
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21, 24 ]
+        java: [ 8, 11 ] # These are the JDK's we publish artifacts with.
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Motivation:

We have a lot of jobs in our build and run each of them against every JDK version we want to support. The for quality checks, this is unnecessary because we only emit artifacts for JDK 8 and 11.

Modifications:

Reduce the PR quality checks to only run for JDK 8 and 11.

Result:

Less build work.