### PR TITLE
http-netty: Do not store sensitive headers in HTTP/2 HPACK dynamic table

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -215,7 +215,7 @@ public final class HttpHeaderNames {
      */
     public static final CharSequence DPOP = newAsciiString("dpop");
     /**
-     * {@code "dpop"}
+     * {@code "dpop-nonce"}
      *
      * @see <a href="https://tools.ietf.org/html/rfc9449#name-authorization-server-provid">RFC 9449, section 8</a>
      */

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpHeaderNames.java
@@ -209,6 +209,18 @@ public final class HttpHeaderNames {
      */
     public static final CharSequence DATE = newAsciiString("date");
     /**
+     * {@code "dpop"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc9449#section-4.1">RFC 9449, section 4.1</a>
+     */
+    public static final CharSequence DPOP = newAsciiString("dpop");
+    /**
+     * {@code "dpop"}
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc9449#name-authorization-server-provid">RFC 9449, section 8</a>
+     */
+    public static final CharSequence DPOP_NONCE = newAsciiString("dpop-nonce");
+    /**
      * {@code "etag"}
      *
      * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.3">RFC7232, section 2.3</a>

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -57,6 +57,10 @@ public final class H2ProtocolConfigBuilder {
     // Marks common auth/credential headers as <a href="https://tools.ietf.org/html/rfc7541#section-7.1.3">sensitive</a>
     // so they aren't stored in the HPACK dynamic table; includes the
     // <a href="https://datatracker.ietf.org/doc/html/rfc9449#section-4.1">DPoP</a> proof header.
+    // The suffix matches (e.g. "*-token", "*-signature") err on the safe side: some headers ending in
+    // these suffixes may not actually carry secrets, but we prefer to skip indexing them rather than
+    // risk leaking credentials via the HPACK dynamic table. Callers needing a narrower policy can
+    // override via {@link #headersSensitivityDetector(BiPredicate)}.
     private static final BiPredicate<CharSequence, CharSequence> DEFAULT_SENSITIVITY_DETECTOR = (name, value) ->
             contentEqualsIgnoreCase(name, COOKIE)
                     || contentEqualsIgnoreCase(name, DPOP)

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ProtocolConfigBuilder.java
@@ -28,6 +28,14 @@ import java.util.function.BiPredicate;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.buffer.api.CharSequences.contentEqualsIgnoreCase;
+import static io.servicetalk.buffer.api.CharSequences.regionMatches;
+import static io.servicetalk.http.api.HttpHeaderNames.AUTHORIZATION;
+import static io.servicetalk.http.api.HttpHeaderNames.COOKIE;
+import static io.servicetalk.http.api.HttpHeaderNames.DPOP;
+import static io.servicetalk.http.api.HttpHeaderNames.DPOP_NONCE;
+import static io.servicetalk.http.api.HttpHeaderNames.SET_COOKIE;
+import static io.servicetalk.http.api.HttpHeaderNames.SET_COOKIE2;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.disabled;
 import static io.servicetalk.http.netty.H2KeepAlivePolicies.validateKeepAlivePolicy;
 import static io.servicetalk.utils.internal.NumberUtils.ensurePositive;
@@ -39,7 +47,29 @@ import static java.util.Objects.requireNonNull;
  * @see HttpProtocolConfigs#h2()
  */
 public final class H2ProtocolConfigBuilder {
-    private static final BiPredicate<CharSequence, CharSequence> DEFAULT_SENSITIVITY_DETECTOR = (name, value) -> false;
+
+    private static final CharSequence API_KEY_SUFFIX = "api-key";
+    private static final CharSequence AUTHENTICATE_SUFFIX = "authenticate";
+    private static final CharSequence SIGNATURE_SUFFIX = "signature";
+    private static final CharSequence TOKEN_SUFFIX = "token";
+    private static final CharSequence TOKEN_ID_SUFFIX = "token-id";
+
+    // Marks common auth/credential headers as <a href="https://tools.ietf.org/html/rfc7541#section-7.1.3">sensitive</a>
+    // so they aren't stored in the HPACK dynamic table; includes the
+    // <a href="https://datatracker.ietf.org/doc/html/rfc9449#section-4.1">DPoP</a> proof header.
+    private static final BiPredicate<CharSequence, CharSequence> DEFAULT_SENSITIVITY_DETECTOR = (name, value) ->
+            contentEqualsIgnoreCase(name, COOKIE)
+                    || contentEqualsIgnoreCase(name, DPOP)
+                    || contentEqualsIgnoreCase(name, DPOP_NONCE)
+                    || contentEqualsIgnoreCase(name, SET_COOKIE)
+                    || contentEqualsIgnoreCase(name, SET_COOKIE2)
+                    || endsWithIgnoreCase(name, API_KEY_SUFFIX)
+                    || endsWithIgnoreCase(name, AUTHENTICATE_SUFFIX)
+                    || endsWithIgnoreCase(name, AUTHORIZATION)
+                    || endsWithIgnoreCase(name, SIGNATURE_SUFFIX)
+                    || endsWithIgnoreCase(name, TOKEN_ID_SUFFIX)
+                    || endsWithIgnoreCase(name, TOKEN_SUFFIX);
+
     /**
      * Netty currently doubles the connection window by default so a single stream doesn't exhaust all flow control
      * bytes.
@@ -161,6 +191,12 @@ public final class H2ProtocolConfigBuilder {
     public H2ProtocolConfig build() {
         return new DefaultH2ProtocolConfig(h2Settings, headersFactory, headersSensitivityDetector, frameLoggerConfig,
                 keepAlivePolicy, flowControlQuantum, flowControlIncrement);
+    }
+
+    private static boolean endsWithIgnoreCase(final CharSequence name, final CharSequence suffix) {
+        return name.length() >= suffix.length() &&
+                regionMatches(name, true, name.length() - suffix.length(), suffix, 0,
+                        suffix.length());
     }
 
     private static final class DefaultH2ProtocolConfig implements H2ProtocolConfig {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocolConfigTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocolConfigTest.java
@@ -25,15 +25,21 @@ import io.servicetalk.transport.api.HostAndPort;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.util.function.BiPredicate;
 
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
+import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2Default;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HttpProtocolConfigTest {
 
@@ -202,5 +208,76 @@ class HttpProtocolConfigTest {
 
         assertEquals(32 * 1024, config.maxHeaderFieldLength());
         assertEquals(32 * 1024, config.maxTotalHeaderFieldsLength());
+    }
+
+    @Test
+    void defaultDetectorMarksSensitiveHeaders() {
+        BiPredicate<CharSequence, CharSequence> detector = h2Default().headersSensitivityDetector();
+        assertTrue(detector.test("authorization", "Bearer abc"));
+        assertTrue(detector.test("cookie", "sid=1"));
+        assertTrue(detector.test("set-cookie", "sid=1; Path=/"));
+        assertTrue(detector.test("proxy-authorization", "Basic xyz"));
+        assertTrue(detector.test("x-original-authorization", "Basic xyz"));
+        assertTrue(detector.test("x-forwarded-authorization", "Basic xyz"));
+        assertTrue(detector.test("x-auth-token", "tkn"));
+        assertTrue(detector.test("x-access-token", "tkn"));
+        assertTrue(detector.test("token", "x"));
+        assertTrue(detector.test("x-token-id", "tid"));
+        assertTrue(detector.test("x-csrf-token", "csrf-tkn"));
+        assertTrue(detector.test("www-authenticate", "abc"));
+        assertTrue(detector.test("proxy-authenticate", "abc"));
+        assertTrue(detector.test("abc-signature", "abc"));
+        assertTrue(detector.test("x-api-key", "k"));
+        assertTrue(detector.test("api-key", "k"));
+        // Canonical DPoP proof JWT from RFC 9449 §4.2 (Figure 2).
+        assertTrue(detector.test("DPoP", "eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6Ik" +
+                "VDIiwieCI6Imw4dEZyaHgtMzR0VjNoUklDUkRZOXpDa0RscEJoRjQyVVFVZldWQVdCR" +
+                "nMiLCJ5IjoiOVZFNGpmX09rX282NHpiVFRsY3VOSmFqSG10NnY5VERWclUwQ2R2R1JE" +
+                "QSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiItQndDM0VTYzZhY2MybFRjIiwiaHRtIj" +
+                "oiUE9TVCIsImh0dSI6Imh0dHBzOi8vc2VydmVyLmV4YW1wbGUuY29tL3Rva2VuIiwia" +
+                "WF0IjoxNTYyMjY1Mjk2fQ.pAqut2IRDm_De6PR93SYmGBPXpwrAk90e8cP2hjiaG5Qs" +
+                "GSuKDYW7_X620BxqhvYC8ynrrvZLTk41mSRroapUA"));
+        assertTrue(detector.test("dpop", "abc"));
+        assertTrue(detector.test("dpop-nonce", "abc"));
+    }
+
+    @Test
+    void defaultDetectorIgnoresNonSensitiveHeaders() {
+        BiPredicate<CharSequence, CharSequence> detector = h2Default().headersSensitivityDetector();
+        assertFalse(detector.test("", ""));
+        assertFalse(detector.test("content-type", "application/json"));
+        assertFalse(detector.test("user-agent", "ServiceTalk"));
+        assertFalse(detector.test("accept", "*/*"));
+        assertFalse(detector.test("x-request-id", "req-1"));
+        assertFalse(detector.test("authorization-extra", "x"));
+        assertFalse(detector.test("abc-dpop-nonce", "abc"));
+        assertFalse(detector.test("abc-dpop-nonce-abc", "abc"));
+    }
+
+    @Test
+    void defaultDetectorIsCaseInsensitive() {
+        BiPredicate<CharSequence, CharSequence> detector = h2Default().headersSensitivityDetector();
+        assertTrue(detector.test("AUTHORIZATION", "Bearer abc"));
+        assertTrue(detector.test("Authorization", "Bearer abc"));
+        assertTrue(detector.test("proxy-authorization", "abc"));
+        assertTrue(detector.test("x-original-authorization", "abc"));
+        assertTrue(detector.test("x-forwarded-authorization", "abc"));
+        assertTrue(detector.test("Set-Cookie", "sid=1; Path=/"));
+        assertTrue(detector.test("X-Auth-Token", "tkn"));
+        assertTrue(detector.test("X-TOKEN-ID", "tid"));
+        assertTrue(detector.test("DPOP", "abc"));
+    }
+
+    @Test
+    void customDetectorOverridesDefault() {
+        BiPredicate<CharSequence, CharSequence> custom = (name, value) -> false;
+        BiPredicate<CharSequence, CharSequence> configured = h2()
+                .headersSensitivityDetector(custom)
+                .build()
+                .headersSensitivityDetector();
+
+        assertThat(configured, is(sameInstance(custom)));
+        assertFalse(configured.test("authorization", "Bearer abc"));
+        assertFalse(configured.test("cookie", "sid=1"));
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocolConfigTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpProtocolConfigTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.net.InetSocketAddress;
 import java.util.function.BiPredicate;
 
+import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h2;
@@ -212,10 +213,12 @@ class HttpProtocolConfigTest {
 
     @Test
     void defaultDetectorMarksSensitiveHeaders() {
-        BiPredicate<CharSequence, CharSequence> detector = h2Default().headersSensitivityDetector();
+        BiPredicate<CharSequence, CharSequence> detector = bothCharSequenceTypes(
+                h2Default().headersSensitivityDetector());
         assertTrue(detector.test("authorization", "Bearer abc"));
         assertTrue(detector.test("cookie", "sid=1"));
         assertTrue(detector.test("set-cookie", "sid=1; Path=/"));
+        assertTrue(detector.test("set-cookie2", "sid=1; Path=/"));
         assertTrue(detector.test("proxy-authorization", "Basic xyz"));
         assertTrue(detector.test("x-original-authorization", "Basic xyz"));
         assertTrue(detector.test("x-forwarded-authorization", "Basic xyz"));
@@ -243,7 +246,8 @@ class HttpProtocolConfigTest {
 
     @Test
     void defaultDetectorIgnoresNonSensitiveHeaders() {
-        BiPredicate<CharSequence, CharSequence> detector = h2Default().headersSensitivityDetector();
+        BiPredicate<CharSequence, CharSequence> detector = bothCharSequenceTypes(
+                h2Default().headersSensitivityDetector());
         assertFalse(detector.test("", ""));
         assertFalse(detector.test("content-type", "application/json"));
         assertFalse(detector.test("user-agent", "ServiceTalk"));
@@ -256,7 +260,8 @@ class HttpProtocolConfigTest {
 
     @Test
     void defaultDetectorIsCaseInsensitive() {
-        BiPredicate<CharSequence, CharSequence> detector = h2Default().headersSensitivityDetector();
+        BiPredicate<CharSequence, CharSequence> detector = bothCharSequenceTypes(
+                h2Default().headersSensitivityDetector());
         assertTrue(detector.test("AUTHORIZATION", "Bearer abc"));
         assertTrue(detector.test("Authorization", "Bearer abc"));
         assertTrue(detector.test("proxy-authorization", "abc"));
@@ -279,5 +284,17 @@ class HttpProtocolConfigTest {
         assertThat(configured, is(sameInstance(custom)));
         assertFalse(configured.test("authorization", "Bearer abc"));
         assertFalse(configured.test("cookie", "sid=1"));
+    }
+
+    private static BiPredicate<CharSequence, CharSequence> bothCharSequenceTypes(
+            final BiPredicate<CharSequence, CharSequence> detector) {
+        return (name, value) -> {
+            final boolean asIs = detector.test(name, value);
+            final boolean asAscii = detector.test(
+                    newAsciiString(name.toString()), newAsciiString(value.toString()));
+            assertEquals(asIs, asAscii,
+                    () -> "detector disagreed for String vs AsciiString: name=" + name + ", value=" + value);
+            return asIs;
+        };
     }
 }


### PR DESCRIPTION
#### Motivation
Per RFC 7541 §7.1.3, sensitive headers should be marked as never-indexed to prevent storage in the HPACK dynamic table. Without this, intermediaries on a long-lived HTTP/2 connection can retain indexed copies of headers like `Authorization`, `Cookie`, `Set-Cookie`, and `Proxy-Authorization`.

#### Modifications
Update `DEFAULT_SENSITIVITY_DETECTOR` to recognize and flag sensitive headers as never-indexed.


#### Result
`DEFAULT_SENSITIVITY_DETECTOR` now correctly flags sensitive headers, preventing them from being added to the HPACK dynamic table.