### PR TITLE
http-netty: chunk-encode fallback h1 requests created as h2

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AbstractStreamingHttpConnection.java
@@ -198,7 +198,7 @@ abstract class AbstractStreamingHttpConnection<CC extends NettyConnectionContext
                         flatRequest = flatRequest.scanWithMapper(HeaderUtils::appendTrailersMapper);
                     }
                 }
-                addRequestTransferEncodingIfNecessary(request);
+                addRequestTransferEncodingIfNecessary(request, connectionContext().protocol());
             }
 
             final HttpExecutionStrategy strategy = requestExecutionStrategy(request,

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HeaderUtils.java
@@ -373,23 +373,40 @@ final class HeaderUtils {
     }
 
     static void addResponseTransferEncodingIfNecessary(final StreamingHttpResponse response,
-                                                       final HttpRequestMethod requestMethod) {
+                                                       final HttpRequestMethod requestMethod,
+                                                       final HttpProtocolVersion protocolVersion) {
         // We can only add TE: chunked if we can actually send a payload.
         if (serverMaySendPayloadBodyFor(response.status().code(), requestMethod) &&
-                canAddTransferEncodingChunked(response)) {
+                canAddTransferEncodingChunked(response, encodedVersion(response.version(), protocolVersion))) {
             response.headers().add(TRANSFER_ENCODING, CHUNKED);
         }
     }
 
-    static void addRequestTransferEncodingIfNecessary(final StreamingHttpRequest request) {
-        if (clientMaySendPayloadBodyFor(request.method()) && canAddTransferEncodingChunked(request)) {
+    static void addRequestTransferEncodingIfNecessary(final StreamingHttpRequest request,
+                                                      final HttpProtocolVersion protocolVersion) {
+        if (clientMaySendPayloadBodyFor(request.method()) &&
+                canAddTransferEncodingChunked(request, encodedVersion(request.version(), protocolVersion))) {
             request.headers().add(TRANSFER_ENCODING, CHUNKED);
         }
     }
 
-    private static boolean canAddTransferEncodingChunked(final HttpMetaData metaData) {
+    /**
+     * The protocol version a message is actually encoded at, which is not necessarily {@code metaData.version()}: a
+     * message can carry the client's preferred version (e.g. h2) yet be written on a connection ALPN negotiated down
+     * to h1. An h2 transport always encodes as h2; otherwise the message is encoded at the lower of its own version
+     * and the transport, matching {@link HttpRequestEncoder}'s request-line coercion so the transfer-encoding decision
+     * agrees with the wire (chunked for an h2 message sent over h1, none for a message pinned to HTTP/1.0).
+     */
+    private static HttpProtocolVersion encodedVersion(final HttpProtocolVersion messageVersion,
+                                                      final HttpProtocolVersion protocolVersion) {
+        return protocolVersion.major() >= 2 || messageVersion.compareTo(protocolVersion) >= 0 ?
+                protocolVersion : messageVersion;
+    }
+
+    private static boolean canAddTransferEncodingChunked(final HttpMetaData metaData,
+                                                         final HttpProtocolVersion protocolVersion) {
         final HttpHeaders headers = metaData.headers();
-        return chunkedSupported(metaData.version()) &&
+        return chunkedSupported(protocolVersion) &&
                 (mayHaveTrailers(metaData) || !headers.contains(CONTENT_LENGTH)) &&
                 !isTransferEncodingChunked(headers);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/NettyHttpServer.java
@@ -438,7 +438,7 @@ final class NettyHttpServer {
                         flatResponse = flatResponse.scanWithMapper(HeaderUtils::appendTrailersMapper);
                     }
                 }
-                addResponseTransferEncodingIfNecessary(response, requestMethod);
+                addResponseTransferEncodingIfNecessary(response, requestMethod, protocolVersion);
                 return flatResponse;
             }
         }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AlpnClientAndServerTest.java
@@ -15,12 +15,16 @@
  */
 package io.servicetalk.http.netty;
 
+import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.http.api.BlockingHttpClient;
 import io.servicetalk.http.api.HttpProtocolConfig;
 import io.servicetalk.http.api.HttpProtocolVersion;
 import io.servicetalk.http.api.HttpResponse;
 import io.servicetalk.http.api.HttpServiceContext;
 import io.servicetalk.http.api.ReservedBlockingHttpConnection;
+import io.servicetalk.http.api.StreamingHttpClient;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.test.resources.DefaultTestCerts;
 import io.servicetalk.transport.api.ClientSslConfigBuilder;
 import io.servicetalk.transport.api.ServerContext;
@@ -43,6 +47,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.VerificationTestUtils.assertThrows;
 import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
@@ -58,6 +63,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class AlpnClientAndServerTest {
 
@@ -78,6 +84,7 @@ class AlpnClientAndServerTest {
     private HttpProtocolVersion expectedProtocol;
     private BlockingQueue<HttpServiceContext> serviceContext;
     private BlockingQueue<HttpProtocolVersion> requestVersion;
+    private BlockingQueue<Integer> requestPayloadSize;
     private void setUp(List<String> serverSideProtocols,
                        List<String> clientSideProtocols,
                        @Nullable HttpProtocolVersion expectedProtocol,
@@ -91,6 +98,7 @@ class AlpnClientAndServerTest {
     void beforeEach() {
         serviceContext = new LinkedBlockingDeque<>();
         requestVersion = new LinkedBlockingDeque<>();
+        requestPayloadSize = new LinkedBlockingDeque<>();
     }
 
     @SuppressWarnings("unused")
@@ -147,6 +155,7 @@ class AlpnClientAndServerTest {
                 .listenBlocking((ctx, request, responseFactory) -> {
                     serviceContext.put(ctx);
                     requestVersion.put(request.version());
+                    requestPayloadSize.put(request.payloadBody().readableBytes());
                     return responseFactory.ok().payloadBody(PAYLOAD_BODY, textSerializerUtf8());
                 })
                 .toFuture().get();
@@ -228,6 +237,39 @@ class AlpnClientAndServerTest {
         } else {
             assertResponseAndServiceContext(client.request(client.get("/")));
         }
+    }
+
+    @ParameterizedTest(name = "serverSideProtocols={0}, clientSideProtocols={1}," +
+            " expectedProtocol={2}, expectedExceptionType={3}, optionalExceptionWrapperType={4}," +
+            " acceptInsecureConnections={5}")
+    @MethodSource("arguments")
+    void testAlpnClientStreamingRequestPayload(List<String> serverSideProtocols,
+                                               List<String> clientSideProtocols,
+                                               @Nullable HttpProtocolVersion expectedProtocol,
+                                               @Nullable Class<? extends Throwable> expectedExceptionType,
+                                               @Nullable Class<? extends Throwable> optionalExceptionWrapperType,
+                                               boolean acceptInsecureConnections) throws Exception {
+        setUp(serverSideProtocols, clientSideProtocols, expectedProtocol, acceptInsecureConnections);
+        // Protocol-incompatible combinations are exercised by the negotiation tests above.
+        assumeTrue(expectedExceptionType == null);
+
+        final StreamingHttpClient streamingClient = client.asStreamingClient();
+        final Buffer chunk1 = streamingClient.executionContext().bufferAllocator().fromAscii("Hello");
+        final Buffer chunk2 = streamingClient.executionContext().bufferAllocator().fromAscii(" World!");
+        final int expectedBytes = chunk1.readableBytes() + chunk2.readableBytes();
+
+        // An unknown-length body must be framed as Transfer-Encoding: chunked on an h1 connection; verify that still
+        // happens when the client prefers h2 but ALPN falls back to h1.
+        final StreamingHttpRequest request = streamingClient.post("/").payloadBody(from(chunk1, chunk2));
+        final StreamingHttpResponse response = streamingClient.request(request).toFuture().get();
+        assertThat(response.status(), is(OK));
+        assertThat(response.version(), is(expectedProtocol));
+        response.payloadBody().ignoreElements().toFuture().get();
+
+        // Assert the negotiated protocol so a fallback row can't silently degrade into an all-h2 exchange that
+        // never exercises h1 chunked framing.
+        assertThat(requestVersion.take(), is(expectedProtocol));
+        assertThat(requestPayloadSize.take(), is(expectedBytes));
     }
 
     private void assertResponseAndServiceContext(HttpResponse response) throws Exception {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HeaderUtilsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HeaderUtilsTest.java
@@ -19,6 +19,7 @@ import io.servicetalk.http.api.DefaultHttpHeadersFactory;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,10 +30,15 @@ import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.servicetalk.http.api.HttpHeaderValues.CHUNKED;
 import static io.servicetalk.http.api.HttpHeaderValues.GZIP;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_0;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
+import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.StreamingHttpRequests.newRequest;
+import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
 import static io.servicetalk.http.netty.HeaderUtils.addRequestTransferEncodingIfNecessary;
+import static io.servicetalk.http.netty.HeaderUtils.addResponseTransferEncodingIfNecessary;
 import static io.servicetalk.http.netty.HeaderUtils.removeTransferEncodingChunked;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -91,7 +97,7 @@ class HeaderUtilsTest {
     @Test
     void addTransferEncodingIfNecessaryNoHeaders() {
         assertTrue(httpRequest.headers().isEmpty());
-        addRequestTransferEncodingIfNecessary(httpRequest);
+        addRequestTransferEncodingIfNecessary(httpRequest, HTTP_1_1);
         assertOneTransferEncodingChunked(httpRequest.headers());
     }
 
@@ -101,7 +107,7 @@ class HeaderUtilsTest {
         httpRequest.headers().add(CONTENT_LENGTH, "10");
         assertEquals(1, httpRequest.headers().size());
 
-        addRequestTransferEncodingIfNecessary(httpRequest);
+        addRequestTransferEncodingIfNecessary(httpRequest, HTTP_1_1);
 
         assertEquals(1, httpRequest.headers().size());
         assertFalse(isTransferEncodingChunked(httpRequest.headers()));
@@ -114,7 +120,7 @@ class HeaderUtilsTest {
         httpRequest.headers().add(TRANSFER_ENCODING, CHUNKED);
         assertEquals(1, httpRequest.headers().size());
 
-        addRequestTransferEncodingIfNecessary(httpRequest);
+        addRequestTransferEncodingIfNecessary(httpRequest, HTTP_1_1);
         assertOneTransferEncodingChunked(httpRequest.headers());
     }
 
@@ -124,7 +130,7 @@ class HeaderUtilsTest {
         httpRequest.headers().add("Transfer-Encoding", "Chunked");
         assertEquals(1, httpRequest.headers().size());
 
-        addRequestTransferEncodingIfNecessary(httpRequest);
+        addRequestTransferEncodingIfNecessary(httpRequest, HTTP_1_1);
         assertOneTransferEncodingChunked(httpRequest.headers());
     }
 
@@ -134,8 +140,79 @@ class HeaderUtilsTest {
         httpRequest.headers().add(TRANSFER_ENCODING, "cHuNkEd");
         assertEquals(1, httpRequest.headers().size());
 
-        addRequestTransferEncodingIfNecessary(httpRequest);
+        addRequestTransferEncodingIfNecessary(httpRequest, HTTP_1_1);
         assertOneTransferEncodingChunked(httpRequest.headers());
+    }
+
+    @Test
+    void addTransferEncodingUsesConnectionProtocolNotRequestVersion() {
+        // Mirrors ALPN h2->h1 fallback: an h2-created request on an h1 connection must still get TE: chunked.
+        httpRequest = newRequest(GET, "/", HTTP_2_0,
+                HTTP_HEADERS_FACTORY.newHeaders(), DEFAULT_RO_ALLOCATOR, HTTP_HEADERS_FACTORY);
+        assertTrue(httpRequest.headers().isEmpty());
+
+        addRequestTransferEncodingIfNecessary(httpRequest, HTTP_1_1);
+        assertOneTransferEncodingChunked(httpRequest.headers());
+    }
+
+    @Test
+    void addTransferEncodingSkippedForH2Connection() {
+        // h2 frames the body itself, so no TE: chunked even when the request could carry one.
+        httpRequest = newRequest(GET, "/", HTTP_2_0,
+                HTTP_HEADERS_FACTORY.newHeaders(), DEFAULT_RO_ALLOCATOR, HTTP_HEADERS_FACTORY);
+        assertTrue(httpRequest.headers().isEmpty());
+
+        addRequestTransferEncodingIfNecessary(httpRequest, HTTP_2_0);
+        assertTrue(httpRequest.headers().isEmpty());
+    }
+
+    @Test
+    void addTransferEncodingSkippedForSubH2RequestOnH2Connection() {
+        // An h2 transport must never carry TE: chunked, even when the request is versioned below h2.
+        httpRequest = newRequest(GET, "/", HTTP_1_1,
+                HTTP_HEADERS_FACTORY.newHeaders(), DEFAULT_RO_ALLOCATOR, HTTP_HEADERS_FACTORY);
+        assertTrue(httpRequest.headers().isEmpty());
+
+        addRequestTransferEncodingIfNecessary(httpRequest, HTTP_2_0);
+        assertTrue(httpRequest.headers().isEmpty());
+    }
+
+    @Test
+    void addTransferEncodingSkippedForHttp10Request() {
+        // Encoded version is min(request, connection) = HTTP/1.0, which does not support chunked.
+        httpRequest = newRequest(GET, "/", HTTP_1_0,
+                HTTP_HEADERS_FACTORY.newHeaders(), DEFAULT_RO_ALLOCATOR, HTTP_HEADERS_FACTORY);
+        assertTrue(httpRequest.headers().isEmpty());
+
+        addRequestTransferEncodingIfNecessary(httpRequest, HTTP_1_1);
+        assertTrue(httpRequest.headers().isEmpty());
+    }
+
+    @Test
+    void addResponseTransferEncodingForHttp11() {
+        final StreamingHttpResponse response = newResponse(OK, HTTP_1_1,
+                HTTP_HEADERS_FACTORY.newHeaders(), DEFAULT_RO_ALLOCATOR, HTTP_HEADERS_FACTORY);
+        addResponseTransferEncodingIfNecessary(response, GET, HTTP_1_1);
+        assertOneTransferEncodingChunked(response.headers());
+    }
+
+    @Test
+    void addResponseTransferEncodingSkippedForHttp10() {
+        // Encoded version is min(response, connection) = HTTP/1.0, which does not support chunked; such a response
+        // is close-delimited. Guards against keying the decision off the (higher) connection protocol.
+        final StreamingHttpResponse response = newResponse(OK, HTTP_1_0,
+                HTTP_HEADERS_FACTORY.newHeaders(), DEFAULT_RO_ALLOCATOR, HTTP_HEADERS_FACTORY);
+        addResponseTransferEncodingIfNecessary(response, GET, HTTP_1_1);
+        assertTrue(response.headers().isEmpty());
+    }
+
+    @Test
+    void addResponseTransferEncodingSkippedForSubH2ResponseOnH2Connection() {
+        // An h2 transport must never carry TE: chunked, even when the response is versioned below h2.
+        final StreamingHttpResponse response = newResponse(OK, HTTP_1_1,
+                HTTP_HEADERS_FACTORY.newHeaders(), DEFAULT_RO_ALLOCATOR, HTTP_HEADERS_FACTORY);
+        addResponseTransferEncodingIfNecessary(response, GET, HTTP_2_0);
+        assertTrue(response.headers().isEmpty());
     }
 
     private static void assertOneTransferEncodingChunked(final HttpHeaders headers) {


### PR DESCRIPTION
#### Motivation

A client with protocols [h2, h1] over TLS that ALPN-negotiates down to HTTP/1.1
dropped the request payload body. addRequestTransferEncodingIfNecessary keyed
Transfer-Encoding: chunked off request.version(), which is the client's preferred
protocol (h2) and fails chunkedSupported(), so a streaming request on the fallback
h1 connection got neither Content-Length nor chunked framing and the server dropped
the body. The Content-Length and trailer paths already keyed off the connection
protocol; only transfer-encoding used the stale request version. Aggregated requests
were unaffected (they carry a Content-Length).

#### Modifications

Decide chunked framing from the version the message is actually encoded at, computed
once in encodedVersion(): an h2 transport always encodes as h2, otherwise the lower
of the message version and the connection protocol, matching HttpRequestEncoder's
request-line coercion. Both the request and response paths share this helper, so the
framing decision always agrees with the wire: a request created as h2 over an h1
connection is chunk-encoded, while a message pinned to HTTP/1.0 is not (and is
close-delimited instead).

- Add encodedVersion() and route both addRequestTransferEncodingIfNecessary and
  addResponseTransferEncodingIfNecessary through it; the server passes the connection
  protocol it already has in handleResponse.
- Extend AlpnClientAndServerTest with a streaming-payload request across the protocol
  matrix, asserting the negotiated protocol so a fallback row can't silently degrade
  into an all-h2 exchange.
- Add HeaderUtilsTest coverage for the request/response min and h2-transport cases.

#### Results

The h2->h1 fallback delivers the request body intact, and framing stays correct for
HTTP/1.0 messages. No public API change.

