### PR TITLE
loadbalancer: include the load balancer description in log messages

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/CatchAllLoadBalancerObserver.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/CatchAllLoadBalancerObserver.java
@@ -31,18 +31,20 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatchAllLoadBalancerObserver.class);
 
+    private final String lbDescription;
     private final LoadBalancerObserver delegate;
 
-    private CatchAllLoadBalancerObserver(LoadBalancerObserver delegate) {
+    private CatchAllLoadBalancerObserver(String lbDescription, LoadBalancerObserver delegate) {
+        this.lbDescription = lbDescription;
         this.delegate = delegate;
     }
 
     @Override
     public HostObserver hostObserver(Object resolvedAddress) {
         try {
-            return new CatchAllHostObserver(delegate.hostObserver(resolvedAddress));
+            return new CatchAllHostObserver(lbDescription, delegate.hostObserver(resolvedAddress));
         } catch (Throwable ex) {
-            LOGGER.warn("Unexpected exception from {} while getting a HostObserver", delegate, ex);
+            LOGGER.warn("{}: Unexpected exception from {} while getting a HostObserver", lbDescription, delegate, ex);
             return NoopLoadBalancerObserver.NoopHostObserver.INSTANCE;
         }
     }
@@ -52,8 +54,8 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
         try {
             delegate.onServiceDiscoveryEvent(events);
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting an onServiceDiscoveryEvent event",
-                    delegate, unexpected);
+            LOGGER.warn("{}: Unexpected exception from {} while reporting an onServiceDiscoveryEvent event",
+                    lbDescription, delegate, unexpected);
         }
     }
 
@@ -62,7 +64,8 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
         try {
             delegate.onHostsUpdate(oldHosts, newHosts);
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting an onHostsUpdate event", delegate, unexpected);
+            LOGGER.warn("{}: Unexpected exception from {} while reporting an onHostsUpdate event",
+                    lbDescription, delegate, unexpected);
         }
     }
 
@@ -71,8 +74,8 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
         try {
             delegate.onNoAvailableHostException(exception);
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting an onNoAvailableHostException event",
-                    delegate, unexpected);
+            LOGGER.warn("{}: Unexpected exception from {} while reporting an onNoAvailableHostException event",
+                    lbDescription, delegate, unexpected);
         }
     }
 
@@ -81,16 +84,18 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
         try {
             delegate.onNoActiveHostException(hosts, exception);
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting an onNoActiveHostException event",
-                    delegate, unexpected);
+            LOGGER.warn("{}: Unexpected exception from {} while reporting an onNoActiveHostException event",
+                    lbDescription, delegate, unexpected);
         }
     }
 
     private static final class CatchAllHostObserver implements HostObserver {
 
+        private final String lbDescription;
         private final HostObserver delegate;
 
-        CatchAllHostObserver(HostObserver delegate) {
+        CatchAllHostObserver(String lbDescription, HostObserver delegate) {
+            this.lbDescription = lbDescription;
             this.delegate = requireNonNull(delegate, "delegate");
         }
 
@@ -99,8 +104,8 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
             try {
                 delegate.onHostMarkedExpired(connectionCount);
             } catch (Throwable unexpected) {
-                LOGGER.warn("Unexpected exception from {} while reporting an onHostMarkedExpired event",
-                        delegate, unexpected);
+                LOGGER.warn("{}: Unexpected exception from {} while reporting an onHostMarkedExpired event",
+                        lbDescription, delegate, unexpected);
             }
         }
 
@@ -109,8 +114,8 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
             try {
                 delegate.onActiveHostRemoved(connectionCount);
             } catch (Throwable unexpected) {
-                LOGGER.warn("Unexpected exception from {} while reporting an onActiveHostRemoved event",
-                        delegate, unexpected);
+                LOGGER.warn("{}: Unexpected exception from {} while reporting an onActiveHostRemoved event",
+                        lbDescription, delegate, unexpected);
             }
         }
 
@@ -119,8 +124,8 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
             try {
                 delegate.onExpiredHostRevived(connectionCount);
             } catch (Throwable unexpected) {
-                LOGGER.warn("Unexpected exception from {} while reporting an onExpiredHostRevived event",
-                        delegate, unexpected);
+                LOGGER.warn("{}: Unexpected exception from {} while reporting an onExpiredHostRevived event",
+                        lbDescription, delegate, unexpected);
             }
         }
 
@@ -129,8 +134,8 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
             try {
                 delegate.onExpiredHostRemoved(connectionCount);
             } catch (Throwable unexpected) {
-                LOGGER.warn("Unexpected exception from {} while reporting an onExpiredHostRemoved event",
-                        delegate, unexpected);
+                LOGGER.warn("{}: Unexpected exception from {} while reporting an onExpiredHostRemoved event",
+                        lbDescription, delegate, unexpected);
             }
         }
 
@@ -139,8 +144,8 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
             try {
                 delegate.onHostMarkedUnhealthy(cause);
             } catch (Throwable unexpected) {
-                LOGGER.warn("Unexpected exception from {} while reporting an onHostMarkedUnhealthy event",
-                        delegate, unexpected);
+                LOGGER.warn("{}: Unexpected exception from {} while reporting an onHostMarkedUnhealthy event",
+                        lbDescription, delegate, unexpected);
             }
         }
 
@@ -149,13 +154,13 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
             try {
                 delegate.onHostRevived();
             } catch (Throwable unexpected) {
-                LOGGER.warn("Unexpected exception from {} while reporting an onHostRevived event",
-                        delegate, unexpected);
+                LOGGER.warn("{}: Unexpected exception from {} while reporting an onHostRevived event",
+                        lbDescription, delegate, unexpected);
             }
         }
     }
 
-    static LoadBalancerObserver wrap(LoadBalancerObserver observer) {
+    static LoadBalancerObserver wrap(String lbDescription, LoadBalancerObserver observer) {
         requireNonNull(observer, "observer");
         if (observer instanceof CatchAllLoadBalancerObserver) {
             return observer;
@@ -163,6 +168,6 @@ final class CatchAllLoadBalancerObserver implements LoadBalancerObserver {
         if (observer instanceof NoopLoadBalancerObserver) {
             return observer;
         }
-        return new CatchAllLoadBalancerObserver(observer);
+        return new CatchAllLoadBalancerObserver(lbDescription, observer);
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancer.java
@@ -163,7 +163,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                 .replay(1); // Allow for multiple subscribers and provide new subscribers with last signal.
         this.connectionFactory = connectionFactory;
         this.minConnectionsPerHost = minConnectionsPerHost;
-        this.loadBalancerObserver = CatchAllLoadBalancerObserver.wrap(
+        this.loadBalancerObserver = CatchAllLoadBalancerObserver.wrap(lbDescription,
                 loadBalancerObserverFactory.newObserver(lbDescription));
         this.healthCheckConfig = healthCheckConfig;
         this.sequentialExecutor = new SequentialExecutor((uncaughtException) ->
@@ -319,9 +319,9 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
             final Map<ResolvedAddress, ServiceDiscovererEvent<ResolvedAddress>> eventMap = new HashMap<>();
             for (ServiceDiscovererEvent<ResolvedAddress> event : events) {
                 ServiceDiscovererEvent<ResolvedAddress> old = eventMap.put(event.address(), event);
-                if (old != null) {
-                    LOGGER.debug("Multiple ServiceDiscoveryEvent's detected for address {}. Event: {}.",
-                            event.address(), event);
+                if (old != null && LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("{}: Multiple ServiceDiscoveryEvent's detected for address {}. Event: {}.",
+                            DefaultLoadBalancer.this, event.address(), event);
                 }
             }
 
@@ -364,7 +364,8 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
                     }
                 } else if (UNAVAILABLE.equals(event.status())) {
                     host.closeAsyncGracefully()
-                            .beforeOnError(error -> LOGGER.warn("Closing host {} failed.", host.address(), error))
+                            .beforeOnError(error -> LOGGER.warn("{}: Closing host {} failed.",
+                                    DefaultLoadBalancer.this, host.address(), error))
                             .subscribe();
                     hostSetChanged = true;
                 } else {
@@ -666,7 +667,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         if (event instanceof RichServiceDiscovererEvent<?>) {
             weight = ((RichServiceDiscovererEvent<?>) event).loadBalancingWeight();
             if (weight < 0) {
-                LOGGER.debug("{} Unexpected negative weight {} for host {} being set to 1.0",
+                LOGGER.debug("{}: Unexpected negative weight {} for host {} being set to 1.0",
                         lbDescription, weight, event.address());
                 weight = 1;
             }
@@ -679,7 +680,7 @@ final class DefaultLoadBalancer<ResolvedAddress, C extends LoadBalancedConnectio
         if (event instanceof RichServiceDiscovererEvent<?>) {
             priority = ((RichServiceDiscovererEvent<?>) event).priority();
             if (priority < 0) {
-                LOGGER.debug("{} Unexpected negative priority {} for host {} being set to 0",
+                LOGGER.debug("{}: Unexpected negative priority {} for host {} being set to 0",
                         lbDescription, priority, event.address());
                 priority = 0;
             }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/FailurePercentageXdsOutlierDetectorAlgorithm.java
@@ -33,7 +33,13 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
     // data structure for longs which would require boxing.
     private static final long NOT_EVALUATED = Long.MAX_VALUE;
 
+    private final String lbDescription;
+
     private long[] failurePercentages = new long[0];
+
+    FailurePercentageXdsOutlierDetectorAlgorithm(final String lbDescription) {
+        this.lbDescription = lbDescription;
+    }
 
     @Override
     public void detectOutliers(final OutlierDetectorConfig config,
@@ -68,9 +74,9 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
         if (enoughVolumeHosts < config.failurePercentageMinimumHosts()) {
             // not enough hosts with enough volume to do the analysis.
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Not enough hosts with sufficient volume to perform ejection: " +
+                LOGGER.debug("{}: Not enough hosts with sufficient volume to perform ejection: " +
                                 "{} total hosts and {} had sufficient volume. Minimum {} required.",
-                        indicators.size(), enoughVolumeHosts, config.failurePercentageMinimumHosts());
+                        lbDescription, indicators.size(), enoughVolumeHosts, config.failurePercentageMinimumHosts());
             }
             return;
         }
@@ -86,9 +92,9 @@ final class FailurePercentageXdsOutlierDetectorAlgorithm<ResolvedAddress, C exte
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Finished failure percentage analysis. Of {} total hosts {} were already ejected by any " +
-                            "algorithm and {} were flagged as outliers.",
-                    indicators.size(), alreadyEjectedHosts, flaggedCount);
+            LOGGER.debug("{}: Finished failure percentage analysis. Of {} total hosts {} were already ejected by " +
+                            "any algorithm and {} were flagged as outliers.",
+                    lbDescription, indicators.size(), alreadyEjectedHosts, flaggedCount);
         }
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/SuccessRateXdsOutlierDetectorAlgorithm.java
@@ -43,13 +43,19 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
     // data structure for doubles which would require boxing.
     private static final double NOT_EVALUATED = Double.MAX_VALUE;
 
+    private final String lbDescription;
+
     private double[] successRates = new double[0];
+
+    SuccessRateXdsOutlierDetectorAlgorithm(final String lbDescription) {
+        this.lbDescription = lbDescription;
+    }
 
     @Override
     public void detectOutliers(final OutlierDetectorConfig config,
                                final List<? extends XdsHealthIndicator<ResolvedAddress, C>> indicators,
                                final boolean[] outliers) {
-        LOGGER.debug("Started outlier detection.");
+        LOGGER.debug("{}: Started outlier detection.", lbDescription);
         final int size = indicators.size();
         // Because we always overwrite every element before accessing there is no need to zero the array on reuse.
         if (successRates.length != size) {
@@ -79,9 +85,9 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
         if (enoughVolumeHosts < config.successRateMinimumHosts()) {
             // not enough hosts with enough volume to do the analysis.
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Not enough hosts with sufficient volume to perform ejection: " +
+                LOGGER.debug("{}: Not enough hosts with sufficient volume to perform ejection: " +
                         "{} total hosts and {} had sufficient volume. Minimum {} required.",
-                        indicators.size(), enoughVolumeHosts, config.successRateMinimumHosts());
+                        lbDescription, indicators.size(), enoughVolumeHosts, config.successRateMinimumHosts());
             }
             return;
         }
@@ -99,9 +105,9 @@ final class SuccessRateXdsOutlierDetectorAlgorithm<ResolvedAddress, C extends Lo
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Finished success rate analysis. Of {} total hosts {} were already ejected by any algorithm " +
-                            "and {} were flagged as outliers.",
-                    indicators.size(), alreadyEjectedHosts, flaggedCount);
+            LOGGER.debug("{}: Finished success rate analysis. Of {} total hosts {} were already ejected by any " +
+                            "algorithm and {} were flagged as outliers.",
+                    lbDescription, indicators.size(), alreadyEjectedHosts, flaggedCount);
         }
     }
 

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsOutlierDetector.java
@@ -250,7 +250,7 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
             }
             cancellable.nextCancellable(scheduleNextOutliersCheck(config));
             if (emitChange) {
-                LOGGER.debug("Health status change observed. Emitting event.");
+                LOGGER.debug("{}: Health status change observed. Emitting event.", lbDescription);
                 healthStatusChangeProcessor.onNext(null);
             }
         }
@@ -259,10 +259,10 @@ final class XdsOutlierDetector<ResolvedAddress, C extends LoadBalancedConnection
     private List<XdsOutlierDetectorAlgorithm<ResolvedAddress, C>> getAlgorithms(OutlierDetectorConfig config) {
         List<XdsOutlierDetectorAlgorithm<ResolvedAddress, C>> detectors = new ArrayList<>(2);
         if (config.enforcingFailurePercentage() > 0) {
-            detectors.add(new FailurePercentageXdsOutlierDetectorAlgorithm<>());
+            detectors.add(new FailurePercentageXdsOutlierDetectorAlgorithm<>(lbDescription));
         }
         if (config.enforcingSuccessRate() > 0) {
-            detectors.add(new SuccessRateXdsOutlierDetectorAlgorithm<>());
+            detectors.add(new SuccessRateXdsOutlierDetectorAlgorithm<>(lbDescription));
         }
         return detectors;
     }


### PR DESCRIPTION
 #### Motivation

Our log messages don't include which load balancer they're related to which is going to make it tough to know which client is reporting what.

 #### Modifications

Add the load balancer description to our log messages.
