### PR TITLE
log4j-mdc: Fix dependencies

### DIFF
--- a/servicetalk-log4j2-mdc-utils/build.gradle
+++ b/servicetalk-log4j2-mdc-utils/build.gradle
@@ -24,8 +24,6 @@ dependencies {
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-context-api")
 
-  runtimeOnly "org.apache.logging.log4j:log4j-core"
-
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation project(":servicetalk-concurrent")
   testImplementation project(":servicetalk-test-resources")

--- a/servicetalk-log4j2-mdc-utils/gradle.lockfile
+++ b/servicetalk-log4j2-mdc-utils/gradle.lockfile
@@ -4,7 +4,6 @@
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
 org.apache.logging.log4j:log4j-api:2.23.1=compileClasspath,runtimeClasspath
 org.apache.logging.log4j:log4j-bom:2.23.1=compileClasspath,runtimeClasspath
-org.apache.logging.log4j:log4j-core:2.23.1=runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
 org.slf4j:slf4j-api:1.7.36=runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor,testFixturesAnnotationProcessor

--- a/servicetalk-log4j2-mdc/build.gradle
+++ b/servicetalk-log4j2-mdc/build.gradle
@@ -31,6 +31,7 @@ afterEvaluate {
 }
 
 dependencies {
+  api platform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   api project(":servicetalk-log4j2-mdc-utils")
 
   implementation project(":servicetalk-annotations")


### PR DESCRIPTION
Motivation:

In log4j-mdc, we have a dependency on log4j-core but don't include the bom. This can lead to issues since the transitive dependency is now not fully defined.

Modifications:

Add the bom dependency.