### PR TITLE
opentelemetry-http: allow custom span name extraction

### DIFF
--- a/servicetalk-opentelemetry-http/build.gradle
+++ b/servicetalk-opentelemetry-http/build.gradle
@@ -72,7 +72,6 @@ dependencies {
   testImplementation "org.assertj:assertj-core:$assertJCoreVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"
-  testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testRuntimeOnly project(":servicetalk-opentelemetry-asynccontext")
   testRuntimeOnly "io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.17-autoconfigure:" +

--- a/servicetalk-opentelemetry-http/build.gradle
+++ b/servicetalk-opentelemetry-http/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   implementation project(":servicetalk-transport-api")
   implementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api"
   implementation "io.opentelemetry:opentelemetry-context"
+  implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
   testImplementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   testImplementation enforcedPlatform("com.google.protobuf:protobuf-bom:$protobufVersion")

--- a/servicetalk-opentelemetry-http/gradle.lockfile
+++ b/servicetalk-opentelemetry-http/gradle.lockfile
@@ -10,5 +10,5 @@ io.opentelemetry:opentelemetry-api:1.48.0=compileClasspath,runtimeClasspath
 io.opentelemetry:opentelemetry-bom:1.48.0=compileClasspath,runtimeClasspath
 io.opentelemetry:opentelemetry-context:1.48.0=compileClasspath,runtimeClasspath
 org.jctools:jctools-core:4.0.3=runtimeClasspath
-org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcInstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcInstrumentationHelper.java
@@ -97,7 +97,8 @@ final class GrpcInstrumentationHelper extends InstrumentationHelper {
      */
     static GrpcInstrumentationHelper forServer(OpenTelemetryHttpServiceFilter.Builder builder) {
         OpenTelemetry openTelemetry = builder.openTelemetry;
-        SpanNameExtractor<RequestInfo> serverSpanNameExtractor = GrpcSpanNameExtractor.INSTANCE;
+        SpanNameExtractor<RequestInfo> serverSpanNameExtractor =
+                spanNameExtractor(builder, GrpcSpanNameExtractor.INSTANCE);
         InstrumenterBuilder<RequestInfo, GrpcTelemetryStatus> serverInstrumenterBuilder =
                 Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, serverSpanNameExtractor);
         serverInstrumenterBuilder
@@ -122,7 +123,8 @@ final class GrpcInstrumentationHelper extends InstrumentationHelper {
      */
     static GrpcInstrumentationHelper forClient(OpenTelemetryHttpRequesterFilter.Builder builder) {
         OpenTelemetry openTelemetry = builder.openTelemetry;
-        SpanNameExtractor<RequestInfo> clientSpanNameExtractor = GrpcSpanNameExtractor.INSTANCE;
+        SpanNameExtractor<RequestInfo> clientSpanNameExtractor =
+                spanNameExtractor(builder, GrpcSpanNameExtractor.INSTANCE);
         InstrumenterBuilder<RequestInfo, GrpcTelemetryStatus> clientInstrumenterBuilder =
                 Instrumenter.builder(
                         openTelemetry, INSTRUMENTATION_SCOPE_NAME, clientSpanNameExtractor);

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpInstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/HttpInstrumentationHelper.java
@@ -93,8 +93,8 @@ final class HttpInstrumentationHelper extends InstrumentationHelper {
      */
     static HttpInstrumentationHelper forServer(OpenTelemetryHttpServiceFilter.Builder builder) {
         OpenTelemetry openTelemetry = builder.openTelemetry;
-        SpanNameExtractor<RequestInfo> serverSpanNameExtractor =
-                HttpSpanNameExtractor.create(HttpAttributesGetter.SERVER_INSTANCE);
+        SpanNameExtractor<RequestInfo> serverSpanNameExtractor = spanNameExtractor(builder,
+                HttpSpanNameExtractor.create(HttpAttributesGetter.SERVER_INSTANCE));
         InstrumenterBuilder<RequestInfo, HttpResponseMetaData> serverInstrumenterBuilder =
                 Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, serverSpanNameExtractor);
         serverInstrumenterBuilder.setSpanStatusExtractor(HttpSpanStatusExtractor.SERVER_INSTANCE);
@@ -123,8 +123,8 @@ final class HttpInstrumentationHelper extends InstrumentationHelper {
      */
     static HttpInstrumentationHelper forClient(final OpenTelemetryHttpRequesterFilter.Builder builder) {
         OpenTelemetry openTelemetry = builder.openTelemetry;
-        SpanNameExtractor<RequestInfo> clientSpanNameExtractor =
-                HttpSpanNameExtractor.create(HttpAttributesGetter.CLIENT_INSTANCE);
+        SpanNameExtractor<RequestInfo> clientSpanNameExtractor = spanNameExtractor(builder,
+                HttpSpanNameExtractor.create(HttpAttributesGetter.CLIENT_INSTANCE));
         InstrumenterBuilder<RequestInfo, HttpResponseMetaData> clientInstrumenterBuilder =
                 Instrumenter.builder(openTelemetry, INSTRUMENTATION_SCOPE_NAME, clientSpanNameExtractor);
         clientInstrumenterBuilder

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/InstrumentationHelper.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/InstrumentationHelper.java
@@ -49,7 +49,7 @@ abstract class InstrumentationHelper {
             Context parentContext);
 
     static SpanNameExtractor<RequestInfo> spanNameExtractor(OpenTelemetryFilterBuilder<?> builder,
-                                                                      SpanNameExtractor<RequestInfo> defaultExtractor) {
+                                                            SpanNameExtractor<RequestInfo> defaultExtractor) {
         @Nullable Function<HttpRequestMetaData, String> customExtractor = builder.spanNameExtractor;
         if (customExtractor == null) {
             return defaultExtractor;
@@ -60,7 +60,7 @@ abstract class InstrumentationHelper {
                 result = customExtractor.apply(requestInfo.request());
             } catch (Exception ex) {
                 LOGGER.warn("Failed to extract custom span name", ex);
-                result = "<error extracting name>";
+                result = "<error extracting span name>";
             }
             if (result == null) {
                 result = defaultExtractor.extract(requestInfo);

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.opentelemetry.http;
 
+import io.servicetalk.http.api.HttpRequestMetaData;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
@@ -26,6 +28,8 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpServerMetrics;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
@@ -36,6 +40,8 @@ abstract class OpenTelemetryFilterBuilder<T extends OpenTelemetryFilterBuilder<T
     List<String> capturedResponseHeaders = emptyList();
     boolean enableMetrics;
     OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+    @Nullable
+    Function<HttpRequestMetaData, String> spanNameExtractor;
 
     abstract T thisInstance();
 
@@ -79,6 +85,17 @@ abstract class OpenTelemetryFilterBuilder<T extends OpenTelemetryFilterBuilder<T
         this.capturedResponseHeaders =
                 capturedResponseHeaders.isEmpty() ? emptyList() :
                         unmodifiableList(new ArrayList<>(capturedResponseHeaders));
+        return thisInstance();
+    }
+
+    /**
+     * Set a custom span name extractor.
+     *
+     * @param spanNameExtractor the custom span name extractor, or null to use default extractor
+     * @return {@code this} builder
+     */
+    public T spanNameExtractor(@Nullable Function<HttpRequestMetaData, String> spanNameExtractor) {
+        this.spanNameExtractor = spanNameExtractor;
         return thisInstance();
     }
 

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/OpenTelemetryFilterBuilder.java
@@ -91,7 +91,8 @@ abstract class OpenTelemetryFilterBuilder<T extends OpenTelemetryFilterBuilder<T
     /**
      * Set a custom span name extractor.
      *
-     * @param spanNameExtractor the custom span name extractor, or null to use default extractor
+     * @param spanNameExtractor the custom span name extractor, or {@code null} to use default extractor. If the
+     *                          specified extractor returns {@code null}, the default extractor is then used.
      * @return {@code this} builder
      */
     public T spanNameExtractor(@Nullable Function<HttpRequestMetaData, String> spanNameExtractor) {


### PR DESCRIPTION
 #### Motivation

Users may want to customize the span name extraction to add more info from the default which for HTTP is often just 'GET'. This can also be helpful in the case where users want to add the filters twice so they can distinguish between logical and physical spans other than by their implicit structure.

 #### Modifications

All setting a Function<HttpRequestMetadata, String> that will produce the span name.

 #### Result

Customized span name extraction.