### PR TITLE
opentelemetry-http: consolidate filter parameters into OTEL filter builders

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryFilter.java
@@ -33,7 +33,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
 abstract class AbstractOpenTelemetryFilter implements HttpExecutionStrategyInfluencer {
-    static final OpenTelemetryOptions DEFAULT_OPTIONS = new OpenTelemetryOptions.Builder().build();
     static final String INSTRUMENTATION_SCOPE_NAME = "io.servicetalk";
 
     // https://opentelemetry.io/docs/specs/semconv/registry/attributes/peer/

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpRequesterFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpRequesterFilter.java
@@ -43,8 +43,8 @@ abstract class AbstractOpenTelemetryHttpRequesterFilter extends AbstractOpenTele
      * @param builder options to create the opentelemetry filter, including OpenTelemetry instance and componentName
      */
     AbstractOpenTelemetryHttpRequesterFilter(final OpenTelemetryHttpRequesterFilter.Builder builder) {
-        this.httpHelper = HttpInstrumentationHelper.createClient(builder);
-        this.grpcHelper = GrpcInstrumentationHelper.createClient(builder);
+        this.httpHelper = HttpInstrumentationHelper.forClient(builder);
+        this.grpcHelper = GrpcInstrumentationHelper.forClient(builder);
     }
 
     @Override

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpRequesterFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpRequesterFilter.java
@@ -40,12 +40,11 @@ abstract class AbstractOpenTelemetryHttpRequesterFilter extends AbstractOpenTele
     /**
      * Create a new instance.
      *
-     * @param opentelemetryOptions extra options to create the opentelemetry filter, including OpenTelemetry
-     *                            instance and componentName
+     * @param builder options to create the opentelemetry filter, including OpenTelemetry instance and componentName
      */
-    AbstractOpenTelemetryHttpRequesterFilter(final OpenTelemetryOptions opentelemetryOptions) {
-        this.httpHelper = HttpInstrumentationHelper.createClient(opentelemetryOptions);
-        this.grpcHelper = GrpcInstrumentationHelper.createClient(opentelemetryOptions);
+    AbstractOpenTelemetryHttpRequesterFilter(final OpenTelemetryHttpRequesterFilter.Builder builder) {
+        this.httpHelper = HttpInstrumentationHelper.createClient(builder);
+        this.grpcHelper = GrpcInstrumentationHelper.createClient(builder);
     }
 
     @Override

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpServiceFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpServiceFilter.java
@@ -31,9 +31,9 @@ abstract class AbstractOpenTelemetryHttpServiceFilter extends AbstractOpenTeleme
     private final HttpInstrumentationHelper httpHelper;
     private final GrpcInstrumentationHelper grpcHelper;
 
-    AbstractOpenTelemetryHttpServiceFilter(final OpenTelemetryOptions openTelemetryOptions) {
-        this.httpHelper = HttpInstrumentationHelper.createServer(openTelemetryOptions);
-        this.grpcHelper = GrpcInstrumentationHelper.createServer(openTelemetryOptions);
+    AbstractOpenTelemetryHttpServiceFilter(final OpenTelemetryHttpServiceFilter.Builder builder) {
+        this.httpHelper = HttpInstrumentationHelper.createServer(builder);
+        this.grpcHelper = GrpcInstrumentationHelper.createServer(builder);
     }
 
     @Override

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpServiceFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpServiceFilter.java
@@ -32,8 +32,8 @@ abstract class AbstractOpenTelemetryHttpServiceFilter extends AbstractOpenTeleme
     private final GrpcInstrumentationHelper grpcHelper;
 
     AbstractOpenTelemetryHttpServiceFilter(final OpenTelemetryHttpServiceFilter.Builder builder) {
-        this.httpHelper = HttpInstrumentationHelper.createServer(builder);
-        this.grpcHelper = GrpcInstrumentationHelper.createServer(builder);
+        this.httpHelper = HttpInstrumentationHelper.forServer(builder);
+        this.grpcHelper = GrpcInstrumentationHelper.forServer(builder);
     }
 
     @Override

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcClientAttributesExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcClientAttributesExtractor.java
@@ -38,8 +38,8 @@ final class GrpcClientAttributesExtractor extends GrpcSemanticAttributesExtracto
     private static final AttributeKey<String> SERVER_ADDRESS = AttributeKey.stringKey("server.address");
     private static final AttributeKey<Long> SERVER_PORT = AttributeKey.longKey("server.port");
 
-    GrpcClientAttributesExtractor(OpenTelemetryOptions options) {
-        super(options);
+    GrpcClientAttributesExtractor(OpenTelemetryHttpRequesterFilter.Builder builder) {
+        super(builder.capturedRequestHeaders, builder.capturedResponseHeaders);
     }
 
     @Override

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcInstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcInstrumentationHelper.java
@@ -94,7 +94,7 @@ final class GrpcInstrumentationHelper extends InstrumentationHelper {
      * @param builder OpenTelemetryHttpServiceFilter configuration options
      * @return server instrumentation helper
      */
-    static GrpcInstrumentationHelper createServer(OpenTelemetryHttpServiceFilter.Builder builder) {
+    static GrpcInstrumentationHelper forServer(OpenTelemetryHttpServiceFilter.Builder builder) {
         OpenTelemetry openTelemetry = builder.openTelemetry;
         SpanNameExtractor<RequestInfo> serverSpanNameExtractor = GrpcSpanNameExtractor.INSTANCE;
         InstrumenterBuilder<RequestInfo, GrpcTelemetryStatus> serverInstrumenterBuilder =
@@ -119,7 +119,7 @@ final class GrpcInstrumentationHelper extends InstrumentationHelper {
      * @param builder OpenTelemetry configuration options
      * @return client instrumentation helper
      */
-    static GrpcInstrumentationHelper createClient(OpenTelemetryHttpRequesterFilter.Builder builder) {
+    static GrpcInstrumentationHelper forClient(OpenTelemetryHttpRequesterFilter.Builder builder) {
         OpenTelemetry openTelemetry = builder.openTelemetry;
         SpanNameExtractor<RequestInfo> clientSpanNameExtractor = GrpcSpanNameExtractor.INSTANCE;
         InstrumenterBuilder<RequestInfo, GrpcTelemetryStatus> clientInstrumenterBuilder =
@@ -132,7 +132,7 @@ final class GrpcInstrumentationHelper extends InstrumentationHelper {
         if (builder.enableMetrics) {
             clientInstrumenterBuilder.addOperationMetrics(HttpClientMetrics.get());
         }
-        String componentName = builder.componentName.trim();
+        String componentName = builder.componentName;
         if (!componentName.isEmpty()) {
             clientInstrumenterBuilder.addAttributesExtractor(
                     AttributesExtractor.constant(PEER_SERVICE, componentName));

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcInstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcInstrumentationHelper.java
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.servicetalk.opentelemetry.http;
 
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
-import io.servicetalk.transport.api.ConnectionInfo;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
@@ -45,10 +44,10 @@ import static io.servicetalk.opentelemetry.http.AbstractOpenTelemetryFilter.with
 /**
  * Helper class that encapsulates gRPC-specific OpenTelemetry instrumentation logic.
  * <p>
- * This helper handles the creation of gRPC instrumenters and provides methods to track
- * gRPC requests with proper span lifecycle management and gRPC semantic conventions.
+ * This helper handles the creation of gRPC instrumenters and provides methods to track gRPC
+ * requests with proper span lifecycle management and gRPC semantic conventions.
  */
-final class GrpcInstrumentationHelper {
+final class GrpcInstrumentationHelper extends InstrumentationHelper {
 
     private static final CharSequence GRPC_CONTENT_TYPE = newAsciiString("application/grpc");
 
@@ -64,29 +63,23 @@ final class GrpcInstrumentationHelper {
      * Tracks a gRPC request using gRPC-specific OpenTelemetry instrumentation.
      *
      * @param requestHandler function to execute the actual request
-     * @param request the gRPC request
-     * @param connectionInfo connection information (may be null for clients)
+     * @param requestInfo the gRPC request and connection info
+     * @param parentContext the currently active context
      * @return instrumented response single
      */
-    Single<StreamingHttpResponse> trackGrpcRequest(
+    @Override
+    Single<StreamingHttpResponse> doTrackRequest(
             Function<StreamingHttpRequest, Single<StreamingHttpResponse>> requestHandler,
-            StreamingHttpRequest request,
-            @Nullable ConnectionInfo connectionInfo) {
-
-        final Context parentContext = Context.current();
-        final RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
-
-        if (!instrumenter.shouldStart(parentContext, requestInfo)) {
-            return requestHandler.apply(request);
-        }
-
+            RequestInfo requestInfo,
+            Context parentContext) {
         final Context context = instrumenter.start(parentContext, requestInfo);
         try (Scope unused = context.makeCurrent()) {
             final GrpcScopeTracker tracker = isClient ?
                     GrpcScopeTracker.client(context, requestInfo, instrumenter) :
                     GrpcScopeTracker.server(context, requestInfo, instrumenter);
             try {
-                Single<StreamingHttpResponse> response = requestHandler.apply(request);
+                Single<StreamingHttpResponse> response =
+                        requestHandler.apply(requestInfo.request());
                 return withContext(tracker.track(response), context);
             } catch (Throwable t) {
                 tracker.onError(t);
@@ -98,24 +91,24 @@ final class GrpcInstrumentationHelper {
     /**
      * Creates a gRPC server instrumentation helper.
      *
-     * @param openTelemetry the OpenTelemetry instance
-     * @param options OpenTelemetry configuration options
+     * @param options OpenTelemetry configuration options containing the OpenTelemetry instance
      * @return server instrumentation helper
      */
-    static GrpcInstrumentationHelper createServer(OpenTelemetry openTelemetry, OpenTelemetryOptions options) {
+    static GrpcInstrumentationHelper createServer(OpenTelemetryOptions options) {
+        OpenTelemetry openTelemetry = options.openTelemetry();
         SpanNameExtractor<RequestInfo> serverSpanNameExtractor = GrpcSpanNameExtractor.INSTANCE;
         InstrumenterBuilder<RequestInfo, GrpcTelemetryStatus> serverInstrumenterBuilder =
                 Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, serverSpanNameExtractor);
-        serverInstrumenterBuilder.setSpanStatusExtractor(GrpcSpanStatusExtractor.SERVER_INSTANCE);
-
         serverInstrumenterBuilder
+                .setSpanStatusExtractor(GrpcSpanStatusExtractor.SERVER_INSTANCE)
                 .addAttributesExtractor(new GrpcServerAttributesExtractor(options));
         if (options.enableMetrics()) {
             serverInstrumenterBuilder.addOperationMetrics(HttpServerMetrics.get());
         }
 
         Instrumenter<RequestInfo, GrpcTelemetryStatus> instrumenter =
-                serverInstrumenterBuilder.buildServerInstrumenter(RequestHeadersPropagatorGetter.INSTANCE);
+                serverInstrumenterBuilder.buildServerInstrumenter(
+                        RequestHeadersPropagatorGetter.INSTANCE);
 
         return new GrpcInstrumentationHelper(instrumenter, false);
     }
@@ -123,16 +116,16 @@ final class GrpcInstrumentationHelper {
     /**
      * Creates a gRPC client instrumentation helper.
      *
-     * @param openTelemetry the OpenTelemetry instance
-     * @param options OpenTelemetry configuration options
-     * @param componentName component name for peer service attribute
+     * @param options OpenTelemetry configuration options containing the OpenTelemetry instance
+     *                (componentName from options used for peer service attribute)
      * @return client instrumentation helper
      */
-    static GrpcInstrumentationHelper createClient(OpenTelemetry openTelemetry, OpenTelemetryOptions options,
-                                                  String componentName) {
+    static GrpcInstrumentationHelper createClient(OpenTelemetryOptions options) {
+        OpenTelemetry openTelemetry = options.openTelemetry();
         SpanNameExtractor<RequestInfo> clientSpanNameExtractor = GrpcSpanNameExtractor.INSTANCE;
         InstrumenterBuilder<RequestInfo, GrpcTelemetryStatus> clientInstrumenterBuilder =
-                Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, clientSpanNameExtractor);
+                Instrumenter.builder(
+                        openTelemetry, INSTRUMENTATION_SCOPE_NAME, clientSpanNameExtractor);
         clientInstrumenterBuilder
                 .setSpanStatusExtractor(GrpcSpanStatusExtractor.CLIENT_INSTANCE)
                 .addAttributesExtractor(new DeferredGrpcClientAttributesExtractor(options));
@@ -140,14 +133,15 @@ final class GrpcInstrumentationHelper {
         if (options.enableMetrics()) {
             clientInstrumenterBuilder.addOperationMetrics(HttpClientMetrics.get());
         }
-        componentName = componentName.trim();
+        String componentName = options.componentName().trim();
         if (!componentName.isEmpty()) {
             clientInstrumenterBuilder.addAttributesExtractor(
                     AttributesExtractor.constant(PEER_SERVICE, componentName));
         }
 
         Instrumenter<RequestInfo, GrpcTelemetryStatus> instrumenter =
-                clientInstrumenterBuilder.buildClientInstrumenter(RequestHeadersPropagatorSetter.INSTANCE);
+                clientInstrumenterBuilder.buildClientInstrumenter(
+                        RequestHeadersPropagatorSetter.INSTANCE);
 
         return new GrpcInstrumentationHelper(instrumenter, true);
     }
@@ -183,8 +177,8 @@ final class GrpcInstrumentationHelper {
         return true;
     }
 
-    private static final class DeferredGrpcClientAttributesExtractor implements
-            AttributesExtractor<RequestInfo, GrpcTelemetryStatus> {
+    private static final class DeferredGrpcClientAttributesExtractor
+            implements AttributesExtractor<RequestInfo, GrpcTelemetryStatus> {
 
         private final AttributesExtractor<RequestInfo, GrpcTelemetryStatus> delegate;
 
@@ -193,14 +187,17 @@ final class GrpcInstrumentationHelper {
         }
 
         @Override
-        public void onStart(io.opentelemetry.api.common.AttributesBuilder attributes, Context parentContext,
+        public void onStart(AttributesBuilder attributes,
+                            Context parentContext,
                             RequestInfo requestInfo) {
             // noop: we will defer this until the `onEnd` call.
         }
 
         @Override
-        public void onEnd(io.opentelemetry.api.common.AttributesBuilder attributes, Context context,
-                          RequestInfo requestInfo, @Nullable GrpcTelemetryStatus telemetryStatus,
+        public void onEnd(AttributesBuilder attributes,
+                          Context context,
+                          RequestInfo requestInfo,
+                          @Nullable GrpcTelemetryStatus telemetryStatus,
                           @Nullable Throwable error) {
             delegate.onStart(attributes, context, requestInfo);
             delegate.onEnd(attributes, context, requestInfo, telemetryStatus, error);

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcSemanticAttributesExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcSemanticAttributesExtractor.java
@@ -28,6 +28,7 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -53,11 +54,9 @@ abstract class GrpcSemanticAttributesExtractor implements AttributesExtractor<Re
 
     private final AttributesExtractor<RequestInfo, GrpcTelemetryStatus> capturedHeadersExtractor;
 
-    GrpcSemanticAttributesExtractor(OpenTelemetryOptions openTelemetryOptions) {
+    GrpcSemanticAttributesExtractor(List<String> capturedRequestHeaders, List<String> capturedResponseHeaders) {
         this.capturedHeadersExtractor = new GrpcCapturedHeadersExtractor(
-                openTelemetryOptions.capturedRequestHeaders(),
-                openTelemetryOptions.capturedResponseHeaders()
-        );
+                capturedRequestHeaders, capturedResponseHeaders);
     }
 
     @Override

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcServerAttributesExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcServerAttributesExtractor.java
@@ -39,8 +39,8 @@ final class GrpcServerAttributesExtractor extends GrpcSemanticAttributesExtracto
     private static final AttributeKey<String> CLIENT_ADDRESS = AttributeKey.stringKey("client.address");
     private static final AttributeKey<Long> CLIENT_PORT = AttributeKey.longKey("client.port");
 
-    GrpcServerAttributesExtractor(OpenTelemetryOptions openTelemetryOptions) {
-        super(openTelemetryOptions);
+    GrpcServerAttributesExtractor(OpenTelemetryHttpServiceFilter.Builder builder) {
+        super(builder.capturedRequestHeaders, builder.capturedResponseHeaders);
     }
 
     @Override

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpInstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpInstrumentationHelper.java
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.servicetalk.opentelemetry.http;
 
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
-import io.servicetalk.transport.api.ConnectionInfo;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -49,13 +47,12 @@ import static io.servicetalk.opentelemetry.http.AbstractOpenTelemetryFilter.with
  * This helper handles the creation of HTTP instrumenters and provides methods to track
  * HTTP requests with proper span lifecycle management and HTTP semantic conventions.
  */
-final class HttpInstrumentationHelper {
+final class HttpInstrumentationHelper extends InstrumentationHelper {
 
     private final Instrumenter<RequestInfo, HttpResponseMetaData> instrumenter;
     private final boolean isClient;
 
-    private HttpInstrumentationHelper(
-            Instrumenter<RequestInfo, HttpResponseMetaData> instrumenter, boolean isClient) {
+    private HttpInstrumentationHelper(Instrumenter<RequestInfo, HttpResponseMetaData> instrumenter, boolean isClient) {
         this.instrumenter = instrumenter;
         this.isClient = isClient;
     }
@@ -64,28 +61,21 @@ final class HttpInstrumentationHelper {
      * Tracks an HTTP request using HTTP-specific OpenTelemetry instrumentation.
      *
      * @param requestHandler function to execute the actual request
-     * @param request the HTTP request
-     * @param connectionInfo connection information (may be null for clients)
+     * @param requestInfo the HTTP request and connection info
+     * @param parentContext the currently active context
      * @return instrumented response single
      */
-    Single<StreamingHttpResponse> trackHttpRequest(
+    @Override
+    Single<StreamingHttpResponse> doTrackRequest(
             Function<StreamingHttpRequest, Single<StreamingHttpResponse>> requestHandler,
-            StreamingHttpRequest request,
-            @Nullable ConnectionInfo connectionInfo) {
-
-        final Context parentContext = Context.current();
-        final RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
-
-        if (!instrumenter.shouldStart(parentContext, requestInfo)) {
-            return requestHandler.apply(request);
-        }
-
+            RequestInfo requestInfo,
+            Context parentContext) {
         final Context context = instrumenter.start(parentContext, requestInfo);
         try (Scope unused = context.makeCurrent()) {
             final HttpScopeTracker tracker = isClient ? HttpScopeTracker.client(context, requestInfo, instrumenter) :
                     HttpScopeTracker.server(context, requestInfo, instrumenter);
             try {
-                Single<StreamingHttpResponse> response = requestHandler.apply(request);
+                Single<StreamingHttpResponse> response = requestHandler.apply(requestInfo.request());
                 return withContext(tracker.track(response), context);
             } catch (Throwable t) {
                 tracker.onError(t);
@@ -97,11 +87,11 @@ final class HttpInstrumentationHelper {
     /**
      * Creates an HTTP server instrumentation helper.
      *
-     * @param openTelemetry the OpenTelemetry instance
-     * @param options OpenTelemetry configuration options
+     * @param options OpenTelemetry configuration options containing the OpenTelemetry instance
      * @return server instrumentation helper
      */
-    static HttpInstrumentationHelper createServer(OpenTelemetry openTelemetry, OpenTelemetryOptions options) {
+    static HttpInstrumentationHelper createServer(OpenTelemetryOptions options) {
+        OpenTelemetry openTelemetry = options.openTelemetry();
         SpanNameExtractor<RequestInfo> serverSpanNameExtractor =
                 HttpSpanNameExtractor.create(HttpAttributesGetter.SERVER_INSTANCE);
         InstrumenterBuilder<RequestInfo, HttpResponseMetaData> serverInstrumenterBuilder =
@@ -127,13 +117,12 @@ final class HttpInstrumentationHelper {
     /**
      * Creates an HTTP client instrumentation helper.
      *
-     * @param openTelemetry the OpenTelemetry instance
-     * @param options OpenTelemetry configuration options
-     * @param componentName component name for peer service attribute
+     * @param options OpenTelemetry configuration options containing the OpenTelemetry instance
+     *                (componentName from options used for peer service attribute)
      * @return client instrumentation helper
      */
-    static HttpInstrumentationHelper createClient(OpenTelemetry openTelemetry, OpenTelemetryOptions options,
-                                                  String componentName) {
+    static HttpInstrumentationHelper createClient(OpenTelemetryOptions options) {
+        OpenTelemetry openTelemetry = options.openTelemetry();
         SpanNameExtractor<RequestInfo> clientSpanNameExtractor =
                 HttpSpanNameExtractor.create(HttpAttributesGetter.CLIENT_INSTANCE);
         InstrumenterBuilder<RequestInfo, HttpResponseMetaData> clientInstrumenterBuilder =
@@ -145,7 +134,7 @@ final class HttpInstrumentationHelper {
         if (options.enableMetrics()) {
             clientInstrumenterBuilder.addOperationMetrics(HttpClientMetrics.get());
         }
-        componentName = componentName.trim();
+        String componentName = options.componentName().trim();
         if (!componentName.isEmpty()) {
             clientInstrumenterBuilder.addAttributesExtractor(
                     AttributesExtractor.constant(PEER_SERVICE, componentName));

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpInstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpInstrumentationHelper.java
@@ -90,7 +90,7 @@ final class HttpInstrumentationHelper extends InstrumentationHelper {
      * @param builder OpenTelemetryHttpServiceFilter configuration options
      * @return server instrumentation helper
      */
-    static HttpInstrumentationHelper createServer(OpenTelemetryHttpServiceFilter.Builder builder) {
+    static HttpInstrumentationHelper forServer(OpenTelemetryHttpServiceFilter.Builder builder) {
         OpenTelemetry openTelemetry = builder.openTelemetry;
         SpanNameExtractor<RequestInfo> serverSpanNameExtractor =
                 HttpSpanNameExtractor.create(HttpAttributesGetter.SERVER_INSTANCE);
@@ -120,7 +120,7 @@ final class HttpInstrumentationHelper extends InstrumentationHelper {
      * @param builder OpenTelemetry configuration options
      * @return client instrumentation helper
      */
-    static HttpInstrumentationHelper createClient(final OpenTelemetryHttpRequesterFilter.Builder builder) {
+    static HttpInstrumentationHelper forClient(final OpenTelemetryHttpRequesterFilter.Builder builder) {
         OpenTelemetry openTelemetry = builder.openTelemetry;
         SpanNameExtractor<RequestInfo> clientSpanNameExtractor =
                 HttpSpanNameExtractor.create(HttpAttributesGetter.CLIENT_INSTANCE);
@@ -133,7 +133,7 @@ final class HttpInstrumentationHelper extends InstrumentationHelper {
         if (builder.enableMetrics) {
             clientInstrumenterBuilder.addOperationMetrics(HttpClientMetrics.get());
         }
-        String componentName = builder.componentName.trim();
+        String componentName = builder.componentName;
         if (!componentName.isEmpty()) {
             clientInstrumenterBuilder.addAttributesExtractor(
                     AttributesExtractor.constant(PEER_SERVICE, componentName));

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/InstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/InstrumentationHelper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentelemetry.http;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+
+import io.opentelemetry.context.Context;
+
+import java.util.function.Function;
+
+abstract class InstrumentationHelper {
+
+    abstract Single<StreamingHttpResponse> doTrackRequest(
+            Function<StreamingHttpRequest, Single<StreamingHttpResponse>> requestHandler,
+            RequestInfo requestInfo,
+            Context parentContext);
+
+    final Single<StreamingHttpResponse> trackRequest(
+            Function<StreamingHttpRequest, Single<StreamingHttpResponse>> requestHandler,
+            RequestInfo requestInfo,
+            Context parentContext) {
+        return doTrackRequest(requestHandler, requestInfo, parentContext);
+    }
+}

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2025 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.opentelemetry.http;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpClientMetrics;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerMetrics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+abstract class OpenTelemetryFilterBuilder<T extends OpenTelemetryFilterBuilder<T>> {
+    List<String> capturedRequestHeaders = emptyList();
+    List<String> capturedResponseHeaders = emptyList();
+    boolean enableMetrics;
+    OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+
+    abstract T thisInstance();
+
+    // TODO: remove once we can remove the OpenTelemetryOptions
+    final T applyOptions(final OpenTelemetryOptions options) {
+        enableMetrics = options.enableMetrics();
+        capturedRequestHeaders = options.capturedRequestHeaders();
+        capturedResponseHeaders = options.capturedResponseHeaders();
+        return thisInstance();
+    }
+
+    /**
+     * Add the headers to be captured as extra span attributes.
+     *
+     * @param capturedRequestHeaders extra headers to be captured in client/server requests and
+     *     added as extra span attributes
+     * @return {@code this}
+     * @see HttpClientAttributesExtractorBuilder#setCapturedRequestHeaders(List)
+     * @see HttpServerAttributesExtractorBuilder#setCapturedRequestHeaders(List)
+     */
+    public final T capturedRequestHeaders(final List<String> capturedRequestHeaders) {
+        requireNonNull(capturedRequestHeaders, "capturedRequestHeaders");
+        this.capturedRequestHeaders =
+                capturedRequestHeaders.isEmpty() ? emptyList() :
+                        unmodifiableList(new ArrayList<>(capturedRequestHeaders));
+        return thisInstance();
+    }
+
+    /**
+     * Add the headers to be captured as extra span attributes.
+     *
+     * @param capturedResponseHeaders extra headers to be captured in client/server response and
+     *     added as extra span attributes
+     * @return {@code this}
+     * @see HttpClientAttributesExtractorBuilder#setCapturedResponseHeaders(List)
+     * @see HttpServerAttributesExtractorBuilder#setCapturedResponseHeaders(List)
+     */
+    public final T capturedResponseHeaders(final List<String> capturedResponseHeaders) {
+        requireNonNull(capturedResponseHeaders, "capturedResponseHeaders");
+        this.capturedResponseHeaders =
+                capturedResponseHeaders.isEmpty() ? emptyList() :
+                        unmodifiableList(new ArrayList<>(capturedResponseHeaders));
+        return thisInstance();
+    }
+
+    /**
+     * Whether to enable operation metrics or not.
+     *
+     * @param enableMetrics whether to enable operation metrics or not
+     * @return {@code this}
+     * @see InstrumenterBuilder#addOperationMetrics(OperationMetrics)
+     * @see HttpClientMetrics
+     * @see HttpServerMetrics
+     */
+    public final T enableMetrics(final boolean enableMetrics) {
+        this.enableMetrics = enableMetrics;
+        return thisInstance();
+    }
+
+    /**
+     * Set the {@link OpenTelemetry} instance to use for creating spans.
+     *
+     * @param openTelemetry the {@link OpenTelemetry} instance
+     * @return {@code this}
+     */
+    public final T openTelemetry(OpenTelemetry openTelemetry) {
+        this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry");
+        return thisInstance();
+    }
+}

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
@@ -40,6 +40,7 @@ abstract class OpenTelemetryFilterBuilder<T extends OpenTelemetryFilterBuilder<T
     abstract T thisInstance();
 
     // TODO: remove once we can remove the OpenTelemetryOptions
+    @SuppressWarnings("deprecation")
     final T applyOptions(final OpenTelemetryOptions options) {
         enableMetrics = options.enableMetrics();
         capturedRequestHeaders = options.capturedRequestHeaders();
@@ -48,7 +49,7 @@ abstract class OpenTelemetryFilterBuilder<T extends OpenTelemetryFilterBuilder<T
     }
 
     /**
-     * Add the headers to be captured as extra span attributes.
+     * Add the request headers to be captured as extra span attributes.
      *
      * @param capturedRequestHeaders extra headers to be captured in client/server requests and
      *     added as extra span attributes
@@ -65,7 +66,7 @@ abstract class OpenTelemetryFilterBuilder<T extends OpenTelemetryFilterBuilder<T
     }
 
     /**
-     * Add the headers to be captured as extra span attributes.
+     * Add the response headers to be captured as extra span attributes.
      *
      * @param capturedResponseHeaders extra headers to be captured in client/server response and
      *     added as extra span attributes

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
@@ -84,25 +84,29 @@ abstract class OpenTelemetryFilterBuilder<T extends OpenTelemetryFilterBuilder<T
 
     /**
      * Whether to enable operation metrics or not.
-     *
+     * <p>
+     * Note that this has been intentionally kept package private for backwards compatibility with the deprecated
+     * {@link OpenTelemetryOptions.Builder#enableMetrics(boolean)} method.
      * @param enableMetrics whether to enable operation metrics or not
      * @return {@code this}
      * @see InstrumenterBuilder#addOperationMetrics(OperationMetrics)
      * @see HttpClientMetrics
      * @see HttpServerMetrics
      */
-    public final T enableMetrics(final boolean enableMetrics) {
+    final T enableMetrics(final boolean enableMetrics) {
         this.enableMetrics = enableMetrics;
         return thisInstance();
     }
 
     /**
      * Set the {@link OpenTelemetry} instance to use for creating spans.
-     *
+     * <p>
+     * Note that this is deliberately left package private. Beyond testing, there are not any compelling use cases
+     * for an {@link OpenTelemetry} other than {@link GlobalOpenTelemetry#get()}.
      * @param openTelemetry the {@link OpenTelemetry} instance
      * @return {@code this}
      */
-    public final T openTelemetry(OpenTelemetry openTelemetry) {
+    final T openTelemetry(OpenTelemetry openTelemetry) {
         this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry");
         return thisInstance();
     }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -57,10 +57,9 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequestFilter(final OpenTelemetry openTelemetry, String componentName) {
-        super(new OpenTelemetryOptions.Builder()
+        super(new OpenTelemetryHttpRequesterFilter.Builder()
                 .openTelemetry(openTelemetry)
-                .componentName(componentName)
-                .build());
+                .componentName(componentName));
     }
 
     /**
@@ -69,7 +68,7 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      * @param componentName The component name used during building new spans.
      */
     public OpenTelemetryHttpRequestFilter(final String componentName) {
-        this(componentName, DEFAULT_OPTIONS);
+        super(new OpenTelemetryHttpRequesterFilter.Builder().componentName(componentName));
     }
 
     /**
@@ -79,9 +78,9 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      * @param opentelemetryOptions extra options to create the opentelemetry filter
      */
     public OpenTelemetryHttpRequestFilter(final String componentName, final OpenTelemetryOptions opentelemetryOptions) {
-        super(new OpenTelemetryOptions.Builder(opentelemetryOptions)
-                .componentName(componentName)
-                .build());
+        super(new OpenTelemetryHttpRequesterFilter.Builder()
+                .applyOptions(opentelemetryOptions)
+                .componentName(componentName));
     }
 
     /**
@@ -89,6 +88,6 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      * using the hostname as the component name.
      */
     public OpenTelemetryHttpRequestFilter() {
-        this("");
+        super(new OpenTelemetryHttpRequesterFilter.Builder());
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -39,7 +39,7 @@ import java.util.function.UnaryOperator;
  * {@link StreamingHttpResponse#transformMessageBody(UnaryOperator)} response message body.
  * (e.g. {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and
  * therefore will not see the {@link Span} for the current request/response.
- * @deprecated use {@link OpenTelemetryHttpRequesterFilter} instead.
+ * @deprecated use {@link OpenTelemetryHttpRequesterFilter.Builder} instead.
  */
 @Deprecated // FIXME: 0.43 - remove deprecated class
 public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryHttpRequesterFilter {
@@ -52,8 +52,7 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      * @deprecated this method is internal, no user should be setting the {@link OpenTelemetry} as it is obtained by
      * using {@link GlobalOpenTelemetry#get()} and there should be no other implementations but the one available in
      * the classpath, this constructor will be removed in the future releases.
-     * Use {@link #OpenTelemetryHttpRequestFilter(String, OpenTelemetryOptions)} or
-     * {@link #OpenTelemetryHttpRequestFilter()} instead.
+     * Use {@link OpenTelemetryHttpRequesterFilter.Builder} instead.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequestFilter(final OpenTelemetry openTelemetry, String componentName) {
@@ -66,7 +65,9 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      * Create a new instance, searching for any instance of an opentelemetry available.
      *
      * @param componentName The component name used during building new spans.
+     * @deprecated Use {@link OpenTelemetryHttpRequesterFilter.Builder} instead.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequestFilter(final String componentName) {
         super(new OpenTelemetryHttpRequesterFilter.Builder().componentName(componentName));
     }
@@ -76,7 +77,9 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      *
      * @param componentName        The component name used during building new spans.
      * @param opentelemetryOptions extra options to create the opentelemetry filter
+     * @deprecated Use {@link OpenTelemetryHttpRequesterFilter.Builder} instead.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequestFilter(final String componentName, final OpenTelemetryOptions opentelemetryOptions) {
         super(new OpenTelemetryHttpRequesterFilter.Builder()
                 .applyOptions(opentelemetryOptions)
@@ -86,7 +89,9 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
     /**
      * Create a new instance, searching for any instance of an opentelemetry available,
      * using the hostname as the component name.
+     * @deprecated Use {@link OpenTelemetryHttpRequesterFilter.Builder} instead.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequestFilter() {
         super(new OpenTelemetryHttpRequesterFilter.Builder());
     }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequestFilter.java
@@ -36,7 +36,7 @@ import java.util.function.UnaryOperator;
  * Append this filter before others that are expected to see {@link Scope} for this request/response. Filters
  * appended after this filter that use operators with the <strong>after*</strong> prefix on
  * {@link io.servicetalk.http.api.StreamingHttpClient#request(StreamingHttpRequest) response meta data} or the
- * {@link StreamingHttpResponse#transformMessageBody(UnaryOperator)} response message body}
+ * {@link StreamingHttpResponse#transformMessageBody(UnaryOperator)} response message body.
  * (e.g. {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and
  * therefore will not see the {@link Span} for the current request/response.
  * @deprecated use {@link OpenTelemetryHttpRequesterFilter} instead.
@@ -57,7 +57,10 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequestFilter(final OpenTelemetry openTelemetry, String componentName) {
-        super(openTelemetry, componentName, DEFAULT_OPTIONS);
+        super(new OpenTelemetryOptions.Builder()
+                .openTelemetry(openTelemetry)
+                .componentName(componentName)
+                .build());
     }
 
     /**
@@ -76,7 +79,9 @@ public final class OpenTelemetryHttpRequestFilter extends AbstractOpenTelemetryH
      * @param opentelemetryOptions extra options to create the opentelemetry filter
      */
     public OpenTelemetryHttpRequestFilter(final String componentName, final OpenTelemetryOptions opentelemetryOptions) {
-        super(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions);
+        super(new OpenTelemetryOptions.Builder(opentelemetryOptions)
+                .componentName(componentName)
+                .build());
     }
 
     /**

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilter.java
@@ -20,8 +20,6 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
@@ -36,17 +34,31 @@ import java.util.function.UnaryOperator;
  * Append this filter before others that are expected to see {@link Scope} for this request/response. Filters
  * appended after this filter that use operators with the <strong>after*</strong> prefix on
  * {@link io.servicetalk.http.api.StreamingHttpClient#request(StreamingHttpRequest) response meta data} or the
- * {@link StreamingHttpResponse#transformMessageBody(UnaryOperator)} response message body}
+ * {@link StreamingHttpResponse#transformMessageBody(UnaryOperator)} response message body.
  * (e.g. {@link Publisher#afterFinally(Runnable)}) will execute after this filter invokes {@link Scope#close()} and
  * therefore will not see the {@link Span} for the current request/response.
  */
 public final class OpenTelemetryHttpRequesterFilter extends AbstractOpenTelemetryHttpRequesterFilter {
 
     /**
+     * Create a new instance with the provided {@link OpenTelemetryOptions}.
+     * <p>
+     * The options should include client-specific configuration such as componentName.
+     *
+     * @param openTelemetryOptions options to configure the filter, including client-specific settings
+     */
+    public OpenTelemetryHttpRequesterFilter(final OpenTelemetryOptions openTelemetryOptions) {
+        super(openTelemetryOptions);
+    }
+
+    /**
      * Create a new instance, searching for any instance of an opentelemetry available.
      *
      * @param componentName The component name used during building new spans.
+     * @deprecated use {@link #OpenTelemetryHttpRequesterFilter(OpenTelemetryOptions)} with
+     *             {@link OpenTelemetryOptions.Builder#componentName(String)} to create new filter instances.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequesterFilter(final String componentName) {
         this(componentName, DEFAULT_OPTIONS);
     }
@@ -56,22 +68,25 @@ public final class OpenTelemetryHttpRequesterFilter extends AbstractOpenTelemetr
      *
      * @param componentName        The component name used during building new spans.
      * @param opentelemetryOptions extra options to create the opentelemetry filter
+     * @deprecated use {@link #OpenTelemetryHttpRequesterFilter(OpenTelemetryOptions)} with
+     *             {@link OpenTelemetryOptions.Builder} to configure all options including componentName.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequesterFilter(final String componentName,
                                             final OpenTelemetryOptions opentelemetryOptions) {
-        this(GlobalOpenTelemetry.get(), componentName, opentelemetryOptions);
+        super(new OpenTelemetryOptions.Builder(opentelemetryOptions)
+                .componentName(componentName)
+                .build());
     }
 
     /**
      * Create a new instance, searching for any instance of an opentelemetry available,
      * using the hostname as the component name.
+     * @deprecated use {@link #OpenTelemetryHttpRequesterFilter(OpenTelemetryOptions)} with
+     *             {@link OpenTelemetryOptions.Builder} to create new filter instances.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpRequesterFilter() {
         this("");
-    }
-
-    OpenTelemetryHttpRequesterFilter(final OpenTelemetry openTelemetry, String componentName,
-                                     final OpenTelemetryOptions opentelemetryOptions) {
-        super(openTelemetry, componentName, opentelemetryOptions);
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilter.java
@@ -100,9 +100,6 @@ public final class OpenTelemetryHttpRequesterFilter extends AbstractOpenTelemetr
 
         /**
          * Set the component name used during building new spans.
-         * <p>
-         * This is a client-specific option that maps to the {@code peer.service} attribute
-         * and will be ignored when used with server filters.
          *
          * @param componentName the component name
          * @return {@code this}

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
@@ -39,7 +39,7 @@ import io.opentelemetry.context.Context;
  *     {@link io.servicetalk.http.utils.HttpRequestAutoDrainingServiceFilter} immediately after.</li>
  *     <li>To ensure tracing sees the same result status codes as the calling client, add the
  *     {@link io.servicetalk.http.api.HttpExceptionMapperServiceFilter} after this filter.</li>
- *     <li>If you intend to use a {@link io.servicetalk.http.api.HttpLifecycleObserver}, add it using the the
+ *     <li>If you intend to use a {@link io.servicetalk.http.api.HttpLifecycleObserver}, add it using the
  *     HttpLifecycleObserverServiceFilter after the tracing filter to ensure the correct {@link Span} information is
  *     present.</li>
  * </ul>
@@ -64,7 +64,9 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     @SuppressWarnings("DeprecatedIsStillUsed")
     public OpenTelemetryHttpServerFilter(final OpenTelemetry openTelemetry) {
-        super(openTelemetry, DEFAULT_OPTIONS);
+        super(new OpenTelemetryOptions.Builder(DEFAULT_OPTIONS)
+                .openTelemetry(openTelemetry)
+                .build());
     }
 
     /**
@@ -81,6 +83,7 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
      * @param openTelemetryOptions extra options to create the opentelemetry filter
      */
     public OpenTelemetryHttpServerFilter(final OpenTelemetryOptions openTelemetryOptions) {
-        super(GlobalOpenTelemetry.get(), openTelemetryOptions);
+        super(new OpenTelemetryOptions.Builder(openTelemetryOptions)
+                .build());
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
@@ -46,7 +46,7 @@ import io.opentelemetry.context.Context;
  * Be sure to use the
  * {@link io.servicetalk.http.api.HttpServerBuilder#appendNonOffloadingServiceFilter(StreamingHttpServiceFilterFactory)}
  * method for adding these filters as non-offloading filters are always added before offloading filters.
- * @deprecated use {@link OpenTelemetryHttpServiceFilter} instead.
+ * @deprecated use {@link OpenTelemetryHttpServiceFilter.Builder} instead.
  */
 @Deprecated // FIXME: 0.43 - remove deprecated class
 public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHttpServiceFilter {
@@ -58,8 +58,7 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
      * @deprecated this method is internal, no user should be setting the {@link OpenTelemetry} as it is obtained by
      * using {@link GlobalOpenTelemetry#get()} and there should be no other implementations but the one available in
      * the classpath, this constructor will be removed in the future releases.
-     * Use {@link #OpenTelemetryHttpServerFilter(OpenTelemetryOptions)} or {@link #OpenTelemetryHttpServerFilter()}
-     * instead.
+     * Use {@link OpenTelemetryHttpServiceFilter.Builder} instead.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     @SuppressWarnings("DeprecatedIsStillUsed")
@@ -70,7 +69,9 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
     /**
      * Create a new instance using the {@link OpenTelemetry} from {@link GlobalOpenTelemetry#get()} with default
      * {@link OpenTelemetryOptions}.
+     * @deprecated Use {@link OpenTelemetryHttpServiceFilter.Builder} instead.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated class
     public OpenTelemetryHttpServerFilter() {
         super(new OpenTelemetryHttpServiceFilter.Builder());
     }
@@ -79,7 +80,9 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
      * Create a new instance.
      *
      * @param openTelemetryOptions extra options to create the opentelemetry filter
+     * @deprecated Use {@link OpenTelemetryHttpServiceFilter.Builder} instead.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated class
     public OpenTelemetryHttpServerFilter(final OpenTelemetryOptions openTelemetryOptions) {
         super(new OpenTelemetryHttpServiceFilter.Builder().applyOptions(openTelemetryOptions));
     }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServerFilter.java
@@ -64,9 +64,7 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     @SuppressWarnings("DeprecatedIsStillUsed")
     public OpenTelemetryHttpServerFilter(final OpenTelemetry openTelemetry) {
-        super(new OpenTelemetryOptions.Builder(DEFAULT_OPTIONS)
-                .openTelemetry(openTelemetry)
-                .build());
+        super(new OpenTelemetryHttpServiceFilter.Builder().openTelemetry(openTelemetry));
     }
 
     /**
@@ -74,7 +72,7 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
      * {@link OpenTelemetryOptions}.
      */
     public OpenTelemetryHttpServerFilter() {
-        this(DEFAULT_OPTIONS);
+        super(new OpenTelemetryHttpServiceFilter.Builder());
     }
 
     /**
@@ -83,7 +81,6 @@ public final class OpenTelemetryHttpServerFilter extends AbstractOpenTelemetryHt
      * @param openTelemetryOptions extra options to create the opentelemetry filter
      */
     public OpenTelemetryHttpServerFilter(final OpenTelemetryOptions openTelemetryOptions) {
-        super(new OpenTelemetryOptions.Builder(openTelemetryOptions)
-                .build());
+        super(new OpenTelemetryHttpServiceFilter.Builder().applyOptions(openTelemetryOptions));
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
@@ -52,7 +52,7 @@ public final class OpenTelemetryHttpServiceFilter extends AbstractOpenTelemetryH
     /**
      * Create a new instance using the {@link OpenTelemetry} from {@link GlobalOpenTelemetry#get()} with default
      * {@link OpenTelemetryOptions}.
-     * @deprecated use the constructor
+     * @deprecated use the {@link Builder} to construct filter instances.
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpServiceFilter() {

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
@@ -69,7 +69,7 @@ public final class OpenTelemetryHttpServiceFilter extends AbstractOpenTelemetryH
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpServiceFilter(final OpenTelemetryOptions openTelemetryOptions) {
-        super(new Builder(openTelemetryOptions));
+        super(new Builder().applyOptions(openTelemetryOptions));
     }
 
     private OpenTelemetryHttpServiceFilter(Builder builder) {
@@ -80,12 +80,6 @@ public final class OpenTelemetryHttpServiceFilter extends AbstractOpenTelemetryH
      * Builder for constructing {@link OpenTelemetryHttpServiceFilter} filter instances.
      */
     public static final class Builder extends OpenTelemetryFilterBuilder<Builder> {
-
-        Builder(OpenTelemetryOptions options) {
-            capturedRequestHeaders = options.capturedRequestHeaders();
-            capturedResponseHeaders = options.capturedResponseHeaders();
-            enableMetrics = options.enableMetrics();
-        }
 
         /**
          * Create a new builder.

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
@@ -56,7 +56,7 @@ public final class OpenTelemetryHttpServiceFilter extends AbstractOpenTelemetryH
      */
     @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpServiceFilter() {
-        this(DEFAULT_OPTIONS);
+        this(new Builder());
     }
 
     /**
@@ -65,24 +65,45 @@ public final class OpenTelemetryHttpServiceFilter extends AbstractOpenTelemetryH
      * @param openTelemetryOptions extra options to create the opentelemetry filter.
      *                            Client-specific options (componentName, openTelemetry, ignoreSpanSuppression)
      *                            will be ignored for server filters.
+     * @deprecated use the {@link Builder} to construct filter instances.
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpServiceFilter(final OpenTelemetryOptions openTelemetryOptions) {
-        super(openTelemetryOptions);
+        super(new Builder(openTelemetryOptions));
+    }
+
+    private OpenTelemetryHttpServiceFilter(Builder builder) {
+        super(builder);
     }
 
     /**
-     * Create a new instance.
-     *
-     * @param openTelemetry the {@link OpenTelemetry}.
-     * @param openTelemetryOptions extra options to create the opentelemetry filter
-     * @deprecated Use {@link #OpenTelemetryHttpServiceFilter(OpenTelemetryOptions)} instead.
-     * The OpenTelemetry instance should be provided via {@link OpenTelemetryOptions}.
+     * Builder for constructing {@link OpenTelemetryHttpServiceFilter} filter instances.
      */
-    @Deprecated // FIXME: 0.43 - remove deprecated ctor
-    public OpenTelemetryHttpServiceFilter(final OpenTelemetry openTelemetry,
-                                          final OpenTelemetryOptions openTelemetryOptions) {
-        super(new OpenTelemetryOptions.Builder(openTelemetryOptions)
-                .openTelemetry(openTelemetry)
-                .build());
+    public static final class Builder extends OpenTelemetryFilterBuilder<Builder> {
+
+        Builder(OpenTelemetryOptions options) {
+            capturedRequestHeaders = options.capturedRequestHeaders();
+            capturedResponseHeaders = options.capturedResponseHeaders();
+            enableMetrics = options.enableMetrics();
+        }
+
+        /**
+         * Create a new builder.
+         */
+        public Builder() {
+        }
+
+        @Override
+        Builder thisInstance() {
+            return this;
+        }
+
+        /**
+         * Create a new {@link OpenTelemetryHttpServiceFilter} instance.
+         * @return a new {@link OpenTelemetryHttpServiceFilter} instance
+         */
+        public OpenTelemetryHttpServiceFilter build() {
+            return new OpenTelemetryHttpServiceFilter(this);
+        }
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilter.java
@@ -39,7 +39,7 @@ import io.opentelemetry.context.Context;
  *     {@link io.servicetalk.http.utils.HttpRequestAutoDrainingServiceFilter} immediately after.</li>
  *     <li>To ensure tracing sees the same result status codes as the calling client, add the
  *     {@link io.servicetalk.http.api.HttpExceptionMapperServiceFilter} after this filter.</li>
- *     <li>If you intend to use a {@link io.servicetalk.http.api.HttpLifecycleObserver}, add it using the the
+ *     <li>If you intend to use a {@link io.servicetalk.http.api.HttpLifecycleObserver}, add it using the
  *     HttpLifecycleObserverServiceFilter after the tracing filter to ensure the correct {@link Span} information is
  *     present.</li>
  * </ul>
@@ -52,7 +52,9 @@ public final class OpenTelemetryHttpServiceFilter extends AbstractOpenTelemetryH
     /**
      * Create a new instance using the {@link OpenTelemetry} from {@link GlobalOpenTelemetry#get()} with default
      * {@link OpenTelemetryOptions}.
+     * @deprecated use the constructor
      */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
     public OpenTelemetryHttpServiceFilter() {
         this(DEFAULT_OPTIONS);
     }
@@ -60,13 +62,27 @@ public final class OpenTelemetryHttpServiceFilter extends AbstractOpenTelemetryH
     /**
      * Create a new instance.
      *
-     * @param openTelemetryOptions extra options to create the opentelemetry filter
+     * @param openTelemetryOptions extra options to create the opentelemetry filter.
+     *                            Client-specific options (componentName, openTelemetry, ignoreSpanSuppression)
+     *                            will be ignored for server filters.
      */
     public OpenTelemetryHttpServiceFilter(final OpenTelemetryOptions openTelemetryOptions) {
-        this(GlobalOpenTelemetry.get(), openTelemetryOptions);
+        super(openTelemetryOptions);
     }
 
-    OpenTelemetryHttpServiceFilter(final OpenTelemetry openTelemetry, final OpenTelemetryOptions openTelemetryOptions) {
-        super(openTelemetry, openTelemetryOptions);
+    /**
+     * Create a new instance.
+     *
+     * @param openTelemetry the {@link OpenTelemetry}.
+     * @param openTelemetryOptions extra options to create the opentelemetry filter
+     * @deprecated Use {@link #OpenTelemetryHttpServiceFilter(OpenTelemetryOptions)} instead.
+     * The OpenTelemetry instance should be provided via {@link OpenTelemetryOptions}.
+     */
+    @Deprecated // FIXME: 0.43 - remove deprecated ctor
+    public OpenTelemetryHttpServiceFilter(final OpenTelemetry openTelemetry,
+                                          final OpenTelemetryOptions openTelemetryOptions) {
+        super(new OpenTelemetryOptions.Builder(openTelemetryOptions)
+                .openTelemetry(openTelemetry)
+                .build());
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryOptions.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryOptions.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.servicetalk.opentelemetry.http;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
@@ -28,22 +29,30 @@ import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
 
-/**
- * A set of options for configuring OpenTelemetry filters.
- */
+/** A set of options for configuring OpenTelemetry filters. */
 public final class OpenTelemetryOptions {
 
     private final List<String> capturedRequestHeaders;
     private final List<String> capturedResponseHeaders;
     private final boolean enableMetrics;
+    private final OpenTelemetry openTelemetry;
 
-    OpenTelemetryOptions(final List<String> capturedRequestHeaders,
-                         final List<String> capturedResponseHeaders,
-                         final boolean enableMetrics) {
+    // Client-specific options (ignored by server filters)
+    private final String componentName;
+
+    OpenTelemetryOptions(
+            final List<String> capturedRequestHeaders,
+            final List<String> capturedResponseHeaders,
+            final boolean enableMetrics,
+            final OpenTelemetry openTelemetry,
+            final String componentName) {
         this.capturedRequestHeaders = capturedRequestHeaders;
         this.capturedResponseHeaders = capturedResponseHeaders;
         this.enableMetrics = enableMetrics;
+        this.openTelemetry = openTelemetry;
+        this.componentName = componentName;
     }
 
     /**
@@ -80,6 +89,27 @@ public final class OpenTelemetryOptions {
         return enableMetrics;
     }
 
+    /**
+     * The {@link OpenTelemetry} instance to use for creating spans.
+     *
+     * @return the {@link OpenTelemetry} instance
+     */
+    public OpenTelemetry openTelemetry() {
+        return openTelemetry;
+    }
+
+    /**
+     * The component name used during building new spans.
+     * <p>
+     * This is a client-specific option that maps to the {@code peer.service} attribute
+     * and will be ignored when used with server filters.
+     *
+     * @return the component name
+     */
+    public String componentName() {
+        return componentName;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -109,50 +139,74 @@ public final class OpenTelemetryOptions {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() +
-                "{capturedRequestHeaders=" + capturedRequestHeaders +
+        return "OpenTelemetryOptions{" +
+                "capturedRequestHeaders=" + capturedRequestHeaders +
                 ", capturedResponseHeaders=" + capturedResponseHeaders +
                 ", enableMetrics=" + enableMetrics +
+                ", openTelemetry=" + openTelemetry +
+                ", componentName='" + componentName + '\'' +
                 '}';
     }
 
-    /**
-     * A builder for {@link OpenTelemetryOptions}.
-     */
+    /** A builder for {@link OpenTelemetryOptions}. */
     public static final class Builder {
         private List<String> capturedRequestHeaders = emptyList();
         private List<String> capturedResponseHeaders = emptyList();
         private boolean enableMetrics;
+        private OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+
+        // Client-specific options (ignored by server filters)
+        private String componentName = "";
+
+        /**
+         * Create a copy of an existing builder.
+         * @param openTelemetryOptions the {@link Builder} to copy.
+         */
+        public Builder(OpenTelemetryOptions openTelemetryOptions) {
+            this.capturedRequestHeaders = openTelemetryOptions.capturedRequestHeaders;
+            this.capturedResponseHeaders = openTelemetryOptions.capturedResponseHeaders;
+            this.enableMetrics = openTelemetryOptions.enableMetrics;
+            this.openTelemetry = openTelemetryOptions.openTelemetry;
+            this.componentName = openTelemetryOptions.componentName;
+        }
+
+        /**
+         * Create a builder using the default options.
+         */
+        public Builder() {
+        }
 
         /**
          * Add the headers to be captured as extra span attributes.
          *
-         * @param capturedRequestHeaders extra headers to be captured in client/server requests and added as extra span
-         * attributes
-         * @return an instance of itself
+         * @param capturedRequestHeaders extra headers to be captured in client/server requests and
+         *     added as extra span attributes
+         * @return {@code this}
          * @see #capturedRequestHeaders()
          * @see HttpClientAttributesExtractorBuilder#setCapturedRequestHeaders(List)
          * @see HttpServerAttributesExtractorBuilder#setCapturedRequestHeaders(List)
          */
         public Builder capturedRequestHeaders(final List<String> capturedRequestHeaders) {
-            this.capturedRequestHeaders = capturedRequestHeaders.isEmpty() ? emptyList() :
-                    unmodifiableList(new ArrayList<>(capturedRequestHeaders));
+            this.capturedRequestHeaders =
+                    capturedRequestHeaders.isEmpty() ? emptyList() :
+                            unmodifiableList(new ArrayList<>(capturedRequestHeaders));
             return this;
         }
 
         /**
          * Add the headers to be captured as extra span attributes.
          *
-         * @param capturedResponseHeaders extra headers to be captured in client/server response and added as extra span
-         * attributes
-         * @return an instance of itself
+         * @param capturedResponseHeaders extra headers to be captured in client/server response and
+         *     added as extra span attributes
+         * @return {@code this}
          * @see #capturedResponseHeaders()
          * @see HttpClientAttributesExtractorBuilder#setCapturedResponseHeaders(List)
          * @see HttpServerAttributesExtractorBuilder#setCapturedResponseHeaders(List)
          */
         public Builder capturedResponseHeaders(final List<String> capturedResponseHeaders) {
-            this.capturedResponseHeaders = capturedResponseHeaders.isEmpty() ? emptyList() :
-                    unmodifiableList(new ArrayList<>(capturedResponseHeaders));
+            this.capturedResponseHeaders =
+                    capturedResponseHeaders.isEmpty() ? emptyList() :
+                            unmodifiableList(new ArrayList<>(capturedResponseHeaders));
             return this;
         }
 
@@ -160,7 +214,7 @@ public final class OpenTelemetryOptions {
          * Whether to enable operation metrics or not.
          *
          * @param enableMetrics whether to enable operation metrics or not
-         * @return an instance of itself
+         * @return {@code this}
          * @see #enableMetrics()
          * @see InstrumenterBuilder#addOperationMetrics(OperationMetrics)
          * @see HttpClientMetrics
@@ -172,12 +226,39 @@ public final class OpenTelemetryOptions {
         }
 
         /**
+         * Set the {@link OpenTelemetry} instance to use for creating spans.
+         *
+         * @param openTelemetry the {@link OpenTelemetry} instance
+         * @return {@code this}
+         */
+        public Builder openTelemetry(OpenTelemetry openTelemetry) {
+            this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry");
+            return this;
+        }
+
+        /**
+         * Set the component name used during building new spans.
+         * <p>
+         * This is a client-specific option that maps to the {@code peer.service} attribute
+         * and will be ignored when used with server filters.
+         *
+         * @param componentName the component name
+         * @return {@code this}
+         */
+        public Builder componentName(String componentName) {
+            this.componentName = requireNonNull(componentName, "componentName");
+            return this;
+        }
+
+        /**
          * Builds a new {@link OpenTelemetryOptions}.
          *
          * @return a new {@link OpenTelemetryOptions}
          */
         public OpenTelemetryOptions build() {
-            return new OpenTelemetryOptions(capturedRequestHeaders, capturedResponseHeaders, enableMetrics);
+            return new OpenTelemetryOptions(
+                    capturedRequestHeaders, capturedResponseHeaders, enableMetrics,
+                    openTelemetry, componentName);
         }
     }
 }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryOptions.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryOptions.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.servicetalk.opentelemetry.http;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
@@ -29,30 +28,25 @@ import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
-import static java.util.Objects.requireNonNull;
 
-/** A set of options for configuring OpenTelemetry filters. */
+/**
+ * A set of options for configuring OpenTelemetry filters.
+ * @deprecated use the filter specific builders {@link OpenTelemetryHttpRequesterFilter.Builder} and
+ * {@link OpenTelemetryHttpServiceFilter.Builder} instead.
+ */
+@Deprecated // FIXME: 0.43 - remove deprecated class
 public final class OpenTelemetryOptions {
 
     private final List<String> capturedRequestHeaders;
     private final List<String> capturedResponseHeaders;
     private final boolean enableMetrics;
-    private final OpenTelemetry openTelemetry;
 
-    // Client-specific options (ignored by server filters)
-    private final String componentName;
-
-    OpenTelemetryOptions(
-            final List<String> capturedRequestHeaders,
-            final List<String> capturedResponseHeaders,
-            final boolean enableMetrics,
-            final OpenTelemetry openTelemetry,
-            final String componentName) {
+    OpenTelemetryOptions(final List<String> capturedRequestHeaders,
+                         final List<String> capturedResponseHeaders,
+                         final boolean enableMetrics) {
         this.capturedRequestHeaders = capturedRequestHeaders;
         this.capturedResponseHeaders = capturedResponseHeaders;
         this.enableMetrics = enableMetrics;
-        this.openTelemetry = openTelemetry;
-        this.componentName = componentName;
     }
 
     /**
@@ -89,27 +83,6 @@ public final class OpenTelemetryOptions {
         return enableMetrics;
     }
 
-    /**
-     * The {@link OpenTelemetry} instance to use for creating spans.
-     *
-     * @return the {@link OpenTelemetry} instance
-     */
-    public OpenTelemetry openTelemetry() {
-        return openTelemetry;
-    }
-
-    /**
-     * The component name used during building new spans.
-     * <p>
-     * This is a client-specific option that maps to the {@code peer.service} attribute
-     * and will be ignored when used with server filters.
-     *
-     * @return the component name
-     */
-    public String componentName() {
-        return componentName;
-    }
-
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -139,74 +112,50 @@ public final class OpenTelemetryOptions {
 
     @Override
     public String toString() {
-        return "OpenTelemetryOptions{" +
-                "capturedRequestHeaders=" + capturedRequestHeaders +
+        return getClass().getSimpleName() +
+                "{capturedRequestHeaders=" + capturedRequestHeaders +
                 ", capturedResponseHeaders=" + capturedResponseHeaders +
                 ", enableMetrics=" + enableMetrics +
-                ", openTelemetry=" + openTelemetry +
-                ", componentName='" + componentName + '\'' +
                 '}';
     }
 
-    /** A builder for {@link OpenTelemetryOptions}. */
+    /**
+     * A builder for {@link OpenTelemetryOptions}.
+     */
     public static final class Builder {
         private List<String> capturedRequestHeaders = emptyList();
         private List<String> capturedResponseHeaders = emptyList();
         private boolean enableMetrics;
-        private OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
-
-        // Client-specific options (ignored by server filters)
-        private String componentName = "";
-
-        /**
-         * Create a copy of an existing builder.
-         * @param openTelemetryOptions the {@link Builder} to copy.
-         */
-        public Builder(OpenTelemetryOptions openTelemetryOptions) {
-            this.capturedRequestHeaders = openTelemetryOptions.capturedRequestHeaders;
-            this.capturedResponseHeaders = openTelemetryOptions.capturedResponseHeaders;
-            this.enableMetrics = openTelemetryOptions.enableMetrics;
-            this.openTelemetry = openTelemetryOptions.openTelemetry;
-            this.componentName = openTelemetryOptions.componentName;
-        }
-
-        /**
-         * Create a builder using the default options.
-         */
-        public Builder() {
-        }
 
         /**
          * Add the headers to be captured as extra span attributes.
          *
-         * @param capturedRequestHeaders extra headers to be captured in client/server requests and
-         *     added as extra span attributes
-         * @return {@code this}
+         * @param capturedRequestHeaders extra headers to be captured in client/server requests and added as extra span
+         * attributes
+         * @return an instance of itself
          * @see #capturedRequestHeaders()
          * @see HttpClientAttributesExtractorBuilder#setCapturedRequestHeaders(List)
          * @see HttpServerAttributesExtractorBuilder#setCapturedRequestHeaders(List)
          */
         public Builder capturedRequestHeaders(final List<String> capturedRequestHeaders) {
-            this.capturedRequestHeaders =
-                    capturedRequestHeaders.isEmpty() ? emptyList() :
-                            unmodifiableList(new ArrayList<>(capturedRequestHeaders));
+            this.capturedRequestHeaders = capturedRequestHeaders.isEmpty() ? emptyList() :
+                    unmodifiableList(new ArrayList<>(capturedRequestHeaders));
             return this;
         }
 
         /**
          * Add the headers to be captured as extra span attributes.
          *
-         * @param capturedResponseHeaders extra headers to be captured in client/server response and
-         *     added as extra span attributes
-         * @return {@code this}
+         * @param capturedResponseHeaders extra headers to be captured in client/server response and added as extra span
+         * attributes
+         * @return an instance of itself
          * @see #capturedResponseHeaders()
          * @see HttpClientAttributesExtractorBuilder#setCapturedResponseHeaders(List)
          * @see HttpServerAttributesExtractorBuilder#setCapturedResponseHeaders(List)
          */
         public Builder capturedResponseHeaders(final List<String> capturedResponseHeaders) {
-            this.capturedResponseHeaders =
-                    capturedResponseHeaders.isEmpty() ? emptyList() :
-                            unmodifiableList(new ArrayList<>(capturedResponseHeaders));
+            this.capturedResponseHeaders = capturedResponseHeaders.isEmpty() ? emptyList() :
+                    unmodifiableList(new ArrayList<>(capturedResponseHeaders));
             return this;
         }
 
@@ -214,7 +163,7 @@ public final class OpenTelemetryOptions {
          * Whether to enable operation metrics or not.
          *
          * @param enableMetrics whether to enable operation metrics or not
-         * @return {@code this}
+         * @return an instance of itself
          * @see #enableMetrics()
          * @see InstrumenterBuilder#addOperationMetrics(OperationMetrics)
          * @see HttpClientMetrics
@@ -226,39 +175,12 @@ public final class OpenTelemetryOptions {
         }
 
         /**
-         * Set the {@link OpenTelemetry} instance to use for creating spans.
-         *
-         * @param openTelemetry the {@link OpenTelemetry} instance
-         * @return {@code this}
-         */
-        public Builder openTelemetry(OpenTelemetry openTelemetry) {
-            this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry");
-            return this;
-        }
-
-        /**
-         * Set the component name used during building new spans.
-         * <p>
-         * This is a client-specific option that maps to the {@code peer.service} attribute
-         * and will be ignored when used with server filters.
-         *
-         * @param componentName the component name
-         * @return {@code this}
-         */
-        public Builder componentName(String componentName) {
-            this.componentName = requireNonNull(componentName, "componentName");
-            return this;
-        }
-
-        /**
          * Builds a new {@link OpenTelemetryOptions}.
          *
          * @return a new {@link OpenTelemetryOptions}
          */
         public OpenTelemetryOptions build() {
-            return new OpenTelemetryOptions(
-                    capturedRequestHeaders, capturedResponseHeaders, enableMetrics,
-                    openTelemetry, componentName);
+            return new OpenTelemetryOptions(capturedRequestHeaders, capturedResponseHeaders, enableMetrics);
         }
     }
 }

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
@@ -169,27 +169,20 @@ class OpenTelemetryGrpcFilterTest {
     }
 
     private void setUp(boolean error) throws Exception {
-        setUp(error, new OpenTelemetryOptions.Builder().build());
-    }
-
-    private void setUp(boolean error, OpenTelemetryOptions options) throws Exception {
         // Create gRPC server with unified OpenTelemetry HTTP service filter
         // The filter will automatically detect gRPC requests and handle them appropriately
         serverContext = GrpcServers.forAddress(localAddress(0))
                 .initializeHttp(builder -> builder
-                        .appendServiceFilter(new OpenTelemetryHttpServiceFilter(
-                                otelTesting.getOpenTelemetry(),
-                                options)))
+                        .appendServiceFilter(new OpenTelemetryHttpServiceFilter.Builder()
+                                        .openTelemetry(otelTesting.getOpenTelemetry()).build()))
                 .listenAndAwait(new Tester.ServiceFactory(new TestTesterService(error)));
 
         // Create gRPC client with unified OpenTelemetry HTTP requester filter
         // The filter will automatically detect gRPC requests and handle them appropriately
         client = GrpcClients.forAddress(serverHostAndPort(serverContext))
-                .initializeHttp(builder -> builder.appendClientFilter(new OpenTelemetryHttpRequesterFilter(
-                        new OpenTelemetryOptions.Builder(options)
+                .initializeHttp(builder -> builder.appendClientFilter(new OpenTelemetryHttpRequesterFilter.Builder()
                                 .openTelemetry(otelTesting.getOpenTelemetry())
-                                .componentName("test-client")
-                                .build())))
+                                .componentName("test-client").build()))
                 .build(new Tester.ClientFactory());
     }
 

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -387,7 +387,8 @@ class OpenTelemetryHttpRequesterFilterTest {
 
         ServerContext context = buildServer(openTelemetry, false);
         try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequestFilter(openTelemetry, "testClient"))
+                .appendClientFilter(new OpenTelemetryHttpRequesterFilter.Builder()
+                        .openTelemetry(openTelemetry).componentName("testClient").build())
                 .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX))
                 .appendClientFilter(new HttpLifecycleObserverRequesterFilter(
                         new TestHttpLifecycleObserver(errors)))
@@ -478,7 +479,8 @@ class OpenTelemetryHttpRequesterFilterTest {
         HttpServerBuilder httpServerBuilder = HttpServers.forAddress(localAddress(0));
         if (addFilter) {
             httpServerBuilder =
-                httpServerBuilder.appendServiceFilter(new OpenTelemetryHttpServerFilter(givenOpentelemetry));
+                httpServerBuilder.appendServiceFilter(new OpenTelemetryHttpServiceFilter.Builder()
+                        .openTelemetry(givenOpentelemetry).build());
         }
         return httpServerBuilder
             .listenAndAwait((ctx, request, responseFactory) -> {

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -109,10 +109,13 @@ class OpenTelemetryHttpRequesterFilterTest {
     void testInjectWithNoParent() throws Exception {
         final String requestUrl = "/";
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
-        try (ServerContext context = buildServer(openTelemetry, false)) {
+        try (ServerContext context = buildServer(openTelemetry, DEFAULT_OPTIONS, false)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient",
-                        DEFAULT_OPTIONS))
+                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(
+                        new OpenTelemetryOptions.Builder(DEFAULT_OPTIONS)
+                                .openTelemetry(openTelemetry)
+                                .componentName("testClient")
+                                .build()))
                 .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX)).build()) {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
@@ -140,10 +143,13 @@ class OpenTelemetryHttpRequesterFilterTest {
     void testInjectWithAParent() throws Exception {
         final String requestUrl = "/path";
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
-        try (ServerContext context = buildServer(openTelemetry, true)) {
+        try (ServerContext context = buildServer(openTelemetry, DEFAULT_OPTIONS, true)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient",
-                        DEFAULT_OPTIONS))
+                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(
+                        new OpenTelemetryOptions.Builder(DEFAULT_OPTIONS)
+                                .openTelemetry(openTelemetry)
+                                .componentName("testClient")
+                                .build()))
                 .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX)).build()) {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
@@ -191,13 +197,16 @@ class OpenTelemetryHttpRequesterFilterTest {
     @CsvSource({"false, false", "false, true", "true, false", "true, true"})
     void testInjectWithAParentCreated(boolean absoluteForm, boolean withHostHeader) throws Exception {
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
-        try (ServerContext context = buildServer(openTelemetry, true)) {
+        try (ServerContext context = buildServer(openTelemetry, DEFAULT_OPTIONS, true)) {
             HostAndPort serverHostAndPort = serverHostAndPort(context);
             final String requestPath = "/path/to/resource";
             final String requestUrl = absoluteForm ? fullUrl(serverHostAndPort, requestPath) : requestPath;
             try (HttpClient client = forSingleAddress(serverHostAndPort)
-                    .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient",
-                            DEFAULT_OPTIONS))
+                    .appendClientFilter(new OpenTelemetryHttpRequesterFilter(
+                            new OpenTelemetryOptions.Builder(DEFAULT_OPTIONS)
+                                    .openTelemetry(openTelemetry)
+                                    .componentName("testClient")
+                                    .build()))
                     .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX)).build()) {
 
                 Span span = otelTesting.getOpenTelemetry().getTracer("io.serviceTalk").spanBuilder("/")
@@ -252,10 +261,12 @@ class OpenTelemetryHttpRequesterFilterTest {
     void testCaptureHeader() throws Exception {
         final String requestUrl = "/";
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
-        try (ServerContext context = buildServer(openTelemetry, false)) {
+        try (ServerContext context = buildServer(openTelemetry, DEFAULT_OPTIONS, false)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(openTelemetry, "testClient",
+                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(
                     new OpenTelemetryOptions.Builder()
+                        .openTelemetry(openTelemetry)
+                        .componentName("testClient")
                         .capturedResponseHeaders(singletonList("my-header"))
                         .capturedRequestHeaders(singletonList("some-request-header"))
                         .build()))
@@ -385,9 +396,13 @@ class OpenTelemetryHttpRequesterFilterTest {
             }
         };
 
-        ServerContext context = buildServer(openTelemetry, false);
+        ServerContext context = buildServer(openTelemetry, DEFAULT_OPTIONS, false);
         try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequestFilter(openTelemetry, "testClient"))
+                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(
+                        new OpenTelemetryOptions.Builder()
+                                .openTelemetry(openTelemetry)
+                                .componentName("testClient")
+                                .build()))
                 .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX))
                 .appendClientFilter(new HttpLifecycleObserverRequesterFilter(
                         new TestHttpLifecycleObserver(errors)))
@@ -474,11 +489,14 @@ class OpenTelemetryHttpRequesterFilterTest {
         }
     }
 
-    private static ServerContext buildServer(OpenTelemetry givenOpentelemetry, boolean addFilter) throws Exception {
+    private static ServerContext buildServer(OpenTelemetry givenOpentelemetry,
+                                             OpenTelemetryOptions openTelemetryOptions,
+                                             boolean addFilter) throws Exception {
         HttpServerBuilder httpServerBuilder = HttpServers.forAddress(localAddress(0));
         if (addFilter) {
             httpServerBuilder =
-                httpServerBuilder.appendServiceFilter(new OpenTelemetryHttpServerFilter(givenOpentelemetry));
+                httpServerBuilder.appendServiceFilter(new OpenTelemetryHttpServiceFilter(
+                        givenOpentelemetry, openTelemetryOptions));
         }
         return httpServerBuilder
             .listenAndAwait((ctx, request, responseFactory) -> {

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.servicetalk.opentelemetry.http;
 
 import io.servicetalk.buffer.api.Buffer;
@@ -90,7 +91,6 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static io.servicetalk.concurrent.internal.TestTimeoutConstants.CI;
 import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifyServerFilterAsyncContextVisibility;
 import static io.servicetalk.http.netty.HttpClients.forSingleAddress;
-import static io.servicetalk.opentelemetry.http.AbstractOpenTelemetryFilter.DEFAULT_OPTIONS;
 import static io.servicetalk.opentelemetry.http.OpenTelemetryHttpRequesterFilterTest.verifyTraceIdPresentInLogs;
 import static io.servicetalk.opentelemetry.http.TestUtils.SPAN_STATE_SERIALIZER;
 import static io.servicetalk.opentelemetry.http.TestUtils.TRACING_TEST_LOG_LINE_PREFIX;
@@ -176,11 +176,8 @@ class OpenTelemetryHttpServiceFilterTest {
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         try (ServerContext context = buildServer(openTelemetry)) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context))
-                .appendClientFilter(new OpenTelemetryHttpRequesterFilter(
-                        new OpenTelemetryOptions.Builder(DEFAULT_OPTIONS)
-                                .openTelemetry(openTelemetry)
-                                .componentName("testClient")
-                                .build()))
+                .appendClientFilter(new OpenTelemetryHttpRequesterFilter.Builder()
+                        .openTelemetry(openTelemetry).componentName("testClient").build())
                 .build()) {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
@@ -257,11 +254,11 @@ class OpenTelemetryHttpServiceFilterTest {
     @Test
     void testCaptureHeaders() throws Exception {
         final String requestUrl = "/path";
-        try (ServerContext context = buildServer(otelTesting.getOpenTelemetry(),
-            new OpenTelemetryOptions.Builder()
+        try (ServerContext context = buildServer(otelTesting.getOpenTelemetry().getPropagators(),
+            new OpenTelemetryHttpServiceFilter.Builder()
+                    .openTelemetry(otelTesting.getOpenTelemetry())
                 .capturedResponseHeaders(singletonList("my-header"))
-                .capturedRequestHeaders(singletonList("some-request-header"))
-                .build())) {
+                .capturedRequestHeaders(singletonList("some-request-header")))) {
             try (HttpClient client = forSingleAddress(serverHostAndPort(context)).build()) {
                 HttpResponse response = client.request(client.get(requestUrl)
                         .addHeader("some-request-header", "request-header-value"))
@@ -468,8 +465,9 @@ class OpenTelemetryHttpServiceFilterTest {
             throws Exception {
         HttpProtocolConfig config = http2 ? HttpProtocolConfigs.h2Default() : HttpProtocolConfigs.h1Default();
         Queue<Error> errorQueue = new ConcurrentLinkedQueue<>();
-        try (ServerContext context = buildStreamingServer(http2, otelTesting.getOpenTelemetry(),
-                new OpenTelemetryOptions.Builder().build(), useOffloading, errorQueue);
+        try (ServerContext context = buildStreamingServer(http2,
+                new OpenTelemetryHttpServiceFilter.Builder().openTelemetry(otelTesting.getOpenTelemetry()),
+                useOffloading, errorQueue);
              HttpClient client = forSingleAddress(serverHostAndPort(context)).protocols(config).build()) {
                 runWithClient.run(client);
         }
@@ -486,14 +484,12 @@ class OpenTelemetryHttpServiceFilterTest {
         void run(HttpClient client) throws Exception;
     }
 
-    private static ServerContext buildServer(OpenTelemetry givenOpentelemetry,
-                                             OpenTelemetryOptions opentelemetryOptions) throws Exception {
-        HttpServerBuilder serverBuilder = HttpServers.forAddress(localAddress(0));
-        return serverBuilder
-            .appendServiceFilter(new OpenTelemetryHttpServiceFilter(givenOpentelemetry, opentelemetryOptions))
+    private static ServerContext buildServer(ContextPropagators propagators,
+                                             OpenTelemetryHttpServiceFilter.Builder builder) throws Exception {
+        return HttpServers.forAddress(localAddress(0))
+            .appendServiceFilter(builder.build())
             .appendServiceFilter(new TestTracingServerLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX))
             .listenAndAwait((ctx, request, responseFactory) -> {
-                final ContextPropagators propagators = givenOpentelemetry.getPropagators();
                 final Context context = Context.root();
                 Context tracingContext = propagators.getTextMapPropagator()
                     .extract(context, request.headers(), HeadersPropagatorGetter.INSTANCE);
@@ -509,24 +505,25 @@ class OpenTelemetryHttpServiceFilterTest {
     }
 
     private static ServerContext buildServer(OpenTelemetry givenOpentelemetry) throws Exception {
-        return buildServer(givenOpentelemetry, new OpenTelemetryOptions.Builder().build());
+        return buildServer(givenOpentelemetry.getPropagators(),
+                new OpenTelemetryHttpServiceFilter.Builder().openTelemetry(givenOpentelemetry));
     }
 
-    private static ServerContext buildStreamingServer(boolean http2, OpenTelemetry givenOpentelemetry,
-                                                      OpenTelemetryOptions opentelemetryOptions, boolean useOffloading,
+    private static ServerContext buildStreamingServer(boolean http2,
+                                                      OpenTelemetryHttpServiceFilter.Builder filterBuilder,
+                                                      boolean useOffloading,
                                                       Queue<Error> errorQueue) throws Exception {
         HttpProtocolConfig config = http2 ? HttpProtocolConfigs.h2Default() : HttpProtocolConfigs.h1Default();
         HttpServerBuilder builder = HttpServers.forAddress(localAddress(0))
                 .protocols(config)
                 .drainRequestPayloadBody(false);
         if (useOffloading) {
-            builder.appendServiceFilter(new OpenTelemetryHttpServiceFilter(givenOpentelemetry, opentelemetryOptions))
+            builder.appendServiceFilter(filterBuilder.build())
                     .appendServiceFilter(HttpRequestAutoDrainingServiceFilter.INSTANCE)
                     .appendServiceFilter(new HttpLifecycleObserverServiceFilter(
                             new TestHttpLifecycleObserver(errorQueue)));
         } else {
-            builder.appendNonOffloadingServiceFilter(new OpenTelemetryHttpServiceFilter(
-                    givenOpentelemetry, opentelemetryOptions))
+            builder.appendNonOffloadingServiceFilter(filterBuilder.build())
                     .appendNonOffloadingServiceFilter(HttpRequestAutoDrainingServiceFilter.INSTANCE)
                     .appendNonOffloadingServiceFilter(new HttpLifecycleObserverServiceFilter(
                             new TestHttpLifecycleObserver(errorQueue)));


### PR DESCRIPTION
 #### Motivation

Filters were taking multiple separate parameters (OpenTelemetry, componentName, etc.) making the internal API verbose and difficult to extend. Need to consolidate these parameters for cleaner internal APIs and easier future extensibility.

 #### Modifications

Consolidated our configuration into filter builders. We use a shared internal class for common parameter configuration but still have separate builders for clients and servers so we can specialize.

 #### Results

Builders are now the main entry point.
