### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -46,7 +46,7 @@ jobs:
         run:  sudo -E env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel test"
       - name: Publish Test Results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.netty }}
           path: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -65,7 +65,7 @@ jobs:
         run: ./gradlew --no-daemon --parallel test
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-${{ matrix.os_label }}-${{ matrix.java }}
           path: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -46,19 +46,19 @@ jobs:
         run: ./gradlew --parallel -Pdependency.analysis.print.build.health=true quality
       - name: Upload CheckStyle Results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: checkstyle-results-${{ matrix.java }}
           path: '**/build/reports/checkstyle/*.xml'
       - name: Upload PMD Results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: pmd-results-${{ matrix.java }}
           path: '**/build/reports/pmd/*.xml'
       - name: Upload SpotBugs Results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: spotbugs-results-${{ matrix.java }}
           path: '**/build/reports/spotbugs/*.xml'


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/upload-artifact` | [`v5`](https://github.com/actions/upload-artifact/releases/tag/v5) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | ci-netty-snapshot.yml, ci-prb.yml, ci-prq.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
