### PR TITLE
loadbalancer: make address assertion in LoadBalancerTest order-independent

### DIFF
--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LoadBalancerTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LoadBalancerTest.java
@@ -101,7 +101,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LoadBalancerTestScaffold.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/LoadBalancerTestScaffold.java
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.AbstractMap;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +52,6 @@ import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitely;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.hasProperty;


### PR DESCRIPTION
#### Motivation
A flaky test was identified in `LoadBalancerTest`, specifically `resubscribeToEventsWhenAllHostsAreUnhealthy`, using [NonDex](https://github.com/TestingResearchIllinois/NonDex).
The failure was caused by the use of `assertAddresses(...)`, which relied on a specific order of elements in `lb.usedAddresses()`.
Since the load balancer does not guarantee address ordering, this assertion was nondeterministic across runs.

#### Modifications
- Replaced:
```java
assertAddresses(lb.usedAddresses(), "address-2", "address-3", "address-4");
```
with:
```java
assertThat(lb.usedAddresses(), containsInAnyOrder(
    hasProperty("key", is("address-2")),
    hasProperty("key", is("address-3")),
    hasProperty("key", is("address-4"))
));
```
to make the check independent of element order
- Added missing imports for `Collections`, `containsInAnyOrder`, and `hasProperty`

- Also, to resolve the flaky test further down caused by selection in p2c being non-deterministic, I changed the assertion from:
```java
assertConnectionCount(lb.usedAddresses(), connectionsCount("address-2", 0),
                    connectionsCount("address-3", 1), connectionsCount("address-4", 1));
```
to 
```java
Map<String, Integer> connectionCounts = lb.usedAddresses().stream()
                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().size()));

assertEquals(0, connectionCounts.getOrDefault("address-2", -1).intValue(), "address-2 count mismatch");
assertEquals(1, connectionCounts.getOrDefault("address-3", -1).intValue(), "address-3 count mismatch");
assertEquals(1, connectionCounts.getOrDefault("address-4", -1).intValue(), "address-4 count mismatch");
```
- to always pass even if selection is non-deterministic, as it replaces the order-sensitive assertConnectionCount matcher with an explicit Map comparison

#### Result
- The test now verifies the presence of expected addresses without depending on internal iteration order
- Ensures consistent behavior across different JVM execution orders
- No production or API changes, this is a test robustness improvement only


Steps to Reproduce:
1) Add the following to the top of `build.gradle` in the servicetalk-loadbalancer module:
```
plugins {
    id 'edu.illinois.nondex' version '2.1.7'
}
```
2) Add the following to the bottom of `build.gradle` in the servicetalk-loadbalancer module: `apply plugin: 'edu.illinois.nondex'`
3) Run `./gradlew :servicetalk-loadbalancer:nondexTest -DnondexRuns=10` in the terminal from the root repository. It should result in the output for a few of the runs below:
```
EagerNewRoundRobinLoadBalancerTest > resubscribeToEventsWhenAllHostsAreUnhealthy() FAILED
    java.lang.AssertionError: 
    Expected: iterable containing [hasProperty("key", is "address-2"), hasProperty("key", is "address-3"), hasProperty("key", is "address-4")]
         but: item 1:  property 'key' was "address-4"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at io.servicetalk.loadbalancer.LoadBalancerTestScaffold.assertAddresses(LoadBalancerTestScaffold.java:184)
        at io.servicetalk.loadbalancer.LoadBalancerTest.resubscribeToEventsWhenAllHostsAreUnhealthy(LoadBalancerTest.java:704)
```
- It should also result in the following output after the first assertion has been resolved:
```
EagerNewRoundRobinLoadBalancerTest > resubscribeToEventsWhenAllHostsAreUnhealthy() FAILED
    java.lang.AssertionError: 
    Expected: iterable containing [(hasProperty("key", is "address-2") and hasProperty("value", a collection with size <0>)), (hasProperty("key", is "address-3") and hasProperty("value", a collection with size <1>)), (hasProperty("key", is "address-4") and hasProperty("value", a collection with size <1>))]
         but: item 1: hasProperty("key", is "address-3")  property 'key' was "address-4"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at io.servicetalk.loadbalancer.LoadBalancerTestScaffold.assertConnectionCount(LoadBalancerTestScaffold.java:173)
        at io.servicetalk.loadbalancer.LoadBalancerTest.resubscribeToEventsWhenAllHostsAreUnhealthy(LoadBalancerTest.java:726)
```