### PR TITLE
buffer-api: fix zero-length `BufferInputStream` reads

### DIFF
--- a/servicetalk-buffer-api/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-buffer-api/gradle/spotbugs/test-exclusions.xml
@@ -23,4 +23,13 @@
     <Source name="~.*Test\.java"/>
     <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
   </Match>
+  <!-- Test intentionally validates incorrect behavior -->
+  <Match>
+    <Class name="io.servicetalk.buffer.api.BufferInputStreamTest"/>
+    <Or>
+      <Bug pattern="RANGE_ARRAY_LENGTH"/>
+      <Bug pattern="RANGE_ARRAY_OFFSET"/>
+      <Bug pattern="RR_NOT_CHECKED"/>
+    </Or>
+  </Match>
 </FindBugsFilter>

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferInputStream.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferInputStream.java
@@ -42,7 +42,7 @@ final class BufferInputStream extends InputStream {
     public int read(byte[] b, int off, int len) {
         requireNonNull(b);
         if ((off | len) < 0 || len > b.length - off) {
-            throw new IndexOutOfBoundsException();
+            throw new IndexOutOfBoundsException("off=" + off + ", len=" + len + ", b.length=" + b.length);
         }
         if (len == 0) {
             return 0;

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferInputStream.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/BufferInputStream.java
@@ -40,6 +40,13 @@ final class BufferInputStream extends InputStream {
 
     @Override
     public int read(byte[] b, int off, int len) {
+        requireNonNull(b);
+        if ((off | len) < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (len == 0) {
+            return 0;
+        }
         int readableBytes = buffer.readableBytes();
         if (readableBytes == 0) {
             return -1;

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/BufferInputStreamTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/BufferInputStreamTest.java
@@ -27,6 +27,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class BufferInputStreamTest {
 
@@ -67,6 +68,27 @@ class BufferInputStreamTest {
     @Test
     void skipMoreThanIntegerMax() throws Exception {
         testSkip(Long.MAX_VALUE, DATA.length(), "");
+    }
+
+    @Test
+    void readZeroLengthAtEnd() throws Exception {
+        InputStream empty = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii(""));
+        assertThat(empty.read(new byte[1], 0, 0), is(0));
+    }
+
+    @Test
+    void readValidatesNullArrayAtEnd() {
+        InputStream empty = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii(""));
+        assertThrows(NullPointerException.class, () -> empty.read(null, 0, 0));
+    }
+
+    @Test
+    void readValidatesBoundsAtEnd() {
+        InputStream empty = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii(""));
+        byte[] bytes = new byte[1];
+        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, -1, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 0, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 1, 1));
     }
 
     private void testSkip(long n, long skipped, String expected) throws Exception {

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/BufferInputStreamTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/BufferInputStreamTest.java
@@ -89,6 +89,8 @@ class BufferInputStreamTest {
         assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, -1, 0));
         assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 0, -1));
         assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 1, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 0, Integer.MAX_VALUE));
+        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, Integer.MAX_VALUE, 1));
     }
 
     private void testSkip(long n, long skipped, String expected) throws Exception {

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/BufferInputStreamTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/BufferInputStreamTest.java
@@ -72,25 +72,28 @@ class BufferInputStreamTest {
 
     @Test
     void readZeroLengthAtEnd() throws Exception {
-        InputStream empty = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii(""));
-        assertThat(empty.read(new byte[1], 0, 0), is(0));
+        try (InputStream empty = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii(""))) {
+            assertThat(empty.read(new byte[1], 0, 0), is(0));
+        }
     }
 
     @Test
-    void readValidatesNullArrayAtEnd() {
-        InputStream empty = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii(""));
-        assertThrows(NullPointerException.class, () -> empty.read(null, 0, 0));
+    void readValidatesNullArrayAtEnd() throws Exception {
+        try (InputStream empty = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii(""))) {
+            assertThrows(NullPointerException.class, () -> empty.read(null, 0, 0));
+        }
     }
 
     @Test
-    void readValidatesBoundsAtEnd() {
-        InputStream empty = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii(""));
-        byte[] bytes = new byte[1];
-        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, -1, 0));
-        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 0, -1));
-        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 1, 1));
-        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 0, Integer.MAX_VALUE));
-        assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, Integer.MAX_VALUE, 1));
+    void readValidatesBoundsAtEnd() throws Exception {
+        try (InputStream empty = new BufferInputStream(DEFAULT_RO_ALLOCATOR.fromAscii(""))) {
+            byte[] bytes = new byte[1];
+            assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, -1, 0));
+            assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 0, -1));
+            assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 1, 1));
+            assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, 0, Integer.MAX_VALUE));
+            assertThrows(IndexOutOfBoundsException.class, () -> empty.read(bytes, Integer.MAX_VALUE, 1));
+        }
     }
 
     private void testSkip(long n, long skipped, String expected) throws Exception {


### PR DESCRIPTION
#### Motivation

`BufferInputStream.read(byte[], off, len)` returned `-1` for zero-length reads when the backing buffer was already exhausted. `InputStream` expects zero-length reads to return `0` after validating the array and range arguments.

#### Modifications

- Validates the array/range before checking EOF, returns `0` for `len == 0`
- Adds regression coverage for zero-length EOF reads plus invalid arguments at EOF

The bounds check is kept local instead of using `Objects.checkFromIndexSize` because the module still targets Java 8 bytecode.

#### Result

`BufferInputStream` implementation behavior is aligned with `InputStream` javadoc.