### PR TITLE
opentelemetry-http: append 'Physical ' to physical span names

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpServiceFilter.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/AbstractOpenTelemetryHttpServiceFilter.java
@@ -54,13 +54,13 @@ abstract class AbstractOpenTelemetryHttpServiceFilter extends AbstractOpenTeleme
                                                        final StreamingHttpResponseFactory responseFactory) {
         InstrumentationHelper helper = grpcHelper.isGrpcRequest(request) ? grpcHelper : httpHelper;
         Context current = Context.current();
-        RequestInfo requestInfo = new RequestInfo(request, ctx);
+        RequestInfo requestInfo = new RequestInfo(request, ctx, false);
         if (!helper.shouldStart(current, requestInfo)) {
             return delegate.handle(ctx, request, responseFactory);
         } else {
             return helper.trackRequest(
                 req -> delegate.handle(ctx, req, responseFactory),
-                new RequestInfo(request, ctx),
+                requestInfo,
                 current);
         }
     }

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestInfo.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/RequestInfo.java
@@ -31,10 +31,12 @@ final class RequestInfo {
     private final StreamingHttpRequest request;
     @Nullable
     private final ConnectionInfo connectionInfo;
+    private final boolean usePhysicalSpanName;
 
-    RequestInfo(StreamingHttpRequest request, @Nullable ConnectionInfo connectionInfo) {
+    RequestInfo(StreamingHttpRequest request, @Nullable ConnectionInfo connectionInfo, boolean usePhysicalSpanName) {
         this.request = request;
         this.connectionInfo = connectionInfo;
+        this.usePhysicalSpanName = usePhysicalSpanName;
     }
 
     StreamingHttpRequest request() {
@@ -44,5 +46,9 @@ final class RequestInfo {
     @Nullable
     ConnectionInfo connectionInfo() {
         return connectionInfo;
+    }
+
+    boolean usePhysicalSpanName() {
+        return usePhysicalSpanName;
     }
 }

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/HttpAttributesGetterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/HttpAttributesGetterTest.java
@@ -52,7 +52,7 @@ class HttpAttributesGetterTest {
     void clientUrlExtractionNoHostAndPort() {
         String pathQueryFrag = "/foo?bar=baz#frag";
         StreamingHttpRequest request = newRequest(pathQueryFrag);
-        RequestInfo requestInfo = new RequestInfo(request, null);
+        RequestInfo requestInfo = new RequestInfo(request, null, false);
         assertThat(CLIENT_INSTANCE.getUrlFull(requestInfo), nullValue());
     }
 
@@ -61,7 +61,7 @@ class HttpAttributesGetterTest {
         String pathQueryFrag = "/foo?bar=baz#frag";
         StreamingHttpRequest request = newRequest(pathQueryFrag);
         request.addHeader(HOST, "myservice");
-        RequestInfo requestInfo = new RequestInfo(request, null);
+        RequestInfo requestInfo = new RequestInfo(request, null, false);
         assertThat(CLIENT_INSTANCE.getUrlFull(requestInfo), equalTo("http://myservice" + pathQueryFrag));
     }
 
@@ -70,7 +70,7 @@ class HttpAttributesGetterTest {
         String pathQueryFrag = "foo";
         StreamingHttpRequest request = newRequest(pathQueryFrag);
         request.addHeader(HOST, "myservice:8080");
-        RequestInfo requestInfo = new RequestInfo(request, null);
+        RequestInfo requestInfo = new RequestInfo(request, null, false);
         assertThat(CLIENT_INSTANCE.getUrlFull(requestInfo), equalTo("http://myservice:8080/" + pathQueryFrag));
     }
 
@@ -79,7 +79,7 @@ class HttpAttributesGetterTest {
         String pathQueryFrag = "/foo?bar=baz#frag";
         StreamingHttpRequest request = newRequest(pathQueryFrag);
         request.addHeader(HOST, "myservice:8080");
-        RequestInfo requestInfo = new RequestInfo(request, null);
+        RequestInfo requestInfo = new RequestInfo(request, null, false);
         assertThat(CLIENT_INSTANCE.getUrlFull(requestInfo), equalTo("http://myservice:8080" + pathQueryFrag));
     }
 
@@ -88,7 +88,7 @@ class HttpAttributesGetterTest {
         String pathQueryFrag = "/foo?bar=baz#frag";
         StreamingHttpRequest request = newRequest(pathQueryFrag);
         request.addHeader(HOST, "myservice:80");
-        RequestInfo requestInfo = new RequestInfo(request, null);
+        RequestInfo requestInfo = new RequestInfo(request, null, false);
         assertThat(CLIENT_INSTANCE.getUrlFull(requestInfo), equalTo("http://myservice" + pathQueryFrag));
     }
 
@@ -97,7 +97,7 @@ class HttpAttributesGetterTest {
         String pathQueryFrag = "/foo?bar=baz#frag";
         StreamingHttpRequest request = newRequest(pathQueryFrag);
         request.addHeader(HOST, "myservice:443");
-        RequestInfo requestInfo = new RequestInfo(request, null);
+        RequestInfo requestInfo = new RequestInfo(request, null, false);
         assertThat(CLIENT_INSTANCE.getUrlFull(requestInfo), equalTo("https://myservice" + pathQueryFrag));
     }
 
@@ -106,7 +106,7 @@ class HttpAttributesGetterTest {
         String requestTarget = "https://myservice/foo?bar=baz#frag";
         StreamingHttpRequest request = newRequest(requestTarget);
         request.addHeader(HOST, "badservice"); // should be unused
-        RequestInfo requestInfo = new RequestInfo(request, null);
+        RequestInfo requestInfo = new RequestInfo(request, null, false);
         assertThat(CLIENT_INSTANCE.getUrlFull(requestInfo), equalTo(requestTarget));
     }
 
@@ -116,7 +116,7 @@ class HttpAttributesGetterTest {
         ConnectionInfo connectionInfo = mock(ConnectionInfo.class);
         InetSocketAddress inetAddress = new InetSocketAddress("192.168.1.1", 8080);
         when(connectionInfo.remoteAddress()).thenReturn(inetAddress);
-        RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
+        RequestInfo requestInfo = new RequestInfo(request, connectionInfo, false);
 
         // Network attributes
         for (NetworkAttributesGetter<RequestInfo, ?> getter : Arrays.asList(SERVER_INSTANCE, CLIENT_INSTANCE)) {
@@ -142,7 +142,7 @@ class HttpAttributesGetterTest {
         ConnectionInfo connectionInfo = mock(ConnectionInfo.class);
         InetSocketAddress inetAddress = new InetSocketAddress("::1", 8080);
         when(connectionInfo.remoteAddress()).thenReturn(inetAddress);
-        RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
+        RequestInfo requestInfo = new RequestInfo(request, connectionInfo, false);
 
         // Network attributes
         for (NetworkAttributesGetter<RequestInfo, ?> getter : Arrays.asList(SERVER_INSTANCE, CLIENT_INSTANCE)) {
@@ -168,7 +168,7 @@ class HttpAttributesGetterTest {
         ConnectionInfo connectionInfo = mock(ConnectionInfo.class);
         DomainSocketAddress unixAddress = new DomainSocketAddress("/tmp/socket");
         when(connectionInfo.remoteAddress()).thenReturn(unixAddress);
-        RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
+        RequestInfo requestInfo = new RequestInfo(request, connectionInfo, false);
 
         // Network attributes
         for (NetworkAttributesGetter<RequestInfo, ?> getter : Arrays.asList(SERVER_INSTANCE, CLIENT_INSTANCE)) {
@@ -192,7 +192,7 @@ class HttpAttributesGetterTest {
     void attributesWithHostHeaderOnly() {
         StreamingHttpRequest request = newRequest("/path");
         request.addHeader(HOST, "example.com:8080");
-        RequestInfo requestInfo = new RequestInfo(request, null);
+        RequestInfo requestInfo = new RequestInfo(request, null, false);
 
         // Network attributes (null without connection info)
         assertThat(CLIENT_INSTANCE.getNetworkType(requestInfo, null), nullValue());
@@ -220,7 +220,7 @@ class HttpAttributesGetterTest {
         ConnectionInfo connectionInfo = mock(ConnectionInfo.class);
         InetSocketAddress inetAddress = new InetSocketAddress("192.168.1.1", 8080);
         when(connectionInfo.remoteAddress()).thenReturn(inetAddress);
-        RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
+        RequestInfo requestInfo = new RequestInfo(request, connectionInfo, false);
 
         // Network attributes (from connection)
         assertThat(CLIENT_INSTANCE.getNetworkType(requestInfo, null), equalTo("ipv4"));
@@ -248,7 +248,7 @@ class HttpAttributesGetterTest {
         ConnectionInfo connectionInfo = mock(ConnectionInfo.class);
         DomainSocketAddress unixAddress = new DomainSocketAddress("/tmp/socket");
         when(connectionInfo.remoteAddress()).thenReturn(unixAddress);
-        RequestInfo requestInfo = new RequestInfo(request, connectionInfo);
+        RequestInfo requestInfo = new RequestInfo(request, connectionInfo, false);
 
         // Network attributes (from connection)
         assertThat(CLIENT_INSTANCE.getNetworkType(requestInfo, null), nullValue());
@@ -272,7 +272,7 @@ class HttpAttributesGetterTest {
     @Test
     void attributesWithNoConnectionInfo() {
         StreamingHttpRequest request = newRequest("/path");
-        RequestInfo requestInfo = new RequestInfo(request, null);
+        RequestInfo requestInfo = new RequestInfo(request, null, false);
 
         // Network attributes (all null without connection)
         assertThat(CLIENT_INSTANCE.getNetworkType(requestInfo, null), nullValue());

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/HttpSpanStatusExtractorTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/HttpSpanStatusExtractorTest.java
@@ -48,7 +48,7 @@ class HttpSpanStatusExtractorTest {
     @ParameterizedTest(name = "{displayName} [{index}]: isServer={0}")
     @ValueSource(booleans = {true, false})
     void testStatus200To399(boolean isServer) {
-        RequestInfo requestInfo = new RequestInfo(requestMetaData, null);
+        RequestInfo requestInfo = new RequestInfo(requestMetaData, null, false);
         for (int code = 100; code < 400; code++) {
             when(responseMetaData.status()).thenReturn(HttpResponseStatus.of(code, "any"));
             getExtractor(isServer).extract(spanStatusBuilder, requestInfo, responseMetaData, null);
@@ -60,7 +60,7 @@ class HttpSpanStatusExtractorTest {
     @ParameterizedTest(name = "{displayName} [{index}]: isServer={0}")
     @ValueSource(booleans = {true, false})
     void testStatus400to499(boolean isServer) {
-        RequestInfo requestInfo = new RequestInfo(requestMetaData, null);
+        RequestInfo requestInfo = new RequestInfo(requestMetaData, null, false);
         int executions = 0;
         for (int code = 400; code < 500; code++) {
             executions++;
@@ -78,7 +78,7 @@ class HttpSpanStatusExtractorTest {
     @ParameterizedTest(name = "{displayName} [{index}]: isServer={0}")
     @ValueSource(booleans = {true, false})
     void testStatus500to599(boolean isServer) {
-        RequestInfo requestInfo = new RequestInfo(requestMetaData, null);
+        RequestInfo requestInfo = new RequestInfo(requestMetaData, null, false);
         int executions = 0;
         for (int code = 500; code < 600; code++) {
             executions++;
@@ -91,7 +91,7 @@ class HttpSpanStatusExtractorTest {
     @ParameterizedTest(name = "{displayName} [{index}]: isServer={0}")
     @ValueSource(booleans = {true, false})
     void testStatusUnknown(boolean isServer) {
-        RequestInfo requestInfo = new RequestInfo(requestMetaData, null);
+        RequestInfo requestInfo = new RequestInfo(requestMetaData, null, false);
         when(responseMetaData.status()).thenReturn(HttpResponseStatus.of(600, "any"));
         getExtractor(isServer).extract(spanStatusBuilder, requestInfo, responseMetaData, null);
         verify(spanStatusBuilder, times(0)).setStatus(any());
@@ -100,7 +100,7 @@ class HttpSpanStatusExtractorTest {
     @ParameterizedTest(name = "{displayName} [{index}]: isServer={0}")
     @ValueSource(booleans = {true, false})
     void testExceptionError(boolean isServer) {
-        RequestInfo requestInfo = new RequestInfo(requestMetaData, null);
+        RequestInfo requestInfo = new RequestInfo(requestMetaData, null, false);
         getExtractor(isServer).extract(spanStatusBuilder, requestInfo, responseMetaData,
             new RuntimeException());
         verify(spanStatusBuilder).setStatus(StatusCode.ERROR);


### PR DESCRIPTION
 #### Motivation

If users are inserting the OTEL requester filter as both a client filter and a connection filter it can be kind of confusing since both spans will look identical.

 #### Modifications

Prepend 'Physical ' to the connection level spans if we determine that there is a parent logical filter in place.

 #### Result

Clearer traces.