### PR TITLE
Update grpc-java 1.71.0 -> 1.76.3 (test only)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -117,6 +117,6 @@ spotbugsPluginVersion=5.2.5
 dependencyAnalysisPluginVersion=3.10.0
 
 apacheDirectoryServerVersion=1.5.7
-grpcVersion=1.71.0
+grpcVersion=1.76.3
 jsonUnitVersion=2.40.1
 jsonUnit5Version=5.1.1


### PR DESCRIPTION
To have a native macOS protoc binary instead of using the rosetta version.