### PR TITLE
Minor corrections for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-# intellij
+# IntelliJ IDEA
 /.idea
 *.iml
 /*.ipr
@@ -9,14 +9,14 @@ hs_err_pid*
 **/out/
 /.shelf/
 
-# gradle
+# Gradle
 .gradle/
 .out/
 build/
 /buildSrc/.gradle/
 .dist/
 
-# maven (examples)
+# Maven
 target/
 
 # Eclipse
@@ -32,8 +32,9 @@ target/
 /nbdist/
 /.nb-gradle/
 
-#VS Code
+# VSCode
 .vscode/
+bin/
 
 # Mac
 .DS_Store

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -85,7 +85,7 @@ final class ProjectUtils {
 
   static void enforceUtf8FileSystem() {
     def fenc = System.getProperty("file.encoding")
-    if (!"UTF-8".equalsIgnoreCase(fenc)) {
+    if (!("UTF-8".equalsIgnoreCase(fenc) || "UTF8".equalsIgnoreCase(fenc))) {
       throw new GradleException("File encoding must be UTF-8 but is $fenc, consider using a file system that " +
           "supports it or setting the JAVA_TOOL_OPTIONS env var to: -Dfile.encoding=UTF-8.\n\nMake sure the jvm is " +
           "restarted to pickup these changes (e.g. `gradle --stop`, and restart your IDE)!");


### PR DESCRIPTION
#### Motivation

VSCode uses `bin/` folder for compiled classes and slightly different name for UTF-8 encoding.

#### Modifications

- Add `bin/` to `.gitignore`.
- Enhance `servicetalk-gradle-plugin-internal` to understand both `UTF-8` and `UTF8` encoding.

#### Result

The project works well in VSCode.