### PR TITLE
Use only mockito version compatible with all JDK versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,10 +101,7 @@ task validateLocalDocSite(type: Exec) {
 quality.dependsOn validateLocalDocSite
 
 subprojects {
-  // mockito 5 only supports jdk11+
-  if (JavaVersion.current() < JavaVersion.VERSION_11) {
-    project.setProperty("mockitoCoreVersion", mockitoCorePreJdk11Version)
-  } else {
+  if (JavaVersion.current() >= JavaVersion.VERSION_11) {
     apply plugin: "com.autonomousapps.dependency-analysis"
   }
   // Used by ci-release.yaml to determine which modules need to be built/released with JDK11.

--- a/gradle.properties
+++ b/gradle.properties
@@ -97,9 +97,7 @@ junit5Version=5.14.1
 testngVersion=7.5.1
 assertJCoreVersion=3.27.6
 hamcrestVersion=2.2
-mockitoCoreVersion=5.21.0
-# mockito version is overridden for <jdk11 due to incompatibilities with newer bytebuddy and class format
-mockitoCorePreJdk11Version=4.11.0
+mockitoCoreVersion=4.11.0
 spotbugsPluginVersion=5.2.5
 dependencyAnalysisPluginVersion=3.0.4
 


### PR DESCRIPTION
Motivation:

After switching to Gradle 9.x that always have to run on JDK17+, out published test-fixtures accidentally upgraded its transitive mockito dependency to 5.x because the current `JavaVersion` check in `build.gradle` is always false.

Modifications:

- Use only mockito 4.x.

Result:

Avoid ambiguity, we only use mockito 4.x.