### PR TITLE
`ServiceTalkRootPlugin`: skip `javadocAll` task in composite build mode

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
@@ -40,6 +40,13 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
 
   private static void addJavadocAllTask(Project project) {
     project.configure(project) {
+      // Check if this build is being included in a composite build (--include-build)
+      if (gradle.parent != null) {
+        project.logger.lifecycle(
+            "Skipping 'javadocAll' task registration: build is running in composite mode (--include-build)")
+        return
+      }
+
       project.task("javadocAll", type: Javadoc) {
         description = "Consolidate sub-project's Javadoc into a single location"
         group = "documentation"


### PR DESCRIPTION
#### Motivation

Follow-up for #3389.

Gradle 9.2 introduced stricter configuration resolution locking that causes the `javadocAll` task to fail when external projects build with ServiceTalk in composite build mode (using `--include-build`). Error:
```
Resolution attempted without an exclusive lock
```
After trying multiple ways to refactor `javadocAll` task, it was impossible to achieve the state when both local build and composite build work. Because `javadocAll` task is not required for composite builds, we can simply skip it and print a message instead.

#### Modifications

- `ServiceTalkRootPlugin`: log and return immediately from `addJavadocAllTask` if running in a composite build mode.

#### Result

External projects can run composite builds with local version of ServiceTalk, but without registering `javadocAll` task if they use `io.servicetalk.servicetalk-gradle-plugin-internal-root` plugin.