### PR TITLE
Avoid deadlock for `subscribeOn()` in case of unexpected exception

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Completable.java
@@ -2306,10 +2306,10 @@ public abstract class Completable {
         } catch (Throwable t) {
             LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);
             // At this point we are unsure if any signal was sent to the Subscriber and if it is safe to invoke the
-            // Subscriber without violating specifications. However, not propagating the error to the Subscriber will
-            // result in hard to debug scenarios where no further signals may be sent to the Subscriber and hence it
-            // will be hard to distinguish between a "hung" source and a wrongly implemented source that violates the
-            // specifications and throw from subscribe() (Rule 1.9).
+            // Subscriber without violating specifications. However, not propagating the error to the Subscriber
+            // will result in hard to debug scenarios where no further signals may be sent to the Subscriber and
+            // hence it will be hard to distinguish between a "hung" source and a wrongly implemented source that
+            // violates the specifications and throw from subscribe() (Rule 1.9).
             //
             // By doing the following we may violate the rules:
             // 1) Rule 2.12: onSubscribe() MUST be called at most once.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnCompletables.java
@@ -121,7 +121,7 @@ final class PublishAndSubscribeOnCompletables {
 
                 if (shouldOffload.getAsBoolean()) {
                     // offload the remainder of subscribe()
-                    executor().execute(() -> super.handleSubscribe(
+                    executor().execute(() -> offloadedHandleSubscribe(
                             upstreamSubscriber, capturedContext, contextProvider));
                     return;
                 }
@@ -133,6 +133,28 @@ final class PublishAndSubscribeOnCompletables {
 
             // continue non-offloaded subscribe()
             super.handleSubscribe(upstreamSubscriber, capturedContext, contextProvider);
+        }
+
+        private void offloadedHandleSubscribe(final Subscriber upstreamSubscriber,
+                                              final CapturedContext capturedContext,
+                                              final AsyncContextProvider contextProvider) {
+            // Because we run on a different thread, we must ensure any unexpected exception is caught.
+            try {
+                super.handleSubscribe(upstreamSubscriber, capturedContext, contextProvider);
+            } catch (Throwable t) {
+                LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);
+                // At this point we are unsure if any signal was sent to the Subscriber and if it is safe to invoke the
+                // Subscriber without violating specifications. However, not propagating the error to the Subscriber
+                // will result in hard to debug scenarios where no further signals may be sent to the Subscriber and
+                // hence it will be hard to distinguish between a "hung" source and a wrongly implemented source that
+                // violates the specifications and throw from subscribe() (Rule 1.9).
+                //
+                // By doing the following we may violate the rules:
+                // 1) Rule 2.12: onSubscribe() MUST be called at most once.
+                // 2) Rule 1.7: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no
+                // further signals occur.
+                deliverErrorFromSource(upstreamSubscriber, t);
+            }
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublishAndSubscribeOnPublishers.java
@@ -119,7 +119,7 @@ final class PublishAndSubscribeOnPublishers {
 
                 if (shouldOffload.getAsBoolean()) {
                     // offload the remainder of subscribe()
-                    executor().execute(() -> super.handleSubscribe(
+                    executor().execute(() -> offloadedHandleSubscribe(
                             upstreamSubscriber, capturedContext, contextProvider));
                     return;
                 }
@@ -132,6 +132,28 @@ final class PublishAndSubscribeOnPublishers {
 
             // continue non-offloaded subscribe()
             super.handleSubscribe(upstreamSubscriber, capturedContext, contextProvider);
+        }
+
+        private void offloadedHandleSubscribe(final Subscriber<? super T> upstreamSubscriber,
+                                              final CapturedContext capturedContext,
+                                              final AsyncContextProvider contextProvider) {
+            // Because we run on a different thread, we must ensure any unexpected exception is caught.
+            try {
+                super.handleSubscribe(upstreamSubscriber, capturedContext, contextProvider);
+            } catch (Throwable t) {
+                LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);
+                // At this point we are unsure if any signal was sent to the Subscriber and if it is safe to invoke the
+                // Subscriber without violating specifications. However, not propagating the error to the Subscriber
+                // will result in hard to debug scenarios where no further signals may be sent to the Subscriber and
+                // hence it will be hard to distinguish between a "hung" source and a wrongly implemented source that
+                // violates the specifications and throw from subscribe() (Rule 1.9).
+                //
+                // By doing the following we may violate the rules:
+                // 1) Rule 2.12: onSubscribe() MUST be called at most once.
+                // 2) Rule 1.7: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no
+                // further signals occur.
+                deliverErrorFromSource(upstreamSubscriber, t);
+            }
         }
     }
 }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Publisher.java
@@ -4941,10 +4941,10 @@ Kotlin flatMapLatest</a>
         } catch (Throwable t) {
             LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);
             // At this point we are unsure if any signal was sent to the Subscriber and if it is safe to invoke the
-            // Subscriber without violating specifications. However, not propagating the error to the Subscriber will
-            // result in hard to debug scenarios where no further signals may be sent to the Subscriber and hence it
-            // will be hard to distinguish between a "hung" source and a wrongly implemented source that violates the
-            // specifications and throw from subscribe() (Rule 1.9).
+            // Subscriber without violating specifications. However, not propagating the error to the Subscriber
+            // will result in hard to debug scenarios where no further signals may be sent to the Subscriber and
+            // hence it will be hard to distinguish between a "hung" source and a wrongly implemented source that
+            // violates the specifications and throw from subscribe() (Rule 1.9).
             //
             // By doing the following we may violate the rules:
             // 1) Rule 2.12: onSubscribe() MUST be called at most once.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/Single.java
@@ -2748,10 +2748,10 @@ public abstract class Single<T> {
         } catch (Throwable t) {
             LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);
             // At this point we are unsure if any signal was sent to the Subscriber and if it is safe to invoke the
-            // Subscriber without violating specifications. However, not propagating the error to the Subscriber will
-            // result in hard to debug scenarios where no further signals may be sent to the Subscriber and hence it
-            // will be hard to distinguish between a "hung" source and a wrongly implemented source that violates the
-            // specifications and throw from subscribe() (Rule 1.9).
+            // Subscriber without violating specifications. However, not propagating the error to the Subscriber
+            // will result in hard to debug scenarios where no further signals may be sent to the Subscriber and
+            // hence it will be hard to distinguish between a "hung" source and a wrongly implemented source that
+            // violates the specifications and throw from subscribe() (Rule 1.9).
             //
             // By doing the following we may violate the rules:
             // 1) Rule 2.12: onSubscribe() MUST be called at most once.

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncPublisherOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncPublisherOperator.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.TaskBasedAsyncCompletableOperator.safeShouldOffload;
 import static io.servicetalk.concurrent.internal.EmptySubscriptions.EMPTY_SUBSCRIPTION;
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeCancel;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnComplete;
@@ -51,7 +50,8 @@ import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
  */
 abstract class TaskBasedAsyncPublisherOperator<T> extends AbstractNoHandleSubscribePublisher<T> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TaskBasedAsyncPublisherOperator.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(TaskBasedAsyncPublisherOperator.class);
+
     private static final Object NULL_WRAPPER = new Object() {
         @Override
         public String toString() {
@@ -82,22 +82,7 @@ abstract class TaskBasedAsyncPublisherOperator<T> extends AbstractNoHandleSubscr
     @Override
     void handleSubscribe(final Subscriber<? super T> subscriber,
                          final CapturedContext capturedContext, final AsyncContextProvider contextProvider) {
-        try {
-            original.delegateSubscribe(subscriber, capturedContext, contextProvider);
-        } catch (Throwable t) {
-            LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);
-            // At this point we are unsure if any signal was sent to the Subscriber and if it is safe to invoke the
-            // Subscriber without violating specifications. However, not propagating the error to the Subscriber will
-            // result in hard to debug scenarios where no further signals may be sent to the Subscriber and hence it
-            // will be hard to distinguish between a "hung" source and a wrongly implemented source that violates the
-            // specifications and throw from subscribe() (Rule 1.9).
-            //
-            // By doing the following we may violate the rules:
-            // 1) Rule 2.12: onSubscribe() MUST be called at most once.
-            // 2) Rule 1.7: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no
-            // further signals occur.
-            deliverErrorFromSource(subscriber, t);
-        }
+        original.delegateSubscribe(subscriber, capturedContext, contextProvider);
     }
 
     /**

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncSingleOperator.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/TaskBasedAsyncSingleOperator.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeCancel;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnSuccess;
@@ -46,7 +45,8 @@ import static java.util.Objects.requireNonNull;
  */
 abstract class TaskBasedAsyncSingleOperator<T> extends AbstractNoHandleSubscribeSingle<T> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TaskBasedAsyncSingleOperator.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(TaskBasedAsyncSingleOperator.class);
+
     private static final Object NULL_WRAPPER = new Object() {
         @Override
         public String toString() {
@@ -77,22 +77,7 @@ abstract class TaskBasedAsyncSingleOperator<T> extends AbstractNoHandleSubscribe
     @Override
     void handleSubscribe(final Subscriber<? super T> subscriber,
                          final CapturedContext capturedContext, final AsyncContextProvider contextProvider) {
-        try {
-            original.delegateSubscribe(subscriber, capturedContext, contextProvider);
-        } catch (Throwable t) {
-            LOGGER.warn("Unexpected exception from subscribe(), assuming no interaction with the Subscriber.", t);
-            // At this point we are unsure if any signal was sent to the Subscriber and if it is safe to invoke the
-            // Subscriber without violating specifications. However, not propagating the error to the Subscriber will
-            // result in hard to debug scenarios where no further signals may be sent to the Subscriber and hence it
-            // will be hard to distinguish between a "hung" source and a wrongly implemented source that violates the
-            // specifications and throw from subscribe() (Rule 1.9).
-            //
-            // By doing the following we may violate the rules:
-            // 1) Rule 2.12: onSubscribe() MUST be called at most once.
-            // 2) Rule 1.7: Once a terminal state has been signaled (onError, onComplete) it is REQUIRED that no
-            // further signals occur.
-            deliverErrorFromSource(subscriber, t);
-        }
+        original.delegateSubscribe(subscriber, capturedContext, contextProvider);
     }
 
     static final class SingleSubscriberOffloadedTerminals<T> extends AbstractOffloadedSingleValueSubscriber

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeOnTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SubscribeOnTest.java
@@ -15,6 +15,8 @@
  */
 package io.servicetalk.concurrent.api;
 
+import io.servicetalk.concurrent.internal.DeliberateException;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +30,7 @@ import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
@@ -57,16 +60,21 @@ class SubscribeOnTest {
     @ParameterizedTest(name = "{displayName} [{index}] shouldOffload={0}")
     @ValueSource(booleans = {false, true})
     void throwOnSubscribeSingleSubscribeOn(boolean shouldOffload) {
-        ExecutionException ee = assertThrows(ExecutionException.class, () -> new ThrowOnSubscribeSingle()
+        Exception e = assertThrows(Exception.class, () -> new ThrowOnSubscribeSingle()
                 .subscribeOn(EXECUTOR.executor(), () -> shouldOffload).toFuture().get());
-        assertThat(ee.getCause(), is(DELIBERATE_EXCEPTION));
+        if (shouldOffload) {
+            assertThat(e, is(instanceOf(ExecutionException.class)));
+            assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
+        } else {
+            assertThat(e, is(DELIBERATE_EXCEPTION));
+        }
     }
 
     @Test
     void throwOnSubscribeSinglePublishOn() {
-        ExecutionException ee = assertThrows(ExecutionException.class, () -> new ThrowOnSubscribeSingle()
+        Exception e = assertThrows(DeliberateException.class, () -> new ThrowOnSubscribeSingle()
                 .publishOn(EXECUTOR.executor()).toFuture().get());
-        assertThat(ee.getCause(), is(DELIBERATE_EXCEPTION));
+        assertThat(e, is(DELIBERATE_EXCEPTION));
     }
 
     @Test
@@ -82,16 +90,21 @@ class SubscribeOnTest {
     @ParameterizedTest(name = "{displayName} [{index}] shouldOffload={0}")
     @ValueSource(booleans = {false, true})
     void throwOnSubscribeCompletableSubscribeOn(boolean shouldOffload) {
-        ExecutionException ee = assertThrows(ExecutionException.class, () -> new ThrowOnSubscribeCompletable()
+        Exception e = assertThrows(Exception.class, () -> new ThrowOnSubscribeCompletable()
                 .subscribeOn(EXECUTOR.executor(), () -> shouldOffload).toFuture().get());
-        assertThat(ee.getCause(), is(DELIBERATE_EXCEPTION));
+        if (shouldOffload) {
+            assertThat(e, is(instanceOf(ExecutionException.class)));
+            assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
+        } else {
+            assertThat(e, is(DELIBERATE_EXCEPTION));
+        }
     }
 
     @Test
     void throwOnSubscribeCompletablePublishOn() {
-        ExecutionException ee = assertThrows(ExecutionException.class, () -> new ThrowOnSubscribeCompletable()
+        Exception e = assertThrows(DeliberateException.class, () -> new ThrowOnSubscribeCompletable()
                 .publishOn(EXECUTOR.executor()).toFuture().get());
-        assertThat(ee.getCause(), is(DELIBERATE_EXCEPTION));
+        assertThat(e, is(DELIBERATE_EXCEPTION));
     }
 
     @Test
@@ -110,16 +123,21 @@ class SubscribeOnTest {
     @ParameterizedTest(name = "{displayName} [{index}] shouldOffload={0}")
     @ValueSource(booleans = {false, true})
     void throwOnSubscribePublisherSubscribeOn(boolean shouldOffload) {
-        ExecutionException ee = assertThrows(ExecutionException.class, () -> new ThrowOnSubscribePublisher()
+        Exception e = assertThrows(Exception.class, () -> new ThrowOnSubscribePublisher()
                 .subscribeOn(EXECUTOR.executor(), () -> shouldOffload).toFuture().get());
-        assertThat(ee.getCause(), is(DELIBERATE_EXCEPTION));
+        if (shouldOffload) {
+            assertThat(e, is(instanceOf(ExecutionException.class)));
+            assertThat(e.getCause(), is(DELIBERATE_EXCEPTION));
+        } else {
+            assertThat(e, is(DELIBERATE_EXCEPTION));
+        }
     }
 
     @Test
     void throwOnSubscribePublisherPublishOn() {
-        ExecutionException ee = assertThrows(ExecutionException.class, () -> new ThrowOnSubscribePublisher()
+        Exception e = assertThrows(DeliberateException.class, () -> new ThrowOnSubscribePublisher()
                 .publishOn(EXECUTOR.executor()).toFuture().get());
-        assertThat(ee.getCause(), is(DELIBERATE_EXCEPTION));
+        assertThat(e, is(DELIBERATE_EXCEPTION));
     }
 
     private static final class ThrowOnSubscribeSingle extends AbstractSynchronousSingle<Integer> {


### PR DESCRIPTION
Motivation:

If one of the delegate async sources throws an unexpected exception from `subscribe` operation, the offloaded path of `subscribeOn` operator can cause a deadlock because that exception is not delivered to the original `Subscriber`.

Modifications:

- Add `SubscribeOnTest` to demonstrate the described scenario.
- Add `try-catch` around each offloaded `handleSubscribe` call to handle unexpected exceptions.
- Fix javadoc formatting and links for internal methods.

Result:

No deadlock if delegate operators throw an unexpected exception from `subscribe` method after offloading.