### PR TITLE
tcp-netty-internal: copy maps in copy contructors

### DIFF
--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/AbstractTcpConfig.java
@@ -57,7 +57,7 @@ abstract class AbstractTcpConfig {
     }
 
     protected AbstractTcpConfig(final AbstractTcpConfig from) {
-        options = from.options;
+        options = copyMap(from.options);
         idleTimeoutMs = from.idleTimeoutMs;
         flushStrategy = from.flushStrategy;
         wireLoggerConfig = from.wireLoggerConfig;
@@ -141,5 +141,10 @@ abstract class AbstractTcpConfig {
      */
     public final void transportConfig(final TransportConfig transportConfig) {
         this.transportConfig = requireNonNull(transportConfig);
+    }
+
+    @Nullable
+    static <A, B> Map<A, B> copyMap(@Nullable Map<? extends A, ? extends B> other) {
+        return other == null ? null : new HashMap<>(other);
     }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpServerConfig.java
@@ -73,9 +73,9 @@ public final class TcpServerConfig extends AbstractTcpConfig {
     public TcpServerConfig(final TcpServerConfig from) {
         super(from);
         sslConfig = from.sslConfig;
-        listenOptions = from.listenOptions;
+        listenOptions = copyMap(from.listenOptions);
         transportObserver = from.transportObserver;
-        sniConfig = from.sniConfig;
+        sniConfig = copyMap(from.sniConfig);
         sniMaxClientHelloLength = from.sniMaxClientHelloLength;
         sniClientHelloTimeout = from.sniClientHelloTimeout;
         acceptInsecureConnections = from.acceptInsecureConnections;


### PR DESCRIPTION
 #### Motivation

We have copy constructors for our Tcp[Client|Server]Config types but they don't copy the mutable maps internal to them.

 #### Modifications

Copy the maps.
