### PR TITLE
Do not append IP address when `SSLEngine.peerHost` is already an IP

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -41,6 +41,8 @@ import static io.servicetalk.http.netty.HeaderUtils.OBJ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HttpDebugUtils.showPipeline;
 import static io.servicetalk.http.netty.HttpExecutionContextUtils.channelExecutionContext;
 import static io.servicetalk.transport.netty.internal.CloseHandler.forPipelinedRequestResponse;
+import static io.servicetalk.utils.internal.NetworkUtils.isValidIpV4Address;
+import static io.servicetalk.utils.internal.NetworkUtils.isValidIpV6Address;
 import static java.util.Objects.requireNonNull;
 
 final class StreamingConnectionFactory {
@@ -127,7 +129,7 @@ final class StreamingConnectionFactory {
      * hostname resolves to multiple IPs.
      */
     static String toHostAndIpBundle(final String hostname, final InetAddress address) {
-        if (address.isLoopbackAddress()) {
+        if (address.isLoopbackAddress() || isValidIpV4Address(hostname) || isValidIpV6Address(hostname)) {
             // No need to alter the host in this case
             return hostname;
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingConnectionFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingConnectionFactoryTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 class StreamingConnectionFactoryTest {
     static Stream<InetAddress> addresses() throws Exception {
         Stream.Builder<InetAddress> builder = Stream.builder();
@@ -72,5 +73,14 @@ class StreamingConnectionFactoryTest {
         InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
         assertThat(toHostAndIpBundle("localhost", loopbackAddress), is(equalTo("localhost")));
         assertThat(toHostAndIpBundle("servicetalk.io", loopbackAddress), is(equalTo("servicetalk.io")));
+    }
+
+    @Test
+    void ipAddressesAreNotBundled() {
+        InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
+        assertThat(toHostAndIpBundle("127.0.0.1", loopbackAddress), is(equalTo("127.0.0.1")));
+        assertThat(toHostAndIpBundle("192.168.1.1", loopbackAddress), is(equalTo("192.168.1.1")));
+        assertThat(toHostAndIpBundle("::1", loopbackAddress), is(equalTo("::1")));
+        assertThat(toHostAndIpBundle("2001:db8:0:1::1/64", loopbackAddress), is(equalTo("2001:db8:0:1::1/64")));
     }
 }


### PR DESCRIPTION
Motivation:

This is an improvement for an SSLSession cache hit optimization feature introduced in #1958 and #3375. We don't need to append an IP address when the host is already an IP address.

Modifications:

- `StreamingConnectionFactory`: check if the hostname is an IP address before appending the suffix;

Result:

PeerHost is preserved as is when it's already an IP address.