### PR TITLE
http-netty: Reject HTTP/1.1 messages with both Transfer-Encoding and Content-Length

### DIFF
--- a/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
+++ b/servicetalk-benchmarks/src/jmh/java/io/servicetalk/http/netty/HttpResponseDecoderBenchmark.java
@@ -88,7 +88,7 @@ public class HttpResponseDecoderBenchmark {
 
         channel = new EmbeddedChannel(new HttpResponseDecoder(new ArrayDeque<>(), new PollLikePeakArrayDeque<>(),
                 getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE, 8192, 8192, 8192,
-                false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+                false, false, false, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }
 
     @Benchmark

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1SpecExceptions.java
@@ -22,11 +22,14 @@ public final class H1SpecExceptions {
 
     private final boolean allowPrematureClosureBeforePayloadBody;
     private final boolean allowLFWithoutCR;
+    private final boolean allowTransferEncodingWithContentLength;
 
     private H1SpecExceptions(final boolean allowPrematureClosureBeforePayloadBody,
-                             final boolean allowLFWithoutCR) {
+                             final boolean allowLFWithoutCR,
+                             final boolean allowTransferEncodingWithContentLength) {
         this.allowPrematureClosureBeforePayloadBody = allowPrematureClosureBeforePayloadBody;
         this.allowLFWithoutCR = allowLFWithoutCR;
+        this.allowTransferEncodingWithContentLength = allowTransferEncodingWithContentLength;
     }
 
     /**
@@ -54,11 +57,28 @@ public final class H1SpecExceptions {
         return allowLFWithoutCR;
     }
 
+    /**
+     * Allow an HTTP/1.1 message to carry both {@code Transfer-Encoding} and
+     * {@code Content-Length} headers, which is forbidden by
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9112#section-6.1">RFC 9112 section 6.1</a>
+     * because it is a request smuggling vector. When {@code true}, the decoder restores
+     * the RFC 7230 lenient behaviour and strips {@code Content-Length}; for requests it
+     * additionally forces {@code Connection: close} so the connection is not reused for a
+     * smuggled follow-up. Intended only as a temporary mitigation against a broken peer.
+     *
+     * @return {@code true} to accept HTTP/1.1 messages with both {@code Transfer-Encoding}
+     * and {@code Content-Length} headers.
+     */
+    public boolean allowTransferEncodingWithContentLength() {
+        return allowTransferEncodingWithContentLength;
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName() +
                 "{allowPrematureClosureBeforePayloadBody=" + allowPrematureClosureBeforePayloadBody +
                 ", allowLFWithoutCR=" + allowLFWithoutCR +
+                ", allowTransferEncodingWithContentLength=" + allowTransferEncodingWithContentLength +
                 '}';
     }
 
@@ -69,6 +89,7 @@ public final class H1SpecExceptions {
 
         private boolean allowPrematureClosureBeforePayloadBody;
         private boolean allowLFWithoutCR;
+        private boolean allowTransferEncodingWithContentLength;
 
         /**
          * Allows interpreting connection closures as the end of HTTP/1.1 messages if the receiver did not receive any
@@ -99,12 +120,28 @@ public final class H1SpecExceptions {
         }
 
         /**
+         * Allow an HTTP/1.1 message to carry both {@code Transfer-Encoding} and
+         * {@code Content-Length} headers. See
+         * {@link H1SpecExceptions#allowTransferEncodingWithContentLength()}. Default is
+         * {@code false}: such messages are rejected per RFC 9112 section 6.1.
+         *
+         * @param allow {@code true} to accept HTTP/1.1 messages with both
+         * {@code Transfer-Encoding} and {@code Content-Length} headers.
+         * @return {@code this}
+         */
+        public Builder allowTransferEncodingWithContentLength(boolean allow) {
+            this.allowTransferEncodingWithContentLength = allow;
+            return this;
+        }
+
+        /**
          * Builds {@link H1SpecExceptions}.
          *
          * @return a new {@link H1SpecExceptions}
          */
         public H1SpecExceptions build() {
-            return new H1SpecExceptions(allowPrematureClosureBeforePayloadBody, allowLFWithoutCR);
+            return new H1SpecExceptions(allowPrematureClosureBeforePayloadBody, allowLFWithoutCR,
+                    allowTransferEncodingWithContentLength);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientChannelInitializer.java
@@ -58,7 +58,8 @@ final class HttpClientChannelInitializer implements ChannelInitializer {
             pipeline.addLast(new HttpResponseDecoder(methodQueue, signalsQueue, alloc, config.headersFactory(),
                     config.maxStartLineLength(), config.maxHeaderFieldLength(), config.maxTotalHeaderFieldsLength(),
                     config.specExceptions().allowPrematureClosureBeforePayloadBody(),
-                    config.specExceptions().allowLFWithoutCR(), closeHandler));
+                    config.specExceptions().allowLFWithoutCR(),
+                    config.specExceptions().allowTransferEncodingWithContentLength(), closeHandler));
             pipeline.addLast(new HttpRequestEncoder(methodQueue, signalsQueue,
                     config.headersEncodedSizeEstimate(), config.trailersEncodedSizeEstimate(), closeHandler));
         });

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -68,6 +68,7 @@ import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.netty.BufferUtils.newBufferFrom;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY1;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY2;
@@ -76,6 +77,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_ORIGIN;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.UPGRADE;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
@@ -159,6 +161,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
      * </pre>
      */
     private final boolean allowLFWithoutCR;
+    private final boolean allowTransferEncodingWithContentLength;
     @Nullable
     private T message;
     @Nullable
@@ -198,6 +201,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                       final int maxStartLineLength, final int maxHeaderFieldLength,
                       final int maxTotalHeaderFieldsLength,
                       final boolean allowPrematureClosureBeforePayloadBody, final boolean allowLFWithoutCR,
+                      final boolean allowTransferEncodingWithContentLength,
                       final CloseHandler closeHandler) {
         super(alloc);
         this.closeHandler = requireNonNull(closeHandler);
@@ -207,6 +211,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         this.maxTotalHeaderFieldsLength = ensurePositive(maxTotalHeaderFieldsLength, "maxTotalHeaderFieldsLength");
         this.allowPrematureClosureBeforePayloadBody = allowPrematureClosureBeforePayloadBody;
         this.allowLFWithoutCR = allowLFWithoutCR;
+        this.allowTransferEncodingWithContentLength = allowTransferEncodingWithContentLength;
     }
 
     final HttpHeadersFactory headersFactory() {
@@ -775,9 +780,19 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
                     throw new DecoderException(
                             "chunked must be the last encoding present in the Transfer-Encoding header");
                 }
+                // RFC 9112 section 6.1: TE and Content-Length must not both be present.
                 if (contentLength >= 0L) {
-                    // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
+                    if (!allowTransferEncodingWithContentLength) {
+                        throw new DecoderException(
+                                "Content-Length is not allowed in HTTP/1.1 messages that contain a " +
+                                        "Transfer-Encoding header");
+                    }
+                    // Lenient: strip Content-Length; force Connection: close on requests to
+                    // prevent smuggled follow-ups (matches Netty's HttpUtil.setKeepAlive call).
                     message.headers().remove(CONTENT_LENGTH);
+                    if (isDecodingRequest()) {
+                        message.headers().set(CONNECTION, CLOSE);
+                    }
                     this.contentLength = Long.MIN_VALUE;
                 }
             }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -54,6 +54,7 @@ import io.netty.handler.codec.http.HttpExpectationFailedEvent;
 import io.netty.util.AsciiString;
 import io.netty.util.ByteProcessor;
 
+import java.util.Iterator;
 import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http.HttpConstants.COLON;
@@ -72,7 +73,9 @@ import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY1;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY2;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_LOCATION;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_ORIGIN;
+import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.UPGRADE;
+import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
@@ -747,12 +750,36 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         if (isContentAlwaysEmpty(message)) {
             removeTransferEncodingChunked(message.headers());
             return State.SKIP_CONTROL_CHARS;
-        } else if (isTransferEncodingChunked(message.headers())) {
-            if (contentLength >= 0L && HTTP_1_1.equals(message.version())) {
-                // Remove the received content-length header(s), keep only "transfer-encoding: chunked"
-                // See https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
-                message.headers().remove(CONTENT_LENGTH);
-                this.contentLength = Long.MIN_VALUE;
+        }
+        // RFC 9112 section 6.1: Transfer-Encoding is HTTP/1.1-only.
+        if (message.headers().contains(TRANSFER_ENCODING) && !HTTP_1_1.equals(message.version())) {
+            throw new DecoderException("Transfer-Encoding is only allowed in HTTP/1.1 or newer");
+        }
+        if (isTransferEncodingChunked(message.headers())) {
+            if (HTTP_1_1.equals(message.version())) {
+                // RFC 9112 section 6.1: chunked must be the final coding.
+                final Iterator<? extends CharSequence> encodingIt =
+                        message.headers().valuesIterator(TRANSFER_ENCODING);
+                CharSequence lastValue = null;
+                while (encodingIt.hasNext()) {
+                    lastValue = encodingIt.next();
+                }
+                assert lastValue != null;
+                final int vLen = lastValue.length();
+                final int chunkedValueLength = CHUNKED.length();
+                // Stricter than Netty: also rejects multi-header inputs whose last value is
+                // shorter than "chunked" (e.g. "chunked\r\nTransfer-Encoding: gzip").
+                if (vLen < chunkedValueLength ||
+                        !AsciiString.regionMatches(lastValue, true, vLen - chunkedValueLength,
+                                CHUNKED, 0, chunkedValueLength)) {
+                    throw new DecoderException(
+                            "chunked must be the last encoding present in the Transfer-Encoding header");
+                }
+                if (contentLength >= 0L) {
+                    // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
+                    message.headers().remove(CONTENT_LENGTH);
+                    this.contentLength = Long.MIN_VALUE;
+                }
             }
             return State.READ_CHUNK_SIZE;
         } else if (contentLength >= 0L) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestDecoder.java
@@ -57,9 +57,11 @@ final class HttpRequestDecoder extends HttpObjectDecoder<HttpRequestMetaData> im
                        final HttpHeadersFactory headersFactory, final int maxStartLineLength,
                        final int maxHeaderFieldLength, final int maxTotalHeaderLength,
                        final boolean allowPrematureClosureBeforePayloadBody, final boolean allowLFWithoutCR,
+                       final boolean allowTransferEncodingWithContentLength,
                        final CloseHandler closeHandler) {
         super(alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength, maxTotalHeaderLength,
-                allowPrematureClosureBeforePayloadBody, allowLFWithoutCR, closeHandler);
+                allowPrematureClosureBeforePayloadBody, allowLFWithoutCR,
+                allowTransferEncodingWithContentLength, closeHandler);
         this.methodQueue = requireNonNull(methodQueue);
         this.closeHandler = closeHandler;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpResponseDecoder.java
@@ -77,9 +77,11 @@ final class HttpResponseDecoder extends HttpObjectDecoder<HttpResponseMetaData> 
                         final ByteBufAllocator alloc, final HttpHeadersFactory headersFactory,
                         final int maxStartLineLength, int maxHeaderFieldLength, final int maxTotalHeaderLength,
                         final boolean allowPrematureClosureBeforePayloadBody, final boolean allowLFWithoutCR,
+                        final boolean allowTransferEncodingWithContentLength,
                         final CloseHandler closeHandler) {
         super(alloc, headersFactory, maxStartLineLength, maxHeaderFieldLength, maxTotalHeaderLength,
-                allowPrematureClosureBeforePayloadBody, allowLFWithoutCR, closeHandler);
+                allowPrematureClosureBeforePayloadBody, allowLFWithoutCR,
+                allowTransferEncodingWithContentLength, closeHandler);
         this.methodQueue = requireNonNull(methodQueue);
         this.signalsQueue = requireNonNull(signalsQueue);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -202,7 +202,8 @@ final class NettyHttpServer {
             final HttpRequestDecoder decoder = new HttpRequestDecoder(methodQueue, alloc, config.headersFactory(),
                     config.maxStartLineLength(), config.maxHeaderFieldLength(), config.maxTotalHeaderFieldsLength(),
                     config.specExceptions().allowPrematureClosureBeforePayloadBody(),
-                    config.specExceptions().allowLFWithoutCR(), closeHandler);
+                    config.specExceptions().allowLFWithoutCR(),
+                    config.specExceptions().allowTransferEncodingWithContentLength(), closeHandler);
             pipeline.addLast(decoder);
             pipeline.addLast(new HttpResponseEncoder(methodQueue, config.headersEncodedSizeEstimate(),
                     config.trailersEncodedSizeEstimate(), closeHandler, decoder));

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -116,6 +116,15 @@ abstract class HttpObjectDecoderTest {
      */
     abstract EmbeddedChannel channelWithMaxTotalHeaderFieldsLength(int maxTotalHeaderFieldsLength);
 
+    /**
+     * Creates a new channel with
+     * {@link H1SpecExceptions.Builder#allowTransferEncodingWithContentLength(boolean)} set
+     * to {@code true}, used to verify the lenient RFC 7230 strip-Content-Length behaviour.
+     *
+     * @return a new EmbeddedChannel that accepts both Transfer-Encoding and Content-Length.
+     */
+    abstract EmbeddedChannel channelLenientTransferEncodingWithContentLength();
+
     final HttpMetaData assertStartLineForContent() {
         return assertStartLineForContent(channel());
     }
@@ -572,6 +581,14 @@ abstract class HttpObjectDecoderTest {
         validateWithContent(-chunkSize, false, channel);
     }
 
+    /**
+     * RFC 9112 section 6.1: an HTTP/1.1 message must not carry both Transfer-Encoding and
+     * Content-Length. ServiceTalk historically silently stripped Content-Length (RFC 7230
+     * lenient behaviour) which left the connection open and is a request-smuggling vector.
+     * The default is now to reject;
+     * {@link H1SpecExceptions.Builder#allowTransferEncodingWithContentLength(boolean)}
+     * restores the legacy behaviour for break-glass use.
+     */
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")
     @ValueSource(booleans = {true, false})
     void chunkedWithContentLength(boolean crlf) {
@@ -579,16 +596,41 @@ abstract class HttpObjectDecoderTest {
         String br = br(crlf);
         int chunkSize = 128;
         int chunkedContentLength = 2 + 2 + chunkSize + 2 + 5;
-        writeMsg(startLineForContent() + br +
+        DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(startLineForContent() + br +
                 "Host: servicetalk.io" + br +
                 "Connection: keep-alive" + br +
                 "Content-Length: " + chunkedContentLength + br +
-                "Transfer-Encoding: chunked" + br + br, channel);
+                "Transfer-Encoding: chunked" + br + br, channel));
+        assertThat(e.getMessage(), startsWith("Content-Length is not allowed"));
+    }
+
+    /**
+     * Lenient mode: when {@code allowTransferEncodingWithContentLength} is enabled, the
+     * decoder strips {@code Content-Length} and (for requests only) sets
+     * {@code Connection: close} so the connection is not reused for a smuggled follow-up.
+     */
+    @Test
+    void chunkedWithContentLengthLenient() {
+        EmbeddedChannel channel = channelLenientTransferEncodingWithContentLength();
+        int chunkSize = 128;
+        int chunkedContentLength = 2 + 2 + chunkSize + 2 + 5;
+        writeMsg(startLineForContent() + "\r\n" +
+                "Host: servicetalk.io" + "\r\n" +
+                "Connection: keep-alive" + "\r\n" +
+                "Content-Length: " + chunkedContentLength + "\r\n" +
+                "Transfer-Encoding: chunked" + "\r\n\r\n", channel);
         writeChunk(chunkSize, channel);
         writeLastChunk(channel);
-        HttpMetaData metaData = validateWithContent(-chunkSize, false, channel);
-        assertThat("Unexpected content-length header(s)",
+
+        HttpMetaData metaData = assertStartLineForContent(channel);
+        assertSingleHeaderValue(metaData.headers(), HOST, "servicetalk.io");
+        assertSingleHeaderValue(metaData.headers(), TRANSFER_ENCODING, CHUNKED);
+        assertThat("Content-Length must be stripped",
                 metaData.headers().valuesIterator(CONTENT_LENGTH).hasNext(), is(false));
+        // Connection: close is forced on requests only (matches Netty's HttpUtil.setKeepAlive call).
+        assertSingleHeaderValue(metaData.headers(), "Connection", isDecodingRequest() ? "close" : KEEP_ALIVE);
+        assertPayloadSize(chunkSize, channel);
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -703,6 +703,100 @@ abstract class HttpObjectDecoderTest {
         assertFalse(channel.finishAndReleaseAll());
     }
 
+    /**
+     * RFC 9112 section 6.1: {@code Transfer-Encoding} is HTTP/1.1-only. Today the
+     * decoder ignores the protocol version and accepts {@code Transfer-Encoding: chunked}
+     * on HTTP/1.0, which lets a peer desync framing with HTTP/1.0 intermediaries that
+     * reject TE. After the fix the decoder must reject TE on any non-1.1 message.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] httpVersion={0} expectRejected={1} crlf={2}")
+    @MethodSource("transferEncodingProtocolVersionArgs")
+    void transferEncodingRejectedOnNonHttp11(String httpVersion, boolean expectRejected, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        String msg = startLineForContent().replace("HTTP/1.1", httpVersion) + br +
+                "Host: servicetalk.io" + br +
+                "Transfer-Encoding: chunked" + br + br;
+        if (expectRejected) {
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("Transfer-Encoding is only allowed in HTTP/1.1"));
+        } else {
+            // HTTP/1.1 path is unchanged: feed the message and the last-chunk to confirm the
+            // decoder progresses through chunked parsing without throwing.
+            writeMsg(msg, channel);
+            writeLastChunk(channel);
+            assertThat(channel.isOpen(), is(true));
+        }
+    }
+
+    private static Collection<Arguments> transferEncodingProtocolVersionArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (boolean crlf : new boolean[] {true, false}) {
+            // HTTP/1.0 + Transfer-Encoding: chunked must be rejected.
+            arguments.add(Arguments.of("HTTP/1.0", true, crlf));
+            // HTTP/1.1 sanity: continues to be accepted.
+            arguments.add(Arguments.of("HTTP/1.1", false, crlf));
+        }
+        return arguments;
+    }
+
+    /**
+     * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the
+     * message body. Today the decoder only checks whether {@code chunked} is present
+     * anywhere in the {@code Transfer-Encoding} list, so {@code chunked, gzip} is
+     * silently treated as chunked even though gzip is the outermost coding. After the
+     * fix the decoder must reject any value where {@code chunked} is not the last
+     * coding.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" expectRejected={1} crlf={2}")
+    @MethodSource("transferEncodingChunkedLastArgs")
+    void transferEncodingChunkedMustBeLast(String transferEncoding, boolean expectRejected, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        String msg = startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Transfer-Encoding: " + transferEncoding + br + br;
+        if (expectRejected) {
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("chunked must be the last"));
+        } else {
+            // Feed the headers; they must parse without throwing. We don't drain the body
+            // (the decoder transitions to READ_CHUNK_SIZE awaiting more data); tearDown
+            // handles cleanup.
+            writeMsg(msg, channel);
+            assertThat(channel.isOpen(), is(true));
+        }
+    }
+
+    private static Collection<Arguments> transferEncodingChunkedLastArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (boolean crlf : new boolean[] {true, false}) {
+            final String br = crlf ? "\r\n" : "\n";
+            // Single value: chunked alone - accepted.
+            arguments.add(Arguments.of("chunked", false, crlf));
+            // Comma-separated, chunked last - accepted.
+            arguments.add(Arguments.of("gzip, chunked", false, crlf));
+            // No space after comma - still accepted (chunked still last).
+            arguments.add(Arguments.of("gzip,chunked", false, crlf));
+            // Case-insensitive match - accepted.
+            arguments.add(Arguments.of("ChUnKeD", false, crlf));
+            // Trailing OWS - accepted.
+            arguments.add(Arguments.of("chunked  ", false, crlf));
+            // Comma-separated, chunked NOT last - rejected.
+            arguments.add(Arguments.of("chunked, gzip", true, crlf));
+            // Same with whitespace before comma - rejected.
+            arguments.add(Arguments.of("chunked , gzip", true, crlf));
+            // Multi-header: gzip first, chunked last - accepted.
+            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", false, crlf));
+            // Multi-header: chunked first, gzip last (length 4) - rejected.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: gzip", true, crlf));
+            // Multi-header: chunked first, deflate last (length 7, same as "chunked") - rejected.
+            // This case demonstrates the gap closed vs Netty's permissive check.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", true, crlf));
+        }
+        return arguments;
+    }
+
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")
     @ValueSource(booleans = {true, false})
     void unexpectedTrailersAfterContentLength(boolean crlf) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -61,9 +61,16 @@ class HttpRequestDecoderTest extends HttpObjectDecoderTest {
     private final EmbeddedChannel channelSpecException = newChannel(true);
 
     private static EmbeddedChannel newChannel(boolean allowLFWithoutCR) {
+        return newChannel(DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH, allowLFWithoutCR, false);
+    }
+
+    private static EmbeddedChannel newChannel(int maxTotalHeaderFieldsLength,
+                                              boolean allowLFWithoutCR,
+                                              boolean allowTransferEncodingWithContentLength) {
         return new EmbeddedChannel(new HttpRequestDecoder(new ArrayDeque<>(), getByteBufAllocator(DEFAULT_ALLOCATOR),
                 DefaultHttpHeadersFactory.INSTANCE, DEFAULT_MAX_START_LINE_LENGTH, DEFAULT_MAX_HEADER_FIELD_LENGTH,
-                DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH, false, allowLFWithoutCR, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+                maxTotalHeaderFieldsLength, false, allowLFWithoutCR, allowTransferEncodingWithContentLength,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }
 
     @Override
@@ -108,15 +115,12 @@ class HttpRequestDecoderTest extends HttpObjectDecoderTest {
 
     @Override
     EmbeddedChannel channelWithMaxTotalHeaderFieldsLength(int maxTotalHeaderFieldsLength) {
-        return new EmbeddedChannel(new HttpRequestDecoder(new ArrayDeque<>(),
-                getByteBufAllocator(DEFAULT_ALLOCATOR),
-                DefaultHttpHeadersFactory.INSTANCE,
-                DEFAULT_MAX_START_LINE_LENGTH,
-                DEFAULT_MAX_HEADER_FIELD_LENGTH,
-                maxTotalHeaderFieldsLength,
-                false,  // allowPrematureClosureBeforePayloadBody
-                false,  // allowLFWithoutCR
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+        return newChannel(maxTotalHeaderFieldsLength, false, false);
+    }
+
+    @Override
+    EmbeddedChannel channelLenientTransferEncodingWithContentLength() {
+        return newChannel(DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH, false, true);
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -100,12 +100,19 @@ class HttpResponseDecoderTest extends HttpObjectDecoderTest {
     private final EmbeddedChannel channelSpecException = newChannel(true);
 
     private EmbeddedChannel newChannel(boolean allowLFWithoutCR) {
+        return newChannel(DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH, allowLFWithoutCR, false);
+    }
+
+    private EmbeddedChannel newChannel(int maxTotalHeaderFieldsLength,
+                                       boolean allowLFWithoutCR,
+                                       boolean allowTransferEncodingWithContentLength) {
         final ArrayDeque<Signal> signalsQueue = new PollLikePeakArrayDeque<>();
         signalsQueue.offer(REQUEST_SIGNAL);
         return new EmbeddedChannel(new HttpResponseDecoder(methodQueue, signalsQueue,
                 getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE,
-                DEFAULT_MAX_START_LINE_LENGTH, DEFAULT_MAX_HEADER_FIELD_LENGTH, DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH,
-                false, allowLFWithoutCR, UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+                DEFAULT_MAX_START_LINE_LENGTH, DEFAULT_MAX_HEADER_FIELD_LENGTH, maxTotalHeaderFieldsLength,
+                false, allowLFWithoutCR, allowTransferEncodingWithContentLength,
+                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
     }
 
     @Override
@@ -150,17 +157,12 @@ class HttpResponseDecoderTest extends HttpObjectDecoderTest {
 
     @Override
     EmbeddedChannel channelWithMaxTotalHeaderFieldsLength(int maxTotalHeaderFieldsLength) {
-        final ArrayDeque<Signal> signalsQueue = new PollLikePeakArrayDeque<>();
-        signalsQueue.offer(REQUEST_SIGNAL);
-        return new EmbeddedChannel(new HttpResponseDecoder(methodQueue, signalsQueue,
-                getByteBufAllocator(DEFAULT_ALLOCATOR),
-                DefaultHttpHeadersFactory.INSTANCE,
-                DEFAULT_MAX_START_LINE_LENGTH,
-                DEFAULT_MAX_HEADER_FIELD_LENGTH,
-                maxTotalHeaderFieldsLength,
-                false,  // allowPrematureClosureBeforePayloadBody
-                false,  // allowLFWithoutCR
-                UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+        return newChannel(maxTotalHeaderFieldsLength, false, false);
+    }
+
+    @Override
+    EmbeddedChannel channelLenientTransferEncodingWithContentLength() {
+        return newChannel(DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH, false, true);
     }
 
     @Test


### PR DESCRIPTION
#### Motivation
HttpObjectDecoder.readHeaders silently strips Content-Length when an
  HTTP/1.1 message carries both Transfer-Encoding and Content-Length.
  RFC 9112 section 6.1 considers the combination a request-smuggling
  vector and obsoletes the RFC 7230 strip-and-continue handling.

#### Modifications
  - Reject the combination by default with a DecoderException.
  - Expose H1SpecExceptions.Builder#allowTransferEncodingWithContentLength
    to opt back into RFC 7230 lenient handling. When enabled, strip
    Content-Length and (for requests only, matching Netty's
    HttpUtil.setKeepAlive call) force Connection: close.
  - Plumb the flag through H1SpecExceptions, HttpRequestDecoder /
    HttpResponseDecoder constructors, and the NettyHttpServer /
    HttpClientChannelInitializer call sites.
  - Update chunkedWithContentLength to assert strict rejection; add
    chunkedWithContentLengthLenient to cover the opt-in path.

#### Result
  HTTP/1.1 + TE + CL is rejected with a clear DecoderException that
  closes the connection. Operators with a non-compliant peer can
  opt back into legacy strip-and-close via
  allowTransferEncodingWithContentLength.