### PR TITLE
Update spotbugs 4.9.8 -> 4.10.2, spotbugs-plugin 5.2.5 -> 6.5.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -113,7 +113,7 @@ mockitoCoreVersion=4.11.0
 # TODO: Byte buddy is a dependency of Mockito and we need to push it forward to get JDK25 support. Once Our mockito
 #  version moves to the 5.x series we should get a recent enough version of byte buddy to not need to override.
 byteBuddyVersion=1.18.5
-spotbugsPluginVersion=5.2.5
+spotbugsPluginVersion=6.5.8
 dependencyAnalysisPluginVersion=3.10.0
 
 apacheDirectoryServerVersion=1.5.7

--- a/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/main-exclusions.xml
@@ -89,13 +89,6 @@
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
 
-  <!-- MulticastPublisher uses static factory method, constructor is package-private and only called from factory -->
-  <Match>
-    <Class name="io.servicetalk.concurrent.api.MulticastPublisher"/>
-    <Method name="&lt;init&gt;"/>
-    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
-  </Match>
-
   <!-- Reactive Streams protocol guarantees sequential access, these fields are protected by protocol semantics -->
   <Match>
     <Class name="io.servicetalk.concurrent.api.FirstAndTailToPackedSingle$SplicingSubscriber"/>
@@ -124,5 +117,21 @@
     <Class name="io.servicetalk.concurrent.api.SequentialSubscription"/>
     <Field name="sourceEmitted"/>
     <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.concurrent.api.PublisherFlatMapMerge$FlatMapSubscriber"/>
+    <Method name="onError"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+  <!-- ContextMap propagation -->
+  <Match>
+    <Class name="io.servicetalk.concurrent.api.DefaultAsyncContextProvider$CapturedContextImpl"/>
+    <Method name="captured"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.concurrent.api.DefaultThreadFactory$AsyncContextHolderThread"/>
+    <Method name="context"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-concurrent-api/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/test-exclusions.xml
@@ -15,10 +15,19 @@
   ~ limitations under the License.
   -->
 <FindBugsFilter>
-  <!-- Fields are usually initialized in @BeforeClass/@Before methods instead of constructors for tests -->
   <Match>
     <Source name="~.*Test\.java"/>
-    <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+    <Or>
+      <!-- Fields are usually initialized in @BeforeClass/@Before methods instead of constructors for tests -->
+      <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+      <!-- Tests methods can throw any exception type -->
+      <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
+      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
+      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
+      <!-- Tests classes can use simple synchronization -->
+      <Bug pattern="USO_UNSAFE_METHOD_SYNCHRONIZATION"/>
+      <Bug pattern="USO_UNSAFE_OBJECT_SYNCHRONIZATION"/>
+    </Or>
   </Match>
   <!-- Not interested in returned values -->
   <Match>
@@ -52,15 +61,8 @@
     <Bug pattern="DM_GC"/>
   </Match>
   <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-  </Match>
-  <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
-  </Match>
-  <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
+    <Class name="io.servicetalk.concurrent.api.MulticastRealizedSourcePublisherTest$MulticastSubscriber"/>
+    <Method name="onError"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-concurrent-api/gradle/spotbugs/testFixtures-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/testFixtures-exclusions.xml
@@ -33,4 +33,17 @@
     <Method name="wakeupWaiters"/>
     <Bug pattern="NN_NAKED_NOTIFY"/>
   </Match>
+
+  <!-- Test utilities can use simplified synchronization -->
+  <Match>
+    <Or>
+      <Class name="io.servicetalk.concurrent.api.LegacyTestCompletable"/>
+      <Class name="io.servicetalk.concurrent.api.LegacyTestSingle"/>
+    </Or>
+    <Bug pattern="USO_UNSAFE_METHOD_SYNCHRONIZATION"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.concurrent.api.TestSubscription"/>
+    <Bug pattern="USO_UNSAFE_OBJECT_SYNCHRONIZATION"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-dns-discovery-netty/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-dns-discovery-netty/gradle/spotbugs/test-exclusions.xml
@@ -15,32 +15,25 @@
   ~ limitations under the License.
   -->
 <FindBugsFilter>
-  <!-- Fields are usually initialized in @BeforeClass/@Before methods instead of constructors for tests -->
   <Match>
     <Source name="~.*Test\.java"/>
-    <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
-  </Match>
-  <!-- Not interested in returned values -->
-  <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <Or>
+      <!-- Fields are usually initialized in @BeforeClass/@Before methods instead of constructors for tests -->
+      <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+      <!-- Not interested in returned values -->
+      <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+      <!-- Tests methods can throw any exception type -->
+      <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
+      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
+      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
+      <!-- Other patterns we would like to ignore for tests -->
+      <Bug pattern="EI_EXPOSE_REP"/>
+    </Or>
   </Match>
   <!-- SpotBugs incorrectly detects number of usages -->
   <Match>
     <Class name="io.servicetalk.dns.discovery.netty.DnsTestUtils"/>
     <Method name="index"/>
     <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>
-  </Match>
-  <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-  </Match>
-  <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
-  </Match>
-  <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-encoding-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-encoding-api/gradle/spotbugs/main-exclusions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+  ~ Copyright © 2026 Apple Inc. and the ServiceTalk project authors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
   ~ limitations under the License.
   -->
 <FindBugsFilter>
+  <!-- False positive: List is copied and its unmodifiable version returned -->
   <Match>
-    <Class name="io.servicetalk.log4j2.mdc.utils.ServiceTalkThreadContextMap"/>
-    <Or>
-      <Method name="unwrapNull"/>
-    </Or>
-    <Bug pattern="ES_COMPARING_PARAMETER_STRING_WITH_EQ"/>
+    <Class name="io.servicetalk.encoding.api.BufferDecoderGroupBuilder$1"/>
+    <Method name="decoders"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/BufferDecoderGroupBuilder.java
+++ b/servicetalk-encoding-api/src/main/java/io/servicetalk/encoding/api/BufferDecoderGroupBuilder.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.buffer.api.CharSequences.newAsciiString;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
 
 /**
  * Builder for {@link BufferDecoderGroup}s.
@@ -89,7 +90,7 @@ public final class BufferDecoderGroupBuilder {
     public BufferDecoderGroup build() {
         return new BufferDecoderGroup() {
             private final List<BufferDecoder> bufferEncoders = decoders.isEmpty() ? emptyList() :
-                    new ArrayList<>(decoders);
+                    unmodifiableList(new ArrayList<>(decoders));
             @Nullable
             private final CharSequence advertisedMessageEncoding = messageEncoding.length() == 0 ?
                     null : newAsciiString(messageEncoding);

--- a/servicetalk-gradle-plugin-internal/build.gradle
+++ b/servicetalk-gradle-plugin-internal/build.gradle
@@ -21,6 +21,18 @@ apply plugin: "groovy"
 apply plugin: "java-gradle-plugin"
 apply from: "plugin-config.gradle"
 
+// Required version for module
+def javaLanguageVersion = JavaVersion.VERSION_11
+
+java {
+ sourceCompatibility = javaLanguageVersion
+ targetCompatibility = javaLanguageVersion
+}
+
+tasks.withType(JavaCompile).configureEach {
+ options.release = Integer.parseInt(javaLanguageVersion.getMajorVersion())
+}
+
 // Ignore Spotbugs for this module
 spotbugs {
  ignoreFailures = true

--- a/servicetalk-gradle-plugin-internal/gradle.lockfile
+++ b/servicetalk-gradle-plugin-internal/gradle.lockfile
@@ -1,5 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.5=compileClasspath,runtimeClasspath
+com.github.spotbugs.snom:spotbugs-gradle-plugin:6.5.8=compileClasspath,runtimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21=compileClasspath,runtimeClasspath
+org.jetbrains:annotations:13.0=compileClasspath,runtimeClasspath
 empty=annotationProcessor,jmhCompileClasspath,jmhRuntimeClasspath,spotbugsPlugins,testAnnotationProcessor

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/ServiceTalkLibraryPlugin.groovy
@@ -215,7 +215,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
 
   private static void configureToolchains(Project project) {
     def testJavaVersion = System.getenv("TEST_JAVA_VERSION")
-    
+
     // Only override test compilation and execution when TEST_JAVA_VERSION is explicitly set
     // Otherwise, leave existing compilation settings unchanged (modules configure their own --release)
     if (testJavaVersion) {
@@ -236,7 +236,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
           project.tasks.withType(Test) { task -> task.enabled = false }
           return
         }
-        
+
         // Predicate to identify test compile tasks (excludes test fixtures which compile with main sources)
         def isTestCompileTask = { task ->
           def taskName = task.name.toLowerCase()
@@ -257,7 +257,7 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
           // (and JDK 8 doesn't support --release anyway)
           compileTask.options.release.set(null as Integer)
         }
-        
+
         // Configure test execution to use TEST_JAVA_VERSION
         project.tasks.withType(Test).all {
           javaLauncher = toolchainService.launcherFor {
@@ -345,6 +345,8 @@ final class ServiceTalkLibraryPlugin extends ServiceTalkCorePlugin {
 
       spotbugs {
         toolVersion = SPOTBUGS_VERSION
+        // We often apply validation of parameters at the beginning of a constractor in many classes
+        omitVisitors = ["ConstructorThrow"]
       }
 
       // This task defaults to XML reporting for CI, but humans like HTML

--- a/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
+++ b/servicetalk-gradle-plugin-internal/src/main/groovy/io/servicetalk/gradle/plugin/internal/Versions.groovy
@@ -22,6 +22,6 @@ import static org.gradle.api.JavaVersion.VERSION_1_8
 final class Versions {
   static final String CHECKSTYLE_VERSION = "9.2"
   static final String PMD_VERSION = "6.55.0"
-  static final String SPOTBUGS_VERSION = "4.9.8"
+  static final String SPOTBUGS_VERSION = "4.10.2"
   static final JavaVersion TARGET_VERSION = VERSION_1_8
 }

--- a/servicetalk-grpc-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-grpc-api/gradle/spotbugs/main-exclusions.xml
@@ -31,6 +31,13 @@
     <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
 
+  <!-- HttpProtocolVersion isn't mutable -->
+  <Match>
+    <Class name="io.servicetalk.grpc.api.DefaultGrpcServiceContext$DefaultGrpcProtocol"/>
+    <Method name="httpProtocol"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+
   <!-- Exposing Throwable cause intentional -->
   <Match>
     <Class name="io.servicetalk.grpc.api.GrpcStatus"/>

--- a/servicetalk-grpc-netty/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-grpc-netty/gradle/spotbugs/test-exclusions.xml
@@ -79,4 +79,12 @@
     <Method name="verifyObservers"/>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
   </Match>
+  <Match>
+    <Class name="io.servicetalk.grpc.customtransport.Utils$ChannelGrpcServiceContext"/>
+    <Or>
+      <Method name="requestContext"/>
+      <Method name="responseContext"/>
+    </Or>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-grpc-utils/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-grpc-utils/gradle/spotbugs/main-exclusions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+  ~ Copyright © 2026 Apple Inc. and the ServiceTalk project authors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -16,17 +16,11 @@
   -->
 <FindBugsFilter>
   <Match>
-    <Source name="~.*Test\.java"/>
+    <Class name="io.servicetalk.grpc.utils.LoggingGrpcLifecycleObserver$LoggingGrpcExchangeObserver"/>
     <Or>
-      <!-- Fields are usually initialized in @BeforeClass/@Before methods instead of constructors for tests -->
-      <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
-      <!-- False positive, verify() on mock  -->
-      <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
-      <!-- Tests methods can throw any exception type -->
-      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
-      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
-      <!-- Other patterns we would like to ignore for tests -->
-      <Bug pattern="EI_EXPOSE_REP2"/>
+      <Method name="onRequest"/>
+      <Method name="onResponse"/>
     </Or>
+    <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-api/gradle/spotbugs/main-exclusions.xml
@@ -87,22 +87,6 @@
     <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
   </Match>
 
-  <!-- Parameters/state is intentional -->
-  <Match>
-    <Or>
-      <Class name="io.servicetalk.http.api.ContentEncodingHttpServiceFilter"/>
-      <Class name="io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory"/>
-      <Class name="io.servicetalk.http.api.RedirectConfigBuilder"/>
-    </Or>
-    <Or>
-      <Method name ="&lt;init&gt;"/>
-      <Method name ="allowedMethods"/>
-      <Method name ="headersToRedirect"/>
-      <Method name ="trailersToRedirect"/>
-    </Or>
-    <Bug pattern="EI_EXPOSE_REP2"/>
-  </Match>
-
   <Match>
     <Or>
       <Class name="io.servicetalk.http.api.BlockingHttpClient"/>
@@ -309,13 +293,105 @@
     <Method name="catchPayloadFailure"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
-
-  <!-- Parameters/state is intentional -->
+  <!-- False positives or intentional -->
   <Match>
-    <Class name="io.servicetalk.http.api.ProxyConnectResponseException"/>
+    <Class name="io.servicetalk.http.api.AbstractHttpMetaData"/>
+    <Or>
+      <Method name="context"/>
+      <Method name="headers"/>
+      <Method name="version"/>
+    </Or>
     <Or>
       <Bug pattern="EI_EXPOSE_REP"/>
       <Bug pattern="EI_EXPOSE_REP2"/>
     </Or>
+  </Match>
+  <Match>
+    <Or>
+      <Class name="io.servicetalk.http.api.BlockingStreamingHttpMessageBodyUtils$DefaultHttpMessageBodyIterator"/>
+      <Class name="io.servicetalk.http.api.BlockingStreamingToStreamingService$BufferHttpPayloadWriter"/>
+    </Or>
+    <Method name="trailers"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.DefaultBlockingStreamingHttpRequest"/>
+    <Method name="toStreamingRequest"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.DefaultBlockingStreamingHttpServerResponse"/>
+    <Method name="sendMetaData"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.DefaultHttpRequest"/>
+    <Or>
+      <Method name="method"/>
+      <Method name="payloadBody"/>
+    </Or>
+    <Or>
+      <Bug pattern="EI_EXPOSE_REP"/>
+      <Bug pattern="EI_EXPOSE_REP2"/>
+    </Or>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.DefaultHttpResponse"/>
+    <Or>
+      <Method name="payloadBody"/>
+      <Method name="status"/>
+    </Or>
+    <Or>
+      <Bug pattern="EI_EXPOSE_REP"/>
+      <Bug pattern="EI_EXPOSE_REP2"/>
+    </Or>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.DefaultHttpRequestMetaData"/>
+    <Method name="method"/>
+    <Or>
+      <Bug pattern="EI_EXPOSE_REP"/>
+      <Bug pattern="EI_EXPOSE_REP2"/>
+    </Or>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.DefaultHttpResponseMetaData"/>
+    <Method name="status"/>
+    <Or>
+      <Bug pattern="EI_EXPOSE_REP"/>
+      <Bug pattern="EI_EXPOSE_REP2"/>
+    </Or>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.ProxyConnectResponseException"/>
+    <Method name="response"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.RedirectConfigBuilder$DefaultRedirectConfig"/>
+    <Or>
+      <Method name="allowedMethods"/>
+      <Method name="allowedStatuses"/>
+    </Or>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Or>
+      <Class name="io.servicetalk.http.api.ContentEncodingHttpServiceFilter"/>
+      <Class name="io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory"/>
+      <Class name="io.servicetalk.http.api.ProxyConnectResponseException"/>
+    </Or>
+    <Method name ="&lt;init&gt;"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.StreamingHttpPayloadHolder$PreserveTrailersBufferOperator$PreserveTrailersBufferSubscriber"/>
+    <Method name="onNext"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.api.StreamingHttpPayloadHolder$TrailersMapper"/>
+    <Method name="mapOnNext"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/main-exclusions.xml
@@ -32,26 +32,38 @@
     <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
   </Match>
 
-  <!-- Parameters/state is intentional -->
+  <!-- False positives or intentional -->
   <Match>
-    <Class name="io.servicetalk.http.netty.ProxyResponseException"/>
-    <Method name="status"/>
+    <Class name="io.servicetalk.http.netty.H2ParentConnectionContext"/>
+    <Method name="sslSession"/>
     <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
-
-  <!-- Duration isn't mutable -->
   <Match>
-    <Class name="io.servicetalk.http.netty.H2KeepAlivePolicies$KeepAlivePolicyBuilder"/>
+    <Class name="io.servicetalk.http.netty.H2ProtocolConfigBuilder$DefaultH2ProtocolConfig"/>
+    <Method name="initialSettings"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
     <Or>
-      <Method name="ackTimeout"/>
-      <Method name="idleDuration"/>
+      <Class name="io.servicetalk.http.netty.HttpClientConfig$1"/>
+      <Class name="io.servicetalk.http.netty.HttpServerConfig$DelegatingHttpServerSslConfig"/>
     </Or>
+    <Method name="alpnProtocols"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.netty.NettyHttpServer$ChangingFlushStrategy"/>
+    <Method name="apply"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <Class name="io.servicetalk.http.netty.H2ProtocolConfigBuilder"/>
+    <Method name="initialSettings"/>
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
-
-  <!-- Intentional -->
   <Match>
-    <Class name="io.servicetalk.http.netty.RetryingHttpRequesterFilter$HttpResponseException"/>
+    <Class name="io.servicetalk.http.netty.ProxyConnectChannelSingle$ProxyConnectHandler"/>
+    <Method name="channelRead"/>
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 
@@ -130,11 +142,6 @@
     <Class name="io.servicetalk.http.netty.SniCompleteChannelSingle$SniCompleteChannelHandler"/>
     <Method name="handlerAdded"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
-  </Match>
-  <Match>
-    <Class name="io.servicetalk.http.netty.H2ProtocolConfigBuilder"/>
-    <Field name="h2Settings"/>
-    <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 
   <!-- False positive: this is not a Singleton, the filter can be build multiple times by its Builder -->

--- a/servicetalk-http-netty/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-http-netty/gradle/spotbugs/test-exclusions.xml
@@ -15,15 +15,20 @@
   ~ limitations under the License.
   -->
 <FindBugsFilter>
-  <!-- Fields are usually initialized in @BeforeClass/@Before methods instead of constructors for tests -->
   <Match>
     <Source name="~.*Test\.java"/>
-    <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
-  </Match>
-  <!-- Not interested in returned values -->
-  <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <Or>
+      <!-- Fields are usually initialized in @BeforeClass/@Before methods instead of constructors for tests -->
+      <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+      <!-- Not interested in returned values -->
+      <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+      <!-- Tests methods can throw any exception type -->
+      <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
+      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
+      <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
+      <!-- Other patterns we would like to ignore for tests -->
+      <Bug pattern="EI_EXPOSE_REP"/>
+    </Or>
   </Match>
   <Match>
     <Class name="io.servicetalk.http.netty.TestServiceStreaming"/>
@@ -60,19 +65,8 @@
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
   </Match>
   <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-  </Match>
-  <Match>
-    <Or>
-      <Source name="~.*Test\.java"/>
-      <Class name="io.servicetalk.http.netty.InvokingThreadsRecorder"/>
-    </Or>
+    <Class name="io.servicetalk.http.netty.InvokingThreadsRecorder"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
-  </Match>
-  <Match>
-    <Source name="~.*Test\.java"/>
-    <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
   <!-- Test intentionally returns null to verify the null-check -->
   <Match>

--- a/servicetalk-http-router-jersey/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-router-jersey/gradle/spotbugs/main-exclusions.xml
@@ -61,10 +61,9 @@
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
 
-  <!-- Abstract inner class constructor throws exception by design, subclasses are package-private -->
   <Match>
     <Class name="io.servicetalk.http.router.jersey.EndpointEnhancingRequestFilter$AbstractWrappedEndpoint"/>
-    <Method name="&lt;init&gt;"/>
-    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
+    <Method name="getResourceMethod"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-http-utils/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-http-utils/gradle/spotbugs/main-exclusions.xml
@@ -35,4 +35,12 @@
     </Or>
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
+  <Match>
+    <Class name="io.servicetalk.http.utils.LoggingHttpLifecycleObserver$LoggingHttpExchangeObserver"/>
+    <Or>
+      <Method name="onRequest"/>
+      <Method name="onResponse"/>
+    </Or>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-loadbalancer/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-loadbalancer/gradle/spotbugs/main-exclusions.xml
@@ -27,13 +27,6 @@
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 
-  <!-- Class constructor throws exception by design for validation -->
-  <Match>
-    <Class name="io.servicetalk.loadbalancer.XdsHealthIndicator"/>
-    <Method name="&lt;init&gt;"/>
-    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
-  </Match>
-
   <!-- XdsHealthIndicator uses SequentialExecutor for thread safety, sequential execution guarantees -->
   <Match>
     <Class name="io.servicetalk.loadbalancer.XdsHealthIndicator"/>

--- a/servicetalk-loadbalancer/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-loadbalancer/gradle/spotbugs/test-exclusions.xml
@@ -39,4 +39,11 @@
     <Field name="failOpen"/>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
   </Match>
+
+  <!-- False positive: we do not return original indicatorSet -->
+  <Match>
+    <Class name="io.servicetalk.loadbalancer.DefaultLoadBalancerTest$TestOutlierDetector"/>
+    <Field name="indicatorSet"/>
+    <Bug pattern="USO_UNSAFE_ACCESSIBLE_OBJECT_SYNCHRONIZATION"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-opentracing-inmemory/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-opentracing-inmemory/gradle/spotbugs/main-exclusions.xml
@@ -24,4 +24,9 @@
     <Method name="extract"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
+  <Match>
+    <Class name="io.servicetalk.opentracing.inmemory.DefaultInMemorySpanLog"/>
+    <Method name="fields"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-serialization-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-serialization-api/gradle/spotbugs/main-exclusions.xml
@@ -27,12 +27,4 @@
     <Method name="close"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
-
-  <!-- TypeHolder constructor throws exception by design for validation -->
-  <!-- Also, it's a deprecated class that is currently used only by tests -->
-  <Match>
-    <Class name="io.servicetalk.serialization.api.TypeHolder"/>
-    <Method name="&lt;init&gt;"/>
-    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
-  </Match>
 </FindBugsFilter>

--- a/servicetalk-tcp-netty-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-tcp-netty-internal/gradle/spotbugs/main-exclusions.xml
@@ -69,15 +69,4 @@
     <Class name="io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer"/>
     <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
   </Match>
-
-  <!-- These classes are not designed for inheritance and will become final in the next major release -->
-  <!-- FIXME: 0.43 - remove these exclusions -->
-  <Match>
-    <Or>
-      <Class name="io.servicetalk.tcp.netty.internal.TcpClientChannelInitializer"/>
-      <Class name="io.servicetalk.tcp.netty.internal.TcpServerChannelInitializer"/>
-    </Or>
-    <Method name="&lt;init&gt;"/>
-    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
-  </Match>
 </FindBugsFilter>

--- a/servicetalk-traffic-resilience-http/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-traffic-resilience-http/gradle/spotbugs/main-exclusions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+  ~ Copyright © 2026 Apple Inc. and the ServiceTalk project authors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
   ~ limitations under the License.
   -->
 <FindBugsFilter>
+  <!-- False positives or intentional -->
   <Match>
-    <Class name="io.servicetalk.log4j2.mdc.utils.ServiceTalkThreadContextMap"/>
-    <Or>
-      <Method name="unwrapNull"/>
-    </Or>
-    <Bug pattern="ES_COMPARING_PARAMETER_STRING_WITH_EQ"/>
+    <Class name="io.servicetalk.traffic.resilience.http.AbstractTrafficResilienceHttpFilter$SignalConsumer"/>
+    <Method name="onError"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-transport-api/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-transport-api/gradle/spotbugs/main-exclusions.xml
@@ -23,4 +23,15 @@
     </Or>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
   </Match>
+  <!-- False positives or intentional -->
+  <Match>
+    <Class name="io.servicetalk.transport.api.AbstractSslConfig"/>
+    <Or>
+      <Method name="alpnProtocols"/>
+      <Method name="certificateCompressionAlgorithms"/>
+      <Method name="ciphers"/>
+      <Method name="sslProtocols"/>
+    </Or>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-transport-netty-internal/gradle/spotbugs/main-exclusions.xml
@@ -119,13 +119,6 @@
     <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
   </Match>
 
-  <!-- ByteToMessageDecoder constructor throws exception by design for validation -->
-  <Match>
-    <Class name="io.servicetalk.transport.netty.internal.ByteToMessageDecoder"/>
-    <Method name="&lt;init&gt;"/>
-    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
-  </Match>
-
   <!-- WriteStreamSubscriber uses event loop thread confinement for thread safety -->
   <Match>
     <Class name="io.servicetalk.transport.netty.internal.WriteStreamSubscriber"/>
@@ -134,5 +127,11 @@
       <Field name="enqueueWrites"/>
     </Or>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+  </Match>
+  <!-- False positives or intentional -->
+  <Match>
+    <Class name="io.servicetalk.transport.netty.internal.NettyIoThreadFactory$NettyIoThread"/>
+    <Method name="context"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
 </FindBugsFilter>

--- a/servicetalk-transport-netty-internal/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-transport-netty-internal/gradle/spotbugs/test-exclusions.xml
@@ -39,13 +39,6 @@
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
 
-  <!-- Test class constructor throws exception by design -->
-  <Match>
-    <Class name="io.servicetalk.transport.netty.internal.AbstractSslCloseNotifyAlertHandlingTest"/>
-    <Method name="&lt;init&gt;"/>
-    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
-  </Match>
-
   <!-- Test field with controlled single-threaded access -->
   <Match>
     <Class name="io.servicetalk.transport.netty.internal.NettyChannelPublisherTest"/>


### PR DESCRIPTION
Modifications:
1. Bump spotbugs versions
2. `servicetalk-gradle-plugin-internal` now requires JDK11
3. `BufferDecoderGroupBuilder`: store unmodifiable list
4. Update exclusion rules to suppress new false positives