### PR TITLE
http-netty: Close connection after responding to TE+CL HTTP/1.1 messages

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -54,6 +54,7 @@ import io.netty.handler.codec.http.HttpExpectationFailedEvent;
 import io.netty.util.AsciiString;
 import io.netty.util.ByteProcessor;
 
+import java.util.Iterator;
 import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http.HttpConstants.COLON;
@@ -72,7 +73,9 @@ import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY1;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY2;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_LOCATION;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_ORIGIN;
+import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.UPGRADE;
+import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
@@ -748,10 +751,29 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         if (isContentAlwaysEmpty(message)) {
             removeTransferEncodingChunked(message.headers());
             return State.SKIP_CONTROL_CHARS;
-        } else if (isTransferEncodingChunked(message.headers())) {
-            if (contentLength >= 0L && HTTP_1_1.equals(message.version())) {
-                // Remove the received content-length header(s), keep only "transfer-encoding: chunked"
-                // See https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
+        }
+        // RFC 9112 section 6.1: Transfer-Encoding is HTTP/1.1-only.
+        if (message.headers().contains(TRANSFER_ENCODING) && !HTTP_1_1.equals(message.version())) {
+            throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
+        }
+        if (isTransferEncodingChunked(message.headers())) {
+            // RFC 9112 section 6.1: chunked must be the final coding.
+            final Iterator<? extends CharSequence> encodingIt =
+                    message.headers().valuesIterator(TRANSFER_ENCODING);
+            CharSequence lastValue = encodingIt.next();
+            while (encodingIt.hasNext()) {
+                lastValue = encodingIt.next();
+            }
+            final int vLen = lastValue.length();
+            final int chunkedValueLength = CHUNKED.length();
+            if (vLen < chunkedValueLength ||
+                    !AsciiString.regionMatches(lastValue, true, vLen - chunkedValueLength,
+                            CHUNKED, 0, chunkedValueLength)) {
+                throw new StacklessDecoderException(
+                        "chunked must be the last encoding present in the Transfer-Encoding header");
+            }
+            if (contentLength >= 0L) {
+                // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
                 message.headers().remove(CONTENT_LENGTH);
                 this.contentLength = Long.MIN_VALUE;
             }
@@ -1074,6 +1096,10 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
     static final class StacklessDecoderException extends DecoderException {
         private static final long serialVersionUID = 7611225180490304156L;
+
+        StacklessDecoderException(final String message) {
+            super(message);
+        }
 
         StacklessDecoderException(final String message, final Throwable cause) {
             super(message, cause);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -63,8 +63,10 @@ import static io.netty.handler.codec.http.HttpConstants.HT;
 import static io.netty.handler.codec.http.HttpConstants.LF;
 import static io.netty.handler.codec.http.HttpConstants.SP;
 import static io.netty.util.ByteProcessor.FIND_LF;
+import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
 import static io.servicetalk.buffer.api.CharSequences.emptyAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
+import static io.servicetalk.buffer.api.CharSequences.regionMatches;
 import static io.servicetalk.buffer.netty.BufferUtils.newBufferFrom;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
@@ -757,34 +759,30 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             if (!HTTP_1_1.equals(message.version())) {
                 throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
             }
-            // RFC 9112 section 6.3: a request that has Transfer-Encoding without chunked as the
-            // final coding cannot be reliably framed and MUST be rejected. For responses the
-            // legacy "read-until-connection-close" framing still applies, so only enforce on
-            // requests.
-            if (!isTransferEncodingChunked(message.headers())) {
-                if (isDecodingRequest()) {
-                    throw new StacklessDecoderException(
-                            "Transfer-Encoding without chunked is not allowed in requests");
-                }
-            } else {
-                // RFC 9112 section 6.1: chunked must be the final coding.
-                final Iterator<? extends CharSequence> encodingIt =
-                        message.headers().valuesIterator(TRANSFER_ENCODING);
-                CharSequence lastValue = encodingIt.next();
-                while (encodingIt.hasNext()) {
-                    lastValue = encodingIt.next();
-                }
-                if (!endsWithChunkedToken(lastValue)) {
-                    throw new StacklessDecoderException(
-                            "chunked must be the last encoding present in the Transfer-Encoding header");
-                }
-                if (contentLength >= 0L) {
-                    // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
-                    message.headers().remove(CONTENT_LENGTH);
-                    this.contentLength = Long.MIN_VALUE;
-                }
+            // RFC 9112 section 6.3: Transfer-Encoding overrides Content-Length. Drop any received
+            // Content-Length now so it can never be used to frame the body, in any branch below.
+            if (contentLength >= 0L) {
+                // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
+                message.headers().remove(CONTENT_LENGTH);
+                this.contentLength = Long.MIN_VALUE;
+            }
+            // RFC 9112 section 6.1: chunked must be the final coding. There may be multiple
+            // Transfer-Encoding header lines, so check the last value of the last line.
+            final Iterator<? extends CharSequence> encodingIt =
+                    message.headers().valuesIterator(TRANSFER_ENCODING);
+            CharSequence lastValue = encodingIt.next();
+            while (encodingIt.hasNext()) {
+                lastValue = encodingIt.next();
+            }
+            if (endsWithChunkedToken(lastValue)) {
                 return State.READ_CHUNK_SIZE;
             }
+            // RFC 9112 section 6.3: chunked is not the final coding. A request cannot be framed
+            // reliably and MUST be rejected; a response is framed by reading until connection close.
+            if (isDecodingRequest()) {
+                throw new StacklessDecoderException("chunked must be the final Transfer-Encoding coding in requests");
+            }
+            return State.READ_VARIABLE_LENGTH_CONTENT;
         }
         if (contentLength >= 0L) {
             return State.READ_FIXED_LENGTH_CONTENT;
@@ -1093,15 +1091,17 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
     private static boolean endsWithChunkedToken(final CharSequence value) {
         final int vLen = value.length();
         final int chunkedLen = CHUNKED.length();
-        if (vLen < chunkedLen ||
-                !AsciiString.regionMatches(value, true, vLen - chunkedLen, CHUNKED, 0, chunkedLen)) {
+        if (vLen < chunkedLen) {
             return false;
         }
         if (vLen == chunkedLen) {
-            return true;
+            return contentEqualsIgnoreCase(value, CHUNKED);
         }
         final char before = value.charAt(vLen - chunkedLen - 1);
-        return before == ',' || before == ' ' || before == '\t';
+        if (before == ',' || before == ' ' || before == '\t') {
+            return regionMatches(value, true, vLen - chunkedLen, CHUNKED, 0, chunkedLen);
+        }
+        return false;
     }
 
     private static boolean isObsText(final byte value) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -752,33 +752,41 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             removeTransferEncodingChunked(message.headers());
             return State.SKIP_CONTROL_CHARS;
         }
-        // RFC 9112 section 6.1: Transfer-Encoding is HTTP/1.1-only.
-        if (message.headers().contains(TRANSFER_ENCODING) && !HTTP_1_1.equals(message.version())) {
-            throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
+        if (message.headers().contains(TRANSFER_ENCODING)) {
+            // RFC 9112 section 6.1: Transfer-Encoding is HTTP/1.1-only.
+            if (!HTTP_1_1.equals(message.version())) {
+                throw new StacklessDecoderException("Transfer-Encoding is only allowed in HTTP/1.1");
+            }
+            // RFC 9112 section 6.3: a request that has Transfer-Encoding without chunked as the
+            // final coding cannot be reliably framed and MUST be rejected. For responses the
+            // legacy "read-until-connection-close" framing still applies, so only enforce on
+            // requests.
+            if (!isTransferEncodingChunked(message.headers())) {
+                if (isDecodingRequest()) {
+                    throw new StacklessDecoderException(
+                            "Transfer-Encoding without chunked is not allowed in requests");
+                }
+            } else {
+                // RFC 9112 section 6.1: chunked must be the final coding.
+                final Iterator<? extends CharSequence> encodingIt =
+                        message.headers().valuesIterator(TRANSFER_ENCODING);
+                CharSequence lastValue = encodingIt.next();
+                while (encodingIt.hasNext()) {
+                    lastValue = encodingIt.next();
+                }
+                if (!endsWithChunkedToken(lastValue)) {
+                    throw new StacklessDecoderException(
+                            "chunked must be the last encoding present in the Transfer-Encoding header");
+                }
+                if (contentLength >= 0L) {
+                    // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
+                    message.headers().remove(CONTENT_LENGTH);
+                    this.contentLength = Long.MIN_VALUE;
+                }
+                return State.READ_CHUNK_SIZE;
+            }
         }
-        if (isTransferEncodingChunked(message.headers())) {
-            // RFC 9112 section 6.1: chunked must be the final coding.
-            final Iterator<? extends CharSequence> encodingIt =
-                    message.headers().valuesIterator(TRANSFER_ENCODING);
-            CharSequence lastValue = encodingIt.next();
-            while (encodingIt.hasNext()) {
-                lastValue = encodingIt.next();
-            }
-            final int vLen = lastValue.length();
-            final int chunkedValueLength = CHUNKED.length();
-            if (vLen < chunkedValueLength ||
-                    !AsciiString.regionMatches(lastValue, true, vLen - chunkedValueLength,
-                            CHUNKED, 0, chunkedValueLength)) {
-                throw new StacklessDecoderException(
-                        "chunked must be the last encoding present in the Transfer-Encoding header");
-            }
-            if (contentLength >= 0L) {
-                // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
-                message.headers().remove(CONTENT_LENGTH);
-                this.contentLength = Long.MIN_VALUE;
-            }
-            return State.READ_CHUNK_SIZE;
-        } else if (contentLength >= 0L) {
+        if (contentLength >= 0L) {
             return State.READ_FIXED_LENGTH_CONTENT;
         } else {
             return State.READ_VARIABLE_LENGTH_CONTENT;
@@ -1074,6 +1082,26 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
 
     static boolean isVCHAR(final byte value) {
         return value >= '!' && value <= '~';
+    }
+
+    /**
+     * Returns {@code true} if {@code value} ends with the {@code chunked} token (case-insensitive),
+     * either as the entire value or as the final comma-separated token. The character preceding
+     * {@code chunked} must be a comma or OWS (space/tab) to avoid matching tokens like
+     * {@code notchunked}.
+     */
+    private static boolean endsWithChunkedToken(final CharSequence value) {
+        final int vLen = value.length();
+        final int chunkedLen = CHUNKED.length();
+        if (vLen < chunkedLen ||
+                !AsciiString.regionMatches(value, true, vLen - chunkedLen, CHUNKED, 0, chunkedLen)) {
+            return false;
+        }
+        if (vLen == chunkedLen) {
+            return true;
+        }
+        final char before = value.charAt(vLen - chunkedLen - 1);
+        return before == ',' || before == ' ' || before == '\t';
     }
 
     private static boolean isObsText(final byte value) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -762,14 +762,12 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             // RFC 9112 section 6.3: Transfer-Encoding overrides Content-Length. Drop any received
             // Content-Length now so it can never be used to frame the body, in any branch below.
             if (contentLength >= 0L) {
-                // https://tools.ietf.org/html/rfc7230#section-3.3.3, item 3.
                 message.headers().remove(CONTENT_LENGTH);
                 this.contentLength = Long.MIN_VALUE;
             }
             // RFC 9112 section 6.1: chunked must be the final coding. There may be multiple
             // Transfer-Encoding header lines, so check the last value of the last line.
-            final Iterator<? extends CharSequence> encodingIt =
-                    message.headers().valuesIterator(TRANSFER_ENCODING);
+            final Iterator<? extends CharSequence> encodingIt = message.headers().valuesIterator(TRANSFER_ENCODING);
             CharSequence lastValue = encodingIt.next();
             while (encodingIt.hasNext()) {
                 lastValue = encodingIt.next();
@@ -1083,23 +1081,24 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
     }
 
     /**
-     * Returns {@code true} if {@code value} ends with the {@code chunked} token (case-insensitive),
-     * either as the entire value or as the final comma-separated token. The character preceding
-     * {@code chunked} must be a comma or OWS (space/tab) to avoid matching tokens like
-     * {@code notchunked}.
+     * Checks if the given value ends with exactly {@code chunked} (case-insensitive).
+     *
+     * @param value the value to check
+     * @return returns {@code true} if {@code value} ends with the {@code chunked} token (case-insensitive),
+     * either as the entire value or as the final comma-separated token.
      */
     private static boolean endsWithChunkedToken(final CharSequence value) {
-        final int vLen = value.length();
-        final int chunkedLen = CHUNKED.length();
-        if (vLen < chunkedLen) {
+        final int valueLength = value.length();
+        final int chunkedLength = CHUNKED.length();
+        if (valueLength < chunkedLength) {
             return false;
         }
-        if (vLen == chunkedLen) {
+        if (valueLength == chunkedLength) {
             return contentEqualsIgnoreCase(value, CHUNKED);
         }
-        final char before = value.charAt(vLen - chunkedLen - 1);
+        final char before = value.charAt(valueLength - chunkedLength - 1);
         if (before == ',' || before == ' ' || before == '\t') {
-            return regionMatches(value, true, vLen - chunkedLen, CHUNKED, 0, chunkedLen);
+            return regionMatches(value, true, valueLength - chunkedLength, CHUNKED, 0, chunkedLength);
         }
         return false;
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -69,7 +69,9 @@ import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.buffer.api.CharSequences.regionMatches;
 import static io.servicetalk.buffer.netty.BufferUtils.newBufferFrom;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
+import static io.servicetalk.http.api.HeaderUtils.isConnectionClose;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY1;
 import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_KEY2;
@@ -78,6 +80,7 @@ import static io.servicetalk.http.api.HttpHeaderNames.SEC_WEBSOCKET_ORIGIN;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderNames.UPGRADE;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
@@ -762,8 +765,17 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
             // RFC 9112 section 6.3: Transfer-Encoding overrides Content-Length. Drop any received
             // Content-Length now so it can never be used to frame the body, in any branch below.
             if (contentLength >= 0L) {
+                // RFC 9112 section 6.1: this is the forbidden Content-Length + Transfer-Encoding
+                // combination. Process per Transfer-Encoding alone and force Connection: close -
+                // the shouldClose(message) check below signals the close handler so the connection
+                // is torn down after this exchange to avoid request smuggling attacks.
                 message.headers().remove(CONTENT_LENGTH);
                 this.contentLength = Long.MIN_VALUE;
+                // Preserve any Connection values the peer already sent (e.g. upgrade, keep-alive) and
+                // only add close if it isn't there yet, rather than overriding with set(...).
+                if (!isConnectionClose(message.headers())) {
+                    message.headers().add(CONNECTION, CLOSE);
+                }
             }
             // RFC 9112 section 6.1: chunked must be the final coding. There may be multiple
             // Transfer-Encoding header lines, so check the last value of the last line.

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ContentHeadersTest.java
@@ -123,7 +123,6 @@ class ContentHeadersTest extends AbstractNettyHttpServerTest {
                 new RequestTest(aggregatedRequest(TRACE), withoutPayload(), HAVE_NEITHER),
                 new RequestTest(aggregatedRequest(PATCH), withoutPayload(), HAVE_CONTENT_LENGTH_ZERO),
 
-                new RequestTest(aggregatedRequest(GET), transferEncodingGzip(), HAVE_CONTENT_LENGTH),
                 new RequestTest(aggregatedRequest(GET), transferEncodingChunked(), HAVE_TRANSFER_ENCODING_CHUNKED),
                 new RequestTest(aggregatedRequest(GET), transferEncodingGzipAndChunked(),
                         HAVE_TRANSFER_ENCODING_CHUNKED),

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -786,6 +786,103 @@ abstract class HttpObjectDecoderTest {
         assertFalse(channel.finishAndReleaseAll());
     }
 
+    /**
+     * RFC 9112 section 6.1: {@code Transfer-Encoding} is HTTP/1.1-only. Today the
+     * decoder ignores the protocol version and accepts {@code Transfer-Encoding: chunked}
+     * on HTTP/1.0, which lets a peer desync framing with HTTP/1.0 intermediaries that
+     * reject TE. After the fix the decoder must reject TE on any non-1.1 message.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] httpVersion={0} expectRejected={1} crlf={2}")
+    @MethodSource("transferEncodingProtocolVersionArgs")
+    void transferEncodingRejectedOnNonHttp11(String httpVersion, boolean expectRejected, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        String msg = startLineForContent().replace("HTTP/1.1", httpVersion) + br +
+                "Host: servicetalk.io" + br +
+                "Transfer-Encoding: chunked" + br + br;
+        if (expectRejected) {
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("Transfer-Encoding is only allowed in HTTP/1.1"));
+        } else {
+            // HTTP/1.1 path is unchanged: feed the message and the last-chunk to confirm the
+            // decoder progresses through chunked parsing without throwing.
+            writeMsg(msg, channel);
+            writeLastChunk(channel);
+            assertThat(channel.isOpen(), is(true));
+        }
+    }
+
+    private static Collection<Arguments> transferEncodingProtocolVersionArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (boolean crlf : new boolean[] {true, false}) {
+            // HTTP/1.0 + Transfer-Encoding: chunked must be rejected.
+            arguments.add(Arguments.of("HTTP/1.0", true, crlf));
+            // HTTP/1.1 sanity: continues to be accepted.
+            arguments.add(Arguments.of("HTTP/1.1", false, crlf));
+        }
+        return arguments;
+    }
+
+    /**
+     * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the
+     * message body. Today the decoder only checks whether {@code chunked} is present
+     * anywhere in the {@code Transfer-Encoding} list, so {@code chunked, gzip} is
+     * silently treated as chunked even though gzip is the outermost coding. After the
+     * fix the decoder must reject any value where {@code chunked} is not the last
+     * coding.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" expectRejected={1} crlf={2}")
+    @MethodSource("transferEncodingChunkedLastArgs")
+    void transferEncodingChunkedMustBeLast(String transferEncoding, boolean expectRejected, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        String msg = startLineForContent() + br +
+                "Host: servicetalk.io" + br +
+                "Transfer-Encoding: " + transferEncoding + br + br;
+        if (expectRejected) {
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("chunked must be the last"));
+        } else {
+            // Feed the headers; they must parse without throwing and produce decoded metadata
+            // with Transfer-Encoding chunked retained. We don't drain the body (the decoder
+            // transitions to READ_CHUNK_SIZE awaiting more data); tearDown handles cleanup.
+            writeMsg(msg, channel);
+            HttpMetaData metaData = assertStartLineForContent(channel);
+            assertTrue(isTransferEncodingChunked(metaData.headers()));
+        }
+    }
+
+    private static Collection<Arguments> transferEncodingChunkedLastArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (boolean crlf : new boolean[] {true, false}) {
+            final String br = crlf ? "\r\n" : "\n";
+            // Single value: chunked alone - accepted.
+            arguments.add(Arguments.of("chunked", false, crlf));
+            // Comma-separated, chunked last - accepted.
+            arguments.add(Arguments.of("gzip, chunked", false, crlf));
+            // No space after comma - still accepted (chunked still last).
+            arguments.add(Arguments.of("gzip,chunked", false, crlf));
+            // Case-insensitive match - accepted.
+            arguments.add(Arguments.of("ChUnKeD", false, crlf));
+            // Trailing OWS - accepted.
+            arguments.add(Arguments.of("chunked  ", false, crlf));
+            // Repeated chunked as final coding - accepted (RFC 9112 only requires the last be chunked).
+            arguments.add(Arguments.of("chunked, chunked", false, crlf));
+            // Comma-separated, chunked NOT last - rejected.
+            arguments.add(Arguments.of("chunked, gzip", true, crlf));
+            // Same with whitespace before comma - rejected.
+            arguments.add(Arguments.of("chunked , gzip", true, crlf));
+            // Multi-header: gzip first, chunked last - accepted.
+            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", false, crlf));
+            // Multi-header: chunked first, gzip last (length 4) - rejected.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: gzip", true, crlf));
+            // Multi-header: chunked first, deflate last (length 7, same as "chunked") - rejected.
+            // This case demonstrates the gap closed vs Netty's permissive check.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", true, crlf));
+        }
+        return arguments;
+    }
+
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")
     @ValueSource(booleans = {true, false})
     void unexpectedTrailersAfterContentLength(boolean crlf) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -18,6 +18,7 @@ package io.servicetalk.http.netty;
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpMetaData;
+import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.buffer.ByteBuf;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 
@@ -43,16 +45,21 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.AsciiString.contentEquals;
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static io.servicetalk.buffer.netty.BufferUtils.getByteBufAllocator;
+import static io.servicetalk.http.api.HeaderUtils.isConnectionClose;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
 import static io.servicetalk.http.api.HttpHeaderNames.ACCEPT_ENCODING;
+import static io.servicetalk.http.api.HttpHeaderNames.CONNECTION;
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
+import static io.servicetalk.http.api.HttpHeaderValues.CLOSE;
 import static io.servicetalk.http.api.HttpHeaderValues.KEEP_ALIVE;
 import static io.servicetalk.http.netty.H1ProtocolConfigBuilder.DEFAULT_MAX_HEADER_FIELD_LENGTH;
 import static io.servicetalk.http.netty.H1ProtocolConfigBuilder.DEFAULT_MAX_START_LINE_LENGTH;
 import static java.lang.Integer.toHexString;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -69,6 +76,9 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 abstract class HttpObjectDecoderTest {
 
@@ -115,6 +125,9 @@ abstract class HttpObjectDecoderTest {
      * @return a new EmbeddedChannel configured with the specified limit
      */
     abstract EmbeddedChannel channelWithMaxTotalHeaderFieldsLength(int maxTotalHeaderFieldsLength);
+
+    /** Channel wired with the supplied {@link CloseHandler} for verifying close-pipeline interactions. */
+    abstract EmbeddedChannel channelWithCloseHandler(CloseHandler closeHandler);
 
     final HttpMetaData assertStartLineForContent() {
         return assertStartLineForContent(channel());
@@ -572,6 +585,10 @@ abstract class HttpObjectDecoderTest {
         validateWithContent(-chunkSize, false, channel);
     }
 
+    /**
+     * RFC 9112 section 6.1: TE+CL on HTTP/1.1 is processed per Transfer-Encoding alone
+     * (Content-Length stripped), with Connection: close forced to prevent smuggled follow-ups.
+     */
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")
     @ValueSource(booleans = {true, false})
     void chunkedWithContentLength(boolean crlf) {
@@ -581,14 +598,99 @@ abstract class HttpObjectDecoderTest {
         int chunkedContentLength = 2 + 2 + chunkSize + 2 + 5;
         writeMsg(startLineForContent() + br +
                 "Host: servicetalk.io" + br +
-                "Connection: keep-alive" + br +
                 "Content-Length: " + chunkedContentLength + br +
                 "Transfer-Encoding: chunked" + br + br, channel);
         writeChunk(chunkSize, channel);
         writeLastChunk(channel);
-        HttpMetaData metaData = validateWithContent(-chunkSize, false, channel);
-        assertThat("Unexpected content-length header(s)",
-                metaData.headers().valuesIterator(CONTENT_LENGTH).hasNext(), is(false));
+
+        HttpMetaData metaData = assertStartLineForContent(channel);
+        assertSingleHeaderValue(metaData.headers(), HOST, "servicetalk.io");
+        assertSingleHeaderValue(metaData.headers(), TRANSFER_ENCODING, CHUNKED);
+        assertSingleHeaderValue(metaData.headers(), CONNECTION, CLOSE);
+        assertFalse(metaData.headers().contains(CONTENT_LENGTH), "Content-Length must be stripped");
+        assertPayloadSize(chunkSize, channel);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    /** TE+CL signals {@link CloseHandler#protocolClosingInbound} so the connection closes after the response. */
+    @Test
+    void chunkedWithContentLengthSignalsProtocolClosingInbound() {
+        CloseHandler closeHandler = mock(CloseHandler.class);
+        EmbeddedChannel channel = channelWithCloseHandler(closeHandler);
+        int chunkSize = 16;
+        writeMsg(startLineForContent() + "\r\n" +
+                "Host: servicetalk.io\r\n" +
+                "Content-Length: 999\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n", channel);
+        writeChunk(chunkSize, channel);
+        writeLastChunk(channel);
+
+        verify(closeHandler).protocolClosingInbound(any());
+        assertStartLineForContent(channel);
+        assertPayloadSize(chunkSize, channel);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    /**
+     * RFC 9112 section 6.1 close disposition must not clobber Connection values the peer already sent. When
+     * {@code close} is absent it is added while preserving existing values like {@code keep-alive} or
+     * {@code upgrade}; when it is already present (even within a comma-separated value) it is left untouched
+     * rather than duplicated.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] connection=\"{0}\"")
+    @MethodSource("chunkedWithContentLengthConnectionArgs")
+    void chunkedWithContentLengthPreservesConnectionHeader(@Nullable String connectionValue,
+                                                           List<String> expectedConnectionTokens) {
+        EmbeddedChannel channel = channel();
+        int chunkSize = 16;
+        StringBuilder sb = new StringBuilder(startLineForContent()).append("\r\n")
+                .append("Host: servicetalk.io\r\n")
+                .append("Content-Length: 999\r\n")
+                .append("Transfer-Encoding: chunked\r\n");
+        if (connectionValue != null) {
+            sb.append("Connection: ").append(connectionValue).append("\r\n");
+        }
+        sb.append("\r\n");
+        writeMsg(sb.toString(), channel);
+        writeChunk(chunkSize, channel);
+        writeLastChunk(channel);
+
+        HttpMetaData metaData = assertStartLineForContent(channel);
+        assertFalse(metaData.headers().contains(CONTENT_LENGTH), "Content-Length must be stripped");
+        assertTrue(isConnectionClose(metaData.headers()), "Connection: close must be present");
+        assertThat("Unexpected Connection header tokens",
+                connectionTokens(metaData.headers()), containsInAnyOrder(expectedConnectionTokens.toArray()));
+        assertPayloadSize(chunkSize, channel);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    private static Collection<Arguments> chunkedWithContentLengthConnectionArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        // No Connection header: close is added.
+        arguments.add(Arguments.of(null, singletonList("close")));
+        // keep-alive present: preserved, close added alongside (shouldClose still triggers on the close token).
+        arguments.add(Arguments.of("keep-alive", asList("keep-alive", "close")));
+        // upgrade present: preserved, close added alongside.
+        arguments.add(Arguments.of("Upgrade", asList("upgrade", "close")));
+        // close already present: left as-is, not duplicated.
+        arguments.add(Arguments.of("close", singletonList("close")));
+        // close nested in a comma-separated value: recognized, not duplicated, other tokens preserved.
+        arguments.add(Arguments.of("keep-alive, close", asList("keep-alive", "close")));
+        return arguments;
+    }
+
+    /** All {@code Connection} header values, comma-split and lower-cased, gathered across every header line. */
+    private static List<String> connectionTokens(HttpHeaders headers) {
+        final List<String> tokens = new ArrayList<>();
+        for (Iterator<? extends CharSequence> it = headers.valuesIterator(CONNECTION); it.hasNext();) {
+            for (String token : it.next().toString().split(",")) {
+                final String trimmed = token.trim();
+                if (!trimmed.isEmpty()) {
+                    tokens.add(trimmed.toLowerCase(Locale.ENGLISH));
+                }
+            }
+        }
+        return tokens;
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] crlf={0}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -824,31 +824,35 @@ abstract class HttpObjectDecoderTest {
     }
 
     /**
-     * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the
-     * message body. Today the decoder only checks whether {@code chunked} is present
-     * anywhere in the {@code Transfer-Encoding} list, so {@code chunked, gzip} is
-     * silently treated as chunked even though gzip is the outermost coding. After the
-     * fix the decoder must reject any value where {@code chunked} is not the last
-     * coding.
+     * RFC 9112 section 6.1: {@code chunked} must be the final coding applied to the message body. When it is, the
+     * message is chunked-framed (requests and responses alike). When it is not, RFC 9112 section 6.3 splits by
+     * direction: a request cannot be framed reliably and MUST be rejected, while a response is framed by reading
+     * until the connection closes.
      */
-    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" expectRejected={1} crlf={2}")
+    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" chunkedIsFinal={1} crlf={2}")
     @MethodSource("transferEncodingChunkedLastArgs")
-    void transferEncodingChunkedMustBeLast(String transferEncoding, boolean expectRejected, boolean crlf) {
+    void transferEncodingChunkedMustBeLast(String transferEncoding, boolean chunkedIsFinal, boolean crlf) {
         EmbeddedChannel channel = channel(crlf);
         String br = br(crlf);
         String msg = startLineForContent() + br +
                 "Host: servicetalk.io" + br +
                 "Transfer-Encoding: " + transferEncoding + br + br;
-        if (expectRejected) {
-            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
-            assertThat(e.getMessage(), startsWith("chunked must be the last"));
-        } else {
-            // Feed the headers; they must parse without throwing and produce decoded metadata
-            // with Transfer-Encoding chunked retained. We don't drain the body (the decoder
-            // transitions to READ_CHUNK_SIZE awaiting more data); tearDown handles cleanup.
+        if (chunkedIsFinal) {
+            // chunked is the final coding: chunked framing for both requests and responses. We don't drain the
+            // body (the decoder transitions to READ_CHUNK_SIZE awaiting more data); tearDown handles cleanup.
             writeMsg(msg, channel);
             HttpMetaData metaData = assertStartLineForContent(channel);
             assertTrue(isTransferEncodingChunked(metaData.headers()));
+        } else if (isDecodingRequest()) {
+            // RFC 9112 6.3: a request not framed by chunked cannot be framed reliably and is rejected.
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
+        } else {
+            // RFC 9112 6.3: a response not framed by chunked is read until connection close. The headers must
+            // parse and progress without throwing.
+            writeMsg(msg, channel);
+            HttpMetaData metaData = assertStartLineForContent(channel);
+            assertThat(metaData, is(notNullValue()));
         }
     }
 
@@ -856,47 +860,47 @@ abstract class HttpObjectDecoderTest {
         final List<Arguments> arguments = new ArrayList<>();
         for (boolean crlf : new boolean[] {true, false}) {
             final String br = crlf ? "\r\n" : "\n";
-            // Single value: chunked alone - accepted.
-            arguments.add(Arguments.of("chunked", false, crlf));
-            // Comma-separated, chunked last - accepted.
-            arguments.add(Arguments.of("gzip, chunked", false, crlf));
-            // No space after comma - still accepted (chunked still last).
-            arguments.add(Arguments.of("gzip,chunked", false, crlf));
-            // Case-insensitive match - accepted.
-            arguments.add(Arguments.of("ChUnKeD", false, crlf));
-            // Trailing OWS - accepted.
-            arguments.add(Arguments.of("chunked  ", false, crlf));
-            // Repeated chunked as final coding - accepted (RFC 9112 only requires the last be chunked).
-            arguments.add(Arguments.of("chunked, chunked", false, crlf));
-            // Comma-separated, chunked NOT last - rejected.
-            arguments.add(Arguments.of("chunked, gzip", true, crlf));
-            // Same with whitespace before comma - rejected.
-            arguments.add(Arguments.of("chunked , gzip", true, crlf));
-            // Multi-header: gzip first, chunked last - accepted.
-            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", false, crlf));
-            // Multi-header: chunked first, gzip last (length 4) - rejected.
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: gzip", true, crlf));
-            // Multi-header: chunked first, deflate last (length 7, same as "chunked") - rejected.
+            // Single value: chunked alone - chunked-framed.
+            arguments.add(Arguments.of("chunked", true, crlf));
+            // Comma-separated, chunked last - chunked-framed.
+            arguments.add(Arguments.of("gzip, chunked", true, crlf));
+            // No space after comma - still chunked-framed (chunked still last).
+            arguments.add(Arguments.of("gzip,chunked", true, crlf));
+            // Comma-separated, case-insensitive match - chunked-framed.
+            arguments.add(Arguments.of("gzip, ChUnKeD", true, crlf));
+            // HTAB as the OWS separating the previous coding from chunked - chunked-framed.
+            arguments.add(Arguments.of("gzip,\tchunked", true, crlf));
+            // Case-insensitive match - chunked-framed.
+            arguments.add(Arguments.of("ChUnKeD", true, crlf));
+            // Trailing OWS - chunked-framed.
+            arguments.add(Arguments.of("chunked  ", true, crlf));
+            // Repeated chunked as final coding - chunked-framed (RFC 9112 only requires the last be chunked).
+            arguments.add(Arguments.of("chunked, chunked", true, crlf));
+            // Comma-separated, chunked NOT last - request rejects, response reads until close.
+            arguments.add(Arguments.of("chunked, gzip", false, crlf));
+            // Same with whitespace before comma - request rejects, response reads until close.
+            arguments.add(Arguments.of("chunked , gzip", false, crlf));
+            // Multi-header: gzip first, chunked last - chunked-framed.
+            arguments.add(Arguments.of("gzip" + br + "Transfer-Encoding: chunked", true, crlf));
+            // Multi-header: chunked first, gzip last (length 4) - chunked not final.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: gzip", false, crlf));
+            // Multi-header: chunked first, deflate last (length 7, same as "chunked") - chunked not final.
             // This case demonstrates the gap closed vs Netty's permissive check.
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", true, crlf));
-            // Multi-header: chunked first, notchunked last - rejected. The "chunked" suffix of
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", false, crlf));
+            // Multi-header: chunked first, notchunked last - chunked not final. The "chunked" suffix of
             // "notchunked" must NOT be treated as a token boundary match.
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: notchunked", true, crlf));
-            // Single value: notchunked is not chunked at all - the decoder treats this as
-            // "TE without chunked" and rejects on the request side via the test below; for the
-            // response side it is not a "chunked must be last" violation, so we don't include
-            // it here.
-            // Multi-header: chunked first, empty value last - rejected (empty cannot end in chunked).
-            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: ", true, crlf));
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: notchunked", false, crlf));
+            // Multi-header: chunked first, empty value last - chunked not final (empty cannot end in chunked).
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: ", false, crlf));
         }
         return arguments;
     }
 
     /**
-     * RFC 9112 section 6.3: a request that has {@code Transfer-Encoding} without {@code chunked}
-     * as the final coding cannot be reliably framed and MUST be rejected. For responses the
-     * legacy "read-until-connection-close" framing still applies, so the decoder accepts the
-     * headers and falls through to variable-length reads.
+     * RFC 9112 section 6.3: when {@code chunked} is not the final coding, a request cannot be reliably framed and
+     * MUST be rejected, while a response is framed by reading until connection close. In both cases
+     * {@code Transfer-Encoding} overrides {@code Content-Length}, so a response must never be framed by a stray
+     * {@code Content-Length} and that header must be dropped.
      */
     @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" withContentLength={1} crlf={2}")
     @MethodSource("transferEncodingWithoutChunkedArgs")
@@ -914,13 +918,16 @@ abstract class HttpObjectDecoderTest {
         String msg = sb.toString();
         if (isDecodingRequest()) {
             DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
-            assertThat(e.getMessage(), startsWith("Transfer-Encoding without chunked is not allowed in requests"));
+            assertThat(e.getMessage(), startsWith("chunked must be the final Transfer-Encoding coding"));
         } else {
-            // Response side: TE without chunked is legal under RFC 9112 6.3 and frames by
-            // connection close. Feed the headers and confirm decoding progresses.
+            // Response side: a non-chunked-final TE is legal under RFC 9112 6.3 and frames by connection close.
+            // Feed the headers and confirm decoding progresses.
             writeMsg(msg, channel);
             HttpMetaData metaData = assertStartLineForContent(channel);
             assertThat(metaData, is(notNullValue()));
+            // Transfer-Encoding overrides Content-Length: it must be dropped, never used to frame the body.
+            assertThat("Content-Length must be stripped when Transfer-Encoding is present",
+                    metaData.headers().contains(CONTENT_LENGTH), is(false));
         }
     }
 
@@ -929,10 +936,15 @@ abstract class HttpObjectDecoderTest {
         for (boolean crlf : new boolean[] {true, false}) {
             // gzip alone is not chunked-framed.
             arguments.add(Arguments.of("gzip", false, crlf));
-            // gzip + Content-Length: still not chunked; request must reject.
+            // gzip + Content-Length: still not chunked; request rejects, response strips Content-Length.
             arguments.add(Arguments.of("gzip", true, crlf));
-            // Empty TE value with no chunked is also "TE without chunked".
+            // Empty TE value with no chunked is also "not chunked-final".
             arguments.add(Arguments.of("", false, crlf));
+            // chunked present but NOT the final coding: same outcome as no-chunked (regression guard - this case
+            // was previously rejected even for responses; now the response reads until close, never by CL).
+            arguments.add(Arguments.of("chunked, gzip", false, crlf));
+            // chunked-not-final + Content-Length: Transfer-Encoding must override Content-Length on the response.
+            arguments.add(Arguments.of("chunked, gzip", true, crlf));
         }
         return arguments;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpObjectDecoderTest.java
@@ -879,6 +879,60 @@ abstract class HttpObjectDecoderTest {
             // Multi-header: chunked first, deflate last (length 7, same as "chunked") - rejected.
             // This case demonstrates the gap closed vs Netty's permissive check.
             arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: deflate", true, crlf));
+            // Multi-header: chunked first, notchunked last - rejected. The "chunked" suffix of
+            // "notchunked" must NOT be treated as a token boundary match.
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: notchunked", true, crlf));
+            // Single value: notchunked is not chunked at all - the decoder treats this as
+            // "TE without chunked" and rejects on the request side via the test below; for the
+            // response side it is not a "chunked must be last" violation, so we don't include
+            // it here.
+            // Multi-header: chunked first, empty value last - rejected (empty cannot end in chunked).
+            arguments.add(Arguments.of("chunked" + br + "Transfer-Encoding: ", true, crlf));
+        }
+        return arguments;
+    }
+
+    /**
+     * RFC 9112 section 6.3: a request that has {@code Transfer-Encoding} without {@code chunked}
+     * as the final coding cannot be reliably framed and MUST be rejected. For responses the
+     * legacy "read-until-connection-close" framing still applies, so the decoder accepts the
+     * headers and falls through to variable-length reads.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] transferEncoding=\"{0}\" withContentLength={1} crlf={2}")
+    @MethodSource("transferEncodingWithoutChunkedArgs")
+    void transferEncodingWithoutChunked(String transferEncoding, boolean withContentLength, boolean crlf) {
+        EmbeddedChannel channel = channel(crlf);
+        String br = br(crlf);
+        StringBuilder sb = new StringBuilder()
+                .append(startLineForContent()).append(br)
+                .append("Host: servicetalk.io").append(br)
+                .append("Transfer-Encoding: ").append(transferEncoding).append(br);
+        if (withContentLength) {
+            sb.append("Content-Length: 0").append(br);
+        }
+        sb.append(br);
+        String msg = sb.toString();
+        if (isDecodingRequest()) {
+            DecoderException e = assertThrows(DecoderException.class, () -> writeMsg(msg, channel));
+            assertThat(e.getMessage(), startsWith("Transfer-Encoding without chunked is not allowed in requests"));
+        } else {
+            // Response side: TE without chunked is legal under RFC 9112 6.3 and frames by
+            // connection close. Feed the headers and confirm decoding progresses.
+            writeMsg(msg, channel);
+            HttpMetaData metaData = assertStartLineForContent(channel);
+            assertThat(metaData, is(notNullValue()));
+        }
+    }
+
+    private static Collection<Arguments> transferEncodingWithoutChunkedArgs() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (boolean crlf : new boolean[] {true, false}) {
+            // gzip alone is not chunked-framed.
+            arguments.add(Arguments.of("gzip", false, crlf));
+            // gzip + Content-Length: still not chunked; request must reject.
+            arguments.add(Arguments.of("gzip", true, crlf));
+            // Empty TE value with no chunked is also "TE without chunked".
+            arguments.add(Arguments.of("", false, crlf));
         }
         return arguments;
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestDecoderTest.java
@@ -20,6 +20,7 @@ import io.servicetalk.http.api.HttpMetaData;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpRequestMethod;
+import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -117,6 +118,13 @@ class HttpRequestDecoderTest extends HttpObjectDecoderTest {
                 false,  // allowPrematureClosureBeforePayloadBody
                 false,  // allowLFWithoutCR
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+    }
+
+    @Override
+    EmbeddedChannel channelWithCloseHandler(CloseHandler closeHandler) {
+        return new EmbeddedChannel(new HttpRequestDecoder(new ArrayDeque<>(), getByteBufAllocator(DEFAULT_ALLOCATOR),
+                DefaultHttpHeadersFactory.INSTANCE, DEFAULT_MAX_START_LINE_LENGTH, DEFAULT_MAX_HEADER_FIELD_LENGTH,
+                DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH, false, false, closeHandler));
     }
 
     @Test

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpResponseDecoderTest.java
@@ -39,6 +39,7 @@ import io.servicetalk.http.api.HttpRequestMethod;
 import io.servicetalk.http.api.HttpResponseMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.netty.HttpResponseDecoder.Signal;
+import io.servicetalk.transport.netty.internal.CloseHandler;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -162,6 +163,16 @@ class HttpResponseDecoderTest extends HttpObjectDecoderTest {
                 false,  // allowPrematureClosureBeforePayloadBody
                 false,  // allowLFWithoutCR
                 UNSUPPORTED_PROTOCOL_CLOSE_HANDLER));
+    }
+
+    @Override
+    EmbeddedChannel channelWithCloseHandler(CloseHandler closeHandler) {
+        final ArrayDeque<Signal> signalsQueue = new PollLikePeakArrayDeque<>();
+        signalsQueue.offer(REQUEST_SIGNAL);
+        return new EmbeddedChannel(new HttpResponseDecoder(methodQueue, signalsQueue,
+                getByteBufAllocator(DEFAULT_ALLOCATOR), DefaultHttpHeadersFactory.INSTANCE,
+                DEFAULT_MAX_START_LINE_LENGTH, DEFAULT_MAX_HEADER_FIELD_LENGTH, DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH,
+                false, false, closeHandler));
     }
 
     @Test


### PR DESCRIPTION
#### Motivation
RFC 9112 section 6.1 states:

> A server MAY reject a request that contains both Content-Length
> and Transfer-Encoding or process such a request in accordance
> with the Transfer-Encoding alone. Regardless, the server MUST
> close the connection after responding to such a request to
> avoid the potential attacks.

#### Modifications
Up until now, we are not following this rule, so this changeset explicitly closes the connection if the condition is identified.

The tests are adjusted to reflect/test the new behavior.
