### PR TITLE
loadbalancer: insert connections to host in random order

### DIFF
--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -253,7 +253,7 @@ class DefaultHostTest {
             cxns.add(cxn);
         }
         List<TestLoadBalancedConnection> found = host.asEntry().getValue();
-        // There is about a 1 in (2^32) bn chance the insertion order in the same as the addition order.
+        // There is about a 1 in 32! chance the insertion order in the same as the addition order.
         assertNotEquals(cxns, found);
     }
 }


### PR DESCRIPTION
Motivation:

When we create new connections we append them to the connection list. This means that oldest connections always have highest priority but this can cause trouble if there is correlated connection churn.

Modification:

Insert new connections into random positions in the list. This will still let unnecessary connections idle out, but new connections have a good chance at becoming a high use connection.