### PR TITLE
Fix a list of modules inside `servicetalk-bom`

### DIFF
--- a/servicetalk-bom/build.gradle
+++ b/servicetalk-bom/build.gradle
@@ -19,9 +19,9 @@ apply plugin: "java-platform"
 
 description="ServiceTalk BOM that includes all modules"
 
-rootProject.subprojects.findAll { !it.name.endsWith("-bom") && !it.name.endsWith("-dependencies") &&
-                                  !it.name.contains("examples") && !it.name.equals("grpc") &&
-                                  !it.name.equals("http")}.each {
+rootProject.subprojects.findAll { !it.path.endsWith("-bom") && !it.path.endsWith("-dependencies") &&
+                                  !it.path.endsWith("-benchmarks") &&
+                                  !it.path.startsWith(":servicetalk-examples")}.each {
     dependencies.constraints.add("api", it)
 }
 


### PR DESCRIPTION
Motivation:

Currently, `servicetalk-bom` has 2 modules that should not be there:
1. `serialization` that leaks from `:servicetalk-examples:http:serialization`. This is a broken reference because we don't even publish it as an artifact.
2. `servicetalk-benchmarks` that we do not expect users to use.

See https://repo1.maven.org/maven2/io/servicetalk/servicetalk-bom/0.42.56/servicetalk-bom-0.42.56.pom

Modifications:

Adjust `findAll` closure in `servicetalk-bom/build.gradle`.

Result:

`servicetalk-bom` contains only published libraries that we expect users to use.