### PR TITLE
http-netty: more SSL cache improvements

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/StreamingConnectionFactory.java
@@ -91,31 +91,50 @@ final class StreamingConnectionFactory {
             final InetAddress inetAddress = socketAddress.getAddress();
             final String sniHostname = sslConfig.sniHostname();
             final String peerHost = sslConfig.peerHost();
+            final String origHostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
             final String newPeerHost;
             final String newSniHostname;
             final String hostnameVerificationAlgorithm;
+            // We want to bundle the resolved IP into peerHost so the SSLSession cache key differentiates per-IP and
+            // hits the right cached session when a hostname resolves to multiple IPs. JSSE's endpoint identification
+            // would normally validate the cert against peerHost, which would fail once we mangle it. The trick is
+            // that JSSE prefers the SNI name (from SSLParameters.serverNames) over peerHost for verification — so
+            // when we have a name that's valid as an SNI hostname, we smuggle the real name through SNI and let
+            // peerHost carry a cache-friendly value.
             if (sniHostname == null) {
                 if (peerHost == null) {
                     newPeerHost = toHostAddress(inetAddress);
                     newSniHostname = null;
+                    // No hostname info at all — reset the algorithm to "" so Netty 4.2's "HTTPS" default doesn't
+                    // attempt (and fail) verification against the IP literal we just stuffed into peerHost.
                     hostnameVerificationAlgorithm = "";
                 } else {
-                    newPeerHost = toHostAndIpBundle(peerHost, inetAddress);
-                    // We are overriding the peerHost to make it qualified with the resolved address. If sniHostname is
-                    // not set and the hostnameVerificationAlgorithm is set, the SSLEngine will take the peerHost value
-                    // for validation, which will fail to match now that we have changed the value.
-                    if (isValidSniHostname(peerHost)) {
-                        newSniHostname = peerHost;
-                        hostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
+                    // SNIHostName rejects trailing-dot FQDNs; strip so we can still smuggle absolute names via SNI.
+                    final String peerHostForSni = stripTrailingDot(peerHost);
+                    if (isValidSniHostname(peerHostForSni)) {
+                        // Smuggle peerHost through SNI for verification; peerHost is free to be mangled for cache.
+                        newPeerHost = toHostAndIpBundle(peerHostForSni, inetAddress);
+                        newSniHostname = peerHostForSni;
+                        hostnameVerificationAlgorithm = origHostnameVerificationAlgorithm;
+                    } else if (origHostnameVerificationAlgorithm != null &&
+                            !origHostnameVerificationAlgorithm.isEmpty()) {
+                        // Verification required and we can't smuggle the hostname via SNI, so we can't widen
+                        // peerHost to make the cache happy.
+                        newPeerHost = peerHost;
+                        newSniHostname = null;
+                        hostnameVerificationAlgorithm = origHostnameVerificationAlgorithm;
                     } else {
+                        // No verification requested — mangle freely, nothing to validate against.
+                        newPeerHost = toHostAndIpBundle(peerHost, inetAddress);
                         newSniHostname = null;
                         hostnameVerificationAlgorithm = "";
                     }
                 }
             } else {
+                // SNI is set; verification reads it, peerHost is free to be mangled.
                 newPeerHost = toHostAndIpBundle(sniHostname, inetAddress);
                 newSniHostname = sniHostname;
-                hostnameVerificationAlgorithm = sslConfig.hostnameVerificationAlgorithm();
+                hostnameVerificationAlgorithm = origHostnameVerificationAlgorithm;
             }
 
             return config.withSslConfigPeerHost(newPeerHost, socketAddress.getPort(), newSniHostname,
@@ -149,5 +168,10 @@ final class StreamingConnectionFactory {
         } catch (Throwable cause) {
             return false;
         }
+    }
+
+    private static String stripTrailingDot(String hostname) {
+        final int len = hostname.length();
+        return len > 1 && hostname.charAt(len - 1) == '.' ? hostname.substring(0, len - 1) : hostname;
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingConnectionFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/StreamingConnectionFactoryTest.java
@@ -15,20 +15,28 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.tcp.netty.internal.ReadOnlyTcpClientConfig;
+import io.servicetalk.tcp.netty.internal.TcpClientConfig;
+import io.servicetalk.transport.api.ClientSslConfig;
+import io.servicetalk.transport.api.ClientSslConfigBuilder;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.util.Enumeration;
 import java.util.stream.Stream;
 
 import static io.servicetalk.http.netty.StreamingConnectionFactory.toHostAndIpBundle;
+import static io.servicetalk.http.netty.StreamingConnectionFactory.withSslConfigPeerHost;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
@@ -82,5 +90,77 @@ class StreamingConnectionFactoryTest {
         assertThat(toHostAndIpBundle("192.168.1.1", loopbackAddress), is(equalTo("192.168.1.1")));
         assertThat(toHostAndIpBundle("::1", loopbackAddress), is(equalTo("::1")));
         assertThat(toHostAndIpBundle("2001:db8:0:1::1/64", loopbackAddress), is(equalTo("2001:db8:0:1::1/64")));
+    }
+
+    @Test
+    void trailingDotPeerHostIsSmuggledViaSniAndPeerHostIsMangled() throws Exception {
+        ClientSslConfig result = withSslConfig(
+                new ClientSslConfigBuilder().peerHost("example.com.").build(),
+                inetSocketAddress(new byte[] {1, 2, 3, 4}, 443));
+
+        // SNIHostName rejects trailing-dot FQDNs, so we strip it before smuggling.
+        assertThat(result.sniHostname(), is(equalTo("example.com")));
+        assertThat(result.peerHost(), is(equalTo("example.com-1.2.3.4")));
+        assertThat(result.hostnameVerificationAlgorithm(), equalTo("HTTPS"));
+    }
+
+    @Test
+    void regularPeerHostIsSmuggledViaSniAndPeerHostIsMangled() throws Exception {
+        ClientSslConfig result = withSslConfig(
+                new ClientSslConfigBuilder().peerHost("example.com").build(),
+                inetSocketAddress(new byte[] {1, 2, 3, 4}, 443));
+
+        assertThat(result.sniHostname(), is(equalTo("example.com")));
+        assertThat(result.peerHost(), is(equalTo("example.com-1.2.3.4")));
+    }
+
+    @Test
+    void sniInvalidPeerHostWithVerificationPreservesPeerHost() throws Exception {
+        // Underscore makes the name invalid for SNI, so we cannot smuggle it. With verification enabled, mangling
+        // peerHost would silently break verification — so we sacrifice the cache-key widening instead.
+        ClientSslConfig result = withSslConfig(
+                new ClientSslConfigBuilder().peerHost("under_score.example").build(),
+                inetSocketAddress(new byte[] {1, 2, 3, 4}, 443));
+
+        assertThat(result.sniHostname(), is(nullValue()));
+        assertThat(result.peerHost(), is(equalTo("under_score.example")));
+        assertThat(result.hostnameVerificationAlgorithm(), equalTo("HTTPS"));
+    }
+
+    @Test
+    void sniInvalidPeerHostWithoutVerificationIsMangled() throws Exception {
+        ClientSslConfig result = withSslConfig(
+                new ClientSslConfigBuilder()
+                        .peerHost("under_score.example")
+                        .hostnameVerificationAlgorithm("")
+                        .build(),
+                inetSocketAddress(new byte[] {1, 2, 3, 4}, 443));
+
+        assertThat(result.sniHostname(), is(nullValue()));
+        assertThat(result.peerHost(), is(equalTo("under_score.example-1.2.3.4")));
+        assertThat(result.hostnameVerificationAlgorithm(), is(equalTo("")));
+    }
+
+    @Test
+    void noPeerHostNoSniResetsVerificationAlgorithmToEmpty() throws Exception {
+        // Algorithm is reset to "" so Netty 4.2's "HTTPS" default doesn't try to verify against the IP literal.
+        ClientSslConfig result = withSslConfig(
+                new ClientSslConfigBuilder().build(),
+                inetSocketAddress(new byte[] {1, 2, 3, 4}, 443));
+
+        assertThat(result.sniHostname(), is(nullValue()));
+        assertThat(result.peerHost(), is(equalTo("1.2.3.4")));
+        assertThat(result.hostnameVerificationAlgorithm(), is(equalTo("")));
+    }
+
+    private static ClientSslConfig withSslConfig(ClientSslConfig sslConfig, InetSocketAddress resolved) {
+        TcpClientConfig tcpConfig = new TcpClientConfig();
+        tcpConfig.sslConfig(sslConfig);
+        ReadOnlyTcpClientConfig result = withSslConfigPeerHost(resolved, tcpConfig.asReadOnly());
+        return result.sslConfig();
+    }
+
+    private static InetSocketAddress inetSocketAddress(byte[] addr, int port) throws Exception {
+        return new InetSocketAddress(InetAddress.getByAddress(addr), port);
     }
 }


### PR DESCRIPTION
 #### Motivation

We want to make sure we get as many cache hits as we can while still honoring the right hostname validation.

 #### Modifications

Make sure if validation is required, we do so, even if it costs us cache hits.

