### PR TITLE
buffer-api: fix read-only byte buffer slice offsets

### DIFF
--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/ReadOnlyByteBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/ReadOnlyByteBuffer.java
@@ -427,6 +427,8 @@ final class ReadOnlyByteBuffer extends AbstractBuffer {
         return sliceAndPreserveOrder(duplicate);
     }
 
+    // ByteBuffer.slice() drops the source's byte order (always returns BIG_ENDIAN). Restore it so LE-source buffers
+    // keep reading LE after a slice.
     private static ByteBuffer sliceAndPreserveOrder(ByteBuffer buffer) {
         return buffer.slice().order(buffer.order());
     }

--- a/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/ReadOnlyByteBuffer.java
+++ b/servicetalk-buffer-api/src/main/java/io/servicetalk/buffer/api/ReadOnlyByteBuffer.java
@@ -44,8 +44,8 @@ final class ReadOnlyByteBuffer extends AbstractBuffer {
     private final ByteBuffer buffer;
 
     ReadOnlyByteBuffer(ByteBuffer buffer) {
-        super(buffer.position(), buffer.limit());
-        this.buffer = buffer;
+        super(0, buffer.remaining());
+        this.buffer = sliceAndPreserveOrder(buffer);
     }
 
     @Override
@@ -421,9 +421,14 @@ final class ReadOnlyByteBuffer extends AbstractBuffer {
         return sliceByteBuffer0(index, length);
     }
 
-    @SuppressWarnings("PMD.UnnecessaryCast") // false positive
     private ByteBuffer sliceByteBuffer0(int index, int length) {
-        return (ByteBuffer) buffer.duplicate().position(index).limit(index + length);
+        ByteBuffer duplicate = buffer.duplicate();
+        duplicate.position(index).limit(index + length);
+        return sliceAndPreserveOrder(duplicate);
+    }
+
+    private static ByteBuffer sliceAndPreserveOrder(ByteBuffer buffer) {
+        return buffer.slice().order(buffer.order());
     }
 
     @Override

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/CharSequencesTest.java
@@ -15,7 +15,6 @@
  */
 package io.servicetalk.buffer.api;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -200,7 +199,6 @@ class CharSequencesTest {
     }
 
     @Test
-    @Disabled("ReadOnlyByteBuffer#slice() does not account for the slice offset")
     void parseLongFromSlice() {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text");
         assertThat("Unexpected result for AsciiBuffer representation",

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
@@ -67,6 +67,39 @@ class ReadOnlyByteBufferTest {
     }
 
     @Test
+    void sliceStartsAtSliceOffset() {
+        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text");
+        Buffer slice = buffer.slice(4, 2);
+
+        assertEquals(0, slice.readerIndex());
+        assertEquals(2, slice.writerIndex());
+        assertEquals(2, slice.capacity());
+        assertEquals('4', (char) slice.getByte(0));
+        assertEquals('2', (char) slice.getByte(1));
+    }
+
+    @Test
+    void wrapPartialArrayStartsAtOffset() {
+        Buffer buffer = DEFAULT_RO_ALLOCATOR.wrap("text42text".getBytes(US_ASCII), 4, 2);
+
+        assertEquals(0, buffer.readerIndex());
+        assertEquals(2, buffer.writerIndex());
+        assertEquals(2, buffer.capacity());
+        assertEquals('4', (char) buffer.getByte(0));
+        assertEquals('2', (char) buffer.getByte(1));
+    }
+
+    @Test
+    void toNioBufferStartsAtSliceOffset() {
+        ByteBuffer nioBuffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text").toNioBuffer(4, 2);
+
+        assertEquals(0, nioBuffer.position());
+        assertEquals(2, nioBuffer.remaining());
+        assertEquals('4', (char) nioBuffer.get(0));
+        assertEquals('2', (char) nioBuffer.get(1));
+    }
+
+    @Test
     void copy() {
         Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
         assertEquals(buffer, buffer.copy());

--- a/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
+++ b/servicetalk-buffer-api/src/test/java/io/servicetalk/buffer/api/ReadOnlyByteBufferTest.java
@@ -15,25 +15,38 @@
  */
 package io.servicetalk.buffer.api;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
+import java.util.stream.Stream;
 
-import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.DEFAULT_RO_ALLOCATOR;
+import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.PREFER_DIRECT_RO_ALLOCATOR;
+import static io.servicetalk.buffer.api.ReadOnlyBufferAllocators.PREFER_HEAP_RO_ALLOCATOR;
 import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ReadOnlyByteBufferTest {
-    @Test
-    void directFromString() {
+
+    private static Stream<Named<BufferAllocator>> allocators() {
+        return Stream.of(
+                Named.of("heap", PREFER_HEAP_RO_ALLOCATOR),
+                Named.of("direct", PREFER_DIRECT_RO_ALLOCATOR));
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void directFromString(BufferAllocator allocator) {
         String expectedString = "testing";
         ByteBuffer expectedBuffer = allocateDirect(expectedString.length());
         expectedBuffer.put(expectedString.getBytes(US_ASCII));
         expectedBuffer.flip();
-        Buffer buffer1 = DEFAULT_RO_ALLOCATOR.wrap(expectedBuffer);
-        Buffer buffer2 = DEFAULT_RO_ALLOCATOR.fromAscii("testing");
+        Buffer buffer1 = allocator.wrap(expectedBuffer);
+        Buffer buffer2 = allocator.fromAscii("testing");
         assertEquals(buffer1, buffer2);
         assertEquals(expectedBuffer, buffer1.toNioBuffer());
         assertEquals(expectedBuffer, buffer2.toNioBuffer());
@@ -46,29 +59,44 @@ class ReadOnlyByteBufferTest {
         assertEquals("testing", buffer1.toString(US_ASCII));
     }
 
-    @Test
-    void getLong() {
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void getLong(BufferAllocator allocator) {
         ByteBuffer expectedBuffer = allocateDirect(8);
         expectedBuffer.putLong(Long.MAX_VALUE);
         expectedBuffer.flip();
-        Buffer buffer1 = DEFAULT_RO_ALLOCATOR.wrap(expectedBuffer);
+        Buffer buffer1 = allocator.wrap(expectedBuffer);
         assertEquals(Long.MAX_VALUE, buffer1.getLong(buffer1.readerIndex()));
     }
 
-    @Test
-    void getUnsignedShort() {
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void getUnsignedShort(BufferAllocator allocator) {
         ByteBuffer expectedBuffer = allocateDirect(4);
         expectedBuffer.putShort((short) 0xffff);
         expectedBuffer.putShort((short) 0xf234);
         expectedBuffer.flip();
-        Buffer buffer1 = DEFAULT_RO_ALLOCATOR.wrap(expectedBuffer);
+        Buffer buffer1 = allocator.wrap(expectedBuffer);
         assertEquals(0xffff, buffer1.getUnsignedShort(buffer1.readerIndex()));
         assertEquals(0xf234, buffer1.getUnsignedShort(buffer1.readerIndex() + 2));
     }
 
-    @Test
-    void sliceStartsAtSliceOffset() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text");
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void sliceOfLittleEndianBufferPreservesOrder(BufferAllocator allocator) {
+        ByteBuffer src = ByteBuffer.allocate(4).order(LITTLE_ENDIAN)
+                .putShort((short) 0x1234).putShort((short) 0x5678);
+        src.flip();
+        Buffer buffer = allocator.wrap(src).slice(2, 2);
+        // With LE preserved: 0x5678 stored as bytes 0x78 0x56, so getShortLE() reads 0x5678.
+        // If order were dropped to BE, we'd read 0x7856 instead.
+        assertEquals((short) 0x5678, buffer.getShortLE(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void sliceStartsAtSliceOffset(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("text42text");
         Buffer slice = buffer.slice(4, 2);
 
         assertEquals(0, slice.readerIndex());
@@ -78,9 +106,10 @@ class ReadOnlyByteBufferTest {
         assertEquals('2', (char) slice.getByte(1));
     }
 
-    @Test
-    void wrapPartialArrayStartsAtOffset() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.wrap("text42text".getBytes(US_ASCII), 4, 2);
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void wrapPartialArrayStartsAtOffset(BufferAllocator allocator) {
+        Buffer buffer = allocator.wrap("text42text".getBytes(US_ASCII), 4, 2);
 
         assertEquals(0, buffer.readerIndex());
         assertEquals(2, buffer.writerIndex());
@@ -89,9 +118,10 @@ class ReadOnlyByteBufferTest {
         assertEquals('2', (char) buffer.getByte(1));
     }
 
-    @Test
-    void toNioBufferStartsAtSliceOffset() {
-        ByteBuffer nioBuffer = DEFAULT_RO_ALLOCATOR.fromAscii("text42text").toNioBuffer(4, 2);
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void toNioBufferStartsAtSliceOffset(BufferAllocator allocator) {
+        ByteBuffer nioBuffer = allocator.fromAscii("text42text").toNioBuffer(4, 2);
 
         assertEquals(0, nioBuffer.position());
         assertEquals(2, nioBuffer.remaining());
@@ -99,39 +129,74 @@ class ReadOnlyByteBufferTest {
         assertEquals('2', (char) nioBuffer.get(1));
     }
 
-    @Test
-    void copy() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void sliceOfSliceComposesOffsets(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("text42text");
+        Buffer outer = buffer.slice(2, 6);    // "xt42te"
+        Buffer inner = outer.slice(2, 2);     // "42"
+
+        assertEquals(0, inner.readerIndex());
+        assertEquals(2, inner.writerIndex());
+        assertEquals(2, inner.capacity());
+        assertEquals('4', (char) inner.getByte(0));
+        assertEquals('2', (char) inner.getByte(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void sliceAndWrapPartialArrayAreEquivalent(BufferAllocator allocator) {
+        // slice(off, len) on a full wrap and wrap(bytes, off, len) should produce the same buffer under the fixed
+        // coordinate system.
+        byte[] bytes = "text42text".getBytes(US_ASCII);
+        Buffer viaSlice = allocator.wrap(bytes).slice(4, 2);
+        Buffer viaWrap = allocator.wrap(bytes, 4, 2);
+
+        assertEquals(viaSlice, viaWrap);
+        assertEquals(viaSlice.capacity(), viaWrap.capacity());
+        assertEquals(viaSlice.readerIndex(), viaWrap.readerIndex());
+        assertEquals(viaSlice.writerIndex(), viaWrap.writerIndex());
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void copy(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("test");
         assertEquals(buffer, buffer.copy());
     }
 
-    @Test
-    void setNegativeReaderIndex() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void setNegativeReaderIndex(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("test");
         assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(-1));
     }
 
-    @Test
-    void setReaderIndexHigherThanWriterIndex() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void setReaderIndexHigherThanWriterIndex(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("test");
         assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(buffer.writerIndex() + 1));
     }
 
-    @Test
-    void setWriterIndexLowerThanReaderIndex() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void setWriterIndexLowerThanReaderIndex(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("test");
         assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(buffer.readerIndex() - 1));
     }
 
-    @Test
-    void setWriterIndexHigherThanCapacity() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void setWriterIndexHigherThanCapacity(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("test");
         assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(buffer.capacity() + 1));
     }
 
-    @Test
-    void testIndexOf() {
-        Buffer buffer = DEFAULT_RO_ALLOCATOR.fromAscii("test");
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void testIndexOf(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("test");
 
         assertEquals(-1, buffer.indexOf(0, 4, (byte) 'a'));
 

--- a/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/ReadOnlyBufferTest.java
+++ b/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/ReadOnlyBufferTest.java
@@ -16,34 +16,48 @@
 package io.servicetalk.buffer.netty;
 
 import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.buffer.api.BufferAllocator;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
+import java.util.stream.Stream;
 
-import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_DIRECT_ALLOCATOR;
+import static io.servicetalk.buffer.netty.BufferAllocators.PREFER_HEAP_ALLOCATOR;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ReadOnlyBufferTest {
 
-    @Test
-    void capacity() {
-        Buffer buffer = DEFAULT_ALLOCATOR.newBuffer(10).writeBytes("test".getBytes(US_ASCII));
+    private static Stream<Named<BufferAllocator>> allocators() {
+        return Stream.of(
+                Named.of("heap", PREFER_HEAP_ALLOCATOR),
+                Named.of("direct", PREFER_DIRECT_ALLOCATOR));
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void capacity(BufferAllocator allocator) {
+        Buffer buffer = allocator.newBuffer(10).writeBytes("test".getBytes(US_ASCII));
         Buffer readOnly = buffer.asReadOnly();
         assertEquals(buffer.capacity(), readOnly.capacity());
     }
 
-    @Test
-    void maxCapacity() {
-        Buffer buffer = DEFAULT_ALLOCATOR.newBuffer(10).writeBytes("test".getBytes(US_ASCII));
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void maxCapacity(BufferAllocator allocator) {
+        Buffer buffer = allocator.newBuffer(10).writeBytes("test".getBytes(US_ASCII));
         Buffer readOnly = buffer.asReadOnly();
         assertEquals(buffer.maxCapacity(), readOnly.maxCapacity());
     }
 
-    @Test
-    void changeReaderIndexViaReadOnlyView() {
-        Buffer buffer = DEFAULT_ALLOCATOR.fromAscii("test");
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void changeReaderIndexViaReadOnlyView(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("test");
         Buffer readOnly = buffer.asReadOnly();
         assertEquals(buffer.readerIndex(), readOnly.readerIndex());
         readOnly.skipBytes(2);
@@ -51,9 +65,10 @@ class ReadOnlyBufferTest {
         assertEquals(buffer.readerIndex(), readOnly.readerIndex());
     }
 
-    @Test
-    void changeWriterIndexViaReadOnlyView() {
-        Buffer buffer = DEFAULT_ALLOCATOR.fromAscii("test");
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void changeWriterIndexViaReadOnlyView(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("test");
         Buffer readOnly = buffer.asReadOnly();
         assertEquals(buffer.writerIndex(), readOnly.writerIndex());
         readOnly.writerIndex(2);
@@ -61,9 +76,10 @@ class ReadOnlyBufferTest {
         assertEquals(buffer.writerIndex(), readOnly.writerIndex());
     }
 
-    @Test
-    void sliceStartsAtSliceOffset() {
-        Buffer buffer = DEFAULT_ALLOCATOR.fromAscii("text42text").asReadOnly();
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void sliceStartsAtSliceOffset(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("text42text").asReadOnly();
         Buffer slice = buffer.slice(4, 2);
 
         assertEquals(0, slice.readerIndex());
@@ -73,9 +89,10 @@ class ReadOnlyBufferTest {
         assertEquals('2', (char) slice.getByte(1));
     }
 
-    @Test
-    void wrapPartialArrayStartsAtOffset() {
-        Buffer buffer = DEFAULT_ALLOCATOR.wrap("text42text".getBytes(US_ASCII), 4, 2).asReadOnly();
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void wrapPartialArrayStartsAtOffset(BufferAllocator allocator) {
+        Buffer buffer = allocator.wrap("text42text".getBytes(US_ASCII), 4, 2).asReadOnly();
 
         assertEquals(0, buffer.readerIndex());
         assertEquals(2, buffer.writerIndex());
@@ -84,13 +101,42 @@ class ReadOnlyBufferTest {
         assertEquals('2', (char) buffer.getByte(1));
     }
 
-    @Test
-    void toNioBufferStartsAtSliceOffset() {
-        ByteBuffer nioBuffer = DEFAULT_ALLOCATOR.fromAscii("text42text").asReadOnly().toNioBuffer(4, 2);
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void toNioBufferStartsAtSliceOffset(BufferAllocator allocator) {
+        ByteBuffer nioBuffer = allocator.fromAscii("text42text").asReadOnly().toNioBuffer(4, 2);
 
         assertEquals(0, nioBuffer.position());
         assertEquals(2, nioBuffer.remaining());
         assertEquals('4', (char) nioBuffer.get(0));
         assertEquals('2', (char) nioBuffer.get(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void sliceOfSliceComposesOffsets(BufferAllocator allocator) {
+        Buffer buffer = allocator.fromAscii("text42text").asReadOnly();
+        Buffer outer = buffer.slice(2, 6);    // "xt42te"
+        Buffer inner = outer.slice(2, 2);     // "42"
+
+        assertEquals(0, inner.readerIndex());
+        assertEquals(2, inner.writerIndex());
+        assertEquals(2, inner.capacity());
+        assertEquals('4', (char) inner.getByte(0));
+        assertEquals('2', (char) inner.getByte(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    void sliceAndWrapPartialArrayAreEquivalent(BufferAllocator allocator) {
+        // slice(off, len) on a full wrap and wrap(bytes, off, len) should produce the same read-only buffer.
+        byte[] bytes = "text42text".getBytes(US_ASCII);
+        Buffer viaSlice = allocator.wrap(bytes).asReadOnly().slice(4, 2);
+        Buffer viaWrap = allocator.wrap(bytes, 4, 2).asReadOnly();
+
+        assertEquals(viaSlice, viaWrap);
+        assertEquals(viaSlice.capacity(), viaWrap.capacity());
+        assertEquals(viaSlice.readerIndex(), viaWrap.readerIndex());
+        assertEquals(viaSlice.writerIndex(), viaWrap.writerIndex());
     }
 }

--- a/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/ReadOnlyBufferTest.java
+++ b/servicetalk-buffer-netty/src/test/java/io/servicetalk/buffer/netty/ReadOnlyBufferTest.java
@@ -19,6 +19,8 @@ import io.servicetalk.buffer.api.Buffer;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+
 import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,5 +59,38 @@ class ReadOnlyBufferTest {
         readOnly.writerIndex(2);
         assertEquals(2, readOnly.writerIndex());
         assertEquals(buffer.writerIndex(), readOnly.writerIndex());
+    }
+
+    @Test
+    void sliceStartsAtSliceOffset() {
+        Buffer buffer = DEFAULT_ALLOCATOR.fromAscii("text42text").asReadOnly();
+        Buffer slice = buffer.slice(4, 2);
+
+        assertEquals(0, slice.readerIndex());
+        assertEquals(2, slice.writerIndex());
+        assertEquals(2, slice.capacity());
+        assertEquals('4', (char) slice.getByte(0));
+        assertEquals('2', (char) slice.getByte(1));
+    }
+
+    @Test
+    void wrapPartialArrayStartsAtOffset() {
+        Buffer buffer = DEFAULT_ALLOCATOR.wrap("text42text".getBytes(US_ASCII), 4, 2).asReadOnly();
+
+        assertEquals(0, buffer.readerIndex());
+        assertEquals(2, buffer.writerIndex());
+        assertEquals(2, buffer.capacity());
+        assertEquals('4', (char) buffer.getByte(0));
+        assertEquals('2', (char) buffer.getByte(1));
+    }
+
+    @Test
+    void toNioBufferStartsAtSliceOffset() {
+        ByteBuffer nioBuffer = DEFAULT_ALLOCATOR.fromAscii("text42text").asReadOnly().toNioBuffer(4, 2);
+
+        assertEquals(0, nioBuffer.position());
+        assertEquals(2, nioBuffer.remaining());
+        assertEquals('4', (char) nioBuffer.get(0));
+        assertEquals('2', (char) nioBuffer.get(1));
     }
 }


### PR DESCRIPTION
#### Motivation

`ReadOnlyByteBuffer` kept the original `ByteBuffer` position and limit, so sliced or partial wrapped buffers still read from the original absolute offset.

#### Modifications
- Normalizes read-only buffer storage around zero-based `ByteBuffer` slices while preserving byte order.
- Makes `toNioBuffer(index, length)` return a zero-position view for the requested sub-region.
- Enhance tests.

#### Result

Fixes #3559

#### Behavior change

`ReadOnlyBufferAllocators.wrap(byte[], int, int)` and `wrap(ByteBuffer)` now normalize the returned `Buffer`'s coordinates to start at index `0` (previously, `readerIndex()` reflected the source `ByteBuffer`'s absolute position). Callers reading via `readerIndex()`/`writerIndex()` are unaffected; callers using absolute indexing tied to the original `ByteBuffer` position must update their offsets.