### PR TITLE
Propagate HTTP/2 streamId to request context

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractDelegatingHttpRequest.java
@@ -103,12 +103,14 @@ abstract class AbstractDelegatingHttpRequest implements PayloadInfo, HttpRequest
         return original.context();
     }
 
+    @Nullable
     @Deprecated
     @Override
     public ContentCodec encoding() {
         return original.encoding();
     }
 
+    @Nullable
     @Override
     public BufferEncoder contentEncoding() {
         return original.contentEncoding();

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractHttpMetaData.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractHttpMetaData.java
@@ -61,9 +61,10 @@ abstract class AbstractHttpMetaData implements HttpMetaData {
         return this;
     }
 
+    @Nullable
     @Deprecated
     @Override
-    public ContentCodec encoding() {
+    public final ContentCodec encoding() {
         return encoding;
     }
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
@@ -80,6 +80,20 @@ public final class HttpContextKeys {
      */
     public static final Key<String> HTTP_ROUTE = newKey("http.route", String.class);
 
+    /**
+     * The key used to retrieve a virtual stream identifier from the corresponding
+     * {@link HttpRequestMetaData#context() request context}.
+     * <p>
+     * Multiplexed protocols, like <a href="https://datatracker.ietf.org/doc/html/rfc9113">HTTP/2</a>, use streams to
+     * precess every request. The Stream ID is lazy and typically assigned after the request headers are written to the
+     * transport. Therefore, it can not be known in advance on the client-side, but often useful to retrieve later for
+     * correlation with other events.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc9113#name-stream-identifiers">
+     * HTTP/2 Stream Identifiers</a>
+     */
+    public static final Key<Long> STREAM_ID = newKey("STREAM_ID", Long.class);
+
     private HttpContextKeys() {
         // No instances
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequests.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequests.java
@@ -39,7 +39,10 @@ public final class StreamingHttpRequests {
      * @param requestTarget the <a href="https://tools.ietf.org/html/rfc7230#section-3.1.1">request-target</a> of the
      * request.
      * @param version the {@link HttpProtocolVersion} of the request.
-     * @param headers the {@link HttpHeaders} of the request.
+     * @param headers the {@link HttpHeaders} of the request. Note that newly created and returned
+     * {@link StreamingHttpRequest} will use this {@link HttpHeaders} directly, which means later mutation of
+     * {@link HttpHeaders} will have side effects on returned request and should be avoided as these operations are not
+     * thread safe.
      * @param allocator the allocator used for serialization purposes if necessary.
      * @param headersFactory {@link HttpHeadersFactory} to use.
      * @return a new {@link StreamingHttpRequest}.
@@ -60,7 +63,10 @@ public final class StreamingHttpRequests {
      * @param requestTarget the <a href="https://tools.ietf.org/html/rfc7230#section-3.1.1">request-target</a> of the
      * request.
      * @param version the {@link HttpProtocolVersion} of the request.
-     * @param headers the {@link HttpHeaders} of the request.
+     * @param headers the {@link HttpHeaders} of the request. Note that newly created and returned
+     * {@link StreamingHttpRequest} will use this {@link HttpHeaders} directly, which means later mutation of
+     * {@link HttpHeaders} will have side effects on returned request and should be avoided as these operations are not
+     * thread safe.
      * @param allocator the allocator used for serialization purposes if necessary.
      * @param payload a {@link Publisher} for payload that optionally emits {@link HttpHeaders} if the request contains
      * <a href="https://tools.ietf.org/html/rfc7230#section-4.4">trailers</a>.
@@ -81,11 +87,15 @@ public final class StreamingHttpRequests {
     }
 
     /**
-     * Creates a new {@link StreamingHttpRequest} which is read from the transport. If the request contains
-     * <a href="https://tools.ietf.org/html/rfc7230#section-4.4">trailers</a> then the passed {@code payload}
-     * {@link Publisher} must also emit {@link HttpHeaders} before completion.
+     * Creates a new {@link StreamingHttpRequest} which is read from the transport.
+     * <p>
+     * If the request contains <a href="https://tools.ietf.org/html/rfc7230#section-4.4">trailers</a> then the passed
+     * {@code payload} {@link Publisher} must also emit {@link HttpHeaders} before completion.
      *
-     * @param metaData the {@link HttpRequestMetaData} of the request parsed by the transport layer.
+     * @param metaData the {@link HttpRequestMetaData} of the request parsed by the transport layer. Note that newly
+     * created and returned {@link StreamingHttpRequest} will use this {@link HttpRequestMetaData} directly and share
+     * its parts, which means later mutation of {@link HttpRequestMetaData} will have side effects on returned request
+     * and should be avoided as these operations are not thread safe.
      * @param allocator the allocator to use for serialization purposes if necessary.
      * @param payload a {@link Publisher} for payload that optionally emits {@link HttpHeaders} if the request contains
      * <a href="https://tools.ietf.org/html/rfc7230#section-4.4">trailers</a>.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequests.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpRequests.java
@@ -17,6 +17,9 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.buffer.api.BufferAllocator;
 import io.servicetalk.concurrent.api.Publisher;
+import io.servicetalk.context.api.ContextMap;
+
+import javax.annotation.Nullable;
 
 import static io.servicetalk.http.api.DefaultPayloadInfo.forTransportReceive;
 import static io.servicetalk.http.api.DefaultPayloadInfo.forUserCreated;
@@ -65,12 +68,40 @@ public final class StreamingHttpRequests {
      * header is required to accept trailers. {@code false} assumes trailers may be present if other criteria allows.
      * @param headersFactory {@link HttpHeadersFactory} to use.
      * @return a new {@link StreamingHttpRequest}.
+     * @deprecated Use {@link #newTransportRequest(HttpRequestMetaData, BufferAllocator, Publisher, boolean,
+     * HttpHeadersFactory)} instead.
      */
+    @Deprecated
     public static StreamingHttpRequest newTransportRequest(
             final HttpRequestMethod method, final String requestTarget, final HttpProtocolVersion version,
             final HttpHeaders headers, final BufferAllocator allocator, final Publisher<Object> payload,
             final boolean requireTrailerHeader, final HttpHeadersFactory headersFactory) {
         return new DefaultStreamingHttpRequest(method, requestTarget, version, headers, null, null, null, allocator,
                 payload, forTransportReceive(requireTrailerHeader, version, headers), headersFactory);
+    }
+
+    /**
+     * Creates a new {@link StreamingHttpRequest} which is read from the transport. If the request contains
+     * <a href="https://tools.ietf.org/html/rfc7230#section-4.4">trailers</a> then the passed {@code payload}
+     * {@link Publisher} must also emit {@link HttpHeaders} before completion.
+     *
+     * @param metaData the {@link HttpRequestMetaData} of the request parsed by the transport layer.
+     * @param allocator the allocator to use for serialization purposes if necessary.
+     * @param payload a {@link Publisher} for payload that optionally emits {@link HttpHeaders} if the request contains
+     * <a href="https://tools.ietf.org/html/rfc7230#section-4.4">trailers</a>.
+     * @param requireTrailerHeader {@code true} if <a href="https://tools.ietf.org/html/rfc7230#section-4.4">Trailer</a>
+     * header is required to accept trailers. {@code false} assumes trailers may be present if other criteria allows.
+     * @param headersFactory {@link HttpHeadersFactory} to use to allocate trailers if necessary.
+     * @return a new {@link StreamingHttpRequest}.
+     */
+    public static StreamingHttpRequest newTransportRequest(
+            final HttpRequestMetaData metaData, final BufferAllocator allocator, final Publisher<Object> payload,
+            final boolean requireTrailerHeader, final HttpHeadersFactory headersFactory) {
+        @Nullable
+        ContextMap context = metaData instanceof DefaultHttpRequestMetaData ?
+                ((DefaultHttpRequestMetaData) metaData).context0() : metaData.context();
+        return new DefaultStreamingHttpRequest(metaData.method(), metaData.requestTarget(), metaData.version(),
+                metaData.headers(), context, metaData.encoding(), metaData.contentEncoding(), allocator, payload,
+                forTransportReceive(requireTrailerHeader, metaData.version(), metaData.headers()), headersFactory);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -303,8 +303,7 @@ final class NettyHttpServer {
             final Single<StreamingHttpRequest> requestSingle =
                     connection.read().firstAndTail((head, payload) -> {
                         HttpRequestMetaData meta = (HttpRequestMetaData) head;
-                        return newTransportRequest(meta.method(), meta.requestTarget(), meta.version(),
-                                meta.headers(), executionContext().bufferAllocator(), payload,
+                        return newTransportRequest(meta, executionContext().bufferAllocator(), payload,
                                 requireTrailerHeader, headersFactory);
                     });
             toSource(handleRequestAndWriteResponse(requestSingle, handleMultipleRequests))

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpConnectionTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractHttpConnectionTest.java
@@ -54,6 +54,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpHeaderValues.TEXT_PLAIN;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpRequestMetaDataFactory.newRequestMetaData;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpResponseMetaDataFactory.newResponseMetaData;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
@@ -131,7 +132,7 @@ final class AbstractHttpConnectionTest {
 
         HttpHeaders headers = headersFactory.newHeaders();
         headers.add(TRANSFER_ENCODING, CHUNKED);
-        StreamingHttpRequest req = newTransportRequest(GET, "/foo", HTTP_1_1, headers,
+        StreamingHttpRequest req = newTransportRequest(newRequestMetaData(HTTP_1_1, GET, "/foo", headers),
                 allocator, from(chunk1, chunk2, chunk3, trailers), false, headersFactory);
 
         HttpResponseMetaData respMeta = newResponseMetaData(HTTP_1_1, OK,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2StreamIdContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2StreamIdContextTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.BlockingStreamingHttpClient;
+import io.servicetalk.http.api.BlockingStreamingHttpRequest;
+import io.servicetalk.http.api.HttpRequest;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.http.api.StreamingHttpClientFilter;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequester;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.netty.RetryingHttpRequesterFilter.BackOffPolicy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.servicetalk.buffer.api.Matchers.contentEqualTo;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.http.api.HttpContextKeys.STREAM_ID;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.util.Collections.singleton;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class H2StreamIdContextTest {
+
+    private static final String X_HTTP2_STREAM_ID = "x-http2-stream-id";
+
+    @Test
+    void test() throws Exception {
+        AtomicLong expectedStreamIdHolder = new AtomicLong();
+        try (HttpServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .protocols(HttpProtocol.HTTP_2.config)
+                .listenBlockingAndAwait((ctx, request, responseFactory) ->
+                        responseFactory.ok().setHeader(X_HTTP2_STREAM_ID,
+                                String.valueOf(request.context().get(STREAM_ID))));
+             BlockingStreamingHttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                     .protocols(HttpProtocol.HTTP_2.config)
+                     .appendClientFilter(c -> new StreamingHttpClientFilter(c) {
+                         @Override
+                         protected Single<StreamingHttpResponse> request(StreamingHttpRequester delegate,
+                                                                         StreamingHttpRequest request) {
+                             return delegate.request(request.transformMessageBody(publisher -> publisher
+                                     .beforeOnSubscribe(__ -> assertThat(
+                                             "No STREAM_ID assigned before transport subscribes to payload body",
+                                             request.context().get(STREAM_ID), is(expectedStreamIdHolder.get())))));
+                         }
+                     }).buildBlockingStreaming()) {
+
+            for (long expectedStreamId = 3; expectedStreamId <= 7; expectedStreamId += 2) {
+                expectedStreamIdHolder.set(expectedStreamId);
+                // Use of the streaming API is required to delay subscribe to request payload body
+                BlockingStreamingHttpRequest request = client.post("/")
+                        .payloadBody(singleton(client.executionContext().bufferAllocator().fromAscii("hello")));
+                assertThat("Unexpected STREAM_ID before request is sent",
+                        request.context().get(STREAM_ID), is(nullValue()));
+                HttpResponse response = client.request(request).toResponse().toFuture().get();
+                assertThat("STREAM_ID after request is sent does not match expected value",
+                        request.context().get(STREAM_ID), is(expectedStreamId));
+                assertThat("Unexpected STREAM_ID in response",
+                        response.context().get(STREAM_ID), is(nullValue()));
+                assertThat("STREAM_ID observed by the server does not match expected value",
+                        response.headers().get(X_HTTP2_STREAM_ID), contentEqualTo(Long.toString(expectedStreamId)));
+            }
+        }
+    }
+
+    @Test
+    void testWithRetry() throws Exception {
+        AtomicBoolean shouldFail = new AtomicBoolean(true);
+        try (HttpServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .protocols(HttpProtocol.HTTP_2.config)
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> {
+                    if (shouldFail.compareAndSet(true, false)) {
+                        assertThat(request.context().get(STREAM_ID), is(3L));
+                        ctx.closeAsync().toFuture().get();
+                        throw DELIBERATE_EXCEPTION;
+                    }
+                    assertThat(request.context().get(STREAM_ID), is(5L));
+                    return responseFactory.ok().setHeader(X_HTTP2_STREAM_ID,
+                            String.valueOf(request.context().get(STREAM_ID)));
+                });
+             BlockingHttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                     .protocols(HttpProtocol.HTTP_2.config)
+                     .appendClientFilter(new RetryingHttpRequesterFilter.Builder()
+                             .retryOther((metaData, throwable) -> {
+                                 assertThat(metaData.context().get(STREAM_ID), is(3L));
+                                 return BackOffPolicy.ofImmediateBounded();
+                             })
+                             .build())
+                     .buildBlocking()) {
+
+            HttpRequest request = client.get("/");
+            assertThat("Unexpected STREAM_ID before request is sent",
+                    request.context().get(STREAM_ID), is(nullValue()));
+            HttpResponse response = client.request(request);
+            assertThat("STREAM_ID after request is sent does not match expected value",
+                    request.context().get(STREAM_ID), is(5L));
+            assertThat("Unexpected STREAM_ID in response",
+                    response.context().get(STREAM_ID), is(nullValue()));
+            assertThat("STREAM_ID observed by the server does not match expected value",
+                    response.headers().get(X_HTTP2_STREAM_ID), contentEqualTo(Long.toString(5L)));
+        }
+    }
+}


### PR DESCRIPTION
#### Motivation

Multiplexed protocols, such as HTTP/2 and HTTP/3, utilize virtual streams for each request. The stream ID is unknown upfront and is assigned by the protocol at the time client sends metadata (headers). Currently, there is no way for client-side to know what the stream ID assigned for a request was.

#### Modifications

- Introduce `HttpContextKeys.STREAM_ID` key as a way to query stream ID value from request context, and adjust H2 codec to do so.
- Add tests to validate new behavior.

#### Result

`STREAM_ID` value is assigned for a request context as soon as request metadata is sent. Users can extract it and correlate with other logs and events. The ID is updated on every retry of the same request instance.