### PR TITLE
grpc: make gRPC status generated from exceptions a bit more quiet

### DIFF
--- a/servicetalk-grpc-api/build.gradle
+++ b/servicetalk-grpc-api/build.gradle
@@ -46,5 +46,6 @@ dependencies {
 
   testImplementation enforcedPlatform("org.junit:junit-bom:$junit5Version")
   testImplementation project(":servicetalk-test-resources")
+  testImplementation "org.hamcrest:hamcrest"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 }

--- a/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
@@ -192,7 +192,7 @@ IMPORTANT: The description and `details` you supply here are **not** redacted â€
 are transmitted as-is. Treat them as untrusted output: include only information that is safe to expose to the remote
 peer. Anything that is *not* an explicit `GrpcStatusException` is redacted instead, as described next.
 
-[#exposeExceptionDetails]
+[#exceptionRedaction]
 === Exception detail redaction
 
 To avoid leaking internal information to remote peers, the server does **not** echo arbitrary exception detail in the
@@ -200,14 +200,3 @@ To avoid leaking internal information to remote peers, the server does **not** e
 `internal error (ref: <uuid>)`, and for a serialization failure it receives `Serialization error (ref: <uuid>)`. The
 full exception (including the same reference) is always logged on the server, so operators can correlate a
 client-reported reference with the corresponding server log entry without exposing sensitive information.
-
-This is the recommended production behavior. For non-production debugging, the legacy behavior of echoing
-`Throwable.toString()` (and the serializer's message) on the wire can be restored by setting the system property:
-
-[source]
-----
--Dio.servicetalk.grpc.exposeExceptionDetails=true
-----
-
-NOTE: Relying on the client-side description for debugging is discouraged. Prefer out-of-band correlation via the
-opaque reference and server logs, which works regardless of this property.

--- a/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
@@ -156,3 +156,58 @@ similar to the xref:{page-version}@servicetalk-http-api::index.adoc#client[HTTP 
 
 gRPC client uses xref:{page-version}@servicetalk-client-api::service-discovery.adoc[Service Discovery] to discover
 instances of the target service similar to the xref:{page-version}@servicetalk-http-api::index.adoc#client[HTTP Client].
+
+== Error Handling
+
+When a `Service` fails, ServiceTalk maps the `Throwable` to a
+link:{source-root}/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatus.java[GrpcStatus] that is sent
+to the client as the `grpc-status` and (optionally) `grpc-message` trailers. Well-known exception types are mapped to
+specific status codes; any other exception is mapped to `UNKNOWN`.
+
+[#returningErrors]
+=== Returning an error from a service
+
+To return a meaningful, client-facing error, a `Service` should fail with a
+link:{source-root}/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java[GrpcStatusException]
+that it constructs explicitly — either by throwing it (blocking APIs) or by completing the `Single`/`Publisher`
+with it (asynchronous APIs). The status code and description you put on it are sent **verbatim** on the wire.
+
+For most errors the ServiceTalk-native `GrpcStatus` (a status code and an optional human-readable description) is all
+you need:
+
+[source, java]
+----
+// Sent as the grpc-status / grpc-message trailers:
+throw new GrpcStatusException(new GrpcStatus(GrpcStatusCode.INVALID_ARGUMENT, "id must be positive"));
+----
+
+When you need to attach structured, typed error detail (the gRPC
+link:https://grpc.io/docs/guides/error/#richer-error-model[richer error model]), use
+`GrpcStatusException.of(...)` with a `com.google.rpc.Status` — the `details` (a repeated `Any`) are carried in the
+`grpc-status-details-bin` trailer. This is what the
+link:{source-root}/servicetalk-examples/grpc/errors/src/main/java/io/servicetalk/examples/grpc/errors/ErrorExampleServer.java[Application Errors example]
+demonstrates, returning an `INVALID_ARGUMENT` with a `com.google.rpc.BadRequest` detail.
+
+IMPORTANT: The description and `details` you supply here are **not** redacted — they are intended for the client and
+are transmitted as-is. Treat them as untrusted output: include only information that is safe to expose to the remote
+peer. Anything that is *not* an explicit `GrpcStatusException` is redacted instead, as described next.
+
+[#exposeExceptionDetails]
+=== Exception detail redaction
+
+To avoid leaking internal information to remote peers, the server does **not** echo arbitrary exception detail in the
+`grpc-message` description. For an otherwise-unmapped exception the client receives an opaque reference of the form
+`internal error (ref: <uuid>)`, and for a serialization failure it receives `Serialization error (ref: <uuid>)`. The
+full exception (including the same reference) is always logged on the server, so operators can correlate a
+client-reported reference with the corresponding server log entry without exposing sensitive information.
+
+This is the recommended production behavior. For non-production debugging, the legacy behavior of echoing
+`Throwable.toString()` (and the serializer's message) on the wire can be restored by setting the system property:
+
+[source]
+----
+-Dio.servicetalk.grpc.exposeExceptionDetails=true
+----
+
+NOTE: Relying on the client-side description for debugging is discouraged. Prefer out-of-band correlation via the
+opaque reference and server logs, which works regardless of this property.

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExceptionMapperServiceFilter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcExceptionMapperServiceFilter.java
@@ -35,6 +35,7 @@ import static io.servicetalk.grpc.api.GrpcHeaderValues.APPLICATION_GRPC;
 import static io.servicetalk.grpc.api.GrpcStatusCode.fromCodeValue;
 import static io.servicetalk.grpc.api.GrpcStatusException.serverCatchAllShouldLog;
 import static io.servicetalk.grpc.api.GrpcUtils.newErrorResponse;
+import static io.servicetalk.grpc.internal.GrpcStatusUtils.getStatusMessage;
 
 /**
  * Filter that maps known {@link Throwable} subtypes into an gRPC response with an appropriate {@link GrpcStatusCode}.
@@ -95,14 +96,15 @@ public final class GrpcExceptionMapperServiceFilter implements StreamingHttpServ
                             final HttpServiceContext ctx, final StreamingHttpRequest request, final Throwable cause) {
         final CharSequence codeValue = response.headers().get(GRPC_STATUS);
         assert codeValue != null;
-        final String format =
-                "{} during a {} processing for connection='{}', request='{} {} {}' was mapped to grpc-status: {} ({})";
+        final CharSequence message = getStatusMessage(response.headers());
+        final String format = "{} during a {} processing for connection='{}', request='{} {} {}' was mapped to " +
+                "grpc-status: {} ({}), grpc-message: \"{}\"";
         if (debug) {
             LOGGER.debug(format, "Exception", what, ctx, request.method(), request.requestTarget(),
-                    request.version(), codeValue, fromCodeValue(codeValue), cause);
+                    request.version(), codeValue, fromCodeValue(codeValue), message, cause);
         } else {
             LOGGER.error(format, "Unexpected exception", what, ctx, request.method(), request.requestTarget(),
-                    request.version(), codeValue, fromCodeValue(codeValue), cause);
+                    request.version(), codeValue, fromCodeValue(codeValue), message, cause);
         }
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -94,6 +94,7 @@ import static io.servicetalk.grpc.api.GrpcUtils.setStatus;
 import static io.servicetalk.grpc.api.GrpcUtils.setStatusOk;
 import static io.servicetalk.grpc.api.GrpcUtils.validateContentType;
 import static io.servicetalk.grpc.internal.GrpcContextKeys.TRAILERS_ONLY_RESPONSE;
+import static io.servicetalk.grpc.internal.GrpcStatusUtils.getStatusMessage;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
 import static io.servicetalk.http.api.HttpExecutionStrategies.customStrategyBuilder;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
@@ -899,11 +900,11 @@ final class GrpcRouter {
         CharSequence codeValue = headers.get(GRPC_STATUS);
         assert codeValue != null;
         GrpcStatusCode statusCode = GrpcStatusCode.fromCodeValue(codeValue);
-        String msg = "Exception from {} for a request to {} was converted to grpc-status={}";
+        String msg = "Exception from {} for a request to {} was converted to grpc-status={}, grpc-message=\"{}\"";
         if (serverCatchAllShouldLog(error)) {
-            LOGGER.error(msg, where, methodDescriptor.httpPath(), statusCode, error);
+            LOGGER.error(msg, where, methodDescriptor.httpPath(), statusCode, getStatusMessage(headers), error);
         } else {
-            LOGGER.debug(msg, where, methodDescriptor.httpPath(), statusCode, error);
+            LOGGER.debug(msg, where, methodDescriptor.httpPath(), statusCode, getStatusMessage(headers), error);
         }
     }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
@@ -20,9 +20,6 @@ import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.ProxyConnectResponseException;
 import io.servicetalk.serializer.api.SerializationException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
@@ -35,7 +32,6 @@ import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
 import static io.servicetalk.grpc.api.GrpcStatusCode.fromHttp2ErrorCode;
 import static io.servicetalk.grpc.api.GrpcUtils.fromHttpStatus;
-import static java.lang.Boolean.getBoolean;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -44,35 +40,18 @@ import static java.util.Objects.requireNonNull;
 public final class GrpcStatusException extends RuntimeException {
     private static final long serialVersionUID = -1882895535544626915L;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GrpcStatusException.class);
-
     /**
-     * When {@code true}, restores the legacy behavior of echoing {@link Throwable#toString()} of an otherwise-unmapped
-     * server-side exception in the gRPC status description that is sent to the peer. This is intended for
-     * non-production debugging only: it can leak internal class names and message content (file paths, SQL fragments,
-     * configuration values, tokens, PII) to remote clients (CWE-209 / CWE-200). The default ({@code false}) sends an
-     * opaque {@value #UNKNOWN_DESCRIPTION_PREFIX} reference instead, which operators can correlate with the full
-     * exception logged server-side.
-     */
-    static final String EXPOSE_EXCEPTION_DETAILS_PROPERTY = "io.servicetalk.grpc.exposeExceptionDetails";
-
-    /**
-     * Prefix of the opaque description sent to the peer for unmapped server-side exceptions when
-     * {@link #EXPOSE_EXCEPTION_DETAILS_PROPERTY} is not enabled.
+     * Prefix of the opaque description sent to the peer for unmapped server-side exceptions. The detail is not echoed
+     * to the peer to avoid leaking internal information (CWE-209 / CWE-200); the full exception is logged server-side
+     * with the same reference for correlation.
      */
     static final String UNKNOWN_DESCRIPTION_PREFIX = "internal error";
 
     /**
-     * Prefix of the opaque description sent to the peer for server-side serialization failures when
-     * {@link #EXPOSE_EXCEPTION_DETAILS_PROPERTY} is not enabled.
+     * Prefix of the opaque description sent to the peer for server-side serialization failures. See
+     * {@link #UNKNOWN_DESCRIPTION_PREFIX}.
      */
     static final String SERIALIZATION_DESCRIPTION_PREFIX = "Serialization error";
-
-    private static final boolean EXPOSE_EXCEPTION_DETAILS = getBoolean(EXPOSE_EXCEPTION_DETAILS_PROPERTY);
-
-    static {
-        LOGGER.debug("-D{}: {}", EXPOSE_EXCEPTION_DETAILS_PROPERTY, EXPOSE_EXCEPTION_DETAILS);
-    }
 
     private final GrpcStatus status;
     private final Supplier<com.google.rpc.Status> applicationStatusSupplier;
@@ -175,8 +154,8 @@ public final class GrpcStatusException extends RuntimeException {
         } else if (cause instanceof SerializationException) {
             // Avoid leaking serializer internals (the message may contain partial payload content or internal type
             // names) to the remote peer. The category is still conveyed; the detailed message is logged server-side
-            // and can be restored on the wire via the same opt-in as the catch-all below.
-            status = new GrpcStatus(UNKNOWN, cause, serializationErrorDescription(cause));
+            // with the same reference.
+            status = new GrpcStatus(UNKNOWN, cause, redactedDescription(SERIALIZATION_DESCRIPTION_PREFIX));
         } else if (cause instanceof CancellationException) {
             status = new GrpcStatus(CANCELLED, cause);
         } else if (cause instanceof TimeoutException) {
@@ -185,33 +164,12 @@ public final class GrpcStatusException extends RuntimeException {
             final HttpResponseMetaData response = ((ProxyConnectResponseException) cause).response();
             status = new GrpcStatus(fromHttpStatus(response.status()), cause);
         } else {
-            // Avoid leaking internal exception details. Instead, send an opaque reference that operators can correlate
-            // with the full exception logged server-side. Verbose behavior can be restored for non-production debugging
-            // via -Dio.servicetalk.grpc.exposeExceptionDetails=true.
-            status = new GrpcStatus(UNKNOWN, cause, unknownStatusDescription(cause));
+            // Avoid leaking internal exception details to the remote peer (CWE-209 / CWE-200). Instead, send an opaque
+            // reference that operators can correlate with the full exception logged server-side.
+            status = new GrpcStatus(UNKNOWN, cause, redactedDescription(UNKNOWN_DESCRIPTION_PREFIX));
         }
 
         return status;
-    }
-
-    private static String unknownStatusDescription(Throwable cause) {
-        return unknownStatusDescription(cause, EXPOSE_EXCEPTION_DETAILS);
-    }
-
-    // Visible for testing: the EXPOSE_EXCEPTION_DETAILS flag is resolved once at class-init from a system property,
-    // so the description logic is factored out to allow both behaviors to be exercised directly.
-    static String unknownStatusDescription(Throwable cause, boolean exposeExceptionDetails) {
-        return exposeExceptionDetails ? cause.toString() : redactedDescription(UNKNOWN_DESCRIPTION_PREFIX);
-    }
-
-    private static String serializationErrorDescription(Throwable cause) {
-        return serializationErrorDescription(cause, EXPOSE_EXCEPTION_DETAILS);
-    }
-
-    // Visible for testing, see unknownStatusDescription(Throwable, boolean).
-    static String serializationErrorDescription(Throwable cause, boolean exposeExceptionDetails) {
-        return exposeExceptionDetails ? SERIALIZATION_DESCRIPTION_PREFIX + ": " + cause.getMessage()
-                : redactedDescription(SERIALIZATION_DESCRIPTION_PREFIX);
     }
 
     // An opaque, non-identifying description with a reference that operators can correlate with the full exception

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcStatusException.java
@@ -20,6 +20,10 @@ import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.ProxyConnectResponseException;
 import io.servicetalk.serializer.api.SerializationException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -31,6 +35,7 @@ import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
 import static io.servicetalk.grpc.api.GrpcStatusCode.fromHttp2ErrorCode;
 import static io.servicetalk.grpc.api.GrpcUtils.fromHttpStatus;
+import static java.lang.Boolean.getBoolean;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -38,6 +43,36 @@ import static java.util.Objects.requireNonNull;
  */
 public final class GrpcStatusException extends RuntimeException {
     private static final long serialVersionUID = -1882895535544626915L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GrpcStatusException.class);
+
+    /**
+     * When {@code true}, restores the legacy behavior of echoing {@link Throwable#toString()} of an otherwise-unmapped
+     * server-side exception in the gRPC status description that is sent to the peer. This is intended for
+     * non-production debugging only: it can leak internal class names and message content (file paths, SQL fragments,
+     * configuration values, tokens, PII) to remote clients (CWE-209 / CWE-200). The default ({@code false}) sends an
+     * opaque {@value #UNKNOWN_DESCRIPTION_PREFIX} reference instead, which operators can correlate with the full
+     * exception logged server-side.
+     */
+    static final String EXPOSE_EXCEPTION_DETAILS_PROPERTY = "io.servicetalk.grpc.exposeExceptionDetails";
+
+    /**
+     * Prefix of the opaque description sent to the peer for unmapped server-side exceptions when
+     * {@link #EXPOSE_EXCEPTION_DETAILS_PROPERTY} is not enabled.
+     */
+    static final String UNKNOWN_DESCRIPTION_PREFIX = "internal error";
+
+    /**
+     * Prefix of the opaque description sent to the peer for server-side serialization failures when
+     * {@link #EXPOSE_EXCEPTION_DETAILS_PROPERTY} is not enabled.
+     */
+    static final String SERIALIZATION_DESCRIPTION_PREFIX = "Serialization error";
+
+    private static final boolean EXPOSE_EXCEPTION_DETAILS = getBoolean(EXPOSE_EXCEPTION_DETAILS_PROPERTY);
+
+    static {
+        LOGGER.debug("-D{}: {}", EXPOSE_EXCEPTION_DETAILS_PROPERTY, EXPOSE_EXCEPTION_DETAILS);
+    }
 
     private final GrpcStatus status;
     private final Supplier<com.google.rpc.Status> applicationStatusSupplier;
@@ -138,7 +173,10 @@ public final class GrpcStatusException extends RuntimeException {
             status = new GrpcStatus(UNIMPLEMENTED, cause, "Message encoding '" + msgEncException.encoding()
                     + "' not supported ");
         } else if (cause instanceof SerializationException) {
-            status = new GrpcStatus(UNKNOWN, cause, "Serialization error: " + cause.getMessage());
+            // Avoid leaking serializer internals (the message may contain partial payload content or internal type
+            // names) to the remote peer. The category is still conveyed; the detailed message is logged server-side
+            // and can be restored on the wire via the same opt-in as the catch-all below.
+            status = new GrpcStatus(UNKNOWN, cause, serializationErrorDescription(cause));
         } else if (cause instanceof CancellationException) {
             status = new GrpcStatus(CANCELLED, cause);
         } else if (cause instanceof TimeoutException) {
@@ -147,11 +185,39 @@ public final class GrpcStatusException extends RuntimeException {
             final HttpResponseMetaData response = ((ProxyConnectResponseException) cause).response();
             status = new GrpcStatus(fromHttpStatus(response.status()), cause);
         } else {
-            // Initialize detail because cause is often lost
-            status = new GrpcStatus(UNKNOWN, cause, cause.toString());
+            // Avoid leaking internal exception details. Instead, send an opaque reference that operators can correlate
+            // with the full exception logged server-side. Verbose behavior can be restored for non-production debugging
+            // via -Dio.servicetalk.grpc.exposeExceptionDetails=true.
+            status = new GrpcStatus(UNKNOWN, cause, unknownStatusDescription(cause));
         }
 
         return status;
+    }
+
+    private static String unknownStatusDescription(Throwable cause) {
+        return unknownStatusDescription(cause, EXPOSE_EXCEPTION_DETAILS);
+    }
+
+    // Visible for testing: the EXPOSE_EXCEPTION_DETAILS flag is resolved once at class-init from a system property,
+    // so the description logic is factored out to allow both behaviors to be exercised directly.
+    static String unknownStatusDescription(Throwable cause, boolean exposeExceptionDetails) {
+        return exposeExceptionDetails ? cause.toString() : redactedDescription(UNKNOWN_DESCRIPTION_PREFIX);
+    }
+
+    private static String serializationErrorDescription(Throwable cause) {
+        return serializationErrorDescription(cause, EXPOSE_EXCEPTION_DETAILS);
+    }
+
+    // Visible for testing, see unknownStatusDescription(Throwable, boolean).
+    static String serializationErrorDescription(Throwable cause, boolean exposeExceptionDetails) {
+        return exposeExceptionDetails ? SERIALIZATION_DESCRIPTION_PREFIX + ": " + cause.getMessage()
+                : redactedDescription(SERIALIZATION_DESCRIPTION_PREFIX);
+    }
+
+    // An opaque, non-identifying description with a reference that operators can correlate with the full exception
+    // logged server-side (which logs the same reference). See serverCatchAllShouldLog and its callers.
+    private static String redactedDescription(String prefix) {
+        return prefix + " (ref: " + UUID.randomUUID() + ')';
     }
 
     static boolean serverCatchAllShouldLog(Throwable cause) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcUtils.java
@@ -865,11 +865,12 @@ final class GrpcUtils {
         protected HttpHeaders payloadFailed(final Throwable cause, final HttpHeaders trailers) {
             GrpcStatus status = setStatus(trailers, cause, allocator);
             // Swallow exception as we are converting it to the trailers.
-            String msg = "Exception from response payload for a request to {} was converted to grpc-status={}";
+            String msg = "Exception from response payload for a request to {} was converted to grpc-status={}, " +
+                    "grpc-message=\"{}\"";
             if (serverCatchAllShouldLog(cause)) {
-                LOGGER.error(msg, methodDescriptor.httpPath(), status.code(), cause);
+                LOGGER.error(msg, methodDescriptor.httpPath(), status.code(), status.description(), cause);
             } else {
-                LOGGER.debug(msg, methodDescriptor.httpPath(), status.code(), cause);
+                LOGGER.debug(msg, methodDescriptor.httpPath(), status.code(), status.description(), cause);
             }
             return trailers;
         }

--- a/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcStatusExceptionTest.java
+++ b/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcStatusExceptionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.api;
+
+import io.servicetalk.serializer.api.SerializationException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeoutException;
+
+import static io.servicetalk.grpc.api.GrpcStatusCode.CANCELLED;
+import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
+import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
+import static io.servicetalk.grpc.api.GrpcStatusException.SERIALIZATION_DESCRIPTION_PREFIX;
+import static io.servicetalk.grpc.api.GrpcStatusException.UNKNOWN_DESCRIPTION_PREFIX;
+import static io.servicetalk.grpc.api.GrpcStatusException.serializationErrorDescription;
+import static io.servicetalk.grpc.api.GrpcStatusException.toGrpcStatus;
+import static io.servicetalk.grpc.api.GrpcStatusException.unknownStatusDescription;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+class GrpcStatusExceptionTest {
+
+    private static final String SECRET = "top secret string";
+
+    @Test
+    void unmappedExceptionDoesNotLeakDetailsToDescription() {
+        GrpcStatus status = toGrpcStatus(new IllegalStateException(SECRET));
+        assertThat(status.code(), is(UNKNOWN));
+        // The opaque reference must not echo the message or the exception class name to the peer.
+        assertThat(status.description(), allOf(
+                startsWith(UNKNOWN_DESCRIPTION_PREFIX),
+                not(containsString(SECRET)),
+                not(containsString("IllegalStateException"))));
+        // Shape: "internal error (ref: <uuid>)".
+        assertThat(status.description(), matchesPattern(
+                "internal error \\(ref: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\)"));
+    }
+
+    @Test
+    void redactedDescriptionsUseUniqueReferences() {
+        Throwable cause = new RuntimeException(SECRET);
+        String first = unknownStatusDescription(cause, false);
+        String second = unknownStatusDescription(cause, false);
+        assertThat(first, not(is(second)));
+        assertThat(first, not(containsString(SECRET)));
+        assertThat(second, not(containsString(SECRET)));
+    }
+
+    @Test
+    void exposeExceptionDetailsRestoresVerboseDescription() {
+        Throwable cause = new IllegalStateException(SECRET);
+        assertThat(unknownStatusDescription(cause, true), is(cause.toString()));
+    }
+
+    @Test
+    void messageEncodingExceptionMappingUnchanged() {
+        GrpcStatus status = toGrpcStatus(new MessageEncodingException("snappy"));
+        assertThat(status.code(), is(UNIMPLEMENTED));
+        assertThat(status.description(), containsString("snappy"));
+    }
+
+    @Test
+    void serializationExceptionMessageIsRedacted() {
+        GrpcStatus status = toGrpcStatus(new SerializationException("boom"));
+        assertThat(status.code(), is(UNKNOWN));
+        // The category is conveyed but the serializer's message is not echoed to the peer; an opaque reference is
+        // included so the failure can be correlated with the full exception logged server-side.
+        assertThat(status.description(), allOf(
+                startsWith(SERIALIZATION_DESCRIPTION_PREFIX), not(containsString("boom"))));
+        assertThat(status.description(), matchesPattern(
+                "Serialization error \\(ref: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\)"));
+    }
+
+    @Test
+    void exposeExceptionDetailsRestoresSerializationMessage() {
+        assertThat(serializationErrorDescription(new SerializationException("boom"), true),
+                is("Serialization error: boom"));
+    }
+
+    @Test
+    void timeoutAndCancellationCarryNoDescription() {
+        GrpcStatus timeout = toGrpcStatus(new TimeoutException("deadline"));
+        assertThat(timeout.code(), is(DEADLINE_EXCEEDED));
+        assertThat(timeout.description(), is(nullValue()));
+
+        GrpcStatus cancelled = toGrpcStatus(new CancellationException("cancelled"));
+        assertThat(cancelled.code(), is(CANCELLED));
+        assertThat(cancelled.description(), is(nullValue()));
+    }
+
+    @Test
+    void fromThrowableRedactsUnmappedCauseButPreservesExistingStatus() {
+        GrpcStatusException fromUnmapped = GrpcStatusException.fromThrowable(new IllegalStateException(SECRET));
+        assertThat(fromUnmapped.status().code(), is(UNKNOWN));
+        assertThat(fromUnmapped.status().description(), allOf(
+                startsWith(UNKNOWN_DESCRIPTION_PREFIX), not(containsString(SECRET))));
+
+        GrpcStatusException existing = new GrpcStatusException(new GrpcStatus(UNKNOWN, "explicit detail"));
+        assertThat(GrpcStatusException.fromThrowable(existing), is(existing));
+    }
+}

--- a/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcStatusExceptionTest.java
+++ b/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcStatusExceptionTest.java
@@ -28,9 +28,7 @@ import static io.servicetalk.grpc.api.GrpcStatusCode.UNIMPLEMENTED;
 import static io.servicetalk.grpc.api.GrpcStatusCode.UNKNOWN;
 import static io.servicetalk.grpc.api.GrpcStatusException.SERIALIZATION_DESCRIPTION_PREFIX;
 import static io.servicetalk.grpc.api.GrpcStatusException.UNKNOWN_DESCRIPTION_PREFIX;
-import static io.servicetalk.grpc.api.GrpcStatusException.serializationErrorDescription;
 import static io.servicetalk.grpc.api.GrpcStatusException.toGrpcStatus;
-import static io.servicetalk.grpc.api.GrpcStatusException.unknownStatusDescription;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -60,18 +58,11 @@ class GrpcStatusExceptionTest {
 
     @Test
     void redactedDescriptionsUseUniqueReferences() {
-        Throwable cause = new RuntimeException(SECRET);
-        String first = unknownStatusDescription(cause, false);
-        String second = unknownStatusDescription(cause, false);
+        String first = toGrpcStatus(new RuntimeException(SECRET)).description();
+        String second = toGrpcStatus(new RuntimeException(SECRET)).description();
         assertThat(first, not(is(second)));
         assertThat(first, not(containsString(SECRET)));
         assertThat(second, not(containsString(SECRET)));
-    }
-
-    @Test
-    void exposeExceptionDetailsRestoresVerboseDescription() {
-        Throwable cause = new IllegalStateException(SECRET);
-        assertThat(unknownStatusDescription(cause, true), is(cause.toString()));
     }
 
     @Test
@@ -91,12 +82,6 @@ class GrpcStatusExceptionTest {
                 startsWith(SERIALIZATION_DESCRIPTION_PREFIX), not(containsString("boom"))));
         assertThat(status.description(), matchesPattern(
                 "Serialization error \\(ref: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\)"));
-    }
-
-    @Test
-    void exposeExceptionDetailsRestoresSerializationMessage() {
-        assertThat(serializationErrorDescription(new SerializationException("boom"), true),
-                is("Serialization error: boom"));
     }
 
     @Test


### PR DESCRIPTION
 #### Motivation

Currently, unknown errors in gRPC can result in a very verbose exception.

 #### Modifications

Switch it to a compact cause with a UUID reference in case we need to correlate the response received by the client to a server log.

Verbose statuses (existing behavior) can be enabled via the system property: -Dio.servicetalk.grpc.exposeExceptionDetails=true

 #### Result

Smaller, more focused messages that don't emit internal details by default.
