### PR TITLE
Use CatchAll observer within DefaultDnsClient to centralize exception handling

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/CatchAllDnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/CatchAllDnsServiceDiscovererObserver.java
@@ -15,16 +15,14 @@
  */
 package io.servicetalk.dns.discovery.netty;
 
-import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsDiscoveryObserver;
-import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsResolutionObserver;
-import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.ResolutionResult;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+import static io.servicetalk.dns.discovery.netty.NoopDnsServiceDiscovererObserver.NoopDnsDiscoveryObserver;
+import static io.servicetalk.dns.discovery.netty.NoopDnsServiceDiscovererObserver.NoopDnsResolutionObserver;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
@@ -99,49 +97,6 @@ final class CatchAllDnsServiceDiscovererObserver implements DnsServiceDiscoverer
         @Override
         public void resolutionCompleted(final ResolutionResult result) {
             safeReport(() -> observer.resolutionCompleted(result), observer, "resolution completed");
-        }
-    }
-
-    private static final class NoopDnsDiscoveryObserver implements DnsDiscoveryObserver {
-
-        static final DnsDiscoveryObserver INSTANCE = new NoopDnsDiscoveryObserver();
-
-        private NoopDnsDiscoveryObserver() {
-            // Singleton
-        }
-
-        @Override
-        public DnsResolutionObserver onNewResolution(final String name) {
-            return NoopDnsResolutionObserver.INSTANCE;
-        }
-
-        @Override
-        public void discoveryCancelled() {
-            // noop
-        }
-
-        @Override
-        public void discoveryFailed(final Throwable cause) {
-            // noop
-        }
-    }
-
-    private static final class NoopDnsResolutionObserver implements DnsResolutionObserver {
-
-        static final DnsResolutionObserver INSTANCE = new NoopDnsResolutionObserver();
-
-        private NoopDnsResolutionObserver() {
-            // Singleton
-        }
-
-        @Override
-        public void resolutionFailed(final Throwable cause) {
-            // noop
-        }
-
-        @Override
-        public void resolutionCompleted(final ResolutionResult result) {
-            // noop
         }
     }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/CatchAllDnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/CatchAllDnsServiceDiscovererObserver.java
@@ -15,14 +15,16 @@
  */
 package io.servicetalk.dns.discovery.netty;
 
+import io.servicetalk.dns.discovery.netty.NoopDnsServiceDiscovererObserver.NoopDnsDiscoveryObserver;
+import io.servicetalk.dns.discovery.netty.NoopDnsServiceDiscovererObserver.NoopDnsResolutionObserver;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import javax.annotation.Nullable;
 
-import static io.servicetalk.dns.discovery.netty.NoopDnsServiceDiscovererObserver.NoopDnsDiscoveryObserver;
-import static io.servicetalk.dns.discovery.netty.NoopDnsServiceDiscovererObserver.NoopDnsResolutionObserver;
 import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.util.Objects.requireNonNull;
 
@@ -45,86 +47,131 @@ final class CatchAllDnsServiceDiscovererObserver implements DnsServiceDiscoverer
 
     @Override
     @SuppressWarnings("deprecation")
-    public DnsDiscoveryObserver onNewDiscovery(final String name) {
-        return safeReport(() -> observer.onNewDiscovery(name), observer, "new discovery",
-                CatchAllDnsDiscoveryObserver::new, NoopDnsDiscoveryObserver.INSTANCE);
+    public DnsDiscoveryObserver onNewDiscovery(final String discoveryName) {
+        // Deprecated overload: no client id is available, so pass null and idName degrades the logged detail to just
+        // the discovery target rather than dropping attribution entirely.
+        return safeReport(() -> observer.onNewDiscovery(discoveryName), observer, "new discovery", null, discoveryName,
+                o -> new CatchAllDnsDiscoveryObserver(o, null, discoveryName), NoopDnsDiscoveryObserver.INSTANCE);
     }
 
     @Override
-    public DnsDiscoveryObserver onNewDiscovery(final String serviceDiscovererId, final String name) {
-        return safeReport(() -> observer.onNewDiscovery(serviceDiscovererId, name), observer, "new discovery",
-                CatchAllDnsDiscoveryObserver::new, NoopDnsDiscoveryObserver.INSTANCE);
+    public DnsDiscoveryObserver onNewDiscovery(final String serviceDiscovererId, final String discoveryName) {
+        return safeReport(() -> observer.onNewDiscovery(serviceDiscovererId, discoveryName), observer, "new discovery",
+                serviceDiscovererId, discoveryName,
+                o -> new CatchAllDnsDiscoveryObserver(o, serviceDiscovererId, discoveryName),
+                NoopDnsDiscoveryObserver.INSTANCE);
     }
 
     private static final class CatchAllDnsDiscoveryObserver implements DnsDiscoveryObserver {
 
         private final DnsDiscoveryObserver observer;
+        @Nullable
+        private final String serviceDiscovererId;
+        private final String discoveryName;
 
-        private CatchAllDnsDiscoveryObserver(final DnsDiscoveryObserver observer) {
+        private CatchAllDnsDiscoveryObserver(final DnsDiscoveryObserver observer,
+                                             @Nullable final String serviceDiscovererId, final String discoveryName) {
             this.observer = observer;
+            this.serviceDiscovererId = serviceDiscovererId;
+            this.discoveryName = discoveryName;
         }
 
         @Override
-        public DnsResolutionObserver onNewResolution(final String name) {
-            return safeReport(() -> observer.onNewResolution(name), observer, "new resolution",
-                    CatchAllDnsResolutionObserver::new, NoopDnsResolutionObserver.INSTANCE);
+        public DnsResolutionObserver onNewResolution(final String resolutionName) {
+            return safeReport(() -> observer.onNewResolution(resolutionName), observer, "new resolution",
+                    serviceDiscovererId, resolutionName,
+                    o -> new CatchAllDnsResolutionObserver(o, serviceDiscovererId, resolutionName),
+                    NoopDnsResolutionObserver.INSTANCE);
         }
 
         @Override
         public void discoveryCancelled() {
-            safeReport(observer::discoveryCancelled, observer, "discovery cancelled");
+            safeReport(observer::discoveryCancelled, observer, "discovery cancelled",
+                    serviceDiscovererId, discoveryName);
         }
 
         @Override
         public void discoveryFailed(final Throwable cause) {
-            safeReport(() -> observer.discoveryFailed(cause), observer, "discovery failed", cause);
+            safeReport(() -> observer.discoveryFailed(cause), observer, "discovery failed",
+                    serviceDiscovererId, discoveryName, cause);
         }
     }
 
     private static final class CatchAllDnsResolutionObserver implements DnsResolutionObserver {
 
         private final DnsResolutionObserver observer;
+        @Nullable
+        private final String serviceDiscovererId;
+        private final String resolutionName;
 
-        private CatchAllDnsResolutionObserver(final DnsResolutionObserver observer) {
+        private CatchAllDnsResolutionObserver(final DnsResolutionObserver observer,
+                                              @Nullable final String serviceDiscovererId,
+                                              final String resolutionName) {
             this.observer = observer;
+            this.serviceDiscovererId = serviceDiscovererId;
+            this.resolutionName = resolutionName;
         }
 
         @Override
         public void resolutionFailed(final Throwable cause) {
-            safeReport(() -> observer.resolutionFailed(cause), observer, "resolution failed", cause);
+            safeReport(() -> observer.resolutionFailed(cause), observer, "resolution failed",
+                    serviceDiscovererId, resolutionName, cause);
         }
 
         @Override
         public void resolutionCompleted(final ResolutionResult result) {
-            safeReport(() -> observer.resolutionCompleted(result), observer, "resolution completed");
+            safeReport(() -> observer.resolutionCompleted(result), observer, "resolution completed",
+                    serviceDiscovererId, resolutionName, result);
         }
     }
 
     private static <T> T safeReport(final Supplier<T> supplier, final Object observer, final String eventName,
+                                    @Nullable final String serviceDiscovererId, final String targetName,
                                     final UnaryOperator<T> catchAllWrapper, final T defaultValue) {
         try {
             return catchAllWrapper.apply(requireNonNull(supplier.get()));
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting a {} event", observer, eventName, unexpected);
+            LOGGER.warn("Unexpected exception from {} while reporting a {} event{}",
+                    observer, eventName, idName(serviceDiscovererId, targetName), unexpected);
             return defaultValue;
         }
     }
 
-    private static void safeReport(final Runnable runnable, final Object observer, final String eventName) {
+    private static void safeReport(final Runnable runnable, final Object observer, final String eventName,
+                                   @Nullable final String serviceDiscovererId, final String targetName) {
         try {
             runnable.run();
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting a {} event", observer, eventName, unexpected);
+            LOGGER.warn("Unexpected exception from {} while reporting a {} event{}",
+                    observer, eventName, idName(serviceDiscovererId, targetName), unexpected);
         }
     }
 
     private static void safeReport(final Runnable runnable, final Object observer, final String eventName,
+                                   @Nullable final String serviceDiscovererId, final String targetName,
                                    final Throwable original) {
         try {
             runnable.run();
         } catch (Throwable unexpected) {
             addSuppressed(unexpected, original);
-            LOGGER.warn("Unexpected exception from {} while reporting a {} event", observer, eventName, unexpected);
+            LOGGER.warn("Unexpected exception from {} while reporting a {} event{}",
+                    observer, eventName, idName(serviceDiscovererId, targetName), unexpected);
         }
+    }
+
+    private static void safeReport(final Runnable runnable, final Object observer, final String eventName,
+                                   @Nullable final String serviceDiscovererId, final String targetName,
+                                   final Object result) {
+        try {
+            runnable.run();
+        } catch (Throwable unexpected) {
+            LOGGER.warn("Unexpected exception from {} while reporting a {} event{}: {}",
+                    observer, eventName, idName(serviceDiscovererId, targetName), result, unexpected);
+        }
+    }
+
+    private static String idName(@Nullable final String serviceDiscovererId, final String targetName) {
+        return serviceDiscovererId == null ? " (" + targetName + ')' :
+                " (" + serviceDiscovererId + ' ' + targetName + ')';
     }
 }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/CatchAllDnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/CatchAllDnsServiceDiscovererObserver.java
@@ -120,7 +120,7 @@ final class CatchAllDnsServiceDiscovererObserver implements DnsServiceDiscoverer
 
         @Override
         public void resolutionCompleted(final ResolutionResult result) {
-            safeReport(() -> observer.resolutionCompleted(result), observer, "resolution completed",
+            safeReportResult(() -> observer.resolutionCompleted(result), observer, "resolution completed",
                     serviceDiscovererId, resolutionName, result);
         }
     }
@@ -131,8 +131,8 @@ final class CatchAllDnsServiceDiscovererObserver implements DnsServiceDiscoverer
         try {
             return catchAllWrapper.apply(requireNonNull(supplier.get()));
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting a {} event{}",
-                    observer, eventName, idName(serviceDiscovererId, targetName), unexpected);
+            LOGGER.warn("{}: Unexpected exception from {} while reporting a {} event",
+                    idName(serviceDiscovererId, targetName), observer, eventName, unexpected);
             return defaultValue;
         }
     }
@@ -142,8 +142,8 @@ final class CatchAllDnsServiceDiscovererObserver implements DnsServiceDiscoverer
         try {
             runnable.run();
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting a {} event{}",
-                    observer, eventName, idName(serviceDiscovererId, targetName), unexpected);
+            LOGGER.warn("{}: Unexpected exception from {} while reporting a {} event",
+                    idName(serviceDiscovererId, targetName), observer, eventName, unexpected);
         }
     }
 
@@ -154,24 +154,24 @@ final class CatchAllDnsServiceDiscovererObserver implements DnsServiceDiscoverer
             runnable.run();
         } catch (Throwable unexpected) {
             addSuppressed(unexpected, original);
-            LOGGER.warn("Unexpected exception from {} while reporting a {} event{}",
-                    observer, eventName, idName(serviceDiscovererId, targetName), unexpected);
+            LOGGER.warn("{}: Unexpected exception from {} while reporting a {} event",
+                    idName(serviceDiscovererId, targetName), observer, eventName, unexpected);
         }
     }
 
-    private static void safeReport(final Runnable runnable, final Object observer, final String eventName,
-                                   @Nullable final String serviceDiscovererId, final String targetName,
-                                   final Object result) {
+    private static void safeReportResult(final Runnable runnable, final Object observer, final String eventName,
+                                         @Nullable final String serviceDiscovererId, final String targetName,
+                                         final Object result) {
         try {
             runnable.run();
         } catch (Throwable unexpected) {
-            LOGGER.warn("Unexpected exception from {} while reporting a {} event{}: {}",
-                    observer, eventName, idName(serviceDiscovererId, targetName), result, unexpected);
+            LOGGER.warn("{}: Unexpected exception from {} while reporting a {} event: {}",
+                    idName(serviceDiscovererId, targetName), observer, eventName, result, unexpected);
         }
     }
 
     private static String idName(@Nullable final String serviceDiscovererId, final String targetName) {
-        return serviceDiscovererId == null ? " (" + targetName + ')' :
-                " (" + serviceDiscovererId + ' ' + targetName + ')';
+        return serviceDiscovererId == null ? '(' + targetName + ')' :
+                '(' + serviceDiscovererId + ' ' + targetName + ')';
     }
 }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -256,8 +256,6 @@ final class DefaultDnsClient implements DnsClient {
 
     private static <T> Publisher<T> observeDiscovery(final DnsDiscoveryObserver discoveryObserver,
                                                      final Publisher<T> events) {
-        // If the observer is noop there is nothing to report, so avoid wrapping with a beforeFinally that would only
-        // deliver events to nowhere.
         return discoveryObserver == NoopDnsDiscoveryObserver.INSTANCE ? events :
                 events.beforeFinally(new TerminalSignalConsumer() {
                     @Override

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -100,6 +100,8 @@ import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.IPV6_PR
 import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.preferredAddressType;
 import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.toRecordTypeNames;
 import static io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObservers.asSafeObserver;
+import static io.servicetalk.dns.discovery.netty.NoopDnsServiceDiscovererObserver.NoopDnsDiscoveryObserver;
+import static io.servicetalk.dns.discovery.netty.NoopDnsServiceDiscovererObserver.NoopDnsResolutionObserver;
 import static io.servicetalk.dns.discovery.netty.ServiceDiscovererUtils.calculateDifference;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.datagramChannel;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.socketChannel;
@@ -252,15 +254,12 @@ final class DefaultDnsClient implements DnsClient {
         return observer.onNewDiscovery(id, address);
     }
 
-    @Override
-    public Publisher<Collection<ServiceDiscovererEvent<InetAddress>>> dnsQuery(final String address) {
-        requireNonNull(address);
-        return defer(() -> {
-            final DnsDiscoveryObserver discoveryObserver = newDiscoveryObserver(address);
-            ARecordPublisher pub = new ARecordPublisher(address, discoveryObserver);
-            Publisher<? extends Collection<ServiceDiscovererEvent<InetAddress>>> events =
-                    recoverWithInactiveEvents(pub, false, nxInvalidation);
-            return events.beforeFinally(new TerminalSignalConsumer() {
+    private static <T> Publisher<T> observeDiscovery(final DnsDiscoveryObserver discoveryObserver,
+                                                     final Publisher<T> events) {
+        // If the observer is noop there is nothing to report, so avoid wrapping with a beforeFinally that would only
+        // deliver events to nowhere.
+        return discoveryObserver == NoopDnsDiscoveryObserver.INSTANCE ? events :
+                events.beforeFinally(new TerminalSignalConsumer() {
                     @Override
                     public void onComplete() {
                         // this event will never be triggered
@@ -276,6 +275,17 @@ final class DefaultDnsClient implements DnsClient {
                         discoveryObserver.discoveryCancelled();
                     }
                 });
+    }
+
+    @Override
+    public Publisher<Collection<ServiceDiscovererEvent<InetAddress>>> dnsQuery(final String address) {
+        requireNonNull(address);
+        return defer(() -> {
+            final DnsDiscoveryObserver discoveryObserver = newDiscoveryObserver(address);
+            ARecordPublisher pub = new ARecordPublisher(address, discoveryObserver);
+            Publisher<? extends Collection<ServiceDiscovererEvent<InetAddress>>> events =
+                    recoverWithInactiveEvents(pub, false, nxInvalidation);
+            return observeDiscovery(discoveryObserver, events);
         });
     }
 
@@ -338,22 +348,7 @@ final class DefaultDnsClient implements DnsClient {
             }, srvConcurrency)
             .liftSync(SrvInactiveCombinerOperator.EMIT);
 
-            return events.beforeFinally(new TerminalSignalConsumer() {
-                @Override
-                public void onComplete() {
-                    // this event will never be triggered
-                }
-
-                @Override
-                public void onError(final Throwable cause) {
-                    discoveryObserver.discoveryFailed(cause);
-                }
-
-                @Override
-                public void cancel() {
-                    discoveryObserver.discoveryCancelled();
-                }
-            });
+            return observeDiscovery(discoveryObserver, events);
         });
     }
 
@@ -831,12 +826,13 @@ final class DefaultDnsClient implements DnsClient {
                         }
                         ttlNanos = maxTTLNanos;
                     }
+                    final ServiceDiscovererUtils.TwoIntsConsumer reporter =
+                            resolutionObserver == NoopDnsResolutionObserver.INSTANCE ? null :
+                            (nAvailable, nMissing) -> resolutionObserver.resolutionCompleted(
+                                    new DefaultResolutionResult(addresses.size(),
+                                            (int) NANOSECONDS.toSeconds(ttlNanos), nAvailable, nMissing));
                     final List<ServiceDiscovererEvent<T>> events = calculateDifference(activeAddresses, addresses,
-                            comparator(), (nAvailable, nMissing) ->
-                                    resolutionObserver.resolutionCompleted(new DefaultResolutionResult(
-                                            addresses.size(), (int) NANOSECONDS.toSeconds(ttlNanos),
-                                            nAvailable, nMissing)),
-                            missingRecordStatus);
+                            comparator(), reporter, missingRecordStatus);
 
                     if (events != null) {
                         activeAddresses = addresses;

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -31,7 +31,6 @@ import io.servicetalk.concurrent.internal.DuplicateSubscribeException;
 import io.servicetalk.concurrent.internal.RejectedSubscribeError;
 import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsDiscoveryObserver;
 import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.DnsResolutionObserver;
-import io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObserver.ResolutionResult;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.IoExecutor;
 import io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutor;
@@ -100,11 +99,11 @@ import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.IPV4_PR
 import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.IPV6_PREFERRED;
 import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.preferredAddressType;
 import static io.servicetalk.dns.discovery.netty.DnsResolverAddressTypes.toRecordTypeNames;
+import static io.servicetalk.dns.discovery.netty.DnsServiceDiscovererObservers.asSafeObserver;
 import static io.servicetalk.dns.discovery.netty.ServiceDiscovererUtils.calculateDifference;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.datagramChannel;
 import static io.servicetalk.transport.netty.internal.BuilderUtils.socketChannel;
 import static io.servicetalk.transport.netty.internal.EventLoopAwareNettyIoExecutors.toEventLoopAwareNettyIoExecutor;
-import static io.servicetalk.utils.internal.ThrowableUtils.addSuppressed;
 import static java.lang.Integer.toHexString;
 import static java.lang.System.identityHashCode;
 import static java.nio.ByteBuffer.wrap;
@@ -132,7 +131,6 @@ final class DefaultDnsClient implements DnsClient {
     private final long ttlJitterNanos;
     private final long resolutionTimeoutMillis;
     private final ListenableAsyncCloseable asyncCloseable;
-    @Nullable
     private final DnsServiceDiscovererObserver observer;
     private final ServiceDiscovererEvent.Status missingRecordStatus;
     private final boolean nxInvalidation;
@@ -174,7 +172,7 @@ final class DefaultDnsClient implements DnsClient {
         this.maxTTLNanos = SECONDS.toNanos(maxTTL);
         this.ttlJitterNanos = ttlJitterNanos;
         this.addressTypes = dnsResolverAddressTypes;
-        this.observer = observer;
+        this.observer = safeObserver(observer);
         this.missingRecordStatus = missingRecordStatus;
         this.nxInvalidation = nxInvalidation;
         this.id = id + '@' + toHexString(identityHashCode(this));
@@ -246,18 +244,12 @@ final class DefaultDnsClient implements DnsClient {
         return ttlCache;
     }
 
-    @Nullable
+    private static DnsServiceDiscovererObserver safeObserver(@Nullable final DnsServiceDiscovererObserver observer) {
+        return observer == null ? NoopDnsServiceDiscovererObserver.INSTANCE : asSafeObserver(observer);
+    }
+
     private DnsDiscoveryObserver newDiscoveryObserver(final String address) {
-        if (observer == null) {
-            return null;
-        }
-        try {
-            return observer.onNewDiscovery(id, address);
-        } catch (Throwable unexpected) {
-            LOGGER.warn("{} unexpected exception from {} while reporting new DNS discovery for {}",
-                    this, observer, address, unexpected);
-            return null;
-        }
+        return observer.onNewDiscovery(id, address);
     }
 
     @Override
@@ -268,7 +260,7 @@ final class DefaultDnsClient implements DnsClient {
             ARecordPublisher pub = new ARecordPublisher(address, discoveryObserver);
             Publisher<? extends Collection<ServiceDiscovererEvent<InetAddress>>> events =
                     recoverWithInactiveEvents(pub, false, nxInvalidation);
-            return discoveryObserver == null ? events : events.beforeFinally(new TerminalSignalConsumer() {
+            return events.beforeFinally(new TerminalSignalConsumer() {
                     @Override
                     public void onComplete() {
                         // this event will never be triggered
@@ -276,23 +268,12 @@ final class DefaultDnsClient implements DnsClient {
 
                     @Override
                     public void onError(final Throwable cause) {
-                        try {
-                            discoveryObserver.discoveryFailed(cause);
-                        } catch (Throwable unexpected) {
-                            addSuppressed(unexpected, cause);
-                            LOGGER.warn("{} Unexpected exception from observer while reporting discovery failure",
-                                    DefaultDnsClient.this, unexpected);
-                        }
+                        discoveryObserver.discoveryFailed(cause);
                     }
 
                     @Override
                     public void cancel() {
-                        try {
-                            discoveryObserver.discoveryCancelled();
-                        } catch (Throwable unexpected) {
-                            LOGGER.warn("{} Unexpected exception from observer while reporting discovery cancellation",
-                                    DefaultDnsClient.this, unexpected);
-                        }
+                        discoveryObserver.discoveryCancelled();
                     }
                 });
         });
@@ -357,7 +338,7 @@ final class DefaultDnsClient implements DnsClient {
             }, srvConcurrency)
             .liftSync(SrvInactiveCombinerOperator.EMIT);
 
-            return discoveryObserver == null ? events : events.beforeFinally(new TerminalSignalConsumer() {
+            return events.beforeFinally(new TerminalSignalConsumer() {
                 @Override
                 public void onComplete() {
                     // this event will never be triggered
@@ -365,23 +346,12 @@ final class DefaultDnsClient implements DnsClient {
 
                 @Override
                 public void onError(final Throwable cause) {
-                    try {
-                        discoveryObserver.discoveryFailed(cause);
-                    } catch (Throwable unexpected) {
-                        addSuppressed(unexpected, cause);
-                        LOGGER.warn("{} Unexpected exception from observer while reporting discovery failure",
-                                DefaultDnsClient.this, unexpected);
-                    }
+                    discoveryObserver.discoveryFailed(cause);
                 }
 
                 @Override
                 public void cancel() {
-                    try {
-                        discoveryObserver.discoveryCancelled();
-                    } catch (Throwable unexpected) {
-                        LOGGER.warn("{} Unexpected exception from observer while reporting discovery cancellation",
-                                DefaultDnsClient.this, unexpected);
-                    }
+                    discoveryObserver.discoveryCancelled();
                 }
             });
         });
@@ -423,7 +393,7 @@ final class DefaultDnsClient implements DnsClient {
     }
 
     private final class SrvRecordPublisher extends AbstractDnsPublisher<HostAndPort> {
-        private SrvRecordPublisher(final String serviceName, @Nullable final DnsDiscoveryObserver discoveryObserver) {
+        private SrvRecordPublisher(final String serviceName, final DnsDiscoveryObserver discoveryObserver) {
             super(serviceName, discoveryObserver);
         }
 
@@ -510,7 +480,7 @@ final class DefaultDnsClient implements DnsClient {
     }
 
     private class ARecordPublisher extends AbstractDnsPublisher<InetAddress> {
-        ARecordPublisher(final String inetHost, @Nullable final DnsDiscoveryObserver discoveryObserver) {
+        ARecordPublisher(final String inetHost, final DnsDiscoveryObserver discoveryObserver) {
             super(inetHost, discoveryObserver);
         }
 
@@ -632,12 +602,11 @@ final class DefaultDnsClient implements DnsClient {
         /**
          * A {@link DnsDiscoveryObserver} for this publisher that provides visibility into individual DNS resolutions.
          */
-        @Nullable
         protected final DnsDiscoveryObserver discoveryObserver;
         @Nullable
         AbstractDnsSubscription subscription;
 
-        AbstractDnsPublisher(final String name, @Nullable final DnsDiscoveryObserver discoveryObserver) {
+        AbstractDnsPublisher(final String name, final DnsDiscoveryObserver discoveryObserver) {
             this.name = name;
             this.discoveryObserver = discoveryObserver;
             LOGGER.debug("{} initializing a new publisher for {}.", DefaultDnsClient.this, this);
@@ -795,19 +764,8 @@ final class DefaultDnsClient implements DnsClient {
                 }
             }
 
-            @Nullable
             private DnsResolutionObserver newResolutionObserver() {
-                final DnsDiscoveryObserver discoveryObserver = AbstractDnsPublisher.this.discoveryObserver;
-                if (discoveryObserver == null) {
-                    return null;
-                }
-                try {
-                    return discoveryObserver.onNewResolution(name);
-                } catch (Throwable unexpected) {
-                    LOGGER.warn("{} unexpected exception from {} while reporting new DNS resolution for: {}",
-                            DefaultDnsClient.this, observer, name, unexpected);
-                    return null;
-                }
+                return discoveryObserver.onNewResolution(name);
             }
 
             private void cancel0() {
@@ -850,7 +808,7 @@ final class DefaultDnsClient implements DnsClient {
             }
 
             private void handleResolveDone0(final Future<DnsAnswer<T>> addressFuture,
-                                            @Nullable final DnsResolutionObserver resolutionObserver) {
+                                            final DnsResolutionObserver resolutionObserver) {
                 assertInEventloop();
                 assert pendingRequests > 0;
                 if (cancellableForQuery == TERMINATED) {
@@ -858,7 +816,7 @@ final class DefaultDnsClient implements DnsClient {
                 }
                 final Throwable cause = addressFuture.cause();
                 if (cause != null) {
-                    reportResolutionFailed(resolutionObserver, cause);
+                    resolutionObserver.resolutionFailed(cause);
                     cancelAndTerminate0(cause);
                 } else {
                     // DNS lookup can return duplicate InetAddress
@@ -874,8 +832,8 @@ final class DefaultDnsClient implements DnsClient {
                         ttlNanos = maxTTLNanos;
                     }
                     final List<ServiceDiscovererEvent<T>> events = calculateDifference(activeAddresses, addresses,
-                            comparator(), resolutionObserver == null ? null : (nAvailable, nMissing) ->
-                                    reportResolutionResult(resolutionObserver, new DefaultResolutionResult(
+                            comparator(), (nAvailable, nMissing) ->
+                                    resolutionObserver.resolutionCompleted(new DefaultResolutionResult(
                                             addresses.size(), (int) NANOSECONDS.toSeconds(ttlNanos),
                                             nAvailable, nMissing)),
                             missingRecordStatus);
@@ -909,30 +867,6 @@ final class DefaultDnsClient implements DnsClient {
 
                         scheduleQuery0(ttlNanos);
                     }
-                }
-            }
-
-            private void reportResolutionFailed(@Nullable final DnsResolutionObserver resolutionObserver,
-                                                final Throwable cause) {
-                if (resolutionObserver == null) {
-                    return;
-                }
-                try {
-                    resolutionObserver.resolutionFailed(cause);
-                } catch (Throwable unexpected) {
-                    addSuppressed(unexpected, cause);
-                    LOGGER.warn("{} unexpected exception from {} while reporting DNS resolution failure",
-                            DefaultDnsClient.this, resolutionObserver, unexpected);
-                }
-            }
-
-            private void reportResolutionResult(final DnsResolutionObserver resolutionObserver,
-                                                final ResolutionResult result) {
-                try {
-                    resolutionObserver.resolutionCompleted(result);
-                } catch (Throwable unexpected) {
-                    LOGGER.warn("{} unexpected exception from {} while reporting DNS resolution result {}",
-                            DefaultDnsClient.this, resolutionObserver, result, unexpected);
                 }
             }
 

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/NoopDnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/NoopDnsServiceDiscovererObserver.java
@@ -24,6 +24,7 @@ final class NoopDnsServiceDiscovererObserver implements DnsServiceDiscovererObse
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public DnsDiscoveryObserver onNewDiscovery(final String name) {
         return NoopDnsDiscoveryObserver.INSTANCE;
     }

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/NoopDnsServiceDiscovererObserver.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/NoopDnsServiceDiscovererObserver.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.dns.discovery.netty;
+
+final class NoopDnsServiceDiscovererObserver implements DnsServiceDiscovererObserver {
+
+    static final DnsServiceDiscovererObserver INSTANCE = new NoopDnsServiceDiscovererObserver();
+
+    private NoopDnsServiceDiscovererObserver() {
+        // Singleton
+    }
+
+    @Override
+    public DnsDiscoveryObserver onNewDiscovery(final String name) {
+        return NoopDnsDiscoveryObserver.INSTANCE;
+    }
+
+    @Override
+    public DnsDiscoveryObserver onNewDiscovery(final String serviceDiscovererId, final String name) {
+        return NoopDnsDiscoveryObserver.INSTANCE;
+    }
+
+    static final class NoopDnsDiscoveryObserver implements DnsDiscoveryObserver {
+
+        static final DnsDiscoveryObserver INSTANCE = new NoopDnsDiscoveryObserver();
+
+        private NoopDnsDiscoveryObserver() {
+            // Singleton
+        }
+
+        @Override
+        public DnsResolutionObserver onNewResolution(final String name) {
+            return NoopDnsResolutionObserver.INSTANCE;
+        }
+
+        @Override
+        public void discoveryCancelled() {
+            // noop
+        }
+
+        @Override
+        public void discoveryFailed(final Throwable cause) {
+            // noop
+        }
+    }
+
+    static final class NoopDnsResolutionObserver implements DnsResolutionObserver {
+
+        static final DnsResolutionObserver INSTANCE = new NoopDnsResolutionObserver();
+
+        private NoopDnsResolutionObserver() {
+            // Singleton
+        }
+
+        @Override
+        public void resolutionFailed(final Throwable cause) {
+            // noop
+        }
+
+        @Override
+        public void resolutionCompleted(final ResolutionResult result) {
+            // noop
+        }
+    }
+}


### PR DESCRIPTION
#### Motivation

`DefaultDnsClient` held a nullable `DnsServiceDiscovererObserver` and implemented exception safety around it. Every place that called into the observer had to null-check the observer and its returned discovery and resolution observers, and wrap each callback in its own try/catch to log and swallow exceptions. This spread the same defensive boilerplate across the class and duplicated logic that `CatchAllDnsServiceDiscovererObserver` now provides.

The transport side already solved this by defaulting to a Noop observer and wraps user observers with `asSafeObserver`, so call sites can treat the observer as always present and always safe. The DNS client did not previously follow that pattern.

#### Modifications

* Extracted the Noop observer implementations out of `CatchAllDnsServiceDiscovererObserver` into a new top-level `NoopDnsServiceDiscovererObserver` (with nested `NoopDnsDiscoveryObserver` and `NoopDnsResolutionObserver`), so they can be reused as defaults.
* Made `DefaultDnsClient.observer` non-null. It is now assigned via a `safeObserver(...)` helper that maps a null user observer to `NoopDnsServiceDiscovererObserver.INSTANCE` and otherwise wraps it with `DnsServiceDiscovererObservers.asSafeObserver(...)`. This was inspired what we do on the transport side.
* Removed the dead null checks and try/catch blocks from `DefaultDnsClient`.
* Dropped `@Nullable` from the internal discovery/resolution observer fields and parameters that can no longer be null.

#### Result

`DefaultDnsClient` now aligns with the transport side. The observer is always present and always exception-safe, so call sites no longer repeat null checks and try/catch logic.

No public API change. All touched classes are package-private, including the new `NoopDnsServiceDiscovererObserver`. The constructor still accepts a nullable observer.

No behavior change for users. A user observer that throws is still caught, logged, and swallowed, and the client proceeds without further callbacks. The only internal difference is that it proceeds with a Noop observer instead of a null one. The `beforeFinally` terminal handler is now always attached (driving the Noop when no observer is configured), which has negligible overhead and no functional impact.
