### PR TITLE
Fix broken `servicetalk-gradle-plugin-internal` plugin

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
@@ -31,7 +31,12 @@ import static io.servicetalk.gradle.plugin.internal.Versions.CHECKSTYLE_VERSION
 import static io.servicetalk.gradle.plugin.internal.Versions.TARGET_VERSION
 
 class ServiceTalkCorePlugin implements Plugin<Project> {
-  void apply(Project project, boolean publishesArtifacts = true) {
+  @Override
+  void apply(Project project) {
+    apply(project, true)
+  }
+
+  protected void apply(Project project, boolean publishesArtifacts) {
     enforceUtf8FileSystem()
     addBuildContextExtensions project
     enforceProjectVersionScheme project

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -40,8 +40,9 @@ import static org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 import static org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED
 
 final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
+  @Override
   void apply(Project project) {
-    super.apply project
+    super.apply(project, true)
 
     applyJavaLibraryPlugin project
     configureTestFixtures project

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.tasks.javadoc.Javadoc
 import static io.servicetalk.gradle.plugin.internal.ProjectUtils.addQualityTask
 
 final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
+  @Override
   void apply(Project project) {
     super.apply(project, false)
 


### PR DESCRIPTION
#### Motivation

With upgrade to Gradle 9.x it also upgraded Groovy from 3.x to 4.x that has stricter compiler. When a method had parameter with default value, Groovy 3.x will generate two overloads (with and without parameter). In Gradle 9.2 (Groovy 4.x), the compiler is stricter and doesn't recognize the default parameter variant as satisfying the interface contract. In result, external projects failed with the following error:
```
No signature of method: io.servicetalk.gradle.plugin.internal.ServiceTalkCorePlugin.apply()
is applicable for argument types: (org.gradle.api.internal.project.DefaultProject_Decorated, Boolean)
```
It worked locally because Groovy's compiler and runtime working together can resolve the method, but external projects use compiled `.class` file from Groovy 4.x doesn't properly expose the single-parameter method in a way that Java reflection can discover it.

#### Modifications
- `ServiceTalkCorePlugin` explicitly add an overload for `apply(Project)` method required by `Plugin` interface.
- Classes that extend `ServiceTalkCorePlugin` should explicitly call `apply` overload with the required `boolean` value.

#### Result

External projects can use our `servicetalk-gradle-plugin-internal`.