### PR TITLE
Correct how platform boms are defined

### DIFF
--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -34,12 +34,12 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
+  testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-concurrent")
   testFixturesApi project(":servicetalk-concurrent-internal")
   testFixturesApi "org.junit.jupiter:junit-jupiter-api"
   testFixturesApi "org.hamcrest:hamcrest:$hamcrestVersion"
 
-  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation project(":servicetalk-utils-internal")
   testFixturesImplementation project(":servicetalk-concurrent-test-internal")
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"

--- a/servicetalk-http-router-jersey/build.gradle
+++ b/servicetalk-http-router-jersey/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 
   testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson"
 
+  testFixturesApi platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-buffer-api")
   testFixturesApi project(":servicetalk-concurrent-api")

--- a/servicetalk-http-router-jersey3-jakarta10/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta10/build.gradle
@@ -122,6 +122,7 @@ dependencies {
 
   testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson"
 
+  testFixturesApi platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-buffer-api")
   testFixturesApi project(":servicetalk-concurrent-api")

--- a/servicetalk-http-router-jersey3-jakarta9/build.gradle
+++ b/servicetalk-http-router-jersey3-jakarta9/build.gradle
@@ -122,6 +122,7 @@ dependencies {
 
   testRuntimeOnly "org.glassfish.jersey.media:jersey-media-json-jackson"
 
+  testFixturesApi platform("org.glassfish.jersey:jersey-bom:$actualJerseyVersion")
   testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-buffer-api")
   testFixturesApi project(":servicetalk-concurrent-api")

--- a/servicetalk-log4j2-mdc/build.gradle
+++ b/servicetalk-log4j2-mdc/build.gradle
@@ -31,9 +31,9 @@ afterEvaluate {
 }
 
 dependencies {
-  api platform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   api project(":servicetalk-log4j2-mdc-utils")
 
+  implementation platform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   implementation project(":servicetalk-annotations")
   implementation "org.apache.logging.log4j:log4j-core"
 

--- a/servicetalk-opentelemetry-asynccontext/build.gradle
+++ b/servicetalk-opentelemetry-asynccontext/build.gradle
@@ -17,9 +17,9 @@
 apply plugin: "io.servicetalk.servicetalk-gradle-plugin-internal-library"
 
 dependencies {
-  api platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion")
   api project(":servicetalk-concurrent-api")
 
+  implementation platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion")
   implementation "io.opentelemetry:opentelemetry-context"
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-context-api")

--- a/servicetalk-transport-netty-internal/build.gradle
+++ b/servicetalk-transport-netty-internal/build.gradle
@@ -31,7 +31,6 @@ dependencies {
   api "io.netty:netty-handler"
   api "io.netty:netty-transport"
 
-  implementation platform("io.netty:netty-bom:$nettyVersion")
   implementation project(":servicetalk-annotations")
   implementation project(":servicetalk-buffer-netty")
   implementation project(":servicetalk-concurrent-internal")


### PR DESCRIPTION
This is a strategy for making it correct for both generated `pom.xml` and `*.module` files:

1. Add platform bom to the same scope that uses any of its dependencies.
2. There is no need to add a platform bom again under `*Implementation` scope if it was already defined under `*Api` scope.

Result:

Correctly produced `pom.xml` and `*.module` files.