### PR TITLE
Revert "Pin to macOS Sequoia (#3374)"

### DIFF
--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -21,7 +21,7 @@ jobs:
         os_label: [ ubuntu ]
         include:
           - java: 11
-            os: [self-hosted, macos, sequoia]
+            os: [self-hosted, macos, general]
             os_label: macos
     steps:
       - name: Download Artifacts

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -24,7 +24,7 @@ jobs:
         os_label: [ ubuntu ]
         include:
           - java: 11
-            os: [self-hosted, macos, sequoia]
+            os: [self-hosted, macos, general]
             os_label: macos
     steps:
       - name: Checkout Code


### PR DESCRIPTION
This reverts commit 8360453420c4431bfffe86cf21ce3f22bf8fab23.

The Tahoe runners have been updated to 26.2.
