### PR TITLE
Validate generated pom.xml file for all published libraries

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -16,6 +16,7 @@
 package io.servicetalk.gradle.plugin.internal
 
 import com.github.spotbugs.snom.SpotBugsTask
+import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.Pmd
@@ -142,6 +143,28 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
               ciManagement {
                 system = 'ServiceTalk CI'
                 url = "${ciManagementUrl}"
+              }
+              // Validate that all dependencies either have an explicit version or corresponding BOM:
+              withXml {
+                def pomNode = asNode()
+                pomNode.dependencies?.dependency?.each { dep ->
+                  def groupId = dep.groupId.text()
+                  def artifactId = dep.artifactId.text()
+                  def version = dep.version?.text()
+                  if (version == null || version.trim().isEmpty()) {
+                    // Some dependencies have shorter groupId for their corresponding BOM:
+                    def groupIdPrefix = groupId.count('.') == 1 ? groupId :
+                        groupId.substring(0, groupId.lastIndexOf('.'))
+                    def bom = pomNode.dependencyManagement?.dependencies?.dependency?.find { mDep ->
+                      def mGroupId = mDep.groupId.text()
+                      (mGroupId == groupId || mGroupId == groupIdPrefix) && mDep.type?.text() == 'pom'
+                    }
+                    if (!bom) {
+                      throw new GradleException("POM generation failed: Missing version for dependency " +
+                          "'${groupId}:${artifactId}'. Did you forget to add a version number or a platform BOM?")
+                    }
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
Motivation:

We had the same problem twice (see #3078 and #3261), when produced `pom.xml` file for some of our modules was invalid from Maven perspective, and it produced the following warnings:
```
[WARNING] The POM for io.servicetalk:servicetalk-log4j2-mdc:jar:0.42.56 is invalid, transitive dependencies (if any) will not be available: 1 problem was encountered while building the effective model for io.servicetalk:servicetalk-log4j2-mdc:0.42.56
[ERROR] 'dependencies.dependency.version' for org.apache.logging.log4j:log4j-core:jar is missing. @
```
For some reason, Gradle can still resolve dependencies with a missed version, even if their BOM is also missing, but Maven can not.

Modifications:

Enhance `MavenPublication` task to validate the generated `pom.xml` and fail if any dependency does not have a version or corresponding BOM.

Result:

Hopefully, this issue won't happen again. Tested that it failed the build before #3261 was merged.