### PR TITLE
Improve exception message for decoded header line

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -715,7 +715,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         try {
             headers.add(name, value);
         } catch (IllegalCharacterException cause) {
-            throw invalidHeaderName(name, parsingLine, cause);
+            throw invalidHeaderNameOrValue(name, parsingLine, cause);
         }
         // Consume the header line bytes from the buffer.
         consumeCRLF(buffer, lfIndex);
@@ -725,11 +725,11 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         return new DecoderException(message + (parsingLine - 1));
     }
 
-    private static DecoderException invalidHeaderName(final CharSequence name, final int parsingLine,
-                                                      final IllegalCharacterException cause) {
+    private static DecoderException invalidHeaderNameOrValue(final CharSequence name, final int parsingLine,
+                                                             final IllegalCharacterException cause) {
         final String msg = cause.getMessage();
-        throw new StacklessDecoderException(
-                "Invalid header name in line " + (parsingLine - 1) + ": " + (msg != null ? msg : name), cause);
+        throw new StacklessDecoderException("Invalid header name or value for '" + name + "' in line " +
+                (parsingLine - 1) + (msg != null ? ": " + msg : ""), cause);
     }
 
     private static DecoderException invalidHeaderValue(final CharSequence name, final int parsingLine,


### PR DESCRIPTION
Motivation:

Now that we enabled header values validation in #3528, `HttpObjectDecoder` can throw a misleading exception message saying that the header name is invalid, while it could actually be the value.

Modifications:

Improve exception message.

Result:

The top level message clarifies that either name or value are incorrect, cause can be used to identify details.
