### PR TITLE
Adjust maxTotalHeaderFieldsLength when maxHeaderFieldLength is larger

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
@@ -215,9 +215,19 @@ public final class H1ProtocolConfigBuilder {
      * @return a new {@link H1ProtocolConfig}
      */
     public H1ProtocolConfig build() {
+        final int effectiveMaxTotalHeaderFieldsLength;
+        if (maxHeaderFieldLength > maxTotalHeaderFieldsLength) {
+            LOGGER.warn("maxHeaderFieldLength ({}) is greater than maxTotalHeaderFieldsLength ({}), adjusting " +
+                            "maxTotalHeaderFieldsLength to match. Configure the desired value explicitly via " +
+                            "H1ProtocolConfigBuilder#maxTotalHeaderFieldsLength(int).",
+                    maxHeaderFieldLength, maxTotalHeaderFieldsLength);
+            effectiveMaxTotalHeaderFieldsLength = maxHeaderFieldLength;
+        } else {
+            effectiveMaxTotalHeaderFieldsLength = maxTotalHeaderFieldsLength;
+        }
         return new DefaultH1ProtocolConfig(headersFactory, maxPipelinedRequests, maxStartLineLength,
                 maxHeaderFieldLength, headersEncodedSizeEstimate, trailersEncodedSizeEstimate, specExceptions,
-                maxTotalHeaderFieldsLength);
+                effectiveMaxTotalHeaderFieldsLength);
     }
 
     private static final class DefaultH1ProtocolConfig implements H1ProtocolConfig {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocolConfigTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocolConfigTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -55,7 +56,7 @@ class HttpProtocolConfigTest {
                 HttpClients.forSingleAddress("localhost", 8080)
                         .protocols(h2Default(), h1Default());
 
-        Exception e = assertThrows(IllegalStateException.class, () -> builder.build());
+        Exception e = assertThrows(IllegalStateException.class, builder::build);
         assertEquals("Cleartext HTTP/1.1 -> HTTP/2 (h2c) upgrade is not supported", e.getMessage());
     }
 
@@ -81,7 +82,7 @@ class HttpProtocolConfigTest {
     void serverWithNullProtocolConfig() {
         HttpServerBuilder builder = HttpServers.forAddress(localAddress(0));
 
-        assertThrows(NullPointerException.class, () -> builder.protocols(null));
+        assertThrows(NullPointerException.class, () -> builder.protocols((HttpProtocolConfig) null));
     }
 
     @Test
@@ -158,5 +159,48 @@ class HttpProtocolConfigTest {
         Exception e = assertThrows(IllegalArgumentException.class, () ->
             builder.protocols(h2Default(), h2Default()));
         assertThat(e.getMessage(), startsWith("Duplicated configuration"));
+    }
+
+    @Test
+    void maxTotalHeaderFieldsLengthAdjustedWhenFieldLengthIsHigher() {
+        H1ProtocolConfig config = h1()
+                .maxHeaderFieldLength(64 * 1024)
+                .build();
+
+        assertEquals(64 * 1024, config.maxHeaderFieldLength());
+        assertEquals(64 * 1024, config.maxTotalHeaderFieldsLength());
+    }
+
+    @Test
+    void maxTotalHeaderFieldsLengthAdjustedWhenExplicitlySetLower() {
+        H1ProtocolConfig config = h1()
+                .maxHeaderFieldLength(64 * 1024)
+                .maxTotalHeaderFieldsLength(16 * 1024)
+                .build();
+
+        assertEquals(64 * 1024, config.maxHeaderFieldLength());
+        assertEquals(64 * 1024, config.maxTotalHeaderFieldsLength());
+    }
+
+    @Test
+    void maxTotalHeaderFieldsLengthNotAdjustedWhenAlreadySufficient() {
+        H1ProtocolConfig config = h1()
+                .maxHeaderFieldLength(16 * 1024)
+                .maxTotalHeaderFieldsLength(64 * 1024)
+                .build();
+
+        assertEquals(16 * 1024, config.maxHeaderFieldLength());
+        assertEquals(64 * 1024, config.maxTotalHeaderFieldsLength());
+    }
+
+    @Test
+    void maxTotalHeaderFieldsLengthWorksWhenEqual() {
+        H1ProtocolConfig config = h1()
+                .maxHeaderFieldLength(32 * 1024)
+                .maxTotalHeaderFieldsLength(32 * 1024)
+                .build();
+
+        assertEquals(32 * 1024, config.maxHeaderFieldLength());
+        assertEquals(32 * 1024, config.maxTotalHeaderFieldsLength());
     }
 }


### PR DESCRIPTION
This changeset ensures that when maxHeaderFieldLength is explicitly or implicitly configured larger than maxTotalHeaderFieldsLength, the value of maxTotalHeaderFieldsLength is set to match in order to not cause misleading issues at runtime.

We still WARN though, since this likely points towards a misconfiguration and should be addressed eventually by the application code.