### PR TITLE
http-netty: defer CONNECT request until after proxy TLS handshake completes

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectChannelSingle.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ProxyConnectChannelSingle.java
@@ -29,12 +29,14 @@ import io.servicetalk.transport.api.ConnectionObserver.ProxyConnectObserver;
 import io.servicetalk.transport.api.RetryableException;
 import io.servicetalk.transport.netty.internal.ChannelInitializer;
 import io.servicetalk.transport.netty.internal.CloseHandler.InboundDataEndEvent;
+import io.servicetalk.transport.netty.internal.NettyPipelineSslUtils;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.ssl.SslHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,14 +108,42 @@ final class ProxyConnectChannelSingle extends ChannelInitSingle<Channel> {
         @Override
         public void handlerAdded(final ChannelHandlerContext ctx) {
             if (ctx.channel().isActive()) {
-                sendConnectRequest(ctx);
+                onChannelActive(ctx);
             }
         }
 
         @Override
         public void channelActive(final ChannelHandlerContext ctx) {
-            sendConnectRequest(ctx);
+            onChannelActive(ctx);
             ctx.fireChannelActive();
+        }
+
+        private void onChannelActive(final ChannelHandlerContext ctx) {
+            // For a TLS proxy hop the CONNECT belongs inside the tunnel, so defer it until the proxy handshake
+            // completes; a null proxy handler means a plaintext proxy and the CONNECT can be sent immediately.
+            final SslHandler proxySslHandler = NettyPipelineSslUtils.proxySslHandler(ctx.pipeline());
+            if (proxySslHandler == null) {
+                sendConnectRequest(ctx);
+                return;
+            }
+            proxySslHandler.handshakeFuture().addListener(future -> {
+                if (subscriber == null) {
+                    return;
+                }
+                if (future.isSuccess()) {
+                    // Try catch here because we can't lean on the pipeline to catch it.
+                    try {
+                        sendConnectRequest(ctx);
+                    } catch (Throwable t) {
+                        // User code (headers initializer) thrown from a listener would otherwise be swallowed.
+                        failSubscriber(ctx, new ProxyConnectException(ctx.channel() +
+                                " Unexpected exception before proxy CONNECT finished", t));
+                    }
+                } else {
+                    // Surface the SSLException as-is; onProxyConnect is not invoked since no CONNECT was sent.
+                    failSubscriber(ctx, future.cause());
+                }
+            });
         }
 
         private void sendConnectRequest(final ChannelHandlerContext ctx) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -68,6 +68,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
@@ -99,9 +100,12 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -368,6 +372,38 @@ class HttpsProxyTest {
         } else {
             assertThrows(SSLHandshakeException.class, () -> client.request(client.get("/path")));
         }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] protocols={0}")
+    @MethodSource("io.servicetalk.http.netty.HttpProtocol#allCombinations")
+    void testProxyConnectNotInitiatedWhenProxyTlsHandshakeFails(List<HttpProtocol> protocols) throws Exception {
+        // The proxy uses TLS, but the client's proxy trust store omits the test CA, so the proxy certificate is
+        // rejected during the proxy TLS handshake. Because the CONNECT request is only sent inside the established
+        // tunnel, the handshake failure must abort the attempt before any CONNECT is initiated.
+        initMocks();
+        proxyTunnel.sslContext(buildProxySslContext());
+        proxyAddress = proxyTunnel.startProxy();
+        startServer(protocols);
+        client = BuilderUtils.newClientBuilder(serverContext, CLIENT_CTX)
+                .proxyConfig(new ProxyConfigBuilder<>(proxyAddress)
+                        // Default (system) trust store does not trust the test CA -> proxy cert is rejected.
+                        .sslConfig(new ClientSslConfigBuilder().build())
+                        .build())
+                .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                        .peerHost(serverPemHostname()).build())
+                .protocols(toConfigs(protocols))
+                .appendConnectionFactoryFilter(new TransportObserverConnectionFactoryFilter<>(transportObserver))
+                .buildBlocking();
+
+        // Non-retryable SSL failure surfaced as-is (no LB retry, no transport-level wrapping).
+        assertThrows(SSLException.class, () -> client.request(client.get("/path")));
+
+        // TCP connected, but the CONNECT exchange was never initiated because the tunnel handshake failed.
+        verify(connectionObserver, atLeastOnce()).onTransportHandshakeComplete(any());
+        verify(connectionObserver, never()).onProxyConnect(any());
+        verify(proxyConnectObserver, never()).proxyConnectComplete(any());
+        verify(proxyConnectObserver, never()).proxyConnectFailed(any());
+        assertThat(proxyTunnel.connectCount(), is(0));
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NettyPipelineSslUtils.java
@@ -236,6 +236,27 @@ public final class NettyPipelineSslUtils {
     }
 
     /**
+     * Returns the proxy {@link SslHandler} installed by {@link #installProxyTlsStage}, or {@code null} if none is
+     * present (a plaintext proxy hop or a non-proxy connection).
+     *
+     * @param pipeline the pipeline to inspect for the proxy {@link SslHandler}.
+     * @return the proxy {@link SslHandler}, or {@code null} if none is present.
+     */
+    @Nullable
+    public static SslHandler proxySslHandler(final ChannelPipeline pipeline) {
+        final ChannelHandler handler = pipeline.get(PROXY_SSL_HANDLER_NAME);
+        if (handler == null) {
+            return null;
+        }
+        if (!(handler instanceof SslHandler)) {
+            throw new IllegalStateException("Expected an " + SslHandler.class.getName() + " under the reserved '" +
+                    PROXY_SSL_HANDLER_NAME + "' name but found " + handler.getClass().getName() +
+                    ". This is a bug: please report this to the ServiceTalk team.");
+        }
+        return (SslHandler) handler;
+    }
+
+    /**
      * Install the outer (proxy) TLS stage of a layered-TLS pipeline. Adds an eager proxy {@link SslHandler}
      * named {@link #PROXY_SSL_HANDLER_NAME} followed by an internal isolator that drops outer-stage
      * {@link SslHandshakeCompletionEvent} and {@link io.netty.handler.ssl.SslCloseCompletionEvent} from


### PR DESCRIPTION
 #### Motivation

If we're using TLS to a HTTP-Connect proxy, we currently send the CONNECT request right away and it sits buffered behind the TLS handshake. This can lead to surprising observability behavior because it can look like the CONNECT was sent before the TLS handshake completed, we get bonus errors, etc.

 #### Modifications

Defer the CONNECT message until after the proxy TLS handshake completes. If there isn't a TLS connection to the proxy, the behavior is unchanged.

