### PR TITLE
http-netty: ProxyTunnel can enforce client auth (mTLS)

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -97,8 +97,8 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -485,7 +485,7 @@ class HttpsProxyTest {
         final List<HttpProtocol> protocols = singletonList(HttpProtocol.HTTP_1);
         initMocks();
         proxyTunnel.sslContext(buildProxyMtlsSslContext());
-        proxyTunnel.needClientAuth();
+        proxyTunnel.needClientAuth(true);
         proxyAddress = proxyTunnel.startProxy();
         startServer(protocols);
         client = BuilderUtils.newClientBuilder(serverContext, CLIENT_CTX)
@@ -507,10 +507,9 @@ class HttpsProxyTest {
         try (InputStream is = DefaultTestCerts.loadClientPem()) {
             expectedClientCert = cf.generateCertificate(is);
         }
-        final Certificate[] peerCertificates = proxyTunnel.lastPeerCertificates();
-        assertThat(peerCertificates, is(notNullValue()));
-        assertThat(peerCertificates.length, is(greaterThan(0)));
-        assertThat(peerCertificates[0], is(equalTo(expectedClientCert)));
+        final List<Certificate> peerCertificates = proxyTunnel.lastPeerCertificates();
+        assertThat(peerCertificates, is(not(empty())));
+        assertThat(peerCertificates.get(0), is(equalTo(expectedClientCert)));
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/HttpsProxyTest.java
@@ -60,6 +60,8 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -70,6 +72,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.TrustManagerFactory;
 
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -95,6 +98,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -190,6 +194,28 @@ class HttpsProxyTest {
         kmf.init(ks, KEYSTORE_PASSWORD);
         final SSLContext ctx = SSLContext.getInstance("TLS");
         ctx.init(kmf.getKeyManagers(), null, null);
+        return ctx;
+    }
+
+    private static SSLContext buildProxyMtlsSslContext() throws Exception {
+        final KeyStore ks = KeyStore.getInstance("PKCS12");
+        try (InputStream is = DefaultTestCerts.loadServerP12()) {
+            ks.load(is, KEYSTORE_PASSWORD);
+        }
+        final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, KEYSTORE_PASSWORD);
+
+        final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, null);
+        final CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        try (InputStream is = DefaultTestCerts.loadClientCAPem()) {
+            trustStore.setCertificateEntry("client-ca", cf.generateCertificate(is));
+        }
+        final TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustStore);
+
+        final SSLContext ctx = SSLContext.getInstance("TLS");
+        ctx.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
         return ctx;
     }
 
@@ -452,6 +478,39 @@ class HttpsProxyTest {
         assertThat(client.request(client.get("/path")).status(), is(OK));
         verify(connectionObserver, atLeastOnce()).onProxySecurityHandshake(any(SslConfig.class));
         verify(proxySecurityHandshakeObserver, atLeastOnce()).handshakeComplete(any());
+    }
+
+    @Test
+    void testProxyMtlsClientPresentsCertificate() throws Exception {
+        final List<HttpProtocol> protocols = singletonList(HttpProtocol.HTTP_1);
+        initMocks();
+        proxyTunnel.sslContext(buildProxyMtlsSslContext());
+        proxyTunnel.needClientAuth();
+        proxyAddress = proxyTunnel.startProxy();
+        startServer(protocols);
+        client = BuilderUtils.newClientBuilder(serverContext, CLIENT_CTX)
+                .proxyConfig(new ProxyConfigBuilder<>(proxyAddress)
+                        .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                                .keyManager(DefaultTestCerts::loadClientPem, DefaultTestCerts::loadClientKey)
+                                .peerHost(serverPemHostname())
+                                .build())
+                        .build())
+                .sslConfig(new ClientSslConfigBuilder(DefaultTestCerts::loadServerCAPem)
+                        .peerHost(serverPemHostname()).build())
+                .protocols(toConfigs(protocols))
+                .buildBlocking();
+
+        assertThat(client.request(client.get("/path")).status(), is(OK));
+
+        final CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        final Certificate expectedClientCert;
+        try (InputStream is = DefaultTestCerts.loadClientPem()) {
+            expectedClientCert = cf.generateCertificate(is);
+        }
+        final Certificate[] peerCertificates = proxyTunnel.lastPeerCertificates();
+        assertThat(peerCertificates, is(notNullValue()));
+        assertThat(peerCertificates.length, is(greaterThan(0)));
+        assertThat(peerCertificates[0], is(equalTo(expectedClientCert)));
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] protocols={0} proxyTls={1}")

--- a/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.security.cert.Certificate;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -51,6 +52,9 @@ import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.servicetalk.http.api.HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
 import static java.net.InetAddress.getLoopbackAddress;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -64,7 +68,7 @@ public final class ProxyTunnel implements AutoCloseable {
     private final ExecutorService executor = newCachedThreadPool(new DefaultThreadFactory("proxy-tunnel"));
     private final AtomicInteger connectCount = new AtomicInteger();
     private final AtomicReference<HttpHeaders> lastConnectHeaders = new AtomicReference<>();
-    private final AtomicReference<Certificate[]> lastPeerCertificates = new AtomicReference<>();
+    private final AtomicReference<List<Certificate>> lastPeerCertificates = new AtomicReference<>(emptyList());
 
     @Nullable
     private ServerSocket serverSocket;
@@ -128,7 +132,8 @@ public final class ProxyTunnel implements AutoCloseable {
                         lastConnectHeaders.set(headers);
                         if (needClientAuth && socket instanceof SSLSocket) {
                             try {
-                                lastPeerCertificates.set(((SSLSocket) socket).getSession().getPeerCertificates());
+                                lastPeerCertificates.set(unmodifiableList(asList(
+                                        ((SSLSocket) socket).getSession().getPeerCertificates())));
                             } catch (SSLPeerUnverifiedException e) {
                                 LOGGER.debug("Client did not present a certificate socket={}", socket, e);
                             }
@@ -218,7 +223,8 @@ public final class ProxyTunnel implements AutoCloseable {
      * performs a TLS handshake before reading the {@code CONNECT} request. Must be called before {@link #startProxy()}.
      * <p>
      * The {@link SSLContext} controls only server-side identity and trust.  Pass {@code null} (default) for a plaintext
-     * proxy listener. To require the client to present a certificate (mTLS), also call {@link #needClientAuth()}.
+     * proxy listener. To require the client to present a certificate (mTLS), also call
+     * {@link #needClientAuth(boolean)}.
      *
      * @param sslContext the {@link SSLContext} that will be used for the proxy listener, or {@code null} for plaintext
      */
@@ -227,14 +233,15 @@ public final class ProxyTunnel implements AutoCloseable {
     }
 
     /**
-     * Configures this proxy to require a client certificate during the TLS handshake on its listener, enabling mTLS.
-     * Only takes effect when TLS is enabled via {@link #sslContext(SSLContext)}. Must be called before
+     * Configures whether this proxy requires a client certificate during the TLS handshake on its listener, enabling
+     * mTLS. Only takes effect when TLS is enabled via {@link #sslContext(SSLContext)}. Must be called before
      * {@link #startProxy()}. The presented certificate chain can be inspected via {@link #lastPeerCertificates()}.
      *
+     * @param needClientAuth whether the client is required to present a certificate
      * @return {@code this}
      */
-    public ProxyTunnel needClientAuth() {
-        this.needClientAuth = true;
+    public ProxyTunnel needClientAuth(final boolean needClientAuth) {
+        this.needClientAuth = needClientAuth;
         return this;
     }
 
@@ -260,16 +267,14 @@ public final class ProxyTunnel implements AutoCloseable {
 
     /**
      * Returns the client certificate chain presented during the most recent TLS handshake on the proxy listener.
-     * Populated only when TLS with client auth is enabled (see {@link #needClientAuth()}). Useful for tests that
-     * need to assert the client presented its expected identity (true proxy mTLS).
+     * Populated only when TLS with client auth is enabled (see {@link #needClientAuth(boolean)}). Useful for tests
+     * that need to assert the client presented its expected identity (true proxy mTLS).
      *
-     * @return the peer certificate chain from the most recent handshake, or {@code null} if no client certificate
+     * @return the peer certificate chain from the most recent handshake, or an empty list if no client certificate
      * was presented (or the proxy is not using client-auth TLS)
      */
-    @Nullable
-    public Certificate[] lastPeerCertificates() {
-        final Certificate[] certificates = lastPeerCertificates.get();
-        return certificates == null ? null : certificates.clone();
+    public List<Certificate> lastPeerCertificates() {
+        return lastPeerCertificates.get();
     }
 
     private static String readLine(final InputStream in) throws IOException {

--- a/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/ProxyTunnel.java
+++ b/servicetalk-http-netty/src/testFixtures/java/io/servicetalk/http/netty/ProxyTunnel.java
@@ -30,11 +30,15 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.security.cert.Certificate;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
 
 import static io.servicetalk.http.api.HttpHeaderNames.CONTENT_LENGTH;
 import static io.servicetalk.http.api.HttpHeaderNames.HOST;
@@ -60,6 +64,7 @@ public final class ProxyTunnel implements AutoCloseable {
     private final ExecutorService executor = newCachedThreadPool(new DefaultThreadFactory("proxy-tunnel"));
     private final AtomicInteger connectCount = new AtomicInteger();
     private final AtomicReference<HttpHeaders> lastConnectHeaders = new AtomicReference<>();
+    private final AtomicReference<Certificate[]> lastPeerCertificates = new AtomicReference<>();
 
     @Nullable
     private ServerSocket serverSocket;
@@ -67,6 +72,7 @@ public final class ProxyTunnel implements AutoCloseable {
     private volatile String authToken;
     @Nullable
     private volatile SSLContext sslContext;
+    private volatile boolean needClientAuth;
     private volatile ProxyRequestHandler handler = this::handleRequest;
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -97,6 +103,8 @@ public final class ProxyTunnel implements AutoCloseable {
             // Terminate TLS on the proxy listener. The accepted Socket is an SSLSocket whose handshake is performed
             // implicitly on first read/write; downstream code is plain InputStream/OutputStream and is unaffected.
             serverSocket = sslCtx.getServerSocketFactory().createServerSocket(0, 50, getLoopbackAddress());
+            // Client auth is a property of the SSLServerSocket, not the SSLContext, so it must be enabled here.
+            ((SSLServerSocket) serverSocket).setNeedClientAuth(needClientAuth);
         }
         executor.submit(() -> {
             while (!executor.isShutdown()) {
@@ -118,6 +126,13 @@ public final class ProxyTunnel implements AutoCloseable {
 
                         final HttpHeaders headers = readHeaders(in);
                         lastConnectHeaders.set(headers);
+                        if (needClientAuth && socket instanceof SSLSocket) {
+                            try {
+                                lastPeerCertificates.set(((SSLSocket) socket).getSession().getPeerCertificates());
+                            } catch (SSLPeerUnverifiedException e) {
+                                LOGGER.debug("Client did not present a certificate socket={}", socket, e);
+                            }
+                        }
                         final CharSequence hostHeader = headers.get(HOST);
                         if (hostHeader == null || !authority.equalsIgnoreCase(hostHeader.toString())) {
                             badRequest(socket, "Host header value must be identical to authority " +
@@ -202,13 +217,25 @@ public final class ProxyTunnel implements AutoCloseable {
      * Configures this proxy to terminate TLS on its listener using the provided {@link SSLContext}. The proxy then
      * performs a TLS handshake before reading the {@code CONNECT} request. Must be called before {@link #startProxy()}.
      * <p>
-     * Pass an {@link SSLContext} configured with {@code clientAuth=REQUIRE} (or equivalent via the underlying
-     * {@code SSLServerSocket}) to test mTLS-style proxies. Pass {@code null} (default) for a plaintext proxy listener.
+     * The {@link SSLContext} controls only server-side identity and trust.  Pass {@code null} (default) for a plaintext
+     * proxy listener. To require the client to present a certificate (mTLS), also call {@link #needClientAuth()}.
      *
      * @param sslContext the {@link SSLContext} that will be used for the proxy listener, or {@code null} for plaintext
      */
     public void sslContext(@Nullable final SSLContext sslContext) {
         this.sslContext = sslContext;
+    }
+
+    /**
+     * Configures this proxy to require a client certificate during the TLS handshake on its listener, enabling mTLS.
+     * Only takes effect when TLS is enabled via {@link #sslContext(SSLContext)}. Must be called before
+     * {@link #startProxy()}. The presented certificate chain can be inspected via {@link #lastPeerCertificates()}.
+     *
+     * @return {@code this}
+     */
+    public ProxyTunnel needClientAuth() {
+        this.needClientAuth = true;
+        return this;
     }
 
     /**
@@ -229,6 +256,20 @@ public final class ProxyTunnel implements AutoCloseable {
     @Nullable
     public HttpHeaders lastConnectHeaders() {
         return lastConnectHeaders.get();
+    }
+
+    /**
+     * Returns the client certificate chain presented during the most recent TLS handshake on the proxy listener.
+     * Populated only when TLS with client auth is enabled (see {@link #needClientAuth()}). Useful for tests that
+     * need to assert the client presented its expected identity (true proxy mTLS).
+     *
+     * @return the peer certificate chain from the most recent handshake, or {@code null} if no client certificate
+     * was presented (or the proxy is not using client-auth TLS)
+     */
+    @Nullable
+    public Certificate[] lastPeerCertificates() {
+        final Certificate[] certificates = lastPeerCertificates.get();
+        return certificates == null ? null : certificates.clone();
     }
 
     private static String readLine(final InputStream in) throws IOException {


### PR DESCRIPTION
Motivation:

The ProxyTunnel test fixture could terminate TLS on its listener but had no way to require a client certificate, so tests couldn't assert true proxy mTLS. Client auth is a property of the SSLServerSocket (setNeedClientAuth), not the SSLContext, though the fixture's javadoc claimed otherwise.

Modifications:

- Add needClientAuth(), flipping setNeedClientAuth(true) on the TLS server socket.
- Capture the client cert chain and expose it via lastPeerCertificates().
- Fix the misleading sslContext(...) javadoc.
- Add HttpsProxyTest.testProxyMtlsClientPresentsCertificate.

Result:

Tests can assert proxy mTLS without wrapping the SSLContext. Test fixtures only.
