### PR TITLE
http-api: ensure bulk header validation works as expected

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
@@ -657,9 +657,12 @@ final class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> impl
         if (headers == this) {
             return this;
         }
-        if (headers instanceof MultiMap) {
-            putAll((MultiMap<? extends CharSequence, ? extends CharSequence>) headers);
-        } else { // Slow copy
+        if (headers instanceof DefaultHttpHeaders) {
+            DefaultHttpHeaders rhs = (DefaultHttpHeaders) headers;
+            putAll(rhs, validateNames && !rhs.validateNames, validateValues && !rhs.validateValues);
+        } else if (headers instanceof MultiMap) {
+            putAll((MultiMap<? extends CharSequence, ? extends CharSequence>) headers, validateNames, validateValues);
+        } else { // Slow copy either because it's not a compatible data structure or to ensure validation.
             for (final Map.Entry<? extends CharSequence, ? extends CharSequence> header : headers) {
                 add(header.getKey(), header.getValue());
             }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiMap.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiMap.java
@@ -264,8 +264,8 @@ abstract class MultiMap<K, V> {
         }
     }
 
-    final void putAll(final MultiMap<? extends K, ? extends V> multiMap) {
-        putAll0(multiMap);
+    final void putAll(final MultiMap<? extends K, ? extends V> multiMap, boolean validateKey, boolean validateValue) {
+        putAll0(multiMap, validateKey, validateValue);
     }
 
     final void putExclusive(final K key, final V value) {
@@ -501,7 +501,7 @@ abstract class MultiMap<K, V> {
         return putEntry(entries[bucketIndex], keyHash, bucketIndex, key, value);
     }
 
-    private void putAll0(final MultiMap<? extends K, ? extends V> rhs) {
+    private void putAll0(final MultiMap<? extends K, ? extends V> rhs, boolean validateKey, boolean validateValue) {
         if (isKeyEqualityCompatible(rhs)) { // Fast path
             BucketHead<? extends K, ? extends V> rhsBucketHead = rhs.lastBucketHead;
             while (rhsBucketHead != null) {
@@ -510,7 +510,9 @@ abstract class MultiMap<K, V> {
                 final int bucketIndex = index(rhsEntry.keyHash);
                 BucketHead<K, V> bucketHead = entries[bucketIndex];
                 if (bucketHead == null) {
-                    bucketHead = putEntry(null, rhsEntry.keyHash, bucketIndex, rhsEntry.getKey(), rhsEntry.getValue());
+                    bucketHead = putEntry(null, rhsEntry.keyHash, bucketIndex,
+                            maybeValidateKey(validateKey, rhsEntry.getKey()),
+                            maybeValidateValue(validateValue, rhsEntry.getValue()));
                     rhsEntry = rhsEntry.bucketNext;
                     if (rhsEntry == null) {
                         rhsBucketHead = rhsBucketHead.prevBucketHead;
@@ -518,7 +520,9 @@ abstract class MultiMap<K, V> {
                     }
                 }
                 do {
-                    putEntry(bucketHead, rhsEntry.keyHash, bucketIndex, rhsEntry.getKey(), rhsEntry.getValue());
+                    putEntry(bucketHead, rhsEntry.keyHash, bucketIndex,
+                            maybeValidateKey(validateKey, rhsEntry.getKey()),
+                            maybeValidateValue(validateValue, rhsEntry.getValue()));
                     rhsEntry = rhsEntry.bucketNext;
                 } while (rhsEntry != null);
                 rhsBucketHead = rhsBucketHead.prevBucketHead;
@@ -529,12 +533,22 @@ abstract class MultiMap<K, V> {
                 MultiMapEntry<? extends K, ? extends V> rhsEntry = rhsBucketHead.entry;
                 assert rhsEntry != null;
                 do {
-                    putEntry(rhsEntry.keyHash, index(rhsEntry.keyHash), rhsEntry.getKey(), rhsEntry.getValue());
+                    putEntry(rhsEntry.keyHash, index(rhsEntry.keyHash),
+                            maybeValidateKey(validateKey, rhsEntry.getKey()),
+                            maybeValidateValue(validateValue, rhsEntry.getValue()));
                     rhsEntry = rhsEntry.bucketNext;
                 } while (rhsEntry != null);
                 rhsBucketHead = rhsBucketHead.prevBucketHead;
             }
         }
+    }
+
+    private K maybeValidateKey(boolean validate, K key) {
+        return validate ? validateKey(key) : key;
+    }
+
+    private V maybeValidateValue(boolean validate, V value) {
+        return validate ? validateValue(value) : value;
     }
 
     private abstract class EntryIterator<T> implements Iterator<T> {

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpHeadersTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpHeadersTest.java
@@ -15,7 +15,59 @@
  */
 package io.servicetalk.http.api;
 
-public class DefaultHttpHeadersTest extends AbstractHttpHeadersTest {
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DefaultHttpHeadersTest extends AbstractHttpHeadersTest {
+
+    @Test
+    void addHeadersValidatesNamesWhenSourceDoesNot() {
+        DefaultHttpHeaders source = newHeaders(false, false);
+        source.add("invalid name", "value");
+
+        DefaultHttpHeaders dest = newHeaders(true, false);
+        assertThrows(IllegalArgumentException.class, () -> dest.add(source));
+    }
+
+    @Test
+    void addHeadersValidatesValuesWhenSourceDoesNot() {
+        DefaultHttpHeaders source = newHeaders(false, false);
+        source.add("name", "invalid\0value");
+
+        DefaultHttpHeaders dest = newHeaders(false, true);
+        assertThrows(IllegalArgumentException.class, () -> dest.add(source));
+    }
+
+    @Test
+    void addHeadersSkipsNameValidationWhenSourceAlreadyValidates() {
+        // Load an invalid name into a source that claims to validate names.
+        DefaultHttpHeaders raw = newHeaders(false, false);
+        raw.add("invalid name", "value");
+        DefaultHttpHeaders source = newHeaders(true, false);
+        source.putAll(raw, false, false);
+
+        DefaultHttpHeaders dest = newHeaders(true, false);
+        assertDoesNotThrow(() -> dest.add(source));
+    }
+
+    @Test
+    void addHeadersSkipsValueValidationWhenSourceAlreadyValidates() {
+        // Load an invalid value into a source that claims to validate values.
+        DefaultHttpHeaders raw = newHeaders(false, false);
+        raw.add("name", "invalid\0value");
+        DefaultHttpHeaders source = newHeaders(false, true);
+        source.putAll(raw, false, false);
+
+        DefaultHttpHeaders dest = newHeaders(false, true);
+        assertDoesNotThrow(() -> dest.add(source));
+    }
+
+    private static DefaultHttpHeaders newHeaders(boolean validateNames, boolean validateValues) {
+        return new DefaultHttpHeaders(16, validateNames, false, validateValues);
+    }
+
     @Override
     protected HttpHeaders newHeaders() {
         return DefaultHttpHeadersFactory.INSTANCE.newHeaders();


### PR DESCRIPTION
Motivation

When we bulk copy headers from one source to another we don't necessarily ensure the validation rules match. 
Note that this is typically low risk since it requires the intersection of a bulk copy, destination desires validation,
and source does not.

Modifications

Only skip validation if we know the source had at least as strict validation as the destination.
