### PR TITLE
Do not append IP address when `SSLEngine.peerHost` is `localhost`

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -98,7 +98,7 @@ final class StreamingConnectionFactory {
                     newSniHostname = null;
                     hostnameVerificationAlgorithm = "";
                 } else {
-                    newPeerHost = peerHost + '-' + toHostAddress(inetAddress);
+                    newPeerHost = toHostAndIpBundle(peerHost, inetAddress);
                     // We are overriding the peerHost to make it qualified with the resolved address. If sniHostname is
                     // not set and the hostnameVerificationAlgorithm is set, the SSLEngine will take the peerHost value
                     // for validation, which will fail to match now that we have changed the value.
@@ -111,7 +111,7 @@ final class StreamingConnectionFactory {
                     }
                 }
             } else {
-                newPeerHost = sniHostname + '-' + toHostAddress(inetAddress);
+                newPeerHost = toHostAndIpBundle(sniHostname, inetAddress);
                 newSniHostname = sniHostname;
                 hostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
             }
@@ -120,6 +120,18 @@ final class StreamingConnectionFactory {
                     hostnameVerificationAlgorithm);
         }
         return config;
+    }
+
+    /**
+     * Bundling the host with address helps to increase probability for SSLSession resumption cache hits when the
+     * hostname resolves to multiple IPs.
+     */
+    static String toHostAndIpBundle(final String hostname, final InetAddress address) {
+        if (address.isLoopbackAddress()) {
+            // No need to alter the host in this case
+            return hostname;
+        }
+        return hostname + '-' + toHostAddress(address);
     }
 
     static String toHostAddress(final InetAddress address) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingConnectionFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingConnectionFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.servicetalk.http.netty;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -24,6 +25,10 @@ import java.net.NetworkInterface;
 import java.util.Enumeration;
 import java.util.stream.Stream;
 
+import static io.servicetalk.http.netty.StreamingConnectionFactory.toHostAndIpBundle;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StreamingConnectionFactoryTest {
@@ -60,5 +65,12 @@ class StreamingConnectionFactoryTest {
     void mustConvertInetAddressesToValidHostnames(InetAddress address) throws Exception {
         String hostAddress = StreamingConnectionFactory.toHostAddress(address);
         assertTrue(StreamingConnectionFactory.isValidSniHostname(hostAddress), hostAddress);
+    }
+
+    @Test
+    void loopbackAddressIsNotBundled() {
+        InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
+        assertThat(toHostAndIpBundle("localhost", loopbackAddress), is(equalTo("localhost")));
+        assertThat(toHostAndIpBundle("servicetalk.io", loopbackAddress), is(equalTo("servicetalk.io")));
     }
 }


### PR DESCRIPTION
Motivation:

This is an improvement for an SSLSession cache hit optimization feature introduced in #1958. For loopback addresses, we don't need this optimization and can preserve original `localhost` hostname.

Modifications:

- `StreamingConnectionFactory`: check if the address is a loopback address before using it as a suffix for `peerHost`;

Result:

No variations when peerHost is localhost.