### PR TITLE
`ConnectionObserver` does not see enriched `ConnectException`

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptingNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptingNettyHttpServerTest.java
@@ -174,5 +174,10 @@ class ConnectionAcceptingNettyHttpServerTest extends AbstractNettyHttpServerTest
         public void connectionClosed(final Throwable error) {
             observed.add(error);
         }
+
+        @Override
+        public void connectionClosed() {
+            observed.add(new IllegalStateException("Unexpected call to connectionClosed()"));
+        }
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptingNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptingNettyHttpServerTest.java
@@ -16,20 +16,27 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.client.api.ConnectTimeoutException;
+import io.servicetalk.client.api.TransportObserverConnectionFactoryFilter;
 import io.servicetalk.concurrent.api.Single;
 import io.servicetalk.http.api.HttpServerBuilder;
 import io.servicetalk.http.api.SingleAddressHttpClientBuilder;
 import io.servicetalk.http.api.StreamingHttpClient;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.transport.api.ConnectionObserver;
 import io.servicetalk.transport.api.HostAndPort;
+import io.servicetalk.transport.api.RetryableException;
+import io.servicetalk.transport.api.TransportObserver;
 
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 
 import static io.netty.util.internal.PlatformDependent.normalizedOs;
 import static io.servicetalk.client.api.LimitingConnectionFactoryFilter.withMax;
@@ -47,7 +54,9 @@ import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ConnectionAcceptingNettyHttpServerTest extends AbstractNettyHttpServerTest {
@@ -73,10 +82,12 @@ class ConnectionAcceptingNettyHttpServerTest extends AbstractNettyHttpServerTest
                 .enableWireLogging("servicetalk-tests-wire-logger", TRACE, TRUE::booleanValue);
     }
 
-    private StreamingHttpClient newClientWithConnectTimeout() {
+    private StreamingHttpClient newClientWithConnectTimeout(TransportObserver observer) {
         return newClientBuilder()
                 // It's important to use CONNECT_TIMEOUT here to verify that connections aren't establishing.
                 .socketOption(CONNECT_TIMEOUT, CONNECT_TIMEOUT_MILLIS)
+                .appendConnectionFactoryFilter(
+                        new TransportObserverConnectionFactoryFilter<>(observer))
                 .buildStreaming();
     }
 
@@ -100,6 +111,7 @@ class ConnectionAcceptingNettyHttpServerTest extends AbstractNettyHttpServerTest
 
     @Test
     void testIdleTimeout() throws Exception {
+        BlockingQueue<Throwable> observed = new LinkedBlockingQueue<>();
         setUp(CACHED, CACHED);
         final StreamingHttpRequest request = streamingHttpClient().newRequest(GET, SVC_ECHO);
 
@@ -111,15 +123,22 @@ class ConnectionAcceptingNettyHttpServerTest extends AbstractNettyHttpServerTest
         // Connection will establish but remain in the accept-queue
         // (i.e., NOT accepted by the server => occupying 1 backlog entry)
         assertConnectionRequestReceiveTimesOut(request);
-        try (StreamingHttpClient client = newClientWithConnectTimeout()) {
+        try (StreamingHttpClient client = newClientWithConnectTimeout(new ConnectionClosedObserver(observed))) {
             // Since we control the backlog size, this connection won't establish (i.e., NO syn-ack)
             // timeout operator can be used to kill it or socket connection-timeout
             final Single<StreamingHttpResponse> response =
                     client.reserveConnection(request).flatMap(conn -> conn.request(request));
-            final ExecutionException executionException =
-                    assertThrows(ExecutionException.class, () -> awaitIndefinitely(response));
-            assertThat(executionException.getCause(), instanceOf(ConnectTimeoutException.class));
+            final ExecutionException e = assertThrows(ExecutionException.class, () -> awaitIndefinitely(response));
+            assertConnectTimeoutException(e.getCause());
         }
+        assertThat(observed, hasSize(1));
+        observed.forEach(ConnectionAcceptingNettyHttpServerTest::assertConnectTimeoutException);
+    }
+
+    private static void assertConnectTimeoutException(Throwable t) {
+        assertThat(t, is(instanceOf(ConnectTimeoutException.class)));
+        assertThat(t, is(instanceOf(RetryableException.class)));
+        assertThat(t.getCause(), is(instanceOf(io.netty.channel.ConnectTimeoutException.class)));
     }
 
     private void assertConnectionRequestReceiveTimesOut(final StreamingHttpRequest request) {
@@ -136,5 +155,24 @@ class ConnectionAcceptingNettyHttpServerTest extends AbstractNettyHttpServerTest
                         .flatMap(conn -> conn.request(request)));
         assert response != null;
         assertResponse(response, HTTP_1_1, OK, "");
+    }
+
+    private static final class ConnectionClosedObserver implements TransportObserver, ConnectionObserver {
+
+        private final BlockingQueue<Throwable> observed;
+
+        ConnectionClosedObserver(BlockingQueue<Throwable> observed) {
+            this.observed = observed;
+        }
+
+        @Override
+        public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
+            return this;
+        }
+
+        @Override
+        public void connectionClosed(final Throwable error) {
+            observed.add(error);
+        }
     }
 }

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
@@ -176,7 +176,7 @@ public final class TcpConnector {
                                 connectHandler.connectFailed(cause);
                             }
                         });
-                        super.connect(ctx, remoteAddress, localAddress, promise);
+                        ctx.connect(remoteAddress, localAddress, promise);
                     }
                 });
                 connectHandler.accept(channel);
@@ -331,6 +331,8 @@ public final class TcpConnector {
         }
 
         void connectFailed(final Throwable cause) {
+            // Report the error to the observer before propagating it down to the target subscriber.
+            connectionObserver.connectionClosed(cause);
             if (terminatedUpdater.compareAndSet(this, 0, 1)) {
                 target.onError(cause);
             }

--- a/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
+++ b/servicetalk-tcp-netty-internal/src/test/java/io/servicetalk/tcp/netty/internal/TcpTransportObserverErrorsTest.java
@@ -154,6 +154,7 @@ final class TcpTransportObserverErrorsTest extends AbstractTransportObserverTest
             case CONNECTION_REFUSED:
                 verify(clientConnectionObserver, await()).connectionClosed(exceptionCaptor.capture());
                 assertThat(exceptionCaptor.getValue(), instanceOf(ConnectException.class));
+                assertThat(exceptionCaptor.getValue(), instanceOf(RetryableException.class));
                 assertThat(exceptionCaptor.getValue().getMessage(), containsString("refused"));
                 break;
             case CONNECTION_ACCEPTOR:

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -111,6 +111,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
     @Override
     public void init(final Channel channel) {
+        assert channel.eventLoop().inEventLoop();
         channel.pipeline().addLast(new ConnectionObserverHandler(observer, connectionInfoFactory,
                 sslConfig != null, isFastOpen(channel), sslConfig));
     }
@@ -125,12 +126,13 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         private final ConnectionObserver observer;
         private final Function<Channel, ConnectionInfo> connectionInfoFactory;
         private final boolean handshakeOnActive;
+        @Nullable
+        private final SslConfig sslConfig;
+
         private boolean tcpHandshakeComplete;
         private boolean addedCloseListener;
         @Nullable
         private SecurityHandshakeObserver handshakeObserver;
-        @Nullable
-        private final SslConfig sslConfig;
 
         ConnectionObserverHandler(final ConnectionObserver observer,
                                   final Function<Channel, ConnectionInfo> connectionInfoFactory,
@@ -156,30 +158,21 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
         @Override
         public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                            ChannelPromise promise) throws Exception {
-            // The connect promise is the first to be notified of problems in the connect phase, even before the
-            // channel.closeFuture(). We typically want to know about closure before we get to returning the failed
-            // response because it is the cause of the failed response, so we eagerly propagate that in the event of
-            // a failed connect promise. We add our listener to the promise before forwarding the call so we can be
-            // sure this callback is fired early in the failure pathway.
+                            ChannelPromise promise) {
+            // The connect promise is the first to be notified for either success or a failure, even before the
+            // channel.closeFuture(). We use it to attach the channel.closeFuture() listener as soon as possible in case
+            // of a successful connect to report future channel closure. In case of the failure, the decorated error
+            // will be reported to ConnectionObserver inside the similar listener added by TcpConnector.
             promise.addListener((ChannelFuture future) -> {
+                assert ctx.channel().eventLoop().inEventLoop();
                 if (future.isSuccess()) {
                     maybeAddChannelClosedListener(ctx.channel());
                 } else {
-                    assert ctx.channel().eventLoop().inEventLoop();
+                    // Mark as added to avoid double reporting.
                     addedCloseListener = true;
-                    Throwable t = channelError(future.channel());
-                    if (t == null) {
-                        t = future.cause();
-                    }
-                    if (t == null) {
-                        observer.connectionClosed();
-                    } else {
-                        observer.connectionClosed(t);
-                    }
                 }
             });
-            super.connect(ctx, remoteAddress, localAddress, promise);
+            ctx.connect(remoteAddress, localAddress, promise);
         }
 
         @Override
@@ -189,6 +182,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         }
 
         private void whenChannelActive(final Channel channel) {
+            assert channel.eventLoop().inEventLoop();
             maybeAddChannelClosedListener(channel);
             reportTcpHandshakeComplete(channel);
             if (handshakeOnActive) {
@@ -197,7 +191,6 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         }
 
         private void maybeAddChannelClosedListener(Channel channel) {
-            assert channel.eventLoop().inEventLoop();
             if (addedCloseListener) {
                 return;
             }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DeferSslHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/DeferSslHandler.java
@@ -42,6 +42,7 @@ public class DeferSslHandler extends ChannelDuplexHandler {
      * Indicates that we are ready to stop deferring, and add the deferred {@link SslHandler}.
      */
     public void ready() {
+        assert channel.eventLoop().inEventLoop();
         final ChannelPipeline pipeline = channel.pipeline();
         final ConnectionObserverHandler observerHandler = pipeline.get(ConnectionObserverHandler.class);
         if (observerHandler != null) {


### PR DESCRIPTION
Motivation:

`TcpConnector` enriches `ConnectException`s with their retryable wrappers, but `ConnectionObserver.connectionClosed(Throwable)` does not see those.

Modifications:

1. Enhance `ConnectionAcceptingNettyHttpServerTest` to ensure `ConnectionObserver` sees the same retryable exception type as callers on connect timeouts.
2. `TcpTransportObserverErrorsTest`: to ensure connection refused error is retryable.
3. Adjust `ConnectionObserverInitializer` and `TcpConnector` to propagate consistent exception types.

Result:

`ConnectionObserver.connectionClosed(Throwable)` sees the same exception type as the caller.