### PR TITLE
ci: fix publications of junit test reports

### DIFF
--- a/.github/workflows/ci-netty-snapshot.yml
+++ b/.github/workflows/ci-netty-snapshot.yml
@@ -12,6 +12,9 @@ jobs:
     uses: ./.github/workflows/gradle-wrapper-validation.yml
   build:
     needs: gradle-wrapper-validation
+    permissions:
+      contents: read
+      checks: write
     name: Netty ${{ matrix.netty }} Snapshot
     runs-on: ${{ matrix.os }}
     env:
@@ -43,8 +46,9 @@ jobs:
       - name: Build and Test
         run:  sudo -E env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --parallel test"
       - name: Publish Test Results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: '!cancelled()'
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
-          name: test-results-${{ matrix.os }}-${{ matrix.netty }}
-          path: '**/build/test-results/test/TEST-*.xml'
+          files: '**/build/test-results/test/TEST-*.xml'
+          check_name: Test Report Netty ${{ matrix.netty }} Snapshot
+          comment_mode: 'off'

--- a/.github/workflows/ci-prb-reports.yml
+++ b/.github/workflows/ci-prb-reports.yml
@@ -8,15 +8,15 @@ on:
       - completed
 jobs:
   tests:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     permissions:
-      contents: read
       actions: read
       checks: write
     runs-on: ubuntu-latest
     strategy:
       # Matrix should be coordinated with ci-prb.yml.
       matrix:
-        java: [ 8, 11, 17, 21, 24 ]
+        java: [ 8, 11, 17, 21, 25 ]
         os: [ ubuntu-latest ]
         os_label: [ ubuntu ]
         include:
@@ -25,18 +25,16 @@ jobs:
             os_label: macos
     steps:
       - name: Download Artifacts
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          workflow_conclusion: completed
-          commit: ${{ github.event.workflow_run.head_commit.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
           # File location set in ci-prb.yml and must be coordinated.
           name: test-results-${{ matrix.os_label }}-${{ matrix.java }}
       - name: Publish Test Report
-        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1.12.0
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          files: '**/build/test-results/test/TEST-*.xml'
           commit: ${{ github.event.workflow_run.head_commit.id }}
           check_name: Test Report JDK ${{ matrix.java }} ${{ matrix.os_label }}
+          comment_mode: 'off'

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -65,8 +65,9 @@ jobs:
           JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
         run: ./gradlew --no-daemon --parallel test
       - name: Upload Test Results
-        if: always()
+        if: '!cancelled()'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          # File location used in ci-prb-reports.yml and must be coordinated.
           name: test-results-${{ matrix.os_label }}-${{ matrix.java }}
           path: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -13,7 +13,6 @@ jobs:
     needs: gradle-wrapper-validation
     permissions:
       contents: read
-      actions: read
       checks: write
     name: Release
     runs-on: ubuntu-latest
@@ -53,12 +52,12 @@ jobs:
           curl -i --retry 5 -H "Authorization: Bearer $BEARER_TOKEN" -X POST https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io.servicetalk
           echo "Go to https://central.sonatype.com/publishing/deployments to finish publishing artifacts"
       - name: Publish Test Results
-        if: always()
-        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1.12.0
+        if: '!cancelled()'
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-          check_name: Test Report
+          files: '**/build/test-results/test/TEST-*.xml'
+          check_name: Test Report Release
+          comment_mode: 'off'
       - name: Publish Checkstyle Report
         if: always()
         uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f # v1.2

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -23,7 +23,6 @@ jobs:
     needs: gradle-wrapper-validation
     permissions:
       contents: read
-      actions: read
       checks: write
     name: Snapshot
     runs-on: ubuntu-latest
@@ -54,12 +53,12 @@ jobs:
           SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
         run: sudo -E env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon --no-parallel publish"
       - name: Publish Test Results
-        if: always()
-        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1.12.0
+        if: '!cancelled()'
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          files: '**/build/test-results/test/TEST-*.xml'
           check_name: Test Report Snapshot
+          comment_mode: 'off'
       - name: Publish Checkstyle Report
         if: always()
         uses: jwgmeligmeyling/checkstyle-github-action@50292990e18466f2c5d95d04ff5fab931254fa5f # v1.2


### PR DESCRIPTION
Motivation:

The Test Reports do not work for quite a long time. Also, `scacap/action-surefire-report` is now deprecated.

Modifications:
- Replace `scacap/action-surefire-report` with the more popular `EnricoMi/publish-unit-test-result-action`, which is also used by pkl.
- Replace custom `dawidd6/action-download-artifact` action with official `actions/download-artifact` from GitHub.
- Update permissions.
- Publush Test Reports only if pipelines were not cancelled.

Result:

jUnit reports are published on GitHub, making it easier to see the results instead of manual investigation of the build logs.