### PR TITLE
ci: remove unused `al-cheb/configure-pagefile-action`

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -54,13 +54,6 @@ jobs:
         run: chmod +x gradlew
       - name: Clean Gradle project
         run: ./gradlew --parallel clean
-      # https://github.community/t/error-the-paging-file-is-too-small-for-this-operation-to-complete/17141
-      - name: Configure Windows Pagefile
-        if: ${{ runner.os == 'Windows' }}
-        uses: al-cheb/configure-pagefile-action@9b6da52fb72a3c6147c1aad2df22d8d905681adc # v1.5
-        with:
-          minimum-size: 8GB
-          maximum-size: 16GB
       - name: Build and Test (Linux)
         if: runner.os == 'Linux'
         env:


### PR DESCRIPTION
Motivation:

Our pipelines don't have Windows runners configured. This action can be safely removed instead of keeping a dependency on an unofficial action.