### PR TITLE
`GrpcExceptionMapperServiceFilter`: log `GrpcStatusException` as expected

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -900,8 +900,7 @@ final class GrpcRouter {
         assert codeValue != null;
         GrpcStatusCode statusCode = GrpcStatusCode.fromCodeValue(codeValue);
         String msg = "Exception from {} for a request to {} was converted to grpc-status={}";
-        boolean logAsError = !(error instanceof GrpcStatusException) && serverCatchAllShouldLog(error);
-        if (logAsError) {
+        if (serverCatchAllShouldLog(error)) {
             LOGGER.error(msg, where, methodDescriptor.httpPath(), statusCode, error);
         } else {
             LOGGER.debug(msg, where, methodDescriptor.httpPath(), statusCode, error);

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
@@ -155,6 +155,7 @@ public final class GrpcStatusException extends RuntimeException {
     }
 
     static boolean serverCatchAllShouldLog(Throwable cause) {
-        return !(cause instanceof TimeoutException || cause instanceof CancellationException);
+        return !(cause instanceof TimeoutException || cause instanceof CancellationException ||
+                cause instanceof GrpcStatusException);
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -866,7 +866,7 @@ final class GrpcUtils {
             GrpcStatus status = setStatus(trailers, cause, allocator);
             // Swallow exception as we are converting it to the trailers.
             String msg = "Exception from response payload for a request to {} was converted to grpc-status={}";
-            if (!(cause instanceof GrpcStatusException) && serverCatchAllShouldLog(cause)) {
+            if (serverCatchAllShouldLog(cause)) {
                 LOGGER.error(msg, methodDescriptor.httpPath(), status.code(), cause);
             } else {
                 LOGGER.debug(msg, methodDescriptor.httpPath(), status.code(), cause);


### PR DESCRIPTION
Motivation:

`GrpcStatusException` is created by users when they map any issue into appropriate grpc-status. It's common to through this exception type from intermediate HTTP filters to avoid the need to construct gRPC response manually.

Modifications:

- Adjust `GrpcExceptionMapperServiceFilter` to log `GrpcStatusException` at debug level instead of error.
- Simplify other use-cases that already use `GrpcStatusException.serverCatchAllShouldLog`.

Result:

Less noisy logs for already handled exceptions.