### PR TITLE
Make `UnsupportedContentEncodingException` public

### DIFF
--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UnsupportedContentEncodingException.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/UnsupportedContentEncodingException.java
@@ -20,7 +20,7 @@ import io.servicetalk.serializer.api.SerializationException;
 /**
  * Exception thrown when a payload was encoded with an unsupported encoder.
  */
-final class UnsupportedContentEncodingException extends SerializationException {
+public final class UnsupportedContentEncodingException extends SerializationException {
 
     private static final long serialVersionUID = 5645078707423180235L;
 


### PR DESCRIPTION
Motivation:

All other `SerializationException`(s) are public. Currently, users can not read its `encoding()` field because the class is pkg-private.

---
Wanted to make it a separate PR before #3531