### PR TITLE
Avoid unnecessary dependency on `junit-platform-commons` (test only)

### DIFF
--- a/servicetalk-http-netty/build.gradle
+++ b/servicetalk-http-netty/build.gradle
@@ -71,7 +71,6 @@ dependencies {
   testImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$nettyIoUringVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.junit.platform:junit-platform-commons:$junitPlatformVersion"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
   testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
   testImplementation "org.mockito:mockito-junit-jupiter:$mockitoCoreVersion"

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ClientEffectiveStrategyTest.java
@@ -62,8 +62,8 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -587,7 +587,7 @@ class ClientEffectiveStrategyTest {
                 }
             }
             if (firstFlakyException != null) {
-                LOGGER.warn(firstFlakyException, () -> "Flaky throwable detected. Ignoring until test can be fixed.");
+                LOGGER.warn("Flaky throwable detected. Ignoring until test can be fixed.", firstFlakyException);
             }
             verifyOffloads(clientApi, clientStrategy, apiStrategy);
         }


### PR DESCRIPTION
Motivation:

There is no need to use `org.junit.platform.commons.logging.Logger` in `ClientEffectiveStrategyTest`, we can use `org.slf4j.Logger` as we do everywhere.

Modifications:

- `ClientEffectiveStrategyTest`: switch from `org.junit.platform.commons.logging.Logger` to `org.slf4j.Logger`.
- Remove redundant `org.junit.platform:junit-platform-commons` dependency.

Result:

Less test dependencies in use.