### PR TITLE
Align how we log all system property values

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NonBlockingThreadUtils.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/NonBlockingThreadUtils.java
@@ -33,12 +33,12 @@ final class NonBlockingThreadUtils {
 
     static {
         if (WARN_ON_NON_BLOCKING_THREAD) {
-            LOGGER.warn("-D{}: {}. Setting this property to 'true' may be used temporarily to unblock deployment but " +
-                            "exposes the service to the risk of deadlocks or increased I/O latencies which can be " +
-                            "very difficult to diagnose.",
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: Setting this property to 'true' may be used temporarily " +
+                            "to unblock deployment but exposes the service to the risk of deadlocks or increased I/O " +
+                            "latencies which can be very difficult to diagnose.",
                     WARN_ON_NON_BLOCKING_THREAD_PROPERTY, WARN_ON_NON_BLOCKING_THREAD);
         } else {
-            LOGGER.debug("-D{}: {}", WARN_ON_NON_BLOCKING_THREAD_PROPERTY, WARN_ON_NON_BLOCKING_THREAD);
+            LOGGER.debug("-D{}={}", WARN_ON_NON_BLOCKING_THREAD_PROPERTY, WARN_ON_NON_BLOCKING_THREAD);
         }
     }
 

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/PublisherAsBlockingIterable.java
@@ -72,13 +72,22 @@ final class PublisherAsBlockingIterable<T> implements BlockingIterable<T> {
     }
 
     private static final class SubscriberAndIterator<T> implements Subscriber<T>, BlockingIterator<T> {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(SubscriberAndIterator.class);
         /**
          * Allows to re-enable cancelling the subscription on {@link #hasNext(long, TimeUnit)} timeout. This flag
          * will be removed after a couple releases and no issues identified with the new behavior.
          */
-        private static final boolean CANCEL_SUBSCRIPTION_ON_HAS_NEXT_TIMEOUT = Boolean
-                .getBoolean("io.servicetalk.concurrent.api.cancelSubscriptionOnHasNextTimeout");
-        private static final Logger LOGGER = LoggerFactory.getLogger(SubscriberAndIterator.class);
+        private static final String CANCEL_SUBSCRIPTION_ON_HAS_NEXT_TIMEOUT_PROPERTY =
+                "io.servicetalk.concurrent.api.cancelSubscriptionOnHasNextTimeout";
+        private static final boolean CANCEL_SUBSCRIPTION_ON_HAS_NEXT_TIMEOUT =
+                Boolean.getBoolean(CANCEL_SUBSCRIPTION_ON_HAS_NEXT_TIMEOUT_PROPERTY);
+
+        static {
+            LOGGER.debug("-D{}={}", CANCEL_SUBSCRIPTION_ON_HAS_NEXT_TIMEOUT_PROPERTY,
+                    CANCEL_SUBSCRIPTION_ON_HAS_NEXT_TIMEOUT);
+        }
+
         private static final Object CANCELLED_SIGNAL = new Object();
         private static final TerminalNotification COMPLETE_NOTIFICATION = complete();
         private final BlockingQueue<Object> data;

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsServiceDiscovererBuilder.java
@@ -103,7 +103,7 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
         DEFAULT_NEGATIVE_TTL_CACHE_SECONDS = negativeCacheTtlValue < 0 ? Integer.MAX_VALUE : negativeCacheTtlValue;
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("-D{}: {}", SKIP_BINDING_PROPERTY, getBoolean(SKIP_BINDING_PROPERTY));
+            LOGGER.debug("-D{}={}", SKIP_BINDING_PROPERTY, getBoolean(SKIP_BINDING_PROPERTY));
             LOGGER.debug("Default local address to bind to: {}", DEFAULT_LOCAL_ADDRESS);
             LOGGER.debug("Default DnsResolverAddressTypes: {}", DEFAULT_DNS_RESOLVER_ADDRESS_TYPES);
             LOGGER.debug("Default consolidate cache size: {}", DEFAULT_CONSOLIDATE_CACHE_SIZE);
@@ -112,12 +112,12 @@ public final class DefaultDnsServiceDiscovererBuilder implements DnsServiceDisco
             LOGGER.debug("Default TTL poll jitter seconds: {}", DEFAULT_TTL_POLL_JITTER_SECONDS);
             LOGGER.debug("Default TTL cache boundaries in seconds: [{}, {}]",
                     DEFAULT_MIN_TTL_CACHE_SECONDS, DEFAULT_MAX_TTL_CACHE_SECONDS);
-            LOGGER.debug("-D{}: {}", NEGATIVE_TTL_CACHE_SECONDS_PROPERTY, negativeCacheTtlValue);
+            LOGGER.debug("-D{}={}", NEGATIVE_TTL_CACHE_SECONDS_PROPERTY, negativeCacheTtlValue);
             LOGGER.debug("Default negative TTL cache in seconds: {}", DEFAULT_NEGATIVE_TTL_CACHE_SECONDS);
             LOGGER.debug("Default missing records status: {}", DEFAULT_MISSING_RECOREDS_STATUS);
-            LOGGER.debug("-D{}: {}", NX_DOMAIN_INVALIDATES_PROPERTY, DEFAULT_NX_DOMAIN_INVALIDATES);
-            LOGGER.debug("-D{}: {}", TCP_FALLBACK_ON_TIMEOUT_PROPERTY, DEFAULT_TCP_FALLBACK_ON_TIMEOUT);
-            LOGGER.debug("-D{}: {}", DATAGRAM_CHANNEL_STRATEGY_PROPERTY, DEFAULT_DATAGRAM_CHANNEL_STRATEGY);
+            LOGGER.debug("-D{}={}", NX_DOMAIN_INVALIDATES_PROPERTY, DEFAULT_NX_DOMAIN_INVALIDATES);
+            LOGGER.debug("-D{}={}", TCP_FALLBACK_ON_TIMEOUT_PROPERTY, DEFAULT_TCP_FALLBACK_ON_TIMEOUT);
+            LOGGER.debug("-D{}={}", DATAGRAM_CHANNEL_STRATEGY_PROPERTY, DEFAULT_DATAGRAM_CHANNEL_STRATEGY);
         }
     }
 

--- a/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/CompressionDefaults.java
+++ b/servicetalk-encoding-netty/src/main/java/io/servicetalk/encoding/netty/CompressionDefaults.java
@@ -44,6 +44,10 @@ final class CompressionDefaults {
     private static final long RESOLVED_MAX_DECOMPRESSED_BYTES =
             parseMaxDecompressedBytes(System.getProperty(MAX_DECOMPRESSED_BYTES_PROPERTY));
 
+    static {
+        LOGGER.debug("-D{}={}", MAX_DECOMPRESSED_BYTES_PROPERTY, RESOLVED_MAX_DECOMPRESSED_BYTES);
+    }
+
     private CompressionDefaults() {
         // no instances
     }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
@@ -134,16 +134,25 @@ final class GrpcMessageSizeLimiter {
         // warn-only rather than failing at class-load.
         final int value = getInteger(DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, WARN_ONLY);
         if (value < WARN_ONLY) {
-            LOGGER.warn("-D{}: {} is invalid (expected >= {}). Falling back to warn-only mode at {} bytes.",
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is invalid (expected >= {}). Falling back to " +
+                            "warn-only mode at {} bytes.",
                     DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, value, WARN_ONLY, DEFAULT_MAX_MESSAGE_SIZE);
             return WARN_ONLY;
         }
         // getInteger can't distinguish "unset" (the warn-only default) from an explicit value; only warn about the
         // temporary property when it is actually set.
         if (System.getProperty(DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY) != null) {
-            LOGGER.warn("-D{}: {}. This property will be removed in a future release. Configure this value per " +
-                            "client/server builder via maxInboundMessageSize(int) instead.",
-                    DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, value);
+            if (value == WARN_ONLY) {
+                LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: Setting this property to -1 (warn-only mode) may be " +
+                                "used temporarily to unblock deployment but exposes the service to the risk of " +
+                                "aggregating unbounded amount of data on the heap. Configure appropriate value per " +
+                                "client/server builder via maxInboundMessageSize(int) instead.",
+                        DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, value);
+            } else {
+                LOGGER.warn("-D{}={} This property will be removed in the future releases. Configure this value per " +
+                                "client/server builder via maxInboundMessageSize(int) instead.",
+                        DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, value);
+            }
         }
         return value;
     }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DefaultHttpHeadersFactory.java
@@ -37,7 +37,7 @@ public final class DefaultHttpHeadersFactory implements HttpHeadersFactory {
 
     static {
         if (!DEFAULT_VALIDATE_VALUES) {
-            LOGGER.warn("-D{}: {}. This property will be removed in the future releases. " +
+            LOGGER.warn("-D{}={} This property will be removed in the future releases. " +
                             "Configure this value via DefaultHttpHeadersFactory constructor instead.",
                     DEFAULT_VALIDATE_VALUES_PROPERTY, DEFAULT_VALIDATE_VALUES);
         }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HeaderUtils.java
@@ -21,6 +21,9 @@ import io.servicetalk.encoding.api.Identity;
 import io.servicetalk.serialization.api.SerializationException;
 import io.servicetalk.utils.internal.IllegalCharacterException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.List;
@@ -72,6 +75,7 @@ import static java.util.stream.Collectors.toMap;
  * Utilities to use for {@link HttpHeaders} implementations.
  */
 public final class HeaderUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HeaderUtils.class);
     /**
      * Constant used to seed the hash code generation. Could be anything but this was borrowed from murmur3.
      */
@@ -96,8 +100,15 @@ public final class HeaderUtils {
      * <a href="https://www.rfc-editor.org/rfc/rfc2965">RFC2965</a>/
      * <a href="https://www.rfc-editor.org/rfc/rfc2109">RFC2109</a> ({@code false}, the default).
      */
+    private static final String COOKIE_STRICT_RFC_6265_PROPERTY =
+            "io.servicetalk.http.api.headers.cookieParsingStrictRfc6265";
     static final boolean COOKIE_STRICT_RFC_6265 = parseBoolean(getProperty(
-            "io.servicetalk.http.api.headers.cookieParsingStrictRfc6265", "false"));
+            COOKIE_STRICT_RFC_6265_PROPERTY, "false"));
+
+    static {
+        LOGGER.debug("-D{}={}", COOKIE_STRICT_RFC_6265_PROPERTY, COOKIE_STRICT_RFC_6265);
+    }
+
     // ASCII symbols:
     private static final byte HT = 9;
     private static final byte DEL = 127;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
@@ -66,7 +66,7 @@ final class FilterableClientToClient implements StreamingHttpClient {
 
     static {
         if (SKIP_CONCURRENT_REQUEST_CHECK) {
-            LOGGER.warn("-D{}: {}. DANGEROUS_CONFIG_WARNING: Skipping this check may lead to corrupted request " +
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: Skipping this check may lead to corrupted request " +
                     "meta-data and issues that are hard to debug. Address business logic that causes " +
                     "RejectedSubscribeException and remove property that disables it. Enable DEBUG level logging for " +
                     "this class to enhance RejectedSubscribeException with additional diagnostics data.",

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H1ProtocolConfigBuilder.java
@@ -48,7 +48,7 @@ public final class H1ProtocolConfigBuilder {
 
     static {
         if (DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH != DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH_VALUE) {
-            LOGGER.warn("-D{}: {}. This property will be removed in the future releases. " +
+            LOGGER.warn("-D{}={} This property will be removed in the future releases. " +
                             "Configure this value via H1ProtocolConfigBuilder#maxTotalHeaderFieldsLength(int) instead.",
                     DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH_PROPERTY, DEFAULT_MAX_TOTAL_HEADER_FIELDS_LENGTH);
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2HeadersFactory.java
@@ -43,7 +43,7 @@ public final class H2HeadersFactory implements HttpHeadersFactory {
 
     static {
         if (!DEFAULT_VALIDATE_VALUES) {
-            LOGGER.warn("-D{}: {}. This property will be removed in the future releases. " +
+            LOGGER.warn("-D{}={} This property will be removed in the future releases. " +
                             "Configure this value via H2HeadersFactory constructor instead.",
                     DEFAULT_VALIDATE_VALUES_PROPERTY, DEFAULT_VALIDATE_VALUES);
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ServerParentChannelInitializer.java
@@ -57,7 +57,7 @@ final class H2ServerParentChannelInitializer implements ChannelInitializer {
 
     static {
         if (DEFAULT_MAX_CONCURRENT_STREAMS != DEFAULT_MAX_CONCURRENT_STREAMS_VALUE) {
-            LOGGER.warn("-D{}: {}. This property will be removed in future releases. " +
+            LOGGER.warn("-D{}={} This property will be removed in the future releases. " +
                             "Configure this value via H2ProtocolConfigBuilder#initialSettings(Http2Settings) with " +
                             "Http2SettingsBuilder#maxConcurrentStreams(long) instead.",
                     DEFAULT_MAX_CONCURRENT_STREAMS_PROPERTY, DEFAULT_MAX_CONCURRENT_STREAMS);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -20,6 +20,8 @@ import io.servicetalk.http.api.HttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -40,6 +42,8 @@ import static java.lang.System.getProperty;
 
 final class H2ToStH1Utils {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(H2ToStH1Utils.class);
+
     static final CharSequence PROXY_CONNECTION = newAsciiString("proxy-connection");
     /**
      * Keep consistent with {@link io.servicetalk.http.api.HeaderUtils}.
@@ -50,8 +54,14 @@ final class H2ToStH1Utils {
      * <a href="https://www.rfc-editor.org/rfc/rfc2965">RFC2965</a>/
      * <a href="https://www.rfc-editor.org/rfc/rfc2109">RFC2109</a> ({@code false}, the default).
      */
+    private static final String COOKIE_STRICT_RFC_6265_PROPERTY =
+            "io.servicetalk.http.api.headers.cookieParsingStrictRfc6265";
     static final boolean COOKIE_STRICT_RFC_6265 = parseBoolean(getProperty(
-            "io.servicetalk.http.api.headers.cookieParsingStrictRfc6265", "false"));
+            COOKIE_STRICT_RFC_6265_PROPERTY, "false"));
+
+    static {
+        LOGGER.debug("-D{}={}", COOKIE_STRICT_RFC_6265_PROPERTY, COOKIE_STRICT_RFC_6265);
+    }
 
     private H2ToStH1Utils() {
         // no instances.

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -55,7 +55,8 @@ final class HttpConfig {
         final int value = getInteger(DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY,
                 WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE);
         if (value < WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE) {
-            LOGGER.warn("-D{}: {} is invalid (expected >= {}). Falling back to warn-only mode at {} bytes.",
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is invalid (expected >= {}). Falling back to " +
+                            "warn-only mode at {} bytes.",
                     DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, value, WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE,
                     DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE);
             DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE = WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE;
@@ -64,9 +65,17 @@ final class HttpConfig {
             // getInteger can't distinguish "unset" (the warn-only default) from an explicit value; only warn about
             // the temporary property when it is actually set.
             if (System.getProperty(DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY) != null) {
-                LOGGER.warn("-D{}: {}. This property will be removed in the future releases. Configure this value " +
-                                "per client/server builder via maxAggregatedPayloadSize(int) instead.",
-                        DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, value);
+                if (value == WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE) {
+                    LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: Setting this property to -1 (warn-only mode) may " +
+                                    "be used temporarily to unblock deployment but exposes the service to the risk " +
+                                    "of aggregating unbounded amount of data on the heap. Configure appropriate " +
+                                    "value per client/server builder via maxAggregatedPayloadSize(int) instead.",
+                            DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, value);
+                } else {
+                    LOGGER.warn("-D{}={} This property will be removed in the future releases. Configure this value " +
+                                    "per client/server builder via maxAggregatedPayloadSize(int) instead.",
+                            DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, value);
+                }
             }
         }
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptimizedHttp2FrameCodecBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/OptimizedHttp2FrameCodecBuilder.java
@@ -336,7 +336,7 @@ final class OptimizedHttp2FrameCodecBuilder extends Http2FrameCodecBuilder {
                 return defaultValue;
             }
         }
-        LOGGER.debug("-D{}: {}", name, intValue);
+        LOGGER.debug("-D{}={}", name, intValue);
         return intValue;
     }
 }

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/DefaultLoadBalancerBuilder.java
@@ -228,7 +228,7 @@ final class DefaultLoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedCo
         final String value = System.getProperty(DEFAULT_LB_POLICY_PROPERTY_NAME, fallbackPolicyName);
         final String normalized = value.trim().toLowerCase(Locale.ENGLISH);
         if (LB_POLICY_ROUND_ROBIN.equals(normalized) || LB_POLICY_P2C.equals(normalized)) {
-            LOGGER.debug("-D{}: {}", DEFAULT_LB_POLICY_PROPERTY_NAME, normalized);
+            LOGGER.debug("-D{}={}", DEFAULT_LB_POLICY_PROPERTY_NAME, normalized);
             return normalized;
         }
         LOGGER.warn("Unrecognized value '{}' for -D{}, expected one of [{}, {}]. Using default of {}.",

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
@@ -66,19 +66,28 @@ final class MessageSizeLimiter {
         // HttpSerializers instances).
         final int value = getInteger(DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, WARN_ONLY);
         if (value < WARN_ONLY) {
-            LOGGER.warn("-D{}: {} is invalid (expected >= -1, where 0 disables the limit and -1 warns). Falling back " +
-                            "to warn-only mode at {} bytes.", DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value,
-                    DEFAULT_MAX_MESSAGE_SIZE_VALUE);
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is invalid (expected >= {}). Falling back to " +
+                            "warn-only mode at {} bytes.",
+                    DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value, WARN_ONLY, DEFAULT_MAX_MESSAGE_SIZE_VALUE);
             DEFAULT_MAX_MESSAGE_SIZE = WARN_ONLY;
         } else {
             DEFAULT_MAX_MESSAGE_SIZE = value;
             // getInteger can't distinguish "unset" (the warn-only default) from an explicit value; only warn about
             // the temporary property when it is actually set.
             if (System.getProperty(DEFAULT_MAX_MESSAGE_SIZE_PROPERTY) != null) {
-                LOGGER.warn("-D{}: {}. This property is temporary and will be removed in a future release. Configure " +
-                                "the limit per serializer via the 3-arg FixedLengthStreamingSerializer / " +
-                                "VarIntLengthStreamingSerializer constructor instead.",
-                        DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value);
+                if (value == WARN_ONLY) {
+                    LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: Setting this property to -1 (warn-only mode) may " +
+                                    "be used temporarily to unblock deployment but exposes the service to the risk " +
+                                    "of aggregating unbounded amount of data on the heap. Configure appropriate " +
+                                    "value per serializer via the 3-arg FixedLengthStreamingSerializer / " +
+                                    "VarIntLengthStreamingSerializer constructor instead.",
+                            DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value);
+                } else {
+                    LOGGER.warn("-D{}={} This property will be removed in the future release. Configure this value " +
+                                    "per serializer via the 3-arg FixedLengthStreamingSerializer / " +
+                                    "VarIntLengthStreamingSerializer constructor instead.",
+                            DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value);
+                }
             }
         }
     }

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/CloseHandler.java
@@ -55,7 +55,7 @@ public abstract class CloseHandler {
                 LOGGER.info("Error while parsing {}", logLevelPropertyStr, cause);
             }
         }
-        LOGGER.debug("{}={}", logLevelPropertyStr, logLevel);
+        LOGGER.debug("-D{}={}", logLevelPropertyStr, logLevel);
         CLOSE_HANDLER_LOG_LEVEL = logLevel;
     }
 

--- a/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NativeTransportUtils.java
+++ b/servicetalk-transport-netty-internal/src/main/java/io/servicetalk/transport/netty/internal/NativeTransportUtils.java
@@ -60,9 +60,9 @@ final class NativeTransportUtils {
         IS_OSX_OR_BSD = PlatformDependent.isOsx() || os.contains("bsd");
         TRY_IO_URING = new AtomicBoolean(getBoolean(TRY_IO_URING_NAME));
 
-        LOGGER.debug("-D{}: {}", REQUIRE_NATIVE_LIBS_NAME, REQUIRE_NATIVE_LIBS);
-        LOGGER.debug("-D{}: {}", NETTY_NO_NATIVE_NAME, NETTY_NO_NATIVE);
-        LOGGER.debug("-D{}: {}", TRY_IO_URING_NAME, TRY_IO_URING.get());
+        LOGGER.debug("-D{}={}", REQUIRE_NATIVE_LIBS_NAME, REQUIRE_NATIVE_LIBS);
+        LOGGER.debug("-D{}={}", NETTY_NO_NATIVE_NAME, NETTY_NO_NATIVE);
+        LOGGER.debug("-D{}={}", TRY_IO_URING_NAME, TRY_IO_URING.get());
         LOGGER.debug("Operating system: {}", os);
 
         if (IS_LINUX && !Epoll.isAvailable()) {

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent.java
@@ -385,7 +385,7 @@ public final class PlatformDependent {
                 }
                 LOGGER.debug("jctools unpadded: {}available.", queue == null ? "un" : "");
             }
-            LOGGER.debug("{}: {}", useUnpaddedQueuesName, useUnpaddedQueues);
+            LOGGER.debug("-D{}={}", useUnpaddedQueuesName, useUnpaddedQueues);
             USE_UNPADDED_QUEUES = useUnpaddedQueues;
         }
 

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent0.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/PlatformDependent0.java
@@ -61,7 +61,8 @@ final class PlatformDependent0 {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PlatformDependent0.class);
 
-    private static final boolean IS_EXPLICIT_NO_UNSAFE = getBoolean("io.servicetalk.noUnsafe");
+    private static final String IS_EXPLICIT_NO_UNSAFE_PROPERTY = "io.servicetalk.noUnsafe";
+    private static final boolean IS_EXPLICIT_NO_UNSAFE = getBoolean(IS_EXPLICIT_NO_UNSAFE_PROPERTY);
 
     private static final String DEALLOCATOR_CLASS_NAME = "java.nio.DirectByteBuffer$Deallocator";
 
@@ -90,6 +91,7 @@ final class PlatformDependent0 {
     private static final Object DUMMY = new Object();
 
     static {
+        LOGGER.debug("-D{}={}", IS_EXPLICIT_NO_UNSAFE_PROPERTY, IS_EXPLICIT_NO_UNSAFE);
         Object unsafe;
 
         if (IS_EXPLICIT_NO_UNSAFE) {

--- a/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ReflectionUtils.java
+++ b/servicetalk-utils-internal/src/main/java/io/servicetalk/utils/internal/ReflectionUtils.java
@@ -53,6 +53,7 @@ public final class ReflectionUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReflectionUtils.class);
 
     private static final int JAVA_VERSION = javaVersion0();
+    private static final String TRY_REFLECTION_SET_ACCESSIBLE_PROPERTY = "io.servicetalk.tryReflectionSetAccessible";
     private static final boolean IS_EXPLICIT_TRY_REFLECTION_SET_ACCESSIBLE = explicitTryReflectionSetAccessible0();
 
     private ReflectionUtils() {
@@ -116,7 +117,9 @@ public final class ReflectionUtils {
     }
 
     private static boolean explicitTryReflectionSetAccessible0() {
-        return getBoolean("io.servicetalk.tryReflectionSetAccessible", JAVA_VERSION < 9);
+        final boolean value = getBoolean(TRY_REFLECTION_SET_ACCESSIBLE_PROPERTY, JAVA_VERSION < 9);
+        LOGGER.debug("-D{}={}", TRY_REFLECTION_SET_ACCESSIBLE_PROPERTY, value);
+        return value;
     }
 
     static boolean getBoolean(final String name, final boolean def) {


### PR DESCRIPTION
Motivation:

Align all props to use consistent pattern.

Modifications:

- Use `-D{}={}` pattern instead of `-D{}: {}` to help systems with key-value log layout to show properties correctly as a single line.
- Add standard `DANGEROUS_CONFIG_WARNING` prefix where necessary.
- Update formatting and wording to keep things consistent.

Result:

System properties are logged in consistent format and easier to parse for key-value logging systems.