### PR TITLE
http-netty: Cap HTTP/1.1 chunk-size at Integer.MAX_VALUE

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -433,7 +433,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 }
                 onDataSeen();
                 final int lfIndex = crlfIndex(longLFIndex);
-                long chunkSize = getChunkSize(buffer, lfIndex);
+                int chunkSize = getChunkSize(buffer, lfIndex);
                 consumeCRLF(buffer, lfIndex);
                 this.chunkSize = chunkSize;
                 if (chunkSize == 0) {
@@ -444,7 +444,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 // fall-through
             }
             case READ_CHUNKED_CONTENT: {
-                final int toRead = min((int) min(Integer.MAX_VALUE, chunkSize), buffer.readableBytes());
+                final int toRead = (int) min(chunkSize, buffer.readableBytes());
                 if (toRead == 0) {
                     return;
                 }
@@ -836,7 +836,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         }
     }
 
-    private static long getChunkSize(final ByteBuf buffer, final int lfIndex) {
+    private static int getChunkSize(final ByteBuf buffer, final int lfIndex) {
         if (lfIndex - 2 < buffer.readerIndex()) {
             throw new DecoderException("Chunked encoding specified but chunk-size not found");
         }
@@ -844,7 +844,13 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 lfIndex - 1 - buffer.readerIndex(), US_ASCII));
     }
 
-    private static long getChunkSize(String hex) {
+    /**
+     * Parses an HTTP/1.1 chunk-size token. Stops at the first {@code ';'}, whitespace, or
+     * ISO control character so any chunk-extension is ignored. Visible for testing the
+     * {@code value < 0} guard which is otherwise unreachable through the public flow given
+     * the {@link #MAX_HEX_CHARS_FOR_LONG} line cap.
+     */
+    static int getChunkSize(String hex) {
         hex = hex.trim();
         for (int i = 0; i < hex.length(); ++i) {
             char c = hex.charAt(i);
@@ -853,9 +859,13 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 break;
             }
         }
-
         try {
-            return parseUnsignedLong(hex, 16);
+            final long value = parseUnsignedLong(hex, 16);
+            if (value < 0 || value > Integer.MAX_VALUE) {
+                throw new NumberFormatException("Chunk size " + Long.toUnsignedString(value)
+                        + " exceeds Integer.MAX_VALUE");
+            }
+            return (int) value;
         } catch (NumberFormatException cause) {
             throw invalidChunkSize(hex, cause);
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -639,12 +639,6 @@ abstract class HttpObjectDecoderTest {
         assertThat(channel.inboundMessages(), is(not(empty())));
     }
 
-    /**
-     * Validates that chunk-size values exceeding {@link Integer#MAX_VALUE} are rejected.
-     * Previously {@link Long#parseUnsignedLong} accepted them and a defensive cast in
-     * {@code READ_CHUNKED_CONTENT} silently clamped to {@link Integer#MAX_VALUE}, leaving
-     * the decoder waiting forever for body bytes that would not arrive.
-     */
     @ParameterizedTest(name = "{displayName} [{index}] chunkSize={0} expectRejected={1} crlf={2}")
     @MethodSource("chunkSizeOverflowArgs")
     void chunkedChunkSizeIntOverflow(String chunkSizeHex, boolean expectRejected, boolean crlf) {
@@ -700,13 +694,6 @@ abstract class HttpObjectDecoderTest {
         assertThat(channel.inboundMessages(), is(not(empty())));
     }
 
-    /**
-     * Direct tests for {@link HttpObjectDecoder#getChunkSize(String)}, exercising branches that
-     * are unreachable through the EmbeddedChannel flow because of the chunk-size line cap.
-     * In particular the {@code value < 0} guard requires a hex string that wraps
-     * {@link Long#parseUnsignedLong} into a negative long, which needs more than 15 hex
-     * characters — the public flow caps the line at 14 hex characters + CRLF.
-     */
     @ParameterizedTest(name = "{displayName} [{index}] hex={0}")
     @ValueSource(strings = {
             // 16 hex F's: parseUnsignedLong -> -1L (0xFFFFFFFFFFFFFFFF). Exercises value < 0.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -639,6 +639,102 @@ abstract class HttpObjectDecoderTest {
         assertThat(channel.inboundMessages(), is(not(empty())));
     }
 
+    /**
+     * Validates that chunk-size values exceeding {@link Integer#MAX_VALUE} are rejected.
+     * Previously {@link Long#parseUnsignedLong} accepted them and a defensive cast in
+     * {@code READ_CHUNKED_CONTENT} silently clamped to {@link Integer#MAX_VALUE}, leaving
+     * the decoder waiting forever for body bytes that would not arrive.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] chunkSize={0} expectRejected={1} crlf={2}")
+    @MethodSource("chunkSizeOverflowArgs")
+    void chunkedChunkSizeIntOverflow(String chunkSizeHex, boolean expectRejected, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
+        if (expectRejected) {
+            DecoderException e = assertThrows(DecoderException.class,
+                    () -> writeMsg(chunkSizeHex + "\r\n", channel));
+            assertThat(e.getMessage(), startsWith("Cannot parse chunk-size"));
+            assertThat(e.getCause(), is(instanceOf(NumberFormatException.class)));
+            assertThat(channel.inboundMessages(), is(not(empty())));
+        } else {
+            // Feed the chunk-size line; no DecoderException should be thrown. We don't
+            // drain the half-finished body; tearDown() handles cleanup.
+            channel.writeInbound(fromAscii(chunkSizeHex + "\r\n"));
+            assertThat(channel.isOpen(), is(true));
+        }
+    }
+
+    private static Collection<Arguments> chunkSizeOverflowArgs() {
+        List<Arguments> arguments = new ArrayList<>();
+        for (boolean crlf : new boolean[] {true, false}) {
+            // Smallest int-overflow value: Integer.MAX_VALUE + 1 (0x80000000).
+            arguments.add(Arguments.of("80000000", true, crlf));
+            // 4 GB declaration: 9 hex chars, value 0x100000000.
+            arguments.add(Arguments.of("100000000", true, crlf));
+            // Largest hex that fits within the current chunk-size line cap
+            // (14 chars + CRLF = 16). Value 0x3FFFFFFFFFFFFF (~1.8 * 10^16).
+            arguments.add(Arguments.of("FFFFFFFFFFFFFF", true, crlf));
+            // Boundary success: exactly Integer.MAX_VALUE (0x7FFFFFFF) must be accepted.
+            arguments.add(Arguments.of("7FFFFFFF", false, crlf));
+        }
+        return arguments;
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")
+    @ValueSource(booleans = {true, false})
+    void chunkedChunkSizeStartsWithExtension(boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        writeMsg(startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Connection: keep-alive" + br +
+                "Transfer-Encoding: chunked" + br + br, channel);
+        // Leading chunk-extension delimiter: chunk-size token is empty after substring.
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(";ext\r\n", channel));
+        assertThat(e.getMessage(), startsWith("Cannot parse chunk-size"));
+        assertThat(e.getCause(), is(instanceOf(NumberFormatException.class)));
+        assertThat(channel.inboundMessages(), is(not(empty())));
+    }
+
+    /**
+     * Direct tests for {@link HttpObjectDecoder#getChunkSize(String)}, exercising branches that
+     * are unreachable through the EmbeddedChannel flow because of the chunk-size line cap.
+     * In particular the {@code value < 0} guard requires a hex string that wraps
+     * {@link Long#parseUnsignedLong} into a negative long, which needs more than 15 hex
+     * characters — the public flow caps the line at 14 hex characters + CRLF.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] hex={0}")
+    @ValueSource(strings = {
+            // 16 hex F's: parseUnsignedLong -> -1L (0xFFFFFFFFFFFFFFFF). Exercises value < 0.
+            "FFFFFFFFFFFFFFFF",
+            // 16 hex chars where the high bit is set: parseUnsignedLong returns Long.MIN_VALUE
+            // (= 0x8000000000000000), also negative.
+            "8000000000000000",
+    })
+    void getChunkSizeRejectsNegativeWrappedValues(String hex) {
+        DecoderException e = assertThrows(DecoderException.class, () -> HttpObjectDecoder.getChunkSize(hex));
+        assertThat(e.getMessage(), startsWith("Cannot parse chunk-size"));
+        assertThat(e.getCause(), is(instanceOf(NumberFormatException.class)));
+        assertThat(e.getCause().getMessage(), startsWith("Chunk size "));
+    }
+
+    @Test
+    void getChunkSizeAcceptsIntegerMaxValue() {
+        assertThat(HttpObjectDecoder.getChunkSize("7FFFFFFF"), is(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void getChunkSizeRejectsIntegerMaxValuePlusOne() {
+        DecoderException e = assertThrows(DecoderException.class,
+                () -> HttpObjectDecoder.getChunkSize("80000000"));
+        assertThat(e.getMessage(), startsWith("Cannot parse chunk-size"));
+        assertThat(e.getCause(), is(instanceOf(NumberFormatException.class)));
+    }
+
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")
     @ValueSource(booleans = {true, false})
     void chunkedNoTrailersNoChunkCRLF(boolean crlf) {


### PR DESCRIPTION
This changeset aligns the chunk-size handling with netty's parser  and cleans up the implementation a little bit w.r.t int/long.