### PR TITLE
loadbalancer: fix weighted P2C second-candidate selection

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/P2CSelector.java
@@ -241,16 +241,27 @@ final class P2CSelector<ResolvedAddress, C extends LoadBalancedConnection>
 
         @Override
         int secondEntry(Random random, int firstPick) {
-            int result;
-            int iteration = 0;
-            do {
-                result = pick(random);
-            } while (result == firstPick && iteration++ < maxEffort);
-            if (firstPick == result) {
-                LOGGER.debug("{}: failed to pick two unique indices after {} selection attempts",
-                        lbDescription(), maxEffort);
+            // With only two entries the distinct index is trivially the other one. Short-circuit to
+            // avoid the weighted retry loop below, which would otherwise waste draws colliding with
+            // firstPick (firstEntry stays weighted, so the weighted tie-break is unaffected).
+            if (aliases.length == 2) {
+                return firstPick == 0 ? 1 : 0;
             }
-            return 0;
+            // Try to draw a weight-respecting index distinct from firstPick. This is best-effort:
+            // with skewed weights the draw may keep landing on firstPick, so cap the attempts.
+            for (int i = 0; i < maxEffort; i++) {
+                final int result = pick(random);
+                if (result != firstPick) {
+                    return result;
+                }
+            }
+            // Weighted retries exhausted. Fall back to a uniform pick among the other indices so the
+            // two candidates are always distinct: P2C needs two different hosts to compare, and the
+            // caller may only examine this single pair (see the size == 2 case in p2c()).
+            LOGGER.debug("{}: failed to pick two unique indices via weighted selection after {} "
+                    + "attempts, falling back to uniform selection", lbDescription(), maxEffort);
+            final int result = random.nextInt(aliases.length - 1);
+            return result < firstPick ? result : result + 1;
         }
 
         @Override

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/P2CSelectorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/P2CSelectorTest.java
@@ -100,6 +100,61 @@ class P2CSelectorTest {
     }
 
     @Test
+    void weightedSelectorFallsBackToDistinctIndexWhenWeightedPicksCollide() throws Exception {
+        List<Host<String, TestLoadBalancedConnection>> hosts = generateHosts(3);
+        when(hosts.get(0).weight()).thenReturn(3.0);
+        when(hosts.get(1).weight()).thenReturn(1.0);
+        when(hosts.get(2).weight()).thenReturn(1.0);
+        when(hosts.get(0).score()).thenReturn(0);
+        when(hosts.get(1).score()).thenReturn(1); // host 1 has the better score, so it wins the pair
+        // firstEntry consumes one nextInt, then maxEffort colliding weighted picks, then one fallback.
+        int[] alwaysZero = new int[maxEffort + 2];
+        selector = new P2CSelector<>(hosts, "testResource", false, maxEffort, failOpen,
+                scriptedRandom(alwaysZero));
+        TestLoadBalancedConnection connection = selector.selectConnection(
+                PREDICATE, null, false).toFuture().get();
+        assertThat(connection.address(), equalTo(hosts.get(1).address()));
+    }
+
+    @Test
+    void twoHostWeightedSelectionIsWeightProportionalOnScoreTies() throws Exception {
+        List<Host<String, TestLoadBalancedConnection>> hosts = generateHosts(2);
+        when(hosts.get(0).weight()).thenReturn(3.0);
+        when(hosts.get(1).weight()).thenReturn(1.0);
+        init(hosts);
+        checkProbabilities(hosts);
+    }
+
+    @Test
+    void weightedSelectorComparesExactlyTheTwoDrawnCandidates() throws Exception {
+        // Unequal weights force the weighted alias-table path (equal weights bypass it) and every
+        // host gets a distinct score. A scripted Random drives firstEntry/secondEntry to chosen
+        // indices - returning 0.0 from nextDouble keeps pick() on the drawn index instead of its
+        // alias - so we can assert that for every ordered pair P2C compares exactly those two hosts
+        // and selects the better-scored one. A selector that pins the second candidate to a fixed
+        // index picks the wrong host for most pairs.
+        final int numHosts = 5;
+        List<Host<String, TestLoadBalancedConnection>> hosts = generateHosts(numHosts);
+        for (int i = 0; i < numHosts; i++) {
+            when(hosts.get(i).weight()).thenReturn(i + 1.0);
+            when(hosts.get(i).score()).thenReturn(i); // higher index == higher (better) score
+        }
+        for (int first = 0; first < numHosts; first++) {
+            for (int second = 0; second < numHosts; second++) {
+                if (first == second) {
+                    continue;
+                }
+                selector = new P2CSelector<>(hosts, "testResource", false, maxEffort, failOpen,
+                        scriptedRandom(first, second));
+                TestLoadBalancedConnection connection = selector.selectConnection(
+                        PREDICATE, null, false).toFuture().get();
+                assertThat("drawn pair (" + first + ", " + second + ")",
+                        connection.address(), equalTo(hosts.get(Math.max(first, second)).address()));
+            }
+        }
+    }
+
+    @Test
     void negativeWeightsTurnIntoUnweightedSelection() throws Exception {
         List<Host<String, TestLoadBalancedConnection>> hosts = SelectorTestHelpers.generateHosts(2);
         when(hosts.get(0).weight()).thenReturn(-1.0);
@@ -324,6 +379,27 @@ class P2CSelectorTest {
         Exception e = assertThrows(ExecutionException.class, () -> selector.selectConnection(
                 PREDICATE, null, false).toFuture().get());
         assertThat(e.getCause(), isA(NoActiveHostException.class));
+    }
+
+    // A Random that hands out a fixed sequence of nextInt() results to drive the two host picks.
+    private static Random scriptedRandom(int... nextInts) {
+        return new Random() {
+            private int index;
+
+            @Override
+            public int nextInt(int bound) {
+                return nextInts[index++] % bound;
+            }
+
+            @Override
+            public double nextDouble() {
+                // pick() follows a host's alias only when `nextDouble() > pp` (pp in [0, 1]), so 0.0
+                // never redirects: pick() collapses to nextInt(len) and the scripted indices win.
+                // This bypasses weight-biasing (covered by unequalWeightDistribution()); here we only
+                // assert which two candidates get compared.
+                return 0.0;
+            }
+        };
     }
 
     private void checkProbabilities(List<Host<String, TestLoadBalancedConnection>> hosts) throws Exception {


### PR DESCRIPTION
Motivation:

P2CSelector.AliasTableEntrySelector.secondEntry() returned 0 unconditionally
instead of the index it computed. In the weighted selection path this made
host index 0 always one of the two compared candidates, biasing selection
toward it and starving the rest.

Fixing that surfaces two further issues in the same weighted path:

- The weighted draw for the second candidate is best-effort and can still
  collide with the first, so P2C could end up comparing a host with itself.
  This is worst for exactly two hosts, where p2c() runs a single iteration
  and cannot resample.
- For two hosts the alias table adds no value: the pair is always {0, 1}, so
  the weighted draw wastes work retrying to avoid a collision.

This must be correct before p2c can become the default policy.

Modifications:

- secondEntry(): return the computed index instead of 0.
- Guarantee the second index differs from the first: attempt up to maxEffort
  weighted draws, then fall back to a uniform pick among the other indices so
  P2C always compares two distinct hosts.
- Short-circuit the two-host case to the other index. firstEntry stays
  weighted, so the weighted tie-break on equal scores is preserved.
- Correct the debug log to match the actual attempt count and describe the
  fallback.
- P2CSelectorTest: add coverage for exact candidate comparison across all
  pairs, the distinct-index fallback, and two-host weight-proportional
  selection on score ties.

Result:

Weighted P2C compares two distinct hosts drawn from the weighted distribution,
with no bias toward index 0 and no wasted work for the two-host case.
Two-host selection remains weight-proportional.

