### PR TITLE
loadbalancer: make XdsOutlierDetector failure-multiplier decay deterministic

### DIFF
--- a/servicetalk-loadbalancer/gradle/spotbugs/main-exclusions.xml
+++ b/servicetalk-loadbalancer/gradle/spotbugs/main-exclusions.xml
@@ -38,6 +38,11 @@
     <Field name="cancelled"/>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
   </Match>
+  <Match>
+    <Class name="io.servicetalk.loadbalancer.XdsHealthIndicator"/>
+    <Field name="revivedAtNanos"/>
+    <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
+  </Match>
 
   <!-- XdsOutlierDetector access methods are package-private and controlled -->
   <Match>

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -324,12 +324,13 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
             LOGGER.debug("{}-{}: host revived", lbDescription, address);
         }
         final Long evictedUntilNanos = this.evictedUntilNanos;
+        assert evictedUntilNanos != null;
         this.evictedUntilNanos = null;
         // Anchor the decay grace period at the scheduled end of the ejection rather than the moment revival was
         // processed, so the multiplier decays on the same schedule whether the host was revived eagerly (isHealthy)
-        // or lazily on a later interval tick. evictedUntilNanos is non-null here (every caller guards on it); on the
-        // cancel path it may be in the future, but the stamp is irrelevant then since `cancelled` short-circuits.
-        revivedAtNanos = evictedUntilNanos == null ? currentTimeNanos() : evictedUntilNanos;
+        // or lazily on a later interval tick. On the cancel path evictedUntilNanos may be in the future, but the
+        // stamp is irrelevant then since `cancelled` short-circuits updateOutlierStatus.
+        revivedAtNanos = evictedUntilNanos;
         // Envoy resets the `consecutive5xx` counter on revival. I'm not sure that's the best because chances
         // are reasonable that it's still a bad host, so we'll want to mark it as an outlier again immediately if
         // the next request also fails.

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/XdsHealthIndicator.java
@@ -60,6 +60,10 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
     private boolean cancelled;
     // reads and writes protected by the helpers `SequentialExecutor`.
     private int failureMultiplier;
+    // Time of the most recent revival, protected by the `SequentialExecutor`. Used to enforce a one-interval grace
+    // period before the failure multiplier starts decaying, so decay timing does not depend on exactly when within
+    // an interval the host was revived. Only meaningful while `failureMultiplier > 0` (always set by then).
+    private long revivedAtNanos;
     // Any thread can read this value at any time but mutations are serialized by the `SequentialExecutor`.
     @Nullable
     private volatile Long evictedUntilNanos;
@@ -120,9 +124,9 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
         if (evictedUntilNanos == null) {
             return true;
         }
-        // Envoy technically will perform revival (un-ejection) on the same timer as the outlier detection. If we want
-        // to remove some overhead from the sad path we can go to that at the cost of leaving hosts unhealthy longer
-        // than the eviction time technically prescribes.
+        // Revive as soon as the ejection time has elapsed, rather than waiting for the next detector interval, to
+        // minimize downtime. The multiplier decay is gated separately (see updateOutlierStatus) so this eager
+        // revival does not make decay path-dependent on selection traffic.
         if (evictedUntilNanos <= currentTimeNanos()) {
             sequentialExecutor.execute(() -> {
                 final Long innerEvictedUntilNanos = this.evictedUntilNanos;
@@ -205,15 +209,16 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
 
         Long evictedUntilNanos = this.evictedUntilNanos;
         if (evictedUntilNanos != null) {
+            // Revive once the ejection has elapsed, but do not re-evaluate the outlier verdict this round. The
+            // counters still hold pre-revival stats (they are only reset once per interval, so a short ejection may
+            // leave the burst that ejected the host still present), not fresh post-revival behavior; re-ejecting on
+            // them would double-count that burst and grow the failure multiplier a second time. The host is
+            // re-evaluated next interval on fresh data, and consecutive-5xx can still re-eject it immediately via
+            // doOnError.
             if (evictedUntilNanos <= currentTimeNanos()) {
                 LOGGER.info("{}-{}: Health indicator revived.", lbDescription, address);
                 sequentialRevive();
             }
-            // If we are evicted or just transitioned out of eviction we shouldn't be marked as an outlier this round.
-            // Note that this differs from the envoy behavior. If we want to mimic it, then I think we need to just
-            // fall through and maybe attempt to eject again.
-            // Note: we deliberately don't decrement `failureMultiplier` on this revival path because that lets the
-            //       multiplier grow if the host continues to be unhealthy in consecutive intervals.
             return false;
         } else if (isOutlier) {
             final boolean result = sequentialTryEject(config, OUTLIER_DETECTOR_CAUSE);
@@ -226,8 +231,12 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
             }
             return result;
         } else {
-            // All we have to do is decrement our failure multiplier.
-            failureMultiplier = max(0, failureMultiplier - 1);
+            // Only decay the multiplier once the host has been healthy for a full interval. Combined with eager
+            // revival, this makes the first decrement land on the same interval it would under timer-only revival,
+            // regardless of when within the interval the host actually revived -- so decay stays deterministic.
+            if (currentTimeNanos() - revivedAtNanos >= config.failureDetectorInterval().toNanos()) {
+                failureMultiplier = max(0, failureMultiplier - 1);
+            }
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("{}-{}: markAsOutlier(isOutlier = false). " +
                         "Failure multiplier: {}", lbDescription, address, failureMultiplier);
@@ -314,7 +323,13 @@ abstract class XdsHealthIndicator<ResolvedAddress, C extends LoadBalancedConnect
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("{}-{}: host revived", lbDescription, address);
         }
-        evictedUntilNanos = null;
+        final Long evictedUntilNanos = this.evictedUntilNanos;
+        this.evictedUntilNanos = null;
+        // Anchor the decay grace period at the scheduled end of the ejection rather than the moment revival was
+        // processed, so the multiplier decays on the same schedule whether the host was revived eagerly (isHealthy)
+        // or lazily on a later interval tick. evictedUntilNanos is non-null here (every caller guards on it); on the
+        // cancel path it may be in the future, but the stamp is irrelevant then since `cancelled` short-circuits.
+        revivedAtNanos = evictedUntilNanos == null ? currentTimeNanos() : evictedUntilNanos;
         // Envoy resets the `consecutive5xx` counter on revival. I'm not sure that's the best because chances
         // are reasonable that it's still a bad host, so we'll want to mark it as an outlier again immediately if
         // the next request also fails.

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -135,17 +135,14 @@ class XdsHealthIndicatorTest {
         assertEquals(1, healthIndicator.ejectionCount);
         assertFalse(healthIndicator.isHealthy());
 
-        // Let the ejection time elapse, then run a round that still judges the host an outlier. updateOutlierStatus
-        // revives it and returns without re-evaluating the verdict this round -- the counters still hold the
-        // pre-revival stats, so re-ejecting on them would double-count. The host becomes healthy and the ejection
-        // count is unchanged; it can only be re-ejected on a subsequent round (on fresh data).
+        // Once the ejection elapses, an outlier round revives without re-ejecting on that round's (stale) stats.
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
         ejectIndicator(true);
         assertTrue(healthIndicator.isHealthy());
         assertEquals(1, healthIndicator.revivalCount);
         assertEquals(1, healthIndicator.ejectionCount);
 
-        // A following round can eject the now-healthy host again.
+        // A later round can eject the now-healthy host again.
         ejectIndicator(true);
         assertFalse(healthIndicator.isHealthy());
         assertEquals(2, healthIndicator.ejectionCount);
@@ -174,9 +171,8 @@ class XdsHealthIndicatorTest {
         testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
         assertTrue(healthIndicator.isHealthy());
 
-        // Give it a healthy round and the multiplier should go down to two. This means the next eviction will
-        // be evicted for three * baseEjectionTime. The decrement only happens once a full interval has elapsed
-        // since the host was revived (the grace period), so advance one interval before the healthy round.
+        // Give it a healthy round and the multiplier should go down to two, so the next eviction lasts 3x base.
+        // Decay only happens a full interval after revival (the grace period), so advance one interval first.
         testExecutor.advanceTimeBy(config.failureDetectorInterval().toNanos(), TimeUnit.NANOSECONDS);
         ejectIndicator(false);
         // now see how long it was ejected
@@ -189,7 +185,7 @@ class XdsHealthIndicatorTest {
 
     @Test
     void failureMultiplierDoesNotDecayWithinTheGracePeriodAfterRevival() {
-        // Eject twice in a row so the multiplier grows to 2.
+        // Grow the multiplier to 2.
         ejectIndicator(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
         assertTrue(healthIndicator.isHealthy());
@@ -197,8 +193,7 @@ class XdsHealthIndicatorTest {
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 2, TimeUnit.NANOSECONDS);
         assertTrue(healthIndicator.isHealthy());
 
-        // A healthy round within the grace period (before a full interval has elapsed since revival) must NOT
-        // decay the multiplier, so the next ejection still lasts 3x base (1 + the un-decayed multiplier of 2).
+        // A healthy round within the grace period must not decay, so the next ejection still lasts 3x base.
         ejectIndicator(false);
         ejectIndicator(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 3 - 1, TimeUnit.NANOSECONDS);
@@ -209,24 +204,80 @@ class XdsHealthIndicatorTest {
 
     @Test
     void failureMultiplierDecayIsAnchoredAtScheduledEjectionEndNotRevivalTime() {
-        // Eject once: multiplier 0 -> 1, ejected until t == baseEjectionTime.
         ejectIndicator(true);
         assertFalse(healthIndicator.isHealthy());
 
-        // Advance well past the ejection end WITHOUT calling isHealthy() (which would revive eagerly), then run a
-        // detection round so the host is revived lazily by updateOutlierStatus rather than by a selector.
+        // Advance past the ejection end without calling isHealthy() (which would revive eagerly), then revive
+        // lazily via a detector tick.
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() + config.failureDetectorInterval().toNanos(),
                 TimeUnit.NANOSECONDS);
         ejectIndicator(false);
         assertTrue(healthIndicator.isHealthy());
         assertEquals(1, healthIndicator.revivalCount);
 
-        // The very next healthy round decays the multiplier even though no time has passed since the lazy revival:
-        // the grace period is measured from the scheduled ejection end, not from when the revival was processed. So
-        // the next ejection lasts only 1x base (multiplier decayed 1 -> 0).
+        // Decay happens on the very next round with no further wait: the grace period runs from the scheduled
+        // ejection end, not the (later) revival time. So the next ejection is only 1x base.
         ejectIndicator(false);
         ejectIndicator(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() - 1, TimeUnit.NANOSECONDS);
+        assertFalse(healthIndicator.isHealthy());
+        testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
+        assertTrue(healthIndicator.isHealthy());
+    }
+
+    @Test
+    void firstMultiplierDecayLandsAtSameTimeForEagerAndLazyRevival() {
+        // Eject two hosts identically, then revive one eagerly (isHealthy at the ejection end) and the other
+        // lazily (a much later detector tick). The grace period is anchored at the scheduled ejection end for
+        // both, so both become eligible to decay at the same time regardless of when revival was processed.
+        TestIndicator eager = new TestIndicator(config);
+        TestIndicator lazy = new TestIndicator(config);
+        updateStatus(eager, true);
+        updateStatus(lazy, true);
+
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
+        assertTrue(eager.isHealthy());
+
+        testExecutor.advanceTimeBy(config.failureDetectorInterval().toNanos(), TimeUnit.NANOSECONDS);
+        updateStatus(lazy, false);
+        assertTrue(lazy.isHealthy());
+
+        // Past the shared grace boundary a healthy round decays both from 1 to 0, so both re-eject for 1x base and
+        // revive at the same time.
+        updateStatus(eager, false);
+        updateStatus(lazy, false);
+        updateStatus(eager, true);
+        updateStatus(lazy, true);
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() - 1, TimeUnit.NANOSECONDS);
+        assertFalse(eager.isHealthy());
+        assertFalse(lazy.isHealthy());
+        testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
+        assertTrue(eager.isHealthy());
+        assertTrue(lazy.isHealthy());
+    }
+
+    @Test
+    void consecutive5xxReEjectionDuringGracePeriodRestartsGraceAtNewEjectionEnd() {
+        // Eject and revive so the host is healthy but still within the decay grace period (multiplier 1).
+        ejectIndicator(true);
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
+        assertTrue(healthIndicator.isHealthy());
+
+        // Re-eject via consecutive 5xx within the grace period: multiplier grows to 2 and a new ejection opens.
+        for (int i = 0; i < config.consecutive5xx(); i++) {
+            healthIndicator.onRequestError(healthIndicator.beforeRequestStart() + 1,
+                    RequestTracker.ErrorClass.EXT_ORIGIN_REQUEST_FAILED);
+        }
+        assertFalse(healthIndicator.isHealthy());
+        assertEquals(2, healthIndicator.ejectionCount);
+
+        // After the new ejection elapses the grace period restarts from the new end: a healthy round right after
+        // does not decay, so the multiplier is still 2 and the next ejection is 3x base.
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 2, TimeUnit.NANOSECONDS);
+        assertTrue(healthIndicator.isHealthy());
+        ejectIndicator(false);
+        ejectIndicator(true);
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 3 - 1, TimeUnit.NANOSECONDS);
         assertFalse(healthIndicator.isHealthy());
         testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
         assertTrue(healthIndicator.isHealthy());
@@ -288,7 +339,11 @@ class XdsHealthIndicatorTest {
     }
 
     private void ejectIndicator(boolean isOutlier) {
-        sequentialExecutor.execute(() -> healthIndicator.updateOutlierStatus(config, isOutlier));
+        updateStatus(healthIndicator, isOutlier);
+    }
+
+    private void updateStatus(TestIndicator indicator, boolean isOutlier) {
+        sequentialExecutor.execute(() -> indicator.updateOutlierStatus(config, isOutlier));
     }
 
     private class TestIndicator extends XdsHealthIndicator<String, TestLoadBalancedConnection> {

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -109,18 +109,18 @@ class XdsHealthIndicatorTest {
     @Test
     void wontEjectWithoutHelperSayingItsOkayToDoSo() {
         healthIndicator.mayEjectHost = false;
-        ejectIndicator(true);
+        updateStatus(true);
         assertTrue(healthIndicator.isHealthy());
 
         // how try to eject if the helper allows
         healthIndicator.mayEjectHost = true;
-        ejectIndicator(true);
+        updateStatus(true);
         assertFalse(healthIndicator.isHealthy());
     }
 
     @Test
     void hostRevival() {
-        ejectIndicator(true);
+        updateStatus(true);
         assertEquals(1, healthIndicator.ejectionCount);
         assertFalse(healthIndicator.isHealthy());
 
@@ -131,26 +131,26 @@ class XdsHealthIndicatorTest {
 
     @Test
     void outlierOnTheExpiringIntervalRevivesButDoesNotReEjectThatRound() {
-        ejectIndicator(true);
+        updateStatus(true);
         assertEquals(1, healthIndicator.ejectionCount);
         assertFalse(healthIndicator.isHealthy());
 
         // Once the ejection elapses, an outlier round revives without re-ejecting on that round's (stale) stats.
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
-        ejectIndicator(true);
+        updateStatus(true);
         assertTrue(healthIndicator.isHealthy());
         assertEquals(1, healthIndicator.revivalCount);
         assertEquals(1, healthIndicator.ejectionCount);
 
         // A later round can eject the now-healthy host again.
-        ejectIndicator(true);
+        updateStatus(true);
         assertFalse(healthIndicator.isHealthy());
         assertEquals(2, healthIndicator.ejectionCount);
     }
 
     @Test
     void failureMultiplier() {
-        ejectIndicator(true);
+        updateStatus(true);
         assertEquals(1, healthIndicator.ejectionCount);
         assertFalse(healthIndicator.isHealthy());
 
@@ -158,14 +158,14 @@ class XdsHealthIndicatorTest {
         assertTrue(healthIndicator.isHealthy());
 
         // Now the ejection time should grow by 2x since it was ejected twice in a row.
-        ejectIndicator(true);
+        updateStatus(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 2 - 1, TimeUnit.NANOSECONDS);
         assertFalse(healthIndicator.isHealthy());
         testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
         assertTrue(healthIndicator.isHealthy());
 
         // one more failure in a row to get our multiplier to 3.
-        ejectIndicator(true);
+        updateStatus(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 3 - 1, TimeUnit.NANOSECONDS);
         assertFalse(healthIndicator.isHealthy());
         testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
@@ -174,9 +174,9 @@ class XdsHealthIndicatorTest {
         // Give it a healthy round and the multiplier should go down to two, so the next eviction lasts 3x base.
         // Decay only happens a full interval after revival (the grace period), so advance one interval first.
         testExecutor.advanceTimeBy(config.failureDetectorInterval().toNanos(), TimeUnit.NANOSECONDS);
-        ejectIndicator(false);
+        updateStatus(false);
         // now see how long it was ejected
-        ejectIndicator(true);
+        updateStatus(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 3 - 1, TimeUnit.NANOSECONDS);
         assertFalse(healthIndicator.isHealthy());
         testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
@@ -186,16 +186,16 @@ class XdsHealthIndicatorTest {
     @Test
     void failureMultiplierDoesNotDecayWithinTheGracePeriodAfterRevival() {
         // Grow the multiplier to 2.
-        ejectIndicator(true);
+        updateStatus(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
         assertTrue(healthIndicator.isHealthy());
-        ejectIndicator(true);
+        updateStatus(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 2, TimeUnit.NANOSECONDS);
         assertTrue(healthIndicator.isHealthy());
 
         // A healthy round within the grace period must not decay, so the next ejection still lasts 3x base.
-        ejectIndicator(false);
-        ejectIndicator(true);
+        updateStatus(false);
+        updateStatus(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 3 - 1, TimeUnit.NANOSECONDS);
         assertFalse(healthIndicator.isHealthy());
         testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
@@ -204,21 +204,21 @@ class XdsHealthIndicatorTest {
 
     @Test
     void failureMultiplierDecayIsAnchoredAtScheduledEjectionEndNotRevivalTime() {
-        ejectIndicator(true);
+        updateStatus(true);
         assertFalse(healthIndicator.isHealthy());
 
         // Advance past the ejection end without calling isHealthy() (which would revive eagerly), then revive
         // lazily via a detector tick.
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() + config.failureDetectorInterval().toNanos(),
                 TimeUnit.NANOSECONDS);
-        ejectIndicator(false);
+        updateStatus(false);
         assertTrue(healthIndicator.isHealthy());
         assertEquals(1, healthIndicator.revivalCount);
 
         // Decay happens on the very next round with no further wait: the grace period runs from the scheduled
         // ejection end, not the (later) revival time. So the next ejection is only 1x base.
-        ejectIndicator(false);
-        ejectIndicator(true);
+        updateStatus(false);
+        updateStatus(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() - 1, TimeUnit.NANOSECONDS);
         assertFalse(healthIndicator.isHealthy());
         testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
@@ -259,7 +259,7 @@ class XdsHealthIndicatorTest {
     @Test
     void consecutive5xxReEjectionDuringGracePeriodRestartsGraceAtNewEjectionEnd() {
         // Eject and revive so the host is healthy but still within the decay grace period (multiplier 1).
-        ejectIndicator(true);
+        updateStatus(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
         assertTrue(healthIndicator.isHealthy());
 
@@ -275,8 +275,8 @@ class XdsHealthIndicatorTest {
         // does not decay, so the multiplier is still 2 and the next ejection is 3x base.
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 2, TimeUnit.NANOSECONDS);
         assertTrue(healthIndicator.isHealthy());
-        ejectIndicator(false);
-        ejectIndicator(true);
+        updateStatus(false);
+        updateStatus(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 3 - 1, TimeUnit.NANOSECONDS);
         assertFalse(healthIndicator.isHealthy());
         testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
@@ -292,7 +292,7 @@ class XdsHealthIndicatorTest {
 
         // Eject as many times in a row to get the ejection time maxed out.
         for (long i = 0; i < MAX_EJECTION_SECONDS; i++) {
-            ejectIndicator(true);
+            updateStatus(true);
             // ensure the indicator is ejected until the very last nanosecond.
             testExecutor.advanceTimeBy(ofSeconds(i + 1).toNanos() - 1, TimeUnit.NANOSECONDS);
             assertFalse(healthIndicator.isHealthy());
@@ -302,7 +302,7 @@ class XdsHealthIndicatorTest {
         }
 
         // Eject again and we should still be unhealthy only until maxEjectionTime.
-        ejectIndicator(true);
+        updateStatus(true);
         assertFalse(healthIndicator.isHealthy());
         // ensure the indicator is ejected until the very last nanosecond.
         testExecutor.advanceTimeBy(config.maxEjectionTime().toNanos() - 1, TimeUnit.NANOSECONDS);
@@ -316,9 +316,9 @@ class XdsHealthIndicatorTest {
         // since revival has elapsed; after that every healthy round decrements.
         testExecutor.advanceTimeBy(config.failureDetectorInterval().toNanos(), TimeUnit.NANOSECONDS);
         for (int i = 0; i < 8; i++) {
-            ejectIndicator(false);
+            updateStatus(false);
         }
-        ejectIndicator(true);
+        updateStatus(true);
         testExecutor.advanceTimeBy(ofSeconds(2).toNanos() - 1, TimeUnit.NANOSECONDS);
         assertFalse(healthIndicator.isHealthy());
         testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
@@ -338,7 +338,7 @@ class XdsHealthIndicatorTest {
         assertTrue(healthIndicator.cancelled);
     }
 
-    private void ejectIndicator(boolean isOutlier) {
+    private void updateStatus(boolean isOutlier) {
         updateStatus(healthIndicator, isOutlier);
     }
 

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -60,6 +60,10 @@ class XdsHealthIndicatorTest {
         return new OutlierDetectorConfig.Builder()
                 .maxEjectionTime(ofSeconds(MAX_EJECTION_SECONDS))
                 .baseEjectionTime(ofSeconds(1))
+                // The failure multiplier only decays after a full interval has elapsed since revival (the grace
+                // period). Pin the interval to the base ejection time with no jitter so the decay boundaries are
+                // deterministic in these tests.
+                .failureDetectorInterval(ofSeconds(1), ZERO)
                 .ejectionTimeJitter(ZERO);
     }
 
@@ -126,6 +130,28 @@ class XdsHealthIndicatorTest {
     }
 
     @Test
+    void outlierOnTheExpiringIntervalRevivesButDoesNotReEjectThatRound() {
+        ejectIndicator(true);
+        assertEquals(1, healthIndicator.ejectionCount);
+        assertFalse(healthIndicator.isHealthy());
+
+        // Let the ejection time elapse, then run a round that still judges the host an outlier. updateOutlierStatus
+        // revives it and returns without re-evaluating the verdict this round -- the counters still hold the
+        // pre-revival stats, so re-ejecting on them would double-count. The host becomes healthy and the ejection
+        // count is unchanged; it can only be re-ejected on a subsequent round (on fresh data).
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
+        ejectIndicator(true);
+        assertTrue(healthIndicator.isHealthy());
+        assertEquals(1, healthIndicator.revivalCount);
+        assertEquals(1, healthIndicator.ejectionCount);
+
+        // A following round can eject the now-healthy host again.
+        ejectIndicator(true);
+        assertFalse(healthIndicator.isHealthy());
+        assertEquals(2, healthIndicator.ejectionCount);
+    }
+
+    @Test
     void failureMultiplier() {
         ejectIndicator(true);
         assertEquals(1, healthIndicator.ejectionCount);
@@ -149,9 +175,31 @@ class XdsHealthIndicatorTest {
         assertTrue(healthIndicator.isHealthy());
 
         // Give it a healthy round and the multiplier should go down to two. This means the next eviction will
-        // be evicted for three * baseEjectionTime.
+        // be evicted for three * baseEjectionTime. The decrement only happens once a full interval has elapsed
+        // since the host was revived (the grace period), so advance one interval before the healthy round.
+        testExecutor.advanceTimeBy(config.failureDetectorInterval().toNanos(), TimeUnit.NANOSECONDS);
         ejectIndicator(false);
         // now see how long it was ejected
+        ejectIndicator(true);
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 3 - 1, TimeUnit.NANOSECONDS);
+        assertFalse(healthIndicator.isHealthy());
+        testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
+        assertTrue(healthIndicator.isHealthy());
+    }
+
+    @Test
+    void failureMultiplierDoesNotDecayWithinTheGracePeriodAfterRevival() {
+        // Eject twice in a row so the multiplier grows to 2.
+        ejectIndicator(true);
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos(), TimeUnit.NANOSECONDS);
+        assertTrue(healthIndicator.isHealthy());
+        ejectIndicator(true);
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 2, TimeUnit.NANOSECONDS);
+        assertTrue(healthIndicator.isHealthy());
+
+        // A healthy round within the grace period (before a full interval has elapsed since revival) must NOT
+        // decay the multiplier, so the next ejection still lasts 3x base (1 + the un-decayed multiplier of 2).
+        ejectIndicator(false);
         ejectIndicator(true);
         testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() * 3 - 1, TimeUnit.NANOSECONDS);
         assertFalse(healthIndicator.isHealthy());
@@ -188,7 +236,9 @@ class XdsHealthIndicatorTest {
         assertTrue(healthIndicator.isHealthy());
 
         // now set it healthy 8 times in a row to decrement the multiplier and make sure we get the right
-        // delay for the next failure which should be 2x the base.
+        // delay for the next failure which should be 2x the base. Advance one interval first so the grace period
+        // since revival has elapsed; after that every healthy round decrements.
+        testExecutor.advanceTimeBy(config.failureDetectorInterval().toNanos(), TimeUnit.NANOSECONDS);
         for (int i = 0; i < 8; i++) {
             ejectIndicator(false);
         }

--- a/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
+++ b/servicetalk-loadbalancer/src/test/java/io/servicetalk/loadbalancer/XdsHealthIndicatorTest.java
@@ -208,6 +208,31 @@ class XdsHealthIndicatorTest {
     }
 
     @Test
+    void failureMultiplierDecayIsAnchoredAtScheduledEjectionEndNotRevivalTime() {
+        // Eject once: multiplier 0 -> 1, ejected until t == baseEjectionTime.
+        ejectIndicator(true);
+        assertFalse(healthIndicator.isHealthy());
+
+        // Advance well past the ejection end WITHOUT calling isHealthy() (which would revive eagerly), then run a
+        // detection round so the host is revived lazily by updateOutlierStatus rather than by a selector.
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() + config.failureDetectorInterval().toNanos(),
+                TimeUnit.NANOSECONDS);
+        ejectIndicator(false);
+        assertTrue(healthIndicator.isHealthy());
+        assertEquals(1, healthIndicator.revivalCount);
+
+        // The very next healthy round decays the multiplier even though no time has passed since the lazy revival:
+        // the grace period is measured from the scheduled ejection end, not from when the revival was processed. So
+        // the next ejection lasts only 1x base (multiplier decayed 1 -> 0).
+        ejectIndicator(false);
+        ejectIndicator(true);
+        testExecutor.advanceTimeBy(config.baseEjectionTime().toNanos() - 1, TimeUnit.NANOSECONDS);
+        assertFalse(healthIndicator.isHealthy());
+        testExecutor.advanceTimeBy(1, TimeUnit.NANOSECONDS);
+        assertTrue(healthIndicator.isHealthy());
+    }
+
+    @Test
     void failureMultiplierOverflow() {
         // make sure out configuration is actually correct
         assertEquals(ofSeconds(1), config.baseEjectionTime());


### PR DESCRIPTION
 #### Motivation

XdsHealthIndicator revives an ejected host eagerly, as soon as its ejection time elapses (via isHealthy()). But the failure multiplier was decremented in the healthy branch of updateOutlierStatus, which only runs once the host has already been revived. Whether the multiplier decayed on a given interval therefore depended on whether a selection thread had happened to call isHealthy() and revive the host before the detector's tick, so two hosts ejected identically could decay differently based on traffic.

 #### Modifications

- Record revivedAtNanos on revival and decay the failure multiplier only once a full failureDetectorInterval has elapsed since then, rather than on every healthy interval, so decay is deterministic regardless of when within an interval the host was revived.
- Anchor revivedAtNanos at the ejection's scheduled end (evictedUntilNanos), not the moment revival was processed, so decay timing is identical whether the host was revived eagerly or lazily on a later interval tick.

 #### Result

The failure multiplier decays deterministically, one step per healthy interval, independent of selection traffic, while eager revival is retained so recovered hosts return to rotation without waiting for the next interval.