### PR TITLE
Fix `Central Portal manual Repo Close` release step

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -66,8 +66,8 @@ jobs:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
         run: |
-          BEARER_TOKEN=printf "$SONATYPE_USER:$SONATYPE_TOKEN" | base64
-          curl --retry 5 -H "Authorization: Bearer $BEARER_TOKEN" -X POST https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io.servicetalk
+          BEARER_TOKEN=$(printf "$SONATYPE_USER:$SONATYPE_TOKEN" | base64)
+          curl -i --retry 5 -H "Authorization: Bearer $BEARER_TOKEN" -X POST https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io.servicetalk
           echo "Go to https://central.sonatype.com/publishing/deployments to finish publishing artifacts"
       - name: Publish Test Results
         if: always()


### PR DESCRIPTION
Motivation:

`Central Portal manual Repo Close` step of `ci-release.yml` failed with `line 1: ***:***: command not found` error.
Example: https://github.com/apple/servicetalk/actions/runs/16994269111/job/48181052478

Modifications:

- Wrap the `printf` command in command substitution when assigning to variable.
- Add `-i` for curl to print response headers to stdout (helps see returned response status).

Result:

The step should complete successfully.