### PR TITLE
http-netty: remove dependency on loadbalancer-experimental

### DIFF
--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -48,8 +48,6 @@ dependencies {
   implementation "io.netty:netty-transport"
   implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-  runtimeOnly project(":servicetalk-loadbalancer-experimental-provider")
-
   testImplementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-buffer-api"))


### PR DESCRIPTION
 #### Motivation

We switched the default over to DefaultLoadBalancer already but still include the experimental module.

 #### Modifications

Remove the dependency.

