### PR TITLE
client-api: fix leak in DefaultClientGroup

### DIFF
--- a/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultClientGroup.java
+++ b/servicetalk-client-api/src/main/java/io/servicetalk/client/api/DefaultClientGroup.java
@@ -128,8 +128,14 @@ final class DefaultClientGroup<Key, Client extends ListenableAsyncCloseable> imp
             throw new IllegalArgumentException("Failed to create new client", t);
         }
 
-        final boolean replaced = clientMap.replace(key, PLACEHOLDER_CLIENT, client);
-        assert replaced : "Expected to replace PLACEHOLDER_CLIENT";
+        if (!clientMap.replace(key, PLACEHOLDER_CLIENT, client)) {
+            // closeAsync() drained our PLACEHOLDER reservation after our earlier `closed` check. The newly
+            // created client was never inserted into the map, so nothing else will close it.
+            assert closed : "Expected group to be closed when PLACEHOLDER_CLIENT replacement fails";
+            client.closeAsync().subscribe();
+            LOGGER.debug("Recently created client {} was closed, group {} closed before insertion", client, this);
+            throw new IllegalStateException(CLOSED_EXCEPTION_MSG);
+        }
         toSource(client.onClose()).subscribe(new RemoveClientOnClose(key, client));
         LOGGER.debug("A new client {} was created", client);
 

--- a/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultClientGroupTest.java
+++ b/servicetalk-client-api/src/test/java/io/servicetalk/client/api/DefaultClientGroupTest.java
@@ -15,11 +15,24 @@
  */
 package io.servicetalk.client.api;
 
+import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.ListenableAsyncCloseable;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static io.servicetalk.concurrent.api.AsyncCloseables.emptyAsyncCloseable;
+import static io.servicetalk.concurrent.api.Completable.completed;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DefaultClientGroupTest {
@@ -33,5 +46,60 @@ class DefaultClientGroupTest {
         assertThrows(IllegalStateException.class, () -> cg.get("foo"));
         // Ensure this doesn't hang
         assertThrows(IllegalStateException.class, () -> cg.get("foo"));
+    }
+
+    @Test
+    void clientCreatedConcurrentlyWithCloseIsClosed() throws Exception {
+        CountDownLatch factoryEntered = new CountDownLatch(1);
+        CountDownLatch releaseFactory = new CountDownLatch(1);
+        AtomicBoolean clientClosed = new AtomicBoolean();
+        ListenableAsyncCloseable client = new ListenableAsyncCloseable() {
+            @Override
+            public Completable onClose() {
+                return completed();
+            }
+
+            @Override
+            public Completable onClosing() {
+                return completed();
+            }
+
+            @Override
+            public Completable closeAsync() {
+                clientClosed.set(true);
+                return completed();
+            }
+        };
+
+        DefaultClientGroup<String, ListenableAsyncCloseable> cg = new DefaultClientGroup<>(key -> {
+            factoryEntered.countDown();
+            try {
+                releaseFactory.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
+            return client;
+        });
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<ListenableAsyncCloseable> getFuture = executor.submit(() -> cg.get("foo"));
+
+            // Wait until the creator thread is parked inside the factory
+            assertThat(factoryEntered.await(5, TimeUnit.SECONDS), is(true));
+            // Drain the group
+            cg.closeAsync().toFuture().get();
+            // Let the factory return. The creator should now close the client it just built and throw.
+            releaseFactory.countDown();
+
+            ExecutionException ee = assertThrows(ExecutionException.class,
+                    () -> getFuture.get(5, TimeUnit.SECONDS));
+            assertThat(ee.getCause(), instanceOf(IllegalStateException.class));
+            assertThat("Freshly-created client must be closed when close wins the race",
+                    clientClosed.get(), is(true));
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
 #### Motivation

If we fail to swap the sentinal for a newly created client it's because the group is closing and the cleanup has already removed it. That means we need to close the client or else it will be orphaned.

 #### Modifications

- Close the client if we fail to insert it into the map.
- Add a test.
