### PR TITLE
http-netty: Enforce RFC 9112 Transfer-Encoding correctness

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -148,6 +148,14 @@ public final class HeaderUtils {
      * The values of all {@link HttpHeaderNames#TRANSFER_ENCODING} headers are interpreted as comma-separated values,
      * with spaces between values trimmed. If any of these values is  {@link HttpHeaderValues#CHUNKED}, this method
      * return {@code true}, otherwise it returns {@code false}.
+     * <p>
+     * This checks for {@link HttpHeaderValues#CHUNKED} <b>anywhere</b> among the values, regardless of position.
+     * Per <a href="https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1">RFC 9112, Section 6.1</a>, {@code
+     * chunked} only governs the actual message framing when it is the <b>final</b> coding (e.g. {@code chunked} is
+     * final in {@code "gzip, chunked"} but not in {@code "chunked, gzip"}). This method does not distinguish the
+     * two: it returns {@code true} for both. Callers that need to know whether {@code chunked} framing actually
+     * applies to the message (as opposed to merely being named somewhere in the header) must perform that
+     * additional check themselves.
      *
      * @param headers The {@link HttpHeaders} to check.
      * @return {@code} true if {@code headers} indicates {@code transfer-encoding} {@code chunked}, {@code false}

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -1110,11 +1110,15 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         if (valueLength == chunkedLength) {
             return contentEqualsIgnoreCase(value, CHUNKED);
         }
-        final char before = value.charAt(valueLength - chunkedLength - 1);
-        if (before == ',' || before == ' ' || before == '\t') {
-            return regionMatches(value, true, valueLength - chunkedLength, CHUNKED, 0, chunkedLength);
+        // List elements are comma-separated (RFC 9110 section 5.6.1): skip any OWS (SP/HTAB) immediately
+        // preceding "chunked", then require a comma. A bare SP/HTAB with no comma (e.g. "gzip chunked") is not
+        // a valid element separator and must not be mistaken for "chunked" being a distinct, final coding.
+        int sepIndex = valueLength - chunkedLength - 1;
+        while (sepIndex >= 0 && (value.charAt(sepIndex) == ' ' || value.charAt(sepIndex) == '\t')) {
+            sepIndex--;
         }
-        return false;
+        return sepIndex >= 0 && value.charAt(sepIndex) == ','
+                && regionMatches(value, true, valueLength - chunkedLength, CHUNKED, 0, chunkedLength);
     }
 
     private static boolean isObsText(final byte value) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -54,6 +54,7 @@ import io.netty.handler.codec.http.HttpExpectationFailedEvent;
 import io.netty.util.AsciiString;
 import io.netty.util.ByteProcessor;
 
+import java.util.Iterator;
 import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http.HttpConstants.COLON;
@@ -72,7 +73,9 @@ import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY1;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY2;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_LOCATION;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_ORIGIN;
+import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.UPGRADE;
+import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
@@ -748,10 +751,29 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         if (isContentAlwaysEmpty(message)) {
             removeTransferEncodingChunked(message.headers());
             return State.SKIP_CONTROL_CHARS;
-        } else if (isTransferEncodingChunked(message.headers())) {
-            if (contentLength >= 0L && HTTP_1_1.equals(message.version())) {
-                // Remove the received content-length header(s), keep only "transfer-encoding: chunked"
-                // See https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
+        }
+        // RFC 9112 section 6.1: Transfer-Encoding is HTTP/1.1-only.
+        if (message.headers().contains(TRANSFER_ENCODING) && !HTTP_1_1.equals(message.version())) {
+            throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
+        }
+        if (isTransferEncodingChunked(message.headers())) {
+            // RFC 9112 section 6.1: chunked must be the final coding.
+            final Iterator<? extends CharSequence> encodingIt =
+                    message.headers().valuesIterator(TRANSFER_ENCODING);
+            CharSequence lastValue = encodingIt.next();
+            while (encodingIt.hasNext()) {
+                lastValue = encodingIt.next();
+            }
+            final int vLen = lastValue.length();
+            final int chunkedValueLength = CHUNKED.length();
+            if (vLen < chunkedValueLength ||
+                    !AsciiString.regionMatches(lastValue, true, vLen - chunkedValueLength,
+                            CHUNKED, 0, chunkedValueLength)) {
+                throw new StacklessDecoderException(
+                        "chunked must be the last encoding present in the Transfer-Encoding header");
+            }
+            if (contentLength >= 0L) {
+                // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
                 message.headers().remove(CONTENT_LENGTH);
                 this.contentLength = Long.MIN_VALUE;
             }
@@ -1074,6 +1096,10 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
     static final class StacklessDecoderException extends DecoderException {
         private static final long serialVersionUID = 7611225180490304156L;
+
+        StacklessDecoderException(final String message) {
+            super(message);
+        }
 
         StacklessDecoderException(final String message, final Throwable cause) {
             super(message, cause);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -63,8 +63,10 @@ import static io.netty.handler.codec.http.HttpConstants.HT;
 import static io.netty.handler.codec.http.HttpConstants.LF;
 import static io.netty.handler.codec.http.HttpConstants.SP;
 import static io.netty.util.ByteProcessor.FIND_LF;
+import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.CharSequences.emptyAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.buffer.api.CharSequences.regionMatches;
 import static io.servicetalk.buffer.netty.BufferUtils.newBufferFrom;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
@@ -757,34 +759,30 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             if (!HTTP_1_1.equals(message.version())) {
                 throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
             }
-            // RFC 9112 section 6.3: a request that has Transfer-Encoding without chunked as the
-            // final coding cannot be reliably framed and MUST be rejected. For responses the
-            // legacy "read-until-connection-close" framing still applies, so only enforce on
-            // requests.
-            if (!isTransferEncodingChunked(message.headers())) {
-                if (isDecodingRequest()) {
-                    throw new StacklessDecoderException(
-                            "Transfer-Encoding without chunked is not allowed in requests");
-                }
-            } else {
-                // RFC 9112 section 6.1: chunked must be the final coding.
-                final Iterator<? extends CharSequence> encodingIt =
-                        message.headers().valuesIterator(TRANSFER_ENCODING);
-                CharSequence lastValue = encodingIt.next();
-                while (encodingIt.hasNext()) {
-                    lastValue = encodingIt.next();
-                }
-                if (!endsWithChunkedToken(lastValue)) {
-                    throw new StacklessDecoderException(
-                            "chunked must be the last encoding present in the Transfer-Encoding header");
-                }
-                if (contentLength >= 0L) {
-                    // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
-                    message.headers().remove(CONTENT_LENGTH);
-                    this.contentLength = Long.MIN_VALUE;
-                }
+            // RFC 9112 section 6.3: Transfer-Encoding overrides Content-Length. Drop any received
+            // Content-Length now so it can never be used to frame the body, in any branch below.
+            if (contentLength >= 0L) {
+                // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
+                message.headers().remove(CONTENT_LENGTH);
+                this.contentLength = Long.MIN_VALUE;
+            }
+            // RFC 9112 section 6.1: chunked must be the final coding. There may be multiple
+            // Transfer-Encoding header lines, so check the last value of the last line.
+            final Iterator<? extends CharSequence> encodingIt =
+                    message.headers().valuesIterator(TRANSFER_ENCODING);
+            CharSequence lastValue = encodingIt.next();
+            while (encodingIt.hasNext()) {
+                lastValue = encodingIt.next();
+            }
+            if (endsWithChunkedToken(lastValue)) {
                 return State.READ_CHUNK_SIZE;
             }
+            // RFC 9112 section 6.3: chunked is not the final coding. A request cannot be framed
+            // reliably and MUST be rejected; a response is framed by reading until connection close.
+            if (isDecodingRequest()) {
+                throw new StacklessDecoderException("chunked must be the final Transfer-Encoding coding in requests");
+            }
+            return State.READ_VARIABLE_LENGTH_CONTENT;
         }
         if (contentLength >= 0L) {
             return State.READ_FIXED_LENGTH_CONTENT;
@@ -1093,15 +1091,17 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
     private static boolean endsWithChunkedToken(final CharSequence value) {
         final int vLen = value.length();
         final int chunkedLen = CHUNKED.length();
-        if (vLen < chunkedLen ||
-                !AsciiString.regionMatches(value, true, vLen - chunkedLen, CHUNKED, 0, chunkedLen)) {
+        if (vLen < chunkedLen) {
             return false;
         }
         if (vLen == chunkedLen) {
-            return true;
+            return contentEqualsIgnoreCase(value, CHUNKED);
         }
         final char before = value.charAt(vLen - chunkedLen - 1);
-        return before == ',' || before == ' ' || before == '\t';
+        if (before == ',' || before == ' ' || before == '\t') {
+            return regionMatches(value, true, vLen - chunkedLen, CHUNKED, 0, chunkedLen);
+        }
+        return false;
     }
 
     private static boolean isObsText(final byte value) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -752,33 +752,41 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             removeTransferEncodingChunked(message.headers());
             return State.SKIP_CONTROL_CHARS;
         }
-        // RFC 9112 section 6.1: Transfer-Encoding is HTTP/1.1-only.
-        if (message.headers().contains(TRANSFER_ENCODING) && !HTTP_1_1.equals(message.version())) {
-            throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
+        if (message.headers().contains(TRANSFER_ENCODING)) {
+            // RFC 9112 section 6.1: Transfer-Encoding is HTTP/1.1-only.
+            if (!HTTP_1_1.equals(message.version())) {
+                throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
+            }
+            // RFC 9112 section 6.3: a request that has Transfer-Encoding without chunked as the
+            // final coding cannot be reliably framed and MUST be rejected. For responses the
+            // legacy "read-until-connection-close" framing still applies, so only enforce on
+            // requests.
+            if (!isTransferEncodingChunked(message.headers())) {
+                if (isDecodingRequest()) {
+                    throw new StacklessDecoderException(
+                            "Transfer-Encoding without chunked is not allowed in requests");
+                }
+            } else {
+                // RFC 9112 section 6.1: chunked must be the final coding.
+                final Iterator<? extends CharSequence> encodingIt =
+                        message.headers().valuesIterator(TRANSFER_ENCODING);
+                CharSequence lastValue = encodingIt.next();
+                while (encodingIt.hasNext()) {
+                    lastValue = encodingIt.next();
+                }
+                if (!endsWithChunkedToken(lastValue)) {
+                    throw new StacklessDecoderException(
+                            "chunked must be the last encoding present in the Transfer-Encoding header");
+                }
+                if (contentLength >= 0L) {
+                    // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
+                    message.headers().remove(CONTENT_LENGTH);
+                    this.contentLength = Long.MIN_VALUE;
+                }
+                return State.READ_CHUNK_SIZE;
+            }
         }
-        if (isTransferEncodingChunked(message.headers())) {
-            // RFC 9112 section 6.1: chunked must be the final coding.
-            final Iterator<? extends CharSequence> encodingIt =
-                    message.headers().valuesIterator(TRANSFER_ENCODING);
-            CharSequence lastValue = encodingIt.next();
-            while (encodingIt.hasNext()) {
-                lastValue = encodingIt.next();
-            }
-            final int vLen = lastValue.length();
-            final int chunkedValueLength = CHUNKED.length();
-            if (vLen < chunkedValueLength ||
-                    !AsciiString.regionMatches(lastValue, true, vLen - chunkedValueLength,
-                            CHUNKED, 0, chunkedValueLength)) {
-                throw new StacklessDecoderException(
-                        "chunked must be the last encoding present in the Transfer-Encoding header");
-            }
-            if (contentLength >= 0L) {
-                // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
-                message.headers().remove(CONTENT_LENGTH);
-                this.contentLength = Long.MIN_VALUE;
-            }
-            return State.READ_CHUNK_SIZE;
-        } else if (contentLength >= 0L) {
+        if (contentLength >= 0L) {
             return State.READ_FIXED_LENGTH_CONTENT;
         } else {
             return State.READ_VARIABLE_LENGTH_CONTENT;
@@ -1074,6 +1082,26 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
     static boolean isVCHAR(final byte value) {
         return value >= '!' && value <= '~';
+    }
+
+    /**
+     * Returns {@code true} if {@code value} ends with the {@code chunked} token (case-insensitive),
+     * either as the entire value or as the final comma-separated token. The character preceding
+     * {@code chunked} must be a comma or OWS (space/tab) to avoid matching tokens like
+     * {@code notchunked}.
+     */
+    private static boolean endsWithChunkedToken(final CharSequence value) {
+        final int vLen = value.length();
+        final int chunkedLen = CHUNKED.length();
+        if (vLen < chunkedLen ||
+                !AsciiString.regionMatches(value, true, vLen - chunkedLen, CHUNKED, 0, chunkedLen)) {
+            return false;
+        }
+        if (vLen == chunkedLen) {
+            return true;
+        }
+        final char before = value.charAt(vLen - chunkedLen - 1);
+        return before == ',' || before == ' ' || before == '\t';
     }
 
     private static boolean isObsText(final byte value) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -63,7 +63,6 @@ import static io.netty.handler.codec.http.HttpConstants.HT;
 import static io.netty.handler.codec.http.HttpConstants.LF;
 import static io.netty.handler.codec.http.HttpConstants.SP;
 import static io.netty.util.ByteProcessor.FIND_LF;
-import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.CharSequences.emptyAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.regionMatches;
@@ -763,22 +762,14 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                 throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
             }
 
-            // There may be multiple Transfer-Encoding header lines; only the last coding of the last line
-            // decides whether chunked framing applies, so a single pass tracks the last value seen.
-            final Iterator<? extends CharSequence> encodingIt = message.headers().valuesIterator(TRANSFER_ENCODING);
-            CharSequence lastValue = encodingIt.next();
-            while (encodingIt.hasNext()) {
-                lastValue = encodingIt.next();
-            }
-            // RFC 9112 section 6.1: chunked must be the final coding to apply chunked framing. Deliberate
+            // RFC 9112 section 6.1: chunked must be the final coding to apply chunked framing, and a sender
+            // "MUST NOT apply the chunked transfer coding more than once to a message body". Deliberate
             // deviation from RFC 9112 section 6.3, which would otherwise let some non-chunked-final shapes
             // fall back to Content-Length (e.g. plain "gzip") or to framing a response by connection close
-            // (e.g. "chunked, gzip"): any Transfer-Encoding whose final coding isn't chunked is rejected
-            // outright here, for both requests and responses, since it's an ambiguous/smuggling-adjacent
-            // signal regardless of whether chunked appears earlier in the list or not at all.
-            if (!endsWithChunkedToken(lastValue)) {
-                throw new StacklessDecoderException("chunked must be the final Transfer-Encoding coding");
-            }
+            // (e.g. "chunked, gzip"): any Transfer-Encoding whose final coding isn't chunked, or that names
+            // chunked more than once, is rejected outright here, for both requests and responses, since it's
+            // an ambiguous/smuggling-adjacent signal regardless of the shape it takes.
+            validateTransferEncodingChunked(message.headers().valuesIterator(TRANSFER_ENCODING));
             // RFC 9112 section 6.3: Transfer-Encoding overrides Content-Length. Drop any received
             // Content-Length now so it can never be used to frame the body.
             if (contentLength >= 0L) {
@@ -1095,30 +1086,55 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
     }
 
     /**
-     * Checks if the given value ends with exactly {@code chunked} (case-insensitive).
+     * Validates that {@code chunked} appears exactly once across all {@code Transfer-Encoding} header field-lines
+     * and that it is the final coding, per RFC 9112 section 6.1: chunked must be the final transfer coding to
+     * apply chunked framing, and a sender "MUST NOT apply the chunked transfer coding more than once to a message
+     * body (i.e., chunking an already chunked message is not allowed)". Stops scanning as soon as a second
+     * {@code chunked} token is found, without inspecting the remaining tokens or header lines.
      *
-     * @param value the value to check
-     * @return returns {@code true} if {@code value} ends with the {@code chunked} token (case-insensitive),
-     * either as the entire value or as the final comma-separated token.
+     * @param encodingIt an iterator over each {@code Transfer-Encoding} header field-line value, in wire order
+     * @throws StacklessDecoderException if chunked is not the final coding, or appears more than once
      */
-    private static boolean endsWithChunkedToken(final CharSequence value) {
-        final int valueLength = value.length();
+    private static void validateTransferEncodingChunked(final Iterator<? extends CharSequence> encodingIt) {
         final int chunkedLength = CHUNKED.length();
-        if (valueLength < chunkedLength) {
-            return false;
+        boolean chunkedSeen = false;
+        boolean lastTokenIsChunked = false;
+        while (encodingIt.hasNext()) {
+            final CharSequence value = encodingIt.next();
+            final int valueLength = value.length();
+            int tokenStart = 0;
+            // List elements are comma-separated (RFC 9110 section 5.6.1); walk tokens left-to-right, trimming
+            // any OWS (SP/HTAB) at their edges, so a bare SP/HTAB with no comma (e.g. "gzip chunked") is not
+            // mistaken for two distinct tokens.
+            for (int i = 0; i <= valueLength; i++) {
+                if (i == valueLength || value.charAt(i) == ',') {
+                    int tokenEnd = i;
+                    while (tokenStart < tokenEnd && isOWSChar(value.charAt(tokenStart))) {
+                        tokenStart++;
+                    }
+                    while (tokenEnd > tokenStart && isOWSChar(value.charAt(tokenEnd - 1))) {
+                        tokenEnd--;
+                    }
+                    lastTokenIsChunked = tokenEnd - tokenStart == chunkedLength &&
+                            regionMatches(value, true, tokenStart, CHUNKED, 0, chunkedLength);
+                    if (lastTokenIsChunked) {
+                        if (chunkedSeen) {
+                            throw new StacklessDecoderException(
+                                    "chunked transfer coding must not be applied more than once");
+                        }
+                        chunkedSeen = true;
+                    }
+                    tokenStart = i + 1;
+                }
+            }
         }
-        if (valueLength == chunkedLength) {
-            return contentEqualsIgnoreCase(value, CHUNKED);
+        if (!lastTokenIsChunked) {
+            throw new StacklessDecoderException("chunked must be the final Transfer-Encoding coding");
         }
-        // List elements are comma-separated (RFC 9110 section 5.6.1): skip any OWS (SP/HTAB) immediately
-        // preceding "chunked", then require a comma. A bare SP/HTAB with no comma (e.g. "gzip chunked") is not
-        // a valid element separator and must not be mistaken for "chunked" being a distinct, final coding.
-        int sepIndex = valueLength - chunkedLength - 1;
-        while (sepIndex >= 0 && (value.charAt(sepIndex) == ' ' || value.charAt(sepIndex) == '\t')) {
-            sepIndex--;
-        }
-        return sepIndex >= 0 && value.charAt(sepIndex) == ','
-                && regionMatches(value, true, valueLength - chunkedLength, CHUNKED, 0, chunkedLength);
+    }
+
+    private static boolean isOWSChar(final char value) {
+        return value == ' ' || value == '\t';
     }
 
     private static boolean isObsText(final byte value) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -69,7 +69,9 @@ import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.regionMatches;
 import static io.servicetalk.buffer.netty.BufferUtils.newBufferFrom;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
+import static io.servicetalk.http.api.HeaderUtils.isConnectionClose;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY1;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY2;
@@ -78,6 +80,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_ORIGIN;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.UPGRADE;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
@@ -759,28 +762,39 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             if (!HTTP_1_1.equals(message.version())) {
                 throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
             }
-            // RFC 9112 section 6.3: Transfer-Encoding overrides Content-Length. Drop any received
-            // Content-Length now so it can never be used to frame the body, in any branch below.
-            if (contentLength >= 0L) {
-                message.headers().remove(CONTENT_LENGTH);
-                this.contentLength = Long.MIN_VALUE;
-            }
-            // RFC 9112 section 6.1: chunked must be the final coding. There may be multiple
-            // Transfer-Encoding header lines, so check the last value of the last line.
+
+            // There may be multiple Transfer-Encoding header lines; only the last coding of the last line
+            // decides whether chunked framing applies, so a single pass tracks the last value seen.
             final Iterator<? extends CharSequence> encodingIt = message.headers().valuesIterator(TRANSFER_ENCODING);
             CharSequence lastValue = encodingIt.next();
             while (encodingIt.hasNext()) {
                 lastValue = encodingIt.next();
             }
-            if (endsWithChunkedToken(lastValue)) {
-                return State.READ_CHUNK_SIZE;
+            // RFC 9112 section 6.1: chunked must be the final coding to apply chunked framing. Deliberate
+            // deviation from RFC 9112 section 6.3, which would otherwise let some non-chunked-final shapes
+            // fall back to Content-Length (e.g. plain "gzip") or to framing a response by connection close
+            // (e.g. "chunked, gzip"): any Transfer-Encoding whose final coding isn't chunked is rejected
+            // outright here, for both requests and responses, since it's an ambiguous/smuggling-adjacent
+            // signal regardless of whether chunked appears earlier in the list or not at all.
+            if (!endsWithChunkedToken(lastValue)) {
+                throw new StacklessDecoderException("chunked must be the final Transfer-Encoding coding");
             }
-            // RFC 9112 section 6.3: chunked is not the final coding. A request cannot be framed
-            // reliably and MUST be rejected; a response is framed by reading until connection close.
-            if (isDecodingRequest()) {
-                throw new StacklessDecoderException("chunked must be the final Transfer-Encoding coding in requests");
+            // RFC 9112 section 6.3: Transfer-Encoding overrides Content-Length. Drop any received
+            // Content-Length now so it can never be used to frame the body.
+            if (contentLength >= 0L) {
+                // RFC 9112 section 6.1: this is the forbidden Content-Length + Transfer-Encoding
+                // combination. Process per Transfer-Encoding alone and force Connection: close -
+                // the shouldClose(message) check below signals the close handler so the connection
+                // is torn down after this exchange to avoid request smuggling attacks.
+                message.headers().remove(CONTENT_LENGTH);
+                this.contentLength = Long.MIN_VALUE;
+                // Preserve any Connection values the peer already sent (e.g. upgrade, keep-alive) and
+                // only add close if it isn't there yet, rather than overriding with set(...).
+                if (!isConnectionClose(message.headers())) {
+                    message.headers().add(CONNECTION, CLOSE);
+                }
             }
-            return State.READ_VARIABLE_LENGTH_CONTENT;
+            return State.READ_CHUNK_SIZE;
         }
         if (contentLength >= 0L) {
             return State.READ_FIXED_LENGTH_CONTENT;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -762,14 +762,12 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             // RFC 9112 section 6.3: Transfer-Encoding overrides Content-Length. Drop any received
             // Content-Length now so it can never be used to frame the body, in any branch below.
             if (contentLength >= 0L) {
-                // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
                 message.headers().remove(CONTENT_LENGTH);
                 this.contentLength = Long.MIN_VALUE;
             }
             // RFC 9112 section 6.1: chunked must be the final coding. There may be multiple
             // Transfer-Encoding header lines, so check the last value of the last line.
-            final Iterator<? extends CharSequence> encodingIt =
-                    message.headers().valuesIterator(TRANSFER_ENCODING);
+            final Iterator<? extends CharSequence> encodingIt = message.headers().valuesIterator(TRANSFER_ENCODING);
             CharSequence lastValue = encodingIt.next();
             while (encodingIt.hasNext()) {
                 lastValue = encodingIt.next();
@@ -1083,23 +1081,24 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
     }
 
     /**
-     * Returns {@code true} if {@code value} ends with the {@code chunked} token (case-insensitive),
-     * either as the entire value or as the final comma-separated token. The character preceding
-     * {@code chunked} must be a comma or OWS (space/tab) to avoid matching tokens like
-     * {@code notchunked}.
+     * Checks if the given value ends with exactly {@code chunked} (case-insensitive).
+     *
+     * @param value the value to check
+     * @return returns {@code true} if {@code value} ends with the {@code chunked} token (case-insensitive),
+     * either as the entire value or as the final comma-separated token.
      */
     private static boolean endsWithChunkedToken(final CharSequence value) {
-        final int vLen = value.length();
-        final int chunkedLen = CHUNKED.length();
-        if (vLen < chunkedLen) {
+        final int valueLength = value.length();
+        final int chunkedLength = CHUNKED.length();
+        if (valueLength < chunkedLength) {
             return false;
         }
-        if (vLen == chunkedLen) {
+        if (valueLength == chunkedLength) {
             return contentEqualsIgnoreCase(value, CHUNKED);
         }
-        final char before = value.charAt(vLen - chunkedLen - 1);
+        final char before = value.charAt(valueLength - chunkedLength - 1);
         if (before == ',' || before == ' ' || before == '\t') {
-            return regionMatches(value, true, vLen - chunkedLen, CHUNKED, 0, chunkedLen);
+            return regionMatches(value, true, valueLength - chunkedLength, CHUNKED, 0, chunkedLength);
         }
         return false;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -184,9 +184,6 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new ResponseTest(streamingResponse(NOT_MODIFIED), GET, defaults(), HAVE_NEITHER),
                 new ResponseTest(streamingResponse(NOT_MODIFIED), GET, withoutPayload(), HAVE_NEITHER),
 
-                // A lone "Transfer-Encoding: gzip" (no chunked) is now rejected outright by the decoder rather
-                // than tolerated and papered over with the aggregated response's Content-Length - see
-                // HttpObjectDecoderTest#transferEncodingChunkedMustBeLast for the decoder-level coverage.
                 new ResponseTest(aggregatedResponse(OK), GET, transferEncodingChunked(),
                         HAVE_TRANSFER_ENCODING_CHUNKED),
                 new ResponseTest(aggregatedResponse(OK), GET, transferEncodingGzipAndChunked(),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -123,7 +123,6 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new RequestTest(aggregatedRequest(TRACE), withoutPayload(), HAVE_NEITHER),
                 new RequestTest(aggregatedRequest(PATCH), withoutPayload(), HAVE_CONTENT_LENGTH_ZERO),
 
-                new RequestTest(aggregatedRequest(GET), transferEncodingGzip(), HAVE_CONTENT_LENGTH),
                 new RequestTest(aggregatedRequest(GET), transferEncodingChunked(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new RequestTest(aggregatedRequest(GET), transferEncodingGzipAndChunked(),
                         HAVE_TRANSFER_ENCODING_CHUNKED),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -184,7 +184,9 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new ResponseTest(streamingResponse(NOT_MODIFIED), GET, defaults(), HAVE_NEITHER),
                 new ResponseTest(streamingResponse(NOT_MODIFIED), GET, withoutPayload(), HAVE_NEITHER),
 
-                new ResponseTest(aggregatedResponse(OK), GET, transferEncodingGzip(), HAVE_CONTENT_LENGTH),
+                // A lone "Transfer-Encoding: gzip" (no chunked) is now rejected outright by the decoder rather
+                // than tolerated and papered over with the aggregated response's Content-Length - see
+                // HttpObjectDecoderTest#transferEncodingChunkedMustBeLast for the decoder-level coverage.
                 new ResponseTest(aggregatedResponse(OK), GET, transferEncodingChunked(),
                         HAVE_TRANSFER_ENCODING_CHUNKED),
                 new ResponseTest(aggregatedResponse(OK), GET, transferEncodingGzipAndChunked(),
@@ -249,13 +251,6 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 throw new IllegalStateException();
             }
         }, "WithoutPayload");
-    }
-
-    private static UnaryOperator<HttpMetaData> transferEncodingGzip() {
-        return describe(input -> {
-            input.headers().set(TRANSFER_ENCODING, "gzip");
-            return input;
-        }, "ExistingTransferEncodingGzip");
     }
 
     private static UnaryOperator<HttpMetaData> transferEncodingGzipAndChunked() {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -786,6 +786,103 @@ abstract class HttpObjectDecoderTest {
         assertFalse(channel.finishAndReleaseAll());
     }
 
+    /**
+     * RFC 9112 section 6.1: {@code Transfer-Encoding} is HTTP/1.1-only. Today the
+     * decoder ignores the protocol version and accepts {@code Transfer-Encoding: chunked}
+     * on HTTP/1.0, which lets a peer desync framing with HTTP/1.0 intermediaries that
+     * reject TE. After the fix the decoder must reject TE on any non-1.1 message.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] httpVersion={0} expectRejected={1} crlf={2}")
+    @MethodSource("transferEncodingProtocolVersionArgs")
+    void transferEncodingRejectedOnNonHttp11(String httpVersion, boolean expectRejected, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        String msg = startLineForContent().replace("HTTP/1.1", httpVersion) + br +
+                "Host: servicetalk.io" + br +
+                "Transfer-Encoding: chunked" + br + br;
+        if (expectRejected) {
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("Transfer-Encoding is only allowed in HTTP/1.1"));
+        } else {
+            // HTTP/1.1 path is unchanged: feed the message and the last-chunk to confirm the
+            // decoder progresses through chunked parsing without throwing.
+            writeMsg(msg, channel);
+            writeLastChunk(channel);
+            assertThat(channel.isOpen(), is(true));
+        }
+    }
+
+    private static Collection<Arguments> transferEncodingProtocolVersionArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (boolean crlf : new boolean[] {true, false}) {
+            // HTTP/1.0 + Transfer-Encoding: chunked must be rejected.
+            arguments.add(Arguments.of("HTTP/1.0", true, crlf));
+            // HTTP/1.1 sanity: continues to be accepted.
+            arguments.add(Arguments.of("HTTP/1.1", false, crlf));
+        }
+        return arguments;
+    }
+
+    /**
+     * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the
+     * message body. Today the decoder only checks whether {@code chunked} is present
+     * anywhere in the {@code Transfer-Encoding} list, so {@code chunked, gzip} is
+     * silently treated as chunked even though gzip is the outermost coding. After the
+     * fix the decoder must reject any value where {@code chunked} is not the last
+     * coding.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" expectRejected={1} crlf={2}")
+    @MethodSource("transferEncodingChunkedLastArgs")
+    void transferEncodingChunkedMustBeLast(String transferEncoding, boolean expectRejected, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        String msg = startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Transfer-Encoding: " + transferEncoding + br + br;
+        if (expectRejected) {
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("chunked must be the last"));
+        } else {
+            // Feed the headers; they must parse without throwing and produce decoded metadata
+            // with Transfer-Encoding chunked retained. We don't drain the body (the decoder
+            // transitions to READ_CHUNK_SIZE awaiting more data); tearDown handles cleanup.
+            writeMsg(msg, channel);
+            HttpMetaData metaData = assertStartLineForContent(channel);
+            assertTrue(isTransferEncodingChunked(metaData.headers()));
+        }
+    }
+
+    private static Collection<Arguments> transferEncodingChunkedLastArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (boolean crlf : new boolean[] {true, false}) {
+            final String br = crlf ? "\r\n" : "\n";
+            // Single value: chunked alone - accepted.
+            arguments.add(Arguments.of("chunked", false, crlf));
+            // Comma-separated, chunked last - accepted.
+            arguments.add(Arguments.of("gzip, chunked", false, crlf));
+            // No space after comma - still accepted (chunked still last).
+            arguments.add(Arguments.of("gzip,chunked", false, crlf));
+            // Case-insensitive match - accepted.
+            arguments.add(Arguments.of("ChUnKeD", false, crlf));
+            // Trailing OWS - accepted.
+            arguments.add(Arguments.of("chunked  ", false, crlf));
+            // Repeated chunked as final coding - accepted (RFC 9112 only requires the last be chunked).
+            arguments.add(Arguments.of("chunked, chunked", false, crlf));
+            // Comma-separated, chunked NOT last - rejected.
+            arguments.add(Arguments.of("chunked, gzip", true, crlf));
+            // Same with whitespace before comma - rejected.
+            arguments.add(Arguments.of("chunked , gzip", true, crlf));
+            // Multi-header: gzip first, chunked last - accepted.
+            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", false, crlf));
+            // Multi-header: chunked first, gzip last (length 4) - rejected.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: gzip", true, crlf));
+            // Multi-header: chunked first, deflate last (length 7, same as "chunked") - rejected.
+            // This case demonstrates the gap closed vs Netty's permissive check.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", true, crlf));
+        }
+        return arguments;
+    }
+
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")
     @ValueSource(booleans = {true, false})
     void unexpectedTrailersAfterContentLength(boolean crlf) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -926,82 +926,105 @@ abstract class HttpObjectDecoderTest {
     }
 
     /**
-     * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the message body. When it is, the
-     * message is chunked-framed (requests and responses alike). Otherwise - whether some other coding is last (e.g.
-     * {@code chunked, gzip}) or chunked never appears at all (e.g. a lone {@code gzip}, or an empty value) - RFC
-     * 9112 section 6.3 would tolerate several of these shapes (falling back to Content-Length, or framing a
-     * response by connection close); this decoder deliberately deviates from that and rejects all of them
-     * unconditionally, for both requests and responses, since an ambiguous Transfer-Encoding is a
-     * smuggling-adjacent signal regardless of which shape it takes.
+     * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the message body, and a sender
+     * "MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already
+     * chunked message is not allowed)". When chunked is the final coding and appears exactly once, the message is
+     * chunked-framed (requests and responses alike). Otherwise - whether some other coding is last (e.g.
+     * {@code chunked, gzip}), chunked never appears at all (e.g. a lone {@code gzip}, or an empty value), or
+     * chunked appears more than once (e.g. {@code chunked, chunked}) - this decoder rejects the message
+     * unconditionally, for both requests and responses, since an ambiguous or non-conformant Transfer-Encoding is
+     * a smuggling-adjacent signal regardless of which shape it takes. RFC 9112 section 6.3 would otherwise tolerate
+     * some non-chunked-final shapes (falling back to Content-Length, or framing a response by connection close);
+     * this decoder deliberately deviates from that.
      */
-    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" chunkedIsFinal={1} crlf={2}")
+    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" rejectionMessage={1} crlf={2}")
     @MethodSource("transferEncodingChunkedLastArgs")
-    void transferEncodingChunkedMustBeLast(String transferEncoding, boolean chunkedIsFinal, boolean crlf) {
+    void transferEncodingChunkedMustBeLastAndUnique(String transferEncoding, @Nullable String rejectionMessage,
+                                                    boolean crlf) {
         EmbeddedChannel channel = channel(crlf);
         String br = br(crlf);
         String msg = startLineForContent() + br +
                 "Host: servicetalk.io" + br +
                 "Transfer-Encoding: " + transferEncoding + br + br;
-        if (chunkedIsFinal) {
-            // chunked is the final coding: chunked framing for both requests and responses. We don't drain the
-            // body (the decoder transitions to READ_CHUNK_SIZE awaiting more data); tearDown handles cleanup.
+        if (rejectionMessage == null) {
+            // chunked is the final coding and appears exactly once: chunked framing for both requests and
+            // responses. We don't drain the body (the decoder transitions to READ_CHUNK_SIZE awaiting more data);
+            // tearDown handles cleanup.
             writeMsg(msg, channel);
             HttpMetaData metaData = assertStartLineForContent(channel);
             assertTrue(isTransferEncodingChunked(metaData.headers()));
         } else {
             // Deliberate deviation from RFC 9112 6.3: rejected for both requests and responses, not just requests.
             DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
-            assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
+            assertThat(e.getMessage(), startsWith(rejectionMessage));
         }
     }
 
     private static Collection<Arguments> transferEncodingChunkedLastArgs() {
+        final String notFinal = "chunked must be the final Transfer-Encoding coding";
+        final String appliedMoreThanOnce = "chunked transfer coding must not be applied more than once";
         final List<Arguments> arguments = new ArrayList<>();
         for (boolean crlf : new boolean[] {true, false}) {
             final String br = crlf ? "\r\n" : "\n";
             // Single value: chunked alone - chunked-framed.
-            arguments.add(Arguments.of("chunked", true, crlf));
+            arguments.add(Arguments.of("chunked", null, crlf));
             // Comma-separated, chunked last - chunked-framed.
-            arguments.add(Arguments.of("gzip, chunked", true, crlf));
+            arguments.add(Arguments.of("gzip, chunked", null, crlf));
             // No space after comma - still chunked-framed (chunked still last).
-            arguments.add(Arguments.of("gzip,chunked", true, crlf));
+            arguments.add(Arguments.of("gzip,chunked", null, crlf));
             // Comma-separated, case-insensitive match - chunked-framed.
-            arguments.add(Arguments.of("gzip, ChUnKeD", true, crlf));
+            arguments.add(Arguments.of("gzip, ChUnKeD", null, crlf));
             // HTAB as the OWS separating the previous coding from chunked - chunked-framed.
-            arguments.add(Arguments.of("gzip,\tchunked", true, crlf));
+            arguments.add(Arguments.of("gzip,\tchunked", null, crlf));
             // Case-insensitive match - chunked-framed.
-            arguments.add(Arguments.of("ChUnKeD", true, crlf));
+            arguments.add(Arguments.of("ChUnKeD", null, crlf));
             // Trailing OWS: the header-value parser already strips leading/trailing OWS from the whole field
             // value (see #testHeaderFiledValue), so this reaches endsWithChunkedToken as plain "chunked" -
             // chunked-framed, same as the "chunked" case above; kept for documentation purposes.
-            arguments.add(Arguments.of("chunked  ", true, crlf));
-            // Repeated chunked as final coding - chunked-framed (RFC 9112 only requires the last be chunked).
-            arguments.add(Arguments.of("chunked, chunked", true, crlf));
+            arguments.add(Arguments.of("chunked  ", null, crlf));
+            // RFC 9112 section 6.1: a sender MUST NOT apply chunked more than once. Repeated chunked as the final
+            // coding is still rejected even though chunked is technically last.
+            arguments.add(Arguments.of("chunked, chunked", appliedMoreThanOnce, crlf));
+            // Repeated chunked with another coding first - still rejected as applied more than once.
+            arguments.add(Arguments.of("gzip, chunked, chunked", appliedMoreThanOnce, crlf));
+            // Repeated chunked with another coding in between - chunked is still final, but appears twice overall.
+            arguments.add(Arguments.of("chunked, gzip, chunked", appliedMoreThanOnce, crlf));
+            // Case-insensitive duplicate - still rejected as applied more than once.
+            arguments.add(Arguments.of("CHUNKED, chunked", appliedMoreThanOnce, crlf));
+            // No space between the duplicated tokens - still rejected as applied more than once.
+            arguments.add(Arguments.of("chunked,chunked", appliedMoreThanOnce, crlf));
             // Comma-separated, chunked NOT last - rejected regardless of role.
-            arguments.add(Arguments.of("chunked, gzip", false, crlf));
+            arguments.add(Arguments.of("chunked, gzip", notFinal, crlf));
             // Same with whitespace before comma - rejected regardless of role.
-            arguments.add(Arguments.of("chunked , gzip", false, crlf));
+            arguments.add(Arguments.of("chunked , gzip", notFinal, crlf));
             // SP with no comma is not a valid list separator (RFC 9110 section 5.6.1 requires "#" elements to be
             // comma-separated) - must not be mistaken for "chunked" being a distinct, final coding.
-            arguments.add(Arguments.of("gzip chunked", false, crlf));
+            arguments.add(Arguments.of("gzip chunked", notFinal, crlf));
             // Same with HTAB instead of SP - still not a valid separator without a comma.
-            arguments.add(Arguments.of("gzip\tchunked", false, crlf));
+            arguments.add(Arguments.of("gzip\tchunked", notFinal, crlf));
             // Multi-header: gzip first, chunked last - chunked-framed.
-            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", true, crlf));
+            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", null, crlf));
             // Multi-header: chunked first, gzip last (length 4) - chunked not final.
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: gzip", false, crlf));
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: gzip", notFinal, crlf));
             // Multi-header: chunked first, deflate last (length 7, same as "chunked") - chunked not final.
             // This case demonstrates the gap closed vs Netty's permissive check.
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", false, crlf));
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", notFinal, crlf));
             // Multi-header: chunked first, notchunked last - chunked not final. The "chunked" suffix of
             // "notchunked" must NOT be treated as a token boundary match.
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: notchunked", false, crlf));
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: notchunked", notFinal, crlf));
             // Multi-header: chunked first, empty value last - chunked not final (empty cannot end in chunked).
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: ", false, crlf));
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: ", notFinal, crlf));
+            // Multi-header: chunked repeated across separate header lines - RFC 9110 section 5.2 requires combining
+            // multiple field lines of the same name into one comma-joined list, so this is equivalent to
+            // "chunked, chunked" and must be rejected as applied more than once.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: chunked", appliedMoreThanOnce, crlf));
+            // Multi-header: gzip then chunked, then chunked again on a third line - applied more than once.
+            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked" + br +
+                    "Transfer-Encoding: chunked", appliedMoreThanOnce, crlf));
             // Transfer-Encoding present but chunked never appears at all - rejected the same as chunked-not-final.
-            arguments.add(Arguments.of("gzip", false, crlf));
+            arguments.add(Arguments.of("gzip", notFinal, crlf));
             // Empty Transfer-Encoding value - chunked cannot be the final coding either.
-            arguments.add(Arguments.of("", false, crlf));
+            arguments.add(Arguments.of("", notFinal, crlf));
         }
         return arguments;
     }
@@ -1021,6 +1044,20 @@ abstract class HttpObjectDecoderTest {
                 "Transfer-Encoding: chunked, gzip\r\n" +
                 "Content-Length: 0\r\n\r\n"));
         assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
+    }
+
+    /**
+     * Same defense-in-depth property as {@link #transferEncodingChunkedNotFinalRejectedEvenWithContentLength()},
+     * but for the RFC 9112 section 6.1 "chunked applied more than once" violation: rejection happens before
+     * {@code Content-Length} could ever be consulted as a fallback.
+     */
+    @Test
+    void transferEncodingChunkedAppliedMoreThanOnceRejectedEvenWithContentLength() {
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
+                "Host: servicetalk.io\r\n" +
+                "Transfer-Encoding: chunked, chunked\r\n" +
+                "Content-Length: 0\r\n\r\n"));
+        assertThat(e.getMessage(), startsWith("chunked transfer coding must not be applied more than once"));
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpMetaData;
+import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.buffer.ByteBuf;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 
@@ -43,16 +45,21 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.AsciiString.contentEquals;
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
+import static io.servicetalk.http.api.HeaderUtils.isConnectionClose;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
 import static io.servicetalk.http.api.HttpHeaderNames.ACCEPT_ENCODING;
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpHeaderValues.KEEP_ALIVE;
 import static io.servicetalk.http.netty.H1ProtocolConfigBuilder.DEFAULT_MAX_HEADER_FIELD_LENGTH;
 import static io.servicetalk.http.netty.H1ProtocolConfigBuilder.DEFAULT_MAX_START_LINE_LENGTH;
 import static java.lang.Integer.toHexString;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -69,6 +76,9 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 abstract class HttpObjectDecoderTest {
 
@@ -115,6 +125,9 @@ abstract class HttpObjectDecoderTest {
      * @return a new EmbeddedChannel configured with the specified limit
      */
     abstract EmbeddedChannel channelWithMaxTotalHeaderFieldsLength(int maxTotalHeaderFieldsLength);
+
+    /** Channel wired with the supplied {@link CloseHandler} for verifying close-pipeline interactions. */
+    abstract EmbeddedChannel channelWithCloseHandler(CloseHandler closeHandler);
 
     final HttpMetaData assertStartLineForContent() {
         return assertStartLineForContent(channel());
@@ -572,6 +585,10 @@ abstract class HttpObjectDecoderTest {
         validateWithContent(-chunkSize, false, channel);
     }
 
+    /**
+     * RFC 9112 section 6.1: TE+CL on HTTP/1.1 is processed per Transfer-Encoding alone
+     * (Content-Length stripped), with Connection: close forced to prevent smuggled follow-ups.
+     */
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")
     @ValueSource(booleans = {true, false})
     void chunkedWithContentLength(boolean crlf) {
@@ -581,14 +598,99 @@ abstract class HttpObjectDecoderTest {
         int chunkedContentLength = 2 + 2 + chunkSize + 2 + 5;
         writeMsg(startLineForContent() + br +
                 "Host: servicetalk.io" + br +
-                "Connection: keep-alive" + br +
                 "Content-Length: " + chunkedContentLength + br +
                 "Transfer-Encoding: chunked" + br + br, channel);
         writeChunk(chunkSize, channel);
         writeLastChunk(channel);
-        HttpMetaData metaData = validateWithContent(-chunkSize, false, channel);
-        assertThat("Unexpected content-length header(s)",
-                metaData.headers().valuesIterator(CONTENT_LENGTH).hasNext(), is(false));
+
+        HttpMetaData metaData = assertStartLineForContent(channel);
+        assertSingleHeaderValue(metaData.headers(), HOST, "servicetalk.io");
+        assertSingleHeaderValue(metaData.headers(), TRANSFER_ENCODING, CHUNKED);
+        assertSingleHeaderValue(metaData.headers(), CONNECTION, CLOSE);
+        assertFalse(metaData.headers().contains(CONTENT_LENGTH), "Content-Length must be stripped");
+        assertPayloadSize(chunkSize, channel);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    /** TE+CL signals {@link CloseHandler#protocolClosingInbound} so the connection closes after the response. */
+    @Test
+    void chunkedWithContentLengthSignalsProtocolClosingInbound() {
+        CloseHandler closeHandler = mock(CloseHandler.class);
+        EmbeddedChannel channel = channelWithCloseHandler(closeHandler);
+        int chunkSize = 16;
+        writeMsg(startLineForContent() + "\r\n" +
+                "Host: servicetalk.io\r\n" +
+                "Content-Length: 999\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n", channel);
+        writeChunk(chunkSize, channel);
+        writeLastChunk(channel);
+
+        verify(closeHandler).protocolClosingInbound(any());
+        assertStartLineForContent(channel);
+        assertPayloadSize(chunkSize, channel);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    /**
+     * RFC 9112 section 6.1 close disposition must not clobber Connection values the peer already sent. When
+     * {@code close} is absent it is added while preserving existing values like {@code keep-alive} or
+     * {@code upgrade}; when it is already present (even within a comma-separated value) it is left untouched
+     * rather than duplicated.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] connection=\"{0}\"")
+    @MethodSource("chunkedWithContentLengthConnectionArgs")
+    void chunkedWithContentLengthPreservesConnectionHeader(@Nullable String connectionValue,
+                                                           List<String> expectedConnectionTokens) {
+        EmbeddedChannel channel = channel();
+        int chunkSize = 16;
+        StringBuilder sb = new StringBuilder(startLineForContent()).append("\r\n" +
+                "Host: servicetalk.io\r\n" +
+                "Content-Length: 999\r\n" +
+                "Transfer-Encoding: chunked\r\n");
+        if (connectionValue != null) {
+            sb.append("Connection: ").append(connectionValue).append("\r\n");
+        }
+        sb.append("\r\n");
+        writeMsg(sb.toString(), channel);
+        writeChunk(chunkSize, channel);
+        writeLastChunk(channel);
+
+        HttpMetaData metaData = assertStartLineForContent(channel);
+        assertFalse(metaData.headers().contains(CONTENT_LENGTH), "Content-Length must be stripped");
+        assertTrue(isConnectionClose(metaData.headers()), "Connection: close must be present");
+        assertThat("Unexpected Connection header tokens",
+                connectionTokens(metaData.headers()), containsInAnyOrder(expectedConnectionTokens.toArray()));
+        assertPayloadSize(chunkSize, channel);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    private static Collection<Arguments> chunkedWithContentLengthConnectionArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        // No Connection header: close is added.
+        arguments.add(Arguments.of(null, singletonList("close")));
+        // keep-alive present: preserved, close added alongside (shouldClose still triggers on the close token).
+        arguments.add(Arguments.of("keep-alive", asList("keep-alive", "close")));
+        // upgrade present: preserved, close added alongside.
+        arguments.add(Arguments.of("Upgrade", asList("upgrade", "close")));
+        // close already present: left as-is, not duplicated.
+        arguments.add(Arguments.of("close", singletonList("close")));
+        // close nested in a comma-separated value: recognized, not duplicated, other tokens preserved.
+        arguments.add(Arguments.of("keep-alive, close", asList("keep-alive", "close")));
+        return arguments;
+    }
+
+    /** All {@code Connection} header values, comma-split and lower-cased, gathered across every header line. */
+    private static List<String> connectionTokens(HttpHeaders headers) {
+        final List<String> tokens = new ArrayList<>();
+        for (Iterator<? extends CharSequence> it = headers.valuesIterator(CONNECTION); it.hasNext();) {
+            for (String token : it.next().toString().split(",")) {
+                final String trimmed = token.trim();
+                if (!trimmed.isEmpty()) {
+                    tokens.add(trimmed.toLowerCase(Locale.ENGLISH));
+                }
+            }
+        }
+        return tokens;
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")
@@ -825,9 +927,12 @@ abstract class HttpObjectDecoderTest {
 
     /**
      * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the message body. When it is, the
-     * message is chunked-framed (requests and responses alike). When it is not, RFC 9112 section 6.3 splits by
-     * direction: a request cannot be framed reliably and MUST be rejected, while a response is framed by reading
-     * until the connection closes.
+     * message is chunked-framed (requests and responses alike). Otherwise - whether some other coding is last (e.g.
+     * {@code chunked, gzip}) or chunked never appears at all (e.g. a lone {@code gzip}, or an empty value) - RFC
+     * 9112 section 6.3 would tolerate several of these shapes (falling back to Content-Length, or framing a
+     * response by connection close); this decoder deliberately deviates from that and rejects all of them
+     * unconditionally, for both requests and responses, since an ambiguous Transfer-Encoding is a
+     * smuggling-adjacent signal regardless of which shape it takes.
      */
     @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" chunkedIsFinal={1} crlf={2}")
     @MethodSource("transferEncodingChunkedLastArgs")
@@ -843,16 +948,10 @@ abstract class HttpObjectDecoderTest {
             writeMsg(msg, channel);
             HttpMetaData metaData = assertStartLineForContent(channel);
             assertTrue(isTransferEncodingChunked(metaData.headers()));
-        } else if (isDecodingRequest()) {
-            // RFC 9112 6.3: a request not framed by chunked cannot be framed reliably and is rejected.
+        } else {
+            // Deliberate deviation from RFC 9112 6.3: rejected for both requests and responses, not just requests.
             DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
             assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
-        } else {
-            // RFC 9112 6.3: a response not framed by chunked is read until connection close. The headers must
-            // parse and progress without throwing.
-            writeMsg(msg, channel);
-            HttpMetaData metaData = assertStartLineForContent(channel);
-            assertThat(metaData, is(notNullValue()));
         }
     }
 
@@ -876,9 +975,9 @@ abstract class HttpObjectDecoderTest {
             arguments.add(Arguments.of("chunked  ", true, crlf));
             // Repeated chunked as final coding - chunked-framed (RFC 9112 only requires the last be chunked).
             arguments.add(Arguments.of("chunked, chunked", true, crlf));
-            // Comma-separated, chunked NOT last - request rejects, response reads until close.
+            // Comma-separated, chunked NOT last - rejected regardless of role.
             arguments.add(Arguments.of("chunked, gzip", false, crlf));
-            // Same with whitespace before comma - request rejects, response reads until close.
+            // Same with whitespace before comma - rejected regardless of role.
             arguments.add(Arguments.of("chunked , gzip", false, crlf));
             // Multi-header: gzip first, chunked last - chunked-framed.
             arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", true, crlf));
@@ -892,19 +991,24 @@ abstract class HttpObjectDecoderTest {
             arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: notchunked", false, crlf));
             // Multi-header: chunked first, empty value last - chunked not final (empty cannot end in chunked).
             arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: ", false, crlf));
+            // Transfer-Encoding present but chunked never appears at all - rejected the same as chunked-not-final.
+            arguments.add(Arguments.of("gzip", false, crlf));
+            // Empty Transfer-Encoding value - chunked cannot be the final coding either.
+            arguments.add(Arguments.of("", false, crlf));
         }
         return arguments;
     }
 
     /**
-     * RFC 9112 section 6.3: when {@code chunked} is not the final coding, a request cannot be reliably framed and
-     * MUST be rejected, while a response is framed by reading until connection close. In both cases
-     * {@code Transfer-Encoding} overrides {@code Content-Length}, so a response must never be framed by a stray
-     * {@code Content-Length} and that header must be dropped.
+     * RFC 9112 section 6.3 item 4: once {@code chunked} appears anywhere in {@code Transfer-Encoding}, it governs
+     * framing and overrides {@code Content-Length}, whether or not {@code chunked} is the final coding. The RFC
+     * would let a response where chunked is not final fall back to framing by connection close, but this decoder
+     * deliberately deviates from that and rejects the ambiguous encoding unconditionally, for both requests and
+     * responses, rather than tolerating it on the response side.
      */
     @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" withContentLength={1} crlf={2}")
-    @MethodSource("transferEncodingWithoutChunkedArgs")
-    void transferEncodingWithoutChunked(String transferEncoding, boolean withContentLength, boolean crlf) {
+    @MethodSource("transferEncodingChunkedNotFinalArgs")
+    void transferEncodingChunkedNotFinal(String transferEncoding, boolean withContentLength, boolean crlf) {
         EmbeddedChannel channel = channel(crlf);
         String br = br(crlf);
         StringBuilder sb = new StringBuilder()
@@ -916,34 +1020,16 @@ abstract class HttpObjectDecoderTest {
         }
         sb.append(br);
         String msg = sb.toString();
-        if (isDecodingRequest()) {
-            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
-            assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
-        } else {
-            // Response side: a non-chunked-final TE is legal under RFC 9112 6.3 and frames by connection close.
-            // Feed the headers and confirm decoding progresses.
-            writeMsg(msg, channel);
-            HttpMetaData metaData = assertStartLineForContent(channel);
-            assertThat(metaData, is(notNullValue()));
-            // Transfer-Encoding overrides Content-Length: it must be dropped, never used to frame the body.
-            assertThat("Content-Length must be stripped when Transfer-Encoding is present",
-                    metaData.headers().contains(CONTENT_LENGTH), is(false));
-        }
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+        assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
     }
 
-    private static Collection<Arguments> transferEncodingWithoutChunkedArgs() {
+    private static Collection<Arguments> transferEncodingChunkedNotFinalArgs() {
         final List<Arguments> arguments = new ArrayList<>();
         for (boolean crlf : new boolean[] {true, false}) {
-            // gzip alone is not chunked-framed.
-            arguments.add(Arguments.of("gzip", false, crlf));
-            // gzip + Content-Length: still not chunked; request rejects, response strips Content-Length.
-            arguments.add(Arguments.of("gzip", true, crlf));
-            // Empty TE value with no chunked is also "not chunked-final".
-            arguments.add(Arguments.of("", false, crlf));
-            // chunked present but NOT the final coding: same outcome as no-chunked (regression guard - this case
-            // was previously rejected even for responses; now the response reads until close, never by CL).
+            // chunked present but NOT the final coding.
             arguments.add(Arguments.of("chunked, gzip", false, crlf));
-            // chunked-not-final + Content-Length: Transfer-Encoding must override Content-Length on the response.
+            // chunked-not-final + Content-Length: rejected regardless of Content-Length presence.
             arguments.add(Arguments.of("chunked, gzip", true, crlf));
         }
         return arguments;

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -824,31 +824,35 @@ abstract class HttpObjectDecoderTest {
     }
 
     /**
-     * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the
-     * message body. Today the decoder only checks whether {@code chunked} is present
-     * anywhere in the {@code Transfer-Encoding} list, so {@code chunked, gzip} is
-     * silently treated as chunked even though gzip is the outermost coding. After the
-     * fix the decoder must reject any value where {@code chunked} is not the last
-     * coding.
+     * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the message body. When it is, the
+     * message is chunked-framed (requests and responses alike). When it is not, RFC 9112 section 6.3 splits by
+     * direction: a request cannot be framed reliably and MUST be rejected, while a response is framed by reading
+     * until the connection closes.
      */
-    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" expectRejected={1} crlf={2}")
+    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" chunkedIsFinal={1} crlf={2}")
     @MethodSource("transferEncodingChunkedLastArgs")
-    void transferEncodingChunkedMustBeLast(String transferEncoding, boolean expectRejected, boolean crlf) {
+    void transferEncodingChunkedMustBeLast(String transferEncoding, boolean chunkedIsFinal, boolean crlf) {
         EmbeddedChannel channel = channel(crlf);
         String br = br(crlf);
         String msg = startLineForContent() + br +
                 "Host: servicetalk.io" + br +
                 "Transfer-Encoding: " + transferEncoding + br + br;
-        if (expectRejected) {
-            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
-            assertThat(e.getMessage(), startsWith("chunked must be the last"));
-        } else {
-            // Feed the headers; they must parse without throwing and produce decoded metadata
-            // with Transfer-Encoding chunked retained. We don't drain the body (the decoder
-            // transitions to READ_CHUNK_SIZE awaiting more data); tearDown handles cleanup.
+        if (chunkedIsFinal) {
+            // chunked is the final coding: chunked framing for both requests and responses. We don't drain the
+            // body (the decoder transitions to READ_CHUNK_SIZE awaiting more data); tearDown handles cleanup.
             writeMsg(msg, channel);
             HttpMetaData metaData = assertStartLineForContent(channel);
             assertTrue(isTransferEncodingChunked(metaData.headers()));
+        } else if (isDecodingRequest()) {
+            // RFC 9112 6.3: a request not framed by chunked cannot be framed reliably and is rejected.
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
+        } else {
+            // RFC 9112 6.3: a response not framed by chunked is read until connection close. The headers must
+            // parse and progress without throwing.
+            writeMsg(msg, channel);
+            HttpMetaData metaData = assertStartLineForContent(channel);
+            assertThat(metaData, is(notNullValue()));
         }
     }
 
@@ -856,47 +860,47 @@ abstract class HttpObjectDecoderTest {
         final List<Arguments> arguments = new ArrayList<>();
         for (boolean crlf : new boolean[] {true, false}) {
             final String br = crlf ? "\r\n" : "\n";
-            // Single value: chunked alone - accepted.
-            arguments.add(Arguments.of("chunked", false, crlf));
-            // Comma-separated, chunked last - accepted.
-            arguments.add(Arguments.of("gzip, chunked", false, crlf));
-            // No space after comma - still accepted (chunked still last).
-            arguments.add(Arguments.of("gzip,chunked", false, crlf));
-            // Case-insensitive match - accepted.
-            arguments.add(Arguments.of("ChUnKeD", false, crlf));
-            // Trailing OWS - accepted.
-            arguments.add(Arguments.of("chunked  ", false, crlf));
-            // Repeated chunked as final coding - accepted (RFC 9112 only requires the last be chunked).
-            arguments.add(Arguments.of("chunked, chunked", false, crlf));
-            // Comma-separated, chunked NOT last - rejected.
-            arguments.add(Arguments.of("chunked, gzip", true, crlf));
-            // Same with whitespace before comma - rejected.
-            arguments.add(Arguments.of("chunked , gzip", true, crlf));
-            // Multi-header: gzip first, chunked last - accepted.
-            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", false, crlf));
-            // Multi-header: chunked first, gzip last (length 4) - rejected.
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: gzip", true, crlf));
-            // Multi-header: chunked first, deflate last (length 7, same as "chunked") - rejected.
+            // Single value: chunked alone - chunked-framed.
+            arguments.add(Arguments.of("chunked", true, crlf));
+            // Comma-separated, chunked last - chunked-framed.
+            arguments.add(Arguments.of("gzip, chunked", true, crlf));
+            // No space after comma - still chunked-framed (chunked still last).
+            arguments.add(Arguments.of("gzip,chunked", true, crlf));
+            // Comma-separated, case-insensitive match - chunked-framed.
+            arguments.add(Arguments.of("gzip, ChUnKeD", true, crlf));
+            // HTAB as the OWS separating the previous coding from chunked - chunked-framed.
+            arguments.add(Arguments.of("gzip,\tchunked", true, crlf));
+            // Case-insensitive match - chunked-framed.
+            arguments.add(Arguments.of("ChUnKeD", true, crlf));
+            // Trailing OWS - chunked-framed.
+            arguments.add(Arguments.of("chunked  ", true, crlf));
+            // Repeated chunked as final coding - chunked-framed (RFC 9112 only requires the last be chunked).
+            arguments.add(Arguments.of("chunked, chunked", true, crlf));
+            // Comma-separated, chunked NOT last - request rejects, response reads until close.
+            arguments.add(Arguments.of("chunked, gzip", false, crlf));
+            // Same with whitespace before comma - request rejects, response reads until close.
+            arguments.add(Arguments.of("chunked , gzip", false, crlf));
+            // Multi-header: gzip first, chunked last - chunked-framed.
+            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", true, crlf));
+            // Multi-header: chunked first, gzip last (length 4) - chunked not final.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: gzip", false, crlf));
+            // Multi-header: chunked first, deflate last (length 7, same as "chunked") - chunked not final.
             // This case demonstrates the gap closed vs Netty's permissive check.
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", true, crlf));
-            // Multi-header: chunked first, notchunked last - rejected. The "chunked" suffix of
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", false, crlf));
+            // Multi-header: chunked first, notchunked last - chunked not final. The "chunked" suffix of
             // "notchunked" must NOT be treated as a token boundary match.
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: notchunked", true, crlf));
-            // Single value: notchunked is not chunked at all - the decoder treats this as
-            // "TE without chunked" and rejects on the request side via the test below; for the
-            // response side it is not a "chunked must be last" violation, so we don't include
-            // it here.
-            // Multi-header: chunked first, empty value last - rejected (empty cannot end in chunked).
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: ", true, crlf));
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: notchunked", false, crlf));
+            // Multi-header: chunked first, empty value last - chunked not final (empty cannot end in chunked).
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: ", false, crlf));
         }
         return arguments;
     }
 
     /**
-     * RFC 9112 section 6.3: a request that has {@code Transfer-Encoding} without {@code chunked}
-     * as the final coding cannot be reliably framed and MUST be rejected. For responses the
-     * legacy "read-until-connection-close" framing still applies, so the decoder accepts the
-     * headers and falls through to variable-length reads.
+     * RFC 9112 section 6.3: when {@code chunked} is not the final coding, a request cannot be reliably framed and
+     * MUST be rejected, while a response is framed by reading until connection close. In both cases
+     * {@code Transfer-Encoding} overrides {@code Content-Length}, so a response must never be framed by a stray
+     * {@code Content-Length} and that header must be dropped.
      */
     @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" withContentLength={1} crlf={2}")
     @MethodSource("transferEncodingWithoutChunkedArgs")
@@ -914,13 +918,16 @@ abstract class HttpObjectDecoderTest {
         String msg = sb.toString();
         if (isDecodingRequest()) {
             DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
-            assertThat(e.getMessage(), startsWith("Transfer-Encoding without chunked is not allowed in requests"));
+            assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
         } else {
-            // Response side: TE without chunked is legal under RFC 9112 6.3 and frames by
-            // connection close. Feed the headers and confirm decoding progresses.
+            // Response side: a non-chunked-final TE is legal under RFC 9112 6.3 and frames by connection close.
+            // Feed the headers and confirm decoding progresses.
             writeMsg(msg, channel);
             HttpMetaData metaData = assertStartLineForContent(channel);
             assertThat(metaData, is(notNullValue()));
+            // Transfer-Encoding overrides Content-Length: it must be dropped, never used to frame the body.
+            assertThat("Content-Length must be stripped when Transfer-Encoding is present",
+                    metaData.headers().contains(CONTENT_LENGTH), is(false));
         }
     }
 
@@ -929,10 +936,15 @@ abstract class HttpObjectDecoderTest {
         for (boolean crlf : new boolean[] {true, false}) {
             // gzip alone is not chunked-framed.
             arguments.add(Arguments.of("gzip", false, crlf));
-            // gzip + Content-Length: still not chunked; request must reject.
+            // gzip + Content-Length: still not chunked; request rejects, response strips Content-Length.
             arguments.add(Arguments.of("gzip", true, crlf));
-            // Empty TE value with no chunked is also "TE without chunked".
+            // Empty TE value with no chunked is also "not chunked-final".
             arguments.add(Arguments.of("", false, crlf));
+            // chunked present but NOT the final coding: same outcome as no-chunked (regression guard - this case
+            // was previously rejected even for responses; now the response reads until close, never by CL).
+            arguments.add(Arguments.of("chunked, gzip", false, crlf));
+            // chunked-not-final + Content-Length: Transfer-Encoding must override Content-Length on the response.
+            arguments.add(Arguments.of("chunked, gzip", true, crlf));
         }
         return arguments;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -971,7 +971,9 @@ abstract class HttpObjectDecoderTest {
             arguments.add(Arguments.of("gzip,\tchunked", true, crlf));
             // Case-insensitive match - chunked-framed.
             arguments.add(Arguments.of("ChUnKeD", true, crlf));
-            // Trailing OWS - chunked-framed.
+            // Trailing OWS: the header-value parser already strips leading/trailing OWS from the whole field
+            // value (see #testHeaderFiledValue), so this reaches endsWithChunkedToken as plain "chunked" -
+            // chunked-framed, same as the "chunked" case above; kept for documentation purposes.
             arguments.add(Arguments.of("chunked  ", true, crlf));
             // Repeated chunked as final coding - chunked-framed (RFC 9112 only requires the last be chunked).
             arguments.add(Arguments.of("chunked, chunked", true, crlf));
@@ -979,6 +981,11 @@ abstract class HttpObjectDecoderTest {
             arguments.add(Arguments.of("chunked, gzip", false, crlf));
             // Same with whitespace before comma - rejected regardless of role.
             arguments.add(Arguments.of("chunked , gzip", false, crlf));
+            // SP with no comma is not a valid list separator (RFC 9110 section 5.6.1 requires "#" elements to be
+            // comma-separated) - must not be mistaken for "chunked" being a distinct, final coding.
+            arguments.add(Arguments.of("gzip chunked", false, crlf));
+            // Same with HTAB instead of SP - still not a valid separator without a comma.
+            arguments.add(Arguments.of("gzip\tchunked", false, crlf));
             // Multi-header: gzip first, chunked last - chunked-framed.
             arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", true, crlf));
             // Multi-header: chunked first, gzip last (length 4) - chunked not final.
@@ -1003,36 +1010,17 @@ abstract class HttpObjectDecoderTest {
      * RFC 9112 section 6.3 item 4: once {@code chunked} appears anywhere in {@code Transfer-Encoding}, it governs
      * framing and overrides {@code Content-Length}, whether or not {@code chunked} is the final coding. The RFC
      * would let a response where chunked is not final fall back to framing by connection close, but this decoder
-     * deliberately deviates from that and rejects the ambiguous encoding unconditionally, for both requests and
-     * responses, rather than tolerating it on the response side.
+     * deliberately deviates from that and rejects the ambiguous encoding unconditionally - even when a
+     * {@code Content-Length} is also present, proving the rejection happens before {@code Content-Length} could
+     * ever be consulted as a fallback.
      */
-    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" withContentLength={1} crlf={2}")
-    @MethodSource("transferEncodingChunkedNotFinalArgs")
-    void transferEncodingChunkedNotFinal(String transferEncoding, boolean withContentLength, boolean crlf) {
-        EmbeddedChannel channel = channel(crlf);
-        String br = br(crlf);
-        StringBuilder sb = new StringBuilder()
-                .append(startLineForContent()).append(br)
-                .append("Host: servicetalk.io").append(br)
-                .append("Transfer-Encoding: ").append(transferEncoding).append(br);
-        if (withContentLength) {
-            sb.append("Content-Length: 0").append(br);
-        }
-        sb.append(br);
-        String msg = sb.toString();
-        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+    @Test
+    void transferEncodingChunkedNotFinalRejectedEvenWithContentLength() {
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + "\r\n" +
+                "Host: servicetalk.io\r\n" +
+                "Transfer-Encoding: chunked, gzip\r\n" +
+                "Content-Length: 0\r\n\r\n"));
         assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
-    }
-
-    private static Collection<Arguments> transferEncodingChunkedNotFinalArgs() {
-        final List<Arguments> arguments = new ArrayList<>();
-        for (boolean crlf : new boolean[] {true, false}) {
-            // chunked present but NOT the final coding.
-            arguments.add(Arguments.of("chunked, gzip", false, crlf));
-            // chunked-not-final + Content-Length: rejected regardless of Content-Length presence.
-            arguments.add(Arguments.of("chunked, gzip", true, crlf));
-        }
-        return arguments;
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -879,6 +879,60 @@ abstract class HttpObjectDecoderTest {
             // Multi-header: chunked first, deflate last (length 7, same as "chunked") - rejected.
             // This case demonstrates the gap closed vs Netty's permissive check.
             arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", true, crlf));
+            // Multi-header: chunked first, notchunked last - rejected. The "chunked" suffix of
+            // "notchunked" must NOT be treated as a token boundary match.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: notchunked", true, crlf));
+            // Single value: notchunked is not chunked at all - the decoder treats this as
+            // "TE without chunked" and rejects on the request side via the test below; for the
+            // response side it is not a "chunked must be last" violation, so we don't include
+            // it here.
+            // Multi-header: chunked first, empty value last - rejected (empty cannot end in chunked).
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: ", true, crlf));
+        }
+        return arguments;
+    }
+
+    /**
+     * RFC 9112 section 6.3: a request that has {@code Transfer-Encoding} without {@code chunked}
+     * as the final coding cannot be reliably framed and MUST be rejected. For responses the
+     * legacy "read-until-connection-close" framing still applies, so the decoder accepts the
+     * headers and falls through to variable-length reads.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" withContentLength={1} crlf={2}")
+    @MethodSource("transferEncodingWithoutChunkedArgs")
+    void transferEncodingWithoutChunked(String transferEncoding, boolean withContentLength, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        StringBuilder sb = new StringBuilder()
+                .append(startLineForContent()).append(br)
+                .append("Host: servicetalk.io").append(br)
+                .append("Transfer-Encoding: ").append(transferEncoding).append(br);
+        if (withContentLength) {
+            sb.append("Content-Length: 0").append(br);
+        }
+        sb.append(br);
+        String msg = sb.toString();
+        if (isDecodingRequest()) {
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("Transfer-Encoding without chunked is not allowed in requests"));
+        } else {
+            // Response side: TE without chunked is legal under RFC 9112 6.3 and frames by
+            // connection close. Feed the headers and confirm decoding progresses.
+            writeMsg(msg, channel);
+            HttpMetaData metaData = assertStartLineForContent(channel);
+            assertThat(metaData, is(notNullValue()));
+        }
+    }
+
+    private static Collection<Arguments> transferEncodingWithoutChunkedArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (boolean crlf : new boolean[] {true, false}) {
+            // gzip alone is not chunked-framed.
+            arguments.add(Arguments.of("gzip", false, crlf));
+            // gzip + Content-Length: still not chunked; request must reject.
+            arguments.add(Arguments.of("gzip", true, crlf));
+            // Empty TE value with no chunked is also "TE without chunked".
+            arguments.add(Arguments.of("", false, crlf));
         }
         return arguments;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.http.api.HttpMetaData;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -117,6 +118,13 @@ class HttpRequestDecoderTest extends HttpObjectDecoderTest {
                 false,  // allowPrematureClosureBeforePayloadBody
                 false,  // allowLFWithoutCR
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+    }
+
+    @Override
+    EmbeddedChannel channelWithCloseHandler(CloseHandler closeHandler) {
+        return new EmbeddedChannel(new HttpRequestDecoder(new ArrayDeque<>(), getByteBufAllocator(DEFAULT_ALLOCATOR),
+                DefaultHttpHeadersFactory.INSTANCE, DEFAULT_MAX_START_LINE_LENGTH, DEFAULT_MAX_HEADER_FIELD_LENGTH,
+                DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH, false, false, closeHandler));
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -39,6 +39,7 @@ import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.netty.HttpResponseDecoder.Signal;
+import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -162,6 +163,16 @@ class HttpResponseDecoderTest extends HttpObjectDecoderTest {
                 false,  // allowPrematureClosureBeforePayloadBody
                 false,  // allowLFWithoutCR
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+    }
+
+    @Override
+    EmbeddedChannel channelWithCloseHandler(CloseHandler closeHandler) {
+        final Deque<Signal> signalsQueue = new PollLikePeakArrayDeque<>();
+        signalsQueue.offer(REQUEST_SIGNAL);
+        return new EmbeddedChannel(new HttpResponseDecoder(methodQueue, signalsQueue,
+                getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE,
+                DEFAULT_MAX_START_LINE_LENGTH, DEFAULT_MAX_HEADER_FIELD_LENGTH, DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH,
+                false, false, closeHandler));
     }
 
     @Test


### PR DESCRIPTION
#### Motivation
  HttpObjectDecoder.readHeaders does not validate Transfer-Encoding against the RFC 9112 section 6.1 rules: Transfer-Encoding on a non-HTTP/1.1 message is silently accepted, a TE list where chunked is not the final coding is silently treated as chunked-encoded regardless of role, and a message with both Transfer-Encoding and Content-Length is processed per Transfer-Encoding alone without closing the connection afterward as section 6.1 requires.

  #### Modifications
  - Reject any message that carries Transfer-Encoding with a protocol version other than HTTP/1.1, throwing a DecoderException.
  - When chunked is detected, walk the Transfer-Encoding values and require the last one to end with "chunked (case-insensitive). If chunked is present but not final, reject requests but frame responses by reading until connection close, per RFC 9112 section 6.3 item 4. If chunked never appears, leave Content-Length untouched.
  - When Transfer-Encoding governs framing and Content-Length is also present, strip Content-Length and force Connection: close (preserving any existing Connection tokens) so the connection isn't reused, per RFC 9112 section 6.1.
  - Add parameterized tests covering protocol-version handling, the full range of comma-separated and multi-header Transfer-Encoding shapes, and the close-after-respond behavior.

  #### Result
  Transfer-Encoding desync attacks via mismatched protocol version or mismatched coding ordering in a request are rejected with a clear DecoderException. Messages with both Transfer-Encoding and Content-Length are processed per Transfer-Encoding alone and the connection is closed after responding. Legitimate HTTP/1.1 + chunked, gzip,chunked, or TE-without-chunked traffic continues to decode unchanged.

#### Appendix: Behavioral Summary

##### a) ServiceTalk as a server, decoding a malformed client request

  | Malformation | Outcome | Connection |
  |---|---|---|
  | `Transfer-Encoding` on a non-HTTP/1.1 request | Rejected (`DecoderException`) | Closed |
  | `Transfer-Encoding: chunked, gzip` (chunked not final) | Rejected (`DecoderException`, "chunked must be the final Transfer-Encoding coding") | Closed |
  | `Transfer-Encoding: gzip` alone (chunked never appears) | **Now rejected** (`DecoderException`, same message) — deliberate deviation from RFC 9112, which would tolerate this and let Content-Length govern | Closed |
  | `Transfer-Encoding: chunked, chunked` (repeated chunked token) | Accepted as ordinary chunked framing — deliberate, tested, RFC-literal reading (only the *last* coding must be chunked) | Stays open |
  | `Transfer-Encoding: chunked` + `Content-Length` both present | Accepted — Content-Length stripped, `Connection: close` forced (added, existing tokens preserved) | Closed once both inbound and outbound payloads for this exchange complete (graceful close) |
  | Multiple `Content-Length` values that disagree | Rejected (`IllegalArgumentException` → wrapped `DecoderException`) | Closed |
  | Multiple `Content-Length` values that agree | Rejected too — no tolerance for duplicates, even identical ones | Closed |

##### b) ServiceTalk as a client, decoding a malformed response

  | Malformation | Outcome | Connection |
  |---|---|---|
  | `Transfer-Encoding` on a non-HTTP/1.1 response | Rejected (`DecoderException`) | Closed |
  | `Transfer-Encoding: chunked, gzip` (chunked not final) | **Now rejected** (`DecoderException`) — deliberate deviation from RFC 9112 §6.3 item 4, which would let this fall back to close-delimited framing; we reject it unconditionally instead, matching the request-side treatment | Closed |
  | `Transfer-Encoding: gzip` alone (chunked never appears) | **Now rejected** (`DecoderException`, same message) — same deliberate deviation, matching the request-side treatment | Closed |
  | `Transfer-Encoding: chunked, chunked` | Accepted — same as (a), deliberate/RFC-literal, not a bug | Stays open |
  | `Transfer-Encoding: chunked` + `Content-Length` both present | Accepted — Content-Length stripped, `Connection: close` injected into the decoded response object your client code sees, `protocolClosingInbound` fires | Closed once both inbound/outbound for this exchange complete |
  | Multiple disagreeing/duplicate `Content-Length` | Rejected, same as (a) | Closed |