### PR TITLE
http-netty: use a default other than Integer.MAX_VALUE for server MAX_CONCURRENT_STREAMS

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2SettingsBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/Http2SettingsBuilder.java
@@ -25,6 +25,28 @@ import static java.lang.Integer.toHexString;
 /**
  * Builder to help create a {@link Map} for
  * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.1">HTTP/2 Setting</a>.
+ * <p>
+ * Some default values deviate from the
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">RFC 7540 §6.5.2</a> initial values to
+ * impose safer resource ceilings on peers.
+ * <p>
+ * Applied to both clients and servers:
+ * <ul>
+ *   <li>{@code SETTINGS_INITIAL_WINDOW_SIZE}: 1 MiB (RFC: 65535 bytes).</li>
+ *   <li>{@code SETTINGS_MAX_HEADER_LIST_SIZE}: 32 KiB (RFC: unlimited).</li>
+ * </ul>
+ * Applied to clients only:
+ * <ul>
+ *   <li>{@code SETTINGS_MAX_CONCURRENT_STREAMS}: when the server does not advertise this setting, the
+ *       client transport assumes {@code 100} as a per-connection cap rather than treating the peer as
+ *       unbounded. Not configurable through this builder.</li>
+ * </ul>
+ * Applied to servers only:
+ * <ul>
+ *   <li>{@code SETTINGS_MAX_CONCURRENT_STREAMS}: {@code 100} (RFC: unbounded). Applied by the server
+ *       transport when {@link #maxConcurrentStreams(long)} was not called, so
+ *       {@link Http2Settings#maxConcurrentStreams()} may still return {@code null} on the built settings.</li>
+ * </ul>
  */
 public final class Http2SettingsBuilder {
     private static final long MAX_UNSIGNED_INT = 0xffffffffL;
@@ -98,6 +120,10 @@ public final class Http2SettingsBuilder {
     /**
      * Set the value for
      * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_CONCURRENT_STREAMS</a>.
+     * <p>
+     * See the class-level javadoc for the default applied by the server transport when this is not set.
+     * Clients always advertise {@code 0} regardless of the value configured here (server push is not
+     * supported).
      *
      * @param value The value.
      * @return {@code this}.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -33,6 +33,16 @@ import javax.annotation.Nullable;
 import static io.servicetalk.logging.slf4j.internal.Slf4jFixedLevelLoggers.newLogger;
 
 final class H2ServerParentChannelInitializer implements ChannelInitializer {
+    /**
+     * Default advertised {@code SETTINGS_MAX_CONCURRENT_STREAMS} when the user has not configured a value.
+     * RFC 7540 §6.5.2 leaves this setting unbounded when absent; without an advertised cap a peer may open
+     * effectively unbounded streams per connection. Using a value of 100 matches Netty's
+     * {@code Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS} (RFC 7540 §5.1.2 recommended minimum) and the
+     * value the ServiceTalk client assumes when a peer does not advertise this setting — keeping server and
+     * client defaults symmetric.
+     */
+    private static final long DEFAULT_MAX_CONCURRENT_STREAMS = 100L;
+
     private final H2ProtocolConfig config;
     private final io.netty.channel.ChannelInitializer<Http2StreamChannel> streamChannelInitializer;
     private final io.netty.handler.codec.http2.Http2Settings nettySettings;
@@ -43,7 +53,11 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
         this.config = config;
         this.streamChannelInitializer = streamChannelInitializer;
         final Http2Settings h2Settings = config.initialSettings();
-        nettySettings = toNettySettings(h2Settings);
+        final io.netty.handler.codec.http2.Http2Settings translated = toNettySettings(h2Settings);
+        if (h2Settings.maxConcurrentStreams() == null) {
+            translated.maxConcurrentStreams(DEFAULT_MAX_CONCURRENT_STREAMS);
+        }
+        nettySettings = translated;
     }
 
     @Override

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -27,12 +27,17 @@ import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2StreamChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 import static io.servicetalk.logging.slf4j.internal.Slf4jFixedLevelLoggers.newLogger;
+import static java.lang.Long.getLong;
 
 final class H2ServerParentChannelInitializer implements ChannelInitializer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(H2ServerParentChannelInitializer.class);
+
     /**
      * Default advertised {@code SETTINGS_MAX_CONCURRENT_STREAMS} when the user has not configured a value.
      * RFC 7540 §6.5.2 leaves this setting unbounded when absent; without an advertised cap a peer may open
@@ -41,7 +46,22 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
      * value the ServiceTalk client assumes when a peer does not advertise this setting — keeping server and
      * client defaults symmetric.
      */
-    private static final long DEFAULT_MAX_CONCURRENT_STREAMS = 100L;
+    private static final long DEFAULT_MAX_CONCURRENT_STREAMS_VALUE = 100L;
+
+    // FIXME: 0.43 - remove this temporary property
+    static final String DEFAULT_MAX_CONCURRENT_STREAMS_PROPERTY =
+            "io.servicetalk.http.netty.defaultH2ServerMaxConcurrentStreams";
+    static final long DEFAULT_MAX_CONCURRENT_STREAMS =
+            getLong(DEFAULT_MAX_CONCURRENT_STREAMS_PROPERTY, DEFAULT_MAX_CONCURRENT_STREAMS_VALUE);
+
+    static {
+        if (DEFAULT_MAX_CONCURRENT_STREAMS != DEFAULT_MAX_CONCURRENT_STREAMS_VALUE) {
+            LOGGER.warn("-D{}: {}. This property will be removed in future releases. " +
+                            "Configure this value via H2ProtocolConfigBuilder#initialSettings(Http2Settings) with " +
+                            "Http2SettingsBuilder#maxConcurrentStreams(long) instead.",
+                    DEFAULT_MAX_CONCURRENT_STREAMS_PROPERTY, DEFAULT_MAX_CONCURRENT_STREAMS);
+        }
+    }
 
     private final H2ProtocolConfig config;
     private final io.netty.channel.ChannelInitializer<Http2StreamChannel> streamChannelInitializer;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ServerDefaultMaxConcurrentStreamsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ServerDefaultMaxConcurrentStreamsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.http.api.HttpClient;
+import io.servicetalk.http.api.HttpResponse;
+import io.servicetalk.http.api.HttpServerContext;
+import io.servicetalk.http.api.ReservedHttpConnection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
+import static io.servicetalk.http.netty.AbstractStreamingHttpConnection.MAX_CONCURRENCY_NO_OFFLOADING;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class H2ServerDefaultMaxConcurrentStreamsTest {
+
+    @Test
+    void serverAdvertisesDefaultMaxConcurrentStreamsWhenUnset() throws Exception {
+        // Explicitly do NOT call maxConcurrentStreams() on the H2 settings — exercise the server-side default
+        // applied by H2ServerParentChannelInitializer.
+        try (HttpServerContext serverContext = HttpServers.forAddress(localAddress(0))
+                .protocols(HttpProtocol.HTTP_2.config)
+                .listenBlockingAndAwait((ctx, request, responseFactory) -> responseFactory.ok());
+             HttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                     .protocols(HttpProtocol.HTTP_2.config)
+                     .build()) {
+
+            BlockingQueue<Integer> maxConcurrentStreams = new LinkedBlockingDeque<>();
+            try (ReservedHttpConnection connection = client.reserveConnection(client.get("/")).map(conn -> {
+                // We should avoid racy behavior because the max concurrency event streams are set to replay the last
+                // message they observed to new subscribers.
+                conn.transportEventStream(MAX_CONCURRENCY_NO_OFFLOADING)
+                        .forEach(event -> maxConcurrentStreams.add(event.event()));
+                return conn;
+            }).toFuture().get()) {
+                // In some cases preface and initial settings won't be sent until after we make the first request.
+                HttpResponse response = connection.request(connection.get("/")).toFuture().get();
+                assertThat(response.status(), is(OK));
+
+                while (maxConcurrentStreams.take() != 100) {
+                    // we spin until we get the value we expect, or the test times out.
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
 #### Motivation

It's a bit rough for a server to truly handle Integer.MAX_VALUE concurrent streams and can be a DoS vector.

 #### Modifications

- Set a reasonable default of 100. This matches the client default behavior of assuming a value of 100 if none is sent.
- Improve the documentation.
