### PR TITLE
fix(grpc-utils): don't log null throwable 

### DIFF
--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/LoggingHttpLifecycleObserver.java
@@ -175,42 +175,52 @@ final class LoggingHttpLifecycleObserver implements HttpLifecycleObserver {
                 unwrappedRequestResult = Result.cancelled;
             }
             assert responseResult != null;
-            final Throwable maybeException = ThrowableUtils.combine(responseResult, requestResult);
+            final Throwable throwable = ThrowableUtils.combine(responseResult, requestResult);
             if (responseMetaData != null) {
-                final String logMessage = "connection='{}' " +
-                        "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} " +
-                        "requestResult={} responseCode={} responseHeadersCount={} responseSize={} " +
-                        "responseTrailersCount={} responseResult={} responseTime={}ms totalTime={}ms";
-                if (maybeException == null) {
-                    logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
-                            requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                            requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
-                            responseMetaData.status().code(), responseMetaData.headers().size(), responseSize,
-                            responseTrailersCount, unwrapResult(responseResult), responseTimeMs, durationMs(startTime));
-                } else {
-                    logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
-                            requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                            requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
-                            responseMetaData.status().code(), responseMetaData.headers().size(), responseSize,
-                            responseTrailersCount, unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
-                            maybeException);
-                }
+                logWithResponse(requestMetaData, unwrappedRequestResult, responseMetaData, throwable);
             } else {
-                final String logMessage = "connection='{}' " +
-                        "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} " +
-                        "requestResult={} responseResult={} responseTime={}ms totalTime={}ms";
-                if (maybeException == null) {
-                    logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
-                            requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                            requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
-                            unwrapResult(responseResult), responseTimeMs, durationMs(startTime));
-                } else {
-                    logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
-                            requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
-                            requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
-                            unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
-                            maybeException);
-                }
+                logWithoutResponse(requestMetaData, unwrappedRequestResult, throwable);
+            }
+        }
+
+        private void logWithResponse(final HttpRequestMetaData requestMetaData, final Object unwrappedRequestResult,
+                                     final HttpResponseMetaData responseMetaData, @Nullable final Throwable throwable) {
+            final String logMessage = "connection='{}' " +
+                    "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} " +
+                    "requestResult={} responseCode={} responseHeadersCount={} responseSize={} " +
+                    "responseTrailersCount={} responseResult={} responseTime={}ms totalTime={}ms";
+            if (throwable == null) {
+                logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
+                        requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
+                        requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
+                        responseMetaData.status().code(), responseMetaData.headers().size(), responseSize,
+                        responseTrailersCount, unwrapResult(responseResult), responseTimeMs, durationMs(startTime));
+            } else {
+                logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
+                        requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
+                        requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
+                        responseMetaData.status().code(), responseMetaData.headers().size(), responseSize,
+                        responseTrailersCount, unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
+                        throwable);
+            }
+        }
+
+        private void logWithoutResponse(final HttpRequestMetaData requestMetaData, final Object unwrappedRequestResult,
+                                        @Nullable final Throwable maybeException) {
+            final String logMessage = "connection='{}' " +
+                    "request=\"{} {} {}\" requestHeadersCount={} requestSize={} requestTrailersCount={} " +
+                    "requestResult={} responseResult={} responseTime={}ms totalTime={}ms";
+            if (maybeException == null) {
+                logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
+                        requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
+                        requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
+                        unwrapResult(responseResult), responseTimeMs, durationMs(startTime));
+            } else {
+                logger.log(logMessage, connInfo == null ? "unknown" : connInfo,
+                        requestMetaData.method(), requestMetaData.requestTarget(), requestMetaData.version(),
+                        requestMetaData.headers().size(), requestSize, requestTrailersCount, unwrappedRequestResult,
+                        unwrapResult(responseResult), responseTimeMs, durationMs(startTime),
+                        maybeException);
             }
         }
 


### PR DESCRIPTION
#### Motivation

Some logging frameworks get confused and warn when you pass null as the
last argument to a log statement because they can't figure out if its
meant to be a throwable or one of the values you are trying to put into
a placeholder.

#### Modifications

This fixes the LoggingGrpcLifecycleObserver to avoid passing a null
throwable as when no error is present in the request processing chain.

#### Result

No more errors from logging framework for the common case of a
successful response.