### PR TITLE
Always return `DomainSocketAddress` for Unix Domain Socket transport

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
@@ -15,66 +15,176 @@
  */
 package io.servicetalk.grpc.netty;
 
+import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
+import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.api.GrpcServerContext;
 import io.servicetalk.grpc.api.GrpcServiceContext;
-import io.servicetalk.transport.api.IoExecutor;
-import io.servicetalk.transport.api.ServerContext;
+import io.servicetalk.http.api.HttpConnectionContext;
+import io.servicetalk.http.api.StreamingHttpConnectionFilter;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.DelegatingConnectionAcceptor;
+import io.servicetalk.transport.api.DomainSocketAddress;
+import io.servicetalk.transport.api.TransportObserver;
+import io.servicetalk.transport.netty.internal.GlobalExecutionContext;
 
 import io.grpc.examples.helloworld.Greeter.BlockingGreeterClient;
+import io.grpc.examples.helloworld.Greeter.BlockingGreeterService;
 import io.grpc.examples.helloworld.Greeter.ClientFactory;
-import io.grpc.examples.helloworld.Greeter.GreeterService;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.ExecutionException;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.grpc.netty.GrpcClients.forResolvedAddress;
 import static io.servicetalk.grpc.netty.GrpcServers.forAddress;
-import static io.servicetalk.transport.netty.NettyIoExecutors.createIoExecutor;
 import static io.servicetalk.transport.netty.internal.AddressUtils.newSocketAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class GrpcUdsTest {
-    @Nullable
-    private static IoExecutor ioExecutor;
-
-    @BeforeAll
-    static void beforeClass() {
-        ioExecutor = createIoExecutor("io-executor");
-    }
-
-    @AfterAll
-    static void afterClass() throws ExecutionException, InterruptedException {
-        ioExecutor.closeAsync().toFuture().get();
-    }
 
     @Test
     void udsRoundTrip() throws Exception {
-        assumeTrue(ioExecutor.isUnixDomainSocketSupported());
+        assumeTrue(GlobalExecutionContext.globalExecutionContext().ioExecutor().isUnixDomainSocketSupported(),
+                "Unix Domain Socket is not supported in this environment");
+
+        Queue<Throwable> errors = new LinkedBlockingQueue<>();
+
         String greetingPrefix = "Hello ";
         String name = "foo";
-        try (ServerContext serverContext = forAddress(newSocketAddress())
-                .initializeHttp(builder -> builder.ioExecutor(ioExecutor))
-                .listenAndAwait(new GreeterService() {
+        DomainSocketAddress domainSocketAddress = newSocketAddress();
+        try (GrpcServerContext serverContext = forAddress(domainSocketAddress)
+                .initializeHttp(builder -> builder
+                        .appendEarlyConnectionAcceptor(ctx -> {
+                            assertSameAddress(ctx.localAddress(), domainSocketAddress, errors);
+                            assertSameAddressType(ctx.remoteAddress(), domainSocketAddress, errors);
+                            return Completable.completed();
+                        })
+                        .appendLateConnectionAcceptor(ctx -> {
+                            assertSameAddress(ctx.localAddress(), domainSocketAddress, errors);
+                            assertSameAddressType(ctx.remoteAddress(), domainSocketAddress, errors);
+                            return Completable.completed();
+                        })
+                        .appendConnectionAcceptorFilter(original -> new DelegatingConnectionAcceptor(original) {
+                            @Override
+                            public Completable accept(ConnectionContext ctx) {
+                                assertSameAddress(ctx.localAddress(), domainSocketAddress, errors);
+                                assertSameAddressType(ctx.remoteAddress(), domainSocketAddress, errors);
+                                return Completable.completed();
+                            }
+                        })
+                        .transportObserver(new AssertingTransportObserver(false, domainSocketAddress, errors)))
+                .listenAndAwait(new BlockingGreeterService() {
                     @Override
-                    public Single<HelloReply> sayHello(GrpcServiceContext ctx, HelloRequest request) {
-                        return succeeded(HelloReply.newBuilder()
-                                .setMessage(greetingPrefix + request.getName()).build());
+                    public HelloReply sayHello(GrpcServiceContext ctx, HelloRequest request) {
+                        assertSameAddress(ctx.localAddress(), domainSocketAddress, errors);
+                        assertSameAddressType(ctx.remoteAddress(), domainSocketAddress, errors);
+                        return HelloReply.newBuilder().setMessage(greetingPrefix + request.getName()).build();
                     }
-                });
-             BlockingGreeterClient client = forResolvedAddress(serverContext.listenAddress())
-                     .buildBlocking(new ClientFactory())) {
-            HelloRequest request = HelloRequest.newBuilder().setName(name).build();
-            HelloReply response = client.sayHello(request);
-            assertThat(response.getMessage(), is(equalTo(greetingPrefix + name)));
+                })) {
+
+            assertSameAddress(serverContext.listenAddress(), domainSocketAddress, errors);
+            try (BlockingGreeterClient client = forResolvedAddress(domainSocketAddress)
+                    .initializeHttp(builder -> builder
+                            .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(
+                                    new AssertingTransportObserver(true, domainSocketAddress, errors)))
+                            .appendConnectionFilter(connection -> new StreamingHttpConnectionFilter(connection) {
+                                @Override
+                                public Single<StreamingHttpResponse> request(final StreamingHttpRequest request) {
+                                    HttpConnectionContext ctx = connectionContext();
+                                    assertSameAddressType(ctx.localAddress(), domainSocketAddress, errors);
+                                    assertSameAddress(ctx.remoteAddress(), domainSocketAddress, errors);
+                                    return delegate().request(request);
+                                }
+                            })).buildBlocking(new ClientFactory())) {
+
+                HelloRequest request = HelloRequest.newBuilder().setName(name).build();
+                HelloReply response = client.sayHello(request);
+                assertThat(response.getMessage(), is(equalTo(greetingPrefix + name)));
+            }
+        }
+    }
+
+    private static void assertSameAddress(Object actual, DomainSocketAddress expected, Queue<Throwable> errors) {
+        try {
+            assertThat(actual, is(instanceOf(expected.getClass())));
+            assertThat(((DomainSocketAddress) actual).getPath(), is(equalTo(expected.getPath())));
+        } catch (Throwable t) {
+            errors.add(t);
+        }
+    }
+
+    private static void assertSameAddressType(Object actual, DomainSocketAddress expected, Queue<Throwable> errors) {
+        try {
+            assertThat(actual, is(instanceOf(expected.getClass())));
+            assertThat(((DomainSocketAddress) actual).getPath(), is(emptyString()));
+        } catch (Throwable t) {
+            errors.add(t);
+        }
+    }
+
+    private static final class AssertingTransportObserver implements TransportObserver, ConnectionObserver {
+        private final boolean isClient;
+        private final DomainSocketAddress domainSocketAddress;
+        private final Queue<Throwable> errors;
+
+        AssertingTransportObserver(boolean isClient, DomainSocketAddress domainSocketAddress,
+                                   Queue<Throwable> errors) {
+            this.isClient = isClient;
+            this.domainSocketAddress = domainSocketAddress;
+            this.errors = errors;
+        }
+
+        @Override
+        public ConnectionObserver onNewConnection(@Nullable Object localAddress, Object remoteAddress) {
+            try {
+                if (isClient) {
+                    assertThat(localAddress, is(nullValue()));
+                    assertSameAddress(remoteAddress, domainSocketAddress, errors);
+                } else {
+                    assertThat(localAddress, is(notNullValue()));
+                    assertSameAddress(localAddress, domainSocketAddress, errors);
+                    assertSameAddressType(remoteAddress, domainSocketAddress, errors);
+                }
+            } catch (Throwable t) {
+                errors.add(t);
+            }
+            return this;
+        }
+
+        @Override
+        public void onTransportHandshakeComplete(ConnectionInfo info) {
+            assertInfo(info);
+        }
+
+        @Override
+        public DataObserver connectionEstablished(ConnectionInfo info) {
+            assertInfo(info);
+            return ConnectionObserver.super.connectionEstablished(info);
+        }
+
+        private void assertInfo(ConnectionInfo info) {
+            if (isClient) {
+                assertSameAddressType(info.localAddress(), domainSocketAddress, errors);
+                assertSameAddress(info.remoteAddress(), domainSocketAddress, errors);
+            } else {
+                assertSameAddress(info.localAddress(), domainSocketAddress, errors);
+                assertSameAddressType(info.remoteAddress(), domainSocketAddress, errors);
+            }
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ParentConnectionContext.java
@@ -58,6 +58,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.netty.HttpExecutionContextUtils.channelExecutionContext;
 import static io.servicetalk.http.netty.NettyHttp2ExceptionUtils.wrapIfNecessary;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.fromNettyAddress;
 import static io.servicetalk.transport.netty.internal.NettyPipelineSslUtils.extractSslSession;
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.getOption;
 
@@ -111,12 +112,12 @@ class H2ParentConnectionContext extends NettyChannelListenableAsyncCloseable imp
 
     @Override
     public final SocketAddress localAddress() {
-        return channel().localAddress();
+        return fromNettyAddress(channel().localAddress());
     }
 
     @Override
     public final SocketAddress remoteAddress() {
-        return channel().remoteAddress();
+        return fromNettyAddress(channel().remoteAddress());
     }
 
     @Nullable

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/EarlyConnectionContext.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/EarlyConnectionContext.java
@@ -27,6 +27,7 @@ import java.net.SocketOption;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
+import static io.servicetalk.transport.netty.internal.BuilderUtils.fromNettyAddress;
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.getOption;
 
 final class EarlyConnectionContext extends NettyChannelListenableAsyncCloseable implements ConnectionContext {
@@ -57,12 +58,12 @@ final class EarlyConnectionContext extends NettyChannelListenableAsyncCloseable 
 
     @Override
     public SocketAddress localAddress() {
-        return channel.localAddress();
+        return fromNettyAddress(channel.localAddress());
     }
 
     @Override
     public SocketAddress remoteAddress() {
-        return channel.remoteAddress();
+        return fromNettyAddress(channel.remoteAddress());
     }
 
     @Override

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerBinder.java
@@ -56,6 +56,7 @@ import static io.servicetalk.concurrent.api.Completable.defer;
 import static io.servicetalk.concurrent.api.Executors.immediate;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.fromNettyAddress;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.toNettyAddress;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
 import static io.servicetalk.transport.netty.internal.CopyByteBufHandlerChannelInitializer.POOLED_ALLOCATOR;
@@ -165,7 +166,8 @@ public final class TcpServerBinder {
             @Override
             protected void initChannel(final Channel channel) {
                 Single<CC> connectionSingle = connectionFunction.apply(channel,
-                        config.transportObserver().onNewConnection(channel.localAddress(), channel.remoteAddress()));
+                        config.transportObserver().onNewConnection(
+                                fromNettyAddress(channel.localAddress()), fromNettyAddress(channel.remoteAddress())));
 
                 connectionSingle = wrapConnectionAcceptors(connectionSingle, channel, executionContext, config,
                         earlyConnectionAcceptor, lateConnectionAcceptor, connectionAcceptor);

--- a/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
+++ b/servicetalk-test-resources/src/main/java/io/servicetalk/test/resources/TestUtils.java
@@ -40,7 +40,7 @@ public final class TestUtils {
      * @param errors The queue of captured errors.
      */
     public static void assertNoAsyncErrors(final Queue<? extends Throwable> errors) {
-        assertNoAsyncErrors("Async errors occurred. See suppressed!", errors);
+        assertNoAsyncErrors("Async errors occurred.", errors);
     }
 
     /**
@@ -55,7 +55,7 @@ public final class TestUtils {
             return;
         }
 
-        final AssertionError error = null != message ? new AssertionError(message) : new AssertionError();
+        final AssertionError error = new AssertionError(message + " See " + errors.size() + " suppressed error(s):");
         Throwable t;
         while ((t = errors.poll()) != null) {
             addSuppressed(error, t);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
@@ -133,7 +133,7 @@ public final class BuilderUtils {
     }
 
     /**
-     * If {@code address} if a ServiceTalk specific address it is unwrapped into a Netty address.
+     * If {@code address} of a ServiceTalk specific type it is converted into a corresponding Netty address type.
      *
      * @param address the address to convert.
      * @return an address that Netty understands.
@@ -152,6 +152,22 @@ public final class BuilderUtils {
             return toResolvedInetSocketAddress((HostAndPort) address);
         }
         throw new IllegalArgumentException("Unsupported address: " + address);
+    }
+
+    /**
+     * If {@code address} of a Netty specific type it is converted into a corresponding ServiceTalk address type.
+     *
+     * @param address the address to convert.
+     * @return an address that ServiceTalk public API expects.
+     */
+    public static SocketAddress fromNettyAddress(SocketAddress address) {
+        // The order of the instance of checks is important because `DomainSocketAddress` is also of type
+        // `SocketAddress`, and we want to identify the more specific types before returning the fallback
+        // `SocketAddress` type.
+        if (address instanceof DomainSocketAddress) {
+            return new io.servicetalk.transport.api.DomainSocketAddress(((DomainSocketAddress) address).path());
+        }
+        return address;
     }
 
     /**

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
 import static io.netty.channel.ChannelOption.TCP_FASTOPEN_CONNECT;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.fromNettyAddress;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.channelError;
 import static io.servicetalk.transport.netty.internal.SocketOptionUtils.getOption;
 import static java.util.Objects.requireNonNull;
@@ -285,12 +286,12 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
         @Override
         public SocketAddress localAddress() {
-            return channel.localAddress();
+            return fromNettyAddress(channel.localAddress());
         }
 
         @Override
         public SocketAddress remoteAddress() {
-            return channel.remoteAddress();
+            return fromNettyAddress(channel.remoteAddress());
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -82,6 +82,7 @@ import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.fromNettyAddress;
 import static io.servicetalk.transport.netty.internal.ChannelCloseUtils.close;
 import static io.servicetalk.transport.netty.internal.ChannelSet.CHANNEL_CLOSEABLE_KEY;
 import static io.servicetalk.transport.netty.internal.CloseHandler.UNSUPPORTED_PROTOCOL_CLOSE_HANDLER;
@@ -686,12 +687,12 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
 
     @Override
     public SocketAddress localAddress() {
-        return channel().localAddress();
+        return fromNettyAddress(channel().localAddress());
     }
 
     @Override
     public SocketAddress remoteAddress() {
-        return channel().remoteAddress();
+        return fromNettyAddress(channel().remoteAddress());
     }
 
     @Nullable

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyServerContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyServerContext.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
 import static io.servicetalk.concurrent.api.AsyncCloseables.toListenableAsyncCloseable;
 import static io.servicetalk.concurrent.api.Executors.immediate;
+import static io.servicetalk.transport.netty.internal.BuilderUtils.fromNettyAddress;
 
 /**
  * {@link ServerContext} implementation using a netty {@link Channel}.
@@ -83,7 +84,7 @@ public final class NettyServerContext implements ServerContext {
 
     @Override
     public SocketAddress listenAddress() {
-        return listenChannel.localAddress();
+        return fromNettyAddress(listenChannel.localAddress());
     }
 
     @Override


### PR DESCRIPTION
#### Motivation

In #3307 we observed that when users create server or client with `io.servicetalk.transport.api.DomainSocketAddress` type, after bootstrap they see `io.netty.channel.unix.DomainSocketAddress` type returned from our `ServerContext` and `ConnectionInfo` API. This is unexpected behavior. Users don't expect to operate with a different type at runtime.

#### Modifications

- Enhance `HttpUdsTest` and `GrpcUdsTest` to assert expected behavior.
- Add `BuilderUtils.fromNettyAddress(SocketAddress)` utility to mirror behavior of `BuilderUtils.toNettyAddress(Object)` for necessary cases.
- Use this new utility to convert `SocketAddress` type to satisfy test assertions.

#### Result

Users consistently see `io.servicetalk.transport.api.DomainSocketAddress` type returned from all our public API if they use Unix Domain Socket transport.