### PR TITLE
transport-api: clarify that the IoExecutor is just for I/O

### DIFF
--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionContext.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ExecutionContext.java
@@ -32,8 +32,8 @@ public interface ExecutionContext<ES extends ExecutionStrategy> {
     BufferAllocator bufferAllocator();
 
     /**
-     * Get the {@link IoExecutor} that is used to handle the I/O.
-     * @return The {@link IoExecutor} that is used to handle the I/O.
+     * Get the {@link IoExecutor} that is used to handle network transport I/O operations.
+     * @return The {@link IoExecutor} that is used to handle network transport I/O operations.
      */
     IoExecutor ioExecutor();
 

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/IoExecutor.java
@@ -23,7 +23,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
 /**
- * {@link Executor} that handles IO.
+ * {@link Executor} that handles network transport I/O operations.
+ * <p> This executor is specifically designed for network-related I/O operations such as socket connections.
+ * It is not intended for general I/O operations or general offloading work.
  */
 public interface IoExecutor extends Executor {
 
@@ -52,8 +54,8 @@ public interface IoExecutor extends Executor {
 
     /**
      * Returns a boolean supplier, if this IoExecutor supports {@link IoThreadFactory.IoThread} markers, that
-     * conditionally recommends offloading if the current thread is an IO thread. If this IoExecutor does not support
-     * IoThread marker interface then the boolean supplier will always return {@code true}.
+     * conditionally recommends offloading if the current thread is a network I/O thread. If this IoExecutor does not
+     * support IoThread marker interface then the boolean supplier will always return {@code true}.
      *
      * @return a Boolean supplier to recommend offloading appropriately based upon IoExecutor configuration.
      */


### PR DESCRIPTION
 #### Motivation

The distinction between IoExecutor and Executor can be a little subtle and the name implies that it may be used for arbitrary I/O operations. However, that is not the case and it should only be used for network I/O.

 #### Modifications

Make the docs a bit more clear.
