### PR TITLE
Defer `connectionEstablished` and ensure `connectionClosed` for early…

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/NettyPipelinedConnectionBenchmark.java
@@ -24,6 +24,7 @@ import io.servicetalk.concurrent.api.Publisher;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.SslConfig;
 import io.servicetalk.transport.netty.internal.FlushStrategies;
@@ -278,6 +279,10 @@ public class NettyPipelinedConnectionBenchmark {
             @Override
             public Completable closeAsync() {
                 return Completable.never();
+            }
+
+            @Override
+            public void notifyConnectionEstablished(final ConnectionObserver connectionObserver) {
             }
         };
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AlpnLBHttpConnectionFactory.java
@@ -87,7 +87,8 @@ final class AlpnLBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpC
                             h2Config, reqRespFactoryFunc.apply(HttpProtocolVersion.HTTP_2_0), tcpConfig.flushStrategy(),
                             tcpConfig.idleTimeoutMs(), tcpConfig.sslConfig(),
                             new H2ClientParentChannelInitializer(h2Config),
-                            connectionObserver, config.allowDropTrailersReadFromTransport());
+                            connectionObserver, config.allowDropTrailersReadFromTransport())
+                            .whenOnSuccess(conn -> conn.notifyConnectionEstablished(connectionObserver));
                 default:
                     return unknownAlpnProtocol(protocol);
             }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultNettyHttpConnectionContext.java
@@ -20,6 +20,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpConnectionContext;
 import io.servicetalk.http.api.HttpExecutionContext;
 import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.DelegatingConnectionContext;
 import io.servicetalk.transport.netty.internal.FlushStrategy;
 import io.servicetalk.transport.netty.internal.NettyConnectionContext;
@@ -66,5 +67,10 @@ final class DefaultNettyHttpConnectionContext extends DelegatingConnectionContex
     @Override
     public Channel nettyChannel() {
         return nettyConnectionContext.nettyChannel();
+    }
+
+    @Override
+    public void notifyConnectionEstablished(final ConnectionObserver connectionObserver) {
+        nettyConnectionContext.notifyConnectionEstablished(connectionObserver);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ClientParentConnectionContext.java
@@ -207,7 +207,6 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
             if (subscriber != null) {
                 Subscriber<? super H2ClientParentConnection> subscriberCopy = subscriber;
                 subscriber = null;
-                multiplexedObserver = observer.multiplexedConnectionEstablished(this);
                 subscriberCopy.onSuccess(this);
             }
         }
@@ -255,6 +254,11 @@ final class H2ClientParentConnectionContext extends H2ParentConnectionContext {
             } else {
                 return failed(new IllegalArgumentException("Unknown key: " + eventKey));
             }
+        }
+
+        @Override
+        public void notifyConnectionEstablished(final ConnectionObserver connectionObserver) {
+            multiplexedObserver = connectionObserver.multiplexedConnectionEstablished(this);
         }
 
         @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2LBHttpConnectionFactory.java
@@ -57,6 +57,7 @@ final class H2LBHttpConnectionFactory<ResolvedAddress> extends AbstractLBHttpCon
                         tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(), tcpConfig.sslConfig(),
                         new TcpClientChannelInitializer(tcpConfig, connectionObserver, executionContext, false).andThen(
                                 new H2ClientParentChannelInitializer(config.h2Config())), connectionObserver,
-                        config.allowDropTrailersReadFromTransport()), observer);
+                        config.allowDropTrailersReadFromTransport())
+                        .whenOnSuccess(conn -> conn.notifyConnectionEstablished(connectionObserver)), observer);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -531,6 +531,11 @@ final class NettyHttpServer {
         }
 
         @Override
+        public void notifyConnectionEstablished(final ConnectionObserver connectionObserver) {
+            connection.notifyConnectionEstablished(connectionObserver);
+        }
+
+        @Override
         public String toString() {
             return connection.toString();
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectLBHttpConnectionFactory.java
@@ -144,6 +144,7 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
                             tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(), tcpConfig.sslConfig(),
                             NoopChannelInitializer.INSTANCE, HTTP_1_1, connectionObserver, true, OBJ_EXPECT_CONTINUE),
                         HTTP_1_1, channel)
+                        .whenOnSuccess(conn -> conn.notifyConnectionEstablished(connectionObserver))
                         .map(conn -> new PipelinedStreamingHttpConnection(conn, config.h1Config(),
                                 reqRespFactoryFunc.apply(HTTP_1_1), config.allowDropTrailersReadFromTransport()));
                 break;
@@ -154,7 +155,8 @@ final class ProxyConnectLBHttpConnectionFactory<ResolvedAddress>
                 result = H2ClientParentConnectionContext.initChannel(channel, executionContext, h2Config,
                         reqRespFactoryFunc.apply(HTTP_2_0), tcpConfig.flushStrategy(), tcpConfig.idleTimeoutMs(),
                         tcpConfig.sslConfig(), new H2ClientParentChannelInitializer(h2Config), connectionObserver,
-                        config.allowDropTrailersReadFromTransport());
+                        config.allowDropTrailersReadFromTransport())
+                        .whenOnSuccess(conn -> conn.notifyConnectionEstablished(connectionObserver));
                 break;
             default:
                 result = unknownAlpnProtocol(protocol);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -77,7 +77,8 @@ final class StreamingConnectionFactory {
                 initializer.andThen(new HttpClientChannelInitializer(
                         getByteBufAllocator(builderExecutionContext.bufferAllocator()), h1Config, closeHandler)),
                 HTTP_1_1, connectionObserver, true, OBJ_EXPECT_CONTINUE),
-                HTTP_1_1, channel);
+                HTTP_1_1, channel)
+                .whenOnSuccess(conn -> conn.notifyConnectionEstablished(connectionObserver));
     }
 
     static ReadOnlyTcpClientConfig withSslConfigPeerHost(Object resolvedRemoteAddress,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionFactoryFilterTest.java
@@ -35,6 +35,7 @@ import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpConnectionFilter;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ExecutionStrategy;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
@@ -220,6 +221,11 @@ final class ConnectionFactoryFilterTest {
         @Override
         public Single<Throwable> transportError() {
             return delegate.transportError();
+        }
+
+        @Override
+        public void notifyConnectionEstablished(final ConnectionObserver connectionObserver) {
+            delegate.notifyConnectionEstablished(connectionObserver);
         }
     }
 }

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
@@ -145,7 +145,10 @@ final class TcpTransportObserverErrorsTest extends AbstractTransportObserverTest
             verify(clientConnectionObserver).onTransportHandshakeComplete(any());
             verify(clientConnectionObserver).connectionEstablished(any(ConnectionInfo.class));
             verify(serverConnectionObserver, await()).onTransportHandshakeComplete(any());
-            verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
+            if (errorSource != ErrorSource.CONNECTION_ACCEPTOR) {
+                // Connection acceptor rejects the connection before it's established on server-side
+                verify(serverConnectionObserver, await()).connectionEstablished(any(ConnectionInfo.class));
+            }
         } else {
             assertThat(connection, is(nullValue()));
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -31,6 +31,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.kqueue.KQueue;
+import io.netty.util.AttributeKey;
 
 import java.net.SocketAddress;
 import java.net.SocketOption;
@@ -48,6 +49,14 @@ import static java.util.Objects.requireNonNull;
  * A {@link ChannelInitializer} that registers a {@link ConnectionObserver} for all channels.
  */
 public final class ConnectionObserverInitializer implements ChannelInitializer {
+
+    /**
+     * An attribute key that indicates the {@link ConnectionObserverInitializer} has been applied to a channel.
+     * When this attribute is set, the channel has a close listener that will call
+     * {@link ConnectionObserver#connectionClosed(Throwable)} when the channel closes.
+     */
+    public static final AttributeKey<Boolean> CONNECTION_OBSERVER_INITIALIZED =
+            AttributeKey.newInstance("ConnectionObserverInitialized");
 
     private final ConnectionObserver observer;
     private final Function<Channel, ConnectionInfo> connectionInfoFactory;
@@ -111,6 +120,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
     @Override
     public void init(final Channel channel) {
+        channel.attr(CONNECTION_OBSERVER_INITIALIZED).set(Boolean.TRUE);
         channel.pipeline().addLast(new ConnectionObserverHandler(observer, connectionInfoFactory,
                 sslConfig != null, isFastOpen(channel), sslConfig));
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DefaultNettyConnection.java
@@ -820,6 +820,11 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
         return fromSource(transportError);
     }
 
+    @Override
+    public void notifyConnectionEstablished(final ConnectionObserver connectionObserver) {
+        dataObserver = connectionObserver.connectionEstablished(this);
+    }
+
     private static final class NoopChannelOutboundListener implements ChannelOutboundListener {
         private static final ChannelOutboundListener INSTANCE = new NoopChannelOutboundListener();
 
@@ -1020,9 +1025,6 @@ public final class DefaultNettyConnection<Read, Write> extends NettyChannelListe
             assert subscriber != null;
             SingleSource.Subscriber<? super DefaultNettyConnection<Read, Write>> subscriberCopy = subscriber;
             subscriber = null;
-            // TODO: how can we make sure we have the correct context information here.
-            //  See HttpTransportObserverAsyncContextTest. It has some assertions for 'broken' behavior.
-            connection.dataObserver = observer.connectionEstablished(connection);
             subscriberCopy.onSuccess(connection);
         }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyConnectionContext.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyConnectionContext.java
@@ -19,6 +19,7 @@ import io.servicetalk.concurrent.Cancellable;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.ConnectionObserver;
 
 import io.netty.channel.Channel;
 
@@ -67,6 +68,8 @@ public interface NettyConnectionContext extends ConnectionContext {
      * @return the Netty {@link Channel} backing this connection.
      */
     Channel nettyChannel();
+
+    void notifyConnectionEstablished(ConnectionObserver connectionObserver);
 
     /**
      * A provider of {@link FlushStrategy} to update the {@link FlushStrategy} for a {@link NettyConnectionContext}.

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelinedConnection.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelinedConnection.java
@@ -24,6 +24,7 @@ import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.concurrent.api.internal.SubscribablePublisher;
 import io.servicetalk.concurrent.internal.ConcurrentUtils;
 import io.servicetalk.transport.api.ConnectionContext;
+import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.ExecutionContext;
 import io.servicetalk.transport.api.SslConfig;
 
@@ -216,6 +217,11 @@ public final class NettyPipelinedConnection<Req, Resp> implements NettyConnectio
     @Override
     public FlushStrategy defaultFlushStrategy() {
         return connection.defaultFlushStrategy();
+    }
+
+    @Override
+    public void notifyConnectionEstablished(final ConnectionObserver connectionObserver) {
+        connection.notifyConnectionEstablished(connectionObserver);
     }
 
     private void closeConnection(final Subscriber<? super Resp> subscriber, final Throwable cause) {


### PR DESCRIPTION
… acceptor rejection

Previously, `TransportObserver#connectionEstablished` callbacks were invoked before `ConnectionAcceptors` completed. This meant:

1. The duration between `onNewConnection` and `connectionEstablished` did not include time spent in acceptors, making it difficult to accurately measure total connection establishment time including application-level acceptance logic.

2. `connectionEstablished` could be signaled even if an acceptor subsequently rejected the connection.

Additionally, when an `EarlyConnectionAcceptor` rejected a connection, `connectionClosed` was never called on the observer because the `ConnectionObserverInitializer` (which sets up the close listener) is only added during pipeline initialization—which never happens for early acceptor rejection since the connection `Single` is never subscribed.

- `connectionEstablished` is now called via `whenOnSuccess` after `wrapConnectionAcceptors()` completes successfully
- Added logic to call `connectionClosed(cause)` directly when a connection fails before `ConnectionObserverInitializer` is set up (early acceptor case)

- Added `CONNECTION_OBSERVER_INITIALIZED` attribute that is set when `init()` is called, indicating the close listener is in place
- This attribute is used by `TcpServerBinder` to determine whether to call `connectionClosed` directly or rely on the existing close listener

- Added `whenOnSuccess` to call `notifyConnectionEstablished` after connection initialization

- `H2LBHttpConnectionFactory`, `AlpnLBHttpConnectionFactory`, and `ProxyConnectLBHttpConnectionFactory`: Added `whenOnSuccess` to call `notifyConnectionEstablished` after `H2ClientParentConnectionContext.initChannel()`

- Added `notifyConnectionEstablished` call for raw TCP client connections

- Added comprehensive tests in `EarlyAndLateConnectionAcceptorTest`:
  - `connectionEstablishedCalledAfterAcceptors`: Verifies order is early → late → `connectionEstablished`
  - `earlyAcceptorRejectsConnectionEstablishedNotCalled`: Verifies `connectionEstablished` is NOT called when early acceptor rejects
  - `lateAcceptorRejectsConnectionEstablishedNotCalled`: Verifies `connectionEstablished` is NOT called when late acceptor rejects
  - `earlyAcceptorRejectsConnectionClosedCalledOnObserver`: Verifies `connectionClosed` IS called when early acceptor rejects
- Updated `TcpTransportObserverErrorsTest` for new behavior

- `connectionEstablished` is now called AFTER all connection acceptors complete
- If a connection acceptor rejects, `connectionEstablished` is NOT called
- `connectionClosed` is now guaranteed to be called for all rejection scenarios:
  - Early acceptor rejection: Called directly in error handler
  - Late/old acceptor rejection: Called via `ConnectionObserverInitializer` close listener
  - SSL handshake failure: Called via `ConnectionObserverInitializer` close listener

The `TransportObserver` lifecycle is now correct and complete:
- Time between `onNewConnection` and `connectionEstablished` accurately reflects full connection establishment duration including acceptor processing
- `connectionClosed` is always called when a connection fails, regardless of which stage of initialization the failure occurs

#### Motivation
<!-- Explain the context around why you're making this change. What is the problem you're trying to solve. -->

#### Modifications
<!-- Describe or list the modifications you've done. -->

#### Result
<!-- Describe the final outcome of this change. Highlight if there is any risk, behavior change, or API change. -->
