### PR TITLE
Tighten usage of Vary HTTP header

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpRequesterFilter.java
@@ -132,7 +132,7 @@ public final class ContentCodingHttpRequesterFilter
                                                         final BufferAllocator allocator) {
         ContentCodec coding = request.encoding();
         if (coding != null && !identity().equals(coding)) {
-            addContentEncoding(request.headers(), coding.name());
+            addContentEncoding(request.headers(), coding.name(), false);
             request.transformPayloadBody(pub -> coding.encode(pub, allocator));
         }
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentCodingHttpServiceFilter.java
@@ -145,7 +145,7 @@ public final class ContentCodingHttpServiceFilter implements StreamingHttpServic
 
         ContentCodec coding = codingForResponse(requestHeaders, response, supportedEncodings);
         if (coding != null) {
-            addContentEncoding(response.headers(), coding.name());
+            addContentEncoding(response.headers(), coding.name(), true);
             response.transformPayloadBody(bufferPublisher -> coding.encode(bufferPublisher, allocator));
         }
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpRequesterFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpRequesterFilter.java
@@ -94,7 +94,7 @@ public final class ContentEncodingHttpRequesterFilter implements
             BufferEncoder encoder = request.contentEncoding();
             final StreamingHttpRequest encodedRequest;
             if (encoder != null && !identityEncoder().equals(encoder)) {
-                addContentEncoding(request.headers(), encoder.encodingName());
+                addContentEncoding(request.headers(), encoder.encodingName(), false);
                 // After we encode the content length is unlikely to still be correct, remove it!
                 request.headers().remove(CONTENT_LENGTH);
                 encodedRequest = request.transformPayloadBody(pub -> encoder.streamingEncoder().serialize(pub,

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/ContentEncodingHttpServiceFilter.java
@@ -121,7 +121,7 @@ public final class ContentEncodingHttpServiceFilter implements StreamingHttpServ
                             return response;
                         }
 
-                        addContentEncoding(response.headers(), encoder.encodingName());
+                        addContentEncoding(response.headers(), encoder.encodingName(), true);
                         // After we encode the content length is unlikely to still be correct, remove it!
                         response.headers().remove(CONTENT_LENGTH);
                         return response.transformPayloadBody(bufPub ->

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -203,11 +203,13 @@ public final class HeaderUtils {
         return headers.contains(CONTENT_LENGTH);
     }
 
-    static void addContentEncoding(final HttpHeaders headers, CharSequence encoding) {
-        // H2 does not support TE / Transfer-Encoding, so we rely in the presentation encoding only.
+    static void addContentEncoding(final HttpHeaders headers, final CharSequence encoding, final boolean vary) {
+        // H2 does not support TE / Transfer-Encoding, so we rely on the presentation encoding only.
         // https://tools.ietf.org/html/rfc7540#section-8.1.2.2
         headers.add(CONTENT_ENCODING, encoding);
-        headers.add(VARY, CONTENT_ENCODING);
+        if (vary) {
+            headers.add(VARY, ACCEPT_ENCODING);
+        }
     }
 
     static boolean hasContentEncoding(final HttpHeaders headers) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentEncodingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkContentEncodingTest.java
@@ -21,8 +21,6 @@ import io.servicetalk.encoding.api.BufferEncoder;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.ContentEncodingHttpRequesterFilter;
 import io.servicetalk.http.api.ContentEncodingHttpServiceFilter;
-import io.servicetalk.http.api.HttpHeaderNames;
-import io.servicetalk.http.api.HttpHeaderValues;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpClientFilter;


### PR DESCRIPTION
Motivation:
The current behavior around the Vary HTTP header has two issues associated:

 - It is a response-only header, so the client should not send it when sending a compressed payload.
 - The Vary header describes the parts of the request message that influenced the content of the response it occurs in. This in practice means for a server to return Accept-Encoding, but we return Content-Encoding which is not correct.

Modifications:
This changeset first makes sure that the client actually never sends the vary header with its request, even if the payload is being compressed. Then, if the vary header is set by the server side it is not set to Content-Encoding but rather to Accept-Encoding, which influenced the compression decision on the response from the incoming request.

Result:
Vary header behavior which aligns better with HTTP protocol expectations.