### PR TITLE
`[Bi|CatchAll]TransportObserver`: implement deprecated methods too

### DIFF
--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -73,6 +73,13 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
+        public void onTransportHandshakeComplete() {
+            first.onTransportHandshakeComplete();
+            second.onTransportHandshakeComplete();
+        }
+
+        @Override
         public void onTransportHandshakeComplete(final ConnectionInfo info) {
             first.onTransportHandshakeComplete(info);
             second.onTransportHandshakeComplete(info);
@@ -260,6 +267,13 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
+        public void itemRead() {
+            first.itemRead();
+            second.itemRead();
+        }
+
+        @Override
         public void itemRead(@Nullable final Object item) {
             first.itemRead(item);
             second.itemRead(item);
@@ -301,6 +315,13 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
+        public void itemReceived() {
+            first.itemReceived();
+            second.itemReceived();
+        }
+
+        @Override
         public void itemReceived(@Nullable final Object item) {
             first.itemReceived(item);
             second.itemReceived(item);
@@ -310,6 +331,13 @@ final class BiTransportObserver implements TransportObserver {
         public void onFlushRequest() {
             first.onFlushRequest();
             second.onFlushRequest();
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void itemWritten() {
+            first.itemWritten();
+            second.itemWritten();
         }
 
         @Override

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -85,6 +85,12 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
+        public void onTransportHandshakeComplete() {
+            safeReport(observer::onTransportHandshakeComplete, observer, "transport handshake complete");
+        }
+
+        @Override
         public void onTransportHandshakeComplete(final ConnectionInfo info) {
             safeReport(() -> observer.onTransportHandshakeComplete(info), observer, "transport handshake complete");
         }
@@ -256,6 +262,12 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
+        public void itemRead() {
+            safeReport(observer::itemRead, observer, "item read");
+        }
+
+        @Override
         public void itemRead(@Nullable final Object item) {
             safeReport(() -> observer.itemRead(item), observer, "item read");
         }
@@ -290,6 +302,12 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
+        public void itemReceived() {
+            safeReport(observer::itemReceived, observer, "item received");
+        }
+
+        @Override
         public void itemReceived(@Nullable final Object item) {
             safeReport(() -> observer.itemReceived(item), observer, "item received");
         }
@@ -297,6 +315,12 @@ final class CatchAllTransportObserver implements TransportObserver {
         @Override
         public void onFlushRequest() {
             safeReport(observer::onFlushRequest, observer, "flush request");
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void itemWritten() {
+            safeReport(observer::itemWritten, observer, "item written");
         }
 
         @Override


### PR DESCRIPTION
#### Motivation:

This is not a bug because ST does not invoke these deprecated methods anymore, but it's still weird that these two implementations don't cover all possible methods.

#### Modifications:
- Implement deprecated methods for `BiTransportObserver` and `CatchAllTransportObserver`.

#### Result:

`BiTransportObserver` and `CatchAllTransportObserver` have consistent behavior for all methods.