### PR TITLE
buffer-api: fix `getUnsignedShort()` mask

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AbstractBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/AbstractBuffer.java
@@ -131,7 +131,7 @@ abstract class AbstractBuffer implements Buffer {
 
     @Override
     public final int getUnsignedShort(int index) {
-        return getShort(index) & 0xfff;
+        return getShort(index) & 0xffff;
     }
 
     @Override

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
@@ -56,6 +56,17 @@ class ReadOnlyByteBufferTest {
     }
 
     @Test
+    void getUnsignedShort() {
+        ByteBuffer expectedBuffer = allocateDirect(4);
+        expectedBuffer.putShort((short) 0xffff);
+        expectedBuffer.putShort((short) 0xf234);
+        expectedBuffer.flip();
+        Buffer buffer1 = DEFAULT_RO_ALLOCATOR.wrap(expectedBuffer);
+        assertEquals(0xffff, buffer1.getUnsignedShort(buffer1.readerIndex()));
+        assertEquals(0xf234, buffer1.getUnsignedShort(buffer1.readerIndex() + 2));
+    }
+
+    @Test
     void copy() {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
         assertEquals(buffer, buffer.copy());


### PR DESCRIPTION
#### Motivation:
`AbstractBuffer.getUnsignedShort(int)` masked with `0xfff` instead of `0xffff`, so any short value with any of the upper 4 bits set (`0x1000..0xffff`) returned the wrong number — e.g. `0xffff` read as `4095` instead of `65535`.  

#### Modifications:
- `AbstractBuffer.getUnsignedShort`: mask with `0xffff`.
- Add `ReadOnlyByteBufferTest.getUnsignedShort` covering values that trip the old mask.

#### Result:
`Buffer.getUnsignedShort(int)` returns the correct unsigned value for the full 16-bit domain on read-only buffers.