### PR TITLE
http-netty: cleanup the rules for whether a message can have a body/CL header

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -51,7 +51,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h2HeadersSanitizeForH1;
 import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
-import static io.servicetalk.http.netty.HeaderUtils.responseMayHaveContent;
+import static io.servicetalk.http.netty.HeaderUtils.responseMayHaveContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.serverMaySendPayloadBodyFor;
 
 final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
@@ -200,7 +200,7 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 if (serverMaySendPayloadBodyFor(statusCode, method) && fullResponse) {
                     h2Headers.set(CONTENT_LENGTH, ZERO);
                 }
-            } else if (!responseMayHaveContent(statusCode, method)) {
+            } else if (!responseMayHaveContentLength(statusCode, method)) {
                 throw protocolError(ctx, streamId, fullResponse, "content-length (" + h2Headers.get(CONTENT_LENGTH) +
                         ") header is not expected for status code " + statusCode + " in response to " + method.name() +
                         " request");

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -58,6 +58,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.PATCH;
 import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.api.HttpRequestMethod.PUT;
 import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
+import static io.servicetalk.http.api.HttpResponseStatus.NOT_MODIFIED;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATIONAL_1XX;
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
@@ -102,7 +103,11 @@ final class HeaderUtils {
 
     static boolean canAddResponseContentLength(final StreamingHttpResponse response,
                                                final HttpRequestMethod requestMethod) {
-        return canAddContentLength(response) && serverMaySendPayloadBodyFor(response.status().code(), requestMethod);
+        // Body-derived auto-CL only applies when a body is allowed. For body-forbidden responses
+        // (HEAD, 1xx, 204, 304, 2xx-CONNECT), CL=0 from an empty payload publisher would be
+        // fabricated (e.g. HEAD's CL should mirror GET's, not be 0).
+        return canAddContentLength(response) &&
+                serverMaySendPayloadBodyFor(response.status().code(), requestMethod);
     }
 
     static boolean clientMaySendPayloadBodyFor(final HttpRequestMethod requestMethod) {
@@ -111,10 +116,47 @@ final class HeaderUtils {
         return !TRACE.equals(requestMethod);
     }
 
+    /**
+     * Whether RFC framing rules permit a message body in this response.
+     * <p>
+     * False for HEAD requests and for status codes 1xx, 204, and 304, plus 2xx responses to CONNECT.
+     * <p>
+     * Used to gate framework auto-derivation of framing (CL from an aggregated payload, or
+     * {@code TE: chunked} from a streaming payload). Even though RFC 7230 §3.3.1 permits a
+     * server to send {@code Transfer-Encoding} on a 304/HEAD as a projection of what GET would
+     * have applied, ServiceTalk doesn't know what coding GET would use, so auto-fabricating it
+     * is meaningless.
+     * <p>
+     * See {@link #responseMayHaveContentLength} for the distinct CL-permitted question: HEAD and
+     * 304 forbid bodies but permit {@code Content-Length} (and {@code Transfer-Encoding}, by the
+     * same RFC).
+     */
     static boolean serverMaySendPayloadBodyFor(final int statusCode, final HttpRequestMethod requestMethod) {
-        // (for HEAD) the server MUST NOT send a message body in the response.
+        // A server MUST NOT send a message body in a HEAD response.
         // https://tools.ietf.org/html/rfc7231#section-4.3.2
-        return !HEAD.equals(requestMethod) && !isEmptyResponseStatus(statusCode)
+        // A server MUST NOT send a message body in a 1xx (Informational), 204 (No Content), or
+        // 304 (Not Modified) response. https://tools.ietf.org/html/rfc7230#section-3.3.3
+        return !HEAD.equals(requestMethod)
+                && !INFORMATIONAL_1XX.contains(statusCode)
+                && statusCode != NO_CONTENT.code()
+                && statusCode != NOT_MODIFIED.code()
+                && !isEmptyConnectResponse(requestMethod, statusCode);
+    }
+
+    /**
+     * Whether RFC framing rules permit a {@code Content-Length} header on this response.
+     * <p>
+     * False only for 1xx, 204, and 2xx responses to CONNECT. Notably 304 and HEAD permit CL:
+     * both are body-forbidden but CL is permitted (and meaningful). See
+     * {@link #serverMaySendPayloadBodyFor} for the body-allowed question.
+     */
+    static boolean responseMayHaveContentLength(final int statusCode,
+                                                final HttpRequestMethod requestMethod) {
+        // A server MUST NOT send a Content-Length header field in any response with a status code
+        // of 1xx (Informational) or 204 (No Content).
+        // https://tools.ietf.org/html/rfc7230#section-3.3.2
+        return !INFORMATIONAL_1XX.contains(statusCode)
+                && statusCode != NO_CONTENT.code()
                 && !isEmptyConnectResponse(requestMethod, statusCode);
     }
 
@@ -165,11 +207,6 @@ final class HeaderUtils {
         // payload body and the method semantics do not anticipate such a body.
         // https://tools.ietf.org/html/rfc7230#section-3.3.2
         return POST.equals(requestMethod) || PUT.equals(requestMethod) || PATCH.equals(requestMethod);
-    }
-
-    static boolean responseMayHaveContent(final int statusCode,
-                                          final HttpRequestMethod requestMethod) {
-        return !isEmptyResponseStatus(statusCode) && !isEmptyConnectResponse(requestMethod, statusCode);
     }
 
     static ScanMapper<Object, Object> appendTrailersMapper() {
@@ -339,6 +376,7 @@ final class HeaderUtils {
 
     static void addResponseTransferEncodingIfNecessary(final StreamingHttpResponse response,
                                                        final HttpRequestMethod requestMethod) {
+        // We can only add TE: chunked if we can actually send a payload.
         if (serverMaySendPayloadBodyFor(response.status().code(), requestMethod) &&
                 canAddTransferEncodingChunked(response)) {
             response.headers().add(TRANSFER_ENCODING, CHUNKED);
@@ -371,13 +409,6 @@ final class HeaderUtils {
         // to CONNECT.
         // https://tools.ietf.org/html/rfc7231#section-4.3.6
         return CONNECT.equals(requestMethod) && SUCCESSFUL_2XX.contains(statusCode);
-    }
-
-    private static boolean isEmptyResponseStatus(final int statusCode) {
-        // A server MUST NOT send a Content-Length header field in any response with a status code of
-        // 1xx (Informational) or 204 (No Content).
-        // https://tools.ietf.org/html/rfc7230#section-3.3.2
-        return INFORMATIONAL_1XX.contains(statusCode) || statusCode == NO_CONTENT.code();
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -137,10 +137,8 @@ final class HeaderUtils {
         // A server MUST NOT send a message body in a 1xx (Informational), 204 (No Content), or
         // 304 (Not Modified) response. https://tools.ietf.org/html/rfc7230#section-3.3.3
         return !HEAD.equals(requestMethod)
-                && !INFORMATIONAL_1XX.contains(statusCode)
-                && statusCode != NO_CONTENT.code()
                 && statusCode != NOT_MODIFIED.code()
-                && !isEmptyConnectResponse(requestMethod, statusCode);
+                && responseMayHaveContentLength(statusCode, requestMethod);
     }
 
     /**

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -66,6 +66,7 @@ import static io.servicetalk.http.api.HttpRequestMethod.POST;
 import static io.servicetalk.http.api.HttpRequestMethod.PUT;
 import static io.servicetalk.http.api.HttpRequestMethod.TRACE;
 import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.http.api.HttpResponseStatus.NOT_MODIFIED;
 import static io.servicetalk.http.api.HttpResponseStatus.NO_CONTENT;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
@@ -167,6 +168,22 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new ResponseTest(aggregatedResponse(NO_CONTENT), OPTIONS, withoutPayload(), HAVE_NEITHER),
                 new ResponseTest(aggregatedResponse(NO_CONTENT), TRACE, withoutPayload(), HAVE_NEITHER),
                 new ResponseTest(aggregatedResponse(NO_CONTENT), PATCH, withoutPayload(), HAVE_NEITHER),
+
+                // 304 Not Modified: per RFC 7230 §3.3 the response cannot contain a message body, so neither
+                // Content-Length (auto-derived) nor Transfer-Encoding: chunked should be added by the framework.
+                new ResponseTest(aggregatedResponse(NOT_MODIFIED), GET, withoutPayload(), HAVE_NEITHER),
+                new ResponseTest(aggregatedResponse(NOT_MODIFIED), HEAD, withoutPayload(), HAVE_NEITHER),
+                new ResponseTest(aggregatedResponse(NOT_MODIFIED), POST, withoutPayload(), HAVE_NEITHER),
+                new ResponseTest(aggregatedResponse(NOT_MODIFIED), PUT, withoutPayload(), HAVE_NEITHER),
+                new ResponseTest(aggregatedResponse(NOT_MODIFIED), DELETE, withoutPayload(), HAVE_NEITHER),
+                new ResponseTest(aggregatedResponse(NOT_MODIFIED), CONNECT, withoutPayload(), HAVE_NEITHER),
+                new ResponseTest(aggregatedResponse(NOT_MODIFIED), OPTIONS, withoutPayload(), HAVE_NEITHER),
+                new ResponseTest(aggregatedResponse(NOT_MODIFIED), TRACE, withoutPayload(), HAVE_NEITHER),
+                new ResponseTest(aggregatedResponse(NOT_MODIFIED), PATCH, withoutPayload(), HAVE_NEITHER),
+                // Streaming 304 cases: the headline wire-level bug — chunked framing must not be added since 304
+                // cannot have a body. With a non-empty streaming payload, the body must also be \dropped.
+                new ResponseTest(streamingResponse(NOT_MODIFIED), GET, defaults(), HAVE_NEITHER),
+                new ResponseTest(streamingResponse(NOT_MODIFIED), GET, withoutPayload(), HAVE_NEITHER),
 
                 new ResponseTest(aggregatedResponse(OK), GET, transferEncodingGzip(), HAVE_CONTENT_LENGTH),
                 new ResponseTest(aggregatedResponse(OK), GET, transferEncodingChunked(),


### PR DESCRIPTION
#### Motivation

Our HeaderUtils doesn't currently treat the 304 response correctly: it says
that it can have a body but it explicitly cannot.
https://datatracker.ietf.org/doc/html/rfc9110#status.304

#### Modifications

- Follow the spec a bit more closely - don't auto-add TE headers to 304 responses
- Cleanup some of the naming in our utility methods to make the distinction
  between "can have Content-Length header" and "can have a real payload"
  more clear.

#### Result

Tighter behavior.