### PR TITLE
codeql-analysis: exclude groovy files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,7 @@ on:
       - '.gitignore'
       - '**.adoc'
       - '**.txt'
+      - '**.groovy'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main, '0.41' ]


### PR DESCRIPTION
Motivation:

It just doesn't work for groovy files, no need to run it: https://github.com/apple/servicetalk/actions/runs/20868834058/job/59966119009?pr=3393
