### PR TITLE
Fix int overflow when sizing `FromInputStreamPublisher` buffer

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/FromInputStreamPublisher.java
@@ -202,7 +202,7 @@ final class FromInputStreamPublisher<T> extends SubscribablePublisher<T> {
             final int readChunkSize = mapper.maxBufferSize();
             final byte[] buffer;
             if (readByte >= 0) {
-                buffer = new byte[min(available + 1, readChunkSize)];
+                buffer = new byte[min(addWithOverflowProtection(available, 1), readChunkSize)];
                 buffer[writeIdx++] = (byte) readByte;
             } else {
                 buffer = new byte[min(available, readChunkSize)];

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/FromInputStreamPublisherTest.java
@@ -41,6 +41,7 @@ import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Math.ceil;
 import static java.lang.Math.min;
 import static java.lang.System.arraycopy;
+import static java.util.stream.IntStream.concat;
 import static java.util.stream.IntStream.generate;
 import static java.util.stream.IntStream.of;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -678,5 +679,16 @@ class FromInputStreamPublisherTest {
         toSource(pub).subscribe(sub1);
         sub1.awaitSubscription().request(1);
         sub1.awaitOnComplete();
+    }
+
+    @Test
+    void dontFailWhenSingleReadTriggersAvailabilityExceedingVmArraySizeLimit() throws Throwable {
+        // available() reports nothing before the first byte is read (as many InputStream implementations do), but the
+        // single read() unblocks availability of more data than Integer.MAX_VALUE bytes, which available() saturates to
+        // Integer.MAX_VALUE. Buffer sizing must not overflow when accounting for the already read byte.
+        initChunkedStream(smallBuff, concat(of(0, MAX_VALUE), ofAll(0)),
+                                     concat(of(smallBuff.length), ofAll(0)));
+
+        verifySuccess(new byte[][] {smallBuff});
     }
 }


### PR DESCRIPTION
Motivation

`FromInputStreamPublisher` sized its read buffer with `min(available + 1, readChunkSize)`, which can overflow and result in throwing `NegativeArraySizeException`.

Modifications

- Use `addWithOverflowProtection(available, 1)`.
- Add a test that reproduces the issue.

Result

Such streams no longer fail with `NegativeArraySizeException`.