### PR TITLE
loadbalancer: add a javadoc link to OutlierDetectorConfigs

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -92,6 +92,7 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
      *                              outlier detection.
      * @return {code this}
      * @see #loadBalancingPolicy(LoadBalancingPolicy)
+     * @see OutlierDetectorConfigs for common preconfigured policies
      */
     LoadBalancerBuilder<ResolvedAddress, C> outlierDetectorConfig(OutlierDetectorConfig outlierDetectorConfig);
 


### PR DESCRIPTION
 #### Motivation

We have some common preconfigured policies in OutlierDetectorConfigs that can help users when they want some 'canned' behavior but it may not be the easiest to discover.

 #### Modifications

Add a `@see` link to the LoadBalancerBuilder.outlierDetectorConfig method to point users in the right direction.
