### PR TITLE
http-netty: reject negative maxAggregatedPayloadSize from the builder API

### DIFF
--- a/servicetalk-http-api/docs/modules/ROOT/pages/programming-paradigms.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/programming-paradigms.adoc
@@ -25,12 +25,13 @@ network nor any declared `Content-Length`. A small compressed body that expands 
 therefore rejected.
 
 Adjust or disable this via `HttpServerBuilder#maxAggregatedPayloadSize(int)` /
-`SingleAddressHttpClientBuilder#maxAggregatedPayloadSize(int)` (pass `0` to disable, or `-1` for *warn-only* mode --
-oversized aggregated messages are still served/delivered but a warning is logged, rate-limited to once every five
-minutes per client/server, so you can evaluate the limit before enforcing it). Users who unexpectedly hit the
+`SingleAddressHttpClientBuilder#maxAggregatedPayloadSize(int)` (pass `0` to disable). A programmatically configured
+limit is definitive: it is always enforced and never runs in warn-only mode. Users who unexpectedly hit the
 default limit can temporarily change it globally with the
-`io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize` system property, which accepts the same values
-(including `-1` to warn globally); an explicit builder call takes precedence over the property. This is a temporary
+`io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize` system property, which -- unlike the builder
+methods -- also accepts `-1` for *warn-only* mode, where oversized aggregated messages are still served/delivered
+but a warning is logged (rate-limited to once every five minutes per client/server) so you can evaluate the limit
+before enforcing it. An explicit builder call takes precedence over the property. This is a temporary
 property that will be removed in future releases. Bodies consumed purely as a stream are not affected.
 ====
 

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -215,34 +215,21 @@ public interface HttpServerBuilder {
     /**
      * Sets the maximum size, in bytes, of an aggregated request payload body that this server will buffer in memory.
      * <p>
-     * This limit applies only when a request is <strong>aggregated</strong> &mdash; for example when the service uses
-     * an {@link HttpRequest aggregated programming paradigm}, or when a filter calls
-     * {@link StreamingHttpRequest#toRequest()}. Requests that are consumed purely as a
-     * {@link StreamingHttpRequest#payloadBody() stream} are not affected. When the aggregated payload would exceed this
-     * limit a {@link PayloadTooLargeException} is raised, which the default exception mapping translates into a
-     * {@link HttpResponseStatus#PAYLOAD_TOO_LARGE 413 Payload Too Large} response.
+     * The limit applies only when a request is <strong>aggregated</strong> (an {@link HttpRequest aggregated
+     * programming paradigm} or a filter calling {@link StreamingHttpRequest#toRequest()}); requests consumed as a
+     * {@link StreamingHttpRequest#payloadBody() stream} are not affected. Exceeding it raises a
+     * {@link PayloadTooLargeException}, which the default exception mapping turns into a
+     * {@link HttpResponseStatus#PAYLOAD_TOO_LARGE 413 Payload Too Large} response. The limit is measured against the
+     * fully decoded payload at the point of aggregation &mdash; <em>after</em> any decompression or body transformation
+     * by earlier filters &mdash; not the bytes received from the network nor any declared {@code Content-Length}.
      * <p>
-     * The limit is measured against the fully decoded payload buffered in memory at the point of aggregation &mdash;
-     * that is, <em>after</em> any decompression or body transformation applied by filters earlier in the pipeline
-     * &mdash; not the number of bytes received from the network nor any declared {@code Content-Length}. A small
-     * compressed request that expands beyond this limit once decoded will therefore be rejected.
-     * <p>
-     * The default value is 4 MiB. Pass {@code 0} to disable the limit, or {@code -1} for <strong>warn-only</strong>
-     * mode: oversized aggregated requests are still served, but a warning (rate-limited to once every five minutes per
-     * server) is logged so the limit can be evaluated before it is enforced. A server configured to accept both TLS and
-     * cleartext connections (see {@link #sslConfig(ServerSslConfig, boolean)}) tracks the two negotiation outcomes
-     * separately and may therefore emit up to two such warnings per interval. Users who unexpectedly hit the default
-     * limit can temporarily set the {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system
-     * property to change the default globally; it accepts the same values as this method (including {@code -1} to warn
-     * globally), and an explicit call to this method takes precedence over the property. This is a temporary property
-     * that will be removed in future releases.
-     * <p>
-     * For an independent, opt-in limit that can fail fast on {@code Content-Length} or bound bytes at a chosen position
-     * in the filter chain (e.g. before a decompressor), see {@code PayloadSizeLimitingHttpServiceFilter}; both apply.
+     * The default is 4 MiB and can be overridden globally, including a warn-only mode, via the temporary
+     * {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system property; an explicit call to
+     * this method always takes precedence and is enforced (never warn-only). For an independent, opt-in limit that can
+     * fail fast on {@code Content-Length}, see {@code PayloadSizeLimitingHttpServiceFilter}; both apply.
      *
-     * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a request is aggregated,
-     * {@code 0} to disable the limit, or {@code -1} to warn (but not reject) when the default limit is exceeded. Other
-     * negative values are rejected.
+     * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a request is aggregated;
+     * {@code 0} disables the limit. Must be non-negative.
      * @return {@code this}
      */
     // FIXME: 0.43 - consider removing default impl

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -223,10 +223,11 @@ public interface HttpServerBuilder {
      * fully decoded payload at the point of aggregation &mdash; <em>after</em> any decompression or body transformation
      * by earlier filters &mdash; not the bytes received from the network nor any declared {@code Content-Length}.
      * <p>
-     * The default is 4 MiB and can be overridden globally, including a warn-only mode, via the temporary
-     * {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system property; an explicit call to
-     * this method always takes precedence and is enforced (never warn-only). For an independent, opt-in limit that can
-     * fail fast on {@code Content-Length}, see {@code PayloadSizeLimitingHttpServiceFilter}; both apply.
+     * The default is 4 MiB, overridable globally via the temporary
+     * {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system property, which also accepts
+     * {@code -1} for warn-only mode (oversized requests are served but logged); an explicit call here always takes
+     * precedence and is enforced. For an opt-in limit that fails fast on {@code Content-Length}, see
+     * {@code PayloadSizeLimitingHttpServiceFilter}; both apply.
      *
      * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a request is aggregated;
      * {@code 0} disables the limit. Must be non-negative.

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -165,31 +165,20 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
     /**
      * Sets the maximum size, in bytes, of an aggregated response payload body that this client will buffer in memory.
      * <p>
-     * This limit applies only when a response is <strong>aggregated</strong> &mdash; for example when the client uses
-     * an {@link HttpResponse aggregated programming paradigm}, or when a filter calls
-     * {@link StreamingHttpResponse#toResponse()}. Responses that are consumed purely as a
-     * {@link StreamingHttpResponse#payloadBody() stream} are not affected. When the aggregated payload would exceed
-     * this limit a {@link PayloadTooLargeException} is raised to the caller.
+     * The limit applies only when a response is <strong>aggregated</strong> (an {@link HttpResponse aggregated
+     * programming paradigm} or a filter calling {@link StreamingHttpResponse#toResponse()}); responses consumed as a
+     * {@link StreamingHttpResponse#payloadBody() stream} are not affected. Exceeding it raises a
+     * {@link PayloadTooLargeException} to the caller. The limit is measured against the fully decoded payload at the
+     * point of aggregation &mdash; <em>after</em> any decompression or body transformation by earlier filters &mdash;
+     * not the bytes received from the network nor any declared {@code Content-Length}.
      * <p>
-     * The limit is measured against the fully decoded payload buffered in memory at the point of aggregation &mdash;
-     * that is, <em>after</em> any decompression or body transformation applied by filters earlier in the pipeline
-     * &mdash; not the number of bytes received from the network nor any declared {@code Content-Length}. A small
-     * compressed response that expands beyond this limit once decoded will therefore be rejected.
-     * <p>
-     * The default value is 4 MiB. Pass {@code 0} to disable the limit, or {@code -1} for <strong>warn-only</strong>
-     * mode: oversized aggregated responses are still delivered, but a warning (rate-limited to once every five minutes
-     * per client) is logged so the limit can be evaluated before it is enforced. Users who unexpectedly hit the default
-     * limit can temporarily set the {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system
-     * property to change the default globally; it accepts the same values as this method (including {@code -1} to warn
-     * globally), and an explicit call to this method takes precedence over the property. This is a temporary property
-     * that will be removed in future releases.
-     * <p>
-     * For an independent, opt-in limit that can fail fast on {@code Content-Length} or bound bytes at a chosen position
-     * in the filter chain (e.g. before a decompressor), see {@code PayloadSizeLimitingHttpRequesterFilter}; both apply.
+     * The default is 4 MiB and can be overridden globally, including a warn-only mode, via the temporary
+     * {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system property; an explicit call to
+     * this method always takes precedence and is enforced (never warn-only). For an independent, opt-in limit that can
+     * fail fast on {@code Content-Length}, see {@code PayloadSizeLimitingHttpRequesterFilter}; both apply.
      *
-     * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a response is aggregated,
-     * {@code 0} to disable the limit, or {@code -1} to warn (but not reject) when the default limit is exceeded. Other
-     * negative values are rejected.
+     * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a response is aggregated;
+     * {@code 0} disables the limit. Must be non-negative.
      * @return {@code this}
      */
     // FIXME: 0.43 - consider removing default impl

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -172,10 +172,11 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * point of aggregation &mdash; <em>after</em> any decompression or body transformation by earlier filters &mdash;
      * not the bytes received from the network nor any declared {@code Content-Length}.
      * <p>
-     * The default is 4 MiB and can be overridden globally, including a warn-only mode, via the temporary
-     * {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system property; an explicit call to
-     * this method always takes precedence and is enforced (never warn-only). For an independent, opt-in limit that can
-     * fail fast on {@code Content-Length}, see {@code PayloadSizeLimitingHttpRequesterFilter}; both apply.
+     * The default is 4 MiB, overridable globally via the temporary
+     * {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system property, which also accepts
+     * {@code -1} for warn-only mode (oversized responses are delivered but logged); an explicit call here always takes
+     * precedence and is enforced. For an opt-in limit that fails fast on {@code Content-Length}, see
+     * {@code PayloadSizeLimitingHttpRequesterFilter}; both apply.
      *
      * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a response is aggregated;
      * {@code 0} disables the limit. Must be non-negative.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -26,6 +26,7 @@ import java.util.function.LongConsumer;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.lang.Integer.getInteger;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -37,8 +38,10 @@ final class HttpConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpConfig.class);
 
     static final int DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE = 4 * 1024 * 1024;
-    // Magic value accepted by maxAggregatedPayloadSize(int): warn (rate-limited) when the default limit is exceeded
-    // but let the payload through rather than rejecting it.
+    // Magic value accepted by the temporaryDefaultMaxAggregatedPayloadSize system property (but not by the
+    // maxAggregatedPayloadSize(int) builder API): warn (rate-limited) when the default limit is exceeded but let the
+    // payload through rather than rejecting it. It exists to ease rollout of a global default; a value set
+    // programmatically is always definitive.
     static final int WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE = -1;
     // FIXME: 0.43 - remove this temporary property
     static final String DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY =
@@ -48,8 +51,8 @@ final class HttpConfig {
     static {
         final int value = getInteger(DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY,
                 DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE);
-        // Mirror the validation applied to maxAggregatedPayloadSize(int): values below the warn-only magic value are
-        // invalid. Don't throw from this static initializer; fall back to the hardcoded default instead.
+        // The property additionally accepts the warn-only magic value; only values below it are invalid. Don't throw
+        // from this static initializer; fall back to the hardcoded default instead.
         if (value < WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE) {
             LOGGER.warn("-D{}: {} is invalid (expected >= {}). Falling back to the default of {} bytes.",
                     DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, value, WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE,
@@ -113,11 +116,7 @@ final class HttpConfig {
     }
 
     void maxAggregatedPayloadSize(int maxAggregatedPayloadSize) {
-        if (maxAggregatedPayloadSize < WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE) {
-            throw new IllegalArgumentException("maxAggregatedPayloadSize: " + maxAggregatedPayloadSize +
-                    " (expected >= " + WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE + ")");
-        }
-        this.maxAggregatedPayloadSize = maxAggregatedPayloadSize;
+        this.maxAggregatedPayloadSize = ensureNonNegative(maxAggregatedPayloadSize, "maxAggregatedPayloadSize");
     }
 
     /**

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultAggregatedPayloadSizeLimitTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultAggregatedPayloadSizeLimitTest.java
@@ -46,7 +46,6 @@ import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpResponseStatus.PAYLOAD_TOO_LARGE;
 import static io.servicetalk.http.netty.BuilderUtils.newClientBuilder;
 import static io.servicetalk.http.netty.BuilderUtils.newServerBuilder;
-import static io.servicetalk.http.netty.HttpConfig.DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -142,45 +141,18 @@ class DefaultAggregatedPayloadSizeLimitTest {
 
     @ParameterizedTest
     @EnumSource(HttpProtocol.class)
-    void belowWarnModeLimitRejected(HttpProtocol protocol) {
-        // -1 is the warn-only magic value; anything more negative is invalid.
+    void negativeServerLimitRejected(HttpProtocol protocol) {
+        // A programmatically configured limit must be non-negative; warn-only mode (-1) is only available via the
+        // system property, not through the builder API.
         assertThrows(IllegalArgumentException.class,
-                () -> newServerBuilder(SERVER_CTX, protocol).maxAggregatedPayloadSize(-2));
+                () -> newServerBuilder(SERVER_CTX, protocol).maxAggregatedPayloadSize(-1));
     }
 
     @ParameterizedTest
     @EnumSource(HttpProtocol.class)
-    void belowWarnModeClientLimitRejected(HttpProtocol protocol) {
+    void negativeClientLimitRejected(HttpProtocol protocol) {
         assertThrows(IllegalArgumentException.class, () ->
-                newClientBuilder(HostAndPort.of("localhost", 8080), CLIENT_CTX, protocol).maxAggregatedPayloadSize(-2));
-    }
-
-    @ParameterizedTest
-    @EnumSource(HttpProtocol.class)
-    void serverWarnModeAllowsOversizedAggregatedRequest(HttpProtocol protocol) throws Exception {
-        // Warn-only mode (-1): an oversized aggregated request is logged but still served, not rejected with 413.
-        try (HttpServerContext server = startEchoServer(protocol, -1);
-             StreamingHttpClient client = newStreamingClient(server, protocol, 0)) {
-            HttpClient aggregated = client.asClient();
-            String body = repeat('x', DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE + 1);
-            HttpResponse response = aggregated.request(
-                    aggregated.post("/").payloadBody(alloc(client).fromAscii(body))).toFuture().get();
-            assertThat(response.status(), is(OK));
-            assertThat(response.payloadBody().toString(US_ASCII), equalTo(body));
-        }
-    }
-
-    @ParameterizedTest
-    @EnumSource(HttpProtocol.class)
-    void clientWarnModeAllowsOversizedAggregatedResponse(HttpProtocol protocol) throws Exception {
-        final int responseSize = DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE + 1;
-        try (HttpServerContext server = startSingleBufferResponseServer(protocol, responseSize);
-             StreamingHttpClient client = newStreamingClient(server, protocol, -1)) {
-            HttpClient aggregated = client.asClient();
-            HttpResponse response = aggregated.request(aggregated.get("/")).toFuture().get();
-            assertThat(response.status(), is(OK));
-            assertThat(response.payloadBody().readableBytes(), is(responseSize));
-        }
+                newClientBuilder(HostAndPort.of("localhost", 8080), CLIENT_CTX, protocol).maxAggregatedPayloadSize(-1));
     }
 
     @ParameterizedTest
@@ -296,15 +268,6 @@ class DefaultAggregatedPayloadSizeLimitTest {
                 })
                 .listenStreamingAndAwait((ctx, request, factory) ->
                         succeeded(factory.ok().payloadBody(request.payloadBody())));
-    }
-
-    private static HttpServerContext startSingleBufferResponseServer(HttpProtocol protocol, int responseSize)
-            throws Exception {
-        // Responds with a single buffer of responseSize bytes (cheaper than one buffer per byte for large payloads).
-        return newServerBuilder(SERVER_CTX, protocol).listenStreamingAndAwait((ctx, request, factory) -> {
-            Buffer body = ctx.executionContext().bufferAllocator().fromAscii(repeat('x', responseSize));
-            return succeeded(factory.ok().payloadBody(Publisher.from(body)));
-        });
     }
 
     private static StreamingHttpClient newStreamingClient(HttpServerContext server, HttpProtocol protocol,


### PR DESCRIPTION
#### Motivation

The warn-only sentinel (-1) was accepted by both the temporary `temporaryDefaultMaxAggregatedPayloadSize` system property and the `maxAggregatedPayloadSize(int)` builder API. Warn-only exists only to ease rollout of a global default; a value set programmatically should be definitive, so accepting -1 (or any other negative value) through the builder was unintended.

#### Modifications

- Validate the builder value with `NumberUtils.ensureNonNegative`. The property still accepts -1 for warn-only, and the -1 default it seeds reaches the limiter by direct field assignment, never through the validated setter.
- Trim the `maxAggregatedPayloadSize` javadoc on `HttpServerBuilder` and `SingleAddressHttpClientBuilder`, and the `programming-paradigms` website docs, to describe warn-only as a property-only capability.
- Update tests: assert the builder now rejects -1, and drop the two integration tests that configured warn-only through the builder (warn-only is still covered at the unit level via `toAggregatedPayloadSizeLimiter`).

#### Result

The builder rejects negative values, so a programmatically configured limit is always definitive. No behavior change for the system property, and no public API signature change.