### PR TITLE
opentelemetry-http: Enhance OpenTelemetryHttpRequesterFilterTest

### DIFF
--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -16,7 +16,6 @@
 
 package io.servicetalk.opentelemetry.http;
 
-import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpClient;
@@ -52,7 +51,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +78,6 @@ import static io.servicetalk.opentelemetry.http.TestUtils.TRACING_TEST_LOG_LINE_
 import static io.servicetalk.opentelemetry.http.TestUtils.TestTracingClientLoggerFilter;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
-import static java.util.Collections.replaceAll;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -461,7 +458,6 @@ class OpenTelemetryHttpRequesterFilterTest {
                                 span.hasAttribute(TestHttpLifecycleObserver.ON_REQUEST_KEY, "set");
                                 span.hasAttribute(TestHttpLifecycleObserver.ON_RESPONSE_ERROR_KEY, "set");
                                 span.hasAttribute(TestHttpLifecycleObserver.ON_EXCHANGE_FINALLY_KEY, "set");
-
                             }));
                     break;
                 default:
@@ -485,7 +481,7 @@ class OpenTelemetryHttpRequesterFilterTest {
         }
         return httpServerBuilder
             .listenAndAwait((ctx, request, responseFactory) -> {
-                if (request.path().equals("/slow")) {
+                if ("/slow".equals(request.path())) {
                     return Single.never();
                 }
                 final ContextPropagators propagators = givenOpentelemetry.getPropagators();

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestHttpLifecycleObserver.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestHttpLifecycleObserver.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentelemetry.http;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.http.api.HttpHeaders;
+import io.servicetalk.http.api.HttpLifecycleObserver;
+import io.servicetalk.http.api.HttpRequestMetaData;
+import io.servicetalk.http.api.HttpResponseMetaData;
+import io.servicetalk.transport.api.ConnectionInfo;
+
+import javax.annotation.Nullable;
+import java.util.Queue;
+
+final class TestHttpLifecycleObserver implements HttpLifecycleObserver {
+
+    static final AttributeKey<String> ON_NEW_EXCHANGE_KEY = AttributeKey.stringKey("onNewExchange");
+    static final AttributeKey<String> ON_EXCHANGE_FINALLY_KEY = AttributeKey.stringKey("onExchangeFinally");
+
+    static final AttributeKey<String> ON_REQUEST_KEY = AttributeKey.stringKey("onRequest");
+    static final AttributeKey<String> ON_REQUEST_DATA_KEY = AttributeKey.stringKey("onRequestData");
+    static final AttributeKey<String> ON_REQUEST_TRAILERS_KEY = AttributeKey.stringKey("onRequestTrailers");
+    static final AttributeKey<String> ON_REQUEST_COMPLETE_KEY = AttributeKey.stringKey("onRequestComplete");
+    static final AttributeKey<String> ON_REQUEST_ERROR_KEY = AttributeKey.stringKey("onRequestError");
+    static final AttributeKey<String> ON_REQUEST_CANCEL_KEY = AttributeKey.stringKey("onRequestCancel");
+
+    static final AttributeKey<String> ON_RESPONSE_KEY = AttributeKey.stringKey("onResponse");
+    static final AttributeKey<String> ON_RESPONSE_ERROR_KEY = AttributeKey.stringKey("onResponseError");
+    static final AttributeKey<String> ON_RESPONSE_CANCEL_KEY = AttributeKey.stringKey("onResponseCancel");
+    static final AttributeKey<String> ON_RESPONSE_DATA_KEY = AttributeKey.stringKey("onResponseData");
+    static final AttributeKey<String> ON_RESPONSE_TRAILERS_KEY = AttributeKey.stringKey("onResponseTrailers");
+    static final AttributeKey<String> ON_RESPONSE_COMPLETE_KEY = AttributeKey.stringKey("onResponseComplete");
+    static final AttributeKey<String> ON_RESPONSE_BODY_ERROR_KEY = AttributeKey.stringKey("onResponseBodyError");
+    static final AttributeKey<String> ON_RESPONSE_BODY_CANCEL_KEY = AttributeKey.stringKey("onResponseBodyCancel");
+
+    private final Queue<Error> errorQueue;
+
+    // Protected by synchronization
+    @Nullable
+    private Span initialSpan;
+
+    TestHttpLifecycleObserver(Queue<Error> errorQueue) {
+        this.errorQueue = errorQueue;
+    }
+
+    @Override
+    public HttpExchangeObserver onNewExchange() {
+        setKey(ON_NEW_EXCHANGE_KEY);
+        return new HttpExchangeObserver() {
+            @Override
+            public void onConnectionSelected(ConnectionInfo info) {
+            }
+
+            @Override
+            public HttpRequestObserver onRequest(HttpRequestMetaData requestMetaData) {
+                setKey(ON_REQUEST_KEY);
+                return new HttpRequestObserver() {
+                    @Override
+                    public void onRequestData(Buffer data) {
+                        setKey(ON_REQUEST_DATA_KEY);
+                    }
+
+                    @Override
+                    public void onRequestTrailers(HttpHeaders trailers) {
+                        setKey(ON_REQUEST_TRAILERS_KEY);
+                    }
+
+                    @Override
+                    public void onRequestComplete() {
+                        setKey(ON_REQUEST_COMPLETE_KEY);
+                    }
+
+                    @Override
+                    public void onRequestError(Throwable cause) {
+                        setKey(ON_REQUEST_ERROR_KEY);
+                    }
+
+                    @Override
+                    public void onRequestCancel() {
+                        setKey(ON_REQUEST_CANCEL_KEY);
+                    }
+                };
+            }
+
+            @Override
+            public HttpResponseObserver onResponse(HttpResponseMetaData responseMetaData) {
+                setKey(ON_RESPONSE_KEY);
+                return new HttpResponseObserver() {
+                    @Override
+                    public void onResponseData(Buffer data) {
+                        setKey(ON_RESPONSE_DATA_KEY);
+                    }
+
+                    @Override
+                    public void onResponseTrailers(HttpHeaders trailers) {
+                        setKey(ON_RESPONSE_TRAILERS_KEY);
+                    }
+
+                    @Override
+                    public void onResponseComplete() {
+                        setKey(ON_RESPONSE_COMPLETE_KEY);
+                    }
+
+                    @Override
+                    public void onResponseError(Throwable cause) {
+                        setKey(ON_RESPONSE_BODY_ERROR_KEY);
+                    }
+
+                    @Override
+                    public void onResponseCancel() {
+                        setKey(ON_RESPONSE_BODY_CANCEL_KEY);
+                    }
+                };
+            }
+
+            @Override
+            public void onResponseError(Throwable cause) {
+                setKey(ON_RESPONSE_ERROR_KEY);
+            }
+
+            @Override
+            public void onResponseCancel() {
+                setKey(ON_RESPONSE_CANCEL_KEY);
+            }
+
+            @Override
+            public void onExchangeFinally() {
+                setKey(ON_EXCHANGE_FINALLY_KEY);
+            }
+        };
+    }
+
+    private void setKey(AttributeKey<String> key) {
+        System.err.println("Setting key " + key);
+        final Span current = Span.current();
+        current.setAttribute(key, "set");
+        final Span initialSpan;
+        synchronized (this) {
+            if (this.initialSpan == null) {
+                this.initialSpan = current;
+            }
+            initialSpan = this.initialSpan;
+        }
+        if (Span.getInvalid().equals(current)) {
+            errorQueue.offer(new AssertionError("Detected the invalid span"));
+        } else if (!current.equals(initialSpan)) {
+            errorQueue.offer(new AssertionError("Found unexpected unrelated span detected in " +
+                    key.getKey() + ". Initial: " + initialSpan + ", current: " + current));
+        }
+    }
+}

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestHttpLifecycleObserver.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestHttpLifecycleObserver.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.opentelemetry.http;
 
-import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.trace.Span;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpLifecycleObserver;
@@ -24,8 +22,11 @@ import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.transport.api.ConnectionInfo;
 
-import javax.annotation.Nullable;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+
 import java.util.Queue;
+import javax.annotation.Nullable;
 
 final class TestHttpLifecycleObserver implements HttpLifecycleObserver {
 
@@ -146,7 +147,6 @@ final class TestHttpLifecycleObserver implements HttpLifecycleObserver {
     }
 
     private void setKey(AttributeKey<String> key) {
-        System.err.println("Setting key " + key);
         final Span current = Span.current();
         current.setAttribute(key, "set");
         final Span initialSpan;


### PR DESCRIPTION
Motivation:

We want to make sure our request observers are able to see the right spans and add attributes.

Modifications:

Reuse the TestHttpLifecycleObserver that we have built out for the server side.

Result:

Better test coverage.