### PR TITLE
serializer-utils: reject negative maxMessageSize from the serializer constructors

### DIFF
--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializer.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializer.java
@@ -26,6 +26,7 @@ import java.util.function.BiFunction;
 import java.util.function.ToIntFunction;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.lang.Integer.BYTES;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -42,16 +43,19 @@ public final class FixedLengthStreamingSerializer<T> implements StreamingSeriali
 
     /**
      * Create a new instance that limits deserialized messages to the default maximum size
-     * ({@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_VALUE} bytes, overridable via the
-     * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property). Use
+     * ({@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_VALUE} bytes). The default can be changed globally via the
+     * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property (a temporary property that will be
+     * removed in a future release), which also accepts {@code -1} to enable warn-only mode globally (a rate-limited
+     * log instead of rejecting). Use
      * {@link #FixedLengthStreamingSerializer(SerializerDeserializer, ToIntFunction, int)} to configure a different
-     * limit, disable it, or warn instead of rejecting.
+     * limit or disable it.
      * @param serializer The {@link SerializerDeserializer} used to serialize/deserialize individual objects.
      * @param bytesEstimator Provides the length in bytes for each {@link T} being serialized.
      */
     public FixedLengthStreamingSerializer(final SerializerDeserializer<T> serializer,
                                           final ToIntFunction<T> bytesEstimator) {
-        this(serializer, bytesEstimator, MessageSizeLimiter.DEFAULT_MAX_MESSAGE_SIZE);
+        this(serializer, bytesEstimator,
+                MessageSizeLimiter.forMaxMessageSize(MessageSizeLimiter.DEFAULT_MAX_MESSAGE_SIZE));
     }
 
     /**
@@ -61,15 +65,21 @@ public final class FixedLengthStreamingSerializer<T> implements StreamingSeriali
      * @param maxMessageSize The maximum length (in bytes) declared by a frame's length prefix that will be accepted
      * during deserialization. A frame declaring a larger length is rejected with a
      * {@link io.servicetalk.serializer.api.MaxMessageSizeExceededException} before any of its bytes are buffered.
-     * {@code 0} disables the limit; {@code -1} logs a rate-limited warning at the default threshold but lets the
-     * message through (a rollout aid, not steady-state protection); other negative values are rejected.
+     * {@code 0} disables the limit and any positive value enforces it. Must be non-negative.
      */
     public FixedLengthStreamingSerializer(final SerializerDeserializer<T> serializer,
                                           final ToIntFunction<T> bytesEstimator,
                                           final int maxMessageSize) {
+        this(serializer, bytesEstimator,
+                MessageSizeLimiter.forMaxMessageSize(ensureNonNegative(maxMessageSize, "maxMessageSize")));
+    }
+
+    private FixedLengthStreamingSerializer(final SerializerDeserializer<T> serializer,
+                                           final ToIntFunction<T> bytesEstimator,
+                                           final MessageSizeLimiter sizeLimiter) {
         this.serializer = requireNonNull(serializer);
         this.bytesEstimator = requireNonNull(bytesEstimator);
-        this.sizeLimiter = MessageSizeLimiter.forMaxMessageSize(maxMessageSize);
+        this.sizeLimiter = sizeLimiter;
     }
 
     @Override

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializer.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializer.java
@@ -26,6 +26,7 @@ import java.util.function.BiFunction;
 import java.util.function.ToIntFunction;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -52,17 +53,20 @@ public final class VarIntLengthStreamingSerializer<T> implements StreamingSerial
 
     /**
      * Create a new instance that limits deserialized messages to the default maximum size
-     * ({@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_VALUE} bytes, overridable via the
-     * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property). Use
+     * ({@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_VALUE} bytes). The default can be changed globally via the
+     * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property (a temporary property that will be
+     * removed in a future release), which also accepts {@code -1} to enable warn-only mode globally (a rate-limited
+     * log instead of rejecting). Use
      * {@link #VarIntLengthStreamingSerializer(SerializerDeserializer, ToIntFunction, int)} to configure a different
-     * limit, disable it, or warn instead of rejecting.
+     * limit or disable it.
      *
      * @param serializer The {@link SerializerDeserializer} used to serialize/deserialize individual objects.
      * @param bytesEstimator Estimates the length in bytes for each {@link T} being serialized.
      */
     public VarIntLengthStreamingSerializer(final SerializerDeserializer<T> serializer,
                                            final ToIntFunction<T> bytesEstimator) {
-        this(serializer, bytesEstimator, MessageSizeLimiter.DEFAULT_MAX_MESSAGE_SIZE);
+        this(serializer, bytesEstimator,
+                MessageSizeLimiter.forMaxMessageSize(MessageSizeLimiter.DEFAULT_MAX_MESSAGE_SIZE));
     }
 
     /**
@@ -73,15 +77,21 @@ public final class VarIntLengthStreamingSerializer<T> implements StreamingSerial
      * @param maxMessageSize The maximum length (in bytes) declared by a frame's length prefix that will be accepted
      * during deserialization. A frame declaring a larger length is rejected with a
      * {@link io.servicetalk.serializer.api.MaxMessageSizeExceededException} before any of its bytes are buffered.
-     * {@code 0} disables the limit; {@code -1} logs a rate-limited warning at the default threshold but lets the
-     * message through (a rollout aid, not steady-state protection); other negative values are rejected.
+     * {@code 0} disables the limit and any positive value enforces it. Must be non-negative.
      */
     public VarIntLengthStreamingSerializer(final SerializerDeserializer<T> serializer,
                                            final ToIntFunction<T> bytesEstimator,
                                            final int maxMessageSize) {
+        this(serializer, bytesEstimator,
+                MessageSizeLimiter.forMaxMessageSize(ensureNonNegative(maxMessageSize, "maxMessageSize")));
+    }
+
+    private VarIntLengthStreamingSerializer(final SerializerDeserializer<T> serializer,
+                                            final ToIntFunction<T> bytesEstimator,
+                                            final MessageSizeLimiter sizeLimiter) {
         this.serializer = requireNonNull(serializer);
         this.bytesEstimator = requireNonNull(bytesEstimator);
-        this.sizeLimiter = MessageSizeLimiter.forMaxMessageSize(maxMessageSize);
+        this.sizeLimiter = sizeLimiter;
     }
 
     @Override

--- a/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializerTest.java
+++ b/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializerTest.java
@@ -19,6 +19,8 @@ import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.serializer.api.MaxMessageSizeExceededException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
@@ -56,10 +58,11 @@ class FixedLengthStreamingSerializerTest {
                 DEFAULT_ALLOCATOR).toFuture().get(), contains(oversized));
     }
 
-    @Test
-    void invalidMaxMessageSizeRejected() {
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -2})
+    void negativeMaxMessageSizeRejected(int maxMessageSize) {
         assertThrows(IllegalArgumentException.class, () -> new FixedLengthStreamingSerializer<>(
-                stringSerializer(UTF_8), String::length, -2));
+                stringSerializer(UTF_8), String::length, maxMessageSize));
     }
 
     @Test

--- a/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializerTest.java
+++ b/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -105,10 +106,11 @@ class VarIntLengthStreamingSerializerTest {
                 DEFAULT_ALLOCATOR).toFuture().get(), contains(oversized));
     }
 
-    @Test
-    void invalidMaxMessageSizeRejected() {
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -2})
+    void negativeMaxMessageSizeRejected(int maxMessageSize) {
         assertThrows(IllegalArgumentException.class, () -> new VarIntLengthStreamingSerializer<>(
-                stringSerializer(UTF_8), String::length, -2));
+                stringSerializer(UTF_8), String::length, maxMessageSize));
     }
 
     @Test


### PR DESCRIPTION
#### Motivation

The warn-only sentinel (-1) was accepted by both the temporary temporaryDefaultMaxMessageSize system property and the public 3-arg FixedLengthStreamingSerializer / VarIntLengthStreamingSerializer constructors. Warn-only exists only to ease rollout of a global default; a value configured programmatically should be definitive, so accepting -1 (or any other negative) through the constructor was unintended and inconsistent with the gRPC / HTTP builder APIs.

#### Modifications

- Validate the constructor value with NumberUtils.ensureNonNegative. The property still accepts -1 for warn-only, and the -1 default it seeds reaches the limiter through a private constructor, never the validated int constructor.
- Drop warn-only from the 3-arg constructor javadoc; the default constructor documents warn-only as a property-only capability.

#### Result

The constructor rejects negative values, so a programmatically configured limit is always definitive. No behavior change for the system property, and no public API signature change.