### PR TITLE
Remove redundant `@Nonnull` annotations

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FirstAndTailToPackedSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FirstAndTailToPackedSingle.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiFunction;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
@@ -218,7 +217,6 @@ final class FirstAndTailToPackedSingle<Packed, T> implements PublisherToSingleOp
             }
         }
 
-        @Nonnull
         private Publisher<T> newTailPublisher() {
             return new SubscribablePublisher<T>() {
                 @Override

--- a/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/ByteArrayJacksonDeserializer.java
+++ b/servicetalk-data-jackson/src/main/java/io/servicetalk/data/jackson/ByteArrayJacksonDeserializer.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 
 import java.io.IOException;
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static java.util.Collections.emptyList;
@@ -37,7 +36,6 @@ final class ByteArrayJacksonDeserializer<T> extends AbstractJacksonDeserializer<
         this.feeder = feeder;
     }
 
-    @Nonnull
     @Override
     Iterable<T> doDeserialize(final Buffer buffer, @Nullable List<T> resultHolder) throws IOException {
         if (buffer.hasArray()) {

--- a/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/JacksonSerializationProviderTest.java
+++ b/servicetalk-data-jackson/src/test/java/io/servicetalk/data/jackson/JacksonSerializationProviderTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.List;
-import javax.annotation.Nonnull;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static java.util.Collections.singletonList;
@@ -248,7 +247,6 @@ class JacksonSerializationProviderTest {
         }
     }
 
-    @Nonnull
     private Buffer serializePojo(final TestPojo expected) {
         final Buffer serialized = DEFAULT_ALLOCATOR.newBuffer();
         serializationProvider.serialize(expected, serialized);

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingStreamingHttpService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/StreamingHttpServiceToBlockingStreamingHttpService.java
@@ -25,7 +25,6 @@ import io.servicetalk.concurrent.api.internal.SubscribableCompletable;
 import io.servicetalk.concurrent.internal.ConcurrentSubscription;
 
 import java.io.IOException;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
@@ -55,7 +54,6 @@ final class StreamingHttpServiceToBlockingStreamingHttpService implements Blocki
         futureGetCancelOnInterrupt(handleBlockingRequest(ctx, request, svcResponse).toFuture());
     }
 
-    @Nonnull
     private Completable handleBlockingRequest(final HttpServiceContext ctx,
                                               final BlockingStreamingHttpRequest request,
                                               final BlockingStreamingHttpServerResponse svcResponse) {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StrategyInfluencerChainBuilderTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/StrategyInfluencerChainBuilderTest.java
@@ -20,8 +20,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 
-import javax.annotation.Nonnull;
-
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -93,7 +91,6 @@ class StrategyInfluencerChainBuilderTest {
         inOrder.verify(influencer3).requiredOffloads();
     }
 
-    @Nonnull
     private HttpExecutionStrategyInfluencer newNoInfluenceInfluencer() {
         HttpExecutionStrategyInfluencer influencer1 = mock(HttpExecutionStrategyInfluencer.class);
         when(influencer1.requiredOffloads()).thenReturn(HttpExecutionStrategies.offloadNone());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -82,7 +82,6 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 
@@ -415,7 +414,6 @@ final class NettyHttpServer {
             return handleMultipleRequests ? defer(() -> exchange).repeat(__ -> true).ignoreElements() : exchange;
         }
 
-        @Nonnull
         private static Publisher<Object> handleResponse(final HttpProtocolVersion protocolVersion,
                                                         final HttpRequestMethod requestMethod,
                                                         final StreamingHttpResponse response) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
@@ -50,7 +50,6 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -133,7 +132,6 @@ class ConnectionFactoryFilterTest {
         return response;
     }
 
-    @Nonnull
     private static UnaryOperator<FilterableStreamingHttpConnection> connectionCounter(
             final AtomicInteger activeConnections, @Nullable final CountDownLatch doneLatch) {
         return connection -> {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpClientAsyncContextTest.java
@@ -38,7 +38,6 @@ import java.net.InetSocketAddress;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.Nonnull;
 
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -72,7 +71,6 @@ class HttpClientAsyncContextTest {
         }
     }
 
-    @Nonnull
     private static SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> buildClient(
             final boolean useImmediate, final Queue<Throwable> errorQueue, final ServerContext serverContext) {
         SingleAddressHttpClientBuilder<HostAndPort, InetSocketAddress> clientBuilder = HttpClients.forSingleAddress(

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InsufficientlySizedExecutorHttpTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/InsufficientlySizedExecutorHttpTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.AsyncCloseables.newCompositeCloseable;
@@ -159,7 +158,6 @@ class InsufficientlySizedExecutorHttpTest {
         closeable.close();
     }
 
-    @Nonnull
     private static Executor getExecutorForCapacity(final int capacity) {
         return capacity == 0 ?
                 from(task -> {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterAutoRetryStrategiesTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/RetryingHttpRequesterFilterAutoRetryStrategiesTest.java
@@ -39,7 +39,6 @@ import org.mockito.stubbing.Answer;
 
 import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
 
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.client.api.LoadBalancerReadyEvent.LOAD_BALANCER_READY_EVENT;
@@ -320,7 +319,6 @@ class RetryingHttpRequesterFilterAutoRetryStrategiesTest {
         return f;
     }
 
-    @Nonnull
     private Completable applyRetry(final ContextAwareRetryingHttpClientFilter filter,
                                    final int count, final Throwable t) {
         return filter.retryStrategy(REQUEST_META_DATA, filter.executionContext(), true).apply(count, t);

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/AsynchronousResources.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/resources/AsynchronousResources.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -263,8 +262,8 @@ public class AsynchronousResources {
     @Produces(TEXT_PLAIN)
     @Path("/delayed-text")
     @GET
-    public CompletionStage<String> getDelayedText(@Nonnull @QueryParam("delay") final long delay,
-                                                  @Nonnull @QueryParam("unit") final TimeUnit unit) {
+    public CompletionStage<String> getDelayedText(@QueryParam("delay") final long delay,
+                                                  @QueryParam("unit") final TimeUnit unit) {
         return newCompletionStage(() -> "DONE", delay, unit);
     }
 
@@ -393,8 +392,8 @@ public class AsynchronousResources {
     @Produces(TEXT_PLAIN)
     @Path("/delayed-response-comsta")
     @GET
-    public Response getDelayedResponseCompletionStage(@Nonnull @QueryParam("delay") final long delay,
-                                                      @Nonnull @QueryParam("unit") final TimeUnit unit) {
+    public Response getDelayedResponseCompletionStage(@QueryParam("delay") final long delay,
+                                                      @QueryParam("unit") final TimeUnit unit) {
         final CompletableFuture<String> cf = new CompletableFuture<>();
         final Cancellable cancellable =
                 ctx.executionContext().executor().schedule(() -> cf.complete("DONE"), delay, unit);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinSelector.java
@@ -37,7 +37,6 @@ import io.servicetalk.context.api.ContextMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -107,7 +106,7 @@ final class RoundRobinSelector<ResolvedAddress, C extends LoadBalancedConnection
     }
 
     @Override
-    public HostSelector<ResolvedAddress, C> rebuildWithHosts(@Nonnull List<? extends Host<ResolvedAddress, C>> hosts) {
+    public HostSelector<ResolvedAddress, C> rebuildWithHosts(List<? extends Host<ResolvedAddress, C>> hosts) {
         return new RoundRobinSelector<>(index, hosts, lbDescription(), failOpen, ignoreWeights);
     }
 

--- a/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/DefaultSerializer.java
+++ b/servicetalk-serialization-api/src/main/java/io/servicetalk/serialization/api/DefaultSerializer.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
@@ -258,7 +257,6 @@ public final class DefaultSerializer implements Serializer {
                 .collect(toList());
     }
 
-    @Nonnull
     private static <T> BlockingIterable<Buffer> applySerializer0(final BufferAllocator allocator,
                                                                  final IntUnaryOperator bytesEstimator,
                                                                  final BlockingIterable<T> source,
@@ -305,13 +303,11 @@ public final class DefaultSerializer implements Serializer {
                 .subscribe(subscriber);
     }
 
-    @Nonnull
     private static <T> CloseableIterable<T> applyDeserializer0(final Iterable<Buffer> source,
                                                       final StreamingDeserializer<T> deSerializer) {
         return deserializeAndClose(source, deSerializer::deserialize, deSerializer);
     }
 
-    @Nonnull
     private static <T> CloseableIterable<T> deserializeAggregated0(final Buffer serializedData,
                                                    final StreamingDeserializer<T> deSerializer) {
         return deserializeAndClose(serializedData, deSerializer::deserialize, deSerializer);


### PR DESCRIPTION
#### Motivation

We use `@ElementsAreNonnullByDefault` annotation everywhere. There is no need to have `@Nonnull` annotations by default except some minor cases where we override `@Nullable` into `@Nonnull`.

#### Modifications

- Remove all `@Nonnull` cases that repeat default behavior.

#### Result

No redundant `@Nonnull` annotations in our codebase.