### PR TITLE
Add a template for Pull Request descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+#### Motivation
+<!-- Explain the context around why you're making this change. What is the problem you're trying to solve. -->
+
+#### Modifications
+<!-- Describe or list the modifications you've done. -->
+
+#### Result
+<!-- Describe the final outcome of this change. Highlight if there is any risk, behavior change, or API change. -->


### PR DESCRIPTION
#### Motivation

When people outside our team contribute, they are not familiar with our PR description style.

#### Modifications

- Adds `.github/pull_request_template.md` file.

#### Result

GitHub UI will automatically pre-populate PR description with our template when someone opens a PR.