### PR TITLE
Netty: cap cumulative decompressed size to prevent decompression-bomb DoS

### DIFF
--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/CompressionDefaults.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/CompressionDefaults.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.encoding.netty;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+/**
+ * Resolves the default cumulative-decompressed-bytes cap shared by
+ * {@link ZipCompressionBuilder} and {@link ZipContentCodecBuilder}. The hardcoded fallback is
+ * 64 MiB; operators can override it via the
+ * {@value #MAX_DECOMPRESSED_BYTES_PROPERTY} system property when shipping a build that requires
+ * a different bound (the typical use case is dialing the limit up to keep working through an
+ * unexpected regression). The property is read once at class load.
+ */
+final class CompressionDefaults {
+
+    /**
+     * System property that, when set to a non-negative {@code long}, overrides the default cap
+     * applied to {@link ZipCompressionBuilder#maxDecompressedBytes(long)} and
+     * {@link ZipContentCodecBuilder#maxDecompressedBytes(long)}. {@code 0} disables the cap;
+     * any other value is the cap in bytes. Invalid values are ignored with a warning, falling
+     * back to the hardcoded 64 MiB default.
+     */
+    static final String MAX_DECOMPRESSED_BYTES_PROPERTY = "io.servicetalk.encoding.netty.maxDecompressedBytes";
+    static final long DEFAULT_MAX_DECOMPRESSED_BYTES = 64L << 20; //64MiB
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompressionDefaults.class);
+    private static final long RESOLVED_MAX_DECOMPRESSED_BYTES =
+            parseMaxDecompressedBytes(System.getProperty(MAX_DECOMPRESSED_BYTES_PROPERTY));
+
+    private CompressionDefaults() {
+        // no instances
+    }
+
+    /**
+     * Returns the configured default cap in bytes, or the hardcoded fallback if the property is
+     * unset or invalid.
+     */
+    static long defaultMaxDecompressedBytes() {
+        return RESOLVED_MAX_DECOMPRESSED_BYTES;
+    }
+
+    /**
+     * Parses the system-property value into a cap. Package-private so unit tests can exercise
+     * the parsing without manipulating system properties.
+     */
+    static long parseMaxDecompressedBytes(@Nullable final String rawValue) {
+        if (rawValue == null) {
+            return DEFAULT_MAX_DECOMPRESSED_BYTES;
+        }
+        final long parsed;
+        try {
+            parsed = Long.parseLong(rawValue.trim());
+        } catch (NumberFormatException e) {
+            LOGGER.warn("Ignoring invalid {} value '{}'; using default {}",
+                    MAX_DECOMPRESSED_BYTES_PROPERTY, rawValue, DEFAULT_MAX_DECOMPRESSED_BYTES);
+            return DEFAULT_MAX_DECOMPRESSED_BYTES;
+        }
+        if (parsed < 0) {
+            LOGGER.warn("Ignoring negative {} value {}; using default {}",
+                    MAX_DECOMPRESSED_BYTES_PROPERTY, parsed, DEFAULT_MAX_DECOMPRESSED_BYTES);
+            return DEFAULT_MAX_DECOMPRESSED_BYTES;
+        }
+        return parsed;
+    }
+}

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/DecompressedByteLimitHandler.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/DecompressedByteLimitHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.encoding.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * Caps the cumulative size of decoded chunks flowing inbound through the pipeline. The
+ * decoder's own {@code maxChunkSize} bounds a single inflate step; this handler bounds the
+ * total across all chunks within one channel lifetime, failing fast during decoding rather
+ * than after the entire bomb has been inflated. Subclasses supply the codec-specific
+ * {@link RuntimeException} to throw on overflow.
+ */
+abstract class DecompressedByteLimitHandler extends ChannelInboundHandlerAdapter {
+    private final long maxBytes;
+    private long total;
+
+    DecompressedByteLimitHandler(final long maxBytes) {
+        this.maxBytes = maxBytes;
+    }
+
+    /**
+     * Build the exception to throw when the cap is exceeded. Called once per overflow.
+     *
+     * @param maxBytes the configured cap, included in the exception message for diagnosis.
+     * @return the exception that will propagate up the pipeline.
+     */
+    protected abstract RuntimeException newException(long maxBytes);
+
+    @Override
+    public final void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+        if (msg instanceof ByteBuf) {
+            final int n = ((ByteBuf) msg).readableBytes();
+            // Overflow-safe form of (total + n > maxBytes); both maxBytes and total are
+            // non-negative, and total <= maxBytes is the loop invariant.
+            if (maxBytes - total < n) {
+                ((ByteBuf) msg).release();
+                throw newException(maxBytes);
+            }
+            total += n;
+        }
+        ctx.fireChannelRead(msg);
+    }
+}

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/DeflateCompressionBuilder.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/DeflateCompressionBuilder.java
@@ -28,7 +28,8 @@ final class DeflateCompressionBuilder extends ZipCompressionBuilder {
     public SerializerDeserializer<Buffer> build() {
         return new NettyCompressionSerializer(
                 () -> new JdkZlibEncoder(ZlibWrapper.ZLIB, compressionLevel()),
-                () -> new JdkZlibDecoder(ZlibWrapper.ZLIB, maxChunkSize()));
+                () -> new JdkZlibDecoder(ZlibWrapper.ZLIB, maxChunkSize()),
+                maxDecompressedBytes());
     }
 
     @Override

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/GzipCompressionBuilder.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/GzipCompressionBuilder.java
@@ -28,7 +28,8 @@ final class GzipCompressionBuilder extends ZipCompressionBuilder {
     public SerializerDeserializer<Buffer> build() {
         return new NettyCompressionSerializer(
                 () -> new JdkZlibEncoder(ZlibWrapper.GZIP, compressionLevel()),
-                () -> new JdkZlibDecoder(ZlibWrapper.GZIP, maxChunkSize()));
+                () -> new JdkZlibDecoder(ZlibWrapper.GZIP, maxChunkSize()),
+                maxDecompressedBytes());
     }
 
     @Override

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyChannelContentCodec.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyChannelContentCodec.java
@@ -45,6 +45,7 @@ import static io.servicetalk.buffer.netty.BufferUtils.extractByteBufOrCreate;
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.buffer.netty.BufferUtils.newBufferFrom;
 import static io.servicetalk.concurrent.api.Single.succeeded;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.util.Objects.requireNonNull;
 
 @Deprecated
@@ -57,10 +58,12 @@ final class NettyChannelContentCodec implements ContentCodec { // FIXME: 0.43 - 
     private final CharSequence name;
     private final Supplier<MessageToByteEncoder<ByteBuf>> encoderSupplier;
     private final Supplier<ByteToMessageDecoder> decoderSupplier;
+    private final long maxDecompressedBytes;
 
     NettyChannelContentCodec(final CharSequence name,
                              final Supplier<MessageToByteEncoder<ByteBuf>> encoderSupplier,
-                             final Supplier<ByteToMessageDecoder> decoderSupplier) {
+                             final Supplier<ByteToMessageDecoder> decoderSupplier,
+                             final long maxDecompressedBytes) {
         if (name.length() <= 0) {
             throw new IllegalArgumentException("Name should not be blank.");
         }
@@ -68,6 +71,7 @@ final class NettyChannelContentCodec implements ContentCodec { // FIXME: 0.43 - 
         this.name = name;
         this.encoderSupplier = encoderSupplier;
         this.decoderSupplier = decoderSupplier;
+        this.maxDecompressedBytes = ensureNonNegative(maxDecompressedBytes, "maxDecompressedBytes");
     }
 
     @Override
@@ -222,11 +226,13 @@ final class NettyChannelContentCodec implements ContentCodec { // FIXME: 0.43 - 
         }
 
         final ByteToMessageDecoder decoder = decoderSupplier.get();
-        final EmbeddedChannel channel = newEmbeddedChannel(decoder, allocator);
+        final EmbeddedChannel channel = newEmbeddedDecoderChannel(decoder, allocator, this, maxDecompressedBytes);
 
         try {
             ByteBuf origin = extractByteBufOrCreate(src);
             channel.writeInbound(origin);
+            // Surface cap-exceeded errors (or any other decoder errors) that the pipeline caught.
+            channel.checkException();
 
             Buffer buffer = drainChannelQueueToSingleBuffer(channel.inboundMessages(), allocator);
             if (buffer == null) {
@@ -236,11 +242,13 @@ final class NettyChannelContentCodec implements ContentCodec { // FIXME: 0.43 - 
             cleanup(channel);
             return buffer;
         } catch (CodecDecodingException e) {
+            // The cap handler may leave decoded chunks on the inbound queue when it throws mid-
+            // stream; releaseOnError tolerates that (safeCleanup would trip its assert).
+            releaseOnError(channel);
             throw e;
         } catch (Throwable e) {
+            releaseOnError(channel);
             throw wrapDecodingException(this, e);
-        } finally {
-            safeCleanup(channel);
         }
     }
 
@@ -316,6 +324,27 @@ final class NettyChannelContentCodec implements ContentCodec { // FIXME: 0.43 - 
         return channel;
     }
 
+    private static EmbeddedChannel newEmbeddedDecoderChannel(final ByteToMessageDecoder decoder,
+                                                             final BufferAllocator allocator,
+                                                             final ContentCodec codec,
+                                                             final long maxDecompressedBytes) {
+        final EmbeddedChannel channel = maxDecompressedBytes > 0 ?
+                new EmbeddedChannel(decoder, newLimitHandler(codec, maxDecompressedBytes)) :
+                new EmbeddedChannel(decoder);
+        channel.config().setAllocator(getByteBufAllocator(allocator));
+        return channel;
+    }
+
+    static DecompressedByteLimitHandler newLimitHandler(final ContentCodec codec, final long maxDecompressedBytes) {
+        return new DecompressedByteLimitHandler(maxDecompressedBytes) {
+            @Override
+            protected RuntimeException newException(final long maxBytes) {
+                return new CodecDecodingException(codec,
+                        "Decompressed payload exceeded maxDecompressedBytes=" + maxBytes);
+            }
+        };
+    }
+
     private static void preparePendingData(final EmbeddedChannel channel) {
         try {
             channel.close().sync().get();
@@ -376,6 +405,19 @@ final class NettyChannelContentCodec implements ContentCodec { // FIXME: 0.43 - 
             cleanup(channel);
         } catch (AssertionError error) {
           throw error;
+        } catch (Throwable t) {
+            LOGGER.error("Error while closing embedded channel", t);
+        }
+    }
+
+    /**
+     * Release channel queues on an error path. Unlike {@link #safeCleanup}, this tolerates a
+     * non-empty inbound/outbound queue — which is the expected state after a mid-stream failure
+     * from a pipeline handler.
+     */
+    private static void releaseOnError(final EmbeddedChannel channel) {
+        try {
+            channel.finishAndReleaseAll();
         } catch (Throwable t) {
             LOGGER.error("Error while closing embedded channel", t);
         }

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyCompressionSerializer.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/NettyCompressionSerializer.java
@@ -31,23 +31,26 @@ import org.slf4j.LoggerFactory;
 import java.util.Queue;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 
 import static io.netty.util.internal.PlatformDependent.throwException;
 import static io.servicetalk.buffer.netty.BufferUtils.extractByteBufOrCreate;
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
 import static io.servicetalk.buffer.netty.BufferUtils.toByteBuf;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.util.Objects.requireNonNull;
 
 final class NettyCompressionSerializer implements SerializerDeserializer<Buffer> {
     private static final Logger LOGGER = LoggerFactory.getLogger(NettyCompressionSerializer.class);
     private final Supplier<MessageToByteEncoder<ByteBuf>> encoderSupplier;
     private final Supplier<ByteToMessageDecoder> decoderSupplier;
+    private final long maxDecompressedBytes;
 
     NettyCompressionSerializer(final Supplier<MessageToByteEncoder<ByteBuf>> encoderSupplier,
-                               final Supplier<ByteToMessageDecoder> decoderSupplier) {
+                               final Supplier<ByteToMessageDecoder> decoderSupplier,
+                               final long maxDecompressedBytes) {
         this.encoderSupplier = requireNonNull(encoderSupplier);
         this.decoderSupplier = requireNonNull(decoderSupplier);
+        this.maxDecompressedBytes = ensureNonNegative(maxDecompressedBytes, "maxDecompressedBytes");
     }
 
     @Override
@@ -80,15 +83,23 @@ final class NettyCompressionSerializer implements SerializerDeserializer<Buffer>
         final Buffer buffer = allocator.newBuffer(serializedData.readableBytes());
         final ByteBuf nettyDst = toByteBuf(buffer);
         final ByteToMessageDecoder decoder = decoderSupplier.get();
-        final EmbeddedChannel channel = newEmbeddedChannel(decoder, allocator);
+        final EmbeddedChannel channel = newEmbeddedDecoderChannel(decoder, allocator, maxDecompressedBytes);
         try {
             writeAndUpdateIndex(channel, serializedData, true);
+            // Surface cap-exceeded errors (or any other decoder errors) that the pipeline caught.
+            channel.checkException();
             drainChannelQueueToSingleBuffer(channel.inboundMessages(), nettyDst);
             // no need to advance writerIndex -> NettyBuffer's writerIndex reflects the underlying ByteBuf value.
             cleanup(channel);
             return buffer;
         } catch (Throwable e) {
-            safeCleanup(channel);
+            // The cap handler may leave decoded chunks on the inbound queue when it throws mid-
+            // stream; releaseOnError tolerates that state (unlike safeCleanup, which would surface
+            // an AssertionError under -ea and mask the real cause).
+            releaseOnError(channel);
+            if (e instanceof BufferEncodingException) {
+                throw (BufferEncodingException) e;
+            }
             throw new BufferEncodingException("Unexpected exception during decoding", e);
         }
     }
@@ -108,7 +119,6 @@ final class NettyCompressionSerializer implements SerializerDeserializer<Buffer>
         }
     }
 
-    @Nullable
     static void drainChannelQueueToSingleBuffer(final Queue<Object> queue, final ByteBuf nettyDst) {
         ByteBuf buf;
         while ((buf = (ByteBuf) queue.poll()) != null) {
@@ -124,6 +134,26 @@ final class NettyCompressionSerializer implements SerializerDeserializer<Buffer>
         final EmbeddedChannel channel = new EmbeddedChannel(handler);
         channel.config().setAllocator(getByteBufAllocator(allocator));
         return channel;
+    }
+
+    private static EmbeddedChannel newEmbeddedDecoderChannel(final ByteToMessageDecoder decoder,
+                                                             final BufferAllocator allocator,
+                                                             final long maxDecompressedBytes) {
+        final EmbeddedChannel channel = maxDecompressedBytes > 0 ?
+                new EmbeddedChannel(decoder, newLimitHandler(maxDecompressedBytes)) :
+                new EmbeddedChannel(decoder);
+        channel.config().setAllocator(getByteBufAllocator(allocator));
+        return channel;
+    }
+
+    static DecompressedByteLimitHandler newLimitHandler(final long maxDecompressedBytes) {
+        return new DecompressedByteLimitHandler(maxDecompressedBytes) {
+            @Override
+            protected RuntimeException newException(final long maxBytes) {
+                return new BufferEncodingException(
+                        "Decompressed payload exceeded maxDecompressedBytes=" + maxBytes);
+            }
+        };
     }
 
     static void preparePendingData(final EmbeddedChannel channel) {
@@ -145,6 +175,19 @@ final class NettyCompressionSerializer implements SerializerDeserializer<Buffer>
             cleanup(channel);
         } catch (AssertionError error) {
             throw error;
+        } catch (Throwable t) {
+            LOGGER.debug("Error while closing embedded channel", t);
+        }
+    }
+
+    /**
+     * Release channel queues on an error path. Unlike {@link #safeCleanup}, this tolerates a
+     * non-empty inbound/outbound queue — which is the expected state after a mid-stream failure
+     * from a pipeline handler.
+     */
+    static void releaseOnError(final EmbeddedChannel channel) {
+        try {
+            channel.finishAndReleaseAll();
         } catch (Throwable t) {
             LOGGER.debug("Error while closing embedded channel", t);
         }

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/ZipCompressionBuilder.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/ZipCompressionBuilder.java
@@ -19,6 +19,7 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.serializer.api.SerializerDeserializer;
 import io.servicetalk.serializer.api.StreamingSerializerDeserializer;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 
 /**
@@ -28,6 +29,7 @@ public abstract class ZipCompressionBuilder {
     private static final int DEFAULT_MAX_CHUNK_SIZE = 4 << 20; //4MiB
 
     private int maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
+    private long maxDecompressedBytes = CompressionDefaults.defaultMaxDecompressedBytes();
     private int compressionLevel = 6;
 
     ZipCompressionBuilder() {
@@ -50,12 +52,45 @@ public abstract class ZipCompressionBuilder {
     }
 
     /**
-     * Set the max allowed chunk size to inflate during decoding.
+     * Set the max allowed chunk size the decoder may emit in a single inflate step. This does
+     * <em>not</em> bound the total decompressed payload size; see
+     * {@link #maxDecompressedBytes(long)} for that.
      * @param maxChunkSize the max allowed chunk size to inflate during decoding.
      * @return {@code this}
      */
     public final ZipCompressionBuilder maxChunkSize(final int maxChunkSize) {
         this.maxChunkSize = ensurePositive(maxChunkSize, "maxChunkSize");
+        return this;
+    }
+
+    /**
+     * Set the maximum cumulative size in bytes of the decompressed payload produced by a single
+     * aggregated {@link SerializerDeserializer#deserialize deserialize} call. When the limit is
+     * exceeded the operation fails with a
+     * {@link io.servicetalk.encoding.api.BufferEncodingException}. Used to defend against
+     * decompression-bomb inputs where a small compressed payload expands to an unbounded amount
+     * of memory.
+     * <p>
+     * Unlike {@link #maxChunkSize(int)}, which bounds only a single inflate step inside the codec,
+     * this bound is tracked across every chunk produced for the same input.
+     * <p>
+     * Defaults to 64 MiB. The default can be overridden process-wide via the
+     * {@value CompressionDefaults#MAX_DECOMPRESSED_BYTES_PROPERTY} system property (intended as
+     * an operational escape hatch for unforeseen issues — prefer per-builder configuration).
+     * A value of {@code 0} disables the limit; callers that decode trusted input and need
+     * unbounded decompression can opt out, but doing so re-exposes the decompression-bomb
+     * attack surface.
+     * <p>
+     * This setting does <em>not</em> apply to the streaming {@code buildStreaming()} path.
+     * Streaming consumers typically process much larger payloads and are assumed to apply
+     * back-pressure; a streaming client that aggregates decoded chunks into a single buffer
+     * should enforce its own size bound.
+     * @param maxDecompressedBytes the max total decompressed bytes allowed per aggregated
+     * deserialize call, or {@code 0} for unbounded.
+     * @return {@code this}
+     */
+    public final ZipCompressionBuilder maxDecompressedBytes(final long maxDecompressedBytes) {
+        this.maxDecompressedBytes = ensureNonNegative(maxDecompressedBytes, "maxDecompressedBytes");
         return this;
     }
 
@@ -86,5 +121,14 @@ public abstract class ZipCompressionBuilder {
      */
     final int maxChunkSize() {
         return maxChunkSize;
+    }
+
+    /**
+     * Returns the max total decompressed bytes allowed per aggregated deserialize call, or
+     * {@code 0} for unbounded.
+     * @return the configured cap, or {@code 0} for unbounded.
+     */
+    final long maxDecompressedBytes() {
+        return maxDecompressedBytes;
     }
 }

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/ZipContentCodecBuilder.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/ZipContentCodecBuilder.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.compression.JdkZlibEncoder;
 import io.netty.handler.codec.compression.ZlibWrapper;
 
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 
 /**
@@ -34,6 +35,7 @@ public abstract class ZipContentCodecBuilder {  // FIXME: 0.43 - remove deprecat
     private static final int DEFAULT_MAX_CHUNK_SIZE = 4 << 20; //4MiB
 
     private int maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
+    private long maxDecompressedBytes = CompressionDefaults.defaultMaxDecompressedBytes();
     private int compressionLevel = 6;
 
     ZipContentCodecBuilder() {
@@ -56,12 +58,47 @@ public abstract class ZipContentCodecBuilder {  // FIXME: 0.43 - remove deprecat
     }
 
     /**
-     * Set the max allowed chunk size to inflate during decoding.
+     * Set the max allowed chunk size the decoder may emit in a single inflate step. This does
+     * <em>not</em> bound the total decompressed payload size; see
+     * {@link #maxDecompressedBytes(long)} for that.
      * @param maxChunkSize the max allowed chunk size to inflate during decoding.
      * @return {@code this}
      */
     public final ZipContentCodecBuilder maxChunkSize(final int maxChunkSize) {
         this.maxChunkSize = ensurePositive(maxChunkSize, "maxChunkSize");
+        return this;
+    }
+
+    /**
+     * Set the maximum cumulative size in bytes of the decompressed payload produced by a single
+     * aggregated {@link ContentCodec#decode(io.servicetalk.buffer.api.Buffer,
+     * io.servicetalk.buffer.api.BufferAllocator) decode} call. When the limit is exceeded the
+     * operation fails with a {@link io.servicetalk.encoding.api.CodecDecodingException}. Used to
+     * defend against decompression-bomb inputs where a small compressed payload expands to an
+     * unbounded amount of memory.
+     * <p>
+     * Unlike {@link #maxChunkSize(int)}, which bounds only a single inflate step inside the codec,
+     * this bound is tracked across every chunk produced for the same input.
+     * <p>
+     * Defaults to 64 MiB. The default can be overridden process-wide via the
+     * {@value CompressionDefaults#MAX_DECOMPRESSED_BYTES_PROPERTY} system property (intended as
+     * an operational escape hatch for unforeseen issues — prefer per-builder configuration).
+     * A value of {@code 0} disables the limit; callers that decode trusted input and need
+     * unbounded decompression can opt out, but doing so re-exposes the decompression-bomb
+     * attack surface.
+     * <p>
+     * This setting does <em>not</em> apply to the streaming
+     * {@link ContentCodec#decode(io.servicetalk.concurrent.api.Publisher,
+     * io.servicetalk.buffer.api.BufferAllocator)} path.
+     * Streaming consumers typically process much larger payloads and are assumed to apply
+     * back-pressure; a streaming client that aggregates decoded chunks into a single buffer
+     * should enforce its own size bound.
+     * @param maxDecompressedBytes the max total decompressed bytes allowed per aggregated decode,
+     * or {@code 0} for unbounded.
+     * @return {@code this}
+     */
+    public final ZipContentCodecBuilder maxDecompressedBytes(final long maxDecompressedBytes) {
+        this.maxDecompressedBytes = ensureNonNegative(maxDecompressedBytes, "maxDecompressedBytes");
         return this;
     }
 
@@ -87,6 +124,15 @@ public abstract class ZipContentCodecBuilder {  // FIXME: 0.43 - remove deprecat
         return maxChunkSize;
     }
 
+    /**
+     * Returns the max total decompressed bytes allowed per aggregated decode, or {@code 0} for
+     * unbounded.
+     * @return the configured cap, or {@code 0} for unbounded.
+     */
+    final long maxDecompressedBytes() {
+        return maxDecompressedBytes;
+    }
+
     static final class GzipContentCodecBuilder extends ZipContentCodecBuilder {
 
         private static final CharSequence GZIP = newAsciiString("gzip");
@@ -95,7 +141,8 @@ public abstract class ZipContentCodecBuilder {  // FIXME: 0.43 - remove deprecat
         public ContentCodec build() {
             return new NettyChannelContentCodec(GZIP,
                     () -> new JdkZlibEncoder(ZlibWrapper.GZIP, compressionLevel()),
-                    () -> new JdkZlibDecoder(ZlibWrapper.GZIP, maxChunkSize())
+                    () -> new JdkZlibDecoder(ZlibWrapper.GZIP, maxChunkSize()),
+                    maxDecompressedBytes()
             );
         }
     }
@@ -108,7 +155,8 @@ public abstract class ZipContentCodecBuilder {  // FIXME: 0.43 - remove deprecat
         public ContentCodec build() {
             return new NettyChannelContentCodec(DEFLATE,
                     () -> new JdkZlibEncoder(ZlibWrapper.ZLIB, compressionLevel()),
-                    () -> new JdkZlibDecoder(ZlibWrapper.ZLIB, maxChunkSize())
+                    () -> new JdkZlibDecoder(ZlibWrapper.ZLIB, maxChunkSize()),
+                    maxDecompressedBytes()
             );
         }
     }

--- a/servicetalk-encoding-netty/src/test/java/io/servicetalk/encoding/netty/CompressionDefaultsTest.java
+++ b/servicetalk-encoding-netty/src/test/java/io/servicetalk/encoding/netty/CompressionDefaultsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.encoding.netty;
+
+import org.junit.jupiter.api.Test;
+
+import static io.servicetalk.encoding.netty.CompressionDefaults.DEFAULT_MAX_DECOMPRESSED_BYTES;
+import static io.servicetalk.encoding.netty.CompressionDefaults.parseMaxDecompressedBytes;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Covers parsing of the system-property override for the default cap. The integration with the
+ * static field happens at class load and is not exercised here — that path is straightforward
+ * once parsing is correct.
+ */
+class CompressionDefaultsTest {
+
+    @Test
+    void nullFallsBackToDefault() {
+        assertThat(parseMaxDecompressedBytes(null), equalTo(DEFAULT_MAX_DECOMPRESSED_BYTES));
+    }
+
+    @Test
+    void zeroIsAcceptedAsExplicitOptOut() {
+        assertThat(parseMaxDecompressedBytes("0"), equalTo(0L));
+    }
+
+    @Test
+    void positiveValueIsHonored() {
+        assertThat(parseMaxDecompressedBytes("104857600"), equalTo(100L << 20));
+    }
+
+    @Test
+    void leadingAndTrailingWhitespaceIsTolerated() {
+        assertThat(parseMaxDecompressedBytes("  4096  "), equalTo(4096L));
+    }
+
+    @Test
+    void negativeValueFallsBackToDefault() {
+        assertThat(parseMaxDecompressedBytes("-1"), equalTo(DEFAULT_MAX_DECOMPRESSED_BYTES));
+    }
+
+    @Test
+    void malformedValueFallsBackToDefault() {
+        assertThat(parseMaxDecompressedBytes("not-a-number"), equalTo(DEFAULT_MAX_DECOMPRESSED_BYTES));
+    }
+
+    @Test
+    void emptyStringFallsBackToDefault() {
+        assertThat(parseMaxDecompressedBytes(""), equalTo(DEFAULT_MAX_DECOMPRESSED_BYTES));
+    }
+}

--- a/servicetalk-encoding-netty/src/test/java/io/servicetalk/encoding/netty/NettyChannelContentCodecBombTest.java
+++ b/servicetalk-encoding-netty/src/test/java/io/servicetalk/encoding/netty/NettyChannelContentCodecBombTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.encoding.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.CompositeBuffer;
+import io.servicetalk.encoding.api.CodecDecodingException;
+import io.servicetalk.encoding.api.ContentCodec;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.function.Supplier;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPOutputStream;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Mirrors {@link NettyCompressionSerializerBombTest} for the deprecated
+ * {@link ZipContentCodecBuilder} API which decodes via {@link NettyChannelContentCodec}.
+ *
+ * @deprecated Exercises the deprecated {@link io.servicetalk.encoding.api.ContentCodec} API;
+ * kept until that API is removed alongside {@link ZipContentCodecBuilder}.
+ */
+@Deprecated
+class NettyChannelContentCodecBombTest {
+
+    private static final int TEST_MAX_CHUNK_SIZE = 128 << 20; // 128 MiB
+
+    enum Codec {
+        GZIP(NettyChannelContentCodecBombTest::gzipBomb, ContentCodings::gzip),
+        DEFLATE(NettyChannelContentCodecBombTest::deflateBomb, ContentCodings::deflate);
+
+        final BombFixture bomb;
+        final Supplier<ZipContentCodecBuilder> builder;
+
+        Codec(final BombFixture bomb, final Supplier<ZipContentCodecBuilder> builder) {
+            this.bomb = bomb;
+            this.builder = builder;
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void bombIsRejectedUnderCap(final Codec codec) throws IOException {
+        final int payloadBytes = 64 << 20;
+        final int capBytes = 16 << 20;
+        final byte[] compressed = codec.bomb.build(payloadBytes);
+        final ContentCodec contentCodec = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                .maxDecompressedBytes(capBytes)
+                .build();
+        final Buffer src = DEFAULT_ALLOCATOR.wrap(compressed);
+
+        final CodecDecodingException ex = assertThrows(CodecDecodingException.class,
+                () -> contentCodec.decode(src, DEFAULT_ALLOCATOR));
+        assertThat(rootMessage(ex), containsString("exceeded"));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void underCapRoundTrips(final Codec codec) throws IOException {
+        final int payloadBytes = 10 << 20;
+        final int capBytes = 16 << 20;
+        final byte[] compressed = codec.bomb.build(payloadBytes);
+        final ContentCodec contentCodec = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                .maxDecompressedBytes(capBytes)
+                .build();
+
+        final Buffer decoded = contentCodec.decode(DEFAULT_ALLOCATOR.wrap(compressed), DEFAULT_ALLOCATOR);
+        assertThat(decoded.readableBytes(), equalTo(payloadBytes));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void streamingIsUnboundedByDesign(final Codec codec) throws Exception {
+        // The cap applies to the aggregated decode path only; streaming is intentionally left
+        // uncapped. This test feeds a payload that would trip the aggregated cap through the
+        // streaming API and asserts it round-trips.
+        final int payloadBytes = 64 << 20;
+        final int capBytes = 16 << 20;
+        final byte[] compressed = codec.bomb.build(payloadBytes);
+        final ContentCodec contentCodec = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                .maxDecompressedBytes(capBytes)
+                .build();
+
+        final CompositeBuffer result = contentCodec.decode(from(DEFAULT_ALLOCATOR.wrap(compressed)), DEFAULT_ALLOCATOR)
+                .collect(DEFAULT_ALLOCATOR::newCompositeBuffer, CompositeBuffer::addBuffer)
+                .toFuture().get();
+        assertThat(result.readableBytes(), equalTo(payloadBytes));
+    }
+
+    private static String rootMessage(final Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null && cur.getCause() != cur) {
+            cur = cur.getCause();
+        }
+        return cur.getMessage() != null ? cur.getMessage() : "";
+    }
+
+    @FunctionalInterface
+    interface BombFixture {
+        byte[] build(long decompressedBytes) throws IOException;
+    }
+
+    static byte[] gzipBomb(final long decompressedBytes) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(out)) {
+            writeZeros(gz, decompressedBytes);
+        }
+        return out.toByteArray();
+    }
+
+    static byte[] deflateBomb(final long decompressedBytes) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (DeflaterOutputStream zlib = new DeflaterOutputStream(out)) {
+            writeZeros(zlib, decompressedBytes);
+        }
+        return out.toByteArray();
+    }
+
+    private static void writeZeros(final OutputStream out, final long decompressedBytes) throws IOException {
+        final byte[] chunk = new byte[64 * 1024];
+        long remaining = decompressedBytes;
+        while (remaining > 0) {
+            final int n = (int) Math.min(chunk.length, remaining);
+            out.write(chunk, 0, n);
+            remaining -= n;
+        }
+    }
+}

--- a/servicetalk-encoding-netty/src/test/java/io/servicetalk/encoding/netty/NettyCompressionSerializerBombTest.java
+++ b/servicetalk-encoding-netty/src/test/java/io/servicetalk/encoding/netty/NettyCompressionSerializerBombTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.encoding.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.CompositeBuffer;
+import io.servicetalk.encoding.api.BufferEncodingException;
+import io.servicetalk.serializer.api.SerializerDeserializer;
+import io.servicetalk.serializer.api.StreamingSerializerDeserializer;
+
+import io.netty.handler.codec.compression.JdkZlibDecoder;
+import io.netty.handler.codec.compression.JdkZlibEncoder;
+import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetector.Level;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.function.Supplier;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPOutputStream;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.Publisher.from;
+import static io.servicetalk.encoding.netty.NettyCompression.deflate;
+import static io.servicetalk.encoding.netty.NettyCompression.deflateDefault;
+import static io.servicetalk.encoding.netty.NettyCompression.gzip;
+import static io.servicetalk.encoding.netty.NettyCompression.gzipDefault;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers the {@code maxDecompressedBytes} cap that prevents decompression-bomb DoS on both the
+ * aggregated {@link SerializerDeserializer#deserialize} and streaming
+ * {@link StreamingSerializerDeserializer#deserialize} paths.
+ *
+ * <p>Tests widen {@code maxChunkSize} so that the cumulative {@code maxDecompressedBytes} cap is
+ * the binding limit exercised by each scenario — the default {@code maxChunkSize} (4 MiB) would
+ * otherwise trip the decoder's own per-chunk allocation guard first for larger payloads.
+ */
+class NettyCompressionSerializerBombTest {
+
+    // Large enough to let test payloads flow through per-chunk; the cap is what we're exercising.
+    private static final int TEST_MAX_CHUNK_SIZE = 128 << 20; // 128 MiB
+
+    private static Level originalLeakLevel;
+
+    @BeforeAll
+    static void enableLeakDetection() {
+        originalLeakLevel = ResourceLeakDetector.getLevel();
+        ResourceLeakDetector.setLevel(Level.PARANOID);
+    }
+
+    @AfterAll
+    static void restoreLeakDetection() {
+        ResourceLeakDetector.setLevel(originalLeakLevel);
+    }
+
+    enum Codec {
+        GZIP(NettyCompressionSerializerBombTest::gzipBomb, () -> gzip()),
+        DEFLATE(NettyCompressionSerializerBombTest::deflateBomb, () -> deflate());
+
+        final BombFixture bomb;
+        final Supplier<ZipCompressionBuilder> builder;
+
+        Codec(final BombFixture bomb, final Supplier<ZipCompressionBuilder> builder) {
+            this.bomb = bomb;
+            this.builder = builder;
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void bombIsRejectedUnderCap(final Codec codec) throws IOException {
+        // 64 MiB decompressed from all-zeros input compresses to ~64 KiB — the canonical bomb
+        // shape. Cap at 16 MiB to prove the cumulative limit rejects a payload far larger than
+        // the cap. maxChunkSize is kept wide so we exercise our cap rather than the decoder's
+        // own per-chunk allocation guard.
+        final int payloadBytes = 64 << 20;
+        final int capBytes = 16 << 20;
+        final byte[] compressed = codec.bomb.build(payloadBytes);
+        final SerializerDeserializer<Buffer> serializer = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                .maxDecompressedBytes(capBytes)
+                .build();
+        final Buffer src = DEFAULT_ALLOCATOR.wrap(compressed);
+
+        final BufferEncodingException ex = assertThrows(BufferEncodingException.class,
+                () -> serializer.deserialize(src, DEFAULT_ALLOCATOR));
+        assertThat(rootMessage(ex), containsString("exceeded"));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void underCapRoundTrips(final Codec codec) throws IOException {
+        final int payloadBytes = 10 << 20; // 10 MiB
+        final int capBytes = 16 << 20;     // 16 MiB
+        final byte[] compressed = codec.bomb.build(payloadBytes);
+        final SerializerDeserializer<Buffer> serializer = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                .maxDecompressedBytes(capBytes)
+                .build();
+
+        final Buffer decoded = serializer.deserialize(DEFAULT_ALLOCATOR.wrap(compressed), DEFAULT_ALLOCATOR);
+        assertThat(decoded.readableBytes(), equalTo(payloadBytes));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void zeroCapIsUnbounded(final Codec codec) throws IOException {
+        final int payloadBytes = 8 << 20; // 8 MiB
+        final byte[] compressed = codec.bomb.build(payloadBytes);
+        final SerializerDeserializer<Buffer> serializer = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                // explicit 0 opts out of the default cap.
+                .maxDecompressedBytes(0L)
+                .build();
+
+        final Buffer decoded = assertDoesNotThrow(() -> serializer.deserialize(
+                DEFAULT_ALLOCATOR.wrap(compressed), DEFAULT_ALLOCATOR));
+        assertThat(decoded.readableBytes(), equalTo(payloadBytes));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void exactBoundarySucceeds(final Codec codec) throws IOException {
+        final int capBytes = 1 << 20; // 1 MiB
+        final byte[] compressed = codec.bomb.build(capBytes); // decompresses to exactly cap
+        final SerializerDeserializer<Buffer> serializer = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                .maxDecompressedBytes(capBytes)
+                .build();
+
+        final Buffer decoded = serializer.deserialize(DEFAULT_ALLOCATOR.wrap(compressed), DEFAULT_ALLOCATOR);
+        assertThat(decoded.readableBytes(), equalTo(capBytes));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void oneByteOverBoundaryFails(final Codec codec) throws IOException {
+        final int capBytes = 1 << 20; // 1 MiB
+        final byte[] compressed = codec.bomb.build(capBytes + 1L);
+        final SerializerDeserializer<Buffer> serializer = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                .maxDecompressedBytes(capBytes)
+                .build();
+        final Buffer src = DEFAULT_ALLOCATOR.wrap(compressed);
+
+        final BufferEncodingException ex = assertThrows(BufferEncodingException.class,
+                () -> serializer.deserialize(src, DEFAULT_ALLOCATOR));
+        assertThat(rootMessage(ex), containsString("exceeded"));
+    }
+
+    /**
+     * Concatenated gzip members force the decoder to emit one inbound chunk per member, which is
+     * the only way to exercise the inline {@code DecompressedByteLimitHandler} path through a
+     * single {@code deserialize} call (a single gzip stream produces a single growing output
+     * buffer per decode call). Without the handler, a 6 MiB bomb would be fully inflated into the
+     * channel queue before any cap check runs; with the handler, the pipeline fails fast after
+     * the 2nd or 3rd member. Uses {@link NettyCompressionSerializer} directly because
+     * {@link ZipCompressionBuilder} does not expose {@code decompressConcatenated}.
+     */
+    @Test
+    void handlerRejectsMidStreamOnConcatenatedGzipMembers() throws IOException {
+        final int memberSize = 1 << 20;   // 1 MiB per member
+        final int memberCount = 6;        // 6 MiB total decompressed
+        final int capBytes = 2 << 20;     // 2 MiB cap — should trip after the 2nd or 3rd member
+        final int maxChunkSize = 128 << 20;
+        final byte[] compressed = concatenatedGzipMembers(memberSize, memberCount);
+        final SerializerDeserializer<Buffer> serializer = new NettyCompressionSerializer(
+                () -> new JdkZlibEncoder(ZlibWrapper.GZIP, 6),
+                () -> new JdkZlibDecoder(ZlibWrapper.GZIP, true, maxChunkSize),
+                capBytes);
+        final Buffer src = DEFAULT_ALLOCATOR.wrap(compressed);
+
+        final BufferEncodingException ex = assertThrows(BufferEncodingException.class,
+                () -> serializer.deserialize(src, DEFAULT_ALLOCATOR));
+        assertThat(rootMessage(ex), containsString("exceeded"));
+    }
+
+    private static byte[] concatenatedGzipMembers(final int memberSize, final int memberCount) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (int i = 0; i < memberCount; i++) {
+            try (GZIPOutputStream gz = new GZIPOutputStream(out)) {
+                writeZeros(gz, memberSize);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * The convenience factories on {@link NettyCompression} must be safe-by-default — a service
+     * that drops in {@code gzipDefault()} should be protected from decompression bombs without
+     * any extra configuration. Either the per-chunk {@code maxChunkSize} guard inside
+     * {@code JdkZlibDecoder} or the cumulative {@code maxDecompressedBytes} cap is acceptable;
+     * the test only asserts that the bomb does <em>not</em> silently inflate.
+     */
+    @Test
+    void gzipDefaultRejectsBombsLargerThanDefault() throws IOException {
+        final long payloadBytes = 128L << 20;
+        final byte[] compressed = gzipBomb(payloadBytes);
+        assertThrows(BufferEncodingException.class,
+                () -> gzipDefault().deserialize(DEFAULT_ALLOCATOR.wrap(compressed), DEFAULT_ALLOCATOR));
+    }
+
+    @Test
+    void deflateDefaultRejectsBombsLargerThanDefault() throws IOException {
+        final long payloadBytes = 128L << 20;
+        final byte[] compressed = deflateBomb(payloadBytes);
+        assertThrows(BufferEncodingException.class,
+                () -> deflateDefault().deserialize(DEFAULT_ALLOCATOR.wrap(compressed), DEFAULT_ALLOCATOR));
+    }
+
+    /**
+     * Streaming intentionally ignores {@code maxDecompressedBytes}. Build the streaming
+     * serializer with a deliberately tiny cap and a wide {@code maxChunkSize}; the same payload
+     * that the aggregated path would reject must round-trip through the streaming path.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void streamingIgnoresCap(final Codec codec) throws Exception {
+        final int payloadBytes = 8 << 20;     // 8 MiB
+        final int capBytes = 1 << 20;         // 1 MiB — would reject on aggregated path
+        final byte[] compressed = codec.bomb.build(payloadBytes);
+        final StreamingSerializerDeserializer<Buffer> serializer = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                .maxDecompressedBytes(capBytes)
+                .buildStreaming();
+
+        final CompositeBuffer result = serializer.deserialize(
+                        from(DEFAULT_ALLOCATOR.wrap(compressed)), DEFAULT_ALLOCATOR)
+                .collect(DEFAULT_ALLOCATOR::newCompositeBuffer, CompositeBuffer::addBuffer)
+                .toFuture().get();
+        assertThat(result.readableBytes(), equalTo(payloadBytes));
+    }
+
+    /**
+     * Variant that targets the cumulative cap specifically: with a wide {@code maxChunkSize} the
+     * 64 MiB default is the binding limit, and the resulting exception message must mention
+     * "exceeded" to prove the cap (not the decoder's per-chunk guard) fired.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] codec = {0}")
+    @EnumSource(Codec.class)
+    void defaultBuilderCapEnforcesAt64MiB(final Codec codec) throws IOException {
+        final long payloadBytes = 80L << 20; // 80 MiB > 64 MiB default
+        final byte[] compressed = codec.bomb.build(payloadBytes);
+        // Use the builder directly with widened maxChunkSize so the only binding limit is the
+        // builder's maxDecompressedBytes default. The cap setter is intentionally NOT called.
+        final SerializerDeserializer<Buffer> serializer = codec.builder.get()
+                .maxChunkSize(TEST_MAX_CHUNK_SIZE)
+                .build();
+
+        final BufferEncodingException ex = assertThrows(BufferEncodingException.class,
+                () -> serializer.deserialize(DEFAULT_ALLOCATOR.wrap(compressed), DEFAULT_ALLOCATOR));
+        assertThat(rootMessage(ex), containsString("exceeded"));
+    }
+
+    private static String rootMessage(final Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null && cur.getCause() != cur) {
+            cur = cur.getCause();
+        }
+        return cur.getMessage() != null ? cur.getMessage() : "";
+    }
+
+    @FunctionalInterface
+    interface BombFixture {
+        byte[] build(long decompressedBytes) throws IOException;
+    }
+
+    static byte[] gzipBomb(final long decompressedBytes) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(out)) {
+            writeZeros(gz, decompressedBytes);
+        }
+        return out.toByteArray();
+    }
+
+    static byte[] deflateBomb(final long decompressedBytes) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (DeflaterOutputStream zlib = new DeflaterOutputStream(out)) {
+            writeZeros(zlib, decompressedBytes);
+        }
+        return out.toByteArray();
+    }
+
+    private static void writeZeros(final OutputStream out, final long decompressedBytes) throws IOException {
+        final byte[] chunk = new byte[64 * 1024];
+        long remaining = decompressedBytes;
+        while (remaining > 0) {
+            final int n = (int) Math.min(chunk.length, remaining);
+            out.write(chunk, 0, n);
+            remaining -= n;
+        }
+    }
+}


### PR DESCRIPTION
encoding-netty: cap cumulative decompressed size to prevent decompression-bomb DoS

Motivation:

NettyCompressionSerializer.deserialize and the deprecated NettyChannelContentCodec.decode(Buffer, BufferAllocator) inflate compressed input into a single destination buffer with no cumulative size cap. The existing maxChunkSize bounds only one inflate step inside JdkZlibDecoder, not the total decompressed output, so a small compressed payload can expand to gigabytes of memory and OOM any service that accepts client-provided gzip/deflate content. The streaming variants are protected by subscriber back-pressure.

Modifications:

Add maxDecompressedBytes(long) to ZipCompressionBuilder and the deprecated ZipContentCodecBuilder. When set to a positive value, the build()-produced serializer installs a DecompressedByteLimitHandler after the zlib decoder in the EmbeddedChannel pipeline. The handler tracks cumulative bytes across inbound chunks and throws BufferEncodingException (or CodecDecodingException on the deprecated path) as soon as the cap would be exceeded, releasing the offending ByteBuf before propagating. Netty's ByteToMessageDecoder fires decoded chunks between successive decode() calls, so the cap fires during inflate rather than after the full queue has materialized. The aggregated deserialize call surfaces the pipeline's exception via channel.checkException() and uses a new releaseOnError helper so the error path tolerates a non-empty inbound queue (the existing safeCleanup would otherwise surface an AssertionError under -ea and mask the real cause).

The default cap is 64 MiB, with a process-wide override available via the io.servicetalk.encoding.netty.maxDecompressedBytes system property (parsed once at class load by the new CompressionDefaults helper; falls back to 64 MiB on null, malformed, or negative input with a logged warning). 0 disables the cap. The cap applies to the aggregated path only; the streaming variant remains uncapped per the design intent that streaming consumers apply their own back-pressure.

Result:

NettyCompression.gzipDefault(), deflateDefault(), and the deprecated ContentCodings equivalents now reject decompression bombs by default without any caller action. Operators can raise, lower, or disable the default via the system property; per-builder configuration via .maxDecompressedBytes(long) takes precedence. Behavior change: aggregated deserialize calls that previously decompressed payloads larger than 64 MiB through a default-configured codec now throw - opt out per builder or via the system property if needed.