### PR TITLE
serializer, http, grpc: make warn-only size-limit warnings actionable

### DIFF
--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -69,7 +69,8 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
         this.streamingHttpClient = requireNonNull(streamingHttpClient);
         executionContext = new DefaultGrpcExecutionContext(streamingHttpClient.executionContext());
         this.defaultTimeout = callConfig.defaultTimeout();
-        this.sizeLimiter = GrpcMessageSizeLimiter.forMaxInboundMessageSize(callConfig.maxInboundMessageSize());
+        this.sizeLimiter = GrpcMessageSizeLimiter.forMaxInboundMessageSize(callConfig.maxInboundMessageSize(),
+                streamingHttpClient);
     }
 
     @Deprecated

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
@@ -44,7 +44,7 @@ final class GrpcMessageSizeLimiter {
     /**
      * A no-op limiter that never rejects or warns, regardless of message size.
      */
-    static final GrpcMessageSizeLimiter NONE = new GrpcMessageSizeLimiter(Mode.DISABLED, 0);
+    static final GrpcMessageSizeLimiter NONE = new GrpcMessageSizeLimiter(Mode.DISABLED, 0, null);
 
     // maxInboundMessageSize value selecting warn-only mode (see forMaxInboundMessageSize), and the built-in default.
     private static final int WARN_ONLY = -1;
@@ -65,15 +65,20 @@ final class GrpcMessageSizeLimiter {
     // Non-null if this is a warn-only limiter.
     @Nullable
     private final AtomicLong maxObservedSize;
+    // Identifies the owning client/server in the warning (client-side: the StreamingHttpClient, whose toString carries
+    // the target address); null when not warn-only or when unavailable (server-side).
+    @Nullable
+    private final Object owner;
     @Nullable
     private final Throwable constructionSite;
 
-    private GrpcMessageSizeLimiter(final Mode mode, final int maxMessageSize) {
+    private GrpcMessageSizeLimiter(final Mode mode, final int maxMessageSize, @Nullable final Object owner) {
         this.mode = mode;
         this.maxMessageSize = maxMessageSize;
         // Seed in the past so the first time the limit is exceeded a warning is emitted immediately.
         this.lastWarnNanos = mode == Mode.WARN_ONLY ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
         this.maxObservedSize = mode == Mode.WARN_ONLY ? new AtomicLong() : null;
+        this.owner = mode == Mode.WARN_ONLY ? owner : null;
         this.constructionSite = mode == Mode.WARN_ONLY ? new Throwable(
                 "Client/server with a warn-only maxInboundMessageSize created here (not an error)") : null;
     }
@@ -88,11 +93,22 @@ final class GrpcMessageSizeLimiter {
      * @throws IllegalArgumentException if {@code maxInboundMessageSize < -1}
      */
     static GrpcMessageSizeLimiter forMaxInboundMessageSize(final int maxInboundMessageSize) {
+        return forMaxInboundMessageSize(maxInboundMessageSize, null);
+    }
+
+    /**
+     * Variant of {@link #forMaxInboundMessageSize(int)} that records {@code owner} to identify the client/server in
+     * the warn-only log. The client passes its {@link io.servicetalk.http.api.StreamingHttpClient} (whose
+     * {@code toString()} carries the target address); the server has no equivalent handle and passes {@code null},
+     * relying on the construction stack instead.
+     */
+    static GrpcMessageSizeLimiter forMaxInboundMessageSize(final int maxInboundMessageSize,
+                                                           @Nullable final Object owner) {
         if (maxInboundMessageSize == 0) {
             return NONE;
         }
         if (maxInboundMessageSize > 0) {
-            return new GrpcMessageSizeLimiter(Mode.ENFORCING, maxInboundMessageSize);
+            return new GrpcMessageSizeLimiter(Mode.ENFORCING, maxInboundMessageSize, null);
         }
         // A negative value reaches here only as the property-derived default; the builder/config API rejects
         // negatives up front, so the sole legal negative is the warn-only selector.
@@ -100,7 +116,7 @@ final class GrpcMessageSizeLimiter {
             throw new IllegalArgumentException("maxInboundMessageSize: " + maxInboundMessageSize +
                     " (expected >= " + WARN_ONLY + ')');
         }
-        return new GrpcMessageSizeLimiter(Mode.WARN_ONLY, DEFAULT_MAX_MESSAGE_SIZE);
+        return new GrpcMessageSizeLimiter(Mode.WARN_ONLY, DEFAULT_MAX_MESSAGE_SIZE, owner);
     }
 
     /**
@@ -172,11 +188,12 @@ final class GrpcMessageSizeLimiter {
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
-            LOGGER.warn("gRPC message size={} exceeded the configured maximum inbound message size of {} bytes, but " +
-                    "the limit is configured in warn-only mode so the message is allowed through. Largest message " +
-                    "observed so far is {} bytes. Configure an enforcing maxInboundMessageSize(int) to reject " +
-                    "oversized messages with RESOURCE_EXHAUSTED. This warning is rate-limited to once per 5 minutes " +
-                    "per client/server.", messageSize, maxMessageSize, maxObserved, constructionSite);
+            LOGGER.warn("gRPC message size={} exceeded the configured maximum inbound message size of {} bytes{}, " +
+                    "but the limit is configured in warn-only mode so the message is allowed through. Largest " +
+                    "message observed so far is {} bytes. Configure an enforcing maxInboundMessageSize(int) to " +
+                    "reject oversized messages with RESOURCE_EXHAUSTED. This warning is rate-limited to once per 5 " +
+                    "minutes per client/server.", messageSize, maxMessageSize, owner == null ? "" : " for " + owner,
+                    maxObserved, constructionSite);
         }
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
@@ -65,6 +65,8 @@ final class GrpcMessageSizeLimiter {
     // Non-null if this is a warn-only limiter.
     @Nullable
     private final AtomicLong maxObservedSize;
+    @Nullable
+    private final Throwable constructionSite;
 
     private GrpcMessageSizeLimiter(final Mode mode, final int maxMessageSize) {
         this.mode = mode;
@@ -72,6 +74,8 @@ final class GrpcMessageSizeLimiter {
         // Seed in the past so the first time the limit is exceeded a warning is emitted immediately.
         this.lastWarnNanos = mode == Mode.WARN_ONLY ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
         this.maxObservedSize = mode == Mode.WARN_ONLY ? new AtomicLong() : null;
+        this.constructionSite = mode == Mode.WARN_ONLY ? new Throwable(
+                "Client/server with a warn-only maxInboundMessageSize created here (not an error)") : null;
     }
 
     /**
@@ -163,6 +167,7 @@ final class GrpcMessageSizeLimiter {
     private void maybeWarn(final long messageSize) {
         assert lastWarnNanos != null;
         assert maxObservedSize != null;
+        assert constructionSite != null;
         final long maxObserved = maxObservedSize.accumulateAndGet(messageSize, Math::max);
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
@@ -171,7 +176,7 @@ final class GrpcMessageSizeLimiter {
                     "the limit is configured in warn-only mode so the message is allowed through. Largest message " +
                     "observed so far is {} bytes. Configure an enforcing maxInboundMessageSize(int) to reject " +
                     "oversized messages with RESOURCE_EXHAUSTED. This warning is rate-limited to once per 5 minutes " +
-                    "per client/server.", messageSize, maxMessageSize, maxObserved);
+                    "per client/server.", messageSize, maxMessageSize, maxObserved, constructionSite);
         }
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
@@ -59,16 +59,19 @@ final class GrpcMessageSizeLimiter {
 
     private final Mode mode;
     private final int maxMessageSize;
-    // Non-null iff this is a warn-only limiter. Holds nanoTime() of the last emitted warning so we can rate-limit to
-    // one entry per WARN_INTERVAL_NANOS. Shared across all deframers of the owning client/server.
+    // Non-null if this is a warn-only limiter.
     @Nullable
     private final AtomicLong lastWarnNanos;
+    // Non-null if this is a warn-only limiter.
+    @Nullable
+    private final AtomicLong maxObservedSize;
 
     private GrpcMessageSizeLimiter(final Mode mode, final int maxMessageSize) {
         this.mode = mode;
         this.maxMessageSize = maxMessageSize;
         // Seed in the past so the first time the limit is exceeded a warning is emitted immediately.
         this.lastWarnNanos = mode == Mode.WARN_ONLY ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
+        this.maxObservedSize = mode == Mode.WARN_ONLY ? new AtomicLong() : null;
     }
 
     /**
@@ -159,13 +162,16 @@ final class GrpcMessageSizeLimiter {
 
     private void maybeWarn(final long messageSize) {
         assert lastWarnNanos != null;
+        assert maxObservedSize != null;
+        final long maxObserved = maxObservedSize.accumulateAndGet(messageSize, Math::max);
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
             LOGGER.warn("gRPC message size={} exceeded the configured maximum inbound message size of {} bytes, but " +
-                    "the limit is configured in warn-only mode so the message is allowed through. Configure an " +
-                    "enforcing maxInboundMessageSize(int) to reject oversized messages with RESOURCE_EXHAUSTED. This " +
-                    "warning is rate-limited to once per 5 minutes per client/server.", messageSize, maxMessageSize);
+                    "the limit is configured in warn-only mode so the message is allowed through. Largest message " +
+                    "observed so far is {} bytes. Configure an enforcing maxInboundMessageSize(int) to reject " +
+                    "oversized messages with RESOURCE_EXHAUSTED. This warning is rate-limited to once per 5 minutes " +
+                    "per client/server.", messageSize, maxMessageSize, maxObserved);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
@@ -56,6 +56,8 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
     // Identifies the owning client/server in the warning; null when not warn-only.
     @Nullable
     private final Object owner;
+    @Nullable
+    private final Throwable constructionSite;
 
     private AggregatedPayloadSizeLimiter(final int maxAggregatedSize, final boolean warnOnly,
                                          @Nullable final Object owner) {
@@ -64,6 +66,8 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
         this.lastWarnNanos = warnOnly ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
         this.maxObservedSize = warnOnly ? new AtomicLong() : null;
         this.owner = warnOnly ? owner : null;
+        this.constructionSite = warnOnly ? new Throwable(
+                "Client/server with a warn-only maxAggregatedPayloadSize created here (not an error)") : null;
     }
 
     /**
@@ -112,6 +116,7 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
     private void maybeWarn(final long totalSize) {
         assert lastWarnNanos != null;
         assert maxObservedSize != null;
+        assert constructionSite != null;
         final long maxObserved = maxObservedSize.accumulateAndGet(totalSize, Math::max);
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
@@ -120,7 +125,7 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
                     "limit is configured in warn-only mode so the payload is allowed through. Largest payload " +
                     "observed so far is {} bytes. Configure an enforcing maxAggregatedPayloadSize(int) to reject " +
                     "oversized payloads. This warning is rate-limited to once per 5 minutes per client/server.",
-                    totalSize, maxAggregatedSize, owner, maxObserved);
+                    totalSize, maxAggregatedSize, owner, maxObserved, constructionSite);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
@@ -53,12 +53,17 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
     // Non-null if this is a warn-only limiter.
     @Nullable
     private final AtomicLong maxObservedSize;
+    // Identifies the owning client/server in the warning; null when not warn-only.
+    @Nullable
+    private final Object owner;
 
-    private AggregatedPayloadSizeLimiter(final int maxAggregatedSize, final boolean warnOnly) {
+    private AggregatedPayloadSizeLimiter(final int maxAggregatedSize, final boolean warnOnly,
+                                         @Nullable final Object owner) {
         this.maxAggregatedSize = maxAggregatedSize;
         // Seed in the past so the first time the limit is exceeded a warning is emitted immediately.
         this.lastWarnNanos = warnOnly ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
         this.maxObservedSize = warnOnly ? new AtomicLong() : null;
+        this.owner = warnOnly ? owner : null;
     }
 
     /**
@@ -69,7 +74,7 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
      * @return a limiter, or {@link #NONE} when {@code maxAggregatedSize <= 0}
      */
     static LongConsumer enforcing(final int maxAggregatedSize) {
-        return maxAggregatedSize <= 0 ? NONE : new AggregatedPayloadSizeLimiter(maxAggregatedSize, false);
+        return maxAggregatedSize <= 0 ? NONE : new AggregatedPayloadSizeLimiter(maxAggregatedSize, false, null);
     }
 
     /**
@@ -78,10 +83,11 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
      * per client/server).
      *
      * @param maxAggregatedSize the size in bytes above which a warning is emitted; {@code 0} or negative disables it
+     * @param owner identifies the owning client/server in the warning (e.g. its target/bind address)
      * @return a limiter, or {@link #NONE} when {@code maxAggregatedSize <= 0}
      */
-    static LongConsumer warning(final int maxAggregatedSize) {
-        return maxAggregatedSize <= 0 ? NONE : new AggregatedPayloadSizeLimiter(maxAggregatedSize, true);
+    static LongConsumer warning(final int maxAggregatedSize, @Nullable final Object owner) {
+        return maxAggregatedSize <= 0 ? NONE : new AggregatedPayloadSizeLimiter(maxAggregatedSize, true, owner);
     }
 
     /**
@@ -110,11 +116,11 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
-            LOGGER.warn("Aggregated payload size={} exceeded the configured maximum of {} bytes, but the limit is " +
-                    "configured in warn-only mode so the payload is allowed through. Largest payload observed so far " +
-                    "is {} bytes. Configure an enforcing maxAggregatedPayloadSize(int) to reject oversized payloads. " +
-                    "This warning is rate-limited to once per 5 minutes per client/server.", totalSize,
-                    maxAggregatedSize, maxObserved);
+            LOGGER.warn("Aggregated payload size={} exceeded the configured maximum of {} bytes for {}, but the " +
+                    "limit is configured in warn-only mode so the payload is allowed through. Largest payload " +
+                    "observed so far is {} bytes. Configure an enforcing maxAggregatedPayloadSize(int) to reject " +
+                    "oversized payloads. This warning is rate-limited to once per 5 minutes per client/server.",
+                    totalSize, maxAggregatedSize, owner, maxObserved);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
@@ -47,15 +47,18 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
     static final LongConsumer NONE = size -> { };
 
     private final int maxAggregatedSize;
-    // Non-null iff this is a warn-only limiter. Holds nanoTime() of the last emitted warning so we can rate-limit to
-    // one entry per WARN_INTERVAL_NANOS. Shared across all aggregations of the owning client/server.
+    // Non-null if this is a warn-only limiter.
     @Nullable
     private final AtomicLong lastWarnNanos;
+    // Non-null if this is a warn-only limiter.
+    @Nullable
+    private final AtomicLong maxObservedSize;
 
     private AggregatedPayloadSizeLimiter(final int maxAggregatedSize, final boolean warnOnly) {
         this.maxAggregatedSize = maxAggregatedSize;
         // Seed in the past so the first time the limit is exceeded a warning is emitted immediately.
         this.lastWarnNanos = warnOnly ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
+        this.maxObservedSize = warnOnly ? new AtomicLong() : null;
     }
 
     /**
@@ -102,13 +105,16 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
 
     private void maybeWarn(final long totalSize) {
         assert lastWarnNanos != null;
+        assert maxObservedSize != null;
+        final long maxObserved = maxObservedSize.accumulateAndGet(totalSize, Math::max);
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
             LOGGER.warn("Aggregated payload size={} exceeded the configured maximum of {} bytes, but the limit is " +
-                    "configured in warn-only mode so the payload is allowed through. Configure an enforcing " +
-                    "maxAggregatedPayloadSize(int) to reject oversized payloads. This warning is rate-limited to " +
-                    "once per 5 minutes per client/server.", totalSize, maxAggregatedSize);
+                    "configured in warn-only mode so the payload is allowed through. Largest payload observed so far " +
+                    "is {} bytes. Configure an enforcing maxAggregatedPayloadSize(int) to reject oversized payloads. " +
+                    "This warning is rate-limited to once per 5 minutes per client/server.", totalSize,
+                    maxAggregatedSize, maxObserved);
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultHttpServerBuilder.java
@@ -424,7 +424,7 @@ class DefaultHttpServerBuilder implements HttpServerBuilder {
         final EarlyConnectionAcceptor earlyConnectionAcceptor = buildEarlyConnectionAcceptor(earlyConnectionAcceptors);
         final LateConnectionAcceptor lateConnectionAcceptor = buildLateConnectionAcceptor(lateConnectionAcceptors);
 
-        final ReadOnlyHttpServerConfig roConfig = config.asReadOnly();
+        final ReadOnlyHttpServerConfig roConfig = config.asReadOnly(address);
         final List<StreamingHttpServiceFilterFactory> noOffloadServiceFilters =
                 initNonOffloadsServiceFilters(config.lifecycleObserver());
 
@@ -478,7 +478,7 @@ class DefaultHttpServerBuilder implements HttpServerBuilder {
                 // For non-SSL, if both H1 and H2 are configured at the same time we force-fallback to H1
                 configWithoutSsl.httpConfig().protocols(roConfig.h1Config());
             }
-            ReadOnlyHttpServerConfig roConfigWithoutSsl = configWithoutSsl.asReadOnly();
+            ReadOnlyHttpServerConfig roConfigWithoutSsl = configWithoutSsl.asReadOnly(address);
             return OptionalSslNegotiator.bind(executionContext, roConfig, roConfigWithoutSsl, address,
                     connectionAcceptor, filteredService, earlyConnectionAcceptor,
                     lateConnectionAcceptor);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultMultiAddressUrlHttpClientBuilder.java
@@ -160,7 +160,7 @@ final class DefaultMultiAddressUrlHttpClientBuilder
             urlClient = clientFilterFactory.create(urlClient);
 
             LOGGER.debug("Multi-address client created with base strategy {}", executionContext.executionStrategy());
-            return new FilterableClientToClient(urlClient, executionContext);
+            return new FilterableClientToClient(urlClient, executionContext, "multi-address URL client");
         } catch (final Throwable t) {
             closeables.closeAsync().subscribe();
             throw t;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultPartitionedHttpClientBuilder.java
@@ -132,7 +132,7 @@ final class DefaultPartitionedHttpClientBuilder<U, R> implements PartitionedHttp
                         executionContext, partitionMapFactory);
 
         LOGGER.debug("Partitioned client created with base strategy {}", executionContext.executionStrategy());
-        return new FilterableClientToClient(partitionedClient, executionContext);
+        return new FilterableClientToClient(partitionedClient, executionContext, address);
     }
 
     private static <U> String targetResource(final U address) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -361,7 +361,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
                 LOGGER.debug("Client for {} created with the builder strategy {}, resulting computed strategy is {}.",
                         targetResource, builderStrategy, computedStrategy);
             }
-            return new FilterableClientToClient(wrappedClient, executionContext);
+            return new FilterableClientToClient(wrappedClient, executionContext, targetResource);
         } catch (final Throwable t) {
             closeOnException.closeAsync().subscribe();
             throw t;

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/DefaultSingleAddressHttpClientBuilder.java
@@ -228,7 +228,7 @@ final class DefaultSingleAddressHttpClientBuilder<U, R> implements SingleAddress
 
     private static <U, R> StreamingHttpClient buildStreaming(final HttpClientBuildContext<U, R> ctx) {
         final String targetResource = targetResource(ctx);
-        final ReadOnlyHttpClientConfig roConfig = ctx.httpConfig().asReadOnly();
+        final ReadOnlyHttpClientConfig roConfig = ctx.httpConfig().asReadOnly(targetResource);
         final HttpExecutionStrategy computedStrategy =
                 ctx.builder.strategyComputation.buildForClient(
                         ctx.builder.executionContextBuilder.build().executionStrategy());

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/FilterableClientToClient.java
@@ -77,10 +77,15 @@ final class FilterableClientToClient implements StreamingHttpClient {
     private final Object lock = new Object();
     private final FilterableStreamingHttpClient client;
     private final HttpExecutionContext executionContext;
+    // Human-readable identifier of what this client connects to, surfaced via toString() so callers holding only a
+    // StreamingHttpClient (e.g. the gRPC layer) can log which client it is.
+    private final Object targetAddress;
 
-    FilterableClientToClient(FilterableStreamingHttpClient filteredClient, HttpExecutionContext executionContext) {
+    FilterableClientToClient(FilterableStreamingHttpClient filteredClient, HttpExecutionContext executionContext,
+                             Object targetAddress) {
         client = filteredClient;
         this.executionContext = executionContext;
+        this.targetAddress = targetAddress;
     }
 
     @Override
@@ -292,5 +297,10 @@ final class FilterableClientToClient implements StreamingHttpClient {
     private static void setExecutionStrategy(final HttpRequestMetaData request, final HttpExecutionStrategy strategy) {
         // We do not override HttpExecutionStrategy because users may prefer to use their own.
         request.context().putIfAbsent(HTTP_EXECUTION_STRATEGY_KEY, strategy);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + '{' + targetAddress + '}';
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
@@ -128,9 +128,9 @@ final class HttpClientConfig {
         this.fallbackProxyPeerPort = fallbackProxyPeerPort;
     }
 
-    ReadOnlyHttpClientConfig asReadOnly() {
+    ReadOnlyHttpClientConfig asReadOnly(@Nullable final Object owner) {
         applySslConfigOverrides();
-        final ReadOnlyHttpClientConfig roConfig = new ReadOnlyHttpClientConfig(this);
+        final ReadOnlyHttpClientConfig roConfig = new ReadOnlyHttpClientConfig(this, owner);
         if (roConfig.tcpConfig().sslContext() == null && roConfig.h1Config() != null && roConfig.h2Config() != null) {
             throw new IllegalStateException("Cleartext HTTP/1.1 -> HTTP/2 (h2c) upgrade is not supported");
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -137,8 +137,8 @@ final class HttpConfig {
      * rate-limiting state, so it must be created once per client/server (see {@link ReadOnlyHttpClientConfig} /
      * {@link ReadOnlyHttpServerConfig}) and shared across its connections.
      */
-    LongConsumer newAggregatedPayloadSizeLimiter() {
-        return toAggregatedPayloadSizeLimiter(maxAggregatedPayloadSize, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE);
+    LongConsumer newAggregatedPayloadSizeLimiter(@Nullable final Object owner) {
+        return toAggregatedPayloadSizeLimiter(maxAggregatedPayloadSize, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE, owner);
     }
 
     /**
@@ -149,10 +149,11 @@ final class HttpConfig {
      * {@link #DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE} when {@code resolvedDefault} is not positive, so warn-only
      * mode never silently collapses to "disabled".
      */
-    static LongConsumer toAggregatedPayloadSizeLimiter(final int configured, final int resolvedDefault) {
+    static LongConsumer toAggregatedPayloadSizeLimiter(final int configured, final int resolvedDefault,
+                                                       @Nullable final Object owner) {
         if (configured == WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE) {
             return AggregatedPayloadSizeLimiter.warning(
-                    resolvedDefault > 0 ? resolvedDefault : DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE);
+                    resolvedDefault > 0 ? resolvedDefault : DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, owner);
         }
         return AggregatedPayloadSizeLimiter.enforcing(configured);
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServerConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServerConfig.java
@@ -73,9 +73,9 @@ final class HttpServerConfig {
         return this;
     }
 
-    ReadOnlyHttpServerConfig asReadOnly() {
+    ReadOnlyHttpServerConfig asReadOnly(@Nullable final Object owner) {
         applySslConfigOverrides();
-        final ReadOnlyHttpServerConfig roConfig = new ReadOnlyHttpServerConfig(this);
+        final ReadOnlyHttpServerConfig roConfig = new ReadOnlyHttpServerConfig(this, owner);
         if (roConfig.tcpConfig().sslContext() == null && roConfig.h1Config() != null && roConfig.h2Config() != null) {
             throw new IllegalStateException("Cleartext HTTP/1.1 -> HTTP/2 (h2c) upgrade is not supported");
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpClientConfig.java
@@ -32,14 +32,14 @@ final class ReadOnlyHttpClientConfig {
     private final boolean allowDropTrailers;
     private final LongConsumer payloadSizeLimiter;
 
-    ReadOnlyHttpClientConfig(final HttpClientConfig from) {
+    ReadOnlyHttpClientConfig(final HttpClientConfig from, @Nullable final Object owner) {
         final HttpConfig configs = from.protocolConfigs();
         tcpConfig = from.tcpConfig().asReadOnly();
         h1Config = configs.h1Config();
         h2Config = configs.h2Config();
         proxyConfig = from.proxyConfig();
         allowDropTrailers = configs.allowDropTrailersReadFromTransport();
-        payloadSizeLimiter = configs.newAggregatedPayloadSizeLimiter();
+        payloadSizeLimiter = configs.newAggregatedPayloadSizeLimiter(owner);
     }
 
     ReadOnlyTcpClientConfig tcpConfig() {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpServerConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/ReadOnlyHttpServerConfig.java
@@ -33,13 +33,13 @@ final class ReadOnlyHttpServerConfig {
     @Nullable
     private final HttpLifecycleObserver lifecycleObserver;
 
-    ReadOnlyHttpServerConfig(final HttpServerConfig from) {
+    ReadOnlyHttpServerConfig(final HttpServerConfig from, @Nullable final Object owner) {
         final HttpConfig configs = from.httpConfig();
         tcpConfig = from.tcpConfig().asReadOnly();
         h1Config = configs.h1Config();
         h2Config = configs.h2Config();
         allowDropTrailers = configs.allowDropTrailersReadFromTransport();
-        payloadSizeLimiter = configs.newAggregatedPayloadSizeLimiter();
+        payloadSizeLimiter = configs.newAggregatedPayloadSizeLimiter(owner);
         lifecycleObserver = from.lifecycleObserver();
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiterTest.java
@@ -45,7 +45,7 @@ class AggregatedPayloadSizeLimiterTest {
 
     @Test
     void warningNeverRejects() {
-        final LongConsumer limiter = warning(10);
+        final LongConsumer limiter = warning(10, "test-owner");
         assertDoesNotThrow(() -> limiter.accept(10));
         // Over the limit it warns (rate-limited) but must not throw.
         assertDoesNotThrow(() -> limiter.accept(Long.MAX_VALUE));
@@ -55,13 +55,13 @@ class AggregatedPayloadSizeLimiterTest {
     void nonPositiveSizeIsDisabled() {
         assertSame(NONE, enforcing(0));
         assertSame(NONE, enforcing(-1));
-        assertSame(NONE, warning(0));
+        assertSame(NONE, warning(0, "test-owner"));
         assertDoesNotThrow(() -> NONE.accept(Long.MAX_VALUE));
     }
 
     @Test
     void mapEnforcesPositiveSize() {
-        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(10, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE);
+        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(10, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, "test-owner");
         assertNotSame(NONE, limiter);
         assertDoesNotThrow(() -> limiter.accept(10));
         assertThrows(PayloadTooLargeException.class, () -> limiter.accept(11));
@@ -69,12 +69,12 @@ class AggregatedPayloadSizeLimiterTest {
 
     @Test
     void mapZeroIsDisabled() {
-        assertSame(NONE, toAggregatedPayloadSizeLimiter(0, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE));
+        assertSame(NONE, toAggregatedPayloadSizeLimiter(0, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, "test-owner"));
     }
 
     @Test
     void mapWarnOnlyWarnsAtDefault() {
-        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(-1, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE);
+        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(-1, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, "test-owner");
         assertNotSame(NONE, limiter);
         // Over the default it warns (rate-limited) but must not throw.
         assertDoesNotThrow(() -> limiter.accept((long) DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE + 1));
@@ -83,16 +83,16 @@ class AggregatedPayloadSizeLimiterTest {
     @Test
     void mapWarnOnlyAtRaisedDefault() {
         final int raised = DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE * 2;
-        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(-1, raised);
+        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(-1, raised, "test-owner");
         assertNotSame(NONE, limiter);
         assertDoesNotThrow(() -> limiter.accept((long) raised + 1));
     }
 
     @Test
     void mapWarnOnlyNeverCollapsesToDisabledWhenDefaultNonPositive() {
-        assertNotSame(NONE, toAggregatedPayloadSizeLimiter(-1, -1));
-        assertNotSame(NONE, toAggregatedPayloadSizeLimiter(-1, 0));
-        assertDoesNotThrow(() -> toAggregatedPayloadSizeLimiter(-1, -1).accept(Long.MAX_VALUE));
+        assertNotSame(NONE, toAggregatedPayloadSizeLimiter(-1, -1, "test-owner"));
+        assertNotSame(NONE, toAggregatedPayloadSizeLimiter(-1, 0, "test-owner"));
+        assertDoesNotThrow(() -> toAggregatedPayloadSizeLimiter(-1, -1, "test-owner").accept(Long.MAX_VALUE));
     }
 
     @Test
@@ -100,11 +100,11 @@ class AggregatedPayloadSizeLimiterTest {
         // The configured (builder) value drives the mode; the property-resolved default only supplies the warn
         // threshold. So an explicit builder call always wins over the property's mode.
         // builder enforce beats property warn-only:
-        assertThrows(PayloadTooLargeException.class, () -> toAggregatedPayloadSizeLimiter(10, -1).accept(11));
+        assertThrows(PayloadTooLargeException.class, () -> toAggregatedPayloadSizeLimiter(10, -1, "test-owner").accept(11));
         // builder disable beats property warn-only:
-        assertSame(NONE, toAggregatedPayloadSizeLimiter(0, -1));
+        assertSame(NONE, toAggregatedPayloadSizeLimiter(0, -1, "test-owner"));
         // builder warn-only beats property enforce:
-        final LongConsumer warn = toAggregatedPayloadSizeLimiter(-1, 10);
+        final LongConsumer warn = toAggregatedPayloadSizeLimiter(-1, 10, "test-owner");
         assertNotSame(NONE, warn);
         assertDoesNotThrow(() -> warn.accept(Long.MAX_VALUE));
     }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiterTest.java
@@ -61,7 +61,8 @@ class AggregatedPayloadSizeLimiterTest {
 
     @Test
     void mapEnforcesPositiveSize() {
-        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(10, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, "test-owner");
+        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(10, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE,
+                "test-owner");
         assertNotSame(NONE, limiter);
         assertDoesNotThrow(() -> limiter.accept(10));
         assertThrows(PayloadTooLargeException.class, () -> limiter.accept(11));
@@ -74,7 +75,8 @@ class AggregatedPayloadSizeLimiterTest {
 
     @Test
     void mapWarnOnlyWarnsAtDefault() {
-        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(-1, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, "test-owner");
+        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(-1, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE,
+                "test-owner");
         assertNotSame(NONE, limiter);
         // Over the default it warns (rate-limited) but must not throw.
         assertDoesNotThrow(() -> limiter.accept((long) DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE + 1));
@@ -100,7 +102,8 @@ class AggregatedPayloadSizeLimiterTest {
         // The configured (builder) value drives the mode; the property-resolved default only supplies the warn
         // threshold. So an explicit builder call always wins over the property's mode.
         // builder enforce beats property warn-only:
-        assertThrows(PayloadTooLargeException.class, () -> toAggregatedPayloadSizeLimiter(10, -1, "test-owner").accept(11));
+        assertThrows(PayloadTooLargeException.class, () -> toAggregatedPayloadSizeLimiter(10, -1, "test-owner")
+                .accept(11));
         // builder disable beats property warn-only:
         assertSame(NONE, toAggregatedPayloadSizeLimiter(0, -1, "test-owner"));
         // builder warn-only beats property enforce:

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpRequestEncoderTest.java
@@ -462,7 +462,7 @@ class HttpRequestEncoderTest extends HttpEncoderTest<HttpRequestMetaData> {
                                                 serverChannelLatch.countDown();
                                             }), defaultStrategy(), mock(Protocol.class), observer, false, __ -> false),
                             connection -> { }, null, null).toFuture().get());
-            ReadOnlyHttpClientConfig cConfig = new HttpClientConfig().asReadOnly();
+            ReadOnlyHttpClientConfig cConfig = new HttpClientConfig().asReadOnly(null);
             assertNotNull(cConfig.h1Config());
 
             NettyConnection<Object, Object> conn = resources.prepend(

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServerRespondsOnClosingTest.java
@@ -79,7 +79,7 @@ final class ServerRespondsOnClosingTest {
         final HttpServerConfig httpServerConfig = new HttpServerConfig();
         httpServerConfig.tcpConfig().enableWireLogging("servicetalk-tests-wire-logger", TRACE,
                 Boolean.TRUE::booleanValue);
-        ReadOnlyHttpServerConfig config = httpServerConfig.asReadOnly();
+        ReadOnlyHttpServerConfig config = httpServerConfig.asReadOnly(null);
         ConnectionObserver connectionObserver = NoopConnectionObserver.INSTANCE;
         HttpService service = (ctx, request, responseFactory) -> {
             Processor<HttpResponse, HttpResponse> responseProcessor = newSingleProcessor();

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
@@ -99,12 +99,18 @@ final class MessageSizeLimiter {
     // Non-null if this is a warn-only limiter.
     @Nullable
     private final AtomicLong maxObservedSize;
+    // For the shared default serializers this points at their static initialization rather than a client/server,
+    // which is the best provenance available since serializers carry no owner.
+    @Nullable
+    private final Throwable constructionSite;
 
     private MessageSizeLimiter(final int maxMessageSize, final boolean warnOnly) {
         this.maxMessageSize = maxMessageSize;
         // Seed in the past so the first exceeded message warns immediately.
         this.lastWarnNanos = warnOnly ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
         this.maxObservedSize = warnOnly ? new AtomicLong() : null;
+        this.constructionSite = warnOnly ? new Throwable(
+                "Serializer with a warn-only maxMessageSize created here (not an error)") : null;
     }
 
     /**
@@ -148,6 +154,7 @@ final class MessageSizeLimiter {
     private void maybeWarn(final int length) {
         assert lastWarnNanos != null;
         assert maxObservedSize != null;
+        assert constructionSite != null;
         final long maxObserved = maxObservedSize.accumulateAndGet(length, Math::max);
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
@@ -155,7 +162,7 @@ final class MessageSizeLimiter {
             LOGGER.warn("Message-Length {} exceeded the configured maximum of {} bytes, but the limit is configured " +
                     "in warn-only mode so the message is allowed through. Largest message observed so far is {} " +
                     "bytes. Configure an enforcing maxMessageSize to reject oversized messages. This warning is " +
-                    "rate-limited to once per 5 minutes.", length, maxMessageSize, maxObserved);
+                    "rate-limited to once per 5 minutes.", length, maxMessageSize, maxObserved, constructionSite);
         }
     }
 }

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
@@ -93,15 +93,18 @@ final class MessageSizeLimiter {
     }
 
     private final int maxMessageSize;
-    // Non-null iff this is a warn-only limiter. Holds nanoTime() of the last emitted warning so warnings are
-    // rate-limited to one per WARN_INTERVAL_NANOS, shared across all deframers of the owning serializer.
+    // Non-null if this is a warn-only limiter.
     @Nullable
     private final AtomicLong lastWarnNanos;
+    // Non-null if this is a warn-only limiter.
+    @Nullable
+    private final AtomicLong maxObservedSize;
 
     private MessageSizeLimiter(final int maxMessageSize, final boolean warnOnly) {
         this.maxMessageSize = maxMessageSize;
         // Seed in the past so the first exceeded message warns immediately.
         this.lastWarnNanos = warnOnly ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
+        this.maxObservedSize = warnOnly ? new AtomicLong() : null;
     }
 
     /**
@@ -144,13 +147,15 @@ final class MessageSizeLimiter {
 
     private void maybeWarn(final int length) {
         assert lastWarnNanos != null;
+        assert maxObservedSize != null;
+        final long maxObserved = maxObservedSize.accumulateAndGet(length, Math::max);
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
             LOGGER.warn("Message-Length {} exceeded the configured maximum of {} bytes, but the limit is configured " +
-                    "in warn-only mode so the message is allowed through. Configure an enforcing maxMessageSize to " +
-                    "reject oversized messages. This warning is rate-limited to once per 5 minutes.", length,
-                    maxMessageSize);
+                    "in warn-only mode so the message is allowed through. Largest message observed so far is {} " +
+                    "bytes. Configure an enforcing maxMessageSize to reject oversized messages. This warning is " +
+                    "rate-limited to once per 5 minutes.", length, maxMessageSize, maxObserved);
         }
     }
 }


### PR DESCRIPTION
#### Motivation

In warn-only mode the inbound size limiters logged only the size that tripped the
warning — not how large a limit would accommodate the traffic, nor which
client/server (or line of code) it came from.

#### Modifications

- Report the largest exceeding size seen (tracked across the rate-limit window).
- Name the owning client/server: HTTP threads an owner (client target / server
  bind address) through internal config; gRPC reuses the StreamingHttpClient it
  already holds via a new FilterableClientToClient.toString(). No public API added.
- Attach the construction site as a Throwable (captured once per limiter) to locate
  the code that built it — the only provenance available for the shared serializers.

#### Result

Warn-only warnings now report the largest observed size, the owning client/server
where known, and a construction stack trace.
