### PR TITLE
opentelemetry-http: add ability to not suppress spans

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcInstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcInstrumentationHelper.java
@@ -100,11 +100,6 @@ final class GrpcInstrumentationHelper extends InstrumentationHelper {
         OpenTelemetry openTelemetry = options.openTelemetry();
         SpanNameExtractor<RequestInfo> serverSpanNameExtractor = spanNameExtractor(options,
                 GrpcSpanNameExtractor.INSTANCE);
-        if (options.spanNamePrefix() != null) {
-            serverSpanNameExtractor = requestInfo ->
-                    options.spanNamePrefix().apply(requestInfo.request()) +
-                            GrpcSpanNameExtractor.INSTANCE.extract(requestInfo);
-        }
         InstrumenterBuilder<RequestInfo, GrpcTelemetryStatus> serverInstrumenterBuilder =
                 Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, serverSpanNameExtractor);
         serverInstrumenterBuilder

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/InstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/InstrumentationHelper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentelemetry.http;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+
+import java.util.function.Function;
+
+abstract class InstrumentationHelper {
+
+    private final Instrumenter<RequestInfo, ?> instrumenter;
+    private final boolean ignoreSpanSuppression;
+
+    InstrumentationHelper(Instrumenter<RequestInfo, ?> instrumenter, OpenTelemetryOptions options) {
+        this.instrumenter = instrumenter;
+        this.ignoreSpanSuppression = options.ignoreSpanSuppression();
+    }
+
+    abstract Single<StreamingHttpResponse> doTrackRequest(
+            Function<StreamingHttpRequest, Single<StreamingHttpResponse>> requestHandler,
+            RequestInfo requestInfo,
+            Context parentContext);
+
+    final Single<StreamingHttpResponse> trackRequest(
+            Function<StreamingHttpRequest, Single<StreamingHttpResponse>> requestHandler,
+            RequestInfo requestInfo,
+            Context parentContext) {
+
+        if (!ignoreSpanSuppression && !instrumenter.shouldStart(parentContext, requestInfo)) {
+            return requestHandler.apply(requestInfo.request());
+        }
+        return doTrackRequest(requestHandler, requestInfo, parentContext);
+    }
+
+    static SpanNameExtractor<RequestInfo> spanNameExtractor(
+            OpenTelemetryOptions options, SpanNameExtractor<RequestInfo> parent) {
+        if (options.spanNamePrefix() != null) {
+            return requestInfo ->
+                    options.spanNamePrefix().apply(requestInfo.request()) +
+                            parent.extract(requestInfo);
+        } else {
+            return parent;
+        }
+    }
+}

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/InstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/InstrumentationHelper.java
@@ -52,13 +52,11 @@ abstract class InstrumentationHelper {
     }
 
     static SpanNameExtractor<RequestInfo> spanNameExtractor(
-            OpenTelemetryOptions options, SpanNameExtractor<RequestInfo> parent) {
-        if (options.spanNamePrefix() != null) {
-            return requestInfo ->
-                    options.spanNamePrefix().apply(requestInfo.request()) +
-                            parent.extract(requestInfo);
+            OpenTelemetryOptions options, SpanNameExtractor<RequestInfo> defaultExtractor) {
+        if (options.spanNameExtractor() != null) {
+            return requestInfo -> options.spanNameExtractor().apply(requestInfo.request());
         } else {
-            return parent;
+            return defaultExtractor;
         }
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -36,7 +36,7 @@ import java.util.function.UnaryOperator;
  * Append this filter before others that are expected to see {@link Scope} for this request/response. Filters
  * appended after this filter that use operators with the <strong>after*</strong> prefix on
  * {@link io.servicetalk.http.api.StreamingHttpClient#request(StreamingHttpRequest) response meta data} or the
- * {@link StreamingHttpResponse#transformMessageBody(UnaryOperator)} response message body}
+ * {@link StreamingHttpResponse#transformMessageBody(UnaryOperator)} response message body.
  * (e.g. {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and
  * therefore will not see the {@link Span} for the current request/response.
  * @deprecated use {@link OpenTelemetryHttpRequesterFilter} instead.
@@ -57,7 +57,10 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequestFilter(final OpenTelemetry openTelemetry, String componentName) {
-        super(openTelemetry, componentName, DEFAULT_OPTIONS);
+        super(new OpenTelemetryOptions.Builder()
+                .openTelemetry(openTelemetry)
+                .componentName(componentName)
+                .build());
     }
 
     /**
@@ -76,7 +79,9 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      * @param opentelemetryOptions extra options to create the opentelemetry filter
      */
     public OpenTelemetryHttpRequestFilter(final String componentName, final OpenTelemetryOptions opentelemetryOptions) {
-        super(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions);
+        super(new OpenTelemetryOptions.Builder(opentelemetryOptions)
+                .componentName(componentName)
+                .build());
     }
 
     /**

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilter.java
@@ -20,8 +20,6 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
@@ -36,17 +34,31 @@ import java.util.function.UnaryOperator;
  * Append this filter before others that are expected to see {@link Scope} for this request/response. Filters
  * appended after this filter that use operators with the <strong>after*</strong> prefix on
  * {@link io.servicetalk.http.api.StreamingHttpClient#request(StreamingHttpRequest) response meta data} or the
- * {@link StreamingHttpResponse#transformMessageBody(UnaryOperator)} response message body}
+ * {@link StreamingHttpResponse#transformMessageBody(UnaryOperator)} response message body.
  * (e.g. {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and
  * therefore will not see the {@link Span} for the current request/response.
  */
 public final class OpenTelemetryHttpRequesterFilter extends AbstractOpenTelemetryHttpRequesterFilter {
 
     /**
+     * Create a new instance with the provided {@link OpenTelemetryOptions}.
+     * <p>
+     * The options should include client-specific configuration such as componentName.
+     *
+     * @param openTelemetryOptions options to configure the filter, including client-specific settings
+     */
+    public OpenTelemetryHttpRequesterFilter(final OpenTelemetryOptions openTelemetryOptions) {
+        super(openTelemetryOptions);
+    }
+
+    /**
      * Create a new instance, searching for any instance of an opentelemetry available.
      *
      * @param componentName The component name used during building new spans.
+     * @deprecated use {@link #OpenTelemetryHttpRequesterFilter(OpenTelemetryOptions)} with
+     *             {@link OpenTelemetryOptions.Builder#componentName(String)} to create new filter instances.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequesterFilter(final String componentName) {
         this(componentName, DEFAULT_OPTIONS);
     }
@@ -56,22 +68,25 @@ public final class OpenTelemetryHttpRequesterFilter extends AbstractOpenTelemetr
      *
      * @param componentName        The component name used during building new spans.
      * @param opentelemetryOptions extra options to create the opentelemetry filter
+     * @deprecated use {@link #OpenTelemetryHttpRequesterFilter(OpenTelemetryOptions)} with
+     *             {@link OpenTelemetryOptions.Builder} to configure all options including componentName.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequesterFilter(final String componentName,
                                             final OpenTelemetryOptions opentelemetryOptions) {
-        this(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions);
+        super(new OpenTelemetryOptions.Builder(opentelemetryOptions)
+                .componentName(componentName)
+                .build());
     }
 
     /**
      * Create a new instance, searching for any instance of an opentelemetry available,
      * using the hostname as the component name.
+     * @deprecated use {@link #OpenTelemetryHttpRequesterFilter(OpenTelemetryOptions)} with
+     *             {@link OpenTelemetryOptions.Builder} to create new filter instances.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequesterFilter() {
         this("");
-    }
-
-    OpenTelemetryHttpRequesterFilter(final OpenTelemetry openTelemetry, String componentName,
-                                     final OpenTelemetryOptions opentelemetryOptions) {
-        super(openTelemetry, componentName, opentelemetryOptions);
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
@@ -39,7 +39,7 @@ import io.opentelemetry.context.Context;
  *     {@link io.servicetalk.http.utils.HttpRequestAutoDrainingServiceFilter} immediately after.</li>
  *     <li>To ensure tracing sees the same result status codes as the calling client, add the
  *     {@link io.servicetalk.http.api.HttpExceptionMapperServiceFilter} after this filter.</li>
- *     <li>If you intend to use a {@link io.servicetalk.http.api.HttpLifecycleObserver}, add it using the the
+ *     <li>If you intend to use a {@link io.servicetalk.http.api.HttpLifecycleObserver}, add it using the
  *     HttpLifecycleObserverServiceFilter after the tracing filter to ensure the correct {@link Span} information is
  *     present.</li>
  * </ul>
@@ -64,7 +64,9 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     @SuppressWarnings("DeprecatedIsStillUsed")
     public OpenTelemetryHttpServerFilter(final OpenTelemetry openTelemetry) {
-        super(openTelemetry, DEFAULT_OPTIONS);
+        super(new OpenTelemetryOptions.Builder(DEFAULT_OPTIONS)
+                .openTelemetry(openTelemetry)
+                .build());
     }
 
     /**
@@ -81,6 +83,7 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
      * @param openTelemetryOptions extra options to create the opentelemetry filter
      */
     public OpenTelemetryHttpServerFilter(final OpenTelemetryOptions openTelemetryOptions) {
-        super(GlobalOpenTelemetry.get(), openTelemetryOptions);
+        super(new OpenTelemetryOptions.Builder(openTelemetryOptions)
+                .build());
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
@@ -39,7 +39,7 @@ import io.opentelemetry.context.Context;
  *     {@link io.servicetalk.http.utils.HttpRequestAutoDrainingServiceFilter} immediately after.</li>
  *     <li>To ensure tracing sees the same result status codes as the calling client, add the
  *     {@link io.servicetalk.http.api.HttpExceptionMapperServiceFilter} after this filter.</li>
- *     <li>If you intend to use a {@link io.servicetalk.http.api.HttpLifecycleObserver}, add it using the the
+ *     <li>If you intend to use a {@link io.servicetalk.http.api.HttpLifecycleObserver}, add it using the
  *     HttpLifecycleObserverServiceFilter after the tracing filter to ensure the correct {@link Span} information is
  *     present.</li>
  * </ul>
@@ -52,7 +52,9 @@ public final class OpenTelemetryHttpServiceFilter extends AbstractOpenTelemetryH
     /**
      * Create a new instance using the {@link OpenTelemetry} from {@link GlobalOpenTelemetry#get()} with default
      * {@link OpenTelemetryOptions}.
+     * @deprecated use the constructor
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpServiceFilter() {
         this(DEFAULT_OPTIONS);
     }
@@ -60,13 +62,27 @@ public final class OpenTelemetryHttpServiceFilter extends AbstractOpenTelemetryH
     /**
      * Create a new instance.
      *
-     * @param openTelemetryOptions extra options to create the opentelemetry filter
+     * @param openTelemetryOptions extra options to create the opentelemetry filter.
+     *                            Client-specific options (componentName, openTelemetry, ignoreSpanSuppression)
+     *                            will be ignored for server filters.
      */
     public OpenTelemetryHttpServiceFilter(final OpenTelemetryOptions openTelemetryOptions) {
-        this(GlobalOpenTelemetry.get(), openTelemetryOptions);
+        super(openTelemetryOptions);
     }
 
-    OpenTelemetryHttpServiceFilter(final OpenTelemetry openTelemetry, final OpenTelemetryOptions openTelemetryOptions) {
-        super(openTelemetry, openTelemetryOptions);
+    /**
+     * Create a new instance.
+     *
+     * @param openTelemetry the {@link OpenTelemetry}.
+     * @param openTelemetryOptions extra options to create the opentelemetry filter
+     * @deprecated Use {@link #OpenTelemetryHttpServiceFilter(OpenTelemetryOptions)} instead.
+     * The OpenTelemetry instance should be provided via {@link OpenTelemetryOptions}.
+     */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
+    public OpenTelemetryHttpServiceFilter(final OpenTelemetry openTelemetry,
+                                          final OpenTelemetryOptions openTelemetryOptions) {
+        super(new OpenTelemetryOptions.Builder(openTelemetryOptions)
+                .openTelemetry(openTelemetry)
+                .build());
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryOptions.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryOptions.java
@@ -39,7 +39,7 @@ import static java.util.Objects.requireNonNull;
 public final class OpenTelemetryOptions {
 
     @Nullable
-    private final Function<HttpRequestMetaData, String> spanNamePrefix;
+    private final Function<HttpRequestMetaData, String> spanNameExtractor;
     private final List<String> capturedRequestHeaders;
     private final List<String> capturedResponseHeaders;
     private final boolean enableMetrics;
@@ -51,14 +51,14 @@ public final class OpenTelemetryOptions {
 
     OpenTelemetryOptions(
             @Nullable
-            final Function<HttpRequestMetaData, String> spanNamePrefix,
+            final Function<HttpRequestMetaData, String> spanNameExtractor,
             final List<String> capturedRequestHeaders,
             final List<String> capturedResponseHeaders,
             final boolean enableMetrics,
             final OpenTelemetry openTelemetry,
             final String componentName,
             final boolean ignoreSpanSuppression) {
-        this.spanNamePrefix = spanNamePrefix;
+        this.spanNameExtractor = spanNameExtractor;
         this.capturedRequestHeaders = capturedRequestHeaders;
         this.capturedResponseHeaders = capturedResponseHeaders;
         this.enableMetrics = enableMetrics;
@@ -73,8 +73,8 @@ public final class OpenTelemetryOptions {
      * @return a function that will extract a span name prefix from the {@link HttpRequestMetaData}.
      */
     @Nullable
-    Function<HttpRequestMetaData, String> spanNamePrefix() {
-        return spanNamePrefix;
+    Function<HttpRequestMetaData, String> spanNameExtractor() {
+        return spanNameExtractor;
     }
 
     /**
@@ -171,7 +171,7 @@ public final class OpenTelemetryOptions {
     @Override
     public String toString() {
         return "OpenTelemetryOptions{" +
-                "spanNamePrefix=" + spanNamePrefix +
+                "spanNameExtractor=" + spanNameExtractor +
                 ", capturedRequestHeaders=" + capturedRequestHeaders +
                 ", capturedResponseHeaders=" + capturedResponseHeaders +
                 ", enableMetrics=" + enableMetrics +
@@ -184,7 +184,7 @@ public final class OpenTelemetryOptions {
     /** A builder for {@link OpenTelemetryOptions}. */
     public static final class Builder {
         @Nullable
-        Function<HttpRequestMetaData, String> spanNamePrefix;
+        Function<HttpRequestMetaData, String> spanNameExtractor;
         private List<String> capturedRequestHeaders = emptyList();
         private List<String> capturedResponseHeaders = emptyList();
         private boolean enableMetrics;
@@ -195,7 +195,7 @@ public final class OpenTelemetryOptions {
         private String componentName = "";
 
         public Builder(OpenTelemetryOptions openTelemetryOptions) {
-            this.spanNamePrefix = openTelemetryOptions.spanNamePrefix;
+            this.spanNameExtractor = openTelemetryOptions.spanNameExtractor;
             this.capturedRequestHeaders = openTelemetryOptions.capturedRequestHeaders;
             this.capturedResponseHeaders = openTelemetryOptions.capturedResponseHeaders;
             this.enableMetrics = openTelemetryOptions.enableMetrics;
@@ -209,11 +209,11 @@ public final class OpenTelemetryOptions {
 
         /**
          * Function that maps the provided {@link HttpRequestMetaData} to a span name prefix.
-         * @param spanNamePrefix the span name prefix to append, or {@code null} if no prefix is desired.
+         * @param spanNameExtractor the span name prefix to append, or {@code null} if no prefix is desired.
          * @return {@code this}
          */
-        public Builder spanNamePrefix(@Nullable final Function<HttpRequestMetaData, String> spanNamePrefix) {
-            this.spanNamePrefix = spanNamePrefix;
+        public Builder spanNameExtractor(@Nullable final Function<HttpRequestMetaData, String> spanNameExtractor) {
+            this.spanNameExtractor = spanNameExtractor;
             return this;
         }
 
@@ -309,7 +309,7 @@ public final class OpenTelemetryOptions {
          */
         public OpenTelemetryOptions build() {
             return new OpenTelemetryOptions(
-                    spanNamePrefix, capturedRequestHeaders, capturedResponseHeaders, enableMetrics,
+                    spanNameExtractor, capturedRequestHeaders, capturedResponseHeaders, enableMetrics,
                     openTelemetry, componentName, ignoreSpanSuppression);
         }
     }

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
@@ -182,8 +182,10 @@ class OpenTelemetryGrpcFilterTest {
         // The filter will automatically detect gRPC requests and handle them appropriately
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
                 .initializeHttp(builder -> builder.appendClientFilter(new OpenTelemetryHttpRequesterFilter(
-                        otelTesting.getOpenTelemetry(), "test-client",
-                        new OpenTelemetryOptions.Builder().build())))
+                        new OpenTelemetryOptions.Builder()
+                                .openTelemetry(otelTesting.getOpenTelemetry())
+                                .componentName("test-client")
+                                .build())))
                 .build(new Tester.ClientFactory());
     }
 

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -491,12 +491,12 @@ class OpenTelemetryHttpRequesterFilterTest {
     }
 
     @Test
-    void customSpanNamePrefix() throws Exception {
+    void customSpanNameExtractor() throws Exception {
         final String requestUrl = "/";
-        final String prefix = "Span prefix- ";
+        final String customPrefix = "CustomHttp-";
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         OpenTelemetryOptions openTelemetryOptions = new OpenTelemetryOptions.Builder()
-                .spanNameExtractor(req -> prefix)
+                .spanNameExtractor(req -> customPrefix + req.method() + " " + req.path())
                 .build();
         try (ServerContext context = buildServer(openTelemetry, openTelemetryOptions, true);
              HttpClient client = forSingleAddress(serverHostAndPort(context))
@@ -510,7 +510,7 @@ class OpenTelemetryHttpRequesterFilterTest {
             Thread.sleep(SLEEP_TIME);
             assertThat(otelTesting.getSpans()).hasSize(2);
             otelTesting.getSpans().forEach(spanData ->
-                assertThat(spanData.getName()).startsWith(prefix));
+                assertThat(spanData.getName()).isEqualTo("CustomHttp-GET /"));
         }
     }
 

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -496,7 +496,7 @@ class OpenTelemetryHttpRequesterFilterTest {
         final String prefix = "Span prefix- ";
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         OpenTelemetryOptions openTelemetryOptions = new OpenTelemetryOptions.Builder()
-                .spanNamePrefix(req -> prefix)
+                .spanNameExtractor(req -> prefix)
                 .build();
         try (ServerContext context = buildServer(openTelemetry, openTelemetryOptions, true);
              HttpClient client = forSingleAddress(serverHostAndPort(context))


### PR DESCRIPTION
Motivation:

If people want more than one instance of a filter in a pipeline, for example for tracing the physical requests as well as the logical requests there is currently no way because the spans will be suppressed.

Modifications:

- Add ability to suppress spans.
- To help disambiguate, add ability to prefix the span names.
- Because the filter constructors are getting out of hand, consolidate the parameters into the OpenTelemetryOptions and let that builder be the way to configure filters.

Result:

More flexible filters.
