### PR TITLE
Change `[Early|Late]ConnectionAcceptor` API to accept `ConnectionContext`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -43,6 +43,7 @@ import io.servicetalk.http.utils.HttpRequestAutoDrainingServiceFilter;
 import io.servicetalk.logging.api.LogLevel;
 import io.servicetalk.transport.api.ConnectExecutionStrategy;
 import io.servicetalk.transport.api.ConnectionAcceptorFactory;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.EarlyConnectionAcceptor;
 import io.servicetalk.transport.api.ExecutionStrategy;
@@ -502,9 +503,17 @@ class DefaultHttpServerBuilder implements HttpServerBuilder {
                 .stream()
                 .reduce((prev, acceptor) -> new EarlyConnectionAcceptor() {
                     @Override
+                    @SuppressWarnings("deprecation")
                     public Completable accept(final ConnectionInfo info) {
                         // Defer invocation of the next acceptor, but share context between them.
                         return prev.accept(info).concat(defer(() -> acceptor.accept(info)).shareContextOnSubscribe())
+                                .shareContextOnSubscribe(); // Share context with the rest of the chain.
+                    }
+
+                    @Override
+                    public Completable accept(final ConnectionContext ctx) {
+                        // Defer invocation of the next acceptor, but share context between them.
+                        return prev.accept(ctx).concat(defer(() -> acceptor.accept(ctx)).shareContextOnSubscribe())
                                 .shareContextOnSubscribe(); // Share context with the rest of the chain.
                     }
 
@@ -528,9 +537,17 @@ class DefaultHttpServerBuilder implements HttpServerBuilder {
                 .stream()
                 .reduce((prev, acceptor) -> new LateConnectionAcceptor() {
                     @Override
+                    @SuppressWarnings("deprecation")
                     public Completable accept(final ConnectionInfo info) {
                         // Defer invocation of the next acceptor, but share context between them.
                         return prev.accept(info).concat(defer(() -> acceptor.accept(info)).shareContextOnSubscribe())
+                                .shareContextOnSubscribe(); // Share context with the rest of the chain.
+                    }
+
+                    @Override
+                    public Completable accept(final ConnectionContext ctx) {
+                        // Defer invocation of the next acceptor, but share context between them.
+                        return prev.accept(ctx).concat(defer(() -> acceptor.accept(ctx)).shareContextOnSubscribe())
                                 .shareContextOnSubscribe(); // Share context with the rest of the chain.
                     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -46,6 +46,7 @@ import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
 import io.servicetalk.transport.api.ConnectExecutionStrategy;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.EarlyConnectionAcceptor;
 import io.servicetalk.transport.api.LateConnectionAcceptor;
@@ -591,8 +592,14 @@ abstract class AbstractHttpServiceAsyncContextTest {
     private static EarlyConnectionAcceptor newEarly(boolean useImmediate, EarlyConnectionAcceptor delegate) {
         return new EarlyConnectionAcceptor() {
             @Override
+            @SuppressWarnings("deprecation")
             public Completable accept(ConnectionInfo info) {
                 return delegate.accept(info);
+            }
+
+            @Override
+            public Completable accept(ConnectionContext ctx) {
+                return delegate.accept(ctx);
             }
 
             @Override
@@ -605,8 +612,14 @@ abstract class AbstractHttpServiceAsyncContextTest {
     private static LateConnectionAcceptor newLate(boolean useImmediate, LateConnectionAcceptor delegate) {
         return new LateConnectionAcceptor() {
             @Override
+            @SuppressWarnings("deprecation")
             public Completable accept(ConnectionInfo info) {
                 return delegate.accept(info);
+            }
+
+            @Override
+            public Completable accept(ConnectionContext ctx) {
+                return delegate.accept(ctx);
             }
 
             @Override

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/EarlyConnectionContext.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/EarlyConnectionContext.java
@@ -15,9 +15,10 @@
  */
 package io.servicetalk.tcp.netty.internal;
 
-import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionContext;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.SslConfig;
+import io.servicetalk.transport.netty.internal.NettyChannelListenableAsyncCloseable;
 
 import io.netty.channel.Channel;
 
@@ -28,7 +29,7 @@ import javax.net.ssl.SSLSession;
 
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.getOption;
 
-final class TcpConnectionInfo implements ConnectionInfo {
+final class EarlyConnectionContext extends NettyChannelListenableAsyncCloseable implements ConnectionContext {
 
     private static final Protocol TCP_PROTOCOL = () -> "TCP";
 
@@ -38,10 +39,11 @@ final class TcpConnectionInfo implements ConnectionInfo {
     private final SslConfig sslConfig;
     private final long idleTimeoutMs;
 
-    TcpConnectionInfo(final Channel channel,
-                      final ExecutionContext<?> executionContext,
-                      @Nullable final SslConfig sslConfig,
-                      final long idleTimeoutMs) {
+    EarlyConnectionContext(final Channel channel,
+                           final ExecutionContext<?> executionContext,
+                           @Nullable final SslConfig sslConfig,
+                           final long idleTimeoutMs) {
+        super(channel, executionContext.executor());
         this.channel = channel;
         this.executionContext = executionContext;
         this.sslConfig = sslConfig;
@@ -72,7 +74,7 @@ final class TcpConnectionInfo implements ConnectionInfo {
     @Nullable
     @Override
     public SSLSession sslSession() {
-        return null;
+        return null;    // Expected to always be null at this point for EarlyConnectionAcceptor
     }
 
     @Nullable

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -91,7 +91,7 @@ public class TcpClientChannelInitializer implements ChannelInitializer {    // F
         final ClientSslConfig sslConfig = config.sslConfig();
         if (observer != NoopConnectionObserver.INSTANCE) {
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
-                    channel -> new TcpConnectionInfo(channel,
+                    channel -> new EarlyConnectionContext(channel,
                             // ExecutionContext can be null if users used deprecated ctor
                             executionContext == null ? null : channelExecutionContext(channel, executionContext),
                             sslConfig, config.idleTimeoutMs()), true, deferSslHandler ? null : sslConfig));

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
@@ -243,7 +243,7 @@ public final class TcpServerBinder {
             // AsyncContext propagation is tested by
             // AbstractHttpServiceAsyncContextTest.connectionAcceptorContextDoesNotLeak(...).
             // Defer is required to run the `accept` evaluation later, when we have a Subscriber.
-            Completable earlyCompletable = defer(() -> earlyConnectionAcceptor.accept(new TcpConnectionInfo(
+            Completable earlyCompletable = defer(() -> earlyConnectionAcceptor.accept(new EarlyConnectionContext(
                     channel, channelExecutionContext, config.sslConfig(), config.idleTimeoutMs())));
 
             if (earlyConnectionAcceptor.requiredOffloads().isConnectOffloaded()) {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerChannelInitializer.java
@@ -74,7 +74,7 @@ public class TcpServerChannelInitializer implements ChannelInitializer {    // F
         if (observer != NoopConnectionObserver.INSTANCE) {
             final ServerSslConfig sslConfig = config.sslConfig();
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
-                    channel -> new TcpConnectionInfo(channel,
+                    channel -> new EarlyConnectionContext(channel,
                             // ExecutionContext can be null if users used deprecated ctor
                             executionContext == null ? null : channelExecutionContext(channel, executionContext),
                             sslConfig, config.idleTimeoutMs()), false, sslConfig));

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/EarlyConnectionAcceptor.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/EarlyConnectionAcceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023, 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,13 +29,31 @@ public interface EarlyConnectionAcceptor extends ExecutionStrategyInfluencer<Con
     /**
      * Accept or reject an incoming connection.
      * <p>
-     * Note that the {@link ConnectionInfo#sslSession()} will always return null with this acceptor since it is called
-     * before the TLS handshake is performed (and as a result no SSL session has been established).
+     * Note that the {@link ConnectionInfo#sslSession()} will always return {@code null} with this acceptor since it
+     * is called before the TLS handshake is performed (and as a result no SSL session has been established).
      *
-     * @param info additional information about the connection to make an acceptance decision.
-     * @return a completed (to accept) or a failed (to reject) {@link Completable}
+     * @param info {@link ConnectionInfo} to make an acceptance decision
+     * @return {@link Completable#completed()} to accept, or {@link Completable#failed(Throwable)} to reject with the
+     * cause
+     * @deprecated Implement {@link #accept(ConnectionContext)} instead
      */
+    @Deprecated // FIXME: 0.43 - swap default implementation with non-deprecated method
     Completable accept(ConnectionInfo info);
+
+    /**
+     * Accept or reject an incoming connection.
+     * <p>
+     * Note that the {@link ConnectionContext#sslSession()} will always return {@code null} with this acceptor since it
+     * is called before the TLS handshake is performed (and as a result no SSL session has been established).
+     *
+     * @param ctx {@link ConnectionContext} with full information about the connection to make an acceptance decision
+     * and ability to monitor when it's closed
+     * @return {@link Completable#completed()} to accept, or {@link Completable#failed(Throwable)} to reject with the
+     * cause
+     */
+    default Completable accept(ConnectionContext ctx) {
+        return accept((ConnectionInfo) ctx);
+    }
 
     /**
      * Customize the offloading strategy for this acceptor.

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/LateConnectionAcceptor.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/LateConnectionAcceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2023, 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,25 @@ public interface LateConnectionAcceptor extends ExecutionStrategyInfluencer<Conn
     /**
      * Accept or reject an incoming connection.
      *
-     * @param info additional information about the connection to make an acceptance decision.
-     * @return a completed (to accept) or a failed (to reject) {@link Completable}
+     * @param info {@link ConnectionInfo} to make an acceptance decision
+     * @return {@link Completable#completed()} to accept, or {@link Completable#failed(Throwable)} to reject with the
+     * cause
+     * @deprecated Implement {@link #accept(ConnectionContext)} instead
      */
+    @Deprecated // FIXME: 0.43 - swap default implementation with non-deprecated method
     Completable accept(ConnectionInfo info);
+
+    /**
+     * Accept or reject an incoming connection.
+     *
+     * @param ctx {@link ConnectionContext} with full information about the connection to make an acceptance decision
+     * and ability to monitor when it's closed
+     * @return {@link Completable#completed()} to accept, or {@link Completable#failed(Throwable)} to reject with the
+     * cause
+     */
+    default Completable accept(ConnectionContext ctx) {
+        return accept((ConnectionInfo) ctx);
+    }
 
     /**
      * Customize the offloading strategy for this acceptor.


### PR DESCRIPTION
Motivation:

There are use-cases, when users need to track a lifecycle of accepted connections. For example, maintaining a counter of open connections to make accept/reject decisions.

Modifications:

- Add `accept(ConnectionContext)` overload for `EarlyConnectionAcceptor` and `LateConnectionAcceptor`.
- Add default implementation to maintain backward compatibility.
- Change `TcpConnectionInfo` to `EarlyConnectionContext` and extend `NettyChannelListenableAsyncCloseable`.
- Update code references and tests to use the new method where possible.

Result:

Implementations of `EarlyConnectionAcceptor` and/or `LateConnectionAcceptor` can track connection lifecycle.