### PR TITLE
DnsServiceDiscovererObservers: add `combine` and `unpack` methods

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/BiDnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/BiDnsServiceDiscovererObserver.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsDiscoveryObserver;
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsResolutionObserver;
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.ResolutionResult;
+
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObservers.asSafeObserver;
+
+final class BiDnsServiceDiscovererObserver implements DnsServiceDiscovererObserver {
+
+    private final DnsServiceDiscovererObserver first;
+    private final DnsServiceDiscovererObserver second;
+
+    BiDnsServiceDiscovererObserver(final DnsServiceDiscovererObserver first,
+                                   final DnsServiceDiscovererObserver second) {
+        this.first = asSafeObserver(first);
+        this.second = asSafeObserver(second);
+    }
+
+    DnsServiceDiscovererObserver first() {
+        return first;
+    }
+
+    DnsServiceDiscovererObserver second() {
+        return second;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public DnsDiscoveryObserver onNewDiscovery(final String name) {
+        return new BiDnsDiscoveryObserver(first.onNewDiscovery(name), second.onNewDiscovery(name));
+    }
+
+    @Override
+    public DnsDiscoveryObserver onNewDiscovery(final String serviceDiscovererId, final String name) {
+        return new BiDnsDiscoveryObserver(first.onNewDiscovery(serviceDiscovererId, name),
+                second.onNewDiscovery(serviceDiscovererId, name));
+    }
+
+    private static final class BiDnsDiscoveryObserver implements DnsDiscoveryObserver {
+
+        private final DnsDiscoveryObserver first;
+        private final DnsDiscoveryObserver second;
+
+        private BiDnsDiscoveryObserver(final DnsDiscoveryObserver first, final DnsDiscoveryObserver second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public DnsResolutionObserver onNewResolution(final String name) {
+            return new BiDnsResolutionObserver(first.onNewResolution(name), second.onNewResolution(name));
+        }
+
+        @Override
+        public void discoveryCancelled() {
+            first.discoveryCancelled();
+            second.discoveryCancelled();
+        }
+
+        @Override
+        public void discoveryFailed(final Throwable cause) {
+            first.discoveryFailed(cause);
+            second.discoveryFailed(cause);
+        }
+    }
+
+    private static final class BiDnsResolutionObserver implements DnsResolutionObserver {
+
+        private final DnsResolutionObserver first;
+        private final DnsResolutionObserver second;
+
+        private BiDnsResolutionObserver(final DnsResolutionObserver first, final DnsResolutionObserver second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public void resolutionFailed(final Throwable cause) {
+            first.resolutionFailed(cause);
+            second.resolutionFailed(cause);
+        }
+
+        @Override
+        public void resolutionCompleted(final ResolutionResult result) {
+            first.resolutionCompleted(result);
+            second.resolutionCompleted(result);
+        }
+    }
+}

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/CatchAllDnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/CatchAllDnsServiceDiscovererObserver.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsDiscoveryObserver;
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsResolutionObserver;
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.ResolutionResult;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link DnsServiceDiscovererObserver} wrapper that catches and logs all exceptions.
+ */
+final class CatchAllDnsServiceDiscovererObserver implements DnsServiceDiscovererObserver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CatchAllDnsServiceDiscovererObserver.class);
+
+    private final DnsServiceDiscovererObserver observer;
+
+    CatchAllDnsServiceDiscovererObserver(final DnsServiceDiscovererObserver observer) {
+        this.observer = requireNonNull(observer);
+    }
+
+    DnsServiceDiscovererObserver observer() {
+        return observer;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public DnsDiscoveryObserver onNewDiscovery(final String name) {
+        return safeReport(() -> observer.onNewDiscovery(name), observer, "new discovery",
+                CatchAllDnsDiscoveryObserver::new, NoopDnsDiscoveryObserver.INSTANCE);
+    }
+
+    @Override
+    public DnsDiscoveryObserver onNewDiscovery(final String serviceDiscovererId, final String name) {
+        return safeReport(() -> observer.onNewDiscovery(serviceDiscovererId, name), observer, "new discovery",
+                CatchAllDnsDiscoveryObserver::new, NoopDnsDiscoveryObserver.INSTANCE);
+    }
+
+    private static final class CatchAllDnsDiscoveryObserver implements DnsDiscoveryObserver {
+
+        private final DnsDiscoveryObserver observer;
+
+        private CatchAllDnsDiscoveryObserver(final DnsDiscoveryObserver observer) {
+            this.observer = observer;
+        }
+
+        @Override
+        public DnsResolutionObserver onNewResolution(final String name) {
+            return safeReport(() -> observer.onNewResolution(name), observer, "new resolution",
+                    CatchAllDnsResolutionObserver::new, NoopDnsResolutionObserver.INSTANCE);
+        }
+
+        @Override
+        public void discoveryCancelled() {
+            safeReport(observer::discoveryCancelled, observer, "discovery cancelled");
+        }
+
+        @Override
+        public void discoveryFailed(final Throwable cause) {
+            safeReport(() -> observer.discoveryFailed(cause), observer, "discovery failed", cause);
+        }
+    }
+
+    private static final class CatchAllDnsResolutionObserver implements DnsResolutionObserver {
+
+        private final DnsResolutionObserver observer;
+
+        private CatchAllDnsResolutionObserver(final DnsResolutionObserver observer) {
+            this.observer = observer;
+        }
+
+        @Override
+        public void resolutionFailed(final Throwable cause) {
+            safeReport(() -> observer.resolutionFailed(cause), observer, "resolution failed", cause);
+        }
+
+        @Override
+        public void resolutionCompleted(final ResolutionResult result) {
+            safeReport(() -> observer.resolutionCompleted(result), observer, "resolution completed");
+        }
+    }
+
+    private static final class NoopDnsDiscoveryObserver implements DnsDiscoveryObserver {
+
+        static final DnsDiscoveryObserver INSTANCE = new NoopDnsDiscoveryObserver();
+
+        private NoopDnsDiscoveryObserver() {
+            // Singleton
+        }
+
+        @Override
+        public DnsResolutionObserver onNewResolution(final String name) {
+            return NoopDnsResolutionObserver.INSTANCE;
+        }
+
+        @Override
+        public void discoveryCancelled() {
+            // noop
+        }
+
+        @Override
+        public void discoveryFailed(final Throwable cause) {
+            // noop
+        }
+    }
+
+    private static final class NoopDnsResolutionObserver implements DnsResolutionObserver {
+
+        static final DnsResolutionObserver INSTANCE = new NoopDnsResolutionObserver();
+
+        private NoopDnsResolutionObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void resolutionFailed(final Throwable cause) {
+            // noop
+        }
+
+        @Override
+        public void resolutionCompleted(final ResolutionResult result) {
+            // noop
+        }
+    }
+
+    private static <T> T safeReport(final Supplier<T> supplier, final Object observer, final String eventName,
+                                    final UnaryOperator<T> catchAllWrapper, final T defaultValue) {
+        try {
+            return catchAllWrapper.apply(requireNonNull(supplier.get()));
+        } catch (Throwable unexpected) {
+            LOGGER.warn("Unexpected exception from {} while reporting a {} event", observer, eventName, unexpected);
+            return defaultValue;
+        }
+    }
+
+    private static void safeReport(final Runnable runnable, final Object observer, final String eventName) {
+        try {
+            runnable.run();
+        } catch (Throwable unexpected) {
+            LOGGER.warn("Unexpected exception from {} while reporting a {} event", observer, eventName, unexpected);
+        }
+    }
+
+    private static void safeReport(final Runnable runnable, final Object observer, final String eventName,
+                                   final Throwable original) {
+        try {
+            runnable.run();
+        } catch (Throwable unexpected) {
+            addSuppressed(unexpected, original);
+            LOGGER.warn("Unexpected exception from {} while reporting a {} event", observer, eventName, unexpected);
+        }
+    }
+}

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObservers.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObservers.java
@@ -38,7 +38,7 @@ public final class DnsServiceDiscovererObservers {
      * @return a safe version of the passed {@link DnsServiceDiscovererObserver} that catches and logs all exceptions,
      * but does not rethrow them.
      */
-    public static DnsServiceDiscovererObserver asSafeObserver(final DnsServiceDiscovererObserver observer) {
+    static DnsServiceDiscovererObserver asSafeObserver(final DnsServiceDiscovererObserver observer) {
         if (observer instanceof CatchAllDnsServiceDiscovererObserver) {
             return observer;
         }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObservers.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObservers.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A factory to create different {@link DnsServiceDiscovererObserver}s.
+ */
+public final class DnsServiceDiscovererObservers {
+
+    private DnsServiceDiscovererObservers() {
+        // No instances.
+    }
+
+    /**
+     * Converts passed {@link DnsServiceDiscovererObserver} to a safe version that catches and logs all exceptions, but
+     * does not rethrow them.
+     *
+     * @param observer {@link DnsServiceDiscovererObserver} to convert
+     * @return a safe version of the passed {@link DnsServiceDiscovererObserver} that catches and logs all exceptions,
+     * but does not rethrow them.
+     */
+    public static DnsServiceDiscovererObserver asSafeObserver(final DnsServiceDiscovererObserver observer) {
+        if (observer instanceof CatchAllDnsServiceDiscovererObserver) {
+            return observer;
+        }
+        if (observer instanceof BiDnsServiceDiscovererObserver) {
+            // BiDnsServiceDiscovererObserver is always safe
+            return observer;
+        }
+        return new CatchAllDnsServiceDiscovererObserver(observer);
+    }
+
+    /**
+     * Combines multiple {@link DnsServiceDiscovererObserver}s into a single {@link DnsServiceDiscovererObserver}.
+     * <p>
+     * When more than one observer is provided, the returned observer fans out every event to all combined observers
+     * and is exception-safe: each combined observer is wrapped with
+     * {@link #asSafeObserver(DnsServiceDiscovererObserver)}, so an exception thrown by one observer is caught and
+     * logged rather than rethrown, and never prevents the remaining observers from being notified. When a single
+     * observer is provided it is returned as-is, without this safety wrapping.
+     *
+     * @param other {@link DnsServiceDiscovererObserver}s to combine
+     * @return a {@link DnsServiceDiscovererObserver} that delegates all invocations to the provided
+     * {@link DnsServiceDiscovererObserver}s
+     * @see #asSafeObserver(DnsServiceDiscovererObserver)
+     * @see #unpack(DnsServiceDiscovererObserver)
+     */
+    public static DnsServiceDiscovererObserver combine(final DnsServiceDiscovererObserver... other) {
+        switch (other.length) {
+            case 0:
+                throw new IllegalArgumentException("At least one DnsServiceDiscovererObserver is required to combine");
+            case 1:
+                return requireNonNull(other[0]);
+            default:
+                BiDnsServiceDiscovererObserver bi = new BiDnsServiceDiscovererObserver(other[0], other[1]);
+                for (int i = 2; i < other.length; i++) {
+                    bi = new BiDnsServiceDiscovererObserver(bi, other[i]);
+                }
+                return bi;
+        }
+    }
+
+    /**
+     * Unpacks a {@link DnsServiceDiscovererObserver} into the list of observers it aggregates.
+     * <p>
+     * If the provided {@code observer} was created using the {@link #combine(DnsServiceDiscovererObserver...) combine}
+     * method, this method returns the individual observers that were combined. Otherwise, it returns a singleton list
+     * containing the provided observer.
+     * <p>
+     * Only the observers produced by this class are unwrapped: the aggregating observer created by
+     * {@link #combine(DnsServiceDiscovererObserver...) combine} and the safe wrapper created by
+     * {@link #asSafeObserver(DnsServiceDiscovererObserver) asSafeObserver}. Any other
+     * {@link DnsServiceDiscovererObserver} &mdash; including a third-party implementation that internally wraps or
+     * aggregates other observers &mdash; is treated as opaque: wherever it occurs in the combined structure it appears
+     * as a single element of the returned list, and its contents are never unwrapped.
+     *
+     * @param observer {@link DnsServiceDiscovererObserver} to unpack
+     * @return a {@link List} of {@link DnsServiceDiscovererObserver}s
+     * @see #combine(DnsServiceDiscovererObserver...)
+     */
+    public static List<DnsServiceDiscovererObserver> unpack(final DnsServiceDiscovererObserver observer) {
+        if (observer instanceof BiDnsServiceDiscovererObserver ||
+                observer instanceof CatchAllDnsServiceDiscovererObserver) {
+            final List<DnsServiceDiscovererObserver> result = new ArrayList<>();
+            unpack(observer, result);
+            return Collections.unmodifiableList(result);
+        }
+        return Collections.singletonList(observer);
+    }
+
+    private static void unpack(final DnsServiceDiscovererObserver observer,
+                               final List<DnsServiceDiscovererObserver> result) {
+        if (observer instanceof BiDnsServiceDiscovererObserver) {
+            final BiDnsServiceDiscovererObserver bi = (BiDnsServiceDiscovererObserver) observer;
+            unpack(bi.first(), result);
+            unpack(bi.second(), result);
+        } else if (observer instanceof CatchAllDnsServiceDiscovererObserver) {
+            // combine(...) wraps each combined observer with asSafeObserver(...), so unwrap to expose the original
+            // leaf observer that was provided by the user.
+            unpack(((CatchAllDnsServiceDiscovererObserver) observer).observer(), result);
+        } else {
+            result.add(observer);
+        }
+    }
+}

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserversTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserversTest.java
@@ -303,7 +303,7 @@ class DnsServiceDiscovererObserversTest {
         // one of our types it must stay a single opaque leaf: unpack must not descend into it.
         DnsServiceDiscovererObserver aggregated = combine(mock(DnsServiceDiscovererObserver.class),
                 mock(DnsServiceDiscovererObserver.class));
-        DnsServiceDiscovererObserver thirdParty = name -> aggregated.onNewDiscovery(name);
+        DnsServiceDiscovererObserver thirdParty = aggregated::onNewDiscovery;
 
         assertThat(unpack(thirdParty), contains(thirdParty));
     }

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserversTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererObserversTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsDiscoveryObserver;
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsResolutionObserver;
+import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.ResolutionResult;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObservers.asSafeObserver;
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObservers.combine;
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObservers.unpack;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DnsServiceDiscovererObserversTest {
+
+    private static final String ID = "sd-id";
+    private static final String NAME = "service.example.com";
+    private static final String QUESTION = "question.example.com";
+
+    // ------------------------------------------------------------------ combine
+
+    @Test
+    void combineRequiresAtLeastOneObserver() {
+        assertThrows(IllegalArgumentException.class, DnsServiceDiscovererObservers::combine);
+    }
+
+    @Test
+    void combineSingleReturnsSameInstance() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        assertThat(combine(observer), sameInstance(observer));
+    }
+
+    @Test
+    void combineNullElementThrows() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        assertThrows(NullPointerException.class, () -> combine(observer, null));
+    }
+
+    @Test
+    void combineFansOutEveryEventToAllObservers() {
+        DnsServiceDiscovererObserver o1 = mock(DnsServiceDiscovererObserver.class);
+        DnsServiceDiscovererObserver o2 = mock(DnsServiceDiscovererObserver.class);
+        DnsDiscoveryObserver d1 = mock(DnsDiscoveryObserver.class);
+        DnsDiscoveryObserver d2 = mock(DnsDiscoveryObserver.class);
+        DnsResolutionObserver r1 = mock(DnsResolutionObserver.class);
+        DnsResolutionObserver r2 = mock(DnsResolutionObserver.class);
+        ResolutionResult result = mock(ResolutionResult.class);
+        when(o1.onNewDiscovery(ID, NAME)).thenReturn(d1);
+        when(o2.onNewDiscovery(ID, NAME)).thenReturn(d2);
+        when(d1.onNewResolution(QUESTION)).thenReturn(r1);
+        when(d2.onNewResolution(QUESTION)).thenReturn(r2);
+
+        DnsServiceDiscovererObserver combined = combine(o1, o2);
+
+        DnsDiscoveryObserver discovery = combined.onNewDiscovery(ID, NAME);
+        verify(o1).onNewDiscovery(ID, NAME);
+        verify(o2).onNewDiscovery(ID, NAME);
+
+        DnsResolutionObserver resolution = discovery.onNewResolution(QUESTION);
+        verify(d1).onNewResolution(QUESTION);
+        verify(d2).onNewResolution(QUESTION);
+
+        resolution.resolutionCompleted(result);
+        verify(r1).resolutionCompleted(result);
+        verify(r2).resolutionCompleted(result);
+
+        resolution.resolutionFailed(DELIBERATE_EXCEPTION);
+        verify(r1).resolutionFailed(DELIBERATE_EXCEPTION);
+        verify(r2).resolutionFailed(DELIBERATE_EXCEPTION);
+
+        discovery.discoveryCancelled();
+        verify(d1).discoveryCancelled();
+        verify(d2).discoveryCancelled();
+
+        discovery.discoveryFailed(DELIBERATE_EXCEPTION);
+        verify(d1).discoveryFailed(DELIBERATE_EXCEPTION);
+        verify(d2).discoveryFailed(DELIBERATE_EXCEPTION);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void combineFansOutDeprecatedOnNewDiscovery() {
+        DnsServiceDiscovererObserver o1 = mock(DnsServiceDiscovererObserver.class);
+        DnsServiceDiscovererObserver o2 = mock(DnsServiceDiscovererObserver.class);
+        when(o1.onNewDiscovery(NAME)).thenReturn(mock(DnsDiscoveryObserver.class));
+        when(o2.onNewDiscovery(NAME)).thenReturn(mock(DnsDiscoveryObserver.class));
+
+        combine(o1, o2).onNewDiscovery(NAME);
+
+        verify(o1).onNewDiscovery(NAME);
+        verify(o2).onNewDiscovery(NAME);
+    }
+
+    @Test
+    void combineIsSafeAgainstThrowingObserver() {
+        DnsServiceDiscovererObserver good = mock(DnsServiceDiscovererObserver.class);
+        DnsServiceDiscovererObserver bad = mock(DnsServiceDiscovererObserver.class);
+        DnsDiscoveryObserver goodDiscovery = mock(DnsDiscoveryObserver.class);
+        DnsDiscoveryObserver badDiscovery = mock(DnsDiscoveryObserver.class);
+        when(good.onNewDiscovery(ID, NAME)).thenReturn(goodDiscovery);
+        when(bad.onNewDiscovery(ID, NAME)).thenReturn(badDiscovery);
+        doThrow(DELIBERATE_EXCEPTION).when(badDiscovery).discoveryCancelled();
+
+        // 'bad' comes first: its thrown exception must not prevent 'good' from being notified.
+        DnsServiceDiscovererObserver combined = combine(bad, good);
+        DnsDiscoveryObserver discovery = assertDoesNotThrow(() -> combined.onNewDiscovery(ID, NAME));
+
+        assertDoesNotThrow(discovery::discoveryCancelled);
+        verify(badDiscovery).discoveryCancelled();
+        verify(goodDiscovery).discoveryCancelled();
+    }
+
+    // ------------------------------------------------------------------ asSafeObserver
+
+    @Test
+    void asSafeObserverWrapsPlainObserver() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        DnsServiceDiscovererObserver safe = asSafeObserver(observer);
+        assertThat(safe, notNullValue());
+        assertThat(safe, not(sameInstance(observer)));
+    }
+
+    @Test
+    void asSafeObserverIsIdempotent() {
+        DnsServiceDiscovererObserver safe = asSafeObserver(mock(DnsServiceDiscovererObserver.class));
+        assertThat(asSafeObserver(safe), sameInstance(safe));
+    }
+
+    @Test
+    void asSafeObserverDoesNotRewrapCombined() {
+        DnsServiceDiscovererObserver combined = combine(mock(DnsServiceDiscovererObserver.class),
+                mock(DnsServiceDiscovererObserver.class));
+        assertThat(asSafeObserver(combined), sameInstance(combined));
+    }
+
+    @Test
+    void asSafeObserverSwallowsExceptionFromOnNewDiscovery() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        when(observer.onNewDiscovery(anyString(), anyString())).thenThrow(DELIBERATE_EXCEPTION);
+
+        DnsServiceDiscovererObserver safe = asSafeObserver(observer);
+        DnsDiscoveryObserver discovery = assertDoesNotThrow(() -> safe.onNewDiscovery(ID, NAME));
+        assertThat("Must fall back to a non-null noop observer", discovery, notNullValue());
+        // The returned noop must remain safe to use.
+        assertDoesNotThrow(discovery::discoveryCancelled);
+        assertDoesNotThrow(() -> assertThat(discovery.onNewResolution(QUESTION), notNullValue()));
+    }
+
+    @Test
+    void asSafeObserverHandlesNullReturnedObserver() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        when(observer.onNewDiscovery(anyString(), anyString())).thenReturn(null);
+
+        DnsServiceDiscovererObserver safe = asSafeObserver(observer);
+        DnsDiscoveryObserver discovery = assertDoesNotThrow(() -> safe.onNewDiscovery(ID, NAME));
+        assertThat("A null observer must be replaced with a non-null noop", discovery, notNullValue());
+    }
+
+    @Test
+    void asSafeObserverSwallowsExceptionFromTerminalEvents() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        DnsDiscoveryObserver discovery = mock(DnsDiscoveryObserver.class);
+        DnsResolutionObserver resolution = mock(DnsResolutionObserver.class);
+        when(observer.onNewDiscovery(ID, NAME)).thenReturn(discovery);
+        when(discovery.onNewResolution(QUESTION)).thenReturn(resolution);
+        doThrow(DELIBERATE_EXCEPTION).when(discovery).discoveryFailed(any());
+        doThrow(DELIBERATE_EXCEPTION).when(resolution).resolutionCompleted(any());
+
+        DnsServiceDiscovererObserver safe = asSafeObserver(observer);
+        DnsDiscoveryObserver safeDiscovery = safe.onNewDiscovery(ID, NAME);
+        assertDoesNotThrow(() -> safeDiscovery.discoveryFailed(DELIBERATE_EXCEPTION));
+        verify(discovery).discoveryFailed(DELIBERATE_EXCEPTION);
+
+        DnsResolutionObserver safeResolution = safeDiscovery.onNewResolution(QUESTION);
+        assertDoesNotThrow(() -> safeResolution.resolutionCompleted(mock(ResolutionResult.class)));
+        verify(resolution).resolutionCompleted(any());
+    }
+
+    @Test
+    void asSafeObserverSwallowsExceptionFromResolutionFailed() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        DnsDiscoveryObserver discovery = mock(DnsDiscoveryObserver.class);
+        DnsResolutionObserver resolution = mock(DnsResolutionObserver.class);
+        when(observer.onNewDiscovery(ID, NAME)).thenReturn(discovery);
+        when(discovery.onNewResolution(QUESTION)).thenReturn(resolution);
+        doThrow(DELIBERATE_EXCEPTION).when(resolution).resolutionFailed(any());
+
+        DnsResolutionObserver safeResolution = asSafeObserver(observer).onNewDiscovery(ID, NAME)
+                .onNewResolution(QUESTION);
+        assertDoesNotThrow(() -> safeResolution.resolutionFailed(DELIBERATE_EXCEPTION));
+        verify(resolution).resolutionFailed(DELIBERATE_EXCEPTION);
+    }
+
+    @Test
+    void asSafeObserverSwallowsExceptionFromOnNewResolution() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        DnsDiscoveryObserver discovery = mock(DnsDiscoveryObserver.class);
+        when(observer.onNewDiscovery(ID, NAME)).thenReturn(discovery);
+        when(discovery.onNewResolution(anyString())).thenThrow(DELIBERATE_EXCEPTION);
+
+        DnsDiscoveryObserver safeDiscovery = asSafeObserver(observer).onNewDiscovery(ID, NAME);
+        DnsResolutionObserver resolution = assertDoesNotThrow(() -> safeDiscovery.onNewResolution(QUESTION));
+        assertThat("Must fall back to a non-null noop resolution observer", resolution, notNullValue());
+        // The returned noop must remain safe to use.
+        assertDoesNotThrow(() -> resolution.resolutionCompleted(mock(ResolutionResult.class)));
+        assertDoesNotThrow(() -> resolution.resolutionFailed(DELIBERATE_EXCEPTION));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void asSafeObserverSwallowsExceptionFromDeprecatedOnNewDiscovery() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        when(observer.onNewDiscovery(anyString())).thenThrow(DELIBERATE_EXCEPTION);
+
+        DnsServiceDiscovererObserver safe = asSafeObserver(observer);
+        DnsDiscoveryObserver discovery = assertDoesNotThrow(() -> safe.onNewDiscovery(NAME));
+        assertThat("Must fall back to a non-null noop observer", discovery, notNullValue());
+        assertDoesNotThrow(discovery::discoveryCancelled);
+    }
+
+    @Test
+    void asSafeObserverAttachesOriginalCauseAsSuppressed() {
+        // When reporting a failure event itself throws, the original failure cause must not be lost: it is
+        // attached as a suppressed exception on the throwable that gets logged.
+        RuntimeException reportingFailure = new RuntimeException("observer blew up while reporting");
+        Exception originalCause = new Exception("original discovery failure");
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        DnsDiscoveryObserver discovery = mock(DnsDiscoveryObserver.class);
+        when(observer.onNewDiscovery(ID, NAME)).thenReturn(discovery);
+        doThrow(reportingFailure).when(discovery).discoveryFailed(originalCause);
+
+        DnsDiscoveryObserver safeDiscovery = asSafeObserver(observer).onNewDiscovery(ID, NAME);
+        assertDoesNotThrow(() -> safeDiscovery.discoveryFailed(originalCause));
+        assertThat(reportingFailure.getSuppressed(), arrayContaining(originalCause));
+    }
+
+    // ------------------------------------------------------------------ unpack
+
+    @Test
+    void unpackPlainObserverReturnsSingletonList() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        assertThat(unpack(observer), contains(observer));
+    }
+
+    @Test
+    void unpackReturnsCombinedObserversInOrder() {
+        DnsServiceDiscovererObserver o1 = mock(DnsServiceDiscovererObserver.class);
+        DnsServiceDiscovererObserver o2 = mock(DnsServiceDiscovererObserver.class);
+        DnsServiceDiscovererObserver o3 = mock(DnsServiceDiscovererObserver.class);
+
+        assertThat(unpack(combine(o1, o2, o3)), contains(o1, o2, o3));
+    }
+
+    @Test
+    void unpackUnwrapsSafeWrapper() {
+        DnsServiceDiscovererObserver observer = mock(DnsServiceDiscovererObserver.class);
+        assertThat(unpack(asSafeObserver(observer)), contains(observer));
+    }
+
+    @Test
+    void unpackResultIsUnmodifiable() {
+        List<DnsServiceDiscovererObserver> unpacked = unpack(combine(mock(DnsServiceDiscovererObserver.class),
+                mock(DnsServiceDiscovererObserver.class)));
+        assertThrows(UnsupportedOperationException.class,
+                () -> unpacked.add(mock(DnsServiceDiscovererObserver.class)));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void unpackTreatsThirdPartyAggregatorAsOpaque() {
+        // A third-party observer may internally aggregate observers we know how to unwrap, but since it is not
+        // one of our types it must stay a single opaque leaf: unpack must not descend into it.
+        DnsServiceDiscovererObserver aggregated = combine(mock(DnsServiceDiscovererObserver.class),
+                mock(DnsServiceDiscovererObserver.class));
+        DnsServiceDiscovererObserver thirdParty = name -> aggregated.onNewDiscovery(name);
+
+        assertThat(unpack(thirdParty), contains(thirdParty));
+    }
+}


### PR DESCRIPTION
#### Motivation

Adding `BiDnsServiceDiscovererObserver`,  `DnsServiceDiscovererObservers`, and `CatchAllDnsServiceDiscovererObserver` to enable safe composition of DNS observers. 

#### Modifications

The public API is the static utility class `DnsServiceDiscovererObservers`. Its implementation closely matches `TransportObservers` and `HttpLifecycleObservers`. 

#### Result

This API can help facilitate the integration of DNS metric observers.

#### Caveat

This PR does _not_ integrate `CatchAllDnsServiceDiscovererObserver` into the default DNS observer implementation. This work is reserved for a subsequent PR. 