### PR TITLE
`servicetalk-gradle-plugin-internal`: `project.task` -> `tasks.register`

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ProjectUtils.groovy
@@ -237,7 +237,7 @@ final class ProjectUtils {
 
   static void addQualityTask(Project project) {
     project.configure(project) {
-      project.task("quality") {
+      tasks.register("quality") {
         description = "Run all quality analyzers for all source sets"
         group = "verification"
         if (tasks.findByName("checkstyle")) {

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkCorePlugin.groovy
@@ -65,7 +65,7 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
         }
       }
 
-      project.task("checkstyleResources") {
+      tasks.register("checkstyleResources") {
         description = "Copy Checkstyle resources to its configuration directory"
         group = "verification"
 
@@ -88,7 +88,7 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
         }
       }
 
-      project.task("checkstyleRoot", type: Checkstyle) {
+      tasks.register("checkstyleRoot", Checkstyle) {
         description = "Run Checkstyle analysis for files in the root directory"
         // The classpath field must be non-null, but could be empty because it's not required for this task:
         classpath = project.files([])
@@ -104,7 +104,7 @@ class ServiceTalkCorePlugin implements Plugin<Project> {
         it.dependsOn checkstyleResources
       }
 
-      project.task("checkstyle") {
+      tasks.register("checkstyle") {
         description = "Run Checkstyle analysis for all source sets"
         group = "verification"
         dependsOn tasks.withType(Checkstyle)

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -287,7 +287,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         group = "verification"
       }
 
-      project.task("pmd") {
+      tasks.register("pmd") {
         description = "Run PMD analysis for all source sets"
         group = "verification"
         dependsOn tasks.withType(Pmd)
@@ -326,7 +326,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
         }
       }
 
-      project.task("spotbugs") {
+      tasks.register("spotbugs") {
         description = "Run SpotBugs analysis for all source sets"
         group = "verification"
         dependsOn tasks.withType(SpotBugsTask)

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
@@ -47,7 +47,7 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
         return
       }
 
-      project.task("javadocAll", type: Javadoc) {
+      tasks.register("javadocAll", Javadoc) {
         description = "Consolidate sub-project's Javadoc into a single location"
         group = "documentation"
         destinationDir = file("$buildDir/javadoc")


### PR DESCRIPTION
#### Motivation

Gradle deprecated `project.task` API and recommends using `tasks.register` instead.

#### Modifications

- Switch from `project.task` to `tasks.register` everywhere.

#### Result

`servicetalk-gradle-plugin-internal` doesn't use deprecated gradle API.