### PR TITLE
utils-internal: add OS detection (isLinux, isOsx, normalizedOs)

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptingNettyHttpServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ConnectionAcceptingNettyHttpServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
-import static io.netty.util.internal.PlatformDependent.normalizedOs;
 import static io.servicetalk.client.api.LimitingConnectionFactoryFilter.withMax;
 import static io.servicetalk.concurrent.api.BlockingTestUtils.awaitIndefinitely;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
@@ -50,6 +49,7 @@ import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
 import static io.servicetalk.logging.api.LogLevel.TRACE;
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.CONNECT_TIMEOUT;
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.SO_BACKLOG;
+import static io.servicetalk.utils.internal.PlatformDependent.isLinux;
 import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ConnectionAcceptingNettyHttpServerTest extends AbstractNettyHttpServerTest {
 
-    private static final boolean IS_LINUX = "linux".equals(normalizedOs());
+    private static final boolean IS_LINUX = isLinux();
     // There is an off-by-one behavior difference between macOS & Linux.
     // Linux has a greater-than check
     // (see. https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/include/net/sock.h#L941)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/TcpFastOpenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2020-2021, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import static io.netty.util.internal.PlatformDependent.isOsx;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_1;
 import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
 import static io.servicetalk.http.netty.HttpProtocol.toConfigs;
@@ -46,6 +45,7 @@ import static io.servicetalk.transport.api.ServiceTalkSocketOptions.TCP_FASTOPEN
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.TCP_FASTOPEN_CONNECT;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.utils.internal.PlatformDependent.isOsx;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;

--- a/servicetalk-traffic-resilience-http/build.gradle
+++ b/servicetalk-traffic-resilience-http/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-test-resources")
-  testImplementation "io.netty:netty-common"
+  testRuntimeOnly "io.netty:netty-common"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-traffic-resilience-http/build.gradle
+++ b/servicetalk-traffic-resilience-http/build.gradle
@@ -43,7 +43,6 @@ dependencies {
   testImplementation project(":servicetalk-concurrent-test-internal")
   testImplementation project(":servicetalk-http-netty")
   testImplementation project(":servicetalk-test-resources")
-  testRuntimeOnly "io.netty:netty-common"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"

--- a/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
+++ b/servicetalk-traffic-resilience-http/src/test/java/io/servicetalk/traffic/resilience/http/TrafficResilienceHttpServiceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2024, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.netty.util.internal.PlatformDependent.normalizedOs;
 import static io.servicetalk.capacity.limiter.api.CapacityLimiters.fixedCapacity;
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -73,6 +72,7 @@ import static io.servicetalk.transport.api.ServiceTalkSocketOptions.CONNECT_TIME
 import static io.servicetalk.transport.api.ServiceTalkSocketOptions.SO_BACKLOG;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static io.servicetalk.utils.internal.PlatformDependent.isLinux;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -91,7 +91,7 @@ import static org.mockito.Mockito.when;
 
 class TrafficResilienceHttpServiceFilterTest {
 
-    private static final boolean IS_LINUX = "linux".equals(normalizedOs());
+    private static final boolean IS_LINUX = isLinux();
 
     // There is an off-by-one behavior difference between macOS & Linux.
     // Linux has a greater-than check

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NativeTransportUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NativeTransportUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2021, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.servicetalk.transport.netty.internal;
 
 import io.servicetalk.transport.api.DomainSocketAddress;
 import io.servicetalk.transport.api.FileDescriptorSocketAddress;
+import io.servicetalk.utils.internal.PlatformDependent;
 
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -26,7 +27,6 @@ import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.incubator.channel.uring.IOUring;
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
-import io.netty.util.internal.PlatformDependent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,8 +56,8 @@ final class NativeTransportUtils {
 
     static {
         final String os = PlatformDependent.normalizedOs();
-        IS_LINUX = "linux".equals(os);
-        IS_OSX_OR_BSD = "osx".equals(os) || os.contains("bsd");
+        IS_LINUX = PlatformDependent.isLinux();
+        IS_OSX_OR_BSD = PlatformDependent.isOsx() || os.contains("bsd");
         TRY_IO_URING = new AtomicBoolean(getBoolean(TRY_IO_URING_NAME));
 
         LOGGER.debug("-D{}: {}", REQUIRE_NATIVE_LIBS_NAME, REQUIRE_NATIVE_LIBS);

--- a/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/PlatformDependentNettyParityTest.java
+++ b/servicetalk-transport-netty-internal/src/test/java/io/servicetalk/transport/netty/internal/PlatformDependentNettyParityTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.netty.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.condition.OS.LINUX;
+import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+/**
+ * Ensures {@link io.servicetalk.utils.internal.PlatformDependent}'s OS detection stays in sync with Netty's
+ * normalization, so future Netty bumps that add or rename operating systems are caught.
+ */
+class PlatformDependentNettyParityTest {
+
+    @Test
+    void normalizedOsMatchesNetty() {
+        assertEquals(io.netty.util.internal.PlatformDependent.normalizedOs(),
+                io.servicetalk.utils.internal.PlatformDependent.normalizedOs());
+    }
+
+    @Test
+    void isOsxMatchesNetty() {
+        assertEquals(io.netty.util.internal.PlatformDependent.isOsx(),
+                io.servicetalk.utils.internal.PlatformDependent.isOsx());
+    }
+
+    @Test
+    @EnabledOnOs(LINUX)
+    void linuxHostExpectedCanonicalValues() {
+        assertEquals("linux", io.netty.util.internal.PlatformDependent.normalizedOs());
+        assertEquals("linux", io.servicetalk.utils.internal.PlatformDependent.normalizedOs());
+        assertTrue(io.servicetalk.utils.internal.PlatformDependent.isLinux());
+        assertFalse(io.servicetalk.utils.internal.PlatformDependent.isOsx());
+        assertFalse(io.netty.util.internal.PlatformDependent.isOsx());
+    }
+
+    @Test
+    @EnabledOnOs(MAC)
+    void macHostExpectedCanonicalValues() {
+        assertEquals("osx", io.netty.util.internal.PlatformDependent.normalizedOs());
+        assertEquals("osx", io.servicetalk.utils.internal.PlatformDependent.normalizedOs());
+        assertTrue(io.servicetalk.utils.internal.PlatformDependent.isOsx());
+        assertTrue(io.netty.util.internal.PlatformDependent.isOsx());
+        assertFalse(io.servicetalk.utils.internal.PlatformDependent.isLinux());
+    }
+
+    @Test
+    @EnabledOnOs(WINDOWS)
+    void windowsHostExpectedCanonicalValues() {
+        assertEquals("windows", io.netty.util.internal.PlatformDependent.normalizedOs());
+        assertEquals("windows", io.servicetalk.utils.internal.PlatformDependent.normalizedOs());
+        assertFalse(io.servicetalk.utils.internal.PlatformDependent.isLinux());
+        assertFalse(io.servicetalk.utils.internal.PlatformDependent.isOsx());
+    }
+}

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Locale;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -77,8 +78,48 @@ public final class PlatformDependent {
     private static final int MIN_ALLOWED_SPSC_CHUNK_SIZE = 8; // JCTools does not allow lower initial capacity.
     private static final int MIN_ALLOWED_MPSC_CHUNK_SIZE = 2; // JCTools does not allow lower initial capacity.
 
+    private static final String NORMALIZED_OS = normalizeOs(readOsName());
+    private static final boolean IS_LINUX = "linux".equals(NORMALIZED_OS);
+    private static final boolean IS_OSX = "osx".equals(NORMALIZED_OS);
+
+    static {
+        LOGGER.debug("Detected OS: {}", NORMALIZED_OS);
+    }
+
     private PlatformDependent() {
         // no instantiation
+    }
+
+    /**
+     * Returns {@code true} if the JVM is running on Linux. Determined from the {@code os.name} system property,
+     * equivalent to {@code "linux".equals(normalizedOs())}.
+     *
+     * @return {@code true} if the JVM is running on Linux.
+     */
+    public static boolean isLinux() {
+        return IS_LINUX;
+    }
+
+    /**
+     * Returns {@code true} if the JVM is running on macOS (a.k.a. OSX / Darwin). Determined from the {@code os.name}
+     * system property, equivalent to {@code "osx".equals(normalizedOs())}.
+     *
+     * @return {@code true} if the JVM is running on macOS.
+     */
+    public static boolean isOsx() {
+        return IS_OSX;
+    }
+
+    /**
+     * Returns the canonical name of the operating system the JVM is running on, derived from the {@code os.name}
+     * system property. Possible values include {@code "linux"}, {@code "osx"}, {@code "windows"}, {@code "freebsd"},
+     * {@code "openbsd"}, {@code "netbsd"}, {@code "sunos"}, {@code "aix"}, {@code "hpux"}, {@code "os400"}, or
+     * {@code "unknown"}.
+     *
+     * @return canonical normalized OS name.
+     */
+    public static String normalizedOs() {
+        return NORMALIZED_OS;
     }
 
     /**
@@ -269,6 +310,59 @@ public final class PlatformDependent {
      */
     public static <T> Queue<T> newUnboundedSpscQueue(final int initialCapacity) {
         return Queues.newUnboundedSpscQueue(initialCapacity);
+    }
+
+    private static String readOsName() {
+        try {
+            // Read through doPrivileged so OS detection still works under a SecurityManager that grants the
+            // permission to this code but not to the caller, matching Netty's SystemPropertyUtil behavior.
+            return AccessController.doPrivileged((PrivilegedAction<String>) () -> getProperty("os.name", ""));
+        } catch (SecurityException e) {
+            LOGGER.debug("Unable to read os.name system property; treating as unknown", e);
+            return "";
+        }
+    }
+
+    // Visible for testing.
+    static String normalizeOs(final String value) {
+        final String v = normalize(value);
+        if (v.startsWith("aix")) {
+            return "aix";
+        }
+        if (v.startsWith("hpux")) {
+            return "hpux";
+        }
+        // Avoid matching names such as "os4000" by checking the char after "os400" is not a digit.
+        if (v.startsWith("os400") && (v.length() <= 5 || !Character.isDigit(v.charAt(5)))) {
+            return "os400";
+        }
+        if (v.startsWith("linux")) {
+            return "linux";
+        }
+        if (v.startsWith("macosx") || v.startsWith("osx") || v.startsWith("darwin")) {
+            return "osx";
+        }
+        if (v.startsWith("freebsd")) {
+            return "freebsd";
+        }
+        if (v.startsWith("openbsd")) {
+            return "openbsd";
+        }
+        if (v.startsWith("netbsd")) {
+            return "netbsd";
+        }
+        if (v.startsWith("solaris") || v.startsWith("sunos")) {
+            return "sunos";
+        }
+        if (v.startsWith("windows")) {
+            return "windows";
+        }
+        return "unknown";
+    }
+
+    // Visible for testing.
+    static String normalize(final String value) {
+        return value.toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
     }
 
     private static final class Queues {

--- a/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/PlatformDependentTest.java
+++ b/servicetalk-utils-internal/src/test/java/io/servicetalk/utils/internal/PlatformDependentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2022, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,19 @@ package io.servicetalk.utils.internal;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 
 import static java.lang.Boolean.getBoolean;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.condition.OS.LINUX;
+import static org.junit.jupiter.api.condition.OS.MAC;
 
 class PlatformDependentTest {
 
@@ -39,5 +45,88 @@ class PlatformDependentTest {
         long allocated = PlatformDependent.allocateMemory(1);
         assertThat(allocated, is(Matchers.not(0)));
         PlatformDependent.freeMemory(allocated);
+    }
+
+    @Test
+    void linuxAndOsxAreMutuallyExclusive() {
+        assertFalse(PlatformDependent.isLinux() && PlatformDependent.isOsx());
+    }
+
+    @Test
+    void normalizedOsAgreesWithGetters() {
+        final String os = PlatformDependent.normalizedOs();
+        assertEquals("linux".equals(os), PlatformDependent.isLinux());
+        assertEquals("osx".equals(os), PlatformDependent.isOsx());
+    }
+
+    @Test
+    @EnabledOnOs(LINUX)
+    void linuxHostReportsLinux() {
+        assertTrue(PlatformDependent.isLinux());
+        assertFalse(PlatformDependent.isOsx());
+        assertEquals("linux", PlatformDependent.normalizedOs());
+    }
+
+    @Test
+    @EnabledOnOs(MAC)
+    void osxHostReportsOsx() {
+        assertTrue(PlatformDependent.isOsx());
+        assertFalse(PlatformDependent.isLinux());
+        assertEquals("osx", PlatformDependent.normalizedOs());
+    }
+
+    @Test
+    void normalizeOsCanonicalMapping() {
+        // Linux
+        assertNormalizesTo("linux", "Linux", "linux", "LINUX", "Linux 5.15");
+        // macOS — the real os.name on macOS hosts is "Mac OS X"; "Darwin"/"OSX"/"macosx" also map to "osx".
+        assertNormalizesTo("osx", "Mac OS X", "Darwin", "macosx", "OSX");
+        // Bare "Mac OS" (without trailing X) normalizes to "macos" which doesn't start with any recognized
+        // prefix and therefore returns "unknown" — matches Netty 4.1.x behavior. Locked in to catch any
+        // future predicate change that would silently start matching it.
+        assertNormalizesTo("unknown", "Mac OS");
+        // Windows: still mapped by normalizeOs, even though no isWindows() getter is exposed.
+        assertNormalizesTo("windows", "Windows 11", "Windows Server 2022");
+        // BSDs
+        assertNormalizesTo("freebsd", "FreeBSD 13");
+        assertNormalizesTo("openbsd", "OpenBSD");
+        assertNormalizesTo("netbsd", "NetBSD");
+        // Solaris / SunOS
+        assertNormalizesTo("sunos", "SunOS", "Solaris 11");
+        // Mainframes and legacy
+        assertNormalizesTo("aix", "AIX 7.2");
+        assertNormalizesTo("hpux", "HP-UX");
+        assertNormalizesTo("os400", "OS400");
+        // Unknown
+        assertNormalizesTo("unknown", "BeOS", "Plan9");
+    }
+
+    @Test
+    void normalizeOsEmptyInputIsUnknown() {
+        // readOsName() returns "" if reading the system property is denied; verify it normalizes safely.
+        assertEquals("unknown", PlatformDependent.normalizeOs(""));
+    }
+
+    @Test
+    void normalizeOsOs400DigitBoundary() {
+        // The 6th character must not be a digit, otherwise we'd accidentally bucket "os4000" as "os400".
+        assertEquals("os400", PlatformDependent.normalizeOs("OS400"));
+        assertEquals("unknown", PlatformDependent.normalizeOs("OS4000"));
+    }
+
+    @Test
+    void normalizeStripsAndLowercases() {
+        assertEquals("macosx", PlatformDependent.normalize("Mac OS X"));
+        assertEquals("hpux", PlatformDependent.normalize("HP-UX"));
+        assertEquals("windows10", PlatformDependent.normalize("Windows 10"));
+        assertEquals("", PlatformDependent.normalize(""));
+        assertEquals("freebsd13", PlatformDependent.normalize("Free_BSD/13"));
+    }
+
+    private static void assertNormalizesTo(final String expected, final String... inputs) {
+        for (final String input : inputs) {
+            assertEquals(expected, PlatformDependent.normalizeOs(input),
+                    () -> "normalizeOs(\"" + input + "\")");
+        }
     }
 }


### PR DESCRIPTION
#### Motivation
ServiceTalk has its own PlatformDependent class and so we should use it to detect the OS instead of falling back to Netty's.

#### Modifications
Adds OS detection to ServiceTalk's PlatformDependent, ported from io.netty.util.internal.PlatformDependent's.

Exposes isLinux(), isOsx(), and normalizedOs(); no isWindows() — ST has no Windows-specific branches. Migrates four call sites that previously reached into Netty's internal package, and adds a parity test in transport-netty-internal to catch silent drift on future Netty bumps.