### PR TITLE
opentelemetry-http: HttpAttributesGetter should always try to extract network attributes

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpAttributesGetter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpAttributesGetter.java
@@ -58,18 +58,18 @@ abstract class HttpAttributesGetter
     private HttpAttributesGetter() {}
 
     @Override
-    public String getHttpRequestMethod(final RequestInfo requestInfo) {
+    public final String getHttpRequestMethod(final RequestInfo requestInfo) {
         return requestInfo.request().method().name();
     }
 
     @Override
-    public List<String> getHttpRequestHeader(
+    public final List<String> getHttpRequestHeader(
             final RequestInfo requestInfo, final String name) {
         return getHeaderValues(requestInfo.request().headers(), name);
     }
 
     @Override
-    public Integer getHttpResponseStatusCode(
+    public final Integer getHttpResponseStatusCode(
             final RequestInfo requestInfo,
             final HttpResponseMetaData httpResponseMetaData,
             @Nullable final Throwable error) {
@@ -77,7 +77,7 @@ abstract class HttpAttributesGetter
     }
 
     @Override
-    public List<String> getHttpResponseHeader(
+    public final List<String> getHttpResponseHeader(
             final RequestInfo requestInfo,
             final HttpResponseMetaData httpResponseMetaData,
             final String name) {
@@ -102,7 +102,7 @@ abstract class HttpAttributesGetter
 
     @Nullable
     @Override
-    public String getNetworkTransport(RequestInfo requestInfo, @Nullable HttpResponseMetaData responseMetaData) {
+    public final String getNetworkTransport(RequestInfo requestInfo, @Nullable HttpResponseMetaData responseMetaData) {
         ConnectionInfo connectionInfo = requestInfo.connectionInfo();
         if (connectionInfo == null) {
             return null;
@@ -119,7 +119,7 @@ abstract class HttpAttributesGetter
 
     @Nullable
     @Override
-    public String getNetworkType(RequestInfo requestInfo, @Nullable HttpResponseMetaData responseMetaData) {
+    public final String getNetworkType(RequestInfo requestInfo, @Nullable HttpResponseMetaData responseMetaData) {
         ConnectionInfo connectionInfo = requestInfo.connectionInfo();
         if (connectionInfo == null) {
             return null;
@@ -133,6 +133,30 @@ abstract class HttpAttributesGetter
             }
         }
         return null;
+    }
+
+    @Nullable
+    @Override
+    public final InetSocketAddress getNetworkPeerInetSocketAddress(RequestInfo requestInfo,
+                                                                   @Nullable HttpResponseMetaData responseMetaData) {
+        ConnectionInfo connectionInfo = requestInfo.connectionInfo();
+        if (connectionInfo != null && connectionInfo.remoteAddress() instanceof InetSocketAddress) {
+            return (InetSocketAddress) connectionInfo.remoteAddress();
+        }
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public final String getNetworkPeerAddress(RequestInfo requestInfo,
+                                              @Nullable HttpResponseMetaData responseMetaData) {
+        return getResolvedPeerAddress(requestInfo);
+    }
+
+    @Nullable
+    @Override
+    public final Integer getNetworkPeerPort(RequestInfo requestInfo, @Nullable HttpResponseMetaData responseMetaData) {
+        return getResolvedPort(requestInfo);
     }
 
     private static List<String> getHeaderValues(final HttpHeaders headers, final String name) {
@@ -257,18 +281,6 @@ abstract class HttpAttributesGetter
         @Override
         public String getUrlQuery(final RequestInfo requestInfo) {
             return requestInfo.request().query();
-        }
-
-        @Nullable
-        @Override
-        public String getNetworkPeerAddress(RequestInfo requestInfo, @Nullable HttpResponseMetaData responseMetaData) {
-            return getResolvedPeerAddress(requestInfo);
-        }
-
-        @Nullable
-        @Override
-        public Integer getNetworkPeerPort(RequestInfo requestInfo, @Nullable HttpResponseMetaData responseMetaData) {
-            return getResolvedPort(requestInfo);
         }
     }
 

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/HttpAttributesGetterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/HttpAttributesGetterTest.java
@@ -23,10 +23,12 @@ import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
 import io.servicetalk.transport.api.ConnectionInfo;
 import io.servicetalk.transport.api.DomainSocketAddress;
 
+import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 
 import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
@@ -117,14 +119,13 @@ class HttpAttributesGetterTest {
         RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
 
         // Network attributes
-        assertThat(CLIENT_INSTANCE.getNetworkType(requestInfo, null), equalTo("ipv4"));
-        assertThat(SERVER_INSTANCE.getNetworkType(requestInfo, null), equalTo("ipv4"));
-        assertThat(CLIENT_INSTANCE.getNetworkTransport(requestInfo, null), equalTo("tcp"));
-        assertThat(SERVER_INSTANCE.getNetworkTransport(requestInfo, null), equalTo("tcp"));
-
-        // Network peer attributes (server-side only)
-        assertThat(SERVER_INSTANCE.getNetworkPeerAddress(requestInfo, null), equalTo("192.168.1.1"));
-        assertThat(SERVER_INSTANCE.getNetworkPeerPort(requestInfo, null), equalTo(8080));
+        for (NetworkAttributesGetter<RequestInfo, ?> getter : Arrays.asList(SERVER_INSTANCE, CLIENT_INSTANCE)) {
+            assertThat(getter.getNetworkType(requestInfo, null), equalTo("ipv4"));
+            assertThat(getter.getNetworkTransport(requestInfo, null), equalTo("tcp"));
+            assertThat(getter.getNetworkPeerInetSocketAddress(requestInfo, null), equalTo(inetAddress));
+            assertThat(getter.getNetworkPeerAddress(requestInfo, null), equalTo("192.168.1.1"));
+            assertThat(getter.getNetworkPeerPort(requestInfo, null), equalTo(8080));
+        }
 
         // Server attributes (client-side, fallback to connection)
         assertThat(CLIENT_INSTANCE.getServerAddress(requestInfo), equalTo("192.168.1.1"));
@@ -144,14 +145,13 @@ class HttpAttributesGetterTest {
         RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
 
         // Network attributes
-        assertThat(CLIENT_INSTANCE.getNetworkType(requestInfo, null), equalTo("ipv6"));
-        assertThat(SERVER_INSTANCE.getNetworkType(requestInfo, null), equalTo("ipv6"));
-        assertThat(CLIENT_INSTANCE.getNetworkTransport(requestInfo, null), equalTo("tcp"));
-        assertThat(SERVER_INSTANCE.getNetworkTransport(requestInfo, null), equalTo("tcp"));
-
-        // Network peer attributes (server-side only)
-        assertThat(SERVER_INSTANCE.getNetworkPeerAddress(requestInfo, null), equalTo("0:0:0:0:0:0:0:1"));
-        assertThat(SERVER_INSTANCE.getNetworkPeerPort(requestInfo, null), equalTo(8080));
+        for (NetworkAttributesGetter<RequestInfo, ?> getter : Arrays.asList(SERVER_INSTANCE, CLIENT_INSTANCE)) {
+            assertThat(getter.getNetworkType(requestInfo, null), equalTo("ipv6"));
+            assertThat(getter.getNetworkTransport(requestInfo, null), equalTo("tcp"));
+            assertThat(getter.getNetworkPeerInetSocketAddress(requestInfo, null), equalTo(inetAddress));
+            assertThat(getter.getNetworkPeerAddress(requestInfo, null), equalTo("0:0:0:0:0:0:0:1"));
+            assertThat(getter.getNetworkPeerPort(requestInfo, null), equalTo(8080));
+        }
 
         // Server attributes (client-side, fallback to connection)
         assertThat(CLIENT_INSTANCE.getServerAddress(requestInfo), equalTo("0:0:0:0:0:0:0:1"));
@@ -171,14 +171,13 @@ class HttpAttributesGetterTest {
         RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
 
         // Network attributes
-        assertThat(CLIENT_INSTANCE.getNetworkType(requestInfo, null), nullValue());
-        assertThat(SERVER_INSTANCE.getNetworkType(requestInfo, null), nullValue());
-        assertThat(CLIENT_INSTANCE.getNetworkTransport(requestInfo, null), equalTo("unix"));
-        assertThat(SERVER_INSTANCE.getNetworkTransport(requestInfo, null), equalTo("unix"));
-
-        // Network peer attributes (server-side only)
-        assertThat(SERVER_INSTANCE.getNetworkPeerAddress(requestInfo, null), equalTo("/tmp/socket"));
-        assertThat(SERVER_INSTANCE.getNetworkPeerPort(requestInfo, null), nullValue());
+        for (NetworkAttributesGetter<RequestInfo, ?> getter : Arrays.asList(SERVER_INSTANCE, CLIENT_INSTANCE)) {
+            assertThat(getter.getNetworkType(requestInfo, null), nullValue());
+            assertThat(getter.getNetworkTransport(requestInfo, null), equalTo("unix"));
+            assertThat(getter.getNetworkPeerInetSocketAddress(requestInfo, null), nullValue());
+            assertThat(getter.getNetworkPeerAddress(requestInfo, null), equalTo("/tmp/socket"));
+            assertThat(getter.getNetworkPeerPort(requestInfo, null), nullValue());
+        }
 
         // Server attributes (client-side, fallback to connection)
         assertThat(CLIENT_INSTANCE.getServerAddress(requestInfo), equalTo("/tmp/socket"));


### PR DESCRIPTION
#### Motivation

Network attributes are used for both client and server sides but we currently only extract them on the server side. This will cause client connection filters to unexpectedly miss the peer address info even though it's available.

#### Modifications

Always extract the attributes.
