### PR TITLE
opentelemetry-http: add the 'Physical ' prefix to grpc spans

### DIFF
--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcSpanNameExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcSpanNameExtractor.java
@@ -17,6 +17,7 @@
 package io.servicetalk.opentelemetry.http;
 
 import io.servicetalk.http.api.HttpRequestMetaData;
+
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 
 /**

--- a/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcSpanNameExtractor.java
+++ b/servicetalk-opentelemetry-http/src/main/java/io/servicetalk/opentelemetry/http/GrpcSpanNameExtractor.java
@@ -16,6 +16,7 @@
 
 package io.servicetalk.opentelemetry.http;
 
+import io.servicetalk.http.api.HttpRequestMetaData;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 
 /**
@@ -33,8 +34,16 @@ final class GrpcSpanNameExtractor implements SpanNameExtractor<RequestInfo> {
 
     @Override
     public String extract(RequestInfo requestInfo) {
+        String result = baseExtract(requestInfo.request());
+        if (requestInfo.usePhysicalSpanName()) {
+            result = "Physical " + result;
+        }
+        return result;
+    }
+
+    private String baseExtract(HttpRequestMetaData request) {
         // Note that for grpc, the request target is always origin form.
-        String path = requestInfo.request().requestTarget();
+        String path = request.requestTarget();
         if (path.isEmpty()) {
             return "grpc.request";
         }

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
@@ -206,7 +206,7 @@ class OpenTelemetryGrpcFilterTest {
         assertThat(otelTesting.getSpans().get(0).getKind()).isEqualTo(SpanKind.SERVER);
     }
 
-    @RepeatedTest(100)
+    @RepeatedTest(500)
     void connectionAndRequestFiltersCanCoexist() throws Exception {
         setUp(false, ClientFilterPosition.BOTH);
 

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
@@ -31,7 +31,7 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -206,7 +206,7 @@ class OpenTelemetryGrpcFilterTest {
         assertThat(otelTesting.getSpans().get(0).getKind()).isEqualTo(SpanKind.SERVER);
     }
 
-    @RepeatedTest(500)
+    @Test
     void connectionAndRequestFiltersCanCoexist() throws Exception {
         setUp(false, ClientFilterPosition.BOTH);
 


### PR DESCRIPTION
 #### Motivation

We prefix HTTP span names with 'Physical ' if we detect that we've inserted the filter in two positions. However, we forgot to do that for grpc.

 #### Modifications

Add that feature to the grpc filters.

 #### Result

More consistency.
