### PR TITLE
Validate HTTP header values by default

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
@@ -575,7 +575,11 @@ final class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> impl
     }
 
     @Override
-    protected CharSequence validateValue(final CharSequence value) {
+    protected CharSequence validateValue(final CharSequence name, @Nullable final CharSequence value) {
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "Null values are not allowed, encountered null for header name: " + name);
+        }
         if (validateValues) {
             validateHeaderValue(value);
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
@@ -576,7 +576,7 @@ final class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> impl
 
     @Override
     protected CharSequence validateValue(final CharSequence value) {
-        if (validateValues) {
+        if (value != null && validateValues) {
             validateHeaderValue(value);
         }
         return value;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeaders.java
@@ -576,7 +576,7 @@ final class DefaultHttpHeaders extends MultiMap<CharSequence, CharSequence> impl
 
     @Override
     protected CharSequence validateValue(final CharSequence value) {
-        if (value != null && validateValues) {
+        if (validateValues) {
             validateHeaderValue(value);
         }
         return value;

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
@@ -32,7 +32,8 @@ public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
             "io.servicetalk.http.api.temporaryDefaultValidateHeaderValues";
     private static final boolean DEFAULT_VALIDATE_VALUES = defaultValidateValues();
 
-    public static final HttpHeadersFactory INSTANCE = new DefaultHttpHeadersFactory(true, true, DEFAULT_VALIDATE_VALUES);
+    public static final HttpHeadersFactory INSTANCE =
+            new DefaultHttpHeadersFactory(true, true, DEFAULT_VALIDATE_VALUES);
 
     static {
         if (!DEFAULT_VALIDATE_VALUES) {

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
@@ -15,12 +15,32 @@
  */
 package io.servicetalk.http.api;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.System.getProperty;
+
 /**
  * Default implementation of {@link HttpHeadersFactory}.
  */
 public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
 
-    public static final HttpHeadersFactory INSTANCE = new DefaultHttpHeadersFactory(true, true, false);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHttpHeadersFactory.class);
+    // FIXME: 0.43 - remove this temporary property
+    static final String DEFAULT_VALIDATE_VALUES_PROPERTY =
+            "io.servicetalk.http.api.temporaryDefaultValidateHeaderValues";
+    private static final boolean DEFAULT_VALIDATE_VALUES = defaultValidateValues();
+
+    public static final HttpHeadersFactory INSTANCE = new DefaultHttpHeadersFactory(true, true, DEFAULT_VALIDATE_VALUES);
+
+    static {
+        if (!DEFAULT_VALIDATE_VALUES) {
+            LOGGER.warn("-D{}: {}. This property will be removed in the future releases. " +
+                            "Configure this value via DefaultHttpHeadersFactory constructor instead.",
+                    DEFAULT_VALIDATE_VALUES_PROPERTY, DEFAULT_VALIDATE_VALUES);
+        }
+    }
 
     private final boolean validateNames;
     private final boolean validateCookies;
@@ -87,6 +107,10 @@ public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
     @Override
     public boolean validateValues() {
         return validateValues;
+    }
+
+    static boolean defaultValidateValues() {
+        return parseBoolean(getProperty(DEFAULT_VALIDATE_VALUES_PROPERTY, "true"));
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiMap.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/MultiMap.java
@@ -107,9 +107,10 @@ abstract class MultiMap<K, V> {
     /**
      * Validate the value before inserting it into this {@link MultiMap}.
      *
+     * @param key The key for this value.
      * @param value The value which will be inserted.
      */
-    protected abstract V validateValue(V value);
+    protected abstract V validateValue(K key, V value);
 
     /**
      * Generate a hash code for {@code value} using for equality comparisons and {@link #hashCode(Object)}.
@@ -226,7 +227,7 @@ abstract class MultiMap<K, V> {
     final void put(final K key, final V value) {
         final int keyHash = hashCode(validateKey(key));
         final int bucketIndex = index(keyHash);
-        putEntry(keyHash, bucketIndex, key, validateValue(value));
+        putEntry(keyHash, bucketIndex, key, validateValue(key, value));
     }
 
     final void putAll(final K key, final Iterable<? extends V> values) {
@@ -235,14 +236,14 @@ abstract class MultiMap<K, V> {
         BucketHead<K, V> bucketHead = entries[bucketIndex];
         if (bucketHead != null) {
             for (final V v : values) {
-                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(v));
+                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(key, v));
             }
         } else {
             final Iterator<? extends V> valueItr = values.iterator();
             if (valueItr.hasNext()) {
-                bucketHead = putEntry(keyHash, bucketIndex, key, validateValue(valueItr.next()));
+                bucketHead = putEntry(keyHash, bucketIndex, key, validateValue(key, valueItr.next()));
                 while (valueItr.hasNext()) {
-                    putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(valueItr.next()));
+                    putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(key, valueItr.next()));
                 }
             }
         }
@@ -255,12 +256,12 @@ abstract class MultiMap<K, V> {
         BucketHead<K, V> bucketHead = entries[bucketIndex];
         if (bucketHead != null) {
             for (final V v : values) {
-                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(v));
+                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(key, v));
             }
         } else if (values.length != 0) {
-            bucketHead = putEntry(keyHash, bucketIndex, key, validateValue(values[0]));
+            bucketHead = putEntry(keyHash, bucketIndex, key, validateValue(key, values[0]));
             for (int i = 1; i < values.length; ++i) {
-                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(values[i]));
+                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(key, values[i]));
             }
         }
     }
@@ -273,7 +274,7 @@ abstract class MultiMap<K, V> {
         final int keyHash = hashCode(validateKey(key));
         final int bucketIndex = index(keyHash);
         removeAll(key, keyHash, bucketIndex);
-        putEntry(keyHash, bucketIndex, key, validateValue(value));
+        putEntry(keyHash, bucketIndex, key, validateValue(key, value));
     }
 
     final void putExclusive(final K key, final Iterable<? extends V> values) {
@@ -284,13 +285,13 @@ abstract class MultiMap<K, V> {
         if (valueItr.hasNext()) {
             BucketHead<K, V> bucketHead = entries[bucketIndex];
             if (bucketHead == null) {
-                bucketHead = putEntry(keyHash, bucketIndex, key, validateValue(valueItr.next()));
+                bucketHead = putEntry(keyHash, bucketIndex, key, validateValue(key, valueItr.next()));
                 if (!valueItr.hasNext()) {
                     return;
                 }
             }
             do {
-                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(valueItr.next()));
+                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(key, valueItr.next()));
             } while (valueItr.hasNext());
         }
     }
@@ -304,11 +305,11 @@ abstract class MultiMap<K, V> {
             BucketHead<K, V> bucketHead = entries[bucketIndex];
             int i = 0;
             if (bucketHead == null) {
-                bucketHead = putEntry(keyHash, bucketIndex, key, validateValue(values[0]));
+                bucketHead = putEntry(keyHash, bucketIndex, key, validateValue(key, values[0]));
                 i = 1;
             }
             for (; i < values.length; ++i) {
-                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(values[i]));
+                putEntry(bucketHead, keyHash, bucketIndex, key, validateValue(key, values[i]));
             }
         }
     }
@@ -513,7 +514,7 @@ abstract class MultiMap<K, V> {
                 if (bucketHead == null) {
                     bucketHead = putEntry(null, rhsEntry.keyHash, bucketIndex,
                             maybeValidateKey(validateKey, rhsEntry.getKey()),
-                            maybeValidateValue(validateValue, rhsEntry.getValue()));
+                            maybeValidateValue(validateValue, rhsEntry.getKey(), rhsEntry.getValue()));
                     rhsEntry = rhsEntry.bucketNext;
                     if (rhsEntry == null) {
                         rhsBucketHead = rhsBucketHead.prevBucketHead;
@@ -523,7 +524,7 @@ abstract class MultiMap<K, V> {
                 do {
                     putEntry(bucketHead, rhsEntry.keyHash, bucketIndex,
                             maybeValidateKey(validateKey, rhsEntry.getKey()),
-                            maybeValidateValue(validateValue, rhsEntry.getValue()));
+                            maybeValidateValue(validateValue, rhsEntry.getKey(), rhsEntry.getValue()));
                     rhsEntry = rhsEntry.bucketNext;
                 } while (rhsEntry != null);
                 rhsBucketHead = rhsBucketHead.prevBucketHead;
@@ -536,7 +537,7 @@ abstract class MultiMap<K, V> {
                 do {
                     putEntry(rhsEntry.keyHash, index(rhsEntry.keyHash),
                             maybeValidateKey(validateKey, rhsEntry.getKey()),
-                            maybeValidateValue(validateValue, rhsEntry.getValue()));
+                            maybeValidateValue(validateValue, rhsEntry.getKey(), rhsEntry.getValue()));
                     rhsEntry = rhsEntry.bucketNext;
                 } while (rhsEntry != null);
                 rhsBucketHead = rhsBucketHead.prevBucketHead;
@@ -548,8 +549,8 @@ abstract class MultiMap<K, V> {
         return validate ? validateKey(key) : key;
     }
 
-    private V maybeValidateValue(boolean validate, V value) {
-        return validate ? validateValue(value) : value;
+    private V maybeValidateValue(boolean validate, K key, V value) {
+        return validate ? validateValue(key, value) : value;
     }
 
     private abstract class EntryIterator<T> implements Iterator<T> {
@@ -713,10 +714,7 @@ abstract class MultiMap<K, V> {
 
         MultiMapEntry(final K key, final V value, final int keyHash) {
             this.key = requireNonNull(key);
-            if (value == null) {
-                throw new IllegalArgumentException("Null value for key: " + key);
-            }
-            this.value = value;
+            this.value = requireNonNull(value);
             this.keyHash = keyHash;
         }
 

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpHeadersTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/DefaultHttpHeadersTest.java
@@ -17,10 +17,46 @@ package io.servicetalk.http.api;
 
 import org.junit.jupiter.api.Test;
 
+import static java.lang.System.clearProperty;
+import static java.lang.System.getProperty;
+import static java.lang.System.setProperty;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DefaultHttpHeadersTest extends AbstractHttpHeadersTest {
+
+    @Test
+    void defaultFactoryValidatesValues() {
+        assertTrue(DefaultHttpHeadersFactory.INSTANCE.validateValues());
+        assertThrows(IllegalArgumentException.class,
+                () -> DefaultHttpHeadersFactory.INSTANCE.newHeaders().add("name", "invalid\0value"));
+    }
+
+    @Test
+    void explicitFactoryCanDisableValueValidation() {
+        assertDoesNotThrow(() -> new DefaultHttpHeadersFactory(true, true, false).newHeaders()
+                .add("name", "invalid\0value"));
+    }
+
+    @Test
+    void temporaryDefaultValidateValuesPropertyCanDisableDefault() {
+        final String oldValue = getProperty(DefaultHttpHeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY);
+        try {
+            clearProperty(DefaultHttpHeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY);
+            assertTrue(DefaultHttpHeadersFactory.defaultValidateValues());
+
+            setProperty(DefaultHttpHeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY, "false");
+            assertFalse(DefaultHttpHeadersFactory.defaultValidateValues());
+        } finally {
+            if (oldValue == null) {
+                clearProperty(DefaultHttpHeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY);
+            } else {
+                setProperty(DefaultHttpHeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY, oldValue);
+            }
+        }
+    }
 
     @Test
     void addHeadersValidatesNamesWhenSourceDoesNot() {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
@@ -19,6 +19,12 @@ import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.System.getProperty;
+
 /**
  * A {@link HttpHeadersFactory} optimized for HTTP/2.
  *
@@ -27,7 +33,21 @@ import io.servicetalk.http.api.HttpHeadersFactory;
 @Deprecated // FIXME: 0.43 - remove deprecated class
 public final class H2HeadersFactory implements HttpHeadersFactory {
 
-    public static final HttpHeadersFactory INSTANCE = new H2HeadersFactory(true, true, false);
+    private static final Logger LOGGER = LoggerFactory.getLogger(H2HeadersFactory.class);
+    // FIXME: 0.43 - remove this temporary property
+    static final String DEFAULT_VALIDATE_VALUES_PROPERTY =
+            "io.servicetalk.http.api.temporaryDefaultValidateHeaderValues";
+    private static final boolean DEFAULT_VALIDATE_VALUES = defaultValidateValues();
+
+    public static final HttpHeadersFactory INSTANCE = new H2HeadersFactory(true, true, DEFAULT_VALIDATE_VALUES);
+
+    static {
+        if (!DEFAULT_VALIDATE_VALUES) {
+            LOGGER.warn("-D{}: {}. This property will be removed in the future releases. " +
+                            "Configure this value via H2HeadersFactory constructor instead.",
+                    DEFAULT_VALIDATE_VALUES_PROPERTY, DEFAULT_VALIDATE_VALUES);
+        }
+    }
 
     private final HttpHeadersFactory underlying;
 
@@ -87,6 +107,10 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
     @Override
     public boolean validateValues() {
         return underlying.validateValues();
+    }
+
+    static boolean defaultValidateValues() {
+        return parseBoolean(getProperty(DEFAULT_VALIDATE_VALUES_PROPERTY, "true"));
     }
 
     @Override

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2HeadersFactoryTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2HeadersFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import org.junit.jupiter.api.Test;
+
+import static java.lang.System.clearProperty;
+import static java.lang.System.getProperty;
+import static java.lang.System.setProperty;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("deprecation")
+class H2HeadersFactoryTest {
+
+    @Test
+    void defaultFactoryValidatesValues() {
+        assertTrue(H2HeadersFactory.INSTANCE.validateValues());
+        assertThrows(IllegalArgumentException.class,
+                () -> H2HeadersFactory.INSTANCE.newHeaders().add("name", "invalid\0value"));
+    }
+
+    @Test
+    void explicitFactoryCanDisableValueValidation() {
+        assertDoesNotThrow(() -> new H2HeadersFactory(true, true, false).newHeaders()
+                .add("name", "invalid\0value"));
+    }
+
+    @Test
+    void temporaryDefaultValidateValuesPropertyCanDisableDefault() {
+        final String oldValue = getProperty(H2HeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY);
+        try {
+            clearProperty(H2HeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY);
+            assertTrue(H2HeadersFactory.defaultValidateValues());
+
+            setProperty(H2HeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY, "false");
+            assertFalse(H2HeadersFactory.defaultValidateValues());
+        } finally {
+            if (oldValue == null) {
+                clearProperty(H2HeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY);
+            } else {
+                setProperty(H2HeadersFactory.DEFAULT_VALIDATE_VALUES_PROPERTY, oldValue);
+            }
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerPipelineControlFlowTest.java
@@ -271,8 +271,8 @@ class ServerPipelineControlFlowTest {
             IOException e = assertThrows(IOException.class, () -> {
                 switch (protocol) {
                     case HTTP_1:
-                        // \r\n is illegal inside header values
-                        client.request(client.get("/").setHeader("some-header", "invalid\r\nvalue"));
+                        // \r is illegal inside request-target
+                        client.request(client.get("/\r/path"));
                         break;
                     case HTTP_2:
                         // TRACE methods can not have content-length header


### PR DESCRIPTION
#### Motivation
HTTP header field values should not contain illegal characters. Currently, validation was not enabled by default for performance reasons, but we reconsidered it in favor of safe behavior by default.

#### Modifications
- Enable headers values validation for `DefaultHttpHeadersFactory` and deprecated `H2HeadersFactory` by default.
- Provide a `io.servicetalk.http.api.temporaryDefaultValidateHeaderValues` system property to help users rollback pre-existing default behavior.
- Ensure null values are rejected before validation happens.
- Enhance testing.

#### Result
Invalid HTTP header values fail during insertion into `HttpHeaders` collection.

Fixes: #3022