### PR TITLE
log4j2-mdc: use implementation platform for log4j bom

### DIFF
--- a/servicetalk-log4j2-mdc/build.gradle
+++ b/servicetalk-log4j2-mdc/build.gradle
@@ -31,9 +31,9 @@ afterEvaluate {
 }
 
 dependencies {
-  api platform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   api project(":servicetalk-log4j2-mdc-utils")
 
+  implementation platform("org.apache.logging.log4j:log4j-bom:$log4jVersion")
   implementation project(":servicetalk-annotations")
   implementation "org.apache.logging.log4j:log4j-core"
 


### PR DESCRIPTION
Motivation:

In #3261 we made the log4j bom an api platform dependency, which will put the bom dependencies on the compile classpath for users, which is not what we want.

Modifications:

Switch it to implementation platform.