### PR TITLE
loadbalancer: don't resurrect an EXPIRED host with a late connection

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultHost.java
@@ -660,7 +660,12 @@ final class DefaultHost<Addr, C extends LoadBalancedConnection> implements Host<
             for (int i = 0, j = 0; i < newSize; i++) {
                 newList.add(i == insertionIndex ? connection : connections.get(j++));
             }
-            return new ConnState(newList, State.ACTIVE, 0, null);
+            // Adding a connection means the host is reachable, so if it was ACTIVE or UNHEALTHY we (re)mark it
+            // ACTIVE and reset the failure counter. If the host was EXPIRED by service discovery we must preserve
+            // that state: a connection that completes after expiry (e.g. one that was in-flight when the EXPIRED
+            // event arrived) must not resurrect a host that service discovery asked us to drain.
+            final State nextState = state == State.ACTIVE || state == State.UNHEALTHY ? State.ACTIVE : state;
+            return new ConnState(newList, nextState, 0, null);
         }
 
         boolean isActive() {

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/DefaultHostTest.java
@@ -144,6 +144,22 @@ class DefaultHostTest {
     }
 
     @Test
+    void expiredHostNotResurrectedByLateConnection() throws Exception {
+        buildHost();
+        // Establish a connection so the host stays EXPIRED (draining) instead of closing immediately.
+        host.newConnection(any(), false, null).toFuture().get();
+        host.markExpired();
+        verify(mockHostObserver, times(1)).onHostMarkedExpired(1);
+        assertThat(host.canMakeNewConnections(), is(false));
+
+        // A connection that completes after expiry (e.g. one in-flight when the EXPIRED event arrived) must not
+        // resurrect the host back to ACTIVE.
+        host.newConnection(any(), false, null).toFuture().get();
+        assertThat(host.canMakeNewConnections(), is(false));
+        assertThat(host.onClose().toFuture().isDone(), is(false));
+    }
+
+    @Test
     void l4ConsecutiveFailuresAreDetected() throws Exception {
         TestLoadBalancedConnection testLoadBalancedConnection = TestLoadBalancedConnection.mockConnection(
                 DEFAULT_ADDRESS);


### PR DESCRIPTION
#### Motivation

When service discovery marks a host EXPIRED, the host must drain: it may serve requests on existing connections but must not accept new ones or be revived except by an explicit AVAILABLE event (markActiveIfNotClosed).

DefaultHost.ConnState.addNewConnection unconditionally returned a State.ACTIVE ConnState. A connection that was in-flight when the EXPIRED event arrived, and completes shortly after, is still added to the host via addConnection (which only rejects EXPIRED when the connection list is already empty). That add flipped the host EXPIRED -> ACTIVE, silently losing service discovery's drain intent: the host resumed selection and connection warming until the next SD event, which may never come.

The legacy RoundRobinLoadBalancer.Host.addConnection does not have this problem — it only re-marks the host ACTIVE when it was previously ACTIVE or UNHEALTHY and otherwise preserves the existing state.

#### Modifications

- DefaultHost.ConnState.addNewConnection now promotes to ACTIVE only from ACTIVE or UNHEALTHY (the intended revival-on-successful-connection path) and preserves the current state otherwise, so an EXPIRED host stays EXPIRED when a late connection is added.
- Add DefaultHostTest.expiredHostNotResurrectedByLateConnection covering the scenario.

#### Results

A connection completing after expiry no longer resurrects the host; canMakeNewConnections() stays false and the host continues to drain as service discovery intended. This affects any DefaultLoadBalancer user regardless of load balancing policy (P2C or round robin), since the host state machine is shared.