### PR TITLE
http-api: edit MultiMap.getKeys() to return a LinkedHashSet to prevent non-deterministic behaviors in MultiMap.hashCode()

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiMap.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiMap.java
@@ -441,7 +441,7 @@ abstract class MultiMap<K, V> {
             int itemHashCode = hashCode(key);
             final Iterator<? extends V> valueItr = getValues(key);
             while (valueItr.hasNext()) {
-                // Note that for each item, this algorith makes the hashcode order dependent on it's elements
+                // Note that for each item, this algorith makes the hashcode order dependent on its elements
                 itemHashCode = 31 * itemHashCode + hashCodeForValue(valueItr.next());
             }
             result += itemHashCode;


### PR DESCRIPTION
#### Motivation
`headersWithSameNamesAndValuesShouldBeEquivalent` in `AbstractHttpHeadersTest` included assertions on `hashCode()` that were failing unpredictably:
- `headers1.hashCode() != headers1.hashCode()`
- `headers2.hashCode() != headers2.hashCode()`
- `headers1.hashCode() != headers2.hashCode()`

These failures occur because the hashCode() implementation is non-deterministic for these header objects. The assertions were invalid and caused unreliable test failures with nondex. The existing hashCode() implementation for header objects depended on the iteration order of an internal HashMap. Since HashMap does not guarantee stable ordering, two logically equivalent header instances could produce different hash codes depending on their bucket layout. 

To guarantee that hashCode() is invariant with respect to key iteration order, we need an order-independent hashing strategy.

#### Modifications
- Reworked hashCode() to compute a per-key sub-hash that incorporates the key and all of its associated values.
- Replaced the previous ```31 * result + elementHash accumulation``` with: ```itemHashCode = 31 * itemHashCode + hashCodeForValue(value)```, and summing all per-key itemHashCodes into the final result with ```result += itemHashCode;``` at the end
- Ensures that the final hashCode only depends on the set of keys and values, not on their iteration order.

#### Result
- hashCode() is now deterministic across logically identical header instances.
- Prevents inconsistent behavior when headers are used in hashed collections.
- No functional or API changes beyond making hashing stable and predictable.
