### PR TITLE
opentelemetry-http: defer client attribute extraction

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpRequesterFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpRequesterFilter.java
@@ -16,6 +16,7 @@
 
 package io.servicetalk.opentelemetry.http;
 
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
 import io.servicetalk.http.api.FilterableStreamingHttpConnection;
@@ -41,6 +42,8 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExt
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractor;
 
+import javax.annotation.Nullable;
+
 abstract class AbstractOpenTelemetryHttpRequesterFilter extends AbstractOpenTelemetryFilter
         implements StreamingHttpClientFilterFactory, StreamingHttpConnectionFilterFactory {
 
@@ -61,15 +64,9 @@ abstract class AbstractOpenTelemetryHttpRequesterFilter extends AbstractOpenTele
                 HttpSpanNameExtractor.create(ServiceTalkHttpAttributesGetter.CLIENT_INSTANCE);
         InstrumenterBuilder<HttpRequestMetaData, HttpResponseMetaData> clientInstrumenterBuilder =
                 Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, clientSpanNameExtractor);
-        clientInstrumenterBuilder.setSpanStatusExtractor(ServicetalkSpanStatusExtractor.CLIENT_INSTANCE);
-
         clientInstrumenterBuilder
-                .addAttributesExtractor(
-                        HttpClientAttributesExtractor
-                                .builder(ServiceTalkHttpAttributesGetter.CLIENT_INSTANCE)
-                                .setCapturedRequestHeaders(opentelemetryOptions.capturedRequestHeaders())
-                                .setCapturedResponseHeaders(opentelemetryOptions.capturedResponseHeaders())
-                                .build());
+                .setSpanStatusExtractor(ServicetalkSpanStatusExtractor.CLIENT_INSTANCE)
+                .addAttributesExtractor(new DeferredClientAttributesExtractor(opentelemetryOptions));
 
         if (opentelemetryOptions.enableMetrics()) {
             clientInstrumenterBuilder.addOperationMetrics(HttpClientMetrics.get());
@@ -124,6 +121,32 @@ abstract class AbstractOpenTelemetryHttpRequesterFilter extends AbstractOpenTele
                 tracker.onError(t);
                 return Single.failed(t);
             }
+        }
+    }
+
+    private static final class DeferredClientAttributesExtractor implements
+            AttributesExtractor<HttpRequestMetaData, HttpResponseMetaData> {
+
+        private final AttributesExtractor<HttpRequestMetaData, HttpResponseMetaData> delegate;
+
+        private DeferredClientAttributesExtractor(OpenTelemetryOptions openTelemetryOptions) {
+            this.delegate = HttpClientAttributesExtractor
+                    .builder(ServiceTalkHttpAttributesGetter.CLIENT_INSTANCE)
+                    .setCapturedRequestHeaders(openTelemetryOptions.capturedRequestHeaders())
+                    .setCapturedResponseHeaders(openTelemetryOptions.capturedResponseHeaders())
+                    .build();
+        }
+
+        @Override
+        public void onStart(AttributesBuilder attributes, Context parentContext, HttpRequestMetaData metaData) {
+            // noop: we will defer this until the `onEnd` call.
+        }
+
+        @Override
+        public void onEnd(AttributesBuilder attributes, Context context, HttpRequestMetaData requestMetaData,
+                          @Nullable HttpResponseMetaData responseMetaData, @Nullable Throwable error) {
+            delegate.onStart(attributes, context, requestMetaData);
+            delegate.onEnd(attributes, context, requestMetaData, responseMetaData, error);
         }
     }
 }

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -62,6 +62,8 @@ import javax.annotation.Nullable;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
@@ -230,12 +232,12 @@ class OpenTelemetryHttpRequesterFilterTest {
                             assertThat(ta.getSpan(0).getAttributes().get(AttributeKey.stringKey("component")))
                                     .isEqualTo("serviceTalk");
                             assertThat(ta.getSpan(1).getParentSpanId()).isEqualTo(ta.getSpan(0).getSpanId());
-                            if (absoluteForm || withHostHeader) {
-                                assertThat(ta.getSpan(1).getAttributes().get(URL_FULL)).isEqualTo(
-                                        fullUrl(serverHostAndPort, requestPath));
-                            } else {
-                                assertThat(ta.getSpan(1).getAttributes().get(URL_FULL)).isNull();
-                            }
+                            assertThat(ta.getSpan(1).getAttributes().get(URL_FULL)).isEqualTo(
+                                    fullUrl(serverHostAndPort, requestPath));
+                            assertThat(ta.getSpan(1).getAttributes().get(SERVER_ADDRESS)).isEqualTo(
+                                    serverHostAndPort.hostName());
+                            assertThat(ta.getSpan(1).getAttributes().get(SERVER_PORT)).isEqualTo(
+                                    serverHostAndPort.port());
                             assertThat(ta.getSpan(1).getAttributes().get(NETWORK_PROTOCOL_NAME))
                                     .isNull(); // only needs to be set if != http
                             assertThat(ta.getSpan(2).getParentSpanId()).isEqualTo(ta.getSpan(1).getSpanId());


### PR DESCRIPTION
Motivation:

Current client attribute extraction happens on start of the filter which is usually at the front of the pipeline. This doesn't let client filters operate on the request which can often populate important data such as the host header, used for attribute extraction.

Modifications:

Defer client attribute extraction to the `onEnd` phase. Since nothing in there is time sensitive it doesn't make a difference other than the request is as it
is intended.