### PR TITLE
concurrent-api: revert junit platform dep back to testFixturesImplementation

### DIFF
--- a/servicetalk-concurrent-api/build.gradle
+++ b/servicetalk-concurrent-api/build.gradle
@@ -34,12 +34,12 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
-  testFixturesApi platform("org.junit:junit-bom:$junit5Version")
   testFixturesApi project(":servicetalk-concurrent")
   testFixturesApi project(":servicetalk-concurrent-internal")
   testFixturesApi "org.junit.jupiter:junit-jupiter-api"
   testFixturesApi "org.hamcrest:hamcrest:$hamcrestVersion"
 
+  testFixturesImplementation platform("org.junit:junit-bom:$junit5Version")
   testFixturesImplementation project(":servicetalk-utils-internal")
   testFixturesImplementation project(":servicetalk-concurrent-test-internal")
   testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"


### PR DESCRIPTION
Motivation:

We have seen some strange build behavior when exporting the junit-bom as a testFixtureApi platform.
We don't yet know exactly why.

Modifications:

Move it back to testFixturesImplementation until we can get it sorted out.

Note this was originally changed in https://github.com/apple/servicetalk/pull/3263.