### PR TITLE
Minor touch ups on `ConnectionObserverInitializer`

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -111,6 +111,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
     @Override
     public void init(final Channel channel) {
+        assert channel.eventLoop().inEventLoop();
         channel.pipeline().addLast(new ConnectionObserverHandler(observer, connectionInfoFactory,
                 sslConfig != null, isFastOpen(channel), sslConfig));
     }
@@ -125,12 +126,13 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         private final ConnectionObserver observer;
         private final Function<Channel, ConnectionInfo> connectionInfoFactory;
         private final boolean handshakeOnActive;
+        @Nullable
+        private final SslConfig sslConfig;
+
         private boolean tcpHandshakeComplete;
         private boolean addedCloseListener;
         @Nullable
         private SecurityHandshakeObserver handshakeObserver;
-        @Nullable
-        private final SslConfig sslConfig;
 
         ConnectionObserverHandler(final ConnectionObserver observer,
                                   final Function<Channel, ConnectionInfo> connectionInfoFactory,
@@ -163,10 +165,10 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
             // a failed connect promise. We add our listener to the promise before forwarding the call so we can be
             // sure this callback is fired early in the failure pathway.
             promise.addListener((ChannelFuture future) -> {
+                assert ctx.channel().eventLoop().inEventLoop();
                 if (future.isSuccess()) {
                     maybeAddChannelClosedListener(ctx.channel());
                 } else {
-                    assert ctx.channel().eventLoop().inEventLoop();
                     addedCloseListener = true;
                     Throwable t = future.cause();
                     if (t == null) {
@@ -176,7 +178,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
                     }
                 }
             });
-            super.connect(ctx, remoteAddress, localAddress, promise);
+            ctx.connect(remoteAddress, localAddress, promise);
         }
 
         @Override
@@ -186,6 +188,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         }
 
         private void whenChannelActive(final Channel channel) {
+            assert channel.eventLoop().inEventLoop();
             maybeAddChannelClosedListener(channel);
             reportTcpHandshakeComplete(channel);
             if (handshakeOnActive) {
@@ -194,7 +197,6 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         }
 
         private void maybeAddChannelClosedListener(Channel channel) {
-            assert channel.eventLoop().inEventLoop();
             if (addedCloseListener) {
                 return;
             }


### PR DESCRIPTION
Modifications:

1. Ensure we assert event loop thread on every entry point and do not repeat it again in internal methods.
2. Use `ctx.connect(...)` instead of `super.connect(...)` to go straight to the next handler.