### PR TITLE
docs website: fix navigation for OpenTelemetry Tracing page

### DIFF
--- a/servicetalk-opentelemetry-http/docs/modules/ROOT/nav.adoc
+++ b/servicetalk-opentelemetry-http/docs/modules/ROOT/nav.adoc
@@ -2,4 +2,4 @@ ifndef::page-version[]
 :page-version: SNAPSHOT
 endif::[]
 
-include::{page-version}@servicetalk-opentelemetry-http:ROOT:partial$nav-versioned.adoc[]
+include::{page-version}@servicetalk::partial$nav-versioned.adoc[]


### PR DESCRIPTION
Motivation:

When users open [OpenTelemetry Tracing](https://apple.github.io/servicetalk/servicetalk-opentelemetry-http/SNAPSHOT/index.html) page, they loose navigation in the left menu.

Modifications:
- Include `nav-versioned.adoc` from the root.

Result:

Correct navigation menu on all pages.