### PR TITLE
`[Http|Grpc]LifecycleObserver`: let users skip uninterested callbacks

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcLifecycleObserver.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcLifecycleObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,10 +60,14 @@ public interface GrpcLifecycleObserver extends HttpLifecycleObserver {
     interface GrpcExchangeObserver extends HttpExchangeObserver {
 
         @Override
-        GrpcRequestObserver onRequest(HttpRequestMetaData requestMetaData);
+        default GrpcRequestObserver onRequest(HttpRequestMetaData requestMetaData) {
+            return NoopGrpcLifecycleObservers.NOOP_GRPC_REQUEST_OBSERVER;
+        }
 
         @Override
-        GrpcResponseObserver onResponse(HttpResponseMetaData responseMetaData);
+        default GrpcResponseObserver onResponse(HttpResponseMetaData responseMetaData) {
+            return NoopGrpcLifecycleObservers.NOOP_GRPC_RESPONSE_OBSERVER;
+        }
     }
 
     /**
@@ -82,7 +86,8 @@ public interface GrpcLifecycleObserver extends HttpLifecycleObserver {
          * the server listens both gRPC and HTTP traffic or receives non-gRPC requests from untrusted peers.
          */
         @Override
-        void onRequestTrailers(HttpHeaders trailers);
+        default void onRequestTrailers(HttpHeaders trailers) {
+        }
     }
 
     /**
@@ -98,6 +103,7 @@ public interface GrpcLifecycleObserver extends HttpLifecycleObserver {
          *
          * @param status the corresponding {@link GrpcStatus}
          */
-        void onGrpcStatus(GrpcStatus status);
+        default void onGrpcStatus(GrpcStatus status) {
+        }
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/NoopGrpcLifecycleObservers.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/NoopGrpcLifecycleObservers.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import io.servicetalk.grpc.api.GrpcLifecycleObserver.GrpcRequestObserver;
+import io.servicetalk.grpc.api.GrpcLifecycleObserver.GrpcResponseObserver;
+
+final class NoopGrpcLifecycleObservers {
+
+    static final GrpcRequestObserver NOOP_GRPC_REQUEST_OBSERVER = new GrpcRequestObserver() { };
+    static final GrpcResponseObserver NOOP_GRPC_RESPONSE_OBSERVER = new GrpcResponseObserver() { };
+
+    private NoopGrpcLifecycleObservers() {
+        // No instances
+    }
+}

--- a/servicetalk-grpc-netty/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-grpc-netty/gradle/spotbugs/test-exclusions.xml
@@ -73,4 +73,10 @@
     </Or>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
+  <!-- Not interested in returned values -->
+  <Match>
+    <Class name="io.servicetalk.grpc.netty.GrpcLifecycleObserverTest"/>
+    <Method name="verifyObservers"/>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserver.java
+++ b/servicetalk-grpc-utils/src/main/java/io/servicetalk/grpc/utils/LoggingGrpcLifecycleObserver.java
@@ -99,10 +99,6 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
         }
 
         @Override
-        public void onRequestDataRequested(final long n) {
-        }
-
-        @Override
         public void onRequestData(final Buffer data) {
             requestSize += data.readableBytes();
         }
@@ -135,10 +131,6 @@ final class LoggingGrpcLifecycleObserver implements GrpcLifecycleObserver {
             assert this.responseMetaData == null;
             this.responseMetaData = responseMetaData;
             return this;
-        }
-
-        @Override
-        public void onResponseDataRequested(final long n) {
         }
 
         @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLifecycleObserver.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpLifecycleObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021-2023, 2025 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,8 @@ public interface HttpLifecycleObserver {
          *
          * @param info {@link ConnectionInfo} of the selected connection
          */
-        void onConnectionSelected(ConnectionInfo info);
+        default void onConnectionSelected(ConnectionInfo info) {
+        }
 
         /**
          * Callback when a request starts.
@@ -72,7 +73,9 @@ public interface HttpLifecycleObserver {
          * @param requestMetaData The corresponding {@link HttpRequestMetaData}
          * @return an {@link HttpRequestObserver} that provides visibility into request events
          */
-        HttpRequestObserver onRequest(HttpRequestMetaData requestMetaData);
+        default HttpRequestObserver onRequest(HttpRequestMetaData requestMetaData) {
+            return NoopHttpLifecycleObservers.NOOP_HTTP_REQUEST_OBSERVER;
+        }
 
         /**
          * Callback when a response meta-data was observed.
@@ -80,21 +83,25 @@ public interface HttpLifecycleObserver {
          * @param responseMetaData the corresponding {@link HttpResponseMetaData}
          * @return an {@link HttpResponseObserver} that provides visibility into response events
          */
-        HttpResponseObserver onResponse(HttpResponseMetaData responseMetaData);
+        default HttpResponseObserver onResponse(HttpResponseMetaData responseMetaData) {
+            return NoopHttpLifecycleObservers.NOOP_HTTP_RESPONSE_OBSERVER;
+        }
 
         /**
          * Callback if the response meta-data was not received due to an error.
          *
          * @param cause the cause of a response meta-data failure
          */
-        void onResponseError(Throwable cause);
+        default void onResponseError(Throwable cause) {
+        }
 
         /**
          * Callback if the response meta-data was cancelled.
          * <p>
          * Cancellation is the best effort, more events may be signaled after cancel.
          */
-        void onResponseCancel();
+        default void onResponseCancel() {
+        }
 
         /**
          * Callback when the exchange completes.
@@ -103,7 +110,8 @@ public interface HttpLifecycleObserver {
          * {@link HttpResponseObserver} terminate or {@link #onResponseError(Throwable)}/{@link #onResponseCancel()}
          * method is invoked.
          */
-        void onExchangeFinally();
+        default void onExchangeFinally() {
+        }
     }
 
     /**
@@ -122,7 +130,7 @@ public interface HttpLifecycleObserver {
          *
          * @param n number of requested items
          */
-        default void onRequestDataRequested(long n) {   // FIXME: 0.43 - consider removing default impl
+        default void onRequestDataRequested(long n) {
         }
 
         /**
@@ -132,21 +140,24 @@ public interface HttpLifecycleObserver {
          *
          * @param data the request payload body data chunk
          */
-        void onRequestData(Buffer data);
+        default void onRequestData(Buffer data) {
+        }
 
         /**
          * Callback when request trailers were observed.
          *
          * @param trailers trailers of the request
          */
-        void onRequestTrailers(HttpHeaders trailers);
+        default void onRequestTrailers(HttpHeaders trailers) {
+        }
 
         /**
          * Callback if the request completes successfully.
          * <p>
          * This is one of the possible terminal events.
          */
-        void onRequestComplete();
+        default void onRequestComplete() {
+        }
 
         /**
          * Callback if the request fails with an error.
@@ -155,7 +166,8 @@ public interface HttpLifecycleObserver {
          *
          * @param cause {@link Throwable} that fails this request
          */
-        void onRequestError(Throwable cause);
+        default void onRequestError(Throwable cause) {
+        }
 
         /**
          * Callback if the request is cancelled.
@@ -163,7 +175,8 @@ public interface HttpLifecycleObserver {
          * This is one of the possible terminal events.
          * Cancellation is the best effort, more events may be signaled after cancel.
          */
-        void onRequestCancel();
+        default void onRequestCancel() {
+        }
     }
 
     /**
@@ -182,7 +195,7 @@ public interface HttpLifecycleObserver {
          *
          * @param n number of requested items
          */
-        default void onResponseDataRequested(long n) {  // FIXME: 0.43 - consider removing default impl
+        default void onResponseDataRequested(long n) {
         }
 
         /**
@@ -192,21 +205,24 @@ public interface HttpLifecycleObserver {
          *
          * @param data the response payload body data chunk
          */
-        void onResponseData(Buffer data);
+        default void onResponseData(Buffer data) {
+        }
 
         /**
          * Callback when response trailers were observed.
          *
          * @param trailers trailers of the response
          */
-        void onResponseTrailers(HttpHeaders trailers);
+        default void onResponseTrailers(HttpHeaders trailers) {
+        }
 
         /**
          * Callback when the response completes successfully.
          * <p>
          * This is one of the possible terminal events.
          */
-        void onResponseComplete();
+        default void onResponseComplete() {
+        }
 
         /**
          * Callback when the response fails with an error.
@@ -215,7 +231,8 @@ public interface HttpLifecycleObserver {
          *
          * @param cause {@link Throwable} that terminated this response
          */
-        void onResponseError(Throwable cause);
+        default void onResponseError(Throwable cause) {
+        }
 
         /**
          * Callback when the response is cancelled.
@@ -223,6 +240,7 @@ public interface HttpLifecycleObserver {
          * This is one of the possible terminal events.
          * Cancellation is the best effort, more events may be signaled after cancel.
          */
-        void onResponseCancel();
+        default void onResponseCancel() {
+        }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/NoopHttpLifecycleObservers.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/NoopHttpLifecycleObservers.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.http.api.HttpLifecycleObserver.HttpRequestObserver;
+import io.servicetalk.http.api.HttpLifecycleObserver.HttpResponseObserver;
+
+final class NoopHttpLifecycleObservers {
+
+    static final HttpRequestObserver NOOP_HTTP_REQUEST_OBSERVER = new HttpRequestObserver() { };
+    static final HttpResponseObserver NOOP_HTTP_RESPONSE_OBSERVER = new HttpResponseObserver() { };
+
+    private NoopHttpLifecycleObservers() {
+        // No instances
+    }
+}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpMessageDiscardWatchdogServiceFilter.java
@@ -23,7 +23,6 @@ import io.servicetalk.http.api.HttpExecutionStrategies;
 import io.servicetalk.http.api.HttpExecutionStrategy;
 import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpRequestMetaData;
-import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
@@ -31,7 +30,6 @@ import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpService;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
 import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
-import io.servicetalk.transport.api.ConnectionInfo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,7 +122,6 @@ final class HttpMessageDiscardWatchdogServiceFilter implements StreamingHttpServ
 
         @Override
         public HttpExchangeObserver onNewExchange() {
-
             return new HttpExchangeObserver() {
 
                 @Nullable
@@ -133,12 +130,7 @@ final class HttpMessageDiscardWatchdogServiceFilter implements StreamingHttpServ
                 @Override
                 public HttpRequestObserver onRequest(final HttpRequestMetaData requestMetaData) {
                     this.requestContext = requestMetaData.context();
-                    return NoopHttpLifecycleObserver.NoopHttpRequestObserver.INSTANCE;
-                }
-
-                @Override
-                public HttpResponseObserver onResponse(final HttpResponseMetaData responseMetaData) {
-                    return NoopHttpLifecycleObserver.NoopHttpResponseObserver.INSTANCE;
+                    return HttpExchangeObserver.super.onRequest(requestMetaData);
                 }
 
                 @Override
@@ -154,18 +146,6 @@ final class HttpMessageDiscardWatchdogServiceFilter implements StreamingHttpServ
                                     "be fully consumed before discarding.");
                         }
                     }
-                }
-
-                @Override
-                public void onConnectionSelected(final ConnectionInfo info) {
-                }
-
-                @Override
-                public void onResponseError(final Throwable cause) {
-                }
-
-                @Override
-                public void onResponseCancel() {
                 }
             };
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NoopHttpLifecycleObserver.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NoopHttpLifecycleObserver.java
@@ -15,12 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
-import io.servicetalk.buffer.api.Buffer;
-import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpLifecycleObserver;
-import io.servicetalk.http.api.HttpRequestMetaData;
-import io.servicetalk.http.api.HttpResponseMetaData;
-import io.servicetalk.transport.api.ConnectionInfo;
 
 final class NoopHttpLifecycleObserver implements HttpLifecycleObserver {
 
@@ -42,32 +37,6 @@ final class NoopHttpLifecycleObserver implements HttpLifecycleObserver {
         private NoopHttpExchangeObserver() {
             // Singleton
         }
-
-        @Override
-        public void onConnectionSelected(final ConnectionInfo info) {
-        }
-
-        @Override
-        public HttpRequestObserver onRequest(final HttpRequestMetaData requestMetaData) {
-            return NoopHttpRequestObserver.INSTANCE;
-        }
-
-        @Override
-        public HttpResponseObserver onResponse(final HttpResponseMetaData responseMetaData) {
-            return NoopHttpResponseObserver.INSTANCE;
-        }
-
-        @Override
-        public void onResponseError(final Throwable cause) {
-        }
-
-        @Override
-        public void onResponseCancel() {
-        }
-
-        @Override
-        public void onExchangeFinally() {
-        }
     }
 
     static final class NoopHttpRequestObserver implements HttpRequestObserver {
@@ -77,30 +46,6 @@ final class NoopHttpLifecycleObserver implements HttpLifecycleObserver {
         private NoopHttpRequestObserver() {
             // Singleton
         }
-
-        @Override
-        public void onRequestDataRequested(final long n) {
-        }
-
-        @Override
-        public void onRequestData(final Buffer data) {
-        }
-
-        @Override
-        public void onRequestTrailers(final HttpHeaders trailers) {
-        }
-
-        @Override
-        public void onRequestComplete() {
-        }
-
-        @Override
-        public void onRequestError(final Throwable cause) {
-        }
-
-        @Override
-        public void onRequestCancel() {
-        }
     }
 
     static final class NoopHttpResponseObserver implements HttpResponseObserver {
@@ -109,30 +54,6 @@ final class NoopHttpLifecycleObserver implements HttpLifecycleObserver {
 
         private NoopHttpResponseObserver() {
             // Singleton
-        }
-
-        @Override
-        public void onResponseDataRequested(final long n) {
-        }
-
-        @Override
-        public void onResponseData(final Buffer data) {
-        }
-
-        @Override
-        public void onResponseTrailers(final HttpHeaders trailers) {
-        }
-
-        @Override
-        public void onResponseComplete() {
-        }
-
-        @Override
-        public void onResponseError(final Throwable cause) {
-        }
-
-        @Override
-        public void onResponseCancel() {
         }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpServiceAsyncContextTest.java
@@ -547,15 +547,14 @@ abstract class AbstractHttpServiceAsyncContextTest {
         assertNoAsyncErrors(errorQueue);
     }
 
-    private static void makeClientRequestWithIdExpectError(BlockingHttpConnection connection,
-                                                  String requestId) {
+    private static void makeClientRequestWithIdExpectError(BlockingHttpConnection connection, String requestId) {
         HttpRequest request = connection.get("/");
         request.headers().set(REQUEST_ID_HEADER, requestId);
         assertThrows(Exception.class, () -> connection.request(request));
     }
 
     private static void makeClientRequestWithIdExpectCancel(BlockingHttpConnection connection,
-                                                           String requestId, CountDownLatch latch) throws Exception {
+                                                            String requestId, CountDownLatch latch) throws Exception {
         HttpConnection streamingConnection = connection.asConnection();
         HttpRequest request = connection.get("/");
         request.headers().set(REQUEST_ID_HEADER, requestId);
@@ -563,7 +562,7 @@ abstract class AbstractHttpServiceAsyncContextTest {
                 .toFuture();
         latch.await();
         responseFuture.cancel(true);
-        assertThrows(Exception.class, () -> responseFuture.get());
+        assertThrows(Exception.class, responseFuture::get);
     }
 
     private static String makeClientRequestWithId(BlockingHttpConnection connection,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionObserverEventOrderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionObserverEventOrderTest.java
@@ -88,13 +88,13 @@ class ConnectionObserverEventOrderTest {
                 @Override
                 public HttpRequestObserver onRequest(HttpRequestMetaData requestMetaData) {
                     addEvent();
-                    return NoopHttpLifecycleObserver.NoopHttpRequestObserver.INSTANCE;
+                    return HttpExchangeObserver.super.onRequest(requestMetaData);
                 }
 
                 @Override
                 public HttpResponseObserver onResponse(HttpResponseMetaData responseMetaData) {
                     addEvent();
-                    return NoopHttpLifecycleObserver.NoopHttpResponseObserver.INSTANCE;
+                    return HttpExchangeObserver.super.onResponse(responseMetaData);
                 }
 
                 @Override

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
@@ -95,10 +95,6 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
         }
 
         @Override
-        public void onRequestDataRequested(final long n) {
-        }
-
-        @Override
         public void onRequestData(final Buffer data) {
             requestSize += data.readableBytes();
         }
@@ -131,10 +127,6 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
             assert this.responseMetaData == null;
             this.responseMetaData = responseMetaData;
             return this;
-        }
-
-        @Override
-        public void onResponseDataRequested(final long n) {
         }
 
         @Override

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestHttpLifecycleObserver.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestHttpLifecycleObserver.java
@@ -20,7 +20,6 @@ import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpLifecycleObserver;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseMetaData;
-import io.servicetalk.transport.api.ConnectionInfo;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
@@ -63,9 +62,6 @@ final class TestHttpLifecycleObserver implements HttpLifecycleObserver {
     public HttpExchangeObserver onNewExchange() {
         setKey(ON_NEW_EXCHANGE_KEY);
         return new HttpExchangeObserver() {
-            @Override
-            public void onConnectionSelected(ConnectionInfo info) {
-            }
 
             @Override
             public HttpRequestObserver onRequest(HttpRequestMetaData requestMetaData) {

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/NoopTransportObserver.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 final class NoopTransportObserver implements TransportObserver {
 
     private NoopTransportObserver() {
-        // Singleton
+        // No instances
     }
 
     @Override


### PR DESCRIPTION
#### Motivation:

`[Http|Grpc]LifecycleObserver` and all other observers related to it, like `HttpExchangeObserver`, etc. have quite a lot of methods but users are not interested in all of them at the same time. However, the current interface definition forces users to maintain a lot of boilerplate code.

Modifications:
- Add default implementations for all `HttpExchangeObserver` methods and for methods of other related observers.
- Remove boilerplate from existing observer implementations.

Result:

`[Http|Grpc]LifecycleObserver` implementations that are interested only in subset of callbacks will be able to remove boilerplate code.

Similar to #3297.