### PR TITLE
http-netty: document and test HTTP/2 header-name validation

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -232,7 +232,8 @@ final class H2ToStH1Utils {
         }
 
         // These will be used by the netty encoder so we need to make sure when we give it keys they're lower cased.
-        // We also don't need to worry about validation at this point.
+        // validateNames=false: on this outbound path the names were already validated at the HTTP API layer when
+        // they were added to h1Headers (HeaderUtils.validateToken), so ServiceTalkHttp2Headers must not re-validate.
         return new ServiceTalkHttp2Headers(h1Headers, true, false, false);
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptimizedHttp2FrameCodecBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptimizedHttp2FrameCodecBuilder.java
@@ -235,7 +235,9 @@ final class OptimizedHttp2FrameCodecBuilder extends Http2FrameCodecBuilder {
                 .autoAckSettingsFrame(server)
                 // We ack PING frames in KeepAliveManager#pingReceived.
                 .autoAckPingFrame(false)
-                // Inherit headers validation setting from the HttpHeadersFactory.
+                // Inherit name validation from the HttpHeadersFactory. This ties the decoder's validation to the same
+                // flag as the underlying HttpHeaders, so both validation layers toggle together on inbound decode —
+                // see the layering notes on ServiceTalkHttp2Headers.HTTP2_NAME_VALIDATOR.
                 .validateHeaders(config.headersFactory().validateNames())
                 .headerSensitivityDetector(config.headersSensitivityDetector()::test);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ServiceTalkHttp2Headers.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ServiceTalkHttp2Headers.java
@@ -61,9 +61,17 @@ final class ServiceTalkHttp2Headers implements Http2Headers {
 
     private static final ValueConverter<CharSequence> VALUE_CONVERTER = CharSequenceValueConverter.INSTANCE;
 
-    // TODO: use the validators from Netty once they're made public
+    // Enforces only the HTTP/2 lower-case rule; the rest of the RFC 7230 token grammar is enforced by the underlying
+    // HttpHeaders (see HTTP2_NAME_VALIDATOR), so don't add a token-grammar check here.
     private static final ByteProcessor HTTP2_NAME_VALIDATOR_PROCESSOR = (c) -> !isUpperCase(c);
 
+    // HTTP/2 field-name validation is split across two layers, both gated on the same validateNames flag (wired in
+    // OptimizedHttp2FrameCodecBuilder): this wrapper rejects upper-case (the HTTP/2 lower-case rule) and the underlying
+    // HttpHeaders rejects the rest of the RFC 7230 token grammar (non-ASCII, controls, SP/HTAB, DEL, separators) via
+    // HeaderUtils.validateToken. The outbound path skips both (validateNames=false, see h1HeadersToH2Headers) since
+    // names are already validated at the HTTP API layer. On inbound decode Netty's HpackDecoder sink turns the
+    // wrapper's Http2Exception and the underlying's IllegalArgumentException alike into a PROTOCOL_ERROR, so an invalid
+    // name is rejected whichever layer catches it.
     private static final DefaultHeaders.NameValidator<CharSequence> HTTP2_NAME_VALIDATOR = (CharSequence name) -> {
         if (name == null || name.length() == 0) {
             PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -1528,6 +1528,23 @@ class H2PriorKnowledgeFeatureParityTest {
             "upgrade,foo/2",
             "proxy-connection,close"})
     void h2FailsRequestsWithMalformedHeaders(String headerName, String headerValue) throws Exception {
+        assertH2ServerResetsStreamWithProtocolError(headerName, headerValue);
+    }
+
+    // A peer that skips validation (new DefaultHttp2Headers(false)) can put names on the wire that ServiceTalk's own
+    // client would never send. This verifies the inbound decode path rejects invalid HTTP/2 field-names with a
+    // PROTOCOL_ERROR stream reset. The rejection is split across two layers (see ServiceTalkHttp2Headers
+    // .HTTP2_NAME_VALIDATOR): upper-case is caught by ServiceTalkHttp2Headers (HTTP/2 lower-case rule) and other
+    // non-token characters are caught one layer down by the underlying HttpHeaders (HeaderUtils.validateToken); Netty's
+    // HpackDecoder header sink normalises both to a PROTOCOL_ERROR, so the observable outcome here is identical.
+    @ParameterizedTest(name = "{displayName} [{index}] headerName={0}")
+    @ValueSource(strings = {"Uppercase-Name", "invalid name", "invalid;name", "invalid/name", "invalid@name"})
+    void h2ServerResetsStreamForInvalidHeaderName(String headerName) throws Exception {
+        assertH2ServerResetsStreamWithProtocolError(headerName, "some-value");
+    }
+
+    private void assertH2ServerResetsStreamWithProtocolError(CharSequence headerName, CharSequence headerValue)
+            throws Exception {
         setUp(DEFAULT, true);
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
                 .protocols(HttpProtocol.HTTP_2.config)

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkHttp2HeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkHttp2HeadersTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.AsciiString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * HTTP/2 field-name validation is split across two layers (see the comments on
+ * {@code ServiceTalkHttp2Headers.HTTP2_NAME_VALIDATOR}): the wrapper enforces the HTTP/2 lower-case rule and the
+ * underlying {@code HttpHeaders} enforces the RFC 7230 token grammar. These tests pin which layer rejects what;
+ * over the wire both are normalised to a PROTOCOL_ERROR by Netty's HpackDecoder (see
+ * {@code H2PriorKnowledgeFeatureParityTest#h2ServerResetsStreamForInvalidHeaderName}).
+ */
+class ServiceTalkHttp2HeadersTest {
+
+    // Mirror the inbound decode path, where the wrapper and its underlying HttpHeaders share one validateNames flag.
+    private static Http2Headers newHeaders(final boolean validateNames) {
+        return new ServiceTalkHttp2Headers(new H2HeadersFactory(validateNames, false, false).newHeaders(),
+                false, validateNames, false);
+    }
+
+    @Test
+    void wrapperRejectsUpperCaseName() {
+        // Layer 1: the HTTP/2 lower-case rule is enforced by ServiceTalkHttp2Headers itself (Http2Exception).
+        assertThrows(Http2Exception.class, () -> newHeaders(true).add("X-Uppercase", "v"));
+        assertThrows(Http2Exception.class, () -> newHeaders(true).add(new AsciiString("X-Uppercase"), "v"));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] name={0}")
+    @ValueSource(strings = {"invalid name", "invalid;name", "invalid/name", "invalid@name", "invalid(name)"})
+    void underlyingRejectsNonTokenName(final String name) {
+        // Layer 2: non-token characters (SP, separators, controls) are rejected by the underlying HttpHeaders via
+        // HeaderUtils.validateToken, surfacing as IllegalCharacterException (an IllegalArgumentException).
+        assertThrows(IllegalArgumentException.class, () -> newHeaders(true).add(name, "v"));
+    }
+
+    @Test
+    void underlyingRejectsNonAsciiName() {
+        assertThrows(IllegalArgumentException.class,
+                () -> newHeaders(true).add(new AsciiString(new byte[]{(byte) 0xF0}), "v"));
+    }
+
+    @Test
+    void acceptsValidLowerCaseTokenName() {
+        assertDoesNotThrow(() -> newHeaders(true).add("x-custom-header", "v"));
+        // Every special token character permitted by RFC 7230.
+        assertDoesNotThrow(() -> newHeaders(true).add("!#$%&'*+-.^_`|~", "v"));
+    }
+
+    @Test
+    void skipsNameValidationWhenDisabled() {
+        // With validation off on both layers, malformed names are accepted (the opt-out used on the outbound path,
+        // where names were already validated at the HTTP API layer).
+        assertDoesNotThrow(() -> newHeaders(false).add("Uppercase-And-Space Name", "v"));
+        assertDoesNotThrow(() -> newHeaders(false).add(new AsciiString(new byte[]{(byte) 0xF0}), "v"));
+    }
+}


### PR DESCRIPTION
#### Motivation

HTTP/2 header-name validation happens across two layers and is easy to misread. `ServiceTalkHttp2Headers` (the `Http2Headers` wrapper) only enforces the HTTP/2 lower-case rule, while the RFC 7230 token grammar is enforced one layer down by the underlying `HttpHeaders` via `HeaderUtils.validateToken`. Both are gated on the same `HttpHeadersFactory.validateNames()` flag. The split is correct but undocumented, so the wrapper looks like it under-validates when it does not.

#### Modifications

- Comment-only changes describing the two-layer split on `ServiceTalkHttp2Headers.HTTP2_NAME_VALIDATOR`, the outbound `validateNames=false` opt-out in `h1HeadersToH2Headers`, and the shared-flag wiring in `OptimizedHttp2FrameCodecBuilder`.
- Add `ServiceTalkHttp2HeadersTest`: pins which layer rejects what — the wrapper rejects upper-case, the underlying rejects non-token / non-ASCII names, valid lower-case tokens are accepted, and validation is skipped when disabled.
- Add `H2PriorKnowledgeFeatureParityTest.h2ServerResetsStreamForInvalidHeaderName`: a raw peer puts invalid field-names on the wire and the server resets the stream with `PROTOCOL_ERROR`. Extract the existing wire harness into a helper.

#### Result

The two-layer header-name validation is documented and covered end-to-end, so a future change that weakens either layer is caught by tests.
