### PR TITLE
loadbalancer: fix success-rate outlier detector when failure-percentage is also enabled

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
@@ -86,9 +86,9 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Finished failure percentage analysis. Of {} total hosts {} were already ejected by any algorithm " +
-                            "and {} were flagged as outliers by {}.",
-                    indicators.size(), alreadyEjectedHosts, flaggedCount, this.getClass().getSimpleName());
+            LOGGER.debug("Finished failure percentage analysis. Of {} total hosts {} were already ejected by any " +
+                            "algorithm and {} were flagged as outliers.",
+                    indicators.size(), alreadyEjectedHosts, flaggedCount);
         }
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
@@ -20,7 +20,7 @@ import io.servicetalk.client.api.LoadBalancedConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
+import java.util.List;
 
 import static io.servicetalk.loadbalancer.OutlierDetectorConfig.enforcing;
 
@@ -30,20 +30,21 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
     private static final Logger LOGGER = LoggerFactory.getLogger(FailurePercentageXdsOutlierDetectorAlgorithm.class);
 
     // We use a sentinel value to mark values as 'skipped' so we don't need to create a dynamically sized
-    // data structure for doubles which would require boxing.
+    // data structure for longs which would require boxing.
     private static final long NOT_EVALUATED = Long.MAX_VALUE;
 
     @Override
     public void detectOutliers(final OutlierDetectorConfig config,
-                               final Collection<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators) {
+                               final List<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators,
+                               final boolean[] outliers) {
         final long[] failurePercentages = new long[indicators.size()];
         int i = 0;
         int enoughVolumeHosts = 0;
-        int alreadyEjectedHosts = 0;
         for (XdsHealthIndicator<?, ?> indicator : indicators) {
             if (!indicator.isHealthy()) {
+                // Already-ejected hosts are excluded from analysis and left to the caller to keep ejected; we
+                // don't OR them into the verdict.
                 failurePercentages[i] = NOT_EVALUATED;
-                alreadyEjectedHosts++;
             } else {
                 long successes = indicator.getSuccesses();
                 long failures = indicator.getFailures();
@@ -54,7 +55,6 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
                 failurePercentages[i] = totalRequests == 0L ? 0 : failures * 100L / totalRequests;
             }
             i++;
-            indicator.resetCounters();
         }
 
         if (enoughVolumeHosts < config.failurePercentageMinimumHosts()) {
@@ -68,19 +68,18 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
         }
 
         final double failurePercentageThreshold = config.failurePercentageThreshold();
-        int ejectedCount = 0;
-        i = 0;
-        for (XdsHealthIndicator<?, ?> indicator : indicators) {
-            long failurePercentage = failurePercentages[i++];
-            if (indicator.updateOutlierStatus(config, failurePercentage == NOT_EVALUATED ||
-                    failurePercentage >= failurePercentageThreshold &&
-                            enforcing(config.enforcingFailurePercentage()))) {
-                ejectedCount++;
+        int flaggedCount = 0;
+        for (i = 0; i < failurePercentages.length; i++) {
+            long failurePercentage = failurePercentages[i];
+            if (failurePercentage != NOT_EVALUATED && failurePercentage >= failurePercentageThreshold &&
+                    enforcing(config.enforcingFailurePercentage())) {
+                outliers[i] = true;
+                flaggedCount++;
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Finished host ejection. of {} total hosts {} hosts were already " +
-                    "ejected and {} were newly ejected.", indicators.size(), alreadyEjectedHosts, ejectedCount);
+            LOGGER.debug("Finished failure percentage analysis. Of {} total hosts {} were flagged as outliers.",
+                    indicators.size(), flaggedCount);
         }
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
@@ -46,11 +46,13 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
         }
         int i = 0;
         int enoughVolumeHosts = 0;
+        int alreadyEjectedHosts = 0;
         for (XdsHealthIndicator<?, ?> indicator : indicators) {
             if (!indicator.isHealthy()) {
                 // Already-ejected hosts are excluded from analysis and left to the caller to keep ejected; we
                 // don't OR them into the verdict.
                 failurePercentages[i] = NOT_EVALUATED;
+                alreadyEjectedHosts++;
             } else {
                 long successes = indicator.getSuccesses();
                 long failures = indicator.getFailures();
@@ -84,8 +86,9 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Finished failure percentage analysis. Of {} total hosts {} were flagged as outliers.",
-                    indicators.size(), flaggedCount);
+            LOGGER.debug("Finished success rate analysis. Of {} total hosts {} were already ejected by any algorithm " +
+                            "and {} were flagged as outliers by {} algorithm.",
+                    indicators.size(), alreadyEjectedHosts, flaggedCount, this.getClass().getSimpleName());
         }
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
@@ -86,8 +86,8 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Finished success rate analysis. Of {} total hosts {} were already ejected by any algorithm " +
-                            "and {} were flagged as outliers by {} algorithm.",
+            LOGGER.debug("Finished failure percentage analysis. Of {} total hosts {} were already ejected by any algorithm " +
+                            "and {} were flagged as outliers by {}.",
                     indicators.size(), alreadyEjectedHosts, flaggedCount, this.getClass().getSimpleName());
         }
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
@@ -33,11 +33,17 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
     // data structure for longs which would require boxing.
     private static final long NOT_EVALUATED = Long.MAX_VALUE;
 
+    private long[] failurePercentages = new long[0];
+
     @Override
     public void detectOutliers(final OutlierDetectorConfig config,
                                final List<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators,
                                final boolean[] outliers) {
-        final long[] failurePercentages = new long[indicators.size()];
+        final int size = indicators.size();
+        // Because we always overwrite every element before accessing there is no need to zero the array on reuse.
+        if (failurePercentages.length != size) {
+            failurePercentages = new long[size];
+        }
         int i = 0;
         int enoughVolumeHosts = 0;
         for (XdsHealthIndicator<?, ?> indicator : indicators) {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
@@ -100,7 +100,7 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
         }
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Finished success rate analysis. Of {} total hosts {} were already ejected by any algorithm " +
-                            "and {} were flagged as outliers by {} algorithm.",
+                            "and {} were flagged as outliers by {}.",
                     indicators.size(), alreadyEjectedHosts, flaggedCount, this.getClass().getSimpleName());
         }
     }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
@@ -43,12 +43,18 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
     // data structure for doubles which would require boxing.
     private static final double NOT_EVALUATED = Double.MAX_VALUE;
 
+    private double[] successRates = new double[0];
+
     @Override
     public void detectOutliers(final OutlierDetectorConfig config,
                                final List<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators,
                                final boolean[] outliers) {
         LOGGER.debug("Started outlier detection.");
-        final double[] successRates = new double[indicators.size()];
+        final int size = indicators.size();
+        // Because we always overwrite every element before accessing there is no need to zero the array on reuse.
+        if (successRates.length != size) {
+            successRates = new double[size];
+        }
         int i = 0;
         int enoughVolumeHosts = 0;
         for (XdsHealthIndicator<?, ?> indicator : indicators) {

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
@@ -20,7 +20,7 @@ import io.servicetalk.client.api.LoadBalancedConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
+import java.util.List;
 
 import static io.servicetalk.loadbalancer.OutlierDetectorConfig.enforcing;
 
@@ -45,16 +45,17 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
 
     @Override
     public void detectOutliers(final OutlierDetectorConfig config,
-                               final Collection<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators) {
+                               final List<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators,
+                               final boolean[] outliers) {
         LOGGER.debug("Started outlier detection.");
         final double[] successRates = new double[indicators.size()];
         int i = 0;
         int enoughVolumeHosts = 0;
-        int alreadyEjectedHosts = 0;
         for (XdsHealthIndicator<?, ?> indicator : indicators) {
             if (!indicator.isHealthy()) {
+                // Already-ejected hosts are excluded from the statistical analysis and left to the caller to
+                // keep ejected; we don't OR them into the verdict.
                 successRates[i] = NOT_EVALUATED;
-                alreadyEjectedHosts++;
             } else {
                 long successes = indicator.getSuccesses();
                 long failures = indicator.getFailures();
@@ -65,13 +66,12 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
                 successRates[i] = totalRequests > 0 ? (double) successes / (totalRequests) : 1d;
             }
             i++;
-            indicator.resetCounters();
         }
 
         if (enoughVolumeHosts < config.successRateMinimumHosts()) {
             // not enough hosts with enough volume to do the analysis.
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Not enough hosts  with sufficient volume to perform ejection: " +
+                LOGGER.debug("Not enough hosts with sufficient volume to perform ejection: " +
                         "{} total hosts and {} had sufficient volume. Minimum {} required.",
                         indicators.size(), enoughVolumeHosts, config.successRateMinimumHosts());
             }
@@ -81,18 +81,18 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
         final double mean = mean(successRates);
         final double stdev = stdev(successRates, mean);
         final double requiredSuccessRate = mean - stdev * (config.successRateStdevFactor() / 1000d);
-        int ejectedCount = 0;
-        i = 0;
-        for (XdsHealthIndicator<?, ?> indicator : indicators) {
-            double successRate = successRates[i++];
-            if (indicator.updateOutlierStatus(config, successRate == NOT_EVALUATED ||
-                    successRate < requiredSuccessRate && enforcing(config.enforcingSuccessRate()))) {
-                ejectedCount++;
+        int flaggedCount = 0;
+        for (i = 0; i < successRates.length; i++) {
+            double successRate = successRates[i];
+            if (successRate != NOT_EVALUATED && successRate < requiredSuccessRate &&
+                    enforcing(config.enforcingSuccessRate())) {
+                outliers[i] = true;
+                flaggedCount++;
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Finished host ejection. of {} total hosts {} hosts were already " +
-                    "ejected and {} were newly ejected.", indicators.size(), alreadyEjectedHosts, ejectedCount);
+            LOGGER.debug("Finished success rate analysis. Of {} total hosts {} were flagged as outliers.",
+                    indicators.size(), flaggedCount);
         }
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
@@ -57,11 +57,13 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
         }
         int i = 0;
         int enoughVolumeHosts = 0;
+        int alreadyEjectedHosts = 0;
         for (XdsHealthIndicator<?, ?> indicator : indicators) {
             if (!indicator.isHealthy()) {
                 // Already-ejected hosts are excluded from the statistical analysis and left to the caller to
                 // keep ejected; we don't OR them into the verdict.
                 successRates[i] = NOT_EVALUATED;
+                alreadyEjectedHosts++;
             } else {
                 long successes = indicator.getSuccesses();
                 long failures = indicator.getFailures();
@@ -97,8 +99,9 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Finished success rate analysis. Of {} total hosts {} were flagged as outliers.",
-                    indicators.size(), flaggedCount);
+            LOGGER.debug("Finished success rate analysis. Of {} total hosts {} were already ejected by any algorithm " +
+                            "and {} were flagged as outliers by {} algorithm.",
+                    indicators.size(), alreadyEjectedHosts, flaggedCount, this.getClass().getSimpleName());
         }
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
@@ -100,8 +100,8 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
         }
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Finished success rate analysis. Of {} total hosts {} were already ejected by any algorithm " +
-                            "and {} were flagged as outliers by {}.",
-                    indicators.size(), alreadyEjectedHosts, flaggedCount, this.getClass().getSimpleName());
+                            "and {} were flagged as outliers.",
+                    indicators.size(), alreadyEjectedHosts, flaggedCount);
         }
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -212,6 +212,8 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
             // If we are evicted or just transitioned out of eviction we shouldn't be marked as an outlier this round.
             // Note that this differs from the envoy behavior. If we want to mimic it, then I think we need to just
             // fall through and maybe attempt to eject again.
+            // Note: we deliberately don't decrement `failureMultiplier` on this revival path because that lets the
+            //       multiplier grow if the host continues to be unhealthy in consecutive intervals.
             return false;
         } else if (isOutlier) {
             final boolean result = sequentialTryEject(config, OUTLIER_DETECTOR_CAUSE);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -197,13 +197,6 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
         }
     }
 
-    final void forceRevival() {
-        assert sequentialExecutor.isCurrentThreadDraining();
-        if (!cancelled && evictedUntilNanos != null) {
-            sequentialRevive();
-        }
-    }
-
     final boolean updateOutlierStatus(OutlierDetectorConfig config, boolean isOutlier) {
         assert sequentialExecutor.isCurrentThreadDraining();
         if (cancelled) {
@@ -213,12 +206,12 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
         Long evictedUntilNanos = this.evictedUntilNanos;
         if (evictedUntilNanos != null) {
             if (evictedUntilNanos <= currentTimeNanos()) {
+                LOGGER.info("{}-{}: Health indicator revived.", lbDescription, address);
                 sequentialRevive();
             }
             // If we are evicted or just transitioned out of eviction we shouldn't be marked as an outlier this round.
             // Note that this differs from the envoy behavior. If we want to mimic it, then I think we need to just
             // fall through and maybe attempt to eject again.
-            LOGGER.info("{}-{}: Health indicator revived.", lbDescription, address);
             return false;
         } else if (isOutlier) {
             final boolean result = sequentialTryEject(config, OUTLIER_DETECTOR_CAUSE);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -211,14 +210,24 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
         private void sequentialCheckOutliers() {
             assert sequentialExecutor.isCurrentThreadDraining();
 
+            // Snapshot the indicator set into a list so every algorithm and the verdict-application loop below
+            // observe the same hosts in the same order.
+            final List<XdsHealthIndicatorImpl> currentIndicators = new ArrayList<>(indicators);
+            final boolean[] outliers = new boolean[currentIndicators.size()];
             for (XdsOutlierDetectorAlgorithm<ResolvedAddress, C> outlierDetector : algorithms) {
-                outlierDetector.detectOutliers(config, indicators);
+                outlierDetector.detectOutliers(config, currentIndicators, outliers);
+            }
+
+            for (int i = 0; i < currentIndicators.size(); i++) {
+                XdsHealthIndicatorImpl indicator = currentIndicators.get(i);
+                indicator.updateOutlierStatus(config, outliers[i]);
+                indicator.resetCounters();
             }
             cancellable.nextCancellable(scheduleNextOutliersCheck(config));
 
             // Check to see if any of our health states changed from the previous scan and fire an event if they did.
             boolean emitChange = false;
-            for (XdsHealthIndicatorImpl indicator : indicators) {
+            for (XdsHealthIndicatorImpl indicator : currentIndicators) {
                 boolean currentlyIsHealthy = indicator.isHealthy();
                 if (indicator.lastObservedHealthy != currentlyIsHealthy) {
                     indicator.lastObservedHealthy = currentlyIsHealthy;
@@ -240,35 +249,6 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
         if (config.enforcingSuccessRate() > 0) {
             detectors.add(new SuccessRateXdsOutlierDetectorAlgorithm<>());
         }
-        // We need at least one failure detector so that we can decrement the failure multiplier on each interval.
-        if (detectors.isEmpty()) {
-            detectors.add(new AlwaysHealthyOutlierDetectorAlgorithm<>());
-        }
         return detectors;
-    }
-
-    private static final class AlwaysHealthyOutlierDetectorAlgorithm<ResolvedAddress, C extends LoadBalancedConnection>
-            implements XdsOutlierDetectorAlgorithm<ResolvedAddress, C> {
-
-        @Override
-        public void detectOutliers(final OutlierDetectorConfig config,
-                                   final Collection<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators) {
-            int unhealthy = 0;
-            for (XdsHealthIndicator<ResolvedAddress, C> indicator : indicators) {
-                // Hosts can still be marked unhealthy due to consecutive failures.
-                final boolean isHealthy = indicator.isHealthy();
-                if (isHealthy) {
-                    // If the indicator is healthy we need to mark it as health to make sure
-                    // we decrement the failure multiplier.
-                    indicator.updateOutlierStatus(config, false);
-                } else {
-                    unhealthy++;
-                }
-            }
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("NoopOutlierDetector found {} unhealthy instances out of a total of {}.",
-                        unhealthy, indicators.size());
-            }
-        }
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -186,6 +187,11 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
         private final SequentialCancellable cancellable;
         private final List<XdsOutlierDetectorAlgorithm<ResolvedAddress, C>> algorithms;
         private final OutlierDetectorConfig config;
+        // Reused across detection rounds to avoid per-interval garbage. Only accessed on the
+        // `sequentialExecutor` drain thread during a detection pass, and regrown only when the indicator set size
+        // changes.
+        private final List<XdsHealthIndicatorImpl> currentIndicators = new ArrayList<>();
+        private boolean[] outliers = new boolean[0];
 
         Kernel(final OutlierDetectorConfig config) {
             this.config = config;
@@ -210,15 +216,26 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
         private void sequentialCheckOutliers() {
             assert sequentialExecutor.isCurrentThreadDraining();
 
-            // Snapshot the indicator set into a list so every algorithm and the verdict-application loop below
-            // observe the same hosts in the same order.
-            final List<XdsHealthIndicatorImpl> currentIndicators = new ArrayList<>(indicators);
-            final boolean[] outliers = new boolean[currentIndicators.size()];
+            // Snapshot the indicator set so every algorithm and the verdict-application loop observe the same
+            // hosts in the same order. The snapshot list and `outliers` buffer are reused across rounds; we fill
+            // the list manually (rather than addAll) to avoid the intermediate array it would allocate.
+            currentIndicators.clear();
+            for (XdsHealthIndicatorImpl indicator : indicators) {
+                currentIndicators.add(indicator);
+            }
+            final int size = currentIndicators.size();
+            boolean[] outliers = this.outliers;
+            if (outliers.length != size) {
+                outliers = this.outliers = new boolean[size];
+            } else {
+                Arrays.fill(outliers, false);
+            }
+
             for (XdsOutlierDetectorAlgorithm<ResolvedAddress, C> outlierDetector : algorithms) {
                 outlierDetector.detectOutliers(config, currentIndicators, outliers);
             }
 
-            for (int i = 0; i < currentIndicators.size(); i++) {
+            for (int i = 0; i < size; i++) {
                 XdsHealthIndicatorImpl indicator = currentIndicators.get(i);
                 indicator.updateOutlierStatus(config, outliers[i]);
                 indicator.resetCounters();
@@ -227,7 +244,8 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
 
             // Check to see if any of our health states changed from the previous scan and fire an event if they did.
             boolean emitChange = false;
-            for (XdsHealthIndicatorImpl indicator : currentIndicators) {
+            for (int i = 0; i < size; i++) {
+                XdsHealthIndicatorImpl indicator = currentIndicators.get(i);
                 boolean currentlyIsHealthy = indicator.isHealthy();
                 if (indicator.lastObservedHealthy != currentlyIsHealthy) {
                     indicator.lastObservedHealthy = currentlyIsHealthy;

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -235,23 +235,20 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
                 outlierDetector.detectOutliers(config, currentIndicators, outliers);
             }
 
+            boolean emitChange = false;
             for (int i = 0; i < size; i++) {
                 XdsHealthIndicatorImpl indicator = currentIndicators.get(i);
                 indicator.updateOutlierStatus(config, outliers[i]);
                 indicator.resetCounters();
-            }
-            cancellable.nextCancellable(scheduleNextOutliersCheck(config));
 
-            // Check to see if any of our health states changed from the previous scan and fire an event if they did.
-            boolean emitChange = false;
-            for (int i = 0; i < size; i++) {
-                XdsHealthIndicatorImpl indicator = currentIndicators.get(i);
+                // Check to see if any of our health states changed from the previous scan
                 boolean currentlyIsHealthy = indicator.isHealthy();
                 if (indicator.lastObservedHealthy != currentlyIsHealthy) {
                     indicator.lastObservedHealthy = currentlyIsHealthy;
                     emitChange = true;
                 }
             }
+            cancellable.nextCancellable(scheduleNextOutliersCheck(config));
             if (emitChange) {
                 LOGGER.debug("Health status change observed. Emitting event.");
                 healthStatusChangeProcessor.onNext(null);

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithm.java
@@ -17,19 +17,33 @@ package io.servicetalk.loadbalancer;
 
 import io.servicetalk.client.api.LoadBalancedConnection;
 
-import java.util.Collection;
+import java.util.List;
 
 /**
- * Logic that can detect outliers and attempts to mark them as an outlier so that the load balancer
- * can try to route traffic to more healthy hosts.
+ * Logic that identifies outlier hosts based on the request stats collected since the last detection round.
+ * <p>
+ * Multiple algorithms can be active simultaneously (e.g. success-rate and failure-percentage). To match the XDS
+ * model where every dimension is evaluated against the same accumulated dataset, algorithms are pure: they only read
+ * the current stats and mark outliers. They must not mutate host state, reset the stats counters, or eject hosts. The
+ * caller ({@link XdsOutlierDetector}) collects all algorithms' verdicts, applies the combined result to each host
+ * exactly once per round, and resets the counters afterwards.
  */
 @FunctionalInterface
 interface XdsOutlierDetectorAlgorithm<ResolvedAddress, C extends LoadBalancedConnection> {
     /**
-     * Analyze and potentially eject outlier hosts.
+     * Analyze the current stats and mark outlier hosts.
+     * <p>
+     * Implementations read stats from {@code indicators} but must not reset them or change host status. For each host
+     * this algorithm considers an outlier, set the corresponding entry in {@code outliers} to {@code true}. Entries
+     * must only ever be set to {@code true} (never back to {@code false}) because verdicts from all active algorithms
+     * are combined via logical OR. Hosts that are already unhealthy are handled by the caller and should be left out
+     * of the verdict (but may be excluded from statistical analysis as appropriate).
      * @param config the current {@link OutlierDetectorConfig} to use.
-     * @param indicators an ordered list of {@link HealthIndicator} instances to collect stats from.
+     * @param indicators an ordered list of {@link XdsHealthIndicator} instances to collect stats from.
+     * @param outliers a mutable array, indexed in the same order as {@code indicators}, into which this algorithm ORs
+     *                 its outlier verdict.
      */
     void detectOutliers(OutlierDetectorConfig config,
-                        Collection<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators);
+                        List<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators,
+                        boolean[] outliers);
 }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithmTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsOutlierDetectorAlgorithmTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -134,6 +135,98 @@ class XdsOutlierDetectorAlgorithmTest {
         assertTrue(indicator1.isHealthy());
     }
 
+    @Test
+    void successRateDetectorStillEjectsWhenFailurePercentageDetectorIsEnabled() {
+        // Both detectors are enabled. The outlier host has a poor success rate (0.2) but a failure percentage (80%)
+        // below the 85% failure-percentage threshold, so only the success-rate detector can catch it. This guards
+        // against the failure-percentage detector consuming/resetting the shared stats before success rate runs.
+        config = withAllEnforcing()
+                .enforcingConsecutive5xx(0)
+                .maxEjectionPercentage(100)
+                .failureDetectorInterval(Duration.ofSeconds(5), ZERO)
+                .build();
+        outlierDetector = buildOutlierDetector();
+
+        List<HealthIndicator<String, TestLoadBalancedConnection>> indicators = new ArrayList<>(10);
+        for (int i = 0; i < 10; i++) {
+            indicators.add(outlierDetector.newHealthIndicator("address-" + i, observer()));
+        }
+        // 9 hosts with a perfect success rate.
+        for (int i = 0; i < 9; i++) {
+            record(indicators.get(i), 100, 0);
+        }
+        // 1 outlier: 20% success rate, 80% failure percentage (below the 85% failure-percentage threshold).
+        HealthIndicator<String, TestLoadBalancedConnection> outlier = indicators.get(9);
+        record(outlier, 20, 80);
+
+        for (HealthIndicator<String, TestLoadBalancedConnection> indicator : indicators) {
+            assertTrue(indicator.isHealthy());
+        }
+
+        // Trigger an outlier-detection round.
+        testExecutor.advanceTimeBy(config.failureDetectorInterval().toNanos(), TimeUnit.NANOSECONDS);
+
+        assertFalse(outlier.isHealthy(), "success-rate outlier should have been ejected");
+        for (int i = 0; i < 9; i++) {
+            assertTrue(indicators.get(i).isHealthy(), "healthy host should not be ejected");
+        }
+        assertThat(outlierDetector.ejectedHostCount(), equalTo(1));
+    }
+
+    @Test
+    void failurePercentageDetectorStillEjectsWhenSuccessRateDetectorIsEnabled() {
+        config = withAllEnforcing()
+                .enforcingConsecutive5xx(0)
+                .maxEjectionPercentage(100)
+                .failureDetectorInterval(Duration.ofSeconds(5), ZERO)
+                .build();
+        outlierDetector = buildOutlierDetector();
+
+        List<HealthIndicator<String, TestLoadBalancedConnection>> indicators = new ArrayList<>(10);
+        for (int i = 0; i < 10; i++) {
+            HealthIndicator<String, TestLoadBalancedConnection> indicator =
+                    outlierDetector.newHealthIndicator("address-" + i, observer());
+            indicators.add(indicator);
+            int successes = (i + 1) * 10;
+            record(indicator, successes, 100 - successes);
+        }
+
+        testExecutor.advanceTimeBy(config.failureDetectorInterval().toNanos(), TimeUnit.NANOSECONDS);
+
+        // Only address-0 (10% success / 90% failure) crosses the failure-percentage threshold.
+        assertFalse(indicators.get(0).isHealthy(), "failure-percentage outlier should have been ejected");
+        for (int i = 1; i < 10; i++) {
+            assertTrue(indicators.get(i).isHealthy(), "host below failure-percentage threshold should stay healthy");
+        }
+        assertThat(outlierDetector.ejectedHostCount(), equalTo(1));
+    }
+
+    @Test
+    void failureMultiplierDecrementsWhenDetectorsEnabledButVolumeInsufficient() {
+        config = withAllEnforcing().maxEjectionPercentage(100).build();
+        outlierDetector = buildOutlierDetector();
+
+        HealthIndicator<String, TestLoadBalancedConnection> indicator1 =
+                outlierDetector.newHealthIndicator("address-1", observer());
+        eject(indicator1);
+        assertFalse(indicator1.isHealthy());
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
+        assertTrue(indicator1.isHealthy());
+        eject(indicator1);
+        assertFalse(indicator1.isHealthy());
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 2 - 1, TimeUnit.NANOSECONDS);
+        assertFalse(indicator1.isHealthy());
+        testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
+        assertTrue(indicator1.isHealthy());
+
+        // now let two periods elapse so our failure multiplier will get decremented.
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
+        eject(indicator1);
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
+        assertTrue(indicator1.isHealthy());
+    }
+
     private void testEjectPercentage(int maxEjectPercentage) {
         config = withAllEnforcing().maxEjectionPercentage(maxEjectPercentage).build();
         outlierDetector = buildOutlierDetector();
@@ -149,6 +242,16 @@ class XdsOutlierDetectorAlgorithmTest {
         int expectedFailed = max(1, maxEjectPercentage * healthIndicators.size() / 100);
         assertThat(healthIndicators.stream()
                 .filter(indicator -> !indicator.isHealthy()).collect(Collectors.toList()), hasSize(expectedFailed));
+    }
+
+    private void record(HealthIndicator<String, TestLoadBalancedConnection> indicator, int successes, int failures) {
+        for (int i = 0; i < successes; i++) {
+            indicator.onRequestSuccess(indicator.beforeRequestStart());
+        }
+        for (int i = 0; i < failures; i++) {
+            indicator.onRequestError(indicator.beforeRequestStart(),
+                    RequestTracker.ErrorClass.EXT_ORIGIN_REQUEST_FAILED);
+        }
     }
 
     private void eject(HealthIndicator<String, TestLoadBalancedConnection> indicator) {


### PR DESCRIPTION
#### Motivation

XdsOutlierDetector runs each enabled outlier-detection algorithm over the same
health indicators back-to-back, and each algorithm reset the success/failure
counters within its own pass. With both detectors enabled, the first to run
(failure-percentage) zeroed the counters before success-rate read them, so
success-rate saw all zeros every interval and never ejected — silently dead.
Each algorithm also called updateOutlierStatus per host, decaying the failure
multiplier once per enabled detector instead of once per interval.

#### Modifications

- Make XdsOutlierDetectorAlgorithm a pure scorer: it reads stats and ORs its
  verdict into a shared boolean[], no longer resetting counters or changing host
  status.
- XdsOutlierDetector.Kernel now snapshots the indicators once, runs every
  algorithm against the same stats, then applies the combined verdict and resets
  each host exactly once per interval.
- Remove AlwaysHealthyOutlierDetectorAlgorithm and the empty-list fallback; the
  Kernel decrements the multiplier once per host per interval regardless.
- Add regression tests for both detector orderings and for the multiplier decay.

#### Results

Success-rate works again when failure-percentage is enabled, and the multiplier
decays once per interval. Also fixes a latent bug where clusters below the
minimum-host / request-volume thresholds hit an early return that skipped the
decrement entirely, ratcheting ejection times upward without bound.

