### PR TITLE
traffic-resilience-http: Consider the request body for ticket lifetimes

### DIFF
--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/AbstractTrafficResilienceHttpFilter.java
@@ -30,7 +30,7 @@ import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
-import io.servicetalk.http.utils.BeforeFinallyHttpOperator;
+import io.servicetalk.http.utils.AfterFinallyHttpOperator;
 import io.servicetalk.traffic.resilience.http.ClientPeerRejectionPolicy.PassthroughRequestDroppedException;
 import io.servicetalk.traffic.resilience.http.TrafficResiliencyObserver.TicketObserver;
 import io.servicetalk.transport.api.ServerListenContext;
@@ -282,8 +282,8 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
                     }
                     return Single.succeeded(resp).shareContextOnSubscribe();
                 })
-                .liftSync(new BeforeFinallyHttpOperator(
-                        new SignalConsumer(this, ticket, ticketObserver, breaker, startTimeNs), true));
+                .liftSync(new AfterFinallyHttpOperator(
+                        new SignalConsumer(this, request, ticket, ticketObserver, breaker, startTimeNs), true));
     }
 
     private Single<StreamingHttpResponse> dryRunHandleAllow(
@@ -292,7 +292,7 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             final Ticket ticket,
             final TicketObserver ticketObserver, @Nullable final CircuitBreaker breaker, final long startTimeNs) {
         SignalConsumer signalConsumer = new SignalConsumer(
-                this, ticket, ticketObserver, breaker, startTimeNs);
+                this, request, ticket, ticketObserver, breaker, startTimeNs);
         return delegate.apply(request)
                 // This logic has the same general structure as the `handleAllow` case, but there is a twist: we want
                 // to always return the successful single even when we fail the predicates. Because we use a latch in
@@ -308,13 +308,17 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
                     }
                     return resp;
                 })
-                .liftSync(new BeforeFinallyHttpOperator(signalConsumer, true));
+                .liftSync(new AfterFinallyHttpOperator(signalConsumer, true));
     }
 
-    private static final class SignalConsumer implements TerminalSignalConsumer {
+    private static class SignalConsumer implements TerminalSignalConsumer {
 
-        private static final AtomicIntegerFieldUpdater<SignalConsumer> SIGNALLED_UPDATER =
-                AtomicIntegerFieldUpdater.newUpdater(SignalConsumer.class, "signalled");
+        private static final AtomicIntegerFieldUpdater<SignalConsumer> STATE_UPDATER =
+                AtomicIntegerFieldUpdater.newUpdater(SignalConsumer.class, "state");
+        private static final int IDLE = 0;
+        private static final int REQUEST_COMPLETE = 1;
+        private static final int RESPONSE_COMPLETE = 2;
+        private static final int FINISHED = 3;
 
         private final AbstractTrafficResilienceHttpFilter parent;
         private final Ticket ticket;
@@ -323,23 +327,49 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
         private final CircuitBreaker breaker;
         private final long startTimeNs;
 
-        private volatile int signalled;
+        // We store our state in the `state` variable. For responses, we must also store whether we cancelled
+        // or if we errored. In those cases we set the field before transitioning state so we get memory visibility
+        // without needing to make those fields volatile as well.
+        private volatile int state = IDLE;
+        @Nullable
+        private Throwable responseError;
+        private boolean cancelled;
 
-        SignalConsumer(final AbstractTrafficResilienceHttpFilter parent, final Ticket ticket,
-                              final TicketObserver ticketObserver, @Nullable final CircuitBreaker breaker,
-                              final long startTimeNs) {
+        SignalConsumer(final AbstractTrafficResilienceHttpFilter parent, StreamingHttpRequest request,
+                              final Ticket ticket, final TicketObserver ticketObserver,
+                              @Nullable final CircuitBreaker breaker, final long startTimeNs) {
             this.parent = parent;
             this.ticket = ticket;
             this.ticketObserver = ticketObserver;
             this.breaker = breaker;
             this.startTimeNs = startTimeNs;
+            request.transformMessageBody(body -> body.afterFinally(this::requestComplete));
         }
 
         @Override
         public void onComplete() {
-            if (!once()) {
-                return;
+            if (responseFinished()) {
+                doOnComplete();
             }
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+            responseError = throwable;
+            if (responseFinished()) {
+                doOnError(throwable);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            if (responseFinished()) {
+                doCancel();
+            }
+        }
+
+        private void doOnComplete() {
             try {
                 if (breaker != null) {
                     breaker.onSuccess(nanoTime() - startTimeNs, NANOSECONDS);
@@ -350,20 +380,12 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             }
         }
 
-        @Override
-        public void onError(final Throwable throwable) {
-            if (!once()) {
-                return;
-            }
+        private void doOnError(final Throwable throwable) {
             parent.onError(throwable, breaker, startTimeNs, ticket);
             ticketObserver.onError(throwable);
         }
 
-        @Override
-        public void cancel() {
-            if (!once()) {
-                return;
-            }
+        private void doCancel() {
             try {
                 if (breaker != null) {
                     breaker.ignorePermit();
@@ -374,8 +396,32 @@ abstract class AbstractTrafficResilienceHttpFilter implements HttpExecutionStrat
             }
         }
 
-        private boolean once() {
-            return SIGNALLED_UPDATER.compareAndSet(this, 0, 1);
+        private void requestComplete() {
+            if (STATE_UPDATER.compareAndSet(this, IDLE, REQUEST_COMPLETE)) {
+                // nothing to do: it's up to the response to finish now.
+                return;
+            }
+            if (STATE_UPDATER.compareAndSet(this, RESPONSE_COMPLETE, FINISHED)) {
+                // This operation completed the sequence. We need to finish according to how the response completed.
+                // Technically response error and cancellation can race. We give preference to the response error
+                // form because that will likely be the more interesting in terms of observability.
+                Throwable responseError = this.responseError;
+                if (responseError != null) {
+                    doOnError(responseError);
+                } else if (cancelled) {
+                    doCancel();
+                } else {
+                    doOnComplete();
+                }
+            }
+        }
+
+        private boolean responseFinished() {
+            if (STATE_UPDATER.compareAndSet(this, IDLE, RESPONSE_COMPLETE)) {
+                // nothing to do: it's up to the request to finish now.
+                return false;
+            }
+            return STATE_UPDATER.compareAndSet(this, REQUEST_COMPLETE, FINISHED);
         }
     }
 

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilter.java
@@ -149,7 +149,7 @@ public final class TrafficResilienceHttpClientFilter extends AbstractTrafficResi
                                               final boolean dryRun) {
         super(capacityPartitionsSupplier, rejectWhenNotMatchedCapacityPartition, classifier,
                 clientPeerRejectionPolicy.predicate(), breakerRejectionPredicate, onCompletion, onCancellation,
-                onError, circuitBreakerPartitionsSupplier, observer, dryRun);
+                onError, circuitBreakerPartitionsSupplier, observer, /*isClient*/ true, dryRun);
         this.clientPeerRejectionPolicy = clientPeerRejectionPolicy;
         this.forceOpenCircuitOnPeerCircuitRejections = forceOpenCircuitOnPeerCircuitRejections;
         this.focreOpenCircuitOnPeerCircuitRejectionsDelayProvider =

--- a/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilter.java
+++ b/servicetalk-traffic-resilience-http/src/main/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilter.java
@@ -96,7 +96,8 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
                                                final TrafficResiliencyObserver observer,
                                                final boolean dryRun) {
         super(capacityPartitionsSupplier, rejectNotMatched, classifier, __ -> false, __ -> false,
-                onCompletion, onCancellation, onError, circuitBreakerPartitionsSupplier, observer, dryRun);
+                onCompletion, onCancellation, onError, circuitBreakerPartitionsSupplier, observer,
+                /*isClient*/ false, dryRun);
         this.serviceRejectionPolicy = onServiceRejectionPolicy;
     }
 
@@ -108,7 +109,7 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
             final Function<HttpRequestMetaData, CapacityLimiter> capacityPartitions = newCapacityPartitions();
             final Function<HttpRequestMetaData, CircuitBreaker> circuitBreakerPartitions =
                     newCircuitBreakerPartitions();
-            final Function<HttpRequestMetaData, Classification> clacifier = newClassifier();
+            final Function<HttpRequestMetaData, Classification> classifier = newClassifier();
             final Function<HttpResponseMetaData, Duration> delayProvider = newDelayProvider();
 
             @Override
@@ -118,7 +119,7 @@ public final class TrafficResilienceHttpServiceFilter extends AbstractTrafficRes
                 final ServerListenContext actualContext = ctx.parent() instanceof ServerListenContext ?
                         (ServerListenContext) ctx.parent() :
                         ctx;
-                return applyCapacityControl(capacityPartitions, circuitBreakerPartitions, clacifier, delayProvider,
+                return applyCapacityControl(capacityPartitions, circuitBreakerPartitions, classifier, delayProvider,
                         actualContext, request, responseFactory,
                         request1 -> delegate().handle(ctx, request1, responseFactory));
             }

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
@@ -26,19 +26,27 @@ import io.servicetalk.concurrent.internal.DeliberateException;
 import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.FilterableStreamingHttpClient;
+import io.servicetalk.http.api.HttpClient;
 import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.StreamingHttpClientFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.netty.HttpClients;
+import io.servicetalk.http.netty.HttpServers;
+import io.servicetalk.transport.api.ServerContext;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,11 +54,17 @@ import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpResponseStatus.BAD_GATEWAY;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.HttpResponseStatus.TOO_MANY_REQUESTS;
 import static io.servicetalk.traffic.resilience.http.ClientPeerRejectionPolicy.ofPassthrough;
 import static io.servicetalk.traffic.resilience.http.ClientPeerRejectionPolicy.ofRejection;
+import static io.servicetalk.traffic.resilience.http.ClientPeerRejectionPolicy.ofRejectionWithRetries;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -188,6 +202,140 @@ class TrafficResilienceHttpClientFilterTest {
         verify(ticket).failed(DELIBERATE_EXCEPTION);
         verify(ticket, atLeastOnce()).state();
         verifyNoMoreInteractions(limiter, ticket);
+    }
+
+    @Test
+    void testPassThroughUnderCapacity() throws Exception {
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok())) {
+
+            final TrafficResilienceHttpClientFilter filter =
+                    new TrafficResilienceHttpClientFilter.Builder(() -> CapacityLimiters.fixedCapacity(2).build())
+                            .build();
+
+            try (HttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                    .appendClientFilter(filter)
+                    .build()) {
+
+                HttpResponse response = client.request(client.newRequest(HttpRequestMethod.GET, "/"))
+                        .toFuture().get();
+
+                assertThat(response.status(), is(OK));
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] dryRun={0}")
+    @ValueSource(booleans = {false, true})
+    void testPeerRejectionHandling(boolean dryRun) throws Exception {
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                    // Simulate peer rejection
+                    return responseFactory.badGateway();
+                })) {
+
+            final TrafficResilienceHttpClientFilter filter =
+                    new TrafficResilienceHttpClientFilter.Builder(() -> CapacityLimiters.fixedCapacity(5).build())
+                            .rejectionPolicy(ofRejection(resp -> BAD_GATEWAY.equals(resp.status())))
+                            .dryRun(dryRun)
+                            .build();
+
+            try (HttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                    .appendClientFilter(filter)
+                    .build()) {
+
+                if (dryRun) {
+                    // In dry run mode, the response should pass through
+                    HttpResponse response = client.request(client.newRequest(HttpRequestMethod.GET, "/"))
+                            .toFuture().get();
+                    assertThat(response.status(), is(BAD_GATEWAY));
+                } else {
+                    // In normal mode, should throw RequestDroppedException
+                    ExecutionException exception = assertThrows(ExecutionException.class, () ->
+                            client.request(client.newRequest(HttpRequestMethod.GET, "/")).toFuture().get());
+
+                    assertThat(exception.getCause(), is(instanceOf(RequestDroppedException.class)));
+                }
+            }
+        }
+    }
+
+    @Test
+    void testRejectionWhenHittingWatermark() throws Exception {
+        // Use CountDownLatch to control when server responses are sent
+        final CountDownLatch releaseFirstRequest = new CountDownLatch(1);
+        final CountDownLatch firstRequestStarted = new CountDownLatch(1);
+
+        final TrafficResilienceHttpClientFilter filter =
+                new TrafficResilienceHttpClientFilter.Builder(() -> CapacityLimiters.fixedCapacity(1).build())
+                        .build();
+
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                    // Signal that first request has started
+                    firstRequestStarted.countDown();
+                    try {
+                        // Block until we signal to release
+                        releaseFirstRequest.await();
+                        return responseFactory.ok();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                })) {
+
+            try (HttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                    .appendClientFilter(filter)
+                    .build()) {
+
+                // Start first request asynchronously (will hold capacity)
+                Future<HttpResponse> firstResponse = client.request(
+                        client.newRequest(HttpRequestMethod.GET, "/first")).toFuture();
+
+                // Wait for first request to reach server and hold capacity
+                firstRequestStarted.await();
+
+                // Second request should be rejected immediately due to capacity limit
+                ExecutionException exception = assertThrows(ExecutionException.class, () ->
+                        client.request(client.newRequest(HttpRequestMethod.GET, "/second")).toFuture().get());
+
+                assertThat(exception.getCause(), is(instanceOf(RequestDroppedException.class)));
+
+                // Release the first request
+                releaseFirstRequest.countDown();
+
+                // Verify first request completes successfully
+                HttpResponse response = firstResponse.get();
+                assertThat(response.status(), is(OK));
+            }
+        }
+    }
+
+    @Test
+    void testRetryablePeerRejectionHandling() throws Exception {
+        try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                    // Simulate peer rejection with TOO_MANY_REQUESTS
+                    return responseFactory.tooManyRequests();
+                })) {
+
+            final TrafficResilienceHttpClientFilter filter =
+                    new TrafficResilienceHttpClientFilter.Builder(() -> CapacityLimiters.fixedCapacity(5).build())
+                            .rejectionPolicy(ofRejectionWithRetries(
+                                    resp -> TOO_MANY_REQUESTS.equals(resp.status()),
+                                    resp -> Duration.ofMillis(100)))
+                            .build();
+
+            try (HttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                    .appendClientFilter(filter)
+                    .build()) {
+
+                ExecutionException exception = assertThrows(ExecutionException.class, () ->
+                        client.request(client.newRequest(HttpRequestMethod.GET, "/")).toFuture().get());
+
+                assertThat(exception.getCause(), is(instanceOf(DelayedRetryRequestDroppedException.class)));
+            }
+        }
     }
 
     static StreamingHttpRequest newRequest() {

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpClientFilterTest.java
@@ -307,6 +307,9 @@ class TrafficResilienceHttpClientFilterTest {
                 // Verify first request completes successfully
                 HttpResponse response = firstResponse.get();
                 assertThat(response.status(), is(OK));
+
+                // Now try a new request to make our limiter has recovered.
+                client.request(client.newRequest(HttpRequestMethod.GET, "/third")).toFuture().get();
             }
         }
     }


### PR DESCRIPTION
Motivation:

We don't currently track the request lifetime with our capacity limiters but these can be particularly relavent if we're streaming bidirectionally.

Modifications:

Also track the request body.

Result:

More correctness.

#### Motivation
<!-- Explain the context around why you're making this change. What is the problem you're trying to solve. -->

#### Modifications
<!-- Describe or list the modifications you've done. -->

#### Result
<!-- Describe the final outcome of this change. Highlight if there is any risk, behavior change, or API change. -->
