### PR TITLE
Limit the size of DefaultHealthService watch list

### DIFF
--- a/servicetalk-grpc-health/build.gradle
+++ b/servicetalk-grpc-health/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   implementation project(":servicetalk-data-protobuf")
   implementation project(":servicetalk-grpc-protobuf")
   implementation project(":servicetalk-serializer-api")
+  implementation project(":servicetalk-utils-internal")
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation testFixtures(project(":servicetalk-transport-netty-internal"))

--- a/servicetalk-grpc-health/gradle.lockfile
+++ b/servicetalk-grpc-health/gradle.lockfile
@@ -9,5 +9,5 @@ io.netty:netty-bom:4.1.134.Final=runtimeClasspath
 io.netty:netty-buffer:4.1.134.Final=runtimeClasspath
 io.netty:netty-common:4.1.134.Final=runtimeClasspath
 org.jctools:jctools-core:4.0.5=runtimeClasspath
-org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,protobuf,spotbugsPlugins,testAnnotationProcessor,testProtobuf

--- a/servicetalk-grpc-health/src/main/java/io/servicetalk/grpc/health/DefaultHealthService.java
+++ b/servicetalk-grpc-health/src/main/java/io/servicetalk/grpc/health/DefaultHealthService.java
@@ -37,10 +37,12 @@ import static io.servicetalk.concurrent.api.Processors.newPublisherProcessorDrop
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.grpc.api.GrpcStatusCode.FAILED_PRECONDITION;
 import static io.servicetalk.grpc.api.GrpcStatusCode.NOT_FOUND;
+import static io.servicetalk.grpc.api.GrpcStatusCode.RESOURCE_EXHAUSTED;
 import static io.servicetalk.health.v1.HealthCheckResponse.ServingStatus.NOT_SERVING;
 import static io.servicetalk.health.v1.HealthCheckResponse.ServingStatus.SERVICE_UNKNOWN;
 import static io.servicetalk.health.v1.HealthCheckResponse.ServingStatus.SERVING;
 import static io.servicetalk.health.v1.HealthCheckResponse.newBuilder;
+import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -54,28 +56,42 @@ public final class DefaultHealthService implements Health.HealthService {
      * the <a href="https://github.com/grpc/grpc/blob/master/doc/health-checking.md">overall health status</a>.
      */
     public static final String OVERALL_SERVICE_NAME = "";
+    private static final int DEFAULT_MAX_SERVICES = 1000;
     private final Map<String, HealthValue> serviceToStatusMap = new ConcurrentHashMap<>();
     private final Predicate<String> watchAllowed;
+    private final int maxServices;
     private final Lock lock = new ReentrantLock();
     private boolean terminated;
 
     /**
      * Create a new instance. Service {@link #OVERALL_SERVICE_NAME} state is set to {@link ServingStatus#SERVING}.
+     * <p>
+     * Watches are permitted for any service name. The number of tracked services is bounded by a default limit of
+     * {@code 1000}; once reached, a {@link #watch(GrpcServiceContext, HealthCheckRequest)} for a service that isn't
+     * already known fails with {@link GrpcStatusCode#RESOURCE_EXHAUSTED}. Use {@link #DefaultHealthService(Predicate)}
+     * to restrict which service names may be watched, or {@link #DefaultHealthService(Predicate, int)} to also
+     * configure the limit.
      */
     public DefaultHealthService() {
-        this(service -> true);
+        this(service -> true, DEFAULT_MAX_SERVICES);
     }
 
     /**
      * Create a new instance. Service {@link #OVERALL_SERVICE_NAME} state is set to {@link ServingStatus#SERVING}.
      * @param watchAllowed {@link Predicate} that determines if a {@link #watch(GrpcServiceContext, HealthCheckRequest)}
      * request that doesn't match an existing service will succeed or fail with
-     * {@link GrpcStatusCode#FAILED_PRECONDITION}. This can be used to bound memory by restricting watches to expected
-     * service names.
+     * {@link GrpcStatusCode#FAILED_PRECONDITION}.
      */
     public DefaultHealthService(Predicate<String> watchAllowed) {
+        this(watchAllowed, Integer.MAX_VALUE);
+    }
+
+    DefaultHealthService(Predicate<String> watchAllowed, int maxServices) {
         this.watchAllowed = requireNonNull(watchAllowed);
-        serviceToStatusMap.put(OVERALL_SERVICE_NAME, HealthValue.newInstance(SERVING));
+        this.maxServices = ensurePositive(maxServices, "maxServices");
+        final HealthValue overall = HealthValue.newRegistered();
+        overall.next(newBuilder().setStatus(SERVING).build());
+        serviceToStatusMap.put(OVERALL_SERVICE_NAME, overall);
     }
 
     @Override
@@ -90,26 +106,50 @@ public final class DefaultHealthService implements Health.HealthService {
 
     @Override
     public Publisher<HealthCheckResponse> watch(final GrpcServiceContext ctx, final HealthCheckRequest request) {
-        // Try a get first to avoid locking with the assumption that most requests will be to watch existing services.
-        HealthValue healthValue = serviceToStatusMap.get(request.getService());
-        if (healthValue == null) {
-            if (!watchAllowed.test(request.getService())) {
-                return Publisher.failed(new GrpcStatusException(new GrpcStatus(FAILED_PRECONDITION,
-                        "watch not allowed for service " + request.getService())));
-            }
+        final String service = request.getService();
+        return Publisher.defer(() -> {
             lock.lock();
             try {
                 if (terminated) {
                     return Publisher.from(newBuilder().setStatus(NOT_SERVING).build());
                 }
-                healthValue = serviceToStatusMap.computeIfAbsent(request.getService(),
-                        __ -> HealthValue.newInstance(SERVICE_UNKNOWN));
+                HealthValue healthValue = serviceToStatusMap.get(service);
+                if (healthValue == null) {
+                    if (!watchAllowed.test(service)) {
+                        return Publisher.failed(new GrpcStatusException(new GrpcStatus(FAILED_PRECONDITION,
+                                "watch not allowed for service " + service)));
+                    }
+                    if (serviceToStatusMap.size() >= maxServices) {
+                        return Publisher.failed(new GrpcStatusException(new GrpcStatus(RESOURCE_EXHAUSTED,
+                                "max number of watched services reached: " + maxServices)));
+                    }
+                    healthValue = HealthValue.newWatchOnly();
+                    serviceToStatusMap.put(service, healthValue);
+                }
+                healthValue.watcherCount++;
+                final HealthValue watched = healthValue;
+                return watched.publisher.beforeFinally(() -> watcherTerminated(service, watched));
             } finally {
                 lock.unlock();
             }
-        }
+        });
+    }
 
-        return healthValue.publisher;
+    private void watcherTerminated(final String service, final HealthValue healthValue) {
+        lock.lock();
+        try {
+            // Only watch-only entries are evicted; server-registered services persist for check() and late watchers.
+            if (--healthValue.watcherCount == 0 && !healthValue.registered) {
+                serviceToStatusMap.remove(service, healthValue);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // Visible for testing: number of services currently tracked, used to assert watch-only entries are evicted.
+    int trackedServices() {
+        return serviceToStatusMap.size();
     }
 
     /**
@@ -122,18 +162,24 @@ public final class DefaultHealthService implements Health.HealthService {
      * @return {@code true} if this change was applied. {@code false} if it was not due to {@link #terminate()}.
      */
     public boolean setStatus(String service, ServingStatus status) {
-        final HealthCheckResponse resp;
-        final HealthValue healthValue;
+        HealthValue healthValue;
         lock.lock();
         try {
             if (terminated) {
                 return false;
             }
-            resp = newBuilder().setStatus(status).build();
-            healthValue = serviceToStatusMap.computeIfAbsent(service, __ -> new HealthValue());
+            healthValue = serviceToStatusMap.get(service);
+            if (healthValue == null) {
+                healthValue = HealthValue.newRegistered();
+                serviceToStatusMap.put(service, healthValue);
+            } else {
+                // Promote a watch-only entry so it is retained independent of active watchers.
+                healthValue.register();
+            }
         } finally {
             lock.unlock();
         }
+        HealthCheckResponse resp = newBuilder().setStatus(status).build();
         healthValue.next(resp);
         return true;
     }
@@ -181,6 +227,9 @@ public final class DefaultHealthService implements Health.HealthService {
     private static final class HealthValue {
         private final Processor<HealthCheckResponse, HealthCheckResponse> processor;
         private final Publisher<HealthCheckResponse> publisher;
+        // Both guarded by DefaultHealthService.lock.
+        private int watcherCount;
+        private boolean registered;
 
         HealthValue() {
             this.processor = newPublisherProcessorDropHeadOnOverflow(4);
@@ -188,19 +237,30 @@ public final class DefaultHealthService implements Health.HealthService {
                     // Allow multiple subscribers to Subscribe to the resulting Publisher, use a history of 1
                     // so each new subscriber gets the latest state.
                     .replay(1);
-            // Maintain a Subscriber so signals are always delivered to replay and new Subscribers get the latest
-            // signal.
-            publisher.ignoreElements().subscribe();
         }
 
-        static HealthValue newInstance(final HealthCheckResponse initialState) {
+        /**
+         * Marks this value as server-registered and maintains a Subscriber so the latest signal is retained for late
+         * subscribers even when no client is currently watching. Idempotent.
+         * Must be called while holding the lock
+         */
+        void register() {
+            if (!registered) {
+                registered = true;
+                publisher.ignoreElements().subscribe();
+            }
+        }
+
+        static HealthValue newRegistered() {
             HealthValue value = new HealthValue();
-            value.next(initialState);
+            value.register();
             return value;
         }
 
-        static HealthValue newInstance(final ServingStatus status) {
-            return newInstance(newBuilder().setStatus(status).build());
+        static HealthValue newWatchOnly() {
+            HealthValue value = new HealthValue();
+            value.next(newBuilder().setStatus(SERVICE_UNKNOWN).build());
+            return value;
         }
 
         void next(HealthCheckResponse response) {

--- a/servicetalk-grpc-health/src/main/java/io/servicetalk/grpc/health/DefaultHealthService.java
+++ b/servicetalk-grpc-health/src/main/java/io/servicetalk/grpc/health/DefaultHealthService.java
@@ -60,7 +60,7 @@ public final class DefaultHealthService implements Health.HealthService {
     private final Map<String, HealthValue> serviceToStatusMap = new ConcurrentHashMap<>();
     private final Predicate<String> watchAllowed;
     private final int maxServices;
-    private final Lock lock = new ReentrantLock();
+    private final ReentrantLock lock = new ReentrantLock();
     private boolean terminated;
 
     /**
@@ -69,8 +69,7 @@ public final class DefaultHealthService implements Health.HealthService {
      * Watches are permitted for any service name. The number of tracked services is bounded by a default limit of
      * {@code 1000}; once reached, a {@link #watch(GrpcServiceContext, HealthCheckRequest)} for a service that isn't
      * already known fails with {@link GrpcStatusCode#RESOURCE_EXHAUSTED}. Use {@link #DefaultHealthService(Predicate)}
-     * to restrict which service names may be watched, or {@link #DefaultHealthService(Predicate, int)} to also
-     * configure the limit.
+     * to restrict which service names may be watched.
      */
     public DefaultHealthService() {
         this(service -> true, DEFAULT_MAX_SERVICES);
@@ -121,7 +120,7 @@ public final class DefaultHealthService implements Health.HealthService {
                     }
                     if (serviceToStatusMap.size() >= maxServices) {
                         return Publisher.failed(new GrpcStatusException(new GrpcStatus(RESOURCE_EXHAUSTED,
-                                "max number of watched services reached: " + maxServices)));
+                                "max number of watched services reached")));
                     }
                     healthValue = HealthValue.newWatchOnly();
                     serviceToStatusMap.put(service, healthValue);

--- a/servicetalk-grpc-health/src/main/java/io/servicetalk/grpc/health/DefaultHealthService.java
+++ b/servicetalk-grpc-health/src/main/java/io/servicetalk/grpc/health/DefaultHealthService.java
@@ -29,7 +29,6 @@ import io.servicetalk.health.v1.HealthCheckResponse.ServingStatus;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
 
@@ -67,9 +66,10 @@ public final class DefaultHealthService implements Health.HealthService {
      * Create a new instance. Service {@link #OVERALL_SERVICE_NAME} state is set to {@link ServingStatus#SERVING}.
      * <p>
      * Watches are permitted for any service name. The number of tracked services is bounded by a default limit of
-     * {@code 1000}; once reached, a {@link #watch(GrpcServiceContext, HealthCheckRequest)} for a service that isn't
-     * already known fails with {@link GrpcStatusCode#RESOURCE_EXHAUSTED}. Use {@link #DefaultHealthService(Predicate)}
-     * to restrict which service names may be watched.
+     * {@value DEFAULT_MAX_SERVICES}; once reached, a {@link #watch(GrpcServiceContext, HealthCheckRequest)} for a
+     * service that isn't already known fails with {@link GrpcStatusCode#RESOURCE_EXHAUSTED}. Use
+     * {@link #DefaultHealthService(Predicate)} to restrict which service names may be watched, or
+     * {@link #DefaultHealthService(Predicate, int)} to also configure the limit.
      */
     public DefaultHealthService() {
         this(service -> true, DEFAULT_MAX_SERVICES);
@@ -79,18 +79,37 @@ public final class DefaultHealthService implements Health.HealthService {
      * Create a new instance. Service {@link #OVERALL_SERVICE_NAME} state is set to {@link ServingStatus#SERVING}.
      * @param watchAllowed {@link Predicate} that determines if a {@link #watch(GrpcServiceContext, HealthCheckRequest)}
      * request that doesn't match an existing service will succeed or fail with
-     * {@link GrpcStatusCode#FAILED_PRECONDITION}.
+     * {@link GrpcStatusCode#FAILED_PRECONDITION}. This can be used to bound memory by restricting watches to expected
+     * service names. The number of tracked services is additionally bounded by a default limit of
+     * {@value DEFAULT_MAX_SERVICES}; use {@link #DefaultHealthService(Predicate, int)} to configure it.
      */
     public DefaultHealthService(Predicate<String> watchAllowed) {
-        this(watchAllowed, Integer.MAX_VALUE);
+        this(watchAllowed, DEFAULT_MAX_SERVICES);
     }
 
-    DefaultHealthService(Predicate<String> watchAllowed, int maxServices) {
+    /**
+     * Create a new instance. Service {@link #OVERALL_SERVICE_NAME} state is set to {@link ServingStatus#SERVING}.
+     * @param watchAllowed {@link Predicate} that determines if a {@link #watch(GrpcServiceContext, HealthCheckRequest)}
+     * request that doesn't match an existing service will succeed or fail with
+     * {@link GrpcStatusCode#FAILED_PRECONDITION}. This can be used to bound memory by restricting watches to expected
+     * service names.
+     * @param maxServices Upper bound on the number of services tracked, counting both services registered via
+     * {@link #setStatus(String, ServingStatus)} and services created by {@link #watch(GrpcServiceContext,
+     * HealthCheckRequest)}. A {@link #watch(GrpcServiceContext, HealthCheckRequest)} request for a service that isn't
+     * already known will fail with {@link GrpcStatusCode#RESOURCE_EXHAUSTED} once this limit is reached. Must be
+     * positive, and should be sized above the number of services the server registers.
+     */
+    public DefaultHealthService(Predicate<String> watchAllowed, int maxServices) {
         this.watchAllowed = requireNonNull(watchAllowed);
         this.maxServices = ensurePositive(maxServices, "maxServices");
-        final HealthValue overall = HealthValue.newRegistered();
-        overall.next(newBuilder().setStatus(SERVING).build());
-        serviceToStatusMap.put(OVERALL_SERVICE_NAME, overall);
+        lock.lock(); // to satisfy the assert in newRegisteredHealthValue()
+        try {
+            final HealthValue overall = newRegisteredHealthValue();
+            overall.next(newBuilder().setStatus(SERVING).build());
+            serviceToStatusMap.put(OVERALL_SERVICE_NAME, overall);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
@@ -122,28 +141,16 @@ public final class DefaultHealthService implements Health.HealthService {
                         return Publisher.failed(new GrpcStatusException(new GrpcStatus(RESOURCE_EXHAUSTED,
                                 "max number of watched services reached")));
                     }
-                    healthValue = HealthValue.newWatchOnly();
+                    healthValue = newWatchOnlyHealthValue();
                     serviceToStatusMap.put(service, healthValue);
                 }
-                healthValue.watcherCount++;
+                healthValue.incrementWatches();
                 final HealthValue watched = healthValue;
-                return watched.publisher.beforeFinally(() -> watcherTerminated(service, watched));
+                return watched.publisher.beforeFinally(() -> watched.watcherTerminated(service));
             } finally {
                 lock.unlock();
             }
         });
-    }
-
-    private void watcherTerminated(final String service, final HealthValue healthValue) {
-        lock.lock();
-        try {
-            // Only watch-only entries are evicted; server-registered services persist for check() and late watchers.
-            if (--healthValue.watcherCount == 0 && !healthValue.registered) {
-                serviceToStatusMap.remove(service, healthValue);
-            }
-        } finally {
-            lock.unlock();
-        }
     }
 
     // Visible for testing: number of services currently tracked, used to assert watch-only entries are evicted.
@@ -169,7 +176,7 @@ public final class DefaultHealthService implements Health.HealthService {
             }
             healthValue = serviceToStatusMap.get(service);
             if (healthValue == null) {
-                healthValue = HealthValue.newRegistered();
+                healthValue = newRegisteredHealthValue();
                 serviceToStatusMap.put(service, healthValue);
             } else {
                 // Promote a watch-only entry so it is retained independent of active watchers.
@@ -223,7 +230,19 @@ public final class DefaultHealthService implements Health.HealthService {
         return true;
     }
 
-    private static final class HealthValue {
+    private HealthValue newRegisteredHealthValue() {
+        HealthValue value = new HealthValue();
+        value.register();
+        return value;
+    }
+
+    private HealthValue newWatchOnlyHealthValue() {
+        HealthValue value = new HealthValue();
+        value.next(newBuilder().setStatus(SERVICE_UNKNOWN).build());
+        return value;
+    }
+
+    private final class HealthValue {
         private final Processor<HealthCheckResponse, HealthCheckResponse> processor;
         private final Publisher<HealthCheckResponse> publisher;
         // Both guarded by DefaultHealthService.lock.
@@ -244,22 +263,29 @@ public final class DefaultHealthService implements Health.HealthService {
          * Must be called while holding the lock
          */
         void register() {
+            assert lock.isHeldByCurrentThread();
             if (!registered) {
                 registered = true;
                 publisher.ignoreElements().subscribe();
             }
         }
 
-        static HealthValue newRegistered() {
-            HealthValue value = new HealthValue();
-            value.register();
-            return value;
+        void watcherTerminated(final String service) {
+            lock.lock();
+            try {
+                // Only watch-only entries are evicted; server-registered services persist for check() and late watchers
+                watcherCount--;
+                if (watcherCount == 0 && !registered) {
+                    serviceToStatusMap.remove(service, this);
+                }
+            } finally {
+                lock.unlock();
+            }
         }
 
-        static HealthValue newWatchOnly() {
-            HealthValue value = new HealthValue();
-            value.next(newBuilder().setStatus(SERVICE_UNKNOWN).build());
-            return value;
+        void incrementWatches() {
+            assert lock.isHeldByCurrentThread();
+            watcherCount++;
         }
 
         void next(HealthCheckResponse response) {

--- a/servicetalk-grpc-health/src/test/java/io/servicetalk/grpc/health/DefaultHealthServiceTest.java
+++ b/servicetalk-grpc-health/src/test/java/io/servicetalk/grpc/health/DefaultHealthServiceTest.java
@@ -16,6 +16,8 @@
 package io.servicetalk.grpc.health;
 
 import io.servicetalk.concurrent.BlockingIterator;
+import io.servicetalk.concurrent.PublisherSource.Subscriber;
+import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.grpc.api.GrpcStatusCode;
 import io.servicetalk.grpc.api.GrpcStatusException;
 import io.servicetalk.grpc.netty.GrpcClients;
@@ -29,16 +31,24 @@ import io.servicetalk.transport.api.ServerContext;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.grpc.api.GrpcStatusCode.FAILED_PRECONDITION;
 import static io.servicetalk.grpc.api.GrpcStatusCode.NOT_FOUND;
+import static io.servicetalk.grpc.api.GrpcStatusCode.RESOURCE_EXHAUSTED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
 import static io.servicetalk.grpc.health.DefaultHealthService.OVERALL_SERVICE_NAME;
 import static io.servicetalk.health.v1.HealthCheckResponse.ServingStatus.NOT_SERVING;
 import static io.servicetalk.health.v1.HealthCheckResponse.ServingStatus.SERVICE_UNKNOWN;
 import static io.servicetalk.health.v1.HealthCheckResponse.ServingStatus.SERVING;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -155,6 +165,155 @@ final class DefaultHealthServiceTest {
         watchFailure(new DefaultHealthService(name -> {
             throw DELIBERATE_EXCEPTION;
         }), UNKNOWN);
+    }
+
+    @Test
+    void watchBoundedByMaxServices() throws Exception {
+        // OVERALL_SERVICE_NAME already occupies the single allowed slot, so any new watch is rejected.
+        DefaultHealthService service = new DefaultHealthService(name -> true, 1);
+        try (ServerContext serverCtx = GrpcServers.forAddress(localAddress(0)).listenAndAwait(service)) {
+            try (Health.BlockingHealthClient client = GrpcClients.forResolvedAddress(
+                    (InetSocketAddress) serverCtx.listenAddress()).buildBlocking(new Health.ClientFactory())) {
+                // Watching the already-known overall service stays within the bound.
+                assertThat(client.watch(newRequest(OVERALL_SERVICE_NAME)).iterator().next().getStatus(),
+                        equalTo(SERVING));
+
+                assertThat(assertThrows(GrpcStatusException.class,
+                                () -> client.watch(newRequest(UNKNOWN_SERVICE_NAME)).iterator().next()).status().code(),
+                        equalTo(RESOURCE_EXHAUSTED));
+            }
+        }
+    }
+
+    @Test
+    void watchOnlyEntryEvictedWhenWatcherCancels() throws Exception {
+        DefaultHealthService service = new DefaultHealthService();
+        assertThat(service.trackedServices(), equalTo(1)); // OVERALL_SERVICE_NAME
+
+        BlockingQueue<HealthCheckResponse> received = new LinkedBlockingQueue<>();
+        Subscription subscription = subscribeToWatch(service, UNKNOWN_SERVICE_NAME, received);
+        // The watch created a placeholder entry and delivered the initial SERVICE_UNKNOWN.
+        assertThat(received.take().getStatus(), equalTo(SERVICE_UNKNOWN));
+        assertThat(service.trackedServices(), equalTo(2));
+
+        // Cancellation (e.g. client disconnect) must evict the watch-only entry.
+        subscription.cancel();
+        assertThat(service.trackedServices(), equalTo(1));
+    }
+
+    @Test
+    void watchOnlyEntryRetainedWhileAnotherWatcherRemains() throws Exception {
+        DefaultHealthService service = new DefaultHealthService();
+        BlockingQueue<HealthCheckResponse> received1 = new LinkedBlockingQueue<>();
+        BlockingQueue<HealthCheckResponse> received2 = new LinkedBlockingQueue<>();
+        Subscription sub1 = subscribeToWatch(service, UNKNOWN_SERVICE_NAME, received1);
+        Subscription sub2 = subscribeToWatch(service, UNKNOWN_SERVICE_NAME, received2);
+        assertThat(received1.take().getStatus(), equalTo(SERVICE_UNKNOWN));
+        assertThat(received2.take().getStatus(), equalTo(SERVICE_UNKNOWN));
+        assertThat(service.trackedServices(), equalTo(2));
+
+        sub1.cancel();
+        assertThat(service.trackedServices(), equalTo(2)); // still watched by sub2
+        sub2.cancel();
+        assertThat(service.trackedServices(), equalTo(1)); // last watcher gone
+    }
+
+    @Test
+    void registeredServiceRetainedWhenWatcherCancels() throws Exception {
+        DefaultHealthService service = new DefaultHealthService();
+        service.setStatus("svc", SERVING);
+        assertThat(service.trackedServices(), equalTo(2));
+
+        BlockingQueue<HealthCheckResponse> received = new LinkedBlockingQueue<>();
+        Subscription subscription = subscribeToWatch(service, "svc", received);
+        assertThat(received.take().getStatus(), equalTo(SERVING));
+
+        subscription.cancel();
+        // A server-registered service is retained so check() and future watchers still see it.
+        assertThat(service.trackedServices(), equalTo(2));
+        assertThat(service.check(null, newRequest("svc")).toFuture().get().getStatus(), equalTo(SERVING));
+    }
+
+    @Test
+    void watchBeforeRegisterRetainedAfterPromotion() throws Exception {
+        DefaultHealthService service = new DefaultHealthService();
+        BlockingQueue<HealthCheckResponse> received = new LinkedBlockingQueue<>();
+        Subscription subscription = subscribeToWatch(service, "later", received);
+        assertThat(received.take().getStatus(), equalTo(SERVICE_UNKNOWN));
+
+        // Server registers the watched-but-unknown service; the watcher observes the update.
+        service.setStatus("later", SERVING);
+        assertThat(received.take().getStatus(), equalTo(SERVING));
+
+        // Now that it is registered, it survives the watcher leaving.
+        subscription.cancel();
+        assertThat(service.trackedServices(), equalTo(2));
+    }
+
+    @Test
+    void terminateCompletesAndEvictsWatchOnlyWatcher() throws Exception {
+        DefaultHealthService service = new DefaultHealthService();
+        BlockingQueue<HealthCheckResponse> received = new LinkedBlockingQueue<>();
+        CountDownLatch complete = new CountDownLatch(1);
+        subscribeToWatch(service, UNKNOWN_SERVICE_NAME, received, complete);
+        assertThat(received.take().getStatus(), equalTo(SERVICE_UNKNOWN));
+        assertThat(service.trackedServices(), equalTo(2));
+
+        assertThat(service.terminate(), equalTo(true));
+        assertThat(received.take().getStatus(), equalTo(NOT_SERVING));
+        assertThat(complete.await(10, SECONDS), equalTo(true));
+        // Completion drove watcherTerminated, which evicted the watch-only entry; OVERALL_SERVICE_NAME remains.
+        assertThat(service.trackedServices(), equalTo(1));
+    }
+
+    @Test
+    void clearStatusCompletesActiveWatcher() throws Exception {
+        DefaultHealthService service = new DefaultHealthService();
+        service.setStatus("svc", SERVING);
+        assertThat(service.trackedServices(), equalTo(2));
+        BlockingQueue<HealthCheckResponse> received = new LinkedBlockingQueue<>();
+        CountDownLatch complete = new CountDownLatch(1);
+        subscribeToWatch(service, "svc", received, complete);
+        assertThat(received.take().getStatus(), equalTo(SERVING));
+
+        assertThat(service.clearStatus("svc"), equalTo(true));
+        assertThat(received.take().getStatus(), equalTo(SERVICE_UNKNOWN));
+        assertThat(complete.await(10, SECONDS), equalTo(true));
+        // clearStatus removed the entry; the watcher's subsequent watcherTerminated is a harmless no-op.
+        assertThat(service.trackedServices(), equalTo(1));
+    }
+
+    private static Subscription subscribeToWatch(DefaultHealthService service, String name,
+                                                 BlockingQueue<HealthCheckResponse> received) {
+        return subscribeToWatch(service, name, received, new CountDownLatch(1));
+    }
+
+    private static Subscription subscribeToWatch(DefaultHealthService service, String name,
+                                                 BlockingQueue<HealthCheckResponse> received,
+                                                 CountDownLatch complete) {
+        AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
+        toSource(service.watch(null, newRequest(name))).subscribe(new Subscriber<HealthCheckResponse>() {
+            @Override
+            public void onSubscribe(final Subscription subscription) {
+                subscriptionRef.set(subscription);
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(@Nullable final HealthCheckResponse response) {
+                received.add(response);
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+                complete.countDown();
+            }
+        });
+        return subscriptionRef.get();
     }
 
     private static void watchFailure(DefaultHealthService service, GrpcStatusCode expectedCode) throws Exception {


### PR DESCRIPTION
 #### Motivation

For the DefaultHealthService, we can get watches that don't really exist. This could lead to resource exhaustion.

 #### Modifications

- For unknown services, drop the watch entries once there are no more interested parties. Once a status is set, that entry will be retained indefinitely.
- For the default constructor, set a cap of 1000 to the watch list before new unknown watches are rejected. This should be enough for the vast majority of services and also doesn't affect statuses that have been explicitly set.
