### PR TITLE
grpc-api: fix client serializer-cache collision across message types

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -37,8 +37,6 @@ import io.servicetalk.http.api.StreamingHttpRequest;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -58,9 +56,6 @@ import static java.util.Objects.requireNonNull;
 
 final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
     private static final String UNKNOWN_PATH = "";
-    private static final Map<BufferEncoder, GrpcSerializer<?>> serializerMap = new ConcurrentHashMap<>(2);
-    private static final Map<BufferEncoder, GrpcStreamingSerializer<?>> streamingSerializerMap =
-            new ConcurrentHashMap<>(2);
     private final StreamingHttpClient streamingHttpClient;
     private final GrpcExecutionContext executionContext;
     @Nullable
@@ -448,25 +443,21 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
                 methodDescriptor.requestDescriptor().serializerDescriptor().serializer());
     }
 
-    @SuppressWarnings("unchecked")
     private static <Req> GrpcSerializer<Req> serializer(
             MethodDescriptor<Req, ?> methodDescriptor, GrpcSerializer<Req> serializerIdentity,
             @Nullable BufferEncoder compressor) {
-        return compressor == null || compressor == identityEncoder() ? serializerIdentity :
-                (GrpcSerializer<Req>) serializerMap.computeIfAbsent(compressor, key -> new GrpcSerializer<>(
-                        methodDescriptor.requestDescriptor().serializerDescriptor().bytesEstimator(),
-                        methodDescriptor.requestDescriptor().serializerDescriptor().serializer(), key));
+        return compressor == null || compressor == identityEncoder() ? serializerIdentity : new GrpcSerializer<>(
+                methodDescriptor.requestDescriptor().serializerDescriptor().bytesEstimator(),
+                methodDescriptor.requestDescriptor().serializerDescriptor().serializer(), compressor);
     }
 
-    @SuppressWarnings("unchecked")
     private static <Req> GrpcStreamingSerializer<Req> streamingSerializer(
             MethodDescriptor<Req, ?> methodDescriptor, GrpcStreamingSerializer<Req> serializerIdentity,
             @Nullable BufferEncoder compressor) {
         return compressor == null || compressor == identityEncoder() ? serializerIdentity :
-                (GrpcStreamingSerializer<Req>) streamingSerializerMap.computeIfAbsent(compressor, key ->
-                        new GrpcStreamingSerializer<>(
-                                methodDescriptor.requestDescriptor().serializerDescriptor().bytesEstimator(),
-                                methodDescriptor.requestDescriptor().serializerDescriptor().serializer(), key));
+                new GrpcStreamingSerializer<>(
+                        methodDescriptor.requestDescriptor().serializerDescriptor().bytesEstimator(),
+                        methodDescriptor.requestDescriptor().serializerDescriptor().serializer(), compressor);
     }
 
     private static <Resp> GrpcDeserializer<Resp> deserializer(MethodDescriptor<?, Resp> methodDescriptor) {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLargeMessageTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLargeMessageTest.java
@@ -15,9 +15,12 @@
  */
 package io.servicetalk.grpc.netty;
 
+import io.servicetalk.encoding.api.BufferDecoderGroupBuilder;
+import io.servicetalk.grpc.api.DefaultGrpcClientMetadata;
 import io.servicetalk.grpc.api.GrpcServerContext;
 import io.servicetalk.grpc.api.GrpcServiceContext;
 
+import io.grpc.examples.helloworld.Greeter;
 import io.grpc.examples.helloworld.Greeter.BlockingGreeterClient;
 import io.grpc.examples.helloworld.Greeter.BlockingGreeterService;
 import io.grpc.examples.helloworld.Greeter.ClientFactory;
@@ -27,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
+import static io.servicetalk.encoding.netty.NettyBufferEncoders.gzipDefault;
 import static io.servicetalk.grpc.netty.GrpcClients.forAddress;
 import static io.servicetalk.grpc.netty.GrpcServers.forAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
@@ -57,6 +61,42 @@ class GrpcLargeMessageTest {
                      .buildBlocking(new ClientFactory())) {
             HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName(large).build());
             assertThat(reply.getMessage().length(), equalTo(PAYLOAD_SIZE));
+        }
+    }
+
+    // Regression test for a JVM-wide serializer-cache collision in DefaultGrpcClientCallFactory. The static
+    // serializerMap (and streamingSerializerMap) was keyed only by the request BufferEncoder, but the cached
+    // GrpcSerializer embeds a message-type-specific request serializer. So the first client to send a compressed
+    // request with a given codec won the cache entry for that codec across the whole JVM, and any other client
+    // reusing the same codec for a different message type then got a wrong-typed serializer and threw
+    // ClassCastException. Two unrelated services (Greeter/HelloRequest and Tester/TestRequest) share the gzip
+    // request compressor here; both compressed round-trips must succeed.
+    @Test
+    void twoClientsSharingRequestCompressorForDifferentMessageTypes() throws Exception {
+        try (GrpcServerContext greeterServer = forAddress(localAddress(0)).listenAndAwait(
+                     new Greeter.ServiceFactory.Builder()
+                             .bufferDecoderGroup(new BufferDecoderGroupBuilder().add(gzipDefault()).build())
+                             .sayHelloBlocking((ctx, request) ->
+                                     HelloReply.newBuilder().setMessage(request.getName()).build())
+                             .build());
+             BlockingGreeterClient greeterClient = forAddress(serverHostAndPort(greeterServer))
+                     .buildBlocking(new ClientFactory());
+             GrpcServerContext testerServer = forAddress(localAddress(0)).listenAndAwait(
+                     new TesterProto.Tester.ServiceFactory.Builder()
+                             .bufferDecoderGroup(new BufferDecoderGroupBuilder().add(gzipDefault()).build())
+                             .testBlocking((ctx, request) ->
+                                     TesterProto.TestResponse.newBuilder().setMessage(request.getName()).build())
+                             .build());
+             TesterProto.Tester.BlockingTesterClient testerClient = forAddress(serverHostAndPort(testerServer))
+                     .buildBlocking(new TesterProto.Tester.ClientFactory())) {
+
+            HelloReply reply = greeterClient.sayHello(new DefaultGrpcClientMetadata(gzipDefault()),
+                    HelloRequest.newBuilder().setName("hello").build());
+            assertThat(reply.getMessage(), equalTo("hello"));
+
+            TesterProto.TestResponse response = testerClient.test(new DefaultGrpcClientMetadata(gzipDefault()),
+                    TesterProto.TestRequest.newBuilder().setName("world").build());
+            assertThat(response.getMessage(), equalTo("world"));
         }
     }
 }

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLargeMessageTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLargeMessageTest.java
@@ -64,13 +64,8 @@ class GrpcLargeMessageTest {
         }
     }
 
-    // Regression test for a JVM-wide serializer-cache collision in DefaultGrpcClientCallFactory. The static
-    // serializerMap (and streamingSerializerMap) was keyed only by the request BufferEncoder, but the cached
-    // GrpcSerializer embeds a message-type-specific request serializer. So the first client to send a compressed
-    // request with a given codec won the cache entry for that codec across the whole JVM, and any other client
-    // reusing the same codec for a different message type then got a wrong-typed serializer and threw
-    // ClassCastException. Two unrelated services (Greeter/HelloRequest and Tester/TestRequest) share the gzip
-    // request compressor here; both compressed round-trips must succeed.
+    // The compressed request serializer is message-type-specific, so two clients sharing the same request compressor
+    // for different message types must each get their own serializer rather than a shared one keyed only by codec.
     @Test
     void twoClientsSharingRequestCompressorForDifferentMessageTypes() throws Exception {
         try (GrpcServerContext greeterServer = forAddress(localAddress(0)).listenAndAwait(


### PR DESCRIPTION
 #### Motivation

DefaultGrpcClientCallFactory cached request serializers in two static maps keyed
only by the request BufferEncoder (the compression codec). The cached
GrpcSerializer/GrpcStreamingSerializer embeds a message-type-specific request
serializer, so the first client to send a compressed request with a given codec
won that codec's cache entry for the entire JVM. Any other client that later
reused the same codec (e.g. gzip) for a different request message type received
the wrong-typed cached serializer and failed with a ClassCastException during
request serialization, before the request was sent. Only the compressed-request
path was affected; uncompressed requests short-circuit to the identity serializer.

 #### Modifications

- Drop the static serializerMap and streamingSerializerMap. The compressed
  serializer is method-specific and must not be shared across methods keyed only
  by the compressor, so build it per call instead. The uncompressed path still
  returns the shared identity serializer and allocates nothing; only the
  (uncommon) compressed path now allocates a small short-lived serializer, whose
  cost is negligible next to the compression pass it wraps.
- Add a collision regression test in GrpcLargeMessageTest: two clients that share
  the gzip request compressor for different message types (Greeter/HelloRequest
  and Tester/TestRequest); both compressed round-trips must succeed.

 #### Result

Multiple gRPC clients in the same JVM can share a request compression codec for
different message types without colliding. No public API or behavior change.

