### PR TITLE
capacity-limiter: fix spinning bug in FixedCapacityLimiter

### DIFF
--- a/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/FixedCapacityLimiter.java
+++ b/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/FixedCapacityLimiter.java
@@ -122,6 +122,11 @@ final class FixedCapacityLimiter implements CapacityLimiter {
 
         private int release() {
             final int pending = pendingUpdater.decrementAndGet(fixedCapacityProvider);
+            if (pending < 0) {
+                LOGGER.warn("Negative pending requests detected: {}. This is a bug: please report this to the " +
+                        "ServiceTalk team. Capacity Limiter: {}", pending, fixedCapacityProvider);
+                assert pending >= 0; // so it throws when assertions are enabled and we can get a stack trace.
+            }
             fixedCapacityProvider.notifyObserver(pending);
             return max(0, fixedCapacityProvider.capacity - pending);
         }

--- a/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/FixedCapacityLimiter.java
+++ b/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/FixedCapacityLimiter.java
@@ -66,16 +66,14 @@ final class FixedCapacityLimiter implements CapacityLimiter {
         final int effectiveLimit = (capacity * priority) / 100;
         for (;;) {
             final int currPending = pending;
-            if (currPending == effectiveLimit &&
-                    pendingUpdater.compareAndSet(this, currPending, currPending)) {
+            if (currPending >= effectiveLimit) {
                 notifyObserver(currPending);
                 return null;
-            } else if (currPending < effectiveLimit) {
-                final int newPending = currPending + 1;
-                if (pendingUpdater.compareAndSet(this, currPending, newPending)) {
-                    notifyObserver(newPending);
-                    return new DefaultTicket(this, effectiveLimit - newPending, newPending);
-                }
+            }
+            final int newPending = currPending + 1;
+            if (pendingUpdater.compareAndSet(this, currPending, newPending)) {
+                notifyObserver(newPending);
+                return new DefaultTicket(this, effectiveLimit - newPending, newPending);
             }
         }
     }

--- a/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/FixedCapacityLimiterTest.java
+++ b/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/FixedCapacityLimiterTest.java
@@ -74,6 +74,24 @@ class FixedCapacityLimiterTest {
         evaluateExpectingAllow();
     }
 
+    @Test
+    void lowerPriorityAfterSaturationIsRejected() {
+        final FixedCapacityLimiter limiter = new FixedCapacityLimiter(10);
+        for (int i = 0; i < 6; i++) {
+            assertThat(limiter.tryAcquire(() -> 100, null), notNullValue());
+        }
+        // effectiveLimit for priority=50 is 5, pending=6 > 5 — must reject, not spin.
+        assertThat(limiter.tryAcquire(() -> 50, null), nullValue());
+    }
+
+    @Test
+    void zeroPriorityWhilePendingIsRejected() {
+        final FixedCapacityLimiter limiter = new FixedCapacityLimiter(10);
+        assertThat(limiter.tryAcquire(() -> 100, null), notNullValue());
+        // effectiveLimit for priority=0 is 0, pending=1 > 0 — must reject, not spin.
+        assertThat(limiter.tryAcquire(() -> 0, null), nullValue());
+    }
+
     private CapacityLimiter.Ticket evaluateExpectingAllow() {
         final CapacityLimiter.Ticket ticket = provider.tryAcquire(() -> 100, null);
         assertThat("Unexpected result, expected allow.", ticket, notNullValue());


### PR DESCRIPTION
 #### Motivation

We use a spin-loop in the tryAcquire path, and in that path we don't consider the case where our current pending is actually greater than the effective limit. This can happen when a low priority request comes in behind some higher priority requests.

 #### Modifications

- Reject that request too.
- Add a test.
