### PR TITLE
http-router-jersey: guard EndpointEnhancingRequestFilter against concurrent shutdown

### DIFF
--- a/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
+++ b/servicetalk-http-router-jersey/src/main/java/io/servicetalk/http/router/jersey/EndpointEnhancingRequestFilter.java
@@ -65,6 +65,7 @@ import static io.servicetalk.http.router.jersey.internal.RequestProperties.setRe
 import static java.lang.Integer.MAX_VALUE;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import static javax.ws.rs.core.Response.noContent;
 
 /**
@@ -97,7 +98,27 @@ final class EndpointEnhancingRequestFilter implements ContainerRequestFilter {
     @Override
     public void filter(final ContainerRequestContext requestCtx) {
         // If we don't have a ConnectionContext then the request isn't from ServiceTalk and need not be filtered.
-        if (ctxRefProvider.get().get() != null) {
+        final Ref<ConnectionContext> ctxRef;
+        try {
+            ctxRef = ctxRefProvider.get();
+        } catch (RuntimeException e) {
+            // HK2 ServiceLocatorImpl.shutdown() (observed through 4.0.1) deactivates request-scope contexts
+            // outside its write lock before flipping its own state to SHUTDOWN, so an in-flight request can
+            // hit two failure modes:
+            //   1) MultiException wrapping ISE("Could not find an active context for RequestScoped"),
+            //      thrown by Utilities.createService while locator state is still RUNNING.
+            //   2) Raw ISE("<locator> has been shut down"), thrown by ServiceLocatorImpl.checkState()
+            //      once state == SHUTDOWN.
+            // RequestScope.isActive is a one-way latch flipped during shutdown, so it is the authoritative
+            // signal that we are racing against locator teardown — it covers both windows. If false, abort
+            // with 503; otherwise re-throw, the failure was unrelated.
+            if (!requestScope.isActive()) {
+                requestCtx.abortWith(Response.status(SERVICE_UNAVAILABLE).build());
+                return;
+            }
+            throw e;
+        }
+        if (ctxRef.get() != null) {
             enhancedEndpointCache.enhance(requestScope, ctxRefProvider, routeStrategiesConfigProvider,
                     (UriRoutingContext) requestCtx.getUriInfo());
         }

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/BaseJerseyRouterTestSuite.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/BaseJerseyRouterTestSuite.java
@@ -43,7 +43,10 @@ import org.junit.platform.suite.api.SuiteDisplayName;
         MixedModeResourceTest.class,
 
         // AsyncContext
-        AsyncContextTest.class
+        AsyncContextTest.class,
+
+        // Shutdown-race reproducer
+        RouterConcurrentShutdownTest.class
 })
 public abstract class BaseJerseyRouterTestSuite {
     // NOOP

--- a/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/RouterConcurrentShutdownTest.java
+++ b/servicetalk-http-router-jersey/src/testFixtures/java/io/servicetalk/http/router/jersey/RouterConcurrentShutdownTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.router.jersey;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.transport.api.IoExecutor;
+
+import org.glassfish.jersey.process.internal.RequestScope;
+import org.glassfish.jersey.server.ApplicationHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import javax.annotation.Nullable;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static java.net.InetSocketAddress.createUnresolved;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Reproducer for the HK2 shutdown race that causes {@link EndpointEnhancingRequestFilter} to throw an
+ * internal exception when an in-flight request lands during {@code ServiceLocatorImpl.shutdown()}.
+ * Two distinct windows are exercised:
+ * <ol>
+ *   <li>{@link ScopeDeactivatingFilter} — request scope deactivated, locator state still {@code RUNNING}.
+ *       {@code ctxRefProvider.get()} resolves into {@code Utilities.createService}, which throws
+ *       {@code MultiException} wrapping {@code IllegalStateException("Could not find an active context for
+ *       RequestScoped")}.</li>
+ *   <li>{@link LocatorShutdownFilter} — entire HK2 locator shut down, state {@code SHUTDOWN}.
+ *       {@code ctxRefProvider.get()} fails the {@code checkState()} guard and throws a raw
+ *       {@code IllegalStateException("<locator> has been shut down")}, not wrapped in any
+ *       {@code MultiException}.</li>
+ * </ol>
+ * Both must be coalesced into a graceful 503 by {@link EndpointEnhancingRequestFilter}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RouterConcurrentShutdownTest {
+
+    private static final StreamingHttpRequestResponseFactory REQ_RES_FACTORY =
+            new DefaultStreamingHttpRequestResponseFactory(DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE,
+                    HTTP_1_1);
+
+    @Mock
+    private HttpServiceContext ctx;
+
+    /**
+     * Runs before {@link EndpointEnhancingRequestFilter} ({@code @Priority(MAX_VALUE)}) and calls
+     * {@code requestScope.shutdown()} to set {@code isActive = false} while the locator is still alive.
+     * Reproduces the pre-state-flip window where HK2 wraps the failure in a {@code MultiException}.
+     */
+    public static final class ScopeDeactivatingFilter implements ContainerRequestFilter {
+        @Context
+        private RequestScope requestScope;
+
+        @Override
+        public void filter(ContainerRequestContext requestCtx) {
+            requestScope.shutdown();
+        }
+    }
+
+    /**
+     * Runs before {@link EndpointEnhancingRequestFilter} and shuts down the entire HK2 service locator
+     * via {@code InjectionManager.shutdown()}. After this returns, the locator's state is
+     * {@code SHUTDOWN} so subsequent service lookups fail at {@code ServiceLocatorImpl.checkState()}
+     * with a raw, unwrapped {@code IllegalStateException}.
+     */
+    public static final class LocatorShutdownFilter implements ContainerRequestFilter {
+        @Context
+        private ApplicationHandler applicationHandler;
+
+        @Override
+        public void filter(ContainerRequestContext requestCtx) {
+            applicationHandler.getInjectionManager().shutdown();
+        }
+    }
+
+    @Path("/ping")
+    @Produces(MediaType.TEXT_PLAIN)
+    public static final class PingResource {
+        @GET
+        public String ping() {
+            return "pong";
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        final HttpExecutionContext execCtx = mock(HttpExecutionContext.class);
+        when(ctx.executionContext()).thenReturn(execCtx);
+        when(ctx.localAddress()).thenReturn(createUnresolved("localhost", 8080));
+        when(execCtx.bufferAllocator()).thenReturn(DEFAULT_ALLOCATOR);
+        when(execCtx.ioExecutor()).thenReturn(mock(IoExecutor.class));
+        when(execCtx.executionStrategy()).thenReturn(defaultStrategy());
+    }
+
+    @Test
+    void requestScopedContextSurvivesConcurrentShutdown() throws Exception {
+        assertGracefullyAborted(buildRouter(ScopeDeactivatingFilter.class));
+    }
+
+    @Test
+    void requestSurvivesPostLocatorShutdown() throws Exception {
+        assertGracefullyAborted(buildRouter(LocatorShutdownFilter.class));
+    }
+
+    private StreamingHttpService buildRouter(final Class<? extends ContainerRequestFilter> raceFilter) {
+        return new HttpJerseyRouterBuilder().buildStreaming(new Application() {
+            @Override
+            public Set<Class<?>> getClasses() {
+                return new HashSet<>(asList(raceFilter, PingResource.class));
+            }
+        });
+    }
+
+    private void assertGracefullyAborted(final StreamingHttpService router) throws Exception {
+        final StreamingHttpRequest req = REQ_RES_FACTORY.get("/ping");
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Throwable[] error = new Throwable[1];
+        final StreamingHttpResponse[] response = new StreamingHttpResponse[1];
+
+        toSource(router.handle(ctx, req, REQ_RES_FACTORY)).subscribe(
+                new SingleSource.Subscriber<StreamingHttpResponse>() {
+                    @Override
+                    public void onSubscribe(Cancellable cancellable) {
+                    }
+
+                    @Override
+                    public void onSuccess(@Nullable StreamingHttpResponse result) {
+                        response[0] = result;
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        error[0] = t;
+                        latch.countDown();
+                    }
+                });
+
+        assertTrue(latch.await(5, SECONDS), "Timed out waiting for a response");
+        assertThat("Concurrent shutdown must not leak an internal exception to the caller",
+                error[0], nullValue());
+        assertThat("Request during concurrent shutdown must be rejected with 503 Service Unavailable",
+                response[0].status(), is(SERVICE_UNAVAILABLE));
+    }
+}


### PR DESCRIPTION
### Motivation

HK2's ServiceLocatorImpl.shutdown() calls context.shutdown() (which sets
RequestScope.isActive = false) outside its write lock, then re-acquires
the lock to set state = SHUTDOWN. In that window, an in-flight request
reaching EndpointEnhancingRequestFilter causes HK2 to throw:

```
  IllegalStateException: Could not find an active context for
      org.glassfish.jersey.process.internal.RequestScoped
```

HK2 wraps this in a MultiException (via Utilities.createService()) before
it reaches the filter. This is a known HK2 design trade-off (observed through
4.0.1): context shutdown is done intentionally outside the write lock to avoid
deadlocks, leaving a window where the scope is inactive but the locator is not
yet fully shut down. The workaround must live in ServiceTalk permanently.

### Modifications

- EndpointEnhancingRequestFilter.filter(): catch MultiException around
  ctxRefProvider.get() — the actual exception HK2 throws in this window —
  and abort with 503 Service Unavailable if requestScope.isActive() is false.
  RequestScope.isActive is a one-way latch so if it is false in the catch
  the exception was caused by the shutdown race; otherwise re-throw.
- Add RouterConcurrentShutdownTest reproducing the exact production exception
  and asserting a graceful 503 response.
- Wire RouterConcurrentShutdownTest into BaseJerseyRouterTestSuite.

### Result

Requests during concurrent shutdown receive a 503 instead of propagating
an internal HK2 MultiException.