### PR TITLE
opentelemetry-http: stabilize lifecycle cancellation test

### DIFF
--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -84,6 +84,7 @@ import static io.servicetalk.opentelemetry.http.TestUtils.clientBuilder;
 import static io.servicetalk.opentelemetry.http.TestUtils.sleep;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -326,6 +327,7 @@ class OpenTelemetryHttpRequesterFilterTest {
         final boolean transportFailure = resultType == ResultType.TRANSPORT_ERROR;
         OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
         BlockingQueue<Error> errors = new LinkedBlockingQueue<>();
+        TestHttpLifecycleObserver lifecycleObserver = new TestHttpLifecycleObserver(errors);
         TransportObserver transportObserver = new TransportObserver() {
 
             final AtomicReference<Span> span = new AtomicReference<>();
@@ -418,7 +420,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                         .build())
                 .appendClientFilter(new TestTracingClientLoggerFilter(TRACING_TEST_LOG_LINE_PREFIX))
                 .appendClientFilter(new HttpLifecycleObserverRequesterFilter(
-                        new TestHttpLifecycleObserver(errors)))
+                        lifecycleObserver))
                 .appendConnectionFactoryFilter(
                         new TransportObserverConnectionFactoryFilter<>(transportObserver)).build()) {
            // This is necessary to let the load balancer become ready
@@ -461,13 +463,13 @@ class OpenTelemetryHttpRequesterFilterTest {
                     Future<HttpResponse> result = client.request(client.get("/slow")).toFuture();
                     TestUtils.sleep(20);
                     result.cancel(true);
+                    assertTrue(lifecycleObserver.awaitExchangeFinally(10, SECONDS));
                     sleep();
                     otelTesting.assertTraces().hasTracesSatisfyingExactly(ta ->
                             ta.hasSpansSatisfyingExactly(span -> {
                                 span.hasAttribute(TestHttpLifecycleObserver.ON_NEW_EXCHANGE_KEY, "set");
                                 span.hasAttribute(TestHttpLifecycleObserver.ON_REQUEST_KEY, "set");
                                 span.hasAttribute(TestHttpLifecycleObserver.ON_RESPONSE_CANCEL_KEY, "set");
-                                span.hasAttribute(TestHttpLifecycleObserver.ON_EXCHANGE_FINALLY_KEY, "set");
                             }));
                     break;
                 case TRANSPORT_ERROR:

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -463,6 +463,8 @@ class OpenTelemetryHttpRequesterFilterTest {
                     Future<HttpResponse> result = client.request(client.get("/slow")).toFuture();
                     TestUtils.sleep(20);
                     result.cancel(true);
+                    // onExchangeFinally() observes the complete dispatch lifecycle and may run after the tracing
+                    // span ends, which only covers request sent through response received.
                     assertTrue(lifecycleObserver.awaitExchangeFinally(10, SECONDS));
                     sleep();
                     otelTesting.assertTraces().hasTracesSatisfyingExactly(ta ->

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestHttpLifecycleObserver.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestHttpLifecycleObserver.java
@@ -25,6 +25,8 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 
 import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 final class TestHttpLifecycleObserver implements HttpLifecycleObserver {
@@ -49,6 +51,7 @@ final class TestHttpLifecycleObserver implements HttpLifecycleObserver {
     static final AttributeKey<String> ON_RESPONSE_BODY_CANCEL_KEY = AttributeKey.stringKey("onResponseBodyCancel");
 
     private final Queue<Error> errorQueue;
+    private final CountDownLatch exchangeFinallyLatch = new CountDownLatch(1);
 
     // Protected by synchronization
     @Nullable
@@ -138,8 +141,13 @@ final class TestHttpLifecycleObserver implements HttpLifecycleObserver {
             @Override
             public void onExchangeFinally() {
                 setKey(ON_EXCHANGE_FINALLY_KEY);
+                exchangeFinallyLatch.countDown();
             }
         };
+    }
+
+    boolean awaitExchangeFinally(long timeout, TimeUnit unit) throws InterruptedException {
+        return exchangeFinallyLatch.await(timeout, unit);
     }
 
     private void setKey(AttributeKey<String> key) {


### PR DESCRIPTION
#### Motivation

`OpenTelemetryHttpRequesterFilterTest.transportObserver` was flaky when cancelling an HTTP/2 request. The test assumed that `onExchangeFinally()` always runs before the OpenTelemetry span is exported. During cancellation, request termination may complete asynchronously, allowing the span to end before the final lifecycle callback adds its test attribute.

Fixes #3561.

#### Modifications

- Added a latch to `TestHttpLifecycleObserver` to observe `onExchangeFinally()` deterministically.
- Updated the cancellation test to await the final lifecycle callback.
- Removed the assertion that the final callback’s attribute must appear on an already-ended span.
- Preserved validation of the cancellation attribute and the callback’s active span context.

#### Result

The cancellation test no longer depends on timing or span mutability after export. All `transportObserver` HTTP/1.1 and HTTP/2 combinations pass.

There are no production behavior, API, or compatibility changes; only test code is affected.