### PR TITLE
Add observability hooks for TLS CONNECT proxy support

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -129,6 +129,7 @@ class HttpsProxyTest {
     private ConnectionObserver connectionObserver;
     private ProxyConnectObserver proxyConnectObserver;
     private SecurityHandshakeObserver securityHandshakeObserver;
+    private SecurityHandshakeObserver proxySecurityHandshakeObserver;
     private InOrder order;
 
     @Nullable
@@ -152,13 +153,18 @@ class HttpsProxyTest {
 
     void setUp(List<HttpProtocol> protocols, boolean failHandshake,
                Consumer<HttpHeaders> connectRequestHeadersInitializer, boolean proxyTls) throws Exception {
+        setUp(protocols, failHandshake, false, connectRequestHeadersInitializer, proxyTls);
+    }
+
+    void setUp(List<HttpProtocol> protocols, boolean failHandshake, boolean failProxyHandshake,
+               Consumer<HttpHeaders> connectRequestHeadersInitializer, boolean proxyTls) throws Exception {
         initMocks();
         if (proxyTls) {
             proxyTunnel.sslContext(buildProxySslContext());
         }
         proxyAddress = proxyTunnel.startProxy();
         startServer(protocols);
-        createClient(protocols, failHandshake, connectRequestHeadersInitializer, proxyTls);
+        createClient(protocols, failHandshake, failProxyHandshake, connectRequestHeadersInitializer, proxyTls);
     }
 
     /**
@@ -197,11 +203,16 @@ class HttpsProxyTest {
         connectionObserver = mock(ConnectionObserver.class, "connectionObserver");
         proxyConnectObserver = mock(ProxyConnectObserver.class, "proxyConnectObserver");
         securityHandshakeObserver = mock(SecurityHandshakeObserver.class, "securityHandshakeObserver");
+        proxySecurityHandshakeObserver =
+                mock(SecurityHandshakeObserver.class, "proxySecurityHandshakeObserver");
         when(transportObserver.onNewConnection(any(), any())).thenReturn(connectionObserver);
         when(connectionObserver.onProxyConnect(any())).thenReturn(proxyConnectObserver);
         lenient().when(connectionObserver.onSecurityHandshake(any(SslConfig.class)))
                 .thenReturn(securityHandshakeObserver);
-        order = inOrder(transportObserver, connectionObserver, proxyConnectObserver, securityHandshakeObserver);
+        lenient().when(connectionObserver.onProxySecurityHandshake(any(SslConfig.class)))
+                .thenReturn(proxySecurityHandshakeObserver);
+        order = inOrder(transportObserver, connectionObserver, proxyConnectObserver,
+                securityHandshakeObserver, proxySecurityHandshakeObserver);
     }
 
     private void startServer(List<HttpProtocol> protocols) throws Exception {
@@ -214,7 +225,7 @@ class HttpsProxyTest {
         serverAddress = serverHostAndPort(serverContext);
     }
 
-    private void createClient(List<HttpProtocol> protocols, boolean failHandshake,
+    private void createClient(List<HttpProtocol> protocols, boolean failHandshake, boolean failProxyHandshake,
                               Consumer<HttpHeaders> connectRequestHeadersInitializer, boolean proxyTls) {
         assert serverContext != null && proxyAddress != null;
         final ProxyConfigBuilder<HostAndPort> proxyBuilder = new ProxyConfigBuilder<>(proxyAddress)
@@ -222,7 +233,11 @@ class HttpsProxyTest {
         if (proxyTls) {
             // No explicit peerHost — let inference fill it in from the proxy address.  We test the explicit case via
             // testProxySslConfigExplicitPeerHostOverridesInference.
-            proxyBuilder.sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build());
+            // failProxyHandshake omits the test CA from the proxy trust store so the proxy cert is rejected.
+            final ClientSslConfigBuilder proxySslConfig = failProxyHandshake ?
+                    new ClientSslConfigBuilder() :
+                    new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem);
+            proxyBuilder.sslConfig(proxySslConfig.build());
         }
         client = BuilderUtils.newClientBuilder(serverContext, CLIENT_CTX)
                 .proxyConfig(proxyBuilder.build())
@@ -239,7 +254,7 @@ class HttpsProxyTest {
     void testClientRequest(List<HttpProtocol> protocols, boolean proxyTls) throws Exception {
         setUp(protocols, proxyTls);
         assert client != null;
-        assertResponse(client.request(client.get("/path")), protocols.get(0).version);
+        assertResponse(client.request(client.get("/path")), protocols.get(0).version, proxyTls);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")
@@ -258,19 +273,19 @@ class HttpsProxyTest {
 
             HttpRequest request = connection.get("/path");
             assertThat(request.version(), is(expectedVersion));
-            assertResponse(connection.request(request), expectedVersion);
+            assertResponse(connection.request(request), expectedVersion, proxyTls);
         }
         order.verify(connectionObserver).connectionClosed();
     }
 
-    private void assertResponse(HttpResponse httpResponse, HttpProtocolVersion expectedVersion) {
+    private void assertResponse(HttpResponse httpResponse, HttpProtocolVersion expectedVersion, boolean proxyTls) {
         assertThat(httpResponse.status(), is(OK));
         assertThat(httpResponse.version(), is(expectedVersion));
         assertThat(proxyTunnel.connectCount(), is(1));
         assertThat(httpResponse.payloadBody().toString(US_ASCII), is("host: " + serverAddress));
         assertTargetAddress();
 
-        verifyProxyConnectComplete();
+        verifyProxyConnectComplete(proxyTls);
         order.verify(connectionObserver).onSecurityHandshake(any(SslConfig.class));
         order.verify(securityHandshakeObserver).handshakeComplete(any());
         if (expectedVersion.major() > 1) {
@@ -292,7 +307,7 @@ class HttpsProxyTest {
         assertThat(e, is(not(instanceOf(RetryableException.class))));
         assertThat(e.response().status(), is(PROXY_AUTHENTICATION_REQUIRED));
         assertTargetAddress();
-        verifyProxyConnectFailed(e);
+        verifyProxyConnectFailed(e, proxyTls);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")
@@ -301,7 +316,7 @@ class HttpsProxyTest {
         setUp(protocols, false, headers -> headers.set(PROXY_AUTHORIZATION, "basic " + AUTH_TOKEN), proxyTls);
         proxyTunnel.basicAuthToken(AUTH_TOKEN);
         assert client != null;
-        assertResponse(client.request(client.get("/path")), protocols.get(0).version);
+        assertResponse(client.request(client.get("/path")), protocols.get(0).version, proxyTls);
     }
 
     @Test
@@ -376,7 +391,7 @@ class HttpsProxyTest {
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0}")
     @MethodSource("io.servicetalk.http.netty.HttpProtocol#allCombinations")
-    void testProxyConnectNotInitiatedWhenProxyTlsHandshakeFails(List<HttpProtocol> protocols) throws Exception {
+    void testProxyTlsHandshakeFails(List<HttpProtocol> protocols) throws Exception {
         // The proxy uses TLS, but the client's proxy trust store omits the test CA, so the proxy certificate is
         // rejected during the proxy TLS handshake. Because the CONNECT request is only sent inside the established
         // tunnel, the handshake failure must abort the attempt before any CONNECT is initiated.
@@ -397,13 +412,22 @@ class HttpsProxyTest {
 
         // Non-retryable SSL failure surfaced as-is (no LB retry, no transport-level wrapping).
         assertThrows(SSLException.class, () -> client.request(client.get("/path")));
+        assertThat(proxyTunnel.connectCount(), is(0));
 
-        // TCP connected, but the CONNECT exchange was never initiated because the tunnel handshake failed.
+        // The proxy security handshake is reported and fails. atLeastOnce: the LB may re-resolve and retry.
         verify(connectionObserver, atLeastOnce()).onTransportHandshakeComplete(any());
+        verify(connectionObserver, atLeastOnce()).onProxySecurityHandshake(any(SslConfig.class));
+        verify(proxySecurityHandshakeObserver, atLeastOnce()).handshakeFailed(any(SSLException.class));
+        verify(connectionObserver, atLeastOnce()).connectionClosed(any(Throwable.class));
+
+        // The CONNECT exchange never starts, so neither the proxy-connect nor the application handshake fire.
         verify(connectionObserver, never()).onProxyConnect(any());
         verify(proxyConnectObserver, never()).proxyConnectComplete(any());
         verify(proxyConnectObserver, never()).proxyConnectFailed(any());
-        assertThat(proxyTunnel.connectCount(), is(0));
+        verify(proxySecurityHandshakeObserver, never()).handshakeComplete(any());
+        verify(connectionObserver, never()).onSecurityHandshake(any(SslConfig.class));
+        verify(securityHandshakeObserver, never()).handshakeComplete(any());
+        verify(securityHandshakeObserver, never()).handshakeFailed(any());
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")
@@ -434,7 +458,7 @@ class HttpsProxyTest {
         assertThat(e, is(instanceOf(RetryableException.class)));
         assertThat(e.response().status(), is(INTERNAL_SERVER_ERROR));
         assertTargetAddress();
-        verifyProxyConnectFailed(e);
+        verifyProxyConnectFailed(e, proxyTls);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")
@@ -452,7 +476,7 @@ class HttpsProxyTest {
         assertThat(e, is(not(instanceOf(RetryableException.class))));
         assertThat(e.response().status(), is(BAD_REQUEST));
         assertTargetAddress();
-        verifyProxyConnectFailed(e);
+        verifyProxyConnectFailed(e, proxyTls);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")
@@ -468,7 +492,7 @@ class HttpsProxyTest {
         assertThat(e, is(instanceOf(RetryableException.class)));
         assertThat(e.getCause(), is(nullValue()));
         assertTargetAddress();
-        verifyProxyConnectFailed(e);
+        verifyProxyConnectFailed(e, proxyTls);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")
@@ -488,7 +512,7 @@ class HttpsProxyTest {
         assertThat(e, is(instanceOf(RetryableException.class)));
         assertThat(e.getCause(), is(instanceOf(ClosedChannelException.class)));
         assertTargetAddress();
-        verifyProxyConnectComplete();
+        verifyProxyConnectComplete(proxyTls);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")
@@ -507,7 +531,7 @@ class HttpsProxyTest {
         assertThat(e, is(instanceOf(RetryableException.class)));
         assertThat(e.getCause(), is(instanceOf(IOException.class)));
         assertTargetAddress();
-        verifyProxyConnectComplete();
+        verifyProxyConnectComplete(proxyTls);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")
@@ -527,7 +551,7 @@ class HttpsProxyTest {
                 () -> client.request(client.get("/path")));
         assertThat(e, is(instanceOf(RetryableException.class)));
         assertTargetAddress();
-        verifyProxyConnectComplete();
+        verifyProxyConnectComplete(proxyTls);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")
@@ -540,7 +564,7 @@ class HttpsProxyTest {
         assertThat(e, is(not(instanceOf(RetryableException.class))));
         assertTargetAddress();
 
-        verifyProxyConnectComplete();
+        verifyProxyConnectComplete(proxyTls);
         order.verify(connectionObserver).onSecurityHandshake(any(SslConfig.class));
         order.verify(securityHandshakeObserver).handshakeFailed(e);
     }
@@ -549,16 +573,24 @@ class HttpsProxyTest {
         assertThat(targetAddress.get(), is(equalTo(serverAddress.toString())));
     }
 
-    private void verifyProxyConnectFailed(Throwable cause) {
+    private void verifyProxyConnectFailed(Throwable cause, boolean proxyTls) {
         order.verify(transportObserver).onNewConnection(any(), any());
         order.verify(connectionObserver).onTransportHandshakeComplete(any());
+        if (proxyTls) {
+            order.verify(connectionObserver).onProxySecurityHandshake(any(SslConfig.class));
+            order.verify(proxySecurityHandshakeObserver).handshakeComplete(any());
+        }
         order.verify(connectionObserver).onProxyConnect(any());
         order.verify(proxyConnectObserver).proxyConnectFailed(cause);
     }
 
-    private void verifyProxyConnectComplete() {
+    private void verifyProxyConnectComplete(boolean proxyTls) {
         order.verify(transportObserver).onNewConnection(any(), any());
         order.verify(connectionObserver).onTransportHandshakeComplete(any());
+        if (proxyTls) {
+            order.verify(connectionObserver).onProxySecurityHandshake(any(SslConfig.class));
+            order.verify(proxySecurityHandshakeObserver).handshakeComplete(any());
+        }
         order.verify(connectionObserver).onProxyConnect(any());
         order.verify(proxyConnectObserver).proxyConnectComplete(any());
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -86,11 +86,13 @@ import static io.servicetalk.http.api.HttpResponseStatus.PROXY_AUTHENTICATION_RE
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
 import static io.servicetalk.http.netty.HttpProtocol.toConfigs;
 import static io.servicetalk.test.resources.DefaultTestCerts.serverPemHostname;
+import static io.servicetalk.transport.api.ServiceTalkSocketOptions.TCP_FASTOPEN_CONNECT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static io.servicetalk.transport.netty.internal.CloseUtils.safeClose;
 import static java.net.InetAddress.getLoopbackAddress;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -428,6 +430,28 @@ class HttpsProxyTest {
         verify(connectionObserver, never()).onSecurityHandshake(any(SslConfig.class));
         verify(securityHandshakeObserver, never()).handshakeComplete(any());
         verify(securityHandshakeObserver, never()).handshakeFailed(any());
+    }
+
+    @Test
+    void testFastOpenWithProxyTlsReportsProxySecurityHandshake() throws Exception {
+        final List<HttpProtocol> protocols = singletonList(HttpProtocol.HTTP_1);
+        initMocks();
+        proxyTunnel.sslContext(buildProxySslContext());
+        proxyAddress = proxyTunnel.startProxy();
+        startServer(protocols);
+        client = BuilderUtils.newClientBuilder(serverContext, CLIENT_CTX)
+                .proxyConfig(new ProxyConfigBuilder<>(proxyAddress)
+                        .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem).build())
+                        .build())
+                .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                        .peerHost(serverPemHostname()).build())
+                .protocols(toConfigs(protocols))
+                .socketOption(TCP_FASTOPEN_CONNECT, true)
+                .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(transportObserver))
+                .buildBlocking();
+        assertThat(client.request(client.get("/path")).status(), is(OK));
+        verify(connectionObserver, atLeastOnce()).onProxySecurityHandshake(any(SslConfig.class));
+        verify(proxySecurityHandshakeObserver, atLeastOnce()).handshakeComplete(any());
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpClientChannelInitializer.java
@@ -91,14 +91,15 @@ public class TcpClientChannelInitializer implements ChannelInitializer {    // F
 
         final ClientSslConfig sslConfig = config.sslConfig();
         final ClientSslConfig proxySslConfig = config.proxySslConfig();
-        // Observer tracks the inner (origin) handshake only; observability for the proxy stage is intentionally
-        // not surfaced via the connection-level SecurityHandshakeObserver in this version.
+        // proxySslConfig is non-null only for a TLS proxy hop; it drives onProxySecurityHandshake, separate
+        // from the application handshake reported via onSecurityHandshake.
         if (observer != NoopConnectionObserver.INSTANCE) {
             delegate = delegate.andThen(new ConnectionObserverInitializer(observer,
                     channel -> new EarlyConnectionContext(channel,
                             // ExecutionContext can be null if users used deprecated ctor
                             executionContext == null ? null : channelExecutionContext(channel, executionContext),
-                            sslConfig, config.idleTimeoutMs()), true, deferSslHandler ? null : sslConfig));
+                            sslConfig, config.idleTimeoutMs()), true, deferSslHandler ? null : sslConfig,
+                    proxySslConfig));
         }
 
         if (config.idleTimeoutMs() > 0L) {

--- a/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
+++ b/servicetalk-tcp-netty-internal/src/main/java/io/servicetalk/tcp/netty/internal/TcpConnector.java
@@ -414,6 +414,13 @@ public final class TcpConnector {
         }
 
         @Override
+        public SecurityHandshakeObserver onProxySecurityHandshake(SslConfig sslConfig) {
+            try (Scope unused = attachContext()) {
+                return delegate.onProxySecurityHandshake(sslConfig);
+            }
+        }
+
+        @Override
         public ProxyConnectObserver onProxyConnect(Object connectMsg) {
             try (Scope unused = attachContext()) {
                 return delegate.onProxyConnect(connectMsg);

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -103,6 +103,12 @@ final class BiTransportObserver implements TransportObserver {
         }
 
         @Override
+        public SecurityHandshakeObserver onProxySecurityHandshake(final SslConfig sslConfig) {
+            return new BiSecurityHandshakeObserver(first.onProxySecurityHandshake(sslConfig),
+                    second.onProxySecurityHandshake(sslConfig));
+        }
+
+        @Override
         public DataObserver connectionEstablished(final ConnectionInfo info) {
             return new BiDataObserver(first.connectionEstablished(info), second.connectionEstablished(info));
         }

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -115,6 +115,13 @@ final class CatchAllTransportObserver implements TransportObserver {
         }
 
         @Override
+        public SecurityHandshakeObserver onProxySecurityHandshake(final SslConfig sslConfig) {
+            return safeReport(() -> observer.onProxySecurityHandshake(sslConfig), observer,
+                    "proxy security handshake",
+                    CatchAllSecurityHandshakeObserver::new, NoopSecurityHandshakeObserver.INSTANCE);
+        }
+
+        @Override
         public DataObserver connectionEstablished(final ConnectionInfo info) {
             return safeReport(() -> observer.connectionEstablished(info), observer, "connection established",
                     CatchAllDataObserver::new, NoopDataObserver.INSTANCE);

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionInfo.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionInfo.java
@@ -58,6 +58,9 @@ public interface ConnectionInfo {
 
     /**
      * The {@link SocketAddress} to which the associated connection is connected.
+     * <p>
+     * On the client side, when a proxy is configured, this describes the TCP peer (i.e. the proxy), not
+     * the target server the application is communicating with.
      *
      * @return The {@link SocketAddress} to which the associated connection is connected.
      */
@@ -65,6 +68,9 @@ public interface ConnectionInfo {
 
     /**
      * Get the {@link SslConfig} for this connection.
+     * <p>
+     * On the client side, when the connection runs through a TLS proxy, this describes the application SSL
+     * configuration (the handshake performed with the target server), not the proxy SSL configuration.
      *
      * @return The {@link SslConfig} if SSL/TLS is configured, or {@code null} otherwise.
      */
@@ -75,6 +81,9 @@ public interface ConnectionInfo {
 
     /**
      * Get the {@link SSLSession} for this connection.
+     * <p>
+     * On the client side, when the connection runs through a TLS proxy, this describes the application SSL
+     * session (the handshake performed with the target server), not the proxy SSL session.
      *
      * @return The {@link SSLSession} if SSL/TLS is enabled, or {@code null} otherwise.
      */

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/ConnectionObserver.java
@@ -129,7 +129,12 @@ public interface ConnectionObserver {
     }
 
     /**
-     * Callback when a security handshake is initiated.
+     * Callback when the application security handshake is initiated.
+     * <p>
+     * This reports the handshake whose {@link SSLSession} backs the connection used by the application. When
+     * the connection is established through a TLS proxy, the handshake with the proxy itself is reported
+     * separately via {@link #onProxySecurityHandshake(SslConfig)}, and this callback reports the subsequent
+     * handshake performed with the target server.
      * <p>
      * For a typical connection, this callback is invoked after {@link #onTransportHandshakeComplete(ConnectionInfo)}.
      * There are exceptions:
@@ -149,6 +154,25 @@ public interface ConnectionObserver {
      */
     default SecurityHandshakeObserver onSecurityHandshake(SslConfig sslConfig) {
         return onSecurityHandshake();
+    }
+
+    /**
+     * Callback when the proxy security handshake is initiated.
+     * <p>
+     * This reports the TLS handshake with the proxy itself, if TLS to the proxy is configured. Fired only on
+     * the client side, and does not fire for plaintext proxies or non-proxy connections.
+     * <p>
+     * Fires after {@link #onTransportHandshakeComplete(ConnectionInfo)}, and the returned
+     * {@link SecurityHandshakeObserver} terminates before {@link #onProxyConnect(Object)}. On failure the returned
+     * observer receives {@link SecurityHandshakeObserver#handshakeFailed(Throwable) handshakeFailed} and the attempt is
+     * aborted without sending CONNECT, so {@link #onProxyConnect(Object)} is not invoked.
+     *
+     * @param sslConfig the {@link SslConfig} used when performing the proxy security handshake
+     * @return a new {@link SecurityHandshakeObserver} that provides visibility into proxy security
+     * handshake events
+     */
+    default SecurityHandshakeObserver onProxySecurityHandshake(SslConfig sslConfig) {
+        return NoopTransportObserver.NoopSecurityHandshakeObserver.INSTANCE;
     }
 
     /**
@@ -217,6 +241,11 @@ public interface ConnectionObserver {
 
         /**
          * Callback when the proxy connect attempt fails.
+         * <p>
+         * Reports a CONNECT-exchange failure (e.g. a non-2xx response from the proxy). This fires only after the
+         * CONNECT request has been sent. When the connection runs through a TLS proxy and the proxy TLS handshake
+         * itself fails, the CONNECT is never sent and the failure is reported solely via the observer returned by
+         * {@link ConnectionObserver#onProxySecurityHandshake(SslConfig)}.
          *
          * @param cause the cause of the proxy connect failure
          */

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -124,6 +124,13 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
                                          final boolean client,
                                          @Nullable final SslConfig sslConfig,
                                          @Nullable final SslConfig proxySslConfig) {
+        // sslConfig here means "an SslHandler is being installed eagerly" — for any CONNECT proxy the origin
+        // handshake is deferred, so callers pass null sslConfig in that case (see TcpClientChannelInitializer).
+        // proxySslConfig non-null implies CONNECT implies deferral, so sslConfig must be null when proxySslConfig
+        // is set. The deferred origin handshake is reported by DeferSslHandler.ready() rather than this class.
+        assert sslConfig == null || proxySslConfig == null
+                : "sslConfig and proxySslConfig cannot both be non-null: TLS to a CONNECT proxy requires the " +
+                "origin handshake to be deferred, which signals as a null sslConfig at this layer";
         this.observer = requireNonNull(observer);
         this.connectionInfoFactory = requireNonNull(connectionInfoFactory);
         this.client = client;

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -54,6 +54,8 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
     private final boolean client;
     @Nullable
     private final SslConfig sslConfig;
+    @Nullable
+    private final SslConfig proxySslConfig;
 
     /**
      * Creates a new instance.
@@ -91,7 +93,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
     }
 
     /**
-     * Creates a new instance.
+     * Creates a new instance for a connection without a proxy TLS hop.
      *
      * @param observer {@link ConnectionObserver} to report network events
      * @param connectionInfoFactory {@link Function} that creates {@link ConnectionInfo} from the provided
@@ -103,17 +105,37 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
                                          final Function<Channel, ConnectionInfo> connectionInfoFactory,
                                          final boolean client,
                                          @Nullable final SslConfig sslConfig) {
+        this(observer, connectionInfoFactory, client, sslConfig, null);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param observer {@link ConnectionObserver} to report network events
+     * @param connectionInfoFactory {@link Function} that creates {@link ConnectionInfo} from the provided
+     * {@link Channel} to report {@link ConnectionObserver#onTransportHandshakeComplete(ConnectionInfo)}
+     * @param client {@code true} if this initializer is used on the client-side
+     * @param sslConfig the {@link SslConfig} to supply to the observer for the application handshake.
+     * @param proxySslConfig the {@link SslConfig} to supply to the observer for the proxy handshake,
+     * or {@code null} if there is no proxy TLS hop.
+     */
+    public ConnectionObserverInitializer(final ConnectionObserver observer,
+                                         final Function<Channel, ConnectionInfo> connectionInfoFactory,
+                                         final boolean client,
+                                         @Nullable final SslConfig sslConfig,
+                                         @Nullable final SslConfig proxySslConfig) {
         this.observer = requireNonNull(observer);
         this.connectionInfoFactory = requireNonNull(connectionInfoFactory);
         this.client = client;
         this.sslConfig = sslConfig;
+        this.proxySslConfig = proxySslConfig;
     }
 
     @Override
     public void init(final Channel channel) {
         assert channel.eventLoop().inEventLoop();
         channel.pipeline().addLast(new ConnectionObserverHandler(observer, connectionInfoFactory,
-                sslConfig != null, isFastOpen(channel), sslConfig));
+                sslConfig != null, isFastOpen(channel), sslConfig, proxySslConfig));
     }
 
     private boolean isFastOpen(final Channel channel) {
@@ -128,21 +150,27 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         private final boolean handshakeOnActive;
         @Nullable
         private final SslConfig sslConfig;
+        @Nullable
+        private final SslConfig proxySslConfig;
 
         private boolean tcpHandshakeComplete;
         private boolean addedCloseListener;
         @Nullable
         private SecurityHandshakeObserver handshakeObserver;
+        @Nullable
+        private SecurityHandshakeObserver proxyHandshakeObserver;
 
         ConnectionObserverHandler(final ConnectionObserver observer,
                                   final Function<Channel, ConnectionInfo> connectionInfoFactory,
                                   final boolean handshakeOnActive,
                                   final boolean fastOpen,
-                                  @Nullable final SslConfig sslConfig) {
+                                  @Nullable final SslConfig sslConfig,
+                                  @Nullable final SslConfig proxySslConfig) {
             this.observer = observer;
             this.connectionInfoFactory = connectionInfoFactory;
             this.handshakeOnActive = handshakeOnActive;
             this.sslConfig = sslConfig;
+            this.proxySslConfig = proxySslConfig;
             if (fastOpen) {
                 reportSecurityHandshakeStarting(sslConfig);
             }
@@ -191,6 +219,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
             assert channel.eventLoop().inEventLoop();
             maybeAddChannelClosedListener(channel);
             reportTcpHandshakeComplete(channel);
+            reportProxySecurityHandshakeStarting();
             if (handshakeOnActive) {
                 reportSecurityHandshakeStarting(sslConfig);
             }
@@ -228,6 +257,17 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
         @Nullable
         SecurityHandshakeObserver handshakeObserver() {
             return handshakeObserver;
+        }
+
+        private void reportProxySecurityHandshakeStarting() {
+            if (proxySslConfig != null && proxyHandshakeObserver == null) {
+                proxyHandshakeObserver = observer.onProxySecurityHandshake(proxySslConfig);
+            }
+        }
+
+        @Nullable
+        SecurityHandshakeObserver proxyHandshakeObserver() {
+            return proxyHandshakeObserver;
         }
 
         @Override

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializer.java
@@ -135,11 +135,12 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
     public void init(final Channel channel) {
         assert channel.eventLoop().inEventLoop();
         channel.pipeline().addLast(new ConnectionObserverHandler(observer, connectionInfoFactory,
-                sslConfig != null, isFastOpen(channel), sslConfig, proxySslConfig));
+                isFastOpen(channel), sslConfig, proxySslConfig));
     }
 
     private boolean isFastOpen(final Channel channel) {
-        return client && sslConfig != null && Boolean.TRUE.equals(channel.config().getOption(TCP_FASTOPEN_CONNECT)) &&
+        return client && (sslConfig != null || proxySslConfig != null) &&
+                Boolean.TRUE.equals(channel.config().getOption(TCP_FASTOPEN_CONNECT)) &&
                 (Epoll.isTcpFastOpenClientSideAvailable() || KQueue.isTcpFastOpenClientSideAvailable());
     }
 
@@ -147,7 +148,6 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
         private final ConnectionObserver observer;
         private final Function<Channel, ConnectionInfo> connectionInfoFactory;
-        private final boolean handshakeOnActive;
         @Nullable
         private final SslConfig sslConfig;
         @Nullable
@@ -162,17 +162,25 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
 
         ConnectionObserverHandler(final ConnectionObserver observer,
                                   final Function<Channel, ConnectionInfo> connectionInfoFactory,
-                                  final boolean handshakeOnActive,
                                   final boolean fastOpen,
                                   @Nullable final SslConfig sslConfig,
                                   @Nullable final SslConfig proxySslConfig) {
             this.observer = observer;
             this.connectionInfoFactory = connectionInfoFactory;
-            this.handshakeOnActive = handshakeOnActive;
             this.sslConfig = sslConfig;
             this.proxySslConfig = proxySslConfig;
             if (fastOpen) {
-                reportSecurityHandshakeStarting(sslConfig);
+                // Whichever TLS ClientHello piggybacks the SYN is the handshake that's already started by the
+                // time channelActive fires; report it now so the observer measures it from the correct moment.
+                // proxySslConfig non-null → TLS to a CONNECT proxy: proxy ClientHello goes in the SYN.
+                // sslConfig non-null     → direct TLS to the origin: origin ClientHello goes in the SYN.
+                // both null              → no TLS on the wire yet (plaintext direct, forward proxy, or CONNECT
+                //                          proxy with plaintext to the proxy); nothing to report here.
+                if (proxySslConfig != null) {
+                    reportProxySecurityHandshakeStarting();
+                } else if (sslConfig != null) {
+                    reportSecurityHandshakeStarting(sslConfig);
+                }
             }
         }
 
@@ -220,7 +228,7 @@ public final class ConnectionObserverInitializer implements ChannelInitializer {
             maybeAddChannelClosedListener(channel);
             reportTcpHandshakeComplete(channel);
             reportProxySecurityHandshakeStarting();
-            if (handshakeOnActive) {
+            if (sslConfig != null) {
                 reportSecurityHandshakeStarting(sslConfig);
             }
         }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
@@ -260,8 +260,9 @@ public final class NettyPipelineSslUtils {
      * Install the outer (proxy) TLS stage of a layered-TLS pipeline. Adds an eager proxy {@link SslHandler}
      * named {@link #PROXY_SSL_HANDLER_NAME} followed by an internal isolator that drops outer-stage
      * {@link SslHandshakeCompletionEvent} and {@link io.netty.handler.ssl.SslCloseCompletionEvent} from
-     * reaching handlers downstream (which expect inner-stage events). The proxy stage's handshake is
-     * intentionally not reported to the connection-level {@code SecurityHandshakeObserver}.
+     * reaching handlers downstream (which expect application-level TLS events). The proxy handshake is reported to
+     * the {@code SecurityHandshakeObserver} returned by {@link ConnectionObserver#onProxySecurityHandshake(SslConfig)},
+     * separate from the application-level {@link ConnectionObserver#onSecurityHandshake(SslConfig)}.
      *
      * @param channel the channel whose pipeline to install on
      * @param sslContext the {@link SslContext} for the proxy TLS stage
@@ -269,7 +270,7 @@ public final class NettyPipelineSslUtils {
      */
     public static void installProxyTlsStage(final Channel channel, final SslContext sslContext,
                                             final ClientSslConfig sslConfig) {
-        final SslHandler sslHandler = SslUtils.newClientSslHandler(sslContext, sslConfig, channel, false);
+        final SslHandler sslHandler = SslUtils.newClientProxySslHandler(sslContext, sslConfig, channel);
         channel.pipeline()
                 .addLast(PROXY_SSL_HANDLER_NAME, sslHandler)
                 .addLast(ProxySslHandlerEventsIsolatorHandler.HANDLER_NAME,

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslClientChannelInitializer.java
@@ -48,7 +48,7 @@ public class SslClientChannelInitializer implements ChannelInitializer {
 
     @Override
     public void init(Channel channel) {
-        final SslHandler sslHandler = newClientSslHandler(sslContext, sslConfig, channel, true);
+        final SslHandler sslHandler = newClientSslHandler(sslContext, sslConfig, channel);
         channel.pipeline().addLast(APPLICATION_SSL_HANDLER_NAME,
                 deferSslHandler ? new DeferSslHandler(channel, sslHandler, sslConfig, APPLICATION_SSL_HANDLER_NAME)
                         : sslHandler);

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/SslUtils.java
@@ -30,6 +30,7 @@ import io.netty.util.ReferenceCountUtil;
 
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLEngine;
@@ -54,24 +55,42 @@ final class SslUtils {
     }
 
     /**
-     * Creates a new {@link SslHandler} for the client-side which will support SNI if the {@link InetSocketAddress} was
-     * created from a hostname. It will use {@link CopyByteBufHandlerChannelInitializer#POOLED_ALLOCATOR} if required.
+     * Creates a new {@link SslHandler} for the client-side application TLS handshake which will support SNI
+     * if the {@link InetSocketAddress} was created from a hostname. It will use
+     * {@link CopyByteBufHandlerChannelInitializer#POOLED_ALLOCATOR} if required. The handshake is reported to the
+     * application-level {@link SecurityHandshakeObserver}.
      *
      * @param context the {@link SslContext} which will be used to create the {@link SslHandler}
      * @param sslConfig used to obtain configuration for the {@link SslHandler}.
      * @param channel the {@link Channel} if there is a need to report to {@link SecurityHandshakeObserver}
-     * @param reportHandshakeToObserver if {@code true}, register the handshake-future listener that reports to the
-     * {@link SecurityHandshakeObserver}. The first {@link SslHandler} on a connection should report; secondary
-     * handshakes (e.g. an outer proxy TLS handshake fronting an inner origin TLS) currently must not, since the
-     * connection-level observer can only track a single handshake.
      * @return a {@link SslHandler}
      */
     static SslHandler newClientSslHandler(final SslContext context, final ClientSslConfig sslConfig,
-                                          final Channel channel, final boolean reportHandshakeToObserver) {
+                                          final Channel channel) {
+        return newClientSslHandler(context, sslConfig, channel, ConnectionObserverHandler::handshakeObserver);
+    }
+
+    /**
+     * Creates a new {@link SslHandler} for the client-side proxy TLS handshake (the proxy stage of a layered-TLS
+     * pipeline) which will support SNI if the {@link InetSocketAddress} was created from a hostname. It will use
+     * {@link CopyByteBufHandlerChannelInitializer#POOLED_ALLOCATOR} if required. The handshake is reported to the
+     * proxy-stage {@link SecurityHandshakeObserver}.
+     *
+     * @param context the {@link SslContext} which will be used to create the {@link SslHandler}
+     * @param sslConfig used to obtain configuration for the {@link SslHandler}.
+     * @param channel the {@link Channel} if there is a need to report to {@link SecurityHandshakeObserver}
+     * @return a {@link SslHandler}
+     */
+    static SslHandler newClientProxySslHandler(final SslContext context, final ClientSslConfig sslConfig,
+                                               final Channel channel) {
+        return newClientSslHandler(context, sslConfig, channel, ConnectionObserverHandler::proxyHandshakeObserver);
+    }
+
+    private static SslHandler newClientSslHandler(final SslContext context, final ClientSslConfig sslConfig,
+            final Channel channel,
+            final Function<ConnectionObserverHandler, SecurityHandshakeObserver> observerExtractor) {
         SslHandler handler = context.newHandler(POOLED_ALLOCATOR, sslConfig.peerHost(), sslConfig.peerPort());
-        if (reportHandshakeToObserver) {
-            observeHandshakeCompletion(handler, channel);
-        }
+        observeHandshakeCompletion(handler, channel, observerExtractor);
         setHandshakeTimeout(handler, context);
         SSLEngine engine = handler.engine();
         try {
@@ -104,18 +123,27 @@ final class SslUtils {
      */
     static SslHandler newServerSslHandler(final SslContext context, final Channel channel) {
         SslHandler handler = context.newHandler(POOLED_ALLOCATOR);
-        observeHandshakeCompletion(handler, channel);
+        observeHandshakeCompletion(handler, channel, ConnectionObserverHandler::handshakeObserver);
         setHandshakeTimeout(handler, context);
         return handler;
     }
 
-    private static void observeHandshakeCompletion(final SslHandler sslHandler, final Channel channel) {
+    private static void observeHandshakeCompletion(final SslHandler sslHandler, final Channel channel,
+            final Function<ConnectionObserverHandler, SecurityHandshakeObserver> observerExtractor) {
+        // In production the ConnectionObserverHandler is installed earlier in the pipeline (the proxy stage is
+        // only installed by TcpClientChannelInitializer, which installs it first); tolerate a bare pipeline
+        // (unit tests) with a no-op.
         final ConnectionObserverHandler observerHandler = channel.pipeline().get(ConnectionObserverHandler.class);
         if (observerHandler == null) {
             return;
         }
         sslHandler.handshakeFuture().addListener(f -> {
-            SecurityHandshakeObserver handshakeObserver = getHandshakeObserver(observerHandler);
+            SecurityHandshakeObserver handshakeObserver = observerExtractor.apply(observerHandler);
+            if (handshakeObserver == null) {
+                // Fallback to NOOP variant because any issues with observability should not break users runtime.
+                // Correctness of reporting is verified by our tests.
+                handshakeObserver = NoopSecurityHandshakeObserver.INSTANCE;
+            }
             final Throwable cause = wrapIfRetryable(f.cause(), channel.parent() == null);
             if (cause == null) {
                 handshakeObserver.handshakeComplete(sslHandler.engine().getSession());
@@ -124,16 +152,6 @@ final class SslUtils {
                 handshakeObserver.handshakeFailed(cause);
             }
         });
-    }
-
-    private static SecurityHandshakeObserver getHandshakeObserver(final ConnectionObserverHandler handler) {
-        final SecurityHandshakeObserver handshakeObserver = handler.handshakeObserver();
-        if (handshakeObserver == null) {
-            // Fallback to NOOP variant because any issues with observability should not break users runtime.
-            // Correctness of reporting is verified by our tests.
-            return NoopSecurityHandshakeObserver.INSTANCE;
-        }
-        return handshakeObserver;
     }
 
     private static void setHandshakeTimeout(SslHandler handler, SslContext context) {

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializerTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/ConnectionObserverInitializerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import io.servicetalk.transport.api.ConnectionInfo;
+import io.servicetalk.transport.api.ConnectionObserver;
+import io.servicetalk.transport.api.ConnectionObserver.SecurityHandshakeObserver;
+import io.servicetalk.transport.api.SslConfig;
+import io.servicetalk.transport.netty.internal.ConnectionObserverInitializer.ConnectionObserverHandler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the constructor-time observer reporting behavior of {@link ConnectionObserverHandler} under TCP fast-open.
+ */
+final class ConnectionObserverInitializerTest {
+
+    @Test
+    void fastOpenWithApplicationTlsReportsApplicationHandshake() {
+        // TcpFastOpenTest covers fast-open + direct TLS at the request level but doesn't verify which observer
+        // callback fires; this locks in onSecurityHandshake (not onProxySecurityHandshake).
+        final ConnectionObserver observer = mock(ConnectionObserver.class);
+        final SslConfig sslConfig = mock(SslConfig.class);
+        when(observer.onSecurityHandshake(sslConfig)).thenReturn(mock(SecurityHandshakeObserver.class));
+
+        new ConnectionObserverHandler(observer, ch -> mock(ConnectionInfo.class),
+                true /* fastOpen */, sslConfig, null);
+
+        verify(observer).onSecurityHandshake(sslConfig);
+        verify(observer, never()).onProxySecurityHandshake(any(SslConfig.class));
+    }
+
+    @Test
+    void fastOpenWithProxyTlsReportsProxyHandshake() {
+        // HttpsProxyTest.testFastOpenWithProxyTlsReportsProxySecurityHandshake verifies onProxySecurityHandshake
+        // fires eventually, but it can't tell whether it fired at construction time (correct, ClientHello in the
+        // SYN) or later from channelActive (the pre-fix bug). This pins the constructor-time call — the proxy
+        // ClientHello piggybacks the SYN; the application handshake doesn't start until after CONNECT.
+        final ConnectionObserver observer = mock(ConnectionObserver.class);
+        final SslConfig proxySslConfig = mock(SslConfig.class);
+        when(observer.onProxySecurityHandshake(proxySslConfig)).thenReturn(mock(SecurityHandshakeObserver.class));
+
+        new ConnectionObserverHandler(observer, ch -> mock(ConnectionInfo.class),
+                true /* fastOpen */, null /* sslConfig deferred */, proxySslConfig);
+
+        verify(observer).onProxySecurityHandshake(proxySslConfig);
+        verify(observer, never()).onSecurityHandshake(any(SslConfig.class));
+    }
+}


### PR DESCRIPTION
 #### Motivation

Adding a TLS level to the proxy means we now have two TLS handshakes we need to consider. Right now our observability only represents one.

 #### Modifications

Add the observability hooks so we can see what both TLS sessions are doing.
