### PR TITLE
Fix `javadocAll` task after switching to `tasks.register` Gradle API

### DIFF
--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkRootPlugin.groovy
@@ -47,7 +47,7 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
         return
       }
 
-      tasks.register("javadocAll", Javadoc) {
+      def javadocAllTask = tasks.register("javadocAll", Javadoc) {
         description = "Consolidate sub-project's Javadoc into a single location"
         group = "documentation"
         destinationDir = file("$buildDir/javadoc")
@@ -57,12 +57,14 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
         if (JavaVersion.current().isJava11()) {
           options.addBooleanOption('-no-module-directories', true)
         }
+      }
 
-        // Create FileCollections for aggregation (avoids triggering configuration resolution)
-        def aggregatedSources = project.files()
-        def aggregatedClasspath = project.files()
+      gradle.projectsEvaluated {
+        javadocAllTask.configure {
+          // Create FileCollections for aggregation (avoids triggering configuration resolution)
+          def aggregatedSources = project.files()
+          def aggregatedClasspath = project.files()
 
-        gradle.projectsEvaluated {
           subprojects.findAll {
             !it.name.contains("examples")
                 // No need to generate javadoc for -jersey3 modules because they are copied from -jersey
@@ -78,10 +80,10 @@ final class ServiceTalkRootPlugin extends ServiceTalkCorePlugin {
               dependsOn javadocTask
             }
           }
+          // Set the aggregated collections on the task
+          source = aggregatedSources
+          classpath = aggregatedClasspath
         }
-        // Set the aggregated collections on the task
-        source = aggregatedSources
-        classpath = aggregatedClasspath
       }
     }
   }


### PR DESCRIPTION
#### Motivation

After migrating from `project.task()` to `tasks.register()` in #3396, the `javadocAll` task fails with:
```
Gradle#projectsEvaluated(Closure) cannot be executed in the current context
```
This occurs because `gradle.projectsEvaluated()` was called inside the task configuration block, which executes too late in the Gradle lifecycle when using lazy task registration.

#### Modifications

- Extracted `javadocAll` task registration to a variable;
- Moved `gradle.projectsEvaluated()` outside the task configuration block;
- Used `TaskProvider.configure()` inside `projectsEvaluated` callback to lazily configure the task.

#### Result

The `javadocAll` task now works correctly with lazy task registration.