### PR TITLE
ci: pin actions to commit SHAs and tighten Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,14 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "02:00"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "02:00"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -23,9 +23,9 @@ jobs:
         netty: [ 4.1+, 4.2.+ ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -44,7 +44,7 @@ jobs:
         run:  sudo -E env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel test"
       - name: Publish Test Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.netty }}
           path: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -25,7 +25,7 @@ jobs:
             os_label: macos
     steps:
       - name: Download Artifacts
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
@@ -34,7 +34,7 @@ jobs:
           # File location set in ci-prb.yml and must be coordinated.
           name: test-results-${{ matrix.os_label }}-${{ matrix.java }}
       - name: Publish Test Report
-        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f
+        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1.12.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -31,9 +31,9 @@ jobs:
             os_label: macos
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up JDK ${{ matrix.java }} and JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: |
             ${{ matrix.java }}
@@ -58,7 +58,7 @@ jobs:
       - name: Configure Windows Pagefile
         if: ${{ runner.os == 'Windows' }}
         # v1.2
-        uses: al-cheb/configure-pagefile-action@9b6da52fb72a3c6147c1aad2df22d8d905681adc
+        uses: al-cheb/configure-pagefile-action@9b6da52fb72a3c6147c1aad2df22d8d905681adc # v1.5
         with:
           minimum-size: 8GB
           maximum-size: 16GB
@@ -74,7 +74,7 @@ jobs:
         run: ./gradlew --no-daemon --parallel test
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-${{ matrix.os_label }}-${{ matrix.java }}
           path: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -57,7 +57,6 @@ jobs:
       # https://github.community/t/error-the-paging-file-is-too-small-for-this-operation-to-complete/17141
       - name: Configure Windows Pagefile
         if: ${{ runner.os == 'Windows' }}
-        # v1.2
         uses: al-cheb/configure-pagefile-action@9b6da52fb72a3c6147c1aad2df22d8d905681adc # v1.5
         with:
           minimum-size: 8GB

--- a/.github/workflows/ci-prq-reports.yml
+++ b/.github/workflows/ci-prq-reports.yml
@@ -26,7 +26,6 @@ jobs:
           commit: ${{ github.event.workflow_run.head_commit.id }}
           name: checkstyle-results-${{ matrix.java }}
       - name: Publish Checkstyle Report
-        # v1.2
         uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f # v1.2
         with:
           name: Checkstyle Report JDK ${{ matrix.java }}
@@ -49,7 +48,6 @@ jobs:
           commit: ${{ github.event.workflow_run.head_commit.id }}
           name: pmd-results-${{ matrix.java }}
       - name: Publish PMD Report
-        # v1.2
         uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d # v1.2
         with:
           name: PMD Report JDK ${{ matrix.java }}
@@ -72,7 +70,6 @@ jobs:
           commit: ${{ github.event.workflow_run.head_commit.id }}
           name: spotbugs-results-${{ matrix.java }}
       - name: Publish SpotBugs Report
-        # v1.2
         uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e # v1.2
         with:
           name: SpotBugs Report JDK ${{ matrix.java }}

--- a/.github/workflows/ci-prq-reports.yml
+++ b/.github/workflows/ci-prq-reports.yml
@@ -18,7 +18,7 @@ jobs:
         java: [ 8, 11 ] # These are the JDK's we publish artifacts with.
     steps:
       - name: Download Artifacts
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
@@ -27,7 +27,7 @@ jobs:
           name: checkstyle-results-${{ matrix.java }}
       - name: Publish Checkstyle Report
         # v1.2
-        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f
+        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f # v1.2
         with:
           name: Checkstyle Report JDK ${{ matrix.java }}
           path: '**/build/reports/checkstyle/*.xml'
@@ -41,7 +41,7 @@ jobs:
         java: [ 8, 11 ]
     steps:
       - name: Download Artifacts
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
@@ -50,7 +50,7 @@ jobs:
           name: pmd-results-${{ matrix.java }}
       - name: Publish PMD Report
         # v1.2
-        uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d
+        uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d # v1.2
         with:
           name: PMD Report JDK ${{ matrix.java }}
           path: '**/build/reports/pmd/*.xml'
@@ -64,7 +64,7 @@ jobs:
         java: [ 8, 11 ]
     steps:
       - name: Download Artifacts
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
@@ -73,7 +73,7 @@ jobs:
           name: spotbugs-results-${{ matrix.java }}
       - name: Publish SpotBugs Report
         # v1.2
-        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e
+        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e # v1.2
         with:
           name: SpotBugs Report JDK ${{ matrix.java }}
           path: '**/build/reports/spotbugs/*.xml'

--- a/.github/workflows/ci-prq.yml
+++ b/.github/workflows/ci-prq.yml
@@ -24,9 +24,9 @@ jobs:
         java: [ 8, 11 ] # These are the JDK's we publish artifacts with.
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: |
             17
@@ -49,19 +49,19 @@ jobs:
         run: ./gradlew --parallel -Pdependency.analysis.print.build.health=true quality
       - name: Upload CheckStyle Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: checkstyle-results-${{ matrix.java }}
           path: '**/build/reports/checkstyle/*.xml'
       - name: Upload PMD Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pmd-results-${{ matrix.java }}
           path: '**/build/reports/pmd/*.xml'
       - name: Upload SpotBugs Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spotbugs-results-${{ matrix.java }}
           path: '**/build/reports/spotbugs/*.xml'

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check NO SNAPSHOT version suffix
         run: if [[ $(cat gradle.properties | grep version= | sed 's/^version=//') =~ .*-SNAPSHOT ]]; then exit 1; else exit 0; fi
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -54,21 +54,21 @@ jobs:
           echo "Go to https://central.sonatype.com/publishing/deployments to finish publishing artifacts"
       - name: Publish Test Results
         if: always()
-        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f
+        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1.12.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
           check_name: Test Report
       - name: Publish Checkstyle Report
         if: always()
-        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f
+        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f # v1.2
         with:
           name: Checkstyle Report
           path: '**/build/reports/checkstyle/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish PMD Report
         if: always()
-        uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d
+        uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d # v1.2
         with:
           name: PMD Report
           path: '**/build/reports/pmd/*.xml'
@@ -76,7 +76,7 @@ jobs:
       - name: Publish SpotBugs Report
         if: always()
         # v1.2
-        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e
+        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e # v1.2
         with:
           name: SpotBugs Report
           path: '**/build/reports/spotbugs/*.xml'

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -75,7 +75,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish SpotBugs Report
         if: always()
-        # v1.2
         uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e # v1.2
         with:
           name: SpotBugs Report

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check SNAPSHOT version suffix
         run: if [[ $(cat gradle.properties | grep version= | sed 's/^version=//') =~ .*-SNAPSHOT ]]; then exit 0; else exit 1; fi
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -55,28 +55,28 @@ jobs:
         run: sudo -E env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --no-parallel publish"
       - name: Publish Test Results
         if: always()
-        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f
+        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1.12.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
           check_name: Test Report Snapshot
       - name: Publish Checkstyle Report
         if: always()
-        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f
+        uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f # v1.2
         with:
           name: Checkstyle Report Snapshot
           path: '**/build/reports/checkstyle/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish PMD Report
         if: always()
-        uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d
+        uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d # v1.2
         with:
           name: PMD Report Snapshot
           path: '**/build/reports/pmd/*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish SpotBugs Report
         if: always()
-        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e
+        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e # v1.2
         with:
           name: SpotBugs Report Snapshot
           path: '**/build/reports/spotbugs/*.xml'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,9 +42,9 @@ jobs:
         language: [ 'java' ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -52,7 +52,7 @@ jobs:
       - name: Print JDK Version
         run: java -version
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
       - name: Clean Gradle project
@@ -60,4 +60,4 @@ jobs:
       - name: Assemble Gradle project
         run: ./gradlew --parallel --no-build-cache assemble
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,5 +10,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: gradle/actions/wrapper-validation@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0


### PR DESCRIPTION
Motivation

Harden CI against GitHub Actions and dependency supply-chain attacks. Mutable tags allow a compromised upstream to silently change what runs in our workflows.

Modifications

- Pinned all third-party actions to commit SHAs with # vX.Y.Z comments (`uv tool run gha-update`).
- dependabot.yml: switched both ecosystems to weekly with a 7-day cooldown (14 for major versions).

Result

Action references are now immutable — a hijacked tag cannot affect our CI. Dependency updates are batched weekly and held briefly before opening, while security advisories keep their fast path. No behavior change for legitimate workflow runs.