### PR TITLE
http-netty: Use the hostToCharSequenceFunction to build traget resource

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -395,7 +395,8 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
      * ServiceDiscoveryRetryStrategy and LoadBalancer.
      */
     private static <U, R> String targetResource(final HttpClientBuildContext<U, R> ctx) {
-        final String uniqueAddress = ctx.builder.address + "/" + CLIENT_ID.incrementAndGet();
+        final String uniqueAddress = ctx.builder.hostToCharSequenceFunction.apply(ctx.builder.address) + "/" +
+                CLIENT_ID.incrementAndGet();
         return ctx.builder.proxyAddress == null ? uniqueAddress :
                 uniqueAddress + " (via " + ctx.builder.proxyAddress + ")";
     }


### PR DESCRIPTION
Motivation:

Our target resource description is built using the `address.toString()` method, which is going to fall apart fairly fast for non-standard types.

Modifications:

We have the `hostToCharSequenceFunction` present that may be able to do a better job, so we might as well use it.