### PR TITLE
Exclude `servicetalk-gradle-plugin-internal` from `servicetalk-bom`

### DIFF
--- a/servicetalk-bom/build.gradle
+++ b/servicetalk-bom/build.gradle
@@ -21,6 +21,7 @@ description="ServiceTalk BOM that includes all modules"
 
 rootProject.subprojects.findAll { !it.path.endsWith("-bom") && !it.path.endsWith("-dependencies") &&
                                   !it.path.endsWith("-benchmarks") &&
+                                  !it.path.endsWith("servicetalk-gradle-plugin-internal") &&
                                   !it.path.startsWith(":servicetalk-examples")}.each {
     dependencies.constraints.add("api", it)
 }


### PR DESCRIPTION
Motivation:

1. This is not a dependency that we expect users to depend on for their application classpath. Even if someone uses our plugin, it's defined in a different scope, which requires explicit version number and version can not be extracted from bom.
2. Our plugin has dependencies on other plugins, like spotbugs, etc. Gradle plugins are typically published to a different repository, not Maven Central. In result, some tools fail to download its transitive dependencies when they try to make sure that all artifacts listed in the BOM are resolvable.

Modifications:

Exclude `servicetalk-gradle-plugin-internal` from `servicetalk-bom`.

Result:

`servicetalk-bom` does not reference
`servicetalk-gradle-plugin-internal` anymore.