### PR TITLE
capacity-limiter: AIMD and Gradient should ignore unclassified failures

### DIFF
--- a/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/AimdCapacityLimiter.java
+++ b/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/AimdCapacityLimiter.java
@@ -234,8 +234,10 @@ final class AimdCapacityLimiter implements CapacityLimiter {
 
         @Override
         public int failed(Throwable __) {
-            completed();
-            return UNSUPPORTED;
+            // Only react to explicit drop signals and the classification of failures can be configured via the
+            // resilience filters. Unclassified failures are ambiguous — they may indicate overload, application bugs,
+            // or transport faults — so we leave the limit untouched.
+            return ignored();
         }
 
         @Override

--- a/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiter.java
+++ b/servicetalk-capacity-limiter-api/src/main/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiter.java
@@ -305,7 +305,10 @@ final class GradientCapacityLimiter implements CapacityLimiter {
 
         @Override
         public int failed(Throwable __) {
-            return provider.onDrop();
+            // Only react to explicit drop signals and the classification of failures can be configured via the
+            // resilience filters. Unclassified failures are ambiguous — they may indicate overload, application bugs,
+            // or transport faults — so we leave the limit untouched.
+            return provider.onIgnore();
         }
 
         @Override

--- a/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/AimdCapacityLimiterTest.java
+++ b/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/AimdCapacityLimiterTest.java
@@ -88,6 +88,28 @@ class AimdCapacityLimiterTest {
     }
 
     @Test
+    void failedDoesNotChangeLimit() {
+        CapacityLimiter capacityLimiter = CapacityLimiters.dynamicAIMD()
+                .limits(2, 2, 4)
+                .increment(1f)
+                .cooldown(Duration.ZERO)
+                .backoffRatio(.9f, .2f)
+                .build();
+
+        // Drive a handful of failed() releases — none should grow or shrink the limit.
+        for (int i = 0; i < 10; i++) {
+            CapacityLimiter.Ticket ticket = capacityLimiter.tryAcquire(DEFAULT, null);
+            assertThat(ticket, notNullValue());
+            ticket.failed(new Exception("boom"));
+        }
+
+        // Limit is still 2: acquire two, the third must be rejected.
+        assertThat(capacityLimiter.tryAcquire(DEFAULT, null), notNullValue());
+        assertThat(capacityLimiter.tryAcquire(DEFAULT, null), notNullValue());
+        assertThat(capacityLimiter.tryAcquire(DEFAULT, null), nullValue());
+    }
+
+    @Test
     void concurrentEvaluation() throws InterruptedException {
         final CapacityLimiter capacityLimiter = CapacityLimiters.dynamicAIMD()
                 .limits(70, 70, 120)

--- a/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterTest.java
+++ b/servicetalk-capacity-limiter-api/src/test/java/io/servicetalk/capacity/limiter/api/GradientCapacityLimiterTest.java
@@ -37,8 +37,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class GradientCapacityLimiterTest {
 
-    private static final Exception SAD_EXCEPTION = new Exception("sad");
-
     private static final Classification DEFAULT = () -> 0;
 
     private final Observer observer = mock(Observer.class);
@@ -71,7 +69,7 @@ class GradientCapacityLimiterTest {
             CapacityLimiter.Ticket ticket = capacityLimiter.tryAcquire(DEFAULT, null);
             assertThat(ticket, is(notNullValue()));
             currentTime.addAndGet(Duration.ofMillis(10).toNanos());
-            int capacity = ticket.failed(SAD_EXCEPTION);
+            int capacity = ticket.dropped();
             if (capacity == DEFAULT_MIN_LIMIT) {
                 break;
             }
@@ -105,9 +103,9 @@ class GradientCapacityLimiterTest {
         CapacityLimiter.Ticket ticket = capacityLimiter.tryAcquire(DEFAULT, null);
         assertThat(ticket, is(notNullValue()));
         currentTime.addAndGet(Duration.ofMillis(10).toNanos());
-        ticket.failed(SAD_EXCEPTION);
+        ticket.dropped();
 
-        // ticket failure will not use gradient
+        // ticket drop will not use gradient
         verify(observer).onLimitChange(eq(-1.0), eq(-1.0), eq(-1.0), eq(100.0), eq(50.0));
 
         ticket = capacityLimiter.tryAcquire(DEFAULT, null);
@@ -116,5 +114,19 @@ class GradientCapacityLimiterTest {
         // Ticket success should adjust observation upward.
         ticket.completed();
         verify(observer).onLimitChange(not(eq(-1.0)), not(eq(-1.0)), not(eq(-1.0)), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void failedTicketDoesNotChangeLimit() {
+        CapacityLimiter.Ticket ticket = capacityLimiter.tryAcquire(DEFAULT, null);
+        assertThat(ticket, is(notNullValue()));
+        verify(observer).onActiveRequestsIncr();
+        currentTime.addAndGet(Duration.ofMillis(10).toNanos());
+
+        ticket.failed(new Exception("sad"));
+
+        // failed() must release the slot but leave the limit untouched (no onLimitChange).
+        verify(observer).onActiveRequestsDecr();
+        verifyNoMoreInteractions(observer);
     }
 }


### PR DESCRIPTION
 #### Motivation

We have configuration and a default that explicitly classifies failures into either a dropped (RequestDroppedException or TimeoutException) or otherwise send it to the failed classification. If we haven't classified the failure, then we don't actually know what it means and it should be dropped.

 #### Modifications

- Switch both Gradient and AIMD limiters to ignore unclassified failures.
