### PR TITLE
opentelemetry-http: fox url extraction

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -19,6 +19,7 @@ package io.servicetalk.opentelemetry.http;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.HostAndPort;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -57,7 +58,7 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequestFilter(final OpenTelemetry openTelemetry, String componentName) {
-        super(openTelemetry, componentName, DEFAULT_OPTIONS);
+        super(openTelemetry, componentName, DEFAULT_OPTIONS, null);
     }
 
     /**
@@ -76,7 +77,19 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      * @param opentelemetryOptions extra options to create the opentelemetry filter
      */
     public OpenTelemetryHttpRequestFilter(final String componentName, final OpenTelemetryOptions opentelemetryOptions) {
-        super(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions);
+        super(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions, null);
+    }
+
+    /**
+     * Create a new instance, searching for any instance of an opentelemetry available.
+     *
+     * @param componentName        The component name used during building new spans.
+     * @param opentelemetryOptions extra options to create the opentelemetry filter
+     * @param hostAndPort          The host and port of the backend service
+     */
+    public OpenTelemetryHttpRequestFilter(final String componentName, final OpenTelemetryOptions opentelemetryOptions,
+                                          HostAndPort hostAndPort) {
+        super(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions, hostAndPort);
     }
 
     /**

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilter.java
@@ -19,6 +19,7 @@ package io.servicetalk.opentelemetry.http;
 import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.HostAndPort;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -27,6 +28,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 
 import java.util.function.UnaryOperator;
+import javax.annotation.Nullable;
 
 /**
  * An HTTP filter that supports <a href="https://opentelemetry.io/docs/instrumentation/java/">open telemetry</a>.
@@ -59,7 +61,20 @@ public final class OpenTelemetryHttpRequesterFilter extends AbstractOpenTelemetr
      */
     public OpenTelemetryHttpRequesterFilter(final String componentName,
                                             final OpenTelemetryOptions opentelemetryOptions) {
-        this(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions);
+        this(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions, null);
+    }
+
+    /**
+     * Create a new instance, searching for any instance of an opentelemetry available.
+     *
+     * @param componentName        The component name used during building new spans.
+     * @param opentelemetryOptions extra options to create the opentelemetry filter
+     * @param hostAndPort          The host and port of the backend service
+     */
+    public OpenTelemetryHttpRequesterFilter(final String componentName,
+                                            final OpenTelemetryOptions opentelemetryOptions,
+                                            final HostAndPort hostAndPort) {
+        this(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions, hostAndPort);
     }
 
     /**
@@ -71,7 +86,8 @@ public final class OpenTelemetryHttpRequesterFilter extends AbstractOpenTelemetr
     }
 
     OpenTelemetryHttpRequesterFilter(final OpenTelemetry openTelemetry, String componentName,
-                                     final OpenTelemetryOptions opentelemetryOptions) {
-        super(openTelemetry, componentName, opentelemetryOptions);
+                                     final OpenTelemetryOptions opentelemetryOptions,
+                                     @Nullable final HostAndPort hostAndPort) {
+        super(openTelemetry, componentName, opentelemetryOptions, hostAndPort);
     }
 }

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -24,6 +24,7 @@ import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.log4j2.mdc.utils.LoggerStringWriter;
 import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
@@ -59,6 +61,7 @@ import javax.annotation.Nullable;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
@@ -76,7 +79,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
-class OpenTelemetryHttpRequestFilterTest {
+class OpenTelemetryHttpRequesterFilterTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final int SLEEP_TIME = CI ? 500 : 100;
@@ -102,7 +105,8 @@ class OpenTelemetryHttpRequestFilterTest {
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         try (ServerContext context = buildServer(openTelemetry, false)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient", DEFAULT_OPTIONS))
+                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient",
+                        DEFAULT_OPTIONS, null))
                 .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX)).build()) {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
@@ -132,7 +136,8 @@ class OpenTelemetryHttpRequestFilterTest {
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         try (ServerContext context = buildServer(openTelemetry, true)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient", DEFAULT_OPTIONS))
+                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient",
+                        DEFAULT_OPTIONS, null))
                 .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX)).build()) {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
@@ -176,19 +181,23 @@ class OpenTelemetryHttpRequestFilterTest {
         }
     }
 
-    @Test
-    void testInjectWithAParentCreated() throws Exception {
-        final String requestUrl = "/path/to/resource";
+    @ParameterizedTest()
+    @CsvSource({"false, false", "false, true", "true, false", "true, true"})
+    void testInjectWithAParentCreated(boolean absoluteForm, boolean hasServerHostAndPort) throws Exception {
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         try (ServerContext context = buildServer(openTelemetry, true)) {
-            try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient", DEFAULT_OPTIONS))
-                .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX)).build()) {
+            HostAndPort serverHostAndPort = serverHostAndPort(context);
+            final String requestPath = "/path/to/resource";
+            final String requestUrl = absoluteForm ? fullUrl(serverHostAndPort, requestPath) : requestPath;
+            try (HttpClient client = forSingleAddress(serverHostAndPort)
+                    .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient",
+                            DEFAULT_OPTIONS, hasServerHostAndPort ? serverHostAndPort : null))
+                    .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX)).build()) {
 
                 Span span = otelTesting.getOpenTelemetry().getTracer("io.serviceTalk").spanBuilder("/")
-                    .setSpanKind(SpanKind.INTERNAL)
-                    .setAttribute("component", "serviceTalk")
-                    .startSpan();
+                        .setSpanKind(SpanKind.INTERNAL)
+                        .setAttribute("component", "serviceTalk")
+                        .startSpan();
                 TestSpanState serverSpanState;
                 try (Scope scope = span.makeCurrent()) {
                     LOGGER.info("making span={} current", span);
@@ -197,26 +206,32 @@ class OpenTelemetryHttpRequestFilterTest {
                 } finally {
                     span.end();
                 }
-                    verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
+                verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestPath,
                         serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                         TRACING_TEST_LOG_LINE_PREFIX);
-                    assertThat(otelTesting.getSpans()).hasSize(3);
-                    assertThat(otelTesting.getSpans()).extracting("traceId")
+                assertThat(otelTesting.getSpans()).hasSize(3);
+                assertThat(otelTesting.getSpans()).extracting("traceId")
                         .containsExactly(serverSpanState.getTraceId(), serverSpanState.getTraceId(),
-                            serverSpanState.getTraceId());
-                    assertThat(otelTesting.getSpans()).extracting("spanId")
+                                serverSpanState.getTraceId());
+                assertThat(otelTesting.getSpans()).extracting("spanId")
                         .containsAnyOf(serverSpanState.getSpanId());
-                    otelTesting.assertTraces()
+                otelTesting.assertTraces()
                         .hasTracesSatisfyingExactly(ta ->
-                            ta.hasTraceId(serverSpanState.getTraceId()));
+                                ta.hasTraceId(serverSpanState.getTraceId()));
 
-                    otelTesting.assertTraces()
+                otelTesting.assertTraces()
                         .hasTracesSatisfyingExactly(ta -> {
                             assertThat(ta.getSpan(0).getAttributes().get(AttributeKey.stringKey("component")))
                                     .isEqualTo("serviceTalk");
                             assertThat(ta.getSpan(1).getParentSpanId()).isEqualTo(ta.getSpan(0).getSpanId());
+                            if (absoluteForm || hasServerHostAndPort) {
+                                assertThat(ta.getSpan(1).getAttributes().get(URL_FULL)).isEqualTo(
+                                        fullUrl(serverHostAndPort, requestPath));
+                            } else {
+                                assertThat(ta.getSpan(1).getAttributes().get(URL_FULL)).isNull();
+                            }
                             assertThat(ta.getSpan(1).getAttributes().get(NETWORK_PROTOCOL_NAME))
-                                .isNull(); // only needs to be set if != http
+                                    .isNull(); // only needs to be set if != http
                             assertThat(ta.getSpan(2).getParentSpanId()).isEqualTo(ta.getSpan(1).getSpanId());
                         });
             }
@@ -233,7 +248,7 @@ class OpenTelemetryHttpRequestFilterTest {
                     new OpenTelemetryOptions.Builder()
                         .capturedResponseHeaders(singletonList("my-header"))
                         .capturedRequestHeaders(singletonList("some-request-header"))
-                        .build()))
+                        .build(), null))
                 .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX)).build()) {
                 HttpResponse response = client.request(client.get(requestUrl)
                     .addHeader("some-request-header", "request-header-value")).toFuture().get();
@@ -452,5 +467,9 @@ class OpenTelemetryHttpRequestFilterTest {
             }
             assertTrue(foundMatch, "could not find log line with prefix: " + prefix);
         }
+    }
+
+    private static String fullUrl(HostAndPort serverHostAndPort, String requestTarget) {
+        return "http://" + serverHostAndPort.hostName() + ":" + serverHostAndPort.port() + requestTarget;
     }
 }

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilterTest.java
@@ -95,7 +95,7 @@ import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
 import static io.servicetalk.opentelemetry.http.AbstractOpenTelemetryFilter.DEFAULT_OPTIONS;
-import static io.servicetalk.opentelemetry.http.OpenTelemetryHttpRequestFilterTest.verifyTraceIdPresentInLogs;
+import static io.servicetalk.opentelemetry.http.OpenTelemetryHttpRequesterFilterTest.verifyTraceIdPresentInLogs;
 import static io.servicetalk.opentelemetry.http.TestUtils.SPAN_STATE_SERIALIZER;
 import static io.servicetalk.opentelemetry.http.TestUtils.TRACING_TEST_LOG_LINE_PREFIX;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -175,7 +175,8 @@ class OpenTelemetryHttpServiceFilterTest {
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         try (ServerContext context = buildServer(openTelemetry)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient", DEFAULT_OPTIONS))
+                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient",
+                        DEFAULT_OPTIONS, null))
                 .build()) {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/ServiceTalkHttpAttributesGetterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/ServiceTalkHttpAttributesGetterTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentelemetry.http;
+
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.transport.api.HostAndPort;
+
+import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
+import org.junit.jupiter.api.Test;
+
+import static io.servicetalk.http.api.HttpHeaderNames.HOST;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpRequestMetaDataFactory.newRequestMetaData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+class ServiceTalkHttpAttributesGetterTest {
+
+    @Test
+    void clientUrlExtractionNoHostAndPort() {
+        HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> getter =
+                ServiceTalkHttpAttributesGetter.clientGetter(null);
+        String pathQueryFrag = "/foo?bar=baz#frag";
+        HttpRequestMetaData request = newRequest(pathQueryFrag);
+        assertThat(getter.getUrlFull(request), nullValue());
+    }
+
+    @Test
+    void clientUrlExtractionHostHeader() {
+        HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> getter =
+                // host and port should be unused since we have a host header
+                ServiceTalkHttpAttributesGetter.clientGetter(HostAndPort.of("badservice", 443));
+        String pathQueryFrag = "/foo?bar=baz#frag";
+        HttpRequestMetaData request = newRequest(pathQueryFrag);
+        request.addHeader(HOST, "myservice");
+        assertThat(getter.getUrlFull(request), equalTo("http://myservice" + pathQueryFrag));
+    }
+
+    @Test
+    void clientUrlExtractionNoLeadingSlashPath() {
+        HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> getter =
+                ServiceTalkHttpAttributesGetter.clientGetter(HostAndPort.of("myservice", 8080));
+        String pathQueryFrag = "foo";
+        HttpRequestMetaData request = newRequest(pathQueryFrag);
+        assertThat(getter.getUrlFull(request), equalTo("http://myservice:8080/" + pathQueryFrag));
+    }
+
+    @Test
+    void clientUrlExtractionHostAndPortHttpNonDefaultScheme() {
+        HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> getter =
+                ServiceTalkHttpAttributesGetter.clientGetter(HostAndPort.of("myservice", 8080));
+        String pathQueryFrag = "/foo?bar=baz#frag";
+        HttpRequestMetaData request = newRequest(pathQueryFrag);
+        assertThat(getter.getUrlFull(request), equalTo("http://myservice:8080" + pathQueryFrag));
+    }
+
+    @Test
+    void clientUrlExtractionHostAndPortHttpDefaultScheme() {
+        HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> getter =
+                ServiceTalkHttpAttributesGetter.clientGetter(HostAndPort.of("myservice", 80));
+        String pathQueryFrag = "/foo?bar=baz#frag";
+        HttpRequestMetaData request = newRequest(pathQueryFrag);
+        assertThat(getter.getUrlFull(request), equalTo("http://myservice" + pathQueryFrag));
+    }
+
+    @Test
+    void clientUrlExtractionHostAndPortHttpsDefaultScheme() {
+        HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> getter =
+                ServiceTalkHttpAttributesGetter.clientGetter(HostAndPort.of("myservice", 443));
+        String pathQueryFrag = "/foo?bar=baz#frag";
+        HttpRequestMetaData request = newRequest(pathQueryFrag);
+        assertThat(getter.getUrlFull(request), equalTo("https://myservice" + pathQueryFrag));
+    }
+
+    @Test
+    void clientAbsoluteUrl() {
+        HttpClientAttributesGetter<HttpRequestMetaData, HttpResponseMetaData> getter =
+                // host and port should be unused
+                ServiceTalkHttpAttributesGetter.clientGetter(HostAndPort.of("badservice", 80));
+        String requestTarget = "https://myservice/foo?bar=baz#frag";
+        HttpRequestMetaData request = newRequest(requestTarget);
+        request.addHeader(HOST, "badservice"); // should be unused
+        assertThat(getter.getUrlFull(request), equalTo(requestTarget));
+    }
+
+    private static HttpRequestMetaData newRequest(String requestTarget) {
+        return newRequestMetaData(HTTP_1_1, HttpRequestMethod.GET, requestTarget,
+                DefaultHttpHeadersFactory.INSTANCE.newHeaders());
+    }
+}


### PR DESCRIPTION
Motivation:

Our url extraction is wrong in that it doesn't consider possible absolute-form request targets. We also don't allow users to set a host and port in the common case that it's using origin-form request targets and we can't extract a host name or port.

Modifications:

Fix the extraction and make it possible to provide a host and port.