### PR TITLE
ci: remove `semver-major-days` from `github-actions` in `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,3 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-major-days: 14


### PR DESCRIPTION
Motivation:
The property `#/updates/1/cooldown/semver-major-days` is not supported for the package ecosystem `github-actions`.
