### PR TITLE
netty-internal: fix up ZlibOpenSslCertificateCompressionAlgorithm

### DIFF
--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithm.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithm.java
@@ -88,10 +88,28 @@ final class ZlibOpenSslCertificateCompressionAlgorithm implements OpenSslCertifi
             while (!inflater.finished()) {
                 int decompressedBytes = inflater.inflate(output, bytesWritten, uncompressedLen - bytesWritten);
                 bytesWritten += decompressedBytes;
-                if (bytesWritten > uncompressedLen) {
-                    throw new CertificateCompressionException("Number of bytes written (" + bytesWritten + ") " +
-                            "exceeds the uncompressed certificate length (" + uncompressedLen + ")");
+                // Inflater.inflate() can return 0 without setting finished() in three bad scenarios:
+                // truncated input (needsInput), an FDICT zlib header (needsDictionary), or the output buffer
+                // being full while more compressed input remains.
+                if (decompressedBytes == 0) {
+                    if (inflater.needsDictionary()) {
+                        throw new CertificateCompressionException(
+                                "Compressed certificate requires a preset dictionary (FDICT)");
+                    }
+                    if (inflater.needsInput()) {
+                        throw new CertificateCompressionException("Truncated compressed certificate stream");
+                    }
+                    // Must have overflowed the output buffer
+                    assert bytesWritten == uncompressedLen;
+                    throw new CertificateCompressionException("Compressed certificate decompresses to more than " +
+                            "the declared uncompressed length (" + uncompressedLen + ")");
                 }
+            }
+            // RFC 8879 declares uncompressed_length as the exact size; a short stream would also leave
+            // trailing zero bytes in the returned buffer that we'd hand to BoringSSL.
+            if (bytesWritten != uncompressedLen) {
+                throw new CertificateCompressionException("Decompressed certificate length (" + bytesWritten +
+                        ") does not match declared uncompressed length (" + uncompressedLen + ")");
             }
             return output;
         } catch (Exception cause) {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithmTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ZlibOpenSslCertificateCompressionAlgorithmTest.java
@@ -16,15 +16,25 @@
 package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.test.resources.DefaultTestCerts;
+import io.servicetalk.transport.api.CertificateCompressionException;
 
 import io.netty.handler.ssl.OpenSslCertificateCompressionAlgorithm;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.zip.Deflater;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+// SEPARATE_THREAD is required so the timeout can preempt a hang inside the non-interruptible
+// JNI Inflater.inflate() call — the project-wide default uses SAME_THREAD which cannot.
+@Timeout(value = 5, threadMode = ThreadMode.SEPARATE_THREAD)
 class ZlibOpenSslCertificateCompressionAlgorithmTest {
 
     /**
@@ -49,5 +59,48 @@ class ZlibOpenSslCertificateCompressionAlgorithmTest {
             outputStream.write(buffer, 0, temp);
         }
         return outputStream.toByteArray();
+    }
+
+    @Test
+    void decompressTruncatedStreamDoesNotHang() throws Exception {
+        byte[] originalCert = inputStreamToArray(DefaultTestCerts.loadServerPem());
+        byte[] compressed = ZlibOpenSslCertificateCompressionAlgorithm.INSTANCE.compress(null, originalCert);
+        byte[] truncated = Arrays.copyOf(compressed, compressed.length - 4);
+
+        assertThrows(CertificateCompressionException.class, () ->
+                ZlibOpenSslCertificateCompressionAlgorithm.INSTANCE.decompress(
+                        null, originalCert.length, truncated));
+    }
+
+    @Test
+    void decompressFdictStreamDoesNotHang() {
+        byte[] payload = "hello-certificate-payload".getBytes(StandardCharsets.UTF_8);
+        byte[] dictionary = "dict".getBytes(StandardCharsets.UTF_8);
+
+        Deflater deflater = new Deflater();
+        deflater.setDictionary(dictionary);
+        deflater.setInput(payload);
+        deflater.finish();
+        byte[] buffer = new byte[payload.length + dictionary.length + 64];
+        int written = 0;
+        while (!deflater.finished()) {
+            written += deflater.deflate(buffer, written, buffer.length - written);
+        }
+        deflater.end();
+        byte[] compressed = Arrays.copyOf(buffer, written);
+
+        assertThrows(CertificateCompressionException.class, () ->
+                ZlibOpenSslCertificateCompressionAlgorithm.INSTANCE.decompress(
+                        null, payload.length, compressed));
+    }
+
+    @Test
+    void decompressUnderdeclaredUncompressedLenDoesNotHang() throws Exception {
+        byte[] originalCert = inputStreamToArray(DefaultTestCerts.loadServerPem());
+        byte[] compressed = ZlibOpenSslCertificateCompressionAlgorithm.INSTANCE.compress(null, originalCert);
+
+        assertThrows(CertificateCompressionException.class, () ->
+                ZlibOpenSslCertificateCompressionAlgorithm.INSTANCE.decompress(
+                        null, originalCert.length - 1, compressed));
     }
 }


### PR DESCRIPTION
#### Motivation
We don't quite utilize the decompressor signals correctly for certificate decompression.

#### Modifications
Make sure we check whether we're missing input, need a dictionary, or if we've overflowed the expected output.
