### PR TITLE
ci-netty-snapshot.yml: point to Netty 4.2.+

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         java: [ 8 ]
         os: [ ubuntu-latest ]
-        netty: [ 4.1+, 4.2.0.RC+ ]
+        netty: [ 4.1+, 4.2.+ ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
After 4.2.0.Final release, we should point to the next versions instead of the latest RC.