### PR TITLE
loadbalancer: reduce unnecessary null validation

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/BaseHostSelector.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.Single.succeeded;
-import static java.util.Objects.requireNonNull;
 
 abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnection>
         implements HostSelector<ResolvedAddress, C> {
@@ -36,7 +35,7 @@ abstract class BaseHostSelector<ResolvedAddress, C extends LoadBalancedConnectio
     private final List<? extends Host<ResolvedAddress, C>> hosts;
     BaseHostSelector(final List<? extends Host<ResolvedAddress, C>> hosts, final String lbDescription) {
         this.hosts = hosts;
-        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
+        this.lbDescription = lbDescription;
     }
 
     abstract Single<C> selectConnection0(Predicate<C> selector, @Nullable ContextMap context,

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
@@ -55,7 +55,6 @@ import static io.servicetalk.loadbalancer.ConnectTracker.ErrorClass.CANCELLED;
 import static io.servicetalk.loadbalancer.ConnectTracker.ErrorClass.CONNECT_ERROR;
 import static io.servicetalk.loadbalancer.ConnectTracker.ErrorClass.CONNECT_TIMEOUT;
 import static java.util.Collections.emptyList;
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<Addr, C> {
@@ -101,17 +100,16 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
                 final int minConnections,
                 final HostObserver hostObserver, @Nullable final HealthCheckConfig healthCheckConfig,
                 @Nullable final HealthIndicator<Addr, C> healthIndicator) {
-        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
-        this.address = requireNonNull(address, "address");
+        this.lbDescription = lbDescription;
+        this.address = address;
         this.healthIndicator = healthIndicator;
-        this.connectionSelector = requireNonNull(connectionSelector, "connectionSelector");
-        requireNonNull(connectionFactory, "connectionFactory");
+        this.connectionSelector = connectionSelector;
         this.minConnections = minConnections;
         this.connectionFactory = healthIndicator == null ? connectionFactory :
                 new InstrumentedConnectionFactory<>(connectionFactory, healthIndicator);
         assert healthCheckConfig == null || healthCheckConfig.failedThreshold > 0;
         this.healthCheckConfig = healthCheckConfig;
-        this.hostObserver = requireNonNull(hostObserver, "hostObserver");
+        this.hostObserver = hostObserver;
         this.closeable = toAsyncCloseable(this::doClose);
         // Note that we deliberately don't warm the pool initially to prevent the very common race where a client is
         // created and immediately used, thus triggering a race between warmup and initial connection acquisition.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultHostPriorityStrategy.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.TreeMap;
 
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
-import static java.util.Objects.requireNonNull;
 
 final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
 
@@ -40,7 +39,7 @@ final class DefaultHostPriorityStrategy implements HostPriorityStrategy {
 
     // exposed for testing
     DefaultHostPriorityStrategy(final String lbDescription, final int overProvisionPercentage) {
-        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
+        this.lbDescription = lbDescription;
         this.overProvisionPercentage = ensurePositive(overProvisionPercentage, "overProvisionPercentage");
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -65,7 +65,6 @@ import static io.servicetalk.concurrent.api.Single.defer;
 import static io.servicetalk.concurrent.api.Single.failed;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
-import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.lang.Integer.toHexString;
 import static java.lang.System.identityHashCode;
 import static java.util.Collections.emptyList;
@@ -152,30 +151,25 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final LoadBalancerObserverFactory loadBalancerObserverFactory,
             @Nullable final HealthCheckConfig healthCheckConfig,
             final Function<String, OutlierDetector<ResolvedAddress, C>> outlierDetectorFactory) {
-        this.lbDescription = makeDescription(
-                requireNonNull(id, "id"), requireNonNull(targetResource, "targetResource"));
-        this.subsetter = subsetterFactory.newSubsetter(lbDescription);
-        this.hostSelector = requireNonNull(loadBalancingPolicy, "loadBalancingPolicy")
-                .buildSelector(Collections.emptyList(), lbDescription);
-        this.priorityStrategy = requireNonNull(
-                priorityStrategyFactory, "priorityStrategyFactory").apply(lbDescription);
-        this.connectionSelector = requireNonNull(connectionSelectorPolicy,
-                "connectionSelectorPolicy").buildConnectionSelector(lbDescription);
-        this.eventPublisher = requireNonNull(eventPublisher);
+        this.lbDescription = makeDescription(id, targetResource);
+        this.subsetter = requireNonNull(subsetterFactory.newSubsetter(lbDescription));
+        this.hostSelector = requireNonNull(loadBalancingPolicy.buildSelector(emptyList(), lbDescription));
+        this.priorityStrategy = requireNonNull(priorityStrategyFactory.apply(lbDescription));
+        this.connectionSelector = requireNonNull(connectionSelectorPolicy.buildConnectionSelector(lbDescription));
+        this.eventPublisher = eventPublisher;
         this.eventStream = fromSource(eventStreamProcessor)
                 .replay(1); // Allow for multiple subscribers and provide new subscribers with last signal.
-        this.connectionFactory = requireNonNull(connectionFactory);
+        this.connectionFactory = connectionFactory;
         this.minConnectionsPerHost = minConnectionsPerHost;
         this.loadBalancerObserver = CatchAllLoadBalancerObserver.wrap(
-                requireNonNull(loadBalancerObserverFactory, "loadBalancerObserverFactory")
-                .newObserver(lbDescription));
+                loadBalancerObserverFactory.newObserver(lbDescription));
         this.healthCheckConfig = healthCheckConfig;
         this.sequentialExecutor = new SequentialExecutor((uncaughtException) ->
                 LOGGER.error("{}: Uncaught exception in {}", this, this.getClass().getSimpleName(), uncaughtException));
         this.asyncCloseable = toAsyncCloseable(this::doClose);
         // Maintain a Subscriber so signals are always delivered to replay and new Subscribers get the latest signal.
         eventStream.ignoreElements().subscribe();
-        this.outlierDetector = requireNonNull(outlierDetectorFactory, "outlierDetectorFactory").apply(lbDescription);
+        this.outlierDetector = requireNonNull(outlierDetectorFactory.apply(lbDescription));
 
         // When we get a health-status event we should update the host set.
         this.outlierDetectorStatusChangeStream = this.outlierDetector.healthStatusChanged().forEach((ignored) ->
@@ -642,20 +636,30 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         }
     }
 
-    private static double eventWeight(ServiceDiscovererEvent<?> event) {
+    private double eventWeight(ServiceDiscovererEvent<?> event) {
+        double weight = 1;
         if (event instanceof RichServiceDiscovererEvent<?>) {
-            return ((RichServiceDiscovererEvent<?>) event).loadBalancingWeight();
-        } else {
-            return 1.0;
+            weight = ((RichServiceDiscovererEvent<?>) event).loadBalancingWeight();
+            if (weight < 0) {
+                LOGGER.debug("{} Unexpected negative weight {} for host {} being set to 1.0",
+                        lbDescription, weight, event.address());
+                weight = 1;
+            }
         }
+        return weight;
     }
 
-    private static int eventPriority(ServiceDiscovererEvent<?> event) {
+    private int eventPriority(ServiceDiscovererEvent<?> event) {
+        int priority = 0;
         if (event instanceof RichServiceDiscovererEvent<?>) {
-            return ((RichServiceDiscovererEvent<?>) event).priority();
-        } else {
-            return 0;
+            priority = ((RichServiceDiscovererEvent<?>) event).priority();
+            if (priority < 0) {
+                LOGGER.debug("{} Unexpected negative priority {} for host {} being set to 0",
+                        lbDescription, priority, event.address());
+                priority = 0;
+            }
         }
+        return priority;
     }
 
     // Exposed for testing
@@ -674,8 +678,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
 
         PrioritizedHostImpl(final Host<ResolvedAddress, C> delegate, final double serviceDiscoveryWeight,
                             final int priority) {
-            this.delegate = requireNonNull(delegate, "delegate");
-            this.priority = ensureNonNegative(priority, "priority");
+            this.delegate = delegate;
+            this.priority = priority;
             this.serviceDiscoveryWeight = serviceDiscoveryWeight;
             this.loadBalancingWeight = serviceDiscoveryWeight;
         }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/NoopOutlierDetector.java
@@ -22,8 +22,6 @@ import io.servicetalk.concurrent.api.Publisher;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
-import static java.util.Objects.requireNonNull;
-
 // A simple outlier detector implementation that only provides the basic `RequestTracker` implementation
 // so the P2C LoadBalancingPolicy can still be effective.
 final class NoopOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection>
@@ -33,8 +31,8 @@ final class NoopOutlierDetector<ResolvedAddress, C extends LoadBalancedConnectio
     private final Executor executor;
 
     NoopOutlierDetector(OutlierDetectorConfig outlierDetectorConfig, Executor executor) {
-        this.outlierDetectorConfig = requireNonNull(outlierDetectorConfig, "outlierDetectorConfig");
-        this.executor = requireNonNull(executor, "executor");
+        this.outlierDetectorConfig = outlierDetectorConfig;
+        this.executor = executor;
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -82,23 +82,20 @@ public final class OutlierDetectorConfig {
                           final int failurePercentageThreshold, final int enforcingFailurePercentage,
                           final int failurePercentageMinimumHosts, final int failurePercentageRequestVolume,
                           final Duration maxEjectionTime, final Duration ejectionTimeJitter) {
-        this.ewmaHalfLife = requireNonNull(ewmaHalfLife, "ewmaHalfLife");
+        this.ewmaHalfLife = ewmaHalfLife;
         this.ewmaCancellationPenalty = ensureNonNegative(ewmaCancellationPenalty, "ewmaCancellationPenalty");
         this.ewmaErrorPenalty = ensureNonNegative(ewmaErrorPenalty, "ewmaErrorPenalty");
         this.concurrentRequestPenalty = ensureNonNegative(concurrentRequestPenalty, "concurrentRequestPenalty");
         this.cancellationIsError = cancellationIsError;
         this.failedConnectionsThreshold = failedConnectionsThreshold;
-        this.failureDetectorIntervalJitter = requireNonNull(
-                failureDetectorIntervalJitter, "failureDetectorIntervalJitter");
-        this.serviceDiscoveryResubscribeInterval = requireNonNull(
-                serviceDiscoveryResubscribeInterval, "serviceDiscoveryResubscribeInterval");
-        this.serviceDiscoveryResubscribeJitter = requireNonNull(
-                serviceDiscoveryResubscribeJitter, "serviceDiscoveryResubscribeJitter");
+        this.failureDetectorIntervalJitter = failureDetectorIntervalJitter;
+        this.serviceDiscoveryResubscribeInterval = serviceDiscoveryResubscribeInterval;
+        this.serviceDiscoveryResubscribeJitter = serviceDiscoveryResubscribeJitter;
         // xDS settings.
         this.consecutive5xx = consecutive5xx;
-        this.failureDetectorInterval = requireNonNull(failureDetectorInterval, "failureDetectorInterval");
-        this.baseEjectionTime = requireNonNull(baseEjectionTime, "baseEjectionTime");
-        this.ejectionTimeJitter = requireNonNull(ejectionTimeJitter, "ejectionTimeJitter");
+        this.failureDetectorInterval = failureDetectorInterval;
+        this.baseEjectionTime = baseEjectionTime;
+        this.ejectionTimeJitter = ejectionTimeJitter;
         this.maxEjectionPercentage = maxEjectionPercentage;
         this.enforcingConsecutive5xx = enforcingConsecutive5xx;
         this.enforcingSuccessRate = enforcingSuccessRate;
@@ -109,7 +106,7 @@ public final class OutlierDetectorConfig {
         this.enforcingFailurePercentage = enforcingFailurePercentage;
         this.failurePercentageMinimumHosts = failurePercentageMinimumHosts;
         this.failurePercentageRequestVolume = failurePercentageRequestVolume;
-        this.maxEjectionTime = requireNonNull(maxEjectionTime, "maxEjectionTime");
+        this.maxEjectionTime = maxEjectionTime;
     }
 
     /**

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CConnectionSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CConnectionSelector.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.lang.Math.min;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link ConnectionSelector} that attempts to discern between the health of individual connections.
@@ -53,7 +52,7 @@ final class P2CConnectionSelector<C extends LoadBalancedConnection> implements C
 
     private P2CConnectionSelector(final String lbDescription, final int maxEffort, final int corePoolSize,
                                   final boolean forceCorePool) {
-        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
+        this.lbDescription = lbDescription;
         this.maxEffort = ensureNonNegative(maxEffort, "maxEffort");
         this.corePoolSize = ensureNonNegative(corePoolSize, "corePoolSize");
         this.forceCorePool = forceCorePool;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RandomSubsetter.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RandomSubsetter.java
@@ -23,7 +23,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link Subsetter} that takes a random subset of the provided hosts.
@@ -37,7 +36,7 @@ final class RandomSubsetter implements Subsetter {
 
     private RandomSubsetter(final int randomSubsetSize, final String lbDescription) {
         this.randomSubsetSize = ensurePositive(randomSubsetSize, "randomSubsetSize");
-        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
+        this.lbDescription = lbDescription;
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RichServiceDiscovererEvent.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RichServiceDiscovererEvent.java
@@ -20,7 +20,6 @@ import io.servicetalk.client.api.ServiceDiscovererEvent;
 import java.util.Objects;
 
 import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A richer {@link ServiceDiscovererEvent} that can carry weight and priority information.
@@ -37,8 +36,8 @@ final class RichServiceDiscovererEvent<ResolvedAddress> implements ServiceDiscov
         if (weight < 0d) {
             throw new IllegalArgumentException("Illegal weight: " + weight);
         }
-        this.address = requireNonNull(address, "address");
-        this.status = requireNonNull(status, "status");
+        this.address = address;
+        this.status = status;
         this.weight = weight;
         this.priority = ensureNonNegative(priority, "priority");
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancer.java
@@ -172,11 +172,11 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
             final int linearSearchSpace,
             @Nullable final HealthCheckConfig healthCheckConfig) {
         this.id = id + '@' + toHexString(identityHashCode(this));
-        this.targetResource = requireNonNull(targetResourceName);
-        this.eventPublisher = requireNonNull(eventPublisher);
+        this.targetResource = targetResourceName;
+        this.eventPublisher = eventPublisher;
         this.eventStream = fromSource(eventStreamProcessor)
                 .replay(1); // Allow for multiple subscribers and provide new subscribers with last signal.
-        this.connectionFactory = requireNonNull(connectionFactory);
+        this.connectionFactory = connectionFactory;
         this.linearSearchSpace = linearSearchSpace;
         this.healthCheckConfig = healthCheckConfig;
         this.asyncCloseable = toAsyncCloseable(graceful -> {
@@ -1072,7 +1072,7 @@ final class RoundRobinLoadBalancer<ResolvedAddress, C extends LoadBalancedConnec
         private final List<T> delegate;
 
         private ClosedList(final List<T> delegate) {
-            this.delegate = requireNonNull(delegate);
+            this.delegate = delegate;
         }
 
         @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SequentialExecutor.java
@@ -54,7 +54,7 @@ final class SequentialExecutor implements Executor {
     private Thread currentDrainingThread;
 
     SequentialExecutor(final ExceptionHandler exceptionHandler) {
-        this.exceptionHandler = requireNonNull(exceptionHandler, "exceptionHandler");
+        this.exceptionHandler = exceptionHandler;
     }
 
     boolean isCurrentThreadDraining() {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -70,17 +70,17 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
                        final int pendingRequestPenalty,
                        final boolean cancellationIsError, final ResolvedAddress address, String lbDescription,
                        final HostObserver hostObserver) {
-        super(requireNonNull(ewmaHalfLife, "ewmaHalfLife").toNanos(),
+        super(ewmaHalfLife.toNanos(),
                 ensureNonNegative(cancellationPenalty, "cancellationPenalty"),
                 ensureNonNegative(errorPenalty, "errorPenalty"),
                 ensureNonNegative(pendingRequestPenalty, "pendingRequestPenalty"));
         this.cancellationIsError = cancellationIsError;
-        this.sequentialExecutor = requireNonNull(sequentialExecutor, "sequentialExecutor");
-        this.executor = requireNonNull(executor, "executor");
+        this.sequentialExecutor = sequentialExecutor;
+        this.executor = executor;
         assert executor instanceof NormalizedTimeSourceExecutor;
-        this.address = requireNonNull(address, "address");
-        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
-        this.hostObserver = requireNonNull(hostObserver, "hostObserver");
+        this.address = address;
+        this.lbDescription = lbDescription;
+        this.hostObserver = hostObserver;
     }
 
     /**
@@ -112,7 +112,7 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
 
     @Override
     public final void setHost(Host<ResolvedAddress, C> host) {
-        this.host = requireNonNull(host, "host");
+        this.host = host;
     }
 
     @Override

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static io.servicetalk.concurrent.api.Processors.newPublisherProcessorDropHeadOnOverflow;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static java.lang.Math.max;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link OutlierDetector} implementation that supports xDS outlier detector configuration.
@@ -84,9 +83,9 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
     XdsOutlierDetector(final Executor executor, final OutlierDetectorConfig outlierDetectorConfig,
                        final String lbDescription, SequentialExecutor.ExceptionHandler exceptionHandler) {
         this.sequentialExecutor = new SequentialExecutor(exceptionHandler);
-        this.outlierDetectorConfig = requireNonNull(outlierDetectorConfig, "outlierDetectorConfig");
-        this.executor = requireNonNull(executor, "executor");
-        this.lbDescription = requireNonNull(lbDescription, "lbDescription");
+        this.outlierDetectorConfig = outlierDetectorConfig;
+        this.executor = executor;
+        this.lbDescription = lbDescription;
         this.kernel = new Kernel(outlierDetectorConfig);
     }
 
@@ -190,7 +189,7 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
         private final OutlierDetectorConfig config;
 
         Kernel(final OutlierDetectorConfig config) {
-            this.config = requireNonNull(config, "config");
+            this.config = config;
             this.algorithms = getAlgorithms(config);
             this.cancellable = new SequentialCancellable(scheduleNextOutliersCheck(config));
         }


### PR DESCRIPTION
#### Motivation

We do an awful lot of `requireNonNull(..)` in the loadbalancer package. Most of the values we're validating are not user input and our codebase already enforces the @Nullable annotations, so many of them can be dropped.

#### Modifications

Remove a lot of null validations. We also add a few in some places where we might receive nulls from method calls, eg we are not directly checking a reference.
