### PR TITLE
ci: run `gradle-wrapper-validation` before executing workflows

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -8,7 +8,10 @@ on:
 env:
   JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
 jobs:
+  gradle-wrapper-validation:
+    uses: ./.github/workflows/gradle-wrapper-validation.yml
   build:
+    needs: gradle-wrapper-validation
     name: Netty ${{ matrix.netty }} Snapshot
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -14,7 +14,10 @@ on:
       - '**.adoc'
       - '**.txt'
 jobs:
+  gradle-wrapper-validation:
+    uses: ./.github/workflows/gradle-wrapper-validation.yml
   build:
+    needs: gradle-wrapper-validation
     name: JDK ${{ matrix.java }} ${{ matrix.os_label }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -13,7 +13,10 @@ on:
       - '*.adoc'
       - '*.txt'
 jobs:
+  gradle-wrapper-validation:
+    uses: ./.github/workflows/gradle-wrapper-validation.yml
   quality:
+    needs: gradle-wrapper-validation
     name: JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -7,7 +7,10 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+.[0-9]+"
 jobs:
+  gradle-wrapper-validation:
+    uses: ./.github/workflows/gradle-wrapper-validation.yml
   build:
+    needs: gradle-wrapper-validation
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -17,7 +17,10 @@ on:
       - '**.adoc'
       - '*.txt'
 jobs:
+  gradle-wrapper-validation:
+    uses: ./.github/workflows/gradle-wrapper-validation.yml
   build:
+    needs: gradle-wrapper-validation
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,10 @@ on:
     - cron: '0 13 * * 1'
 
 jobs:
+  gradle-wrapper-validation:
+    uses: ./.github/workflows/gradle-wrapper-validation.yml
   analyze:
+    needs: gradle-wrapper-validation
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -3,7 +3,7 @@ permissions:
   contents: read
 on:
   push:
-  pull_request:
+  workflow_call:
 
 jobs:
   validation:


### PR DESCRIPTION
Motivation

Adds a defense-in-depth layer by validating the Gradle wrapper jar before any downstream job runs.

Modifications

- `gradle-wrapper-validation.yml`: added `workflow_call` trigger,removed `pull_request` to avoid duplicate runs when invoked from other workflows;
- Added a `gradle-wrapper-validation` job calling the reusable workflow, and gated the main jobs via `needs: gradle-wrapper-validation` in all other workflows.

Result

Every CI workflow that runs Gradle now blocks until the wrapper jar is verified.