### PR TITLE
`TransportObserver`: let users easily skip uninterested callbacks

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionObserverEventOrderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionObserverEventOrderTest.java
@@ -25,7 +25,6 @@ import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -143,13 +142,13 @@ class ConnectionObserverEventOrderTest {
             @Override
             public DataObserver connectionEstablished(ConnectionInfo info) {
                 addEvent();
-                return NoopTransportObserver.NoopDataObserver.INSTANCE;
+                return ConnectionObserver.super.connectionEstablished(info);
             }
 
             @Override
             public MultiplexedObserver multiplexedConnectionEstablished(ConnectionInfo info) {
                 addEvent();
-                return NoopTransportObserver.NoopMultiplexedObserver.INSTANCE;
+                return ConnectionObserver.super.multiplexedConnectionEstablished(info);
             }
 
             @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/FlushStrategyOnServerTest.java
@@ -21,12 +21,10 @@ import io.servicetalk.http.api.HttpRequest;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpService;
-import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -304,28 +302,6 @@ class FlushStrategyOnServerTest {
         @Override
         public ConnectionObserver onNewConnection(@Nullable Object localAddress, Object remoteAddress) {
             return this;
-        }
-
-        @Override
-        public void onDataRead(int size) {
-        }
-
-        @Override
-        public DataObserver connectionEstablished(final ConnectionInfo info) {
-            return NoopTransportObserver.NoopDataObserver.INSTANCE;
-        }
-
-        @Override
-        public MultiplexedObserver multiplexedConnectionEstablished(final ConnectionInfo info) {
-            return NoopTransportObserver.NoopMultiplexedObserver.INSTANCE;
-        }
-
-        @Override
-        public void connectionClosed(final Throwable error) {
-        }
-
-        @Override
-        public void connectionClosed() {
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpTransportObserverAsyncContextTest.java
@@ -32,8 +32,6 @@ import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopProxyConnectObserver;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopSecurityHandshakeObserver;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -203,19 +201,19 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
             @Override
             public ProxyConnectObserver onProxyConnect(final Object connectMsg) {
                 storageMap.put("onProxyConnect", valueOf(AsyncContext.get(key)));
-                return NoopProxyConnectObserver.INSTANCE;
+                return ConnectionObserver.super.onProxyConnect(connectMsg);
             }
 
             @Override
             public SecurityHandshakeObserver onSecurityHandshake(final SslConfig config) {
                 storageMap.put("onSecurityHandshake", valueOf(AsyncContext.get(key)));
-                return NoopSecurityHandshakeObserver.INSTANCE;
+                return ConnectionObserver.super.onSecurityHandshake(config);
             }
 
             @Override
             public DataObserver connectionEstablished(final ConnectionInfo info) {
                 storageMap.put("connectionEstablished", valueOf(AsyncContext.get(key)));
-                return new AsyncContextCaptureDataObserver();
+                return ConnectionObserver.super.connectionEstablished(info);
             }
 
             @Override
@@ -333,28 +331,9 @@ class HttpTransportObserverAsyncContextTest extends AbstractNettyHttpServerTest 
                 storageMap.put("onFlushRequest", valueOf(AsyncContext.get(key)));
             }
 
-            // For the following callbacks AsyncContext is unknown because protocols can write multiple requests
+            // For other unimplemented callbacks AsyncContext is unknown because protocols can write multiple requests
             // concurrently. Users should use other callbacks above to retrieve the request context and keep it in a
             // class local variable.
-            @Override
-            public void itemWritten(@Nullable final Object item) {
-            }
-
-            @Override
-            public void itemFlushed() {
-            }
-
-            @Override
-            public void writeFailed(final Throwable cause) {
-            }
-
-            @Override
-            public void writeComplete() {
-            }
-
-            @Override
-            public void writeCancelled() {
-            }
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -44,16 +44,12 @@ import io.servicetalk.transport.api.ServerSslConfigBuilder;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopDataObserver;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopMultiplexedObserver;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InOrder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -102,7 +98,6 @@ import static org.mockito.Mockito.when;
 
 class HttpsProxyTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HttpsProxyTest.class);
     private static final String AUTH_TOKEN = "aGVsbG86d29ybGQ=";
 
     @RegisterExtension
@@ -164,9 +159,6 @@ class HttpsProxyTest {
         when(connectionObserver.onProxyConnect(any())).thenReturn(proxyConnectObserver);
         lenient().when(connectionObserver.onSecurityHandshake(any(SslConfig.class)))
                 .thenReturn(securityHandshakeObserver);
-        lenient().when(connectionObserver.connectionEstablished(any())).thenReturn(NoopDataObserver.INSTANCE);
-        lenient().when(connectionObserver.multiplexedConnectionEstablished(any()))
-                .thenReturn(NoopMultiplexedObserver.INSTANCE);
         order = inOrder(transportObserver, connectionObserver, proxyConnectObserver, securityHandshakeObserver);
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SecurityHandshakeObserverTest.java
@@ -19,7 +19,6 @@ import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
-import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
 import io.servicetalk.transport.api.ServerContext;
@@ -27,8 +26,6 @@ import io.servicetalk.transport.api.ServerSslConfigBuilder;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.TransportObserver;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopDataObserver;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopMultiplexedObserver;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -97,10 +94,6 @@ class SecurityHandshakeObserverTest {
         when(clientTransportObserver.onNewConnection(any(), any())).thenReturn(clientConnectionObserver);
         when(clientConnectionObserver.onSecurityHandshake(any(SslConfig.class)))
                 .thenReturn(clientSecurityHandshakeObserver);
-        when(clientConnectionObserver.connectionEstablished(any(ConnectionInfo.class)))
-                .thenReturn(NoopDataObserver.INSTANCE);
-        when(clientConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
-            .thenReturn(NoopMultiplexedObserver.INSTANCE);
         countDownOnClosed(clientConnectionObserver, bothClosed);
         countDownOnHandshakeTermination(clientSecurityHandshakeObserver, bothHandshakeFinished);
         clientOrder = inOrder(clientTransportObserver, clientConnectionObserver, clientSecurityHandshakeObserver);
@@ -111,10 +104,6 @@ class SecurityHandshakeObserverTest {
         when(serverTransportObserver.onNewConnection(any(), any())).thenReturn(serverConnectionObserver);
         when(serverConnectionObserver.onSecurityHandshake(any(SslConfig.class)))
                 .thenReturn(serverSecurityHandshakeObserver);
-        when(serverConnectionObserver.connectionEstablished(any(ConnectionInfo.class)))
-                .thenReturn(NoopDataObserver.INSTANCE);
-        when(serverConnectionObserver.multiplexedConnectionEstablished(any(ConnectionInfo.class)))
-            .thenReturn(NoopMultiplexedObserver.INSTANCE);
         countDownOnClosed(serverConnectionObserver, bothClosed);
         countDownOnHandshakeTermination(serverSecurityHandshakeObserver, bothHandshakeFinished);
         serverOrder = inOrder(serverTransportObserver, serverConnectionObserver, serverSecurityHandshakeObserver);

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/SslCertificateCompressionTest.java
@@ -23,7 +23,6 @@ import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.CertificateCompressionAlgorithms;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
-import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
@@ -31,7 +30,6 @@ import io.servicetalk.transport.api.ServerSslConfigBuilder;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.api.SslProvider;
 import io.servicetalk.transport.api.TransportObserver;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.OpenSslContextOption;
@@ -169,41 +167,6 @@ class SslCertificateCompressionTest {
                             inHandshake = false;
                         }
                     };
-                }
-
-                @Override
-                public void onFlush() {
-                }
-
-                @Override
-                public void onTransportHandshakeComplete(final ConnectionInfo info) {
-                }
-
-                @Override
-                public ProxyConnectObserver onProxyConnect(final Object connectMsg) {
-                    return NoopTransportObserver.NoopProxyConnectObserver.INSTANCE;
-                }
-
-                @Override
-                public DataObserver connectionEstablished(final ConnectionInfo info) {
-                    return NoopTransportObserver.NoopDataObserver.INSTANCE;
-                }
-
-                @Override
-                public MultiplexedObserver multiplexedConnectionEstablished(final ConnectionInfo info) {
-                    return NoopTransportObserver.NoopMultiplexedObserver.INSTANCE;
-                }
-
-                @Override
-                public void connectionWritabilityChanged(final boolean isWritable) {
-                }
-
-                @Override
-                public void connectionClosed(final Throwable error) {
-                }
-
-                @Override
-                public void connectionClosed() {
                 }
             };
         }

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -30,7 +30,6 @@ import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 import io.servicetalk.transport.api.TransportObserver;
-import io.servicetalk.transport.netty.internal.NoopTransportObserver;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -352,7 +351,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                         } else {
                             checkSpan("connectionEstablished");
                         }
-                        return NoopTransportObserver.NoopDataObserver.INSTANCE;
+                        return ConnectionObserver.super.connectionEstablished(info);
                     }
 
                     @Override
@@ -362,7 +361,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                         } else {
                             checkSpan("multiplexedConnectionEstablished");
                         }
-                        return NoopTransportObserver.NoopMultiplexedObserver.INSTANCE;
+                        return ConnectionObserver.super.multiplexedConnectionEstablished(info);
                     }
 
                     @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2023 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 package io.servicetalk.transport.api;
-
-import io.servicetalk.transport.api.NoopTransportObserver.NoopProxyConnectObserver;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
@@ -34,19 +32,22 @@ public interface ConnectionObserver {
      *
      * @param size size of the data chunk read
      */
-    void onDataRead(int size);
+    default void onDataRead(int size) {
+    }
 
     /**
      * Callback when {@code size} bytes are written to the connection.
      *
      * @param size size of the data chunk written
      */
-    void onDataWrite(int size);
+    default void onDataWrite(int size) {
+    }
 
     /**
      * Callback when previously written data is flushed to the connection.
      */
-    void onFlush();
+    default void onFlush() {
+    }
 
     /**
      * Callback when a transport handshake completes.
@@ -85,8 +86,8 @@ public interface ConnectionObserver {
      * @param connectMsg a message sent to a proxy in request to establish a connection to the target server
      * @return a new {@link ProxyConnectObserver} that provides visibility into proxy connect events.
      */
-    default ProxyConnectObserver onProxyConnect(Object connectMsg) {    // FIXME: 0.43 - consider removing default impl
-        return NoopProxyConnectObserver.INSTANCE;
+    default ProxyConnectObserver onProxyConnect(Object connectMsg) {
+        return NoopTransportObserver.NoopProxyConnectObserver.INSTANCE;
     }
 
     /**
@@ -142,7 +143,9 @@ public interface ConnectionObserver {
      * @param info {@link ConnectionInfo} for the established connection
      * @return a new {@link DataObserver} that provides visibility into read and write events
      */
-    DataObserver connectionEstablished(ConnectionInfo info);
+    default DataObserver connectionEstablished(ConnectionInfo info) {
+        return NoopTransportObserver.NoopDataObserver.INSTANCE;
+    }
 
     /**
      * Callback when a multiplexed connection is established and ready.
@@ -150,7 +153,9 @@ public interface ConnectionObserver {
      * @param info {@link ConnectionInfo} for the established connection
      * @return a new {@link MultiplexedObserver} that provides visibility into new streams
      */
-    MultiplexedObserver multiplexedConnectionEstablished(ConnectionInfo info);
+    default MultiplexedObserver multiplexedConnectionEstablished(ConnectionInfo info) {
+        return NoopTransportObserver.NoopMultiplexedObserver.INSTANCE;
+    }
 
     /**
      * Callback when a writable state of the connection changes.
@@ -159,7 +164,7 @@ public interface ConnectionObserver {
      * the requested write operation immediately. If {@code false}, write requests will be queued until the I/O thread
      * is ready to process the queued items and the transport will start applying backpressure.
      */
-    default void connectionWritabilityChanged(boolean isWritable) { // FIXME: 0.43 - consider removing default impl
+    default void connectionWritabilityChanged(boolean isWritable) {
     }
 
     /**
@@ -167,12 +172,14 @@ public interface ConnectionObserver {
      *
      * @param error an occurred error
      */
-    void connectionClosed(Throwable error);
+    default void connectionClosed(Throwable error) {
+    }
 
     /**
      * Callback when the connection is closed.
      */
-    void connectionClosed();
+    default void connectionClosed() {
+    }
 
     /**
      * An observer interface that provides visibility into proxy connect events for establishing a tunnel.
@@ -187,7 +194,8 @@ public interface ConnectionObserver {
          *
          * @param cause the cause of proxy connect failure
          */
-        void proxyConnectFailed(Throwable cause);
+        default void proxyConnectFailed(Throwable cause) {
+        }
 
         /**
          * Callback when the proxy connect attempt is complete successfully.
@@ -196,7 +204,8 @@ public interface ConnectionObserver {
          * protocol implementation (e.g. <a href="https://en.wikipedia.org/wiki/HTTP_tunnel">HTTP Tunnel</a>,
          * <a href="https://en.wikipedia.org/wiki/SOCKS">SOCKS</a>, etc.)
          */
-        void proxyConnectComplete(Object responseMsg);
+        default void proxyConnectComplete(Object responseMsg) {
+        }
     }
 
     /**
@@ -212,14 +221,16 @@ public interface ConnectionObserver {
          *
          * @param cause the cause of handshake failure
          */
-        void handshakeFailed(Throwable cause);
+        default void handshakeFailed(Throwable cause) {
+        }
 
         /**
          * Callback when the handshake is complete successfully.
          *
          * @param sslSession the {@link SSLSession} for this connection
          */
-        void handshakeComplete(SSLSession sslSession);
+        default void handshakeComplete(SSLSession sslSession) {
+        }
     }
 
     /**
@@ -232,14 +243,18 @@ public interface ConnectionObserver {
          *
          * @return {@link ReadObserver} that provides visibility into <strong>read</strong> events
          */
-        ReadObserver onNewRead();
+        default ReadObserver onNewRead() {
+            return NoopTransportObserver.NoopReadObserver.INSTANCE;
+        }
 
         /**
          * Callback when the connection starts writing a new message.
          *
          * @return {@link WriteObserver} that provides visibility into <strong>write</strong> events
          */
-        WriteObserver onNewWrite();
+        default WriteObserver onNewWrite() {
+            return NoopTransportObserver.NoopWriteObserver.INSTANCE;
+        }
     }
 
     /**
@@ -252,7 +267,9 @@ public interface ConnectionObserver {
          *
          * @return {@link StreamObserver} that provides visibility into stream events
          */
-        StreamObserver onNewStream();
+        default StreamObserver onNewStream() {
+            return NoopTransportObserver.NoopStreamObserver.INSTANCE;
+        }
     }
 
     /**
@@ -270,7 +287,8 @@ public interface ConnectionObserver {
          *
          * @param streamId assigned stream identifier
          */
-        void streamIdAssigned(long streamId);   // Use long to comply with HTTP/3 requirements
+        default void streamIdAssigned(long streamId) {   // Use long to comply with HTTP/3 requirements
+        }
 
         /**
          * Callback when the stream is established and ready to be used. It may or may not have an already assigned
@@ -279,19 +297,23 @@ public interface ConnectionObserver {
          * @return a new {@link DataObserver} that provides visibility into read and write events
          * @see #streamIdAssigned(long)
          */
-        DataObserver streamEstablished();
+        default DataObserver streamEstablished() {
+            return NoopTransportObserver.NoopDataObserver.INSTANCE;
+        }
 
         /**
          * Callback when the stream is closed due to an {@link Throwable error}.
          *
          * @param error an occurred error
          */
-        void streamClosed(Throwable error);
+        default void streamClosed(Throwable error) {
+        }
 
         /**
          * Callback when the stream is closed.
          */
-        void streamClosed();
+        default void streamClosed() {
+        }
     }
 
     /**
@@ -308,7 +330,8 @@ public interface ConnectionObserver {
          *
          * @param n number of requested items to read
          */
-        void requestedToRead(long n);
+        default void requestedToRead(long n) {
+        }
 
         /**
          * Invokes when a new item is read.
@@ -318,8 +341,7 @@ public interface ConnectionObserver {
          * @deprecated Use {@link #itemRead(Object)}
          */
         @Deprecated
-        default void itemRead() {
-            // FIXME: 0.43 - remove deprecated method
+        default void itemRead() {   // FIXME: 0.43 - remove deprecated method
         }
 
         /**
@@ -327,24 +349,28 @@ public interface ConnectionObserver {
          *
          * @param item an item that was read
          */
-        void itemRead(@Nullable Object item);
+        default void itemRead(@Nullable Object item) {
+        }
 
         /**
          * Callback when the read operation fails with an {@link Throwable error}.
          *
          * @param cause {@link Throwable} that terminated the read
          */
-        void readFailed(Throwable cause);
+        default void readFailed(Throwable cause) {
+        }
 
         /**
          * Callback when the entire read operation completes successfully.
          */
-        void readComplete();
+        default void readComplete() {
+        }
 
         /**
          * Callback when the read operation is cancelled.
          */
-        void readCancelled();
+        default void readCancelled() {
+        }
     }
 
     /**
@@ -361,7 +387,8 @@ public interface ConnectionObserver {
          *
          * @param n number of requested items to write
          */
-        void requestedToWrite(long n);
+        default void requestedToWrite(long n) {
+        }
 
         /**
          * Callback when an item is received and ready to be written.
@@ -371,8 +398,7 @@ public interface ConnectionObserver {
          * @deprecated Use {{@link #itemReceived(Object)}}
          */
         @Deprecated
-        default void itemReceived() {
-            // FIXME: 0.43 - remove deprecated method
+        default void itemReceived() {   // FIXME: 0.43 - remove deprecated method
         }
 
         /**
@@ -380,12 +406,14 @@ public interface ConnectionObserver {
          *
          * @param item received item
          */
-        void itemReceived(@Nullable Object item);
+        default void itemReceived(@Nullable Object item) {
+        }
 
         /**
          * Callback when flush operation is requested.
          */
-        void onFlushRequest();
+        default void onFlushRequest() {
+        }
 
         /**
          * Callback when an item is written to the transport.
@@ -395,8 +423,7 @@ public interface ConnectionObserver {
          * @deprecated Use {@link #itemWritten(Object)}
          */
         @Deprecated
-        default void itemWritten() {
-            // FIXME: 0.43 - remove deprecated method
+        default void itemWritten() {    // FIXME: 0.43 - remove deprecated method
         }
 
         /**
@@ -404,28 +431,33 @@ public interface ConnectionObserver {
          *
          * @param item written item
          */
-        void itemWritten(@Nullable Object item);
+        default void itemWritten(@Nullable Object item) {
+        }
 
         /**
          * Callback when an item is flushed to the network. Items are flushed in order they have been written.
          */
-        void itemFlushed();
+        default void itemFlushed() {
+        }
 
         /**
          * Callback when the write operation fails with an {@link Throwable error}.
          *
          * @param cause {@link Throwable} that terminated the write
          */
-        void writeFailed(Throwable cause);
+        default void writeFailed(Throwable cause) {
+        }
 
         /**
          * Callback when the entire write operation completes successfully.
          */
-        void writeComplete();
+        default void writeComplete() {
+        }
 
         /**
          * Callback when the write operation is cancelled.
          */
-        void writeCancelled();
+        default void writeCancelled() {
+        }
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -24,11 +24,8 @@ import io.servicetalk.transport.api.ConnectionObserver.StreamObserver;
 import io.servicetalk.transport.api.ConnectionObserver.WriteObserver;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLSession;
 
 final class NoopTransportObserver implements TransportObserver {
-
-    static final TransportObserver INSTANCE = new NoopTransportObserver();
 
     private NoopTransportObserver() {
         // Singleton
@@ -46,59 +43,6 @@ final class NoopTransportObserver implements TransportObserver {
         private NoopConnectionObserver() {
             // Singleton
         }
-
-        @Override
-        public void onDataRead(final int size) {
-        }
-
-        @Override
-        public void onDataWrite(final int size) {
-        }
-
-        @Override
-        public void onFlush() {
-        }
-
-        @Override
-        public void onTransportHandshakeComplete(final ConnectionInfo info) {
-        }
-
-        @Override
-        public ProxyConnectObserver onProxyConnect(final Object connectMsg) {
-            return NoopProxyConnectObserver.INSTANCE;
-        }
-
-        @Override
-        public SecurityHandshakeObserver onSecurityHandshake() {
-            return NoopSecurityHandshakeObserver.INSTANCE;
-        }
-
-        @Override
-        public SecurityHandshakeObserver onSecurityHandshake(final SslConfig sslConfig) {
-            return NoopSecurityHandshakeObserver.INSTANCE;
-        }
-
-        @Override
-        public DataObserver connectionEstablished(final ConnectionInfo info) {
-            return NoopDataObserver.INSTANCE;
-        }
-
-        @Override
-        public MultiplexedObserver multiplexedConnectionEstablished(final ConnectionInfo info) {
-            return NoopMultiplexedObserver.INSTANCE;
-        }
-
-        @Override
-        public void connectionWritabilityChanged(final boolean isWritable) {
-        }
-
-        @Override
-        public void connectionClosed(final Throwable error) {
-        }
-
-        @Override
-        public void connectionClosed() {
-        }
     }
 
     static final class NoopProxyConnectObserver implements ProxyConnectObserver {
@@ -107,14 +51,6 @@ final class NoopTransportObserver implements TransportObserver {
 
         private NoopProxyConnectObserver() {
             // Singleton
-        }
-
-        @Override
-        public void proxyConnectFailed(final Throwable cause) {
-        }
-
-        @Override
-        public void proxyConnectComplete(final Object responseMsg) {
         }
     }
 
@@ -125,14 +61,6 @@ final class NoopTransportObserver implements TransportObserver {
         private NoopSecurityHandshakeObserver() {
             // Singleton
         }
-
-        @Override
-        public void handshakeFailed(final Throwable cause) {
-        }
-
-        @Override
-        public void handshakeComplete(final SSLSession sslSession) {
-        }
     }
 
     static final class NoopDataObserver implements DataObserver {
@@ -141,16 +69,6 @@ final class NoopTransportObserver implements TransportObserver {
 
         private NoopDataObserver() {
             // Singleton
-        }
-
-        @Override
-        public ReadObserver onNewRead() {
-            return NoopReadObserver.INSTANCE;
-        }
-
-        @Override
-        public WriteObserver onNewWrite() {
-            return NoopWriteObserver.INSTANCE;
         }
     }
 
@@ -161,11 +79,6 @@ final class NoopTransportObserver implements TransportObserver {
         private NoopMultiplexedObserver() {
             // Singleton
         }
-
-        @Override
-        public StreamObserver onNewStream() {
-            return NoopStreamObserver.INSTANCE;
-        }
     }
 
     static final class NoopStreamObserver implements StreamObserver {
@@ -174,23 +87,6 @@ final class NoopTransportObserver implements TransportObserver {
 
         private NoopStreamObserver() {
             // Singleton
-        }
-
-        @Override
-        public void streamIdAssigned(final long streamId) {
-        }
-
-        @Override
-        public DataObserver streamEstablished() {
-            return NoopDataObserver.INSTANCE;
-        }
-
-        @Override
-        public void streamClosed(final Throwable error) {
-        }
-
-        @Override
-        public void streamClosed() {
         }
     }
 
@@ -201,26 +97,6 @@ final class NoopTransportObserver implements TransportObserver {
         private NoopReadObserver() {
             // Singleton
         }
-
-        @Override
-        public void requestedToRead(final long n) {
-        }
-
-        @Override
-        public void itemRead(@Nullable final Object item) {
-        }
-
-        @Override
-        public void readFailed(final Throwable cause) {
-        }
-
-        @Override
-        public void readComplete() {
-        }
-
-        @Override
-        public void readCancelled() {
-        }
     }
 
     static final class NoopWriteObserver implements WriteObserver {
@@ -229,38 +105,6 @@ final class NoopTransportObserver implements TransportObserver {
 
         private NoopWriteObserver() {
             // Singleton
-        }
-
-        @Override
-        public void requestedToWrite(final long n) {
-        }
-
-        @Override
-        public void itemReceived(@Nullable final Object item) {
-        }
-
-        @Override
-        public void onFlushRequest() {
-        }
-
-        @Override
-        public void itemWritten(@Nullable final Object item) {
-        }
-
-        @Override
-        public void itemFlushed() {
-        }
-
-        @Override
-        public void writeFailed(final Throwable cause) {
-        }
-
-        @Override
-        public void writeComplete() {
-        }
-
-        @Override
-        public void writeCancelled() {
         }
     }
 }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObserver.java
@@ -16,7 +16,6 @@
 package io.servicetalk.transport.api;
 
 import io.servicetalk.concurrent.api.Executor;
-import io.servicetalk.transport.api.NoopTransportObserver.NoopConnectionObserver;
 
 import javax.annotation.Nullable;
 
@@ -30,6 +29,7 @@ import javax.annotation.Nullable;
  * is executed inside callbacks without offloading, it will negatively impact {@link IoExecutor} and overall performance
  * of the application.
  */
+@FunctionalInterface
 public interface TransportObserver {
 
     /**
@@ -41,7 +41,7 @@ public interface TransportObserver {
     @Deprecated
     default ConnectionObserver onNewConnection() {
         // FIXME: 0.43 - remove deprecated method
-        return NoopConnectionObserver.INSTANCE;
+        return NoopTransportObserver.NoopConnectionObserver.INSTANCE;
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -47,6 +47,7 @@ import io.servicetalk.transport.netty.internal.CloseHandler.CloseEvent;
 import io.servicetalk.transport.netty.internal.CloseHandler.CloseEventObservedException;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopConnectionObserver;
 import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopDataObserver;
+import io.servicetalk.transport.netty.internal.NoopTransportObserver.NoopReadObserver;
 import io.servicetalk.transport.netty.internal.WriteStreamSubscriber.AbortedFirstWriteException;
 
 import io.netty.channel.Channel;
@@ -550,6 +551,9 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
                 return target;
             }
             final ReadObserver observer = dataObserver.onNewRead();
+            if (observer == NoopReadObserver.INSTANCE) {
+                return target;
+            }
             return new PublisherSource.Subscriber<Read>() {
                 @Override
                 public void onSubscribe(final Subscription subscription) {


### PR DESCRIPTION
Motivation:

`TransportObserver` and all other observers related to it, like `ConnectionObserver`, etc. have quite a lot of methods but users are not interested in all of them at the same time. However, the current interface definition forces users to maintain a lot of boilerplate code.

Modifications:
- Add default implementations for all `ConnectionObserver` methods and for methods of other related observers.
- Remove boilerplate from existing `TransportObserver` implementations.
- `DefaultNettyConnection`: skip wiring `ReadObserver` if it's noop.

Result:

`TransportObserver` implementations that are interested only in subset of callbacks will be able to remove boilerplate code.