### PR TITLE
http-netty: check for keep-alive and close in a comma separated way

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -40,12 +40,15 @@ import static io.servicetalk.buffer.api.CharSequences.regionMatches;
 import static io.servicetalk.encoding.api.Identity.identity;
 import static io.servicetalk.encoding.api.internal.HeaderUtils.encodingFor;
 import static io.servicetalk.http.api.HttpHeaderNames.ACCEPT_ENCODING;
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.VARY;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
+import static io.servicetalk.http.api.HttpHeaderValues.KEEP_ALIVE;
 import static io.servicetalk.http.api.UriUtils.TCHAR_HMASK;
 import static io.servicetalk.http.api.UriUtils.TCHAR_LMASK;
 import static io.servicetalk.http.api.UriUtils.isBitSet;
@@ -154,6 +157,35 @@ public final class HeaderUtils {
         // As per https://tools.ietf.org/html/rfc7230#section-3.3.1 the `transfer-encoding` header may contain
         // multiple values, comma separated.
         return containsCommaSeparatedValueIgnoreCase(headers, TRANSFER_ENCODING, CHUNKED);
+    }
+
+    /**
+     * Returns {@code true} if {@code headers} contains a {@link HttpHeaderNames#CONNECTION} header whose
+     * value includes {@link HttpHeaderValues#CLOSE}.
+     * <p>
+     * The {@code Connection} header may carry multiple comma-separated values (for example
+     * {@code Connection: close, Upgrade}); this method returns {@code true} if any of them is {@code close}.
+     *
+     * @param headers The {@link HttpHeaders} to check.
+     * @return {@code true} if {@code headers} indicates {@code Connection: close}, {@code false} otherwise.
+     */
+    public static boolean isConnectionClose(final HttpHeaders headers) {
+        return containsCommaSeparatedValueIgnoreCase(headers, CONNECTION, CLOSE);
+    }
+
+    /**
+     * Returns {@code true} if {@code headers} contains a {@link HttpHeaderNames#CONNECTION} header whose
+     * value includes {@link HttpHeaderValues#KEEP_ALIVE}.
+     * <p>
+     * The {@code Connection} header may carry multiple comma-separated values (for example
+     * {@code Connection: keep-alive, Upgrade}); this method returns {@code true} if any of them is
+     * {@code keep-alive}.
+     *
+     * @param headers The {@link HttpHeaders} to check.
+     * @return {@code true} if {@code headers} indicates {@code Connection: keep-alive}, {@code false} otherwise.
+     */
+    public static boolean isConnectionKeepAlive(final HttpHeaders headers) {
+        return containsCommaSeparatedValueIgnoreCase(headers, CONNECTION, KEEP_ALIVE);
     }
 
     static boolean containsCommaSeparatedValueIgnoreCase(final HttpHeaders headers, final CharSequence name,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpKeepAlive.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpKeepAlive.java
@@ -18,6 +18,8 @@ package io.servicetalk.http.netty;
 import io.servicetalk.http.api.HttpMetaData;
 import io.servicetalk.http.api.StreamingHttpResponse;
 
+import static io.servicetalk.http.api.HeaderUtils.isConnectionClose;
+import static io.servicetalk.http.api.HeaderUtils.isConnectionKeepAlive;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpHeaderValues.KEEP_ALIVE;
@@ -39,8 +41,8 @@ enum HttpKeepAlive {
         this.shouldAddConnectionHeader = shouldAddConnectionHeader;
     }
 
-    // In the interest of performance we are not accommodating for the spec allowing multiple header fields
-    // or comma-separated values for the Connection header. See: https://tools.ietf.org/html/rfc7230#section-3.2.2
+    // Connection can be a comma-separated list (e.g. "close, Upgrade"), so use the helpers that split
+    // on commas rather than doing a whole-value match. See: https://tools.ietf.org/html/rfc7230#section-3.2.2
     static HttpKeepAlive responseKeepAlive(final HttpMetaData metaData) {
         // If multiple protocols are supported we don't know which protocol will be negotiated. Treat any major
         // protocol >= 2 the same.
@@ -49,10 +51,14 @@ enum HttpKeepAlive {
             // HTTP/2 does not use the Connection header field to indicate connection-specific header fields...
             return KEEP_ALIVE_NO_HEADER;
         } else if (HTTP_1_1.equals(metaData.version())) {
-            return metaData.headers().containsIgnoreCase(CONNECTION, CLOSE) ?
+            return isConnectionClose(metaData.headers()) ?
                     CLOSE_ADD_HEADER : KEEP_ALIVE_NO_HEADER;
         } else if (HTTP_1_0.equals(metaData.version())) {
-            return metaData.headers().containsIgnoreCase(CONNECTION, KEEP_ALIVE) ?
+            // An explicit close header takes precedence over keep-alive
+            if (isConnectionClose(metaData.headers())) {
+                return CLOSE_ADD_HEADER;
+            }
+            return isConnectionKeepAlive(metaData.headers()) ?
                     KEEP_ALIVE_ADD_HEADER : CLOSE_NO_HEADER;
         } else {
             return CLOSE_NO_HEADER;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpKeepAliveTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpKeepAliveTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.HttpMetaData;
+import io.servicetalk.http.api.HttpProtocolVersion;
+import io.servicetalk.http.api.StreamingHttpResponse;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
+import static io.servicetalk.http.netty.HttpKeepAlive.CLOSE_ADD_HEADER;
+import static io.servicetalk.http.netty.HttpKeepAlive.CLOSE_NO_HEADER;
+import static io.servicetalk.http.netty.HttpKeepAlive.KEEP_ALIVE_ADD_HEADER;
+import static io.servicetalk.http.netty.HttpKeepAlive.KEEP_ALIVE_NO_HEADER;
+import static io.servicetalk.http.netty.HttpKeepAlive.responseKeepAlive;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class HttpKeepAliveTest {
+
+    private static final DefaultHttpHeadersFactory HEADERS_FACTORY = new DefaultHttpHeadersFactory(false, false, false);
+
+    @Test
+    void http11NoConnectionHeaderIsKeepAlive() {
+        assertThat(responseKeepAlive(metaData(HTTP_1_1)), is(KEEP_ALIVE_NO_HEADER));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"close", "close, Upgrade", "Upgrade, close"})
+    void http11ConnectionWithCloseIsClose(String connectionValue) {
+        assertThat(responseKeepAlive(metaData(HTTP_1_1, connectionValue)), is(CLOSE_ADD_HEADER));
+    }
+
+    @Test
+    void http11MultipleConnectionHeadersWithCloseIsClose() {
+        HttpMetaData meta = metaData(HTTP_1_1);
+        meta.headers().add(CONNECTION, "Upgrade");
+        meta.headers().add(CONNECTION, "close");
+        assertThat(responseKeepAlive(meta), is(CLOSE_ADD_HEADER));
+    }
+
+    @Test
+    void http11ConnectionWithoutCloseIsKeepAlive() {
+        assertThat(responseKeepAlive(metaData(HTTP_1_1, "Upgrade")), is(KEEP_ALIVE_NO_HEADER));
+    }
+
+    @Test
+    void http10NoConnectionHeaderIsClose() {
+        assertThat(responseKeepAlive(metaData(HTTP_1_0)), is(CLOSE_NO_HEADER));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"close", "close, keep-alive", "keep-alive, close"})
+    void http10ConnectionWithCloseIsClose(String connectionValue) {
+        assertThat(responseKeepAlive(metaData(HTTP_1_0, connectionValue)), is(CLOSE_ADD_HEADER));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"keep-alive", "keep-alive, Upgrade", "Upgrade, keep-alive"})
+    void http10ConnectionWithKeepAliveIsKeepAlive(String connectionValue) {
+        assertThat(responseKeepAlive(metaData(HTTP_1_0, connectionValue)), is(KEEP_ALIVE_ADD_HEADER));
+    }
+
+    private static StreamingHttpResponse metaData(final HttpProtocolVersion version) {
+        return newResponse(OK, version, HEADERS_FACTORY.newHeaders(), DEFAULT_ALLOCATOR, HEADERS_FACTORY);
+    }
+
+    private static StreamingHttpResponse metaData(final HttpProtocolVersion version, final String connectionValue) {
+        StreamingHttpResponse response = metaData(version);
+        response.headers().add(CONNECTION, connectionValue);
+        return response;
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpKeepAliveTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpKeepAliveTest.java
@@ -28,6 +28,7 @@ import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
 import static io.servicetalk.http.netty.HttpKeepAlive.CLOSE_ADD_HEADER;
@@ -81,6 +82,17 @@ class HttpKeepAliveTest {
     @ValueSource(strings = {"keep-alive", "keep-alive, Upgrade", "Upgrade, keep-alive"})
     void http10ConnectionWithKeepAliveIsKeepAlive(String connectionValue) {
         assertThat(responseKeepAlive(metaData(HTTP_1_0, connectionValue)), is(KEEP_ALIVE_ADD_HEADER));
+    }
+
+    @Test
+    void http2NoConnectionHeaderIsKeepAliveNoHeader() {
+        assertThat(responseKeepAlive(metaData(HTTP_2_0)), is(KEEP_ALIVE_NO_HEADER));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"close", "keep-alive", "close, Upgrade", "keep-alive, Upgrade"})
+    void http2IgnoresConnectionHeader(String connectionValue) {
+        assertThat(responseKeepAlive(metaData(HTTP_2_0, connectionValue)), is(KEEP_ALIVE_NO_HEADER));
     }
 
     private static StreamingHttpResponse metaData(final HttpProtocolVersion version) {


### PR DESCRIPTION
 #### Motivation

Connection headers could have multiple comma separated values. We just look for exact match headers, which means we won't match headers that have been comma concatenated.

 #### Modifications

- Check within comma separated lists
- Explicitly honor the Connection: close header for HTTP/1.0 with top priority and echo the Connection: close header back to the peer.
