### PR TITLE
Pin to macOS Sequoia

### DIFF
--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -21,7 +21,7 @@ jobs:
         os_label: [ ubuntu ]
         include:
           - java: 11
-            os: [self-hosted, macos, general]
+            os: [self-hosted, macos, sequoia]
             os_label: macos
     steps:
       - name: Download Artifacts

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -24,7 +24,7 @@ jobs:
         os_label: [ ubuntu ]
         include:
           - java: 11
-            os: [self-hosted, macos, general]
+            os: [self-hosted, macos, sequoia]
             os_label: macos
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Motivation:

Temporarily pin to macOS Sequoia until a stable runner with macOS 26 is available.