### PR TITLE
dns-discovery-netty: fix SRV resurrection during A-record backoff

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DefaultDnsClient.java
@@ -18,6 +18,7 @@ package io.servicetalk.dns.discovery.netty;
 import io.servicetalk.client.api.DefaultServiceDiscovererEvent;
 import io.servicetalk.client.api.ServiceDiscovererEvent;
 import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.CompletableSource;
 import io.servicetalk.concurrent.PublisherSource.Subscriber;
 import io.servicetalk.concurrent.PublisherSource.Subscription;
 import io.servicetalk.concurrent.api.Completable;
@@ -87,11 +88,13 @@ import static io.servicetalk.concurrent.api.Publisher.empty;
 import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.RepeatStrategies.repeatWithConstantBackoffDeltaJitter;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.deliverErrorFromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.isRequestNValid;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionForInvalidRequestN;
+import static io.servicetalk.concurrent.internal.SubscriberUtils.newExceptionNormalReturn;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
 import static io.servicetalk.concurrent.internal.ThrowableUtils.unknownStackTrace;
 import static io.servicetalk.dns.discovery.netty.DnsClients.mapEventList;
@@ -281,7 +284,7 @@ final class DefaultDnsClient implements DnsClient {
         requireNonNull(address);
         return defer(() -> {
             final DnsDiscoveryObserver discoveryObserver = newDiscoveryObserver(address);
-            ARecordPublisher pub = new ARecordPublisher(address, discoveryObserver);
+            ARecordPublisher pub = new ARecordPublisher(address, discoveryObserver, false);
             Publisher<? extends Collection<ServiceDiscovererEvent<InetAddress>>> events =
                     recoverWithInactiveEvents(pub, false, nxInvalidation);
             return observeDiscovery(discoveryObserver, events);
@@ -306,39 +309,34 @@ final class DefaultDnsClient implements DnsClient {
                 .flatMapMerge(srvEvent -> {
                 assertInEventloop();
                 if (AVAILABLE.equals(srvEvent.status())) {
-                    return defer(() -> {
-                        final ARecordPublisher aPublisher =
-                                new ARecordPublisher(srvEvent.address().hostName(), discoveryObserver);
-                        final ARecordPublisher prevAPublisher = aRecordMap.putIfAbsent(srvEvent.address().hostName(),
-                                aPublisher);
-                        if (prevAPublisher != null) {
-                            return newDuplicateSrv(serviceName, srvEvent.address().hostName());
-                        }
-
-                        // NXDOMAIN = invalidation for A queries part of SRV lookups for backwards compatibility.
-                        // This is a behavior difference between plain A lookups and SRV rooted A lookups.
-                        Publisher<? extends Collection<ServiceDiscovererEvent<InetAddress>>> returnPub =
-                                recoverWithInactiveEvents(aPublisher, false, true);
-                        return srvFilterDuplicateEvents ?
-                                srvFilterDups(returnPub, availableAddresses, srvEvent.address().port()) :
-                                returnPub.map(ev -> mapEventList(ev, inetAddress ->
-                                        new InetSocketAddress(inetAddress, srvEvent.address().port())));
-                    }).retryWhen(false, (i, cause) -> {
-                        assertInEventloop();
-                        // If this error is because the SRV entry was detected as inactive, then propagate the error and
-                        // don't retry. Otherwise this is a resolution exception (e.g. UnknownHostException), and retry.
-                        return cause.getClass().equals(SrvAddressRemovedException.class) ||
-                                aRecordMap.remove(srvEvent.address().hostName()) == null ?
-                                Completable.failed(cause) : srvHostNameRepeater.apply(i);
-                    }).onErrorComplete(); // retryWhen will propagate onError, but we don't want this.
+                    final String srvHostName = srvEvent.address().hostName();
+                    // Registered up front and serving this target for its whole lifetime, so a concurrent SRV
+                    // removal always finds it (even mid-backoff) and the target cannot be resurrected.
+                    final ARecordPublisher aPublisher = new ARecordPublisher(srvHostName, discoveryObserver, true);
+                    if (aRecordMap.putIfAbsent(srvHostName, aPublisher) != null) {
+                        return newDuplicateSrv(serviceName, srvHostName);
+                    }
+                    // NXDOMAIN = invalidation for A queries part of SRV lookups for backwards compatibility.
+                    // This is a behavior difference between plain A lookups and SRV rooted A lookups.
+                    final Publisher<? extends Collection<ServiceDiscovererEvent<InetAddress>>> returnPub =
+                            recoverWithInactiveEvents(aPublisher, false, true);
+                    // Drop our own entry (key+value) on termination so a re-added host's publisher isn't clobbered.
+                    return (srvFilterDuplicateEvents ?
+                            srvFilterDups(returnPub, availableAddresses, srvEvent.address().port()) :
+                            returnPub.map(ev -> mapEventList(ev, inetAddress ->
+                                    new InetSocketAddress(inetAddress, srvEvent.address().port()))))
+                            .beforeFinally(() -> aRecordMap.remove(srvHostName, aPublisher))
+                            .onErrorComplete(); // an SRV removal cancels the A publisher; don't fail the SRV stream.
                 } else if (srvEvent instanceof SrvInactiveEvent) {
                     // Unwrap the list so we can use it in SrvInactiveCombinerOperator below.
                     return from(((SrvInactiveEvent<HostAndPort, InetSocketAddress>) srvEvent).aggregatedEvents);
                 } else {
                     final String srvHostName = srvEvent.address().hostName();
-                    final ARecordPublisher aPublisher = aRecordMap.remove(srvHostName);
                     ttlCache.clearMinTtl(srvHostName);
+                    final ARecordPublisher aPublisher = aRecordMap.remove(srvHostName);
                     if (aPublisher != null) {
+                        // Cancel the A publisher (resolving, mid-backoff, or not yet subscribed) so
+                        // recoverWithInactiveEvents retracts its last-known addresses and it terminates.
                         aPublisher.cancelAndFail0(
                                 SrvAddressRemovedException.newInstance(DefaultDnsClient.class, "dnsSrvQuery"));
                     }
@@ -388,7 +386,7 @@ final class DefaultDnsClient implements DnsClient {
 
     private final class SrvRecordPublisher extends AbstractDnsPublisher<HostAndPort> {
         private SrvRecordPublisher(final String serviceName, final DnsDiscoveryObserver discoveryObserver) {
-            super(serviceName, discoveryObserver);
+            super(serviceName, discoveryObserver, false);
         }
 
         @Override
@@ -474,8 +472,9 @@ final class DefaultDnsClient implements DnsClient {
     }
 
     private class ARecordPublisher extends AbstractDnsPublisher<InetAddress> {
-        ARecordPublisher(final String inetHost, final DnsDiscoveryObserver discoveryObserver) {
-            super(inetHost, discoveryObserver);
+        ARecordPublisher(final String inetHost, final DnsDiscoveryObserver discoveryObserver,
+                         final boolean retryResolveFailures) {
+            super(inetHost, discoveryObserver, retryResolveFailures);
         }
 
         @Override
@@ -597,12 +596,19 @@ final class DefaultDnsClient implements DnsClient {
          * A {@link DnsDiscoveryObserver} for this publisher that provides visibility into individual DNS resolutions.
          */
         protected final DnsDiscoveryObserver discoveryObserver;
+        /**
+         * When {@code true} (SRV-rooted A lookups), a resolution failure is retried with backoff on the same
+         * subscription, preserving the last-known addresses across attempts, rather than terminating.
+         */
+        private final boolean retryResolveFailures;
         @Nullable
         AbstractDnsSubscription subscription;
 
-        AbstractDnsPublisher(final String name, final DnsDiscoveryObserver discoveryObserver) {
+        AbstractDnsPublisher(final String name, final DnsDiscoveryObserver discoveryObserver,
+                             final boolean retryResolveFailures) {
             this.name = name;
             this.discoveryObserver = discoveryObserver;
+            this.retryResolveFailures = retryResolveFailures;
             LOGGER.debug("{} initializing a new publisher for {}.", DefaultDnsClient.this, this);
         }
 
@@ -660,6 +666,7 @@ final class DefaultDnsClient implements DnsClient {
             @Nullable
             private Cancellable cancellableForQuery;
             private long ttlNanos;
+            private int resolveFailures;
 
             AbstractDnsSubscription(final Subscriber<? super List<ServiceDiscovererEvent<T>>> subscriber) {
                 this.subscriber = subscriber;
@@ -801,6 +808,28 @@ final class DefaultDnsClient implements DnsClient {
                 cancellableForQuery = nettyIoExecutor.schedule(this::executeScheduledQuery0, delay, NANOSECONDS);
             }
 
+            private void scheduleResolveRetry0() {
+                assertInEventloop();
+                // Track the backoff timer as cancellableForQuery so a cancel/removal during backoff aborts the retry.
+                toSource(srvHostNameRepeater.apply(++resolveFailures)).subscribe(new CompletableSource.Subscriber() {
+                    @Override
+                    public void onSubscribe(final Cancellable cancellable) {
+                        assertInEventloop();
+                        cancellableForQuery = cancellable;
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        executeScheduledQuery0();
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                        cancelAndTerminate0(t);
+                    }
+                });
+            }
+
             private void handleResolveDone0(final Future<DnsAnswer<T>> addressFuture,
                                             final DnsResolutionObserver resolutionObserver) {
                 assertInEventloop();
@@ -811,8 +840,33 @@ final class DefaultDnsClient implements DnsClient {
                 final Throwable cause = addressFuture.cause();
                 if (cause != null) {
                     resolutionObserver.resolutionFailed(cause);
-                    cancelAndTerminate0(cause);
+                    if (!retryResolveFailures || closed) {
+                        cancelAndTerminate0(cause);
+                        return;
+                    }
+                    // Retry with backoff on this subscription (not terminate) so the last-known addresses survive
+                    // across attempts: no flapping on transient failures, still retractable on removal. NXDOMAIN
+                    // invalidates them first (SRV-rooted A lookups always treat NXDOMAIN as invalidation); other
+                    // failures keep them.
+                    final List<ServiceDiscovererEvent<T>> inactive =
+                            shouldRevokeState(cause, true) ? generateInactiveEvent() : emptyList();
+                    if (!inactive.isEmpty()) {
+                        try {
+                            subscriber.onNext(inactive);
+                        } catch (final Throwable error) {
+                            // Rule 2.13: a throwing subscriber is a revoking terminal (see shouldRevokeState).
+                            handleTerminalError0(newExceptionNormalReturn(error));
+                            return;
+                        }
+                        if (--pendingRequests == 0) {
+                            // No demand for a retry now; request0 resumes it when demand arrives.
+                            cancellableForQuery = null;
+                            return;
+                        }
+                    }
+                    scheduleResolveRetry0();
                 } else {
+                    resolveFailures = 0;
                     // DNS lookup can return duplicate InetAddress
                     final DnsAnswer<T> dnsAnswer = addressFuture.getNow();
                     final List<T> addresses = dnsAnswer.answer();
@@ -852,7 +906,9 @@ final class DefaultDnsClient implements DnsClient {
 
                             subscriber.onNext(events);
                         } catch (final Throwable error) {
-                            handleTerminalError0(error);
+                            // Rule 2.13: on the SRV-rooted A path a throwing subscriber is a revoking terminal (see
+                            // shouldRevokeState) so its addresses are retracted.
+                            handleTerminalError0(retryResolveFailures ? newExceptionNormalReturn(error) : error);
                         }
                     } else {
                         LOGGER.trace("{} resolution is complete but no changes detected for {} based on result " +

--- a/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
+++ b/servicetalk-dns-discovery-netty/src/test/java/io/servicetalk/dns/discovery/netty/DefaultDnsClientTest.java
@@ -93,6 +93,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -493,12 +494,69 @@ class DefaultDnsClientTest {
         // Expect no changes (SERVFAIL should be retried indefinitely)
         assertThat(subscriber.pollOnNext(50, MILLISECONDS), is(nullValue()));
 
-        // Restore functionality for A queries
+        // Restore A queries. The address was never revoked, so resolution resumes with no change event (like a
+        // TTL re-query returning an identical result); prove it resumed by adding a new address.
         recordStore.removeFail(aFail);
         advanceTime();
+        assertThat(subscriber.pollOnNext(50, MILLISECONDS), is(nullValue()));
 
+        final String ip2 = nextIp();
+        recordStore.addIPv4Address(targetDomain1, DEFAULT_TTL, ip2);
+        advanceTime();
         List<ServiceDiscovererEvent<InetSocketAddress>> resumeSignals = subscriber.takeOnNext(1);
-        assertHasEvent(resumeSignals, ip1, targetPort, AVAILABLE);
+        assertHasEvent(resumeSignals, ip2, targetPort, AVAILABLE);
+    }
+
+    @Test
+    void srvRemovalDuringBackoffDoesNotResurrect() throws Exception {
+        // Backoff delay larger than one advanceTime() step, so a failed A resolution stays parked in backoff
+        // while the SRV record is removed.
+        setup(builder -> builder.srvHostNameRepeatDelay(Duration.ofSeconds(10), ofNanos(1)));
+        final String domain = "sd.servicetalk.io";
+        final String targetDomain1 = "target1.mysvc.servicetalk.io";
+        final String targetDomain2 = "target2.mysvc.servicetalk.io";
+        final int targetPort = 9876;
+        final String ip1 = nextIp();
+        final String ip2 = nextIp();
+        // targetDomain2 stays AVAILABLE throughout so the SRV stream does not fail when targetDomain1 leaves.
+        recordStore.addSrv(domain, targetDomain1, targetPort, DEFAULT_TTL);
+        recordStore.addSrv(domain, targetDomain2, targetPort, DEFAULT_TTL);
+        recordStore.addIPv4Address(targetDomain1, DEFAULT_TTL, ip1);
+        recordStore.addIPv4Address(targetDomain2, DEFAULT_TTL, ip2);
+
+        TestPublisherSubscriber<ServiceDiscovererEvent<InetSocketAddress>> subscriber = dnsSrvQuery(domain);
+        Subscription subscription = subscriber.awaitSubscription();
+        subscription.request(Long.MAX_VALUE);
+        List<ServiceDiscovererEvent<InetSocketAddress>> signals = subscriber.takeOnNext(2);
+        assertHasEvent(signals, ip1, targetPort, AVAILABLE);
+        assertHasEvent(signals, ip2, targetPort, AVAILABLE);
+
+        // Fail subsequent targetDomain1 A queries and advance so its resolution enters the (10s) backoff retry.
+        final TestRecordStore.ServFail aFail = new TestRecordStore.ServFail(targetDomain1, RecordType.A);
+        recordStore.addFail(aFail);
+        advanceTime();
+        advanceTime();
+
+        // Remove the targetDomain1 SRV record while its A resolution is parked in backoff, then restore A queries.
+        recordStore.removeSrv(domain, targetDomain1, targetPort, DEFAULT_TTL);
+        recordStore.removeFail(aFail);
+
+        // The removed target's last-known address must be retracted (though resolution was mid-backoff) and must
+        // never reappear as AVAILABLE.
+        final InetSocketAddress ip1Address = new InetSocketAddress(getByName(ip1), targetPort);
+        boolean retracted = false;
+        for (int i = 0; i < 15; i++) {
+            advanceTime();
+            Supplier<ServiceDiscovererEvent<InetSocketAddress>> event;
+            while ((event = subscriber.pollOnNext(20, MILLISECONDS)) != null) {
+                final ServiceDiscovererEvent<InetSocketAddress> e = event.get();
+                if (ip1Address.equals(e.address())) {
+                    assertThat("removed SRV target was resurrected", e.status(), is(not(AVAILABLE)));
+                    retracted = true;
+                }
+            }
+        }
+        assertThat("expected the removed SRV target's address to be retracted", retracted, is(true));
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] srvFilterDuplicateEvents={0}")


### PR DESCRIPTION
Motivation:

An SRV-rooted A-record resolution that fails with a transient error enters a backoff retry. That retry lived outside the publisher: the target was removed from aRecordMap for the duration of the backoff and a fresh ARecordPublisher (with empty state) was created per attempt. Discarding the per-attempt state caused two problems:

- A concurrent SRV removal during the backoff window found no publisher to cancel, so the removal was lost and the pending retry resurrected a target DNS had reported as gone.
- The last-known addresses could not be retracted when the target was removed mid-backoff, so the load balancer kept stale addresses until the whole SRV subscription was torn down.

Modifications:

- Fold the retry into AbstractDnsSubscription: on a resolution failure a backoff re-query is scheduled on the same subscription, preserving the last-known addresses across attempts. Gated by a retryResolveFailures flag, enabled only for SRV-rooted A lookups. NXDOMAIN still invalidates the addresses first; other failures keep them.
- A single ARecordPublisher now serves a target for its whole lifetime and is registered in aRecordMap up front, so a concurrent SRV removal always finds it (even before the first subscribe or mid-backoff), cancels it, and retracts its last-known addresses.
- Remove the external retryWhen wrapper, preserving its Reactive Streams Rule 2.13 wrapping of subscriber exceptions so those still revoke state.

Result:

A removed SRV target is no longer resurrected by an in-flight backoff retry, and its last-known addresses are retracted immediately on removal. A transient failure that recovers to the same addresses no longer emits a redundant AVAILABLE, matching a TTL re-query that returns an unchanged result.