### PR TITLE
Deprecate `DomainSocketAddress.getPath()` in favor of `path()`

### DIFF
--- a/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/BlockingUdsServer.java
+++ b/servicetalk-examples/http/uds/src/main/java/io/servicetalk/examples/http/uds/blocking/BlockingUdsServer.java
@@ -32,7 +32,7 @@ public final class BlockingUdsServer {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             // After the server is done, clean up the file. This doesn't cover all cases (external forced shutdown,
             // JVM crash, etc.) but best-effort cleanup is sufficient for temp file to allow the example to re-run.
-            if (!new File(udsAddress.getPath()).delete()) {
+            if (!new File(udsAddress.path()).delete()) {
                 System.err.println("failed to delete UDS file: " + udsAddress);
             }
         }));

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcUdsTest.java
@@ -122,7 +122,7 @@ class GrpcUdsTest {
     private static void assertSameAddress(Object actual, DomainSocketAddress expected, Queue<Throwable> errors) {
         try {
             assertThat(actual, is(instanceOf(expected.getClass())));
-            assertThat(((DomainSocketAddress) actual).getPath(), is(equalTo(expected.getPath())));
+            assertThat(((DomainSocketAddress) actual).path(), is(equalTo(expected.path())));
         } catch (Throwable t) {
             errors.add(t);
         }
@@ -131,7 +131,7 @@ class GrpcUdsTest {
     private static void assertSameAddressType(Object actual, DomainSocketAddress expected, Queue<Throwable> errors) {
         try {
             assertThat(actual, is(instanceOf(expected.getClass())));
-            assertThat(((DomainSocketAddress) actual).getPath(), is(emptyString()));
+            assertThat(((DomainSocketAddress) actual).path(), is(emptyString()));
         } catch (Throwable t) {
             errors.add(t);
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpUdsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpUdsTest.java
@@ -111,7 +111,7 @@ class HttpUdsTest {
     private static void assertSameAddress(Object actual, DomainSocketAddress expected, Queue<Throwable> errors) {
         try {
             assertThat(actual, is(instanceOf(expected.getClass())));
-            assertThat(((DomainSocketAddress) actual).getPath(), is(equalTo(expected.getPath())));
+            assertThat(((DomainSocketAddress) actual).path(), is(equalTo(expected.path())));
         } catch (Throwable t) {
             errors.add(t);
         }
@@ -120,7 +120,7 @@ class HttpUdsTest {
     private static void assertSameAddressType(Object actual, DomainSocketAddress expected, Queue<Throwable> errors) {
         try {
             assertThat(actual, is(instanceOf(expected.getClass())));
-            assertThat(((DomainSocketAddress) actual).getPath(), is(emptyString()));
+            assertThat(((DomainSocketAddress) actual).path(), is(emptyString()));
         } catch (Throwable t) {
             errors.add(t);
         }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcSemanticAttributesExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcSemanticAttributesExtractor.java
@@ -130,7 +130,7 @@ abstract class GrpcSemanticAttributesExtractor implements AttributesExtractor<Re
                 }
         } else if (peerResolvedAddress instanceof DomainSocketAddress) {
             DomainSocketAddress domainSocketAddress = (DomainSocketAddress) peerResolvedAddress;
-            attributesBuilder.put(NETWORK_PEER_ADDRESS, domainSocketAddress.getPath());
+            attributesBuilder.put(NETWORK_PEER_ADDRESS, domainSocketAddress.path());
             attributesBuilder.put(NETWORK_TRANSPORT, Constants.UNIX);
         } else {
             // This is unlikely since the resolved form is almost always an `InetSocketAddress`, and

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcServerAttributesExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcServerAttributesExtractor.java
@@ -62,7 +62,7 @@ final class GrpcServerAttributesExtractor extends GrpcSemanticAttributesExtracto
             attributesBuilder.put(CLIENT_ADDRESS, inetSocketAddress.getHostString());
             attributesBuilder.put(CLIENT_PORT, inetSocketAddress.getPort());
         } else if (address instanceof DomainSocketAddress) {
-            attributesBuilder.put(CLIENT_ADDRESS, ((DomainSocketAddress) address).getPath());
+            attributesBuilder.put(CLIENT_ADDRESS, ((DomainSocketAddress) address).path());
         } else {
             // Try to turn it into something meaningful.
             attributesBuilder.put(CLIENT_ADDRESS, address.toString());

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpAttributesGetter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpAttributesGetter.java
@@ -304,7 +304,7 @@ abstract class HttpAttributesGetter
         if (address instanceof InetSocketAddress) {
             return ((InetSocketAddress) address).getAddress().getHostAddress();
         } else if (address instanceof DomainSocketAddress) {
-            return ((DomainSocketAddress) address).getPath();
+            return ((DomainSocketAddress) address).path();
         } else {
             // Try to turn it into something meaningful.
             return address.toString();
@@ -322,7 +322,7 @@ abstract class HttpAttributesGetter
         if (address instanceof InetSocketAddress) {
             return ((InetSocketAddress) address).getHostString();
         } else if (address instanceof DomainSocketAddress) {
-            return ((DomainSocketAddress) address).getPath();
+            return ((DomainSocketAddress) address).path();
         } else {
             // Try to turn it into something meaningful.
             return address.toString();

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DomainSocketAddress.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/DomainSocketAddress.java
@@ -50,13 +50,24 @@ public final class DomainSocketAddress extends SocketAddress {
      * See <a href="https://man7.org/linux/man-pages/man7/unix.7.html">AF_UNIX socket family docs</a>.
      * @return The file system path used to bind/connect for a UNIX domain socket.
      */
-    public String getPath() {
+    public String path() {
         return socketPath;
+    }
+
+    /**
+     * The file system path used to bind/connect for a UNIX domain socket.
+     * See <a href="https://man7.org/linux/man-pages/man7/unix.7.html">AF_UNIX socket family docs</a>.
+     * @return The file system path used to bind/connect for a UNIX domain socket.
+     * @deprecated Use {@link #path() instead}
+     */
+    @Deprecated
+    public String getPath() {   // FIXME: 0.43 - remove deprecated method
+        return path();
     }
 
     @Override
     public String toString() {
-        return getPath();
+        return path();
     }
 
     @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/BuilderUtils.java
@@ -143,7 +143,7 @@ public final class BuilderUtils {
         // `SocketAddress`, and we want to identify the more specific types before returning the fallback
         // `SocketAddress` type.
         if (address instanceof io.servicetalk.transport.api.DomainSocketAddress) {
-            return new DomainSocketAddress(((io.servicetalk.transport.api.DomainSocketAddress) address).getPath());
+            return new DomainSocketAddress(((io.servicetalk.transport.api.DomainSocketAddress) address).path());
         }
         if (address instanceof SocketAddress) {
             return (SocketAddress) address;


### PR DESCRIPTION
Motivation:

In ServiceTalk codebase we don't use "get/set" prefixes.

Modifications:

- Deprecate `DomainSocketAddress.getPath()` and introduce `DomainSocketAddress.path()` instead.

Result:

Consistent method naming.