### PR TITLE
http-netty: validate HTTP/1 request-target

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpRequestEncoder.java
@@ -54,6 +54,7 @@ import static java.util.Objects.requireNonNull;
 final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
     private static final char SLASH = '/';
     private static final char QUESTION_MARK = '?';
+    private static final char DEL = 0x7f;
     private static final int SLASH_AND_SPACE_SHORT = (SLASH << 8) | SP;
     private static final int SPACE_SLASH_AND_SPACE_MEDIUM = (SP << 16) | SLASH_AND_SPACE_SHORT;
 
@@ -107,6 +108,7 @@ final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
         message.method().writeTo(stBuffer);
 
         String uri = message.requestTarget();
+        validateRequestTarget(uri);
 
         if (uri.isEmpty()) {
             // Add " / " as absolute path if uri is not present.
@@ -147,6 +149,16 @@ final class HttpRequestEncoder extends HttpObjectEncoder<HttpRequestMetaData> {
         // if this happens just force http/1.1 to avoid generating an invalid request.
         (message.version().major() == 1 ? message.version() : HTTP_1_1).writeTo(stBuffer);
         stBuffer.writeShort(CRLF_SHORT);
+    }
+
+    private static void validateRequestTarget(final String requestTarget) {
+        for (int i = 0; i < requestTarget.length(); ++i) {
+            final char c = requestTarget.charAt(i);
+            if (c <= 0x1f || c == DEL) {
+                throw new IllegalArgumentException(
+                        "Invalid HTTP/1.x request-target: contains prohibited control character at index " + i);
+            }
+        }
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -162,6 +162,18 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
         assertFalse(channel.finishAndReleaseAll());
     }
 
+    @ParameterizedTest(name = "{index}")
+    @ValueSource(strings = {"/safe\r\nX-Injected: yes", "/safe\nX-Injected: yes", "/safe\rX-Injected: yes",
+            "/safe\f/target", "/safe\u007Ftarget"})
+    void requestTargetControlCharacterThrows(final String requestTarget) {
+        EmbeddedChannel channel = newEmbeddedChannel();
+        HttpRequestMetaData request = newRequestMetaData(HTTP_1_1, GET, requestTarget, INSTANCE.newHeaders());
+
+        IOException e = assertThrows(IOException.class, () -> channel.writeOutbound(request));
+        assertTrue(e.getCause() instanceof IllegalArgumentException);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
     @Test
     void contentLengthNoTrailersHeaderWhiteSpaceEncodedWithValidationOff() {
         EmbeddedChannel channel = newEmbeddedChannel();


### PR DESCRIPTION
#### Motivation
HTTP/1.x request targets are written directly into the request line during encoding. Raw control characters are not valid in that position and should be rejected before bytes are written to the transport.

The inbound decoder already rejects request targets with control characters; this change applies the same expectation to outbound HTTP/1.x encoding.

#### Modifications
- Validate the HTTP/1.x request target before serializing the initial line.
- Reject request targets that contain raw control characters.
- Add `HttpRequestEncoderTest` coverage for CR, LF, CRLF, form-feed, and DEL.

#### Result
Invalid HTTP/1.x request targets fail during encoding instead of producing malformed start lines. Valid percent-encoded request targets are unchanged.
