### PR TITLE
Suppress the display of our lockfiles in Github PR review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Gradle dependency lockfiles are generated. Collapse them in GitHub diffs and
+# exclude them from language statistics.
+gradle.lockfile linguist-generated=true


### PR DESCRIPTION
 #### Motivation

Whenever we update a dependency there are a million lockfiles that pop
up in the review. It's noisy.

 #### Modifications

Collapose those files by default. We should still be able to look at
them if we want.

#### Result
Lockfile changes are no longer rendered by default, but can be loaded with a click if desired.

<img width="1184" height="400" alt="image" src="https://github.com/user-attachments/assets/c740ca3e-4c06-422c-a0b1-23d14378b547" />
