### PR TITLE
Add the unpack method to TransportObservers

### DIFF
--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/BiTransportObserver.java
@@ -38,6 +38,14 @@ final class BiTransportObserver implements TransportObserver {
         this.second = asSafeObserver(second);
     }
 
+    TransportObserver first() {
+        return first;
+    }
+
+    TransportObserver second() {
+        return second;
+    }
+
     @Override
     public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
         return new BiConnectionObserver(first.onNewConnection(localAddress, remoteAddress),

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/CatchAllTransportObserver.java
@@ -55,6 +55,10 @@ final class CatchAllTransportObserver implements TransportObserver {
         this.observer = requireNonNull(observer);
     }
 
+    TransportObserver observer() {
+        return observer;
+    }
+
     @Override
     public ConnectionObserver onNewConnection(@Nullable final Object localAddress, final Object remoteAddress) {
         return safeReport(() -> observer.onNewConnection(localAddress, remoteAddress), observer, "new connection",

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
@@ -97,54 +97,6 @@ public final class TransportObservers {
         return Collections.singletonList(observer);
     }
 
-    /*
-     * Correctness of unpack, by structural induction.
-     *
-     * The parameter is non-null by contract (this package is @ElementsAreNonnullByDefault), so the proof reasons only
-     * about non-null inputs.
-     *
-     * Structural forms. Every TransportObserver is exactly one of three "terms":
-     *   - LEAF   L          : any observer that is neither a BiTransportObserver nor a CatchAllTransportObserver
-     *                         (i.e. an observer supplied by the caller);
-     *   - CATCH  CatchAll(x): a CatchAllTransportObserver wrapping a term x (produced by asSafeObserver, and
-     *                         internally by combine via BiTransportObserver's constructor);
-     *   - BI     Bi(a, b)   : a BiTransportObserver over terms a = first(), b = second().
-     *
-     * Well-formedness lemma (relied on by the induction; guaranteed by this package, not merely assumed):
-     *   1. The three forms are pairwise disjoint. BiTransportObserver and CatchAllTransportObserver are distinct
-     *      package-private *final* classes, so no object is an instance of both and callers cannot subclass either to
-     *      blur the forms. Hence the if / else if / else below partitions all inputs, and the order of the instanceof
-     *      checks is immaterial to correctness.
-     *   2. The term reachable via first()/second()/observer() is a finite, acyclic tree. Both classes have *final*
-     *      fields assigned once, at construction, from already-constructed subterms; producing a cycle would require
-     *      mutating a final field or overriding first()/second(), both impossible for a final class with final state.
-     *      Therefore recursion on strict subterms is well founded and terminates.
-     *   3. No internal node is null. CatchAll's constructor calls requireNonNull, and every BI child passes through
-     *      asSafeObserver (which returns an existing BI/CATCH or wraps a non-null LEAF), so first()/second()/observer()
-     *      never yield null and every recursive call receives a non-null term.
-     *
-     * Specification. Define the intended result leaves(o) as the caller-supplied leaf observers, left to right:
-     *   leaves(L)           = [L]
-     *   leaves(CatchAll(x)) = leaves(x)           // the safe wrapper is transparent
-     *   leaves(Bi(a, b))    = leaves(a) ++ leaves(b)
-     *
-     * Claim. unpack(o, result) appends exactly leaves(o) to result, preserving order.
-     *
-     * Proof by structural induction on the term o (well founded by lemma 2).
-     *   Base case  (o = LEAF): by lemma 1 neither instanceof test matches, so the else branch appends o. That is
-     *                          [L] = leaves(o).
-     *   Step (o = Bi(a, b)):   by the induction hypothesis unpack(first(), result) appends leaves(a) and then
-     *                          unpack(second(), result) appends leaves(b); first precedes second, so result gains
-     *                          leaves(a) ++ leaves(b) = leaves(o). Subterms are non-null by lemma 3.
-     *   Step (o = CatchAll(x)):by the induction hypothesis unpack(observer(), result) appends leaves(x) = leaves(o).
-     *   In every case unpack(o, result) appends leaves(o). QED.
-     *
-     * Corollary (public method). If o is a LEAF, unpack(o) returns singletonList(o) = leaves(o); otherwise it seeds an
-     * empty list, invokes the helper (which appends leaves(o) by the claim), and returns it. Hence unpack(o) =
-     * leaves(o) for every non-null o, mirroring HttpLifecycleObservers.unpack. In particular combine(o1, ..., on)
-     * unpacks back to [o1, ..., on]: combine wraps each argument with asSafeObserver (adding CATCH nodes that leaves()
-     * sees through) and nests them in a left-leaning BI tree whose in-order leaf traversal is o1, ..., on.
-     */
     private static void unpack(final TransportObserver observer, final List<TransportObserver> result) {
         if (observer instanceof BiTransportObserver) {
             final BiTransportObserver bi = (BiTransportObserver) observer;

--- a/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
+++ b/servicetalk-transport-api/src/main/java/io/servicetalk/transport/api/TransportObservers.java
@@ -15,6 +15,10 @@
  */
 package io.servicetalk.transport.api;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -63,6 +67,95 @@ public final class TransportObservers {
                     bi = new BiTransportObserver(bi, other[i]);
                 }
                 return bi;
+        }
+    }
+
+    /**
+     * Unpacks a {@link TransportObserver} into the list of observers it aggregates.
+     * <p>
+     * If the provided {@code observer} was created using the {@link #combine(TransportObserver...) combine} method,
+     * this method returns the individual observers that were combined. Otherwise, it returns a singleton list
+     * containing the provided observer.
+     * <p>
+     * Only the observers produced by this class are unwrapped: the aggregating observer created by
+     * {@link #combine(TransportObserver...) combine} and the safe wrapper created by
+     * {@link #asSafeObserver(TransportObserver) asSafeObserver}. Any other {@link TransportObserver} &mdash; including
+     * a third-party implementation that internally wraps or aggregates other observers &mdash; is treated as opaque:
+     * wherever it occurs in the combined structure it appears as a single element of the returned list, and its
+     * contents are never unwrapped.
+     *
+     * @param observer {@link TransportObserver} to unpack
+     * @return a {@link List} of {@link TransportObserver}s
+     * @see #combine(TransportObserver...)
+     */
+    public static List<TransportObserver> unpack(final TransportObserver observer) {
+        if (observer instanceof BiTransportObserver || observer instanceof CatchAllTransportObserver) {
+            final List<TransportObserver> result = new ArrayList<>();
+            unpack(observer, result);
+            return Collections.unmodifiableList(result);
+        }
+        return Collections.singletonList(observer);
+    }
+
+    /*
+     * Correctness of unpack, by structural induction.
+     *
+     * The parameter is non-null by contract (this package is @ElementsAreNonnullByDefault), so the proof reasons only
+     * about non-null inputs.
+     *
+     * Structural forms. Every TransportObserver is exactly one of three "terms":
+     *   - LEAF   L          : any observer that is neither a BiTransportObserver nor a CatchAllTransportObserver
+     *                         (i.e. an observer supplied by the caller);
+     *   - CATCH  CatchAll(x): a CatchAllTransportObserver wrapping a term x (produced by asSafeObserver, and
+     *                         internally by combine via BiTransportObserver's constructor);
+     *   - BI     Bi(a, b)   : a BiTransportObserver over terms a = first(), b = second().
+     *
+     * Well-formedness lemma (relied on by the induction; guaranteed by this package, not merely assumed):
+     *   1. The three forms are pairwise disjoint. BiTransportObserver and CatchAllTransportObserver are distinct
+     *      package-private *final* classes, so no object is an instance of both and callers cannot subclass either to
+     *      blur the forms. Hence the if / else if / else below partitions all inputs, and the order of the instanceof
+     *      checks is immaterial to correctness.
+     *   2. The term reachable via first()/second()/observer() is a finite, acyclic tree. Both classes have *final*
+     *      fields assigned once, at construction, from already-constructed subterms; producing a cycle would require
+     *      mutating a final field or overriding first()/second(), both impossible for a final class with final state.
+     *      Therefore recursion on strict subterms is well founded and terminates.
+     *   3. No internal node is null. CatchAll's constructor calls requireNonNull, and every BI child passes through
+     *      asSafeObserver (which returns an existing BI/CATCH or wraps a non-null LEAF), so first()/second()/observer()
+     *      never yield null and every recursive call receives a non-null term.
+     *
+     * Specification. Define the intended result leaves(o) as the caller-supplied leaf observers, left to right:
+     *   leaves(L)           = [L]
+     *   leaves(CatchAll(x)) = leaves(x)           // the safe wrapper is transparent
+     *   leaves(Bi(a, b))    = leaves(a) ++ leaves(b)
+     *
+     * Claim. unpack(o, result) appends exactly leaves(o) to result, preserving order.
+     *
+     * Proof by structural induction on the term o (well founded by lemma 2).
+     *   Base case  (o = LEAF): by lemma 1 neither instanceof test matches, so the else branch appends o. That is
+     *                          [L] = leaves(o).
+     *   Step (o = Bi(a, b)):   by the induction hypothesis unpack(first(), result) appends leaves(a) and then
+     *                          unpack(second(), result) appends leaves(b); first precedes second, so result gains
+     *                          leaves(a) ++ leaves(b) = leaves(o). Subterms are non-null by lemma 3.
+     *   Step (o = CatchAll(x)):by the induction hypothesis unpack(observer(), result) appends leaves(x) = leaves(o).
+     *   In every case unpack(o, result) appends leaves(o). QED.
+     *
+     * Corollary (public method). If o is a LEAF, unpack(o) returns singletonList(o) = leaves(o); otherwise it seeds an
+     * empty list, invokes the helper (which appends leaves(o) by the claim), and returns it. Hence unpack(o) =
+     * leaves(o) for every non-null o, mirroring HttpLifecycleObservers.unpack. In particular combine(o1, ..., on)
+     * unpacks back to [o1, ..., on]: combine wraps each argument with asSafeObserver (adding CATCH nodes that leaves()
+     * sees through) and nests them in a left-leaning BI tree whose in-order leaf traversal is o1, ..., on.
+     */
+    private static void unpack(final TransportObserver observer, final List<TransportObserver> result) {
+        if (observer instanceof BiTransportObserver) {
+            final BiTransportObserver bi = (BiTransportObserver) observer;
+            unpack(bi.first(), result);
+            unpack(bi.second(), result);
+        } else if (observer instanceof CatchAllTransportObserver) {
+            // combine(...) wraps each combined observer with asSafeObserver(...), so unwrap to expose the original
+            // leaf observer that was provided by the user.
+            unpack(((CatchAllTransportObserver) observer).observer(), result);
+        } else {
+            result.add(observer);
         }
     }
 }

--- a/servicetalk-transport-api/src/test/java/io/servicetalk/transport/api/TransportObserversTest.java
+++ b/servicetalk-transport-api/src/test/java/io/servicetalk/transport/api/TransportObserversTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.transport.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.servicetalk.transport.api.TransportObservers.asSafeObserver;
+import static io.servicetalk.transport.api.TransportObservers.combine;
+import static io.servicetalk.transport.api.TransportObservers.unpack;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+
+class TransportObserversTest {
+
+    @Test
+    void unpackSingleObserver() {
+        TransportObserver observer = mock(TransportObserver.class);
+        List<TransportObserver> result = unpack(observer);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0), is(sameInstance(observer)));
+    }
+
+    @Test
+    void unpackSafeObserver() {
+        TransportObserver observer = mock(TransportObserver.class);
+        List<TransportObserver> result = unpack(asSafeObserver(observer));
+        assertThat(result, contains(sameInstance(observer)));
+    }
+
+    @Test
+    void unpackCombinedTwo() {
+        TransportObserver first = mock(TransportObserver.class);
+        TransportObserver second = mock(TransportObserver.class);
+        TransportObserver combined = combine(first, second);
+        List<TransportObserver> result = unpack(combined);
+        assertThat(result, contains(sameInstance(first), sameInstance(second)));
+    }
+
+    @Test
+    void unpackCombinedThree() {
+        TransportObserver first = mock(TransportObserver.class);
+        TransportObserver second = mock(TransportObserver.class);
+        TransportObserver third = mock(TransportObserver.class);
+        TransportObserver combined = combine(first, second, third);
+        List<TransportObserver> result = unpack(combined);
+        assertThat(result, contains(sameInstance(first), sameInstance(second), sameInstance(third)));
+    }
+
+    @Test
+    void unpackNestedCombined() {
+        TransportObserver a = mock(TransportObserver.class);
+        TransportObserver b = mock(TransportObserver.class);
+        TransportObserver c = mock(TransportObserver.class);
+        TransportObserver d = mock(TransportObserver.class);
+        TransportObserver inner = combine(a, b);
+        TransportObserver outer = combine(inner, combine(c, d));
+        List<TransportObserver> result = unpack(outer);
+        assertThat(result, contains(sameInstance(a), sameInstance(b), sameInstance(c), sameInstance(d)));
+    }
+}


### PR DESCRIPTION
The unpack method was recently added to `HttpLifecycleObservers` to enable detection of a specific observer implementation within the observer tree created by `HttpLifecycleObservers.combine`. This change adds similar functionality to `TransportObservers`.

#### Motivation
This is useful when integrating metric observers into ServiceTalk services.

#### Modifications
The `unpack` method was added to `TransportObservers`

#### Result
The `unpack` method returns a `List<TransportObserver>` of all found observers
decorated from the root observer.