### PR TITLE
dns-discovery-netty: clear min TTL state for removed SRV targets

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -345,7 +345,9 @@ final class DefaultDnsClient implements DnsClient {
                     // Unwrap the list so we can use it in SrvInactiveCombinerOperator below.
                     return from(((SrvInactiveEvent<HostAndPort, InetSocketAddress>) srvEvent).aggregatedEvents);
                 } else {
-                    final ARecordPublisher aPublisher = aRecordMap.remove(srvEvent.address().hostName());
+                    final String srvHostName = srvEvent.address().hostName();
+                    final ARecordPublisher aPublisher = aRecordMap.remove(srvHostName);
+                    ttlCache.clearMinTtl(srvHostName);
                     if (aPublisher != null) {
                         aPublisher.cancelAndFail0(
                                 SrvAddressRemovedException.newInstance(DefaultDnsClient.class, "dnsSrvQuery"));

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/MinTtlCache.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/MinTtlCache.java
@@ -55,6 +55,10 @@ final class MinTtlCache implements DnsCache {
     }
 
     void prepareForResolution(final String hostname) {
+        clearMinTtl(hostname);
+    }
+
+    void clearMinTtl(final String hostname) {
         minExpiryMap.remove(hostname);
     }
 
@@ -76,6 +80,7 @@ final class MinTtlCache implements DnsCache {
 
     @Override
     public boolean clear(final String hostname) {
+        clearMinTtl(hostname);
         return cache.clear(hostname);
     }
 

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/MinTtlCacheTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/MinTtlCacheTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.resolver.dns.DnsCache;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class MinTtlCacheTest {
+
+    private static final DnsRecord[] EMPTY_ADDITIONALS = new DnsRecord[0];
+    private static final String HOSTNAME = "target.example.com";
+    private static final long INITIAL_TTL = 5;
+    private static final long ORIGINAL_TTL = 20;
+
+    @Test
+    void clearHostClearsMinTtlState() {
+        DnsCache delegate = mock(DnsCache.class);
+        when(delegate.clear(HOSTNAME)).thenReturn(true);
+        MinTtlCache cache = newCache(delegate);
+        cacheAddress(cache);
+
+        assertThat(cache.minTtl(HOSTNAME), is(ORIGINAL_TTL));
+        assertThat(cache.clear(HOSTNAME), is(true));
+        assertThat(cache.minTtl(HOSTNAME), is(INITIAL_TTL));
+        verify(delegate).clear(HOSTNAME);
+    }
+
+    @Test
+    void clearMinTtlDoesNotClearDelegateCache() {
+        DnsCache delegate = mock(DnsCache.class);
+        MinTtlCache cache = newCache(delegate);
+        cacheAddress(cache);
+        clearInvocations(delegate);
+
+        cache.clearMinTtl(HOSTNAME);
+
+        assertThat(cache.minTtl(HOSTNAME), is(INITIAL_TTL));
+        verifyNoInteractions(delegate);
+    }
+
+    private static MinTtlCache newCache(final DnsCache delegate) {
+        return new MinTtlCache(delegate, INITIAL_TTL, unit -> 0);
+    }
+
+    private static void cacheAddress(final MinTtlCache cache) {
+        cache.cache(HOSTNAME, EMPTY_ADDITIONALS, InetAddress.getLoopbackAddress(), ORIGINAL_TTL,
+                mock(EventLoop.class));
+    }
+}


### PR DESCRIPTION
#### Motivation
`MinTtlCache` keeps minimum TTL bookkeeping separately from the delegate DNS cache. When an SRV target is removed, `DefaultDnsClient` removes the corresponding A-record publisher, but the min-TTL bookkeeping for that hostname can remain behind.

That side state should follow the lifecycle of the per-target A-record publisher.

#### Modifications
- Add a local min-TTL cleanup method to `MinTtlCache`.
- Clear min-TTL state when a specific hostname is cleared.
- Clear min-TTL state when an SRV target is removed and its A-record publisher is cancelled.
- Add focused coverage for hostname-specific min-TTL cleanup.

#### Result
Removed SRV targets no longer leave stale min-TTL state behind, while the shared delegate DNS cache is not cleared for unrelated users of the same hostname.