### PR TITLE
chore: restrict GitHub workflow permissions - future-proof

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -1,4 +1,6 @@
 name: Test with the latest Netty Snapshots
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '0 15 * * 1-5'

--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -1,4 +1,6 @@
 name: PR Builder Reports
+permissions:
+  contents: read
 on:
   workflow_run:
     workflows: [ "PR Builder" ]

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -1,4 +1,6 @@
 name: PR Builder
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [ main, '0.41', '0.42' ]

--- a/.github/workflows/ci-prq-reports.yml
+++ b/.github/workflows/ci-prq-reports.yml
@@ -1,4 +1,6 @@
 name: PR Quality Reports
+permissions:
+  contents: read
 on:
   workflow_run:
     workflows: [ "PR Quality" ]

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -1,4 +1,6 @@
 name: PR Quality
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [ main, '0.41', '0.42' ]

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,4 +1,6 @@
 name: Release Publisher
+permissions:
+  contents: read
 on:
   push:
     tags:

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -1,4 +1,6 @@
 name: Snapshot Publisher
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, '0.41', '0.42' ]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,6 @@
 name: CodeQL
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, '0.41', '0.42' ]

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,6 @@
 name: "Validate Gradle Wrapper"
-
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
See https://github.com/swiftlang/github-workflows/issues/167 for additional context

This approach aligns with security best practices, as detailed in the following documentation:

- https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes
- https://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/


The default GITHUB_TOKEN permissions are defined at the repository level. This PR modifies the workflow-level overrides to conform to OpenSSF best practices -> defense in depth.

Allow me to quote OpenSSF:
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

> The highest score is awarded when the permissions definitions in each workflow's yaml file are set as read-only at the top level and the required write permissions are declared at the run-level.”

> Remediation steps
> - Set top-level permissions as read-all or contents: read as described in GitHub's documentation.
> - Set any required write permissions at the job-level. Only set the permissions required for that job; do not set permissions: write-all at the job level.


Compare to the LLVM project:

Top-level: contents read, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L3-L4 -> this makes it future-proof

Job-level: Allow write permissions as needed, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L53-L58
