### PR TITLE
Add UBI9 Devcontainers

### DIFF
--- a/.devcontainer/ubi9/Dockerfile
+++ b/.devcontainer/ubi9/Dockerfile
@@ -25,4 +25,4 @@ RUN bash -c "source /root/.sdkman/bin/sdkman-init.sh && \
     rm -rf /root/.sdkman/tmp/*"
 
 RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
-RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc
+RUN echo 'export PATH=$JAVA_HOME/bin:$PATH' >> ~/.bashrc

--- a/.devcontainer/ubi9/Dockerfile
+++ b/.devcontainer/ubi9/Dockerfile
@@ -1,0 +1,28 @@
+FROM redhat/ubi9
+
+ARG java_version=17.0.19-zulu
+ENV JAVA_VERSION=$java_version
+
+RUN dnf install -y \
+    procps-ng \
+    git \
+    openssl \
+    tar \
+    unzip \
+    wget \
+    zip \
+    zlib-devel \
+    && dnf clean all
+
+# Downloading and installing SDKMAN!
+RUN curl -s "https://get.sdkman.io?ci=true" | bash
+
+# Installing Java removing some unnecessary SDKMAN files
+RUN bash -c "source /root/.sdkman/bin/sdkman-init.sh && \
+    sdk list java | grep zulu && \
+    yes | sdk install java $JAVA_VERSION && \
+    rm -rf /root/.sdkman/archives/* && \
+    rm -rf /root/.sdkman/tmp/*"
+
+RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
+RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc

--- a/.devcontainer/ubi9/devcontainer.json
+++ b/.devcontainer/ubi9/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "servicetalk-ubi9",
+  "containerEnv": {
+  },
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "securityOpt": [ "seccomp=unconfined" ],
+  "runArgs": [
+    "--privileged"
+  ]
+}


### PR DESCRIPTION
Motivation:
Devcontainers are useful for running tests locally in a predictable environment, and for doing stuff in a Linux environment even when your local system is Windows or macOS.

Modification:
Add devcontainer files.
The devcontainer is based on RedHat UBI9, because I think that's more representative of a typical prod environment than Ubuntu is, despite CI using Ubuntu.

Result:
Easy local Linux-based dev workflow.