### PR TITLE
http: revise default aggregation limits and allow warn-only mode

### DIFF
--- a/servicetalk-grpc-api/build.gradle
+++ b/servicetalk-grpc-api/build.gradle
@@ -48,4 +48,5 @@ dependencies {
   testImplementation project(":servicetalk-test-resources")
   testImplementation "org.hamcrest:hamcrest"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
 }

--- a/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
@@ -74,6 +74,11 @@ rate-limited warning is logged (once every five minutes per client/server) inste
 the limit. By default the client warns at 64 MiB and the server warns at 16 MiB; enforcing is planned to become the
 default for servers in a future release.
 
+The built-in defaults can be overridden globally with the
+`io.servicetalk.grpc.netty.defaultClientMaxInboundMessageSize` and
+`io.servicetalk.grpc.netty.defaultServerMaxInboundMessageSize` system properties (same sign convention); a per-builder
+call takes precedence.
+
 NOTE: `maxInboundMessageSize` does not bound the memory used *while* decompressing a compressed message. That is
 governed independently by the codec's own decompressed-bytes cap (`ZipCompressionBuilder#maxDecompressedBytes(long)`,
 *64 MiB* by default), which fails fast before the decoded message is checked against `maxInboundMessageSize`.

--- a/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
@@ -62,18 +62,17 @@ GrpcServers.forPort(8080)
 [#maxInboundMessageSize]
 == Inbound message size limit
 
-To bound memory use, ServiceTalk caps a single decoded inbound gRPC message at *4 MiB* by default (matching
-link:https://github.com/grpc/grpc-java[grpc-java]). A message whose declared length exceeds the limit is rejected with
-`RESOURCE_EXHAUSTED` *before* its payload is buffered. The limit applies on the receiving side of every paradigm: a
-server bounds request messages, a client bounds response messages. For a compressed message it bounds the on-wire
-(still-compressed) length before buffering, and the decoded length after decompression.
+To bound memory use, ServiceTalk limits the size of a single decoded inbound gRPC message. The limit applies on the
+receiving side of every paradigm: a server bounds request messages, a client bounds response messages. For a compressed
+message it bounds the on-wire (still-compressed) length before buffering, and the decoded length after decompression.
 
-Configure it with `GrpcServerBuilder#maxInboundMessageSize(int)` / `GrpcClientBuilder#maxInboundMessageSize(int)`:
-`0` disables the limit and a positive value enforces it (negative values are rejected). The default can be changed
-globally with the temporary `io.servicetalk.grpc.netty.temporaryDefaultMaxInboundMessageSize` system property (to be
-removed in a future release); an explicit builder call takes precedence. Setting that property to `-1` enables a
-*warn-only* rollout mode globally: an oversized message is delivered but a warning is logged (rate-limited to once
-every five minutes per client/server) instead of being rejected.
+Configure it with `GrpcServerBuilder#maxInboundMessageSize(int)` / `GrpcClientBuilder#maxInboundMessageSize(int)`,
+where the sign selects the mode and the magnitude selects the threshold: a *positive* value enforces the limit,
+rejecting a message whose declared length exceeds it with `RESOURCE_EXHAUSTED` *before* its payload is buffered; a
+*negative* value enables *warn-only* mode at `abs(value)` bytes, where an oversized message is delivered but a
+rate-limited warning is logged (once every five minutes per client/server) instead of being rejected; and `0` disables
+the limit. By default the client warns at 64 MiB and the server warns at 16 MiB; enforcing is planned to become the
+default for servers in a future release.
 
 NOTE: `maxInboundMessageSize` does not bound the memory used *while* decompressing a compressed message. That is
 governed independently by the codec's own decompressed-bytes cap (`ZipCompressionBuilder#maxDecompressedBytes(long)`,

--- a/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
+++ b/servicetalk-grpc-api/docs/modules/ROOT/pages/index.adoc
@@ -70,7 +70,7 @@ Configure it with `GrpcServerBuilder#maxInboundMessageSize(int)` / `GrpcClientBu
 where the sign selects the mode and the magnitude selects the threshold: a *positive* value enforces the limit,
 rejecting a message whose declared length exceeds it with `RESOURCE_EXHAUSTED` *before* its payload is buffered; a
 *negative* value enables *warn-only* mode at `abs(value)` bytes, where an oversized message is delivered but a
-rate-limited warning is logged (once every five minutes per client/server) instead of being rejected; and `0` disables
+rate-limited warning is logged per client/server instead of being rejected; and `0` disables
 the limit. By default the client warns at 64 MiB and the server warns at 16 MiB; enforcing is planned to become the
 default for servers in a future release.
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/DefaultGrpcClientCallFactory.java
@@ -70,7 +70,7 @@ final class DefaultGrpcClientCallFactory implements GrpcClientCallFactory {
         executionContext = new DefaultGrpcExecutionContext(streamingHttpClient.executionContext());
         this.defaultTimeout = callConfig.defaultTimeout();
         this.sizeLimiter = GrpcMessageSizeLimiter.forMaxInboundMessageSize(callConfig.maxInboundMessageSize(),
-                streamingHttpClient);
+                GrpcMessageSizeLimiter.Role.CLIENT, streamingHttpClient);
     }
 
     @Deprecated

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -95,18 +95,16 @@ public interface GrpcClientBuilder<U, R> {
     }
 
     /**
-     * Set the maximum size, in bytes, of a decoded inbound (response) gRPC message that this client will accept,
-     * bounding the memory a peer can cause this client to allocate. The sign selects the mode and the magnitude the
-     * threshold: a <em>positive</em> value enforces the limit, rejecting messages whose declared length exceeds it with
-     * {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before their payload is buffered; a <em>negative</em> value enables
-     * warn-only mode at {@code abs(value)} bytes (oversized messages are still delivered, but a rate-limited warning is
-     * logged); and {@code 0} disables the limit. The default is warn-only at 64 MiB.
+     * Set the maximum size, in bytes, of a decoded inbound (response) gRPC message this client accepts, bounding the
+     * memory a peer can make it allocate. The sign selects the mode, the magnitude the threshold: <em>positive</em>
+     * enforces, rejecting a message whose declared length exceeds it with {@link GrpcStatusCode#RESOURCE_EXHAUSTED}
+     * before its payload is buffered; <em>negative</em> warns at {@code abs(value)} bytes (oversized messages are still
+     * delivered, with a rate-limited warning); {@code 0} disables it. Defaults to warn-only at 64 MiB.
      * <p>
-     * For a compressed message this bounds the on-wire length and the decoded length. The memory used while
-     * decompressing is bounded separately by the codec's own decompressed-bytes cap, not by this limit.
+     * For a compressed message this bounds both the on-wire and decoded lengths; decompression memory itself is bounded
+     * separately by the codec's decompressed-bytes cap.
      *
-     * @param maxInboundMessageSize the maximum inbound message size in bytes: positive enforces at that size, negative
-     * warns at its magnitude, {@code 0} disables the limit
+     * @param maxInboundMessageSize bytes: positive enforces, negative warns at its magnitude, {@code 0} disables
      * @return {@code this}.
      */
     default GrpcClientBuilder<U, R> maxInboundMessageSize(int maxInboundMessageSize) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientBuilder.java
@@ -95,19 +95,18 @@ public interface GrpcClientBuilder<U, R> {
     }
 
     /**
-     * Set the maximum size, in bytes, of a decoded inbound (response) gRPC message that this client will accept.
-     * Messages whose declared length exceeds this limit are rejected with
-     * {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before their payload is buffered, bounding the memory a peer can
-     * cause this client to allocate. The default is 4 MiB (matching grpc-java) and can be changed globally via the
-     * {@code io.servicetalk.grpc.netty.temporaryDefaultMaxInboundMessageSize} system property (a temporary property
-     * that will be removed in a future release), which also accepts {@code -1} to enable warn-only mode globally (a
-     * rate-limited log instead of rejecting).
+     * Set the maximum size, in bytes, of a decoded inbound (response) gRPC message that this client will accept,
+     * bounding the memory a peer can cause this client to allocate. The sign selects the mode and the magnitude the
+     * threshold: a <em>positive</em> value enforces the limit, rejecting messages whose declared length exceeds it with
+     * {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before their payload is buffered; a <em>negative</em> value enables
+     * warn-only mode at {@code abs(value)} bytes (oversized messages are still delivered, but a rate-limited warning is
+     * logged); and {@code 0} disables the limit. The default is warn-only at 64 MiB.
      * <p>
      * For a compressed message this bounds the on-wire length and the decoded length. The memory used while
      * decompressing is bounded separately by the codec's own decompressed-bytes cap, not by this limit.
      *
-     * @param maxInboundMessageSize the maximum inbound message size in bytes: {@code 0} disables the limit and any
-     * positive value enforces it. Must be non-negative.
+     * @param maxInboundMessageSize the maximum inbound message size in bytes: positive enforces at that size, negative
+     * warns at its magnitude, {@code 0} disables the limit
      * @return {@code this}.
      */
     default GrpcClientBuilder<U, R> maxInboundMessageSize(int maxInboundMessageSize) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientCallConfig.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcClientCallConfig.java
@@ -80,6 +80,13 @@ public final class GrpcClientCallConfig extends GrpcConfig {
         private Duration defaultTimeout;
 
         /**
+         * Creates a new builder seeded with the client's built-in default inbound message-size limit.
+         */
+        public Builder() {
+            super(GrpcMessageSizeLimiter.DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE);
+        }
+
+        /**
          * Set the default timeout applied to calls that carry no deadline of their own; a timeout specified on a
          * request supersedes this default.
          *

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcConfig.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcConfig.java
@@ -15,8 +15,6 @@
  */
 package io.servicetalk.grpc.api;
 
-import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
-
 /**
  * Base <a href="https://www.grpc.io">gRPC</a> configuration shared by the client
  * ({@link GrpcClientCallConfig}) and server ({@link GrpcServiceConfig}) binding entry points.
@@ -31,7 +29,7 @@ public abstract class GrpcConfig {
 
     /**
      * Returns the maximum inbound message size in bytes. See {@link Builder#maxInboundMessageSize(int)} for the
-     * semantics of the special value {@code 0}.
+     * semantics of the sign and the special value {@code 0}.
      *
      * @return the maximum inbound message size in bytes.
      */
@@ -46,27 +44,29 @@ public abstract class GrpcConfig {
      */
     public abstract static class Builder<B extends Builder<B>> {
 
-        private int maxInboundMessageSize = GrpcMessageSizeLimiter.DEFAULT_MAX_INBOUND_MESSAGE_SIZE;
+        private int maxInboundMessageSize;
 
-        Builder() {
-            // package private constructor to prevent extension.
+        Builder(final int defaultMaxInboundMessageSize) {
+            // package private constructor to prevent extension. The subtype supplies its role's built-in default.
+            this.maxInboundMessageSize = defaultMaxInboundMessageSize;
         }
 
         /**
-         * Set the maximum size, in bytes, of a decoded inbound gRPC message. A message whose declared length exceeds
-         * the limit is rejected with {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before its payload is buffered; for a
-         * compressed message the limit is also applied to the decoded size. Memory used while decompressing is bounded
-         * separately by the codec's own decompressed-bytes cap, not by this limit. Defaults to 4 MiB (matching
-         * grpc-java), or to the value of the {@code io.servicetalk.grpc.netty.temporaryDefaultMaxInboundMessageSize}
-         * system property when it is set (which also accepts {@code -1} for warn-only mode).
+         * Set the maximum size, in bytes, of a decoded inbound gRPC message. The sign selects the mode and the
+         * magnitude the threshold: a <em>positive</em> value enforces the limit &mdash; a message whose declared length
+         * exceeds it is rejected with {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before its payload is buffered, and for
+         * a compressed message the limit is also applied to the decoded size &mdash; a <em>negative</em> value enables
+         * warn-only mode at {@code abs(value)} bytes (oversized messages are still delivered, but a rate-limited
+         * warning is logged), and {@code 0} disables the limit. Memory used while decompressing is bounded separately
+         * by the codec's own decompressed-bytes cap, not by this limit. By default the client warns at 64 MiB and the
+         * server warns at 16 MiB; enforcing is planned to become the default for servers in a future release.
          *
-         * @param maxInboundMessageSize the maximum inbound message size in bytes: {@code 0} disables the limit and any
-         * positive value enforces it. Must be non-negative.
+         * @param maxInboundMessageSize the maximum inbound message size in bytes: positive enforces at that size,
+         * negative warns at its magnitude, {@code 0} disables the limit
          * @return {@code this}.
-         * @throws IllegalArgumentException if {@code maxInboundMessageSize < 0}
          */
         public final B maxInboundMessageSize(final int maxInboundMessageSize) {
-            this.maxInboundMessageSize = ensureNonNegative(maxInboundMessageSize, "maxInboundMessageSize");
+            this.maxInboundMessageSize = maxInboundMessageSize;
             return thisBuilder();
         }
 

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcConfig.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcConfig.java
@@ -52,17 +52,15 @@ public abstract class GrpcConfig {
         }
 
         /**
-         * Set the maximum size, in bytes, of a decoded inbound gRPC message. The sign selects the mode and the
-         * magnitude the threshold: a <em>positive</em> value enforces the limit &mdash; a message whose declared length
-         * exceeds it is rejected with {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before its payload is buffered, and for
-         * a compressed message the limit is also applied to the decoded size &mdash; a <em>negative</em> value enables
-         * warn-only mode at {@code abs(value)} bytes (oversized messages are still delivered, but a rate-limited
-         * warning is logged), and {@code 0} disables the limit. Memory used while decompressing is bounded separately
-         * by the codec's own decompressed-bytes cap, not by this limit. By default the client warns at 64 MiB and the
-         * server warns at 16 MiB; enforcing is planned to become the default for servers in a future release.
+         * Set the maximum size, in bytes, of a decoded inbound gRPC message. The sign selects the mode, the magnitude
+         * the threshold: <em>positive</em> enforces &mdash; a message whose declared length exceeds it is rejected with
+         * {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before buffering (also applied to a compressed message's decoded
+         * size); <em>negative</em> warns at {@code abs(value)} bytes (oversized messages still delivered, with a
+         * rate-limited warning); {@code 0} disables it. Decompression memory is bounded separately by the codec's
+         * decompressed-bytes cap. By default the client warns at 64 MiB and the server at 16 MiB; server enforcing is
+         * planned to become the default in a future release.
          *
-         * @param maxInboundMessageSize the maximum inbound message size in bytes: positive enforces at that size,
-         * negative warns at its magnitude, {@code 0} disables the limit
+         * @param maxInboundMessageSize bytes: positive enforces, negative warns at its magnitude, {@code 0} disables
          * @return {@code this}.
          */
         public final B maxInboundMessageSize(final int maxInboundMessageSize) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
@@ -204,19 +204,18 @@ final class GrpcMessageSizeLimiter {
         try {
             final Integer value = Integer.valueOf(raw.trim());
             if (legacy) {
-                LOGGER.warn("-D{}={} This property is deprecated in favor of -D{} and -D{} and will be removed in a " +
-                                "future release. Configure this value per client/server builder via " +
-                                "maxInboundMessageSize(int) instead.", name, value,
+                LOGGER.warn("-D{}={} is deprecated in favor of -D{} and -D{} and will be removed in a future " +
+                        "release; set maxInboundMessageSize(int) per client/server instead.", name, value,
                         DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY,
                         DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE_PROPERTY);
             } else {
-                LOGGER.warn("-D{}={} This property is temporary and will be removed in a future release. Configure " +
-                        "this value per client/server builder via maxInboundMessageSize(int) instead.", name, value);
+                LOGGER.warn("-D{}={} is temporary and will be removed in a future release; set " +
+                        "maxInboundMessageSize(int) per client/server instead.", name, value);
             }
             return value;
         } catch (NumberFormatException e) {
-            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is not a valid integer; ignoring it and using " +
-                    "the built-in per-client/server defaults.", name, raw);
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: not a valid integer; ignoring it and using the built-in " +
+                    "per-client/server defaults.", name, raw);
             return null;
         }
     }
@@ -232,19 +231,16 @@ final class GrpcMessageSizeLimiter {
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
             final String forOwner = owner == null ? "" : " for " + owner;
             if (role == CLIENT) {
-                LOGGER.warn("gRPC message size={} exceeded the configured maximum inbound message size of {} bytes{}," +
-                        " but the limit is configured in warn-only mode so the message is allowed through. This " +
-                        "client is receiving very large messages, which can cause memory pressure. Largest message " +
-                        "observed so far is {} bytes. Configure an enforcing maxInboundMessageSize(int) to reject " +
-                        "oversized messages with RESOURCE_EXHAUSTED. This warning is rate-limited to once per 5 " +
-                        "minutes per client.", messageSize, maxMessageSize, forOwner, maxObserved, constructionSite);
+                LOGGER.warn("gRPC message size={} exceeded the maximum inbound message size of {} bytes{} (largest " +
+                        "observed {} bytes), allowed through in warn-only mode. Large messages can cause memory " +
+                        "pressure. Rate-limited to once per 5 minutes per client.",
+                        messageSize, maxMessageSize, forOwner, maxObserved, constructionSite);
             } else {
-                LOGGER.warn("gRPC message size={} exceeded the configured maximum inbound message size of {} bytes{}," +
-                        " but the limit is configured in warn-only mode so the message is allowed through. This " +
-                        "server is receiving very large messages, which can cause memory pressure. Largest message " +
-                        "observed so far is {} bytes. Configure an enforcing maxInboundMessageSize(int) to reject " +
-                        "oversized messages with RESOURCE_EXHAUSTED; enforcing is planned to become the default in a " +
-                        "future release. This warning is rate-limited to once per 5 minutes per server.",
+                LOGGER.warn("gRPC message size={} exceeded the maximum inbound message size of {} bytes{} (largest " +
+                        "observed {} bytes), allowed through in warn-only mode. Large messages can cause memory " +
+                        "pressure; set an enforcing maxInboundMessageSize(int) to reject them with " +
+                        "RESOURCE_EXHAUSTED (planned to become the default). Rate-limited to once per 5 minutes per " +
+                        "server.",
                         messageSize, maxMessageSize, forOwner, maxObserved, constructionSite);
             }
         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
@@ -51,25 +51,25 @@ final class GrpcMessageSizeLimiter {
     // limit; a value set programmatically via the builder is always definitive.
     private static final int DEFAULT_CLIENT_MAX_MESSAGE_SIZE = 64 * 1024 * 1024;
     private static final int DEFAULT_SERVER_MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
-    // FIXME: 0.43 - remove these temporary properties
     private static final String DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY =
-            "io.servicetalk.grpc.netty.temporaryDefaultClientMaxInboundMessageSize";
+            "io.servicetalk.grpc.netty.defaultClientMaxInboundMessageSize";
     private static final String DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE_PROPERTY =
-            "io.servicetalk.grpc.netty.temporaryDefaultServerMaxInboundMessageSize";
-    // Deprecated in favor of the client/server-specific properties above; kept for a release or two in case a
-    // deployment already relies on it. A role-specific property, when set, takes precedence over this legacy one.
+            "io.servicetalk.grpc.netty.defaultServerMaxInboundMessageSize";
+    // Deprecated legacy property, superseded by the client/server-specific properties above; kept for a release or
+    // two in case a deployment already relies on it. A role-specific property, when set, takes precedence over it.
+    // FIXME: 0.43 - remove this deprecated property
     private static final String DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY =
             "io.servicetalk.grpc.netty.temporaryDefaultMaxInboundMessageSize";
-    // The built-in per-role default, overridable by the temporary properties using the same sign convention as the
-    // builder API (see forMaxInboundMessageSize). Read back by servicetalk-grpc-netty via a default-built config so the
-    // properties are parsed in exactly one place.
+    // The built-in per-role default, overridable by the client/server default properties using the same sign
+    // convention as the builder API (see forMaxInboundMessageSize). Seeds GrpcConfig.Builder, so the properties are
+    // parsed in exactly one place.
     static final int DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE;
     static final int DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE;
 
     static {
-        final Integer legacy = parseTemporaryProperty(DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, true);
-        final Integer client = parseTemporaryProperty(DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, false);
-        final Integer server = parseTemporaryProperty(DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, false);
+        final Integer legacy = parseDefaultOverride(DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, true);
+        final Integer client = parseDefaultOverride(DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, false);
+        final Integer server = parseDefaultOverride(DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, false);
         DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE = client != null ? client :
                 legacy != null ? legacy : Role.CLIENT.defaultMaxInboundMessageSize;
         DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE = server != null ? server :
@@ -196,7 +196,7 @@ final class GrpcMessageSizeLimiter {
 
     // Don't throw from the static initializer; ignore an invalid value and fall back to the per-role defaults.
     @Nullable
-    private static Integer parseTemporaryProperty(final String name, final boolean legacy) {
+    private static Integer parseDefaultOverride(final String name, final boolean legacy) {
         final String raw = System.getProperty(name);
         if (raw == null) {
             return null;
@@ -204,13 +204,12 @@ final class GrpcMessageSizeLimiter {
         try {
             final Integer value = Integer.valueOf(raw.trim());
             if (legacy) {
-                LOGGER.warn("-D{}={} is deprecated in favor of -D{} and -D{} and will be removed in a future " +
-                        "release; set maxInboundMessageSize(int) per client/server instead.", name, value,
-                        DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY,
+                LOGGER.warn("-D{}={} is a deprecated legacy property, superseded by -D{} and -D{}, and will be " +
+                        "removed in a future release; set maxInboundMessageSize(int) per client/server instead.",
+                        name, value, DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY,
                         DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE_PROPERTY);
             } else {
-                LOGGER.warn("-D{}={} is temporary and will be removed in a future release; set " +
-                        "maxInboundMessageSize(int) per client/server instead.", name, value);
+                LOGGER.info("-D{}={} overrides the built-in default maxInboundMessageSize.", name, value);
             }
             return value;
         } catch (NumberFormatException e) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
@@ -205,11 +205,12 @@ final class GrpcMessageSizeLimiter {
             final Integer value = Integer.valueOf(raw.trim());
             if (legacy) {
                 LOGGER.warn("-D{}={} is a deprecated legacy property, superseded by -D{} and -D{}, and will be " +
-                        "removed in a future release; set maxInboundMessageSize(int) per client/server instead.",
+                        "removed in a future release; use those or set maxInboundMessageSize(int) per " +
+                        "client/server instead.",
                         name, value, DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY,
                         DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE_PROPERTY);
             } else {
-                LOGGER.info("-D{}={} overrides the built-in default maxInboundMessageSize.", name, value);
+                LOGGER.debug("-D{}={}", name, value);
             }
             return value;
         } catch (NumberFormatException e) {
@@ -232,14 +233,14 @@ final class GrpcMessageSizeLimiter {
             if (role == CLIENT) {
                 LOGGER.warn("gRPC message size={} exceeded the maximum inbound message size of {} bytes{} (largest " +
                         "observed {} bytes), allowed through in warn-only mode. Large messages can cause memory " +
-                        "pressure. Rate-limited to once per 5 minutes per client.",
+                        "pressure; set maxInboundMessageSize(int) to enforce (reject with RESOURCE_EXHAUSTED) or " +
+                        "raise the warn threshold. Rate-limited per client.",
                         messageSize, maxMessageSize, forOwner, maxObserved, constructionSite);
             } else {
                 LOGGER.warn("gRPC message size={} exceeded the maximum inbound message size of {} bytes{} (largest " +
                         "observed {} bytes), allowed through in warn-only mode. Large messages can cause memory " +
                         "pressure; set an enforcing maxInboundMessageSize(int) to reject them with " +
-                        "RESOURCE_EXHAUSTED (planned to become the default). Rate-limited to once per 5 minutes per " +
-                        "server.",
+                        "RESOURCE_EXHAUSTED (planned to become the default). Rate-limited per server.",
                         messageSize, maxMessageSize, forOwner, maxObserved, constructionSite);
             }
         }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiter.java
@@ -21,8 +21,8 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.grpc.api.GrpcMessageSizeLimiter.Role.CLIENT;
 import static io.servicetalk.grpc.api.GrpcStatusCode.RESOURCE_EXHAUSTED;
-import static java.lang.Integer.getInteger;
 import static java.lang.System.nanoTime;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -44,18 +44,57 @@ final class GrpcMessageSizeLimiter {
     /**
      * A no-op limiter that never rejects or warns, regardless of message size.
      */
-    static final GrpcMessageSizeLimiter NONE = new GrpcMessageSizeLimiter(Mode.DISABLED, 0, null);
+    static final GrpcMessageSizeLimiter NONE = new GrpcMessageSizeLimiter(Mode.DISABLED, 0, null, null);
 
-    // maxInboundMessageSize value selecting warn-only mode (see forMaxInboundMessageSize), and the built-in default.
-    private static final int WARN_ONLY = -1;
-    // The 4 MiB warn-only threshold, matching grpc-java's io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE.
-    private static final int DEFAULT_MAX_MESSAGE_SIZE = 4 * 1024 * 1024;
-    // FIXME: 0.43 - remove this temporary property
+    // grpc-java enforces at 4 MiB by default (io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE). ServiceTalk instead
+    // warns (rate-limited) by default at larger, per-role thresholds and lets the message through, easing rollout of a
+    // limit; a value set programmatically via the builder is always definitive.
+    private static final int DEFAULT_CLIENT_MAX_MESSAGE_SIZE = 64 * 1024 * 1024;
+    private static final int DEFAULT_SERVER_MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
+    // FIXME: 0.43 - remove these temporary properties
+    private static final String DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY =
+            "io.servicetalk.grpc.netty.temporaryDefaultClientMaxInboundMessageSize";
+    private static final String DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE_PROPERTY =
+            "io.servicetalk.grpc.netty.temporaryDefaultServerMaxInboundMessageSize";
+    // Deprecated in favor of the client/server-specific properties above; kept for a release or two in case a
+    // deployment already relies on it. A role-specific property, when set, takes precedence over this legacy one.
     private static final String DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY =
             "io.servicetalk.grpc.netty.temporaryDefaultMaxInboundMessageSize";
-    static final int DEFAULT_MAX_INBOUND_MESSAGE_SIZE = resolveDefault();
+    // The built-in per-role default, overridable by the temporary properties using the same sign convention as the
+    // builder API (see forMaxInboundMessageSize). Read back by servicetalk-grpc-netty via a default-built config so the
+    // properties are parsed in exactly one place.
+    static final int DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE;
+    static final int DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE;
+
+    static {
+        final Integer legacy = parseTemporaryProperty(DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, true);
+        final Integer client = parseTemporaryProperty(DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, false);
+        final Integer server = parseTemporaryProperty(DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, false);
+        DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE = client != null ? client :
+                legacy != null ? legacy : Role.CLIENT.defaultMaxInboundMessageSize;
+        DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE = server != null ? server :
+                legacy != null ? legacy : Role.SERVER.defaultMaxInboundMessageSize;
+    }
 
     private enum Mode { DISABLED, ENFORCING, WARN_ONLY }
+
+    /**
+     * Whether a limiter belongs to a client or a server. Selects the built-in default limit and the wording of the
+     * warn-only log message.
+     */
+    enum Role {
+        CLIENT(DEFAULT_CLIENT_MAX_MESSAGE_SIZE, "client"),
+        SERVER(DEFAULT_SERVER_MAX_MESSAGE_SIZE, "server");
+
+        // Negative => warn-only (rate-limited) at this magnitude by default rather than rejecting.
+        final int defaultMaxInboundMessageSize;
+        final String description;
+
+        Role(final int defaultWarnSize, final String description) {
+            this.defaultMaxInboundMessageSize = -defaultWarnSize;
+            this.description = description;
+        }
+    }
 
     private final Mode mode;
     private final int maxMessageSize;
@@ -69,54 +108,58 @@ final class GrpcMessageSizeLimiter {
     // the target address); null when not warn-only or when unavailable (server-side).
     @Nullable
     private final Object owner;
+    // The role whose warn-only wording to emit; null when not warn-only.
+    @Nullable
+    private final Role role;
     @Nullable
     private final Throwable constructionSite;
 
-    private GrpcMessageSizeLimiter(final Mode mode, final int maxMessageSize, @Nullable final Object owner) {
+    private GrpcMessageSizeLimiter(final Mode mode, final int maxMessageSize, @Nullable final Role role,
+                                   @Nullable final Object owner) {
         this.mode = mode;
         this.maxMessageSize = maxMessageSize;
+        final boolean warnOnly = mode == Mode.WARN_ONLY;
         // Seed in the past so the first time the limit is exceeded a warning is emitted immediately.
-        this.lastWarnNanos = mode == Mode.WARN_ONLY ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
-        this.maxObservedSize = mode == Mode.WARN_ONLY ? new AtomicLong() : null;
-        this.owner = mode == Mode.WARN_ONLY ? owner : null;
-        this.constructionSite = mode == Mode.WARN_ONLY ? new Throwable(
-                "Client/server with a warn-only maxInboundMessageSize created here (not an error)") : null;
+        this.lastWarnNanos = warnOnly ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
+        this.maxObservedSize = warnOnly ? new AtomicLong() : null;
+        this.owner = warnOnly ? owner : null;
+        this.role = warnOnly ? role : null;
+        this.constructionSite = warnOnly ? new Throwable(
+                "This " + role.description + " with a warn-only maxInboundMessageSize created here (not an error)")
+                : null;
     }
 
     /**
-     * Build a limiter from the {@code maxInboundMessageSize} value configured on the client/server:
-     * {@code 0} disables the limit, {@code > 0} enforces (rejects) at that many bytes, and {@code -1} warns (without
-     * rejecting) at the built-in default limit.
+     * Build a limiter from the {@code maxInboundMessageSize} value configured on the client/server: {@code 0} disables
+     * the limit, {@code > 0} enforces (rejects) at that many bytes, and {@code < 0} warns (without rejecting) at
+     * {@code abs(value)} bytes. The sign selects the mode and the magnitude selects the threshold.
      *
      * @param maxInboundMessageSize the configured maximum inbound message size
+     * @param role selects the built-in default and the warn-only wording
      * @return a limiter, or {@link #NONE} when {@code maxInboundMessageSize == 0}
-     * @throws IllegalArgumentException if {@code maxInboundMessageSize < -1}
      */
-    static GrpcMessageSizeLimiter forMaxInboundMessageSize(final int maxInboundMessageSize) {
-        return forMaxInboundMessageSize(maxInboundMessageSize, null);
+    static GrpcMessageSizeLimiter forMaxInboundMessageSize(final int maxInboundMessageSize, final Role role) {
+        return forMaxInboundMessageSize(maxInboundMessageSize, role, null);
     }
 
     /**
-     * Variant of {@link #forMaxInboundMessageSize(int)} that records {@code owner} to identify the client/server in
-     * the warn-only log. The client passes its {@link io.servicetalk.http.api.StreamingHttpClient} (whose
+     * Variant of {@link #forMaxInboundMessageSize(int, Role)} that records {@code owner} to identify the client/server
+     * in the warn-only log. The client passes its {@link io.servicetalk.http.api.StreamingHttpClient} (whose
      * {@code toString()} carries the target address); the server has no equivalent handle and passes {@code null},
      * relying on the construction stack instead.
      */
-    static GrpcMessageSizeLimiter forMaxInboundMessageSize(final int maxInboundMessageSize,
+    static GrpcMessageSizeLimiter forMaxInboundMessageSize(final int maxInboundMessageSize, final Role role,
                                                            @Nullable final Object owner) {
         if (maxInboundMessageSize == 0) {
             return NONE;
         }
         if (maxInboundMessageSize > 0) {
-            return new GrpcMessageSizeLimiter(Mode.ENFORCING, maxInboundMessageSize, null);
+            return new GrpcMessageSizeLimiter(Mode.ENFORCING, maxInboundMessageSize, null, null);
         }
-        // A negative value reaches here only as the property-derived default; the builder/config API rejects
-        // negatives up front, so the sole legal negative is the warn-only selector.
-        if (maxInboundMessageSize != WARN_ONLY) {
-            throw new IllegalArgumentException("maxInboundMessageSize: " + maxInboundMessageSize +
-                    " (expected >= " + WARN_ONLY + ')');
-        }
-        return new GrpcMessageSizeLimiter(Mode.WARN_ONLY, DEFAULT_MAX_MESSAGE_SIZE, owner);
+        // -Integer.MIN_VALUE overflows back to a negative value; clamp so it stays a warn-only limiter.
+        final int warnThreshold = maxInboundMessageSize == Integer.MIN_VALUE ? Integer.MAX_VALUE :
+                -maxInboundMessageSize;
+        return new GrpcMessageSizeLimiter(Mode.WARN_ONLY, warnThreshold, role, owner);
     }
 
     /**
@@ -151,49 +194,59 @@ final class GrpcMessageSizeLimiter {
         maybeWarn(messageSize);
     }
 
-    private static int resolveDefault() {
-        // Warn-only by default unless the temporary property overrides it. The property also supports the warn-only
-        // selector (-1), which the builder/config API does not expose; only values below it are invalid. Fall back to
-        // warn-only rather than failing at class-load.
-        final int value = getInteger(DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, WARN_ONLY);
-        if (value < WARN_ONLY) {
-            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is invalid (expected >= {}). Falling back to " +
-                            "warn-only mode at {} bytes.",
-                    DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, value, WARN_ONLY, DEFAULT_MAX_MESSAGE_SIZE);
-            return WARN_ONLY;
+    // Don't throw from the static initializer; ignore an invalid value and fall back to the per-role defaults.
+    @Nullable
+    private static Integer parseTemporaryProperty(final String name, final boolean legacy) {
+        final String raw = System.getProperty(name);
+        if (raw == null) {
+            return null;
         }
-        // getInteger can't distinguish "unset" (the warn-only default) from an explicit value; only warn about the
-        // temporary property when it is actually set.
-        if (System.getProperty(DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY) != null) {
-            if (value == WARN_ONLY) {
-                LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: Setting this property to -1 (warn-only mode) may be " +
-                                "used temporarily to unblock deployment but exposes the service to the risk of " +
-                                "aggregating unbounded amount of data on the heap. Configure appropriate value per " +
-                                "client/server builder via maxInboundMessageSize(int) instead.",
-                        DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, value);
+        try {
+            final Integer value = Integer.valueOf(raw.trim());
+            if (legacy) {
+                LOGGER.warn("-D{}={} This property is deprecated in favor of -D{} and -D{} and will be removed in a " +
+                                "future release. Configure this value per client/server builder via " +
+                                "maxInboundMessageSize(int) instead.", name, value,
+                        DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY,
+                        DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE_PROPERTY);
             } else {
-                LOGGER.warn("-D{}={} This property will be removed in the future releases. Configure this value per " +
-                                "client/server builder via maxInboundMessageSize(int) instead.",
-                        DEFAULT_MAX_INBOUND_MESSAGE_SIZE_PROPERTY, value);
+                LOGGER.warn("-D{}={} This property is temporary and will be removed in a future release. Configure " +
+                        "this value per client/server builder via maxInboundMessageSize(int) instead.", name, value);
             }
+            return value;
+        } catch (NumberFormatException e) {
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is not a valid integer; ignoring it and using " +
+                    "the built-in per-client/server defaults.", name, raw);
+            return null;
         }
-        return value;
     }
 
     private void maybeWarn(final long messageSize) {
         assert lastWarnNanos != null;
         assert maxObservedSize != null;
         assert constructionSite != null;
+        assert role != null;
         final long maxObserved = maxObservedSize.accumulateAndGet(messageSize, Math::max);
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
-            LOGGER.warn("gRPC message size={} exceeded the configured maximum inbound message size of {} bytes{}, " +
-                    "but the limit is configured in warn-only mode so the message is allowed through. Largest " +
-                    "message observed so far is {} bytes. Configure an enforcing maxInboundMessageSize(int) to " +
-                    "reject oversized messages with RESOURCE_EXHAUSTED. This warning is rate-limited to once per 5 " +
-                    "minutes per client/server.", messageSize, maxMessageSize, owner == null ? "" : " for " + owner,
-                    maxObserved, constructionSite);
+            final String forOwner = owner == null ? "" : " for " + owner;
+            if (role == CLIENT) {
+                LOGGER.warn("gRPC message size={} exceeded the configured maximum inbound message size of {} bytes{}," +
+                        " but the limit is configured in warn-only mode so the message is allowed through. This " +
+                        "client is receiving very large messages, which can cause memory pressure. Largest message " +
+                        "observed so far is {} bytes. Configure an enforcing maxInboundMessageSize(int) to reject " +
+                        "oversized messages with RESOURCE_EXHAUSTED. This warning is rate-limited to once per 5 " +
+                        "minutes per client.", messageSize, maxMessageSize, forOwner, maxObserved, constructionSite);
+            } else {
+                LOGGER.warn("gRPC message size={} exceeded the configured maximum inbound message size of {} bytes{}," +
+                        " but the limit is configured in warn-only mode so the message is allowed through. This " +
+                        "server is receiving very large messages, which can cause memory pressure. Largest message " +
+                        "observed so far is {} bytes. Configure an enforcing maxInboundMessageSize(int) to reject " +
+                        "oversized messages with RESOURCE_EXHAUSTED; enforcing is planned to become the default in a " +
+                        "future release. This warning is rate-limited to once per 5 minutes per server.",
+                        messageSize, maxMessageSize, forOwner, maxObserved, constructionSite);
+            }
         }
     }
 }

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcRouter.java
@@ -319,11 +319,12 @@ final class GrpcRouter {
          * {@link Builder}. Must be called before routes are added so the limiter is baked into their deserializers.
          *
          * @param maxInboundMessageSize the maximum inbound message size in bytes: {@code 0} disables the limit,
-         * {@code > 0} rejects larger messages with {@code RESOURCE_EXHAUSTED}, and {@code -1} (reachable only via the
-         * default system property, not the builder API) warns without rejecting at the default limit.
+         * {@code > 0} rejects larger messages with {@code RESOURCE_EXHAUSTED}, and {@code < 0} warns without rejecting
+         * at {@code abs(value)} bytes.
          */
         void maxInboundMessageSize(final int maxInboundMessageSize) {
-            this.sizeLimiter = GrpcMessageSizeLimiter.forMaxInboundMessageSize(maxInboundMessageSize);
+            this.sizeLimiter = GrpcMessageSizeLimiter.forMaxInboundMessageSize(maxInboundMessageSize,
+                    GrpcMessageSizeLimiter.Role.SERVER);
         }
 
         static GrpcRouter.Builder merge(final GrpcRouter.Builder... builders) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -94,19 +94,19 @@ public interface GrpcServerBuilder {
     }
 
     /**
-     * Set the maximum size, in bytes, of a decoded inbound (request) gRPC message that this server will accept.
-     * Messages whose declared length exceeds this limit are rejected with
-     * {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before their payload is buffered, bounding the memory a peer can
-     * cause this server to allocate. The default is 4 MiB (matching grpc-java) and can be changed globally via the
-     * {@code io.servicetalk.grpc.netty.temporaryDefaultMaxInboundMessageSize} system property (a temporary property
-     * that will be removed in a future release), which also accepts {@code -1} to enable warn-only mode globally (a
-     * rate-limited log instead of rejecting).
+     * Set the maximum size, in bytes, of a decoded inbound (request) gRPC message that this server will accept,
+     * bounding the memory a peer can cause this server to allocate. The sign selects the mode and the magnitude the
+     * threshold: a <em>positive</em> value enforces the limit, rejecting messages whose declared length exceeds it with
+     * {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before their payload is buffered; a <em>negative</em> value enables
+     * warn-only mode at {@code abs(value)} bytes (oversized messages are still served, but a rate-limited warning is
+     * logged); and {@code 0} disables the limit. The default is warn-only at 16 MiB; enforcing is planned to become the
+     * default in a future release.
      * <p>
      * For a compressed message this bounds the on-wire length and the decoded length. The memory used while
      * decompressing is bounded separately by the codec's own decompressed-bytes cap, not by this limit.
      *
-     * @param maxInboundMessageSize the maximum inbound message size in bytes: {@code 0} disables the limit and any
-     * positive value enforces it. Must be non-negative.
+     * @param maxInboundMessageSize the maximum inbound message size in bytes: positive enforces at that size, negative
+     * warns at its magnitude, {@code 0} disables the limit
      * @return {@code this}.
      */
     default GrpcServerBuilder maxInboundMessageSize(int maxInboundMessageSize) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServerBuilder.java
@@ -94,19 +94,17 @@ public interface GrpcServerBuilder {
     }
 
     /**
-     * Set the maximum size, in bytes, of a decoded inbound (request) gRPC message that this server will accept,
-     * bounding the memory a peer can cause this server to allocate. The sign selects the mode and the magnitude the
-     * threshold: a <em>positive</em> value enforces the limit, rejecting messages whose declared length exceeds it with
-     * {@link GrpcStatusCode#RESOURCE_EXHAUSTED} before their payload is buffered; a <em>negative</em> value enables
-     * warn-only mode at {@code abs(value)} bytes (oversized messages are still served, but a rate-limited warning is
-     * logged); and {@code 0} disables the limit. The default is warn-only at 16 MiB; enforcing is planned to become the
-     * default in a future release.
+     * Set the maximum size, in bytes, of a decoded inbound (request) gRPC message this server accepts, bounding the
+     * memory a peer can make it allocate. The sign selects the mode, the magnitude the threshold: <em>positive</em>
+     * enforces, rejecting a message whose declared length exceeds it with {@link GrpcStatusCode#RESOURCE_EXHAUSTED}
+     * before its payload is buffered; <em>negative</em> warns at {@code abs(value)} bytes (oversized messages are still
+     * served, with a rate-limited warning); {@code 0} disables it. Defaults to warn-only at 16 MiB; enforcing is
+     * planned to become the default in a future release.
      * <p>
-     * For a compressed message this bounds the on-wire length and the decoded length. The memory used while
-     * decompressing is bounded separately by the codec's own decompressed-bytes cap, not by this limit.
+     * For a compressed message this bounds both the on-wire and decoded lengths; decompression memory itself is bounded
+     * separately by the codec's decompressed-bytes cap.
      *
-     * @param maxInboundMessageSize the maximum inbound message size in bytes: positive enforces at that size, negative
-     * warns at its magnitude, {@code 0} disables the limit
+     * @param maxInboundMessageSize bytes: positive enforces, negative warns at its magnitude, {@code 0} disables
      * @return {@code this}.
      */
     default GrpcServerBuilder maxInboundMessageSize(int maxInboundMessageSize) {

--- a/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceConfig.java
+++ b/servicetalk-grpc-api/src/main/java/io/servicetalk/grpc/api/GrpcServiceConfig.java
@@ -79,6 +79,13 @@ public final class GrpcServiceConfig extends GrpcConfig {
         private ExecutionContext<?> executionContext;
 
         /**
+         * Creates a new builder seeded with the server's built-in default inbound message-size limit.
+         */
+        public Builder() {
+            super(GrpcMessageSizeLimiter.DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE);
+        }
+
+        /**
          * Set the {@link ExecutionContext} the bound service runs on; it is adapted to a {@link GrpcExecutionContext}.
          *
          * @param executionContext the {@link ExecutionContext} to use for the bound service.

--- a/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiterTest.java
+++ b/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiterTest.java
@@ -18,6 +18,8 @@ package io.servicetalk.grpc.api;
 import org.junit.jupiter.api.Test;
 
 import static io.servicetalk.grpc.api.GrpcMessageSizeLimiter.NONE;
+import static io.servicetalk.grpc.api.GrpcMessageSizeLimiter.Role.CLIENT;
+import static io.servicetalk.grpc.api.GrpcMessageSizeLimiter.Role.SERVER;
 import static io.servicetalk.grpc.api.GrpcMessageSizeLimiter.forMaxInboundMessageSize;
 import static io.servicetalk.grpc.api.GrpcStatusCode.RESOURCE_EXHAUSTED;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,26 +27,27 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GrpcMessageSizeLimiterTest {
 
     @Test
     void disabledNeverRejects() {
-        assertThat(forMaxInboundMessageSize(0), sameInstance(NONE));
+        assertThat(forMaxInboundMessageSize(0, SERVER), sameInstance(NONE));
         assertDoesNotThrow(() -> NONE.accept(Long.MAX_VALUE));
     }
 
     @Test
     void enforcingAllowsAtOrUnderLimit() {
-        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(10);
+        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(10, SERVER);
         assertDoesNotThrow(() -> limiter.accept(0));
         assertDoesNotThrow(() -> limiter.accept(10));
     }
 
     @Test
     void enforcingRejectsOverLimitWithResourceExhausted() {
-        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(10);
+        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(10, SERVER);
         final GrpcStatusException e = assertThrows(GrpcStatusException.class, () -> limiter.accept(11));
         assertThat(e.status().code(), equalTo(RESOURCE_EXHAUSTED));
         assertThat(e.status().description(), startsWith("gRPC message size=11"));
@@ -53,20 +56,32 @@ class GrpcMessageSizeLimiterTest {
     @Test
     void enforcingDecompressedRejectionHasDistinctDescription() {
         final GrpcStatusException e = assertThrows(GrpcStatusException.class,
-                () -> forMaxInboundMessageSize(10).accept(11, true));
+                () -> forMaxInboundMessageSize(10, SERVER).accept(11, true));
         assertThat(e.status().code(), equalTo(RESOURCE_EXHAUSTED));
         assertThat(e.status().description(), startsWith("Decompressed gRPC message size=11"));
     }
 
     @Test
     void warnOnlyDeliversOverLimit() {
-        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(-1);
+        // Negative selects warn-only mode at abs(value): over the threshold it warns (rate-limited) but must not throw.
+        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(-10, SERVER);
+        assertDoesNotThrow(() -> limiter.accept(11));
         assertDoesNotThrow(() -> limiter.accept(Long.MAX_VALUE));
     }
 
     @Test
-    void belowWarnOnlyIsRejected() {
-        assertThrows(IllegalArgumentException.class, () -> forMaxInboundMessageSize(-2));
-        assertThrows(IllegalArgumentException.class, () -> forMaxInboundMessageSize(Integer.MIN_VALUE));
+    void clientWarnOnlyDeliversOverLimit() {
+        // Exercises the CLIENT warn-message branch: warns (rate-limited) over the threshold but must not throw.
+        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(-10, CLIENT);
+        assertDoesNotThrow(() -> limiter.accept(11));
+        assertDoesNotThrow(() -> limiter.accept(Long.MAX_VALUE));
+    }
+
+    @Test
+    void integerMinValueWarnsRatherThanDisabled() {
+        // -Integer.MIN_VALUE overflows back to a negative; the limiter must stay warn-only, not collapse to disabled.
+        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(Integer.MIN_VALUE, SERVER);
+        assertNotSame(NONE, limiter);
+        assertDoesNotThrow(() -> limiter.accept(Long.MAX_VALUE));
     }
 }

--- a/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiterTest.java
+++ b/servicetalk-grpc-api/src/test/java/io/servicetalk/grpc/api/GrpcMessageSizeLimiterTest.java
@@ -15,10 +15,13 @@
  */
 package io.servicetalk.grpc.api;
 
+import io.servicetalk.grpc.api.GrpcMessageSizeLimiter.Role;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static io.servicetalk.grpc.api.GrpcMessageSizeLimiter.NONE;
-import static io.servicetalk.grpc.api.GrpcMessageSizeLimiter.Role.CLIENT;
 import static io.servicetalk.grpc.api.GrpcMessageSizeLimiter.Role.SERVER;
 import static io.servicetalk.grpc.api.GrpcMessageSizeLimiter.forMaxInboundMessageSize;
 import static io.servicetalk.grpc.api.GrpcStatusCode.RESOURCE_EXHAUSTED;
@@ -61,18 +64,12 @@ class GrpcMessageSizeLimiterTest {
         assertThat(e.status().description(), startsWith("Decompressed gRPC message size=11"));
     }
 
-    @Test
-    void warnOnlyDeliversOverLimit() {
-        // Negative selects warn-only mode at abs(value): over the threshold it warns (rate-limited) but must not throw.
-        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(-10, SERVER);
-        assertDoesNotThrow(() -> limiter.accept(11));
-        assertDoesNotThrow(() -> limiter.accept(Long.MAX_VALUE));
-    }
-
-    @Test
-    void clientWarnOnlyDeliversOverLimit() {
-        // Exercises the CLIENT warn-message branch: warns (rate-limited) over the threshold but must not throw.
-        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(-10, CLIENT);
+    @ParameterizedTest
+    @EnumSource(Role.class)
+    void warnOnlyDeliversOverLimit(final Role role) {
+        // Negative selects warn-only mode at abs(value): over the threshold each role warns (rate-limited) but must
+        // not throw. Parameterizing over Role exercises both the CLIENT and SERVER warn-message branches.
+        final GrpcMessageSizeLimiter limiter = forMaxInboundMessageSize(-10, role);
         assertDoesNotThrow(() -> limiter.accept(11));
         assertDoesNotThrow(() -> limiter.accept(Long.MAX_VALUE));
     }

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -142,7 +142,7 @@ final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
         httpInitializer.initialize(builder);
         Duration timeout = isInfinite(defaultTimeout, GRPC_MAX_TIMEOUT) ? null : defaultTimeout;
         // Only override the config's default when the user set an explicit value, so an unset limit defers to the
-        // GrpcConfig default (which resolves the temporary properties and is warn-only by default).
+        // GrpcConfig default (which resolves the client/server default properties and is warn-only by default).
         final GrpcClientCallConfig.Builder callConfigBuilder = new GrpcClientCallConfig.Builder()
                 .defaultTimeout(timeout);
         if (maxInboundMessageSize != null) {

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -87,7 +87,7 @@ final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
 
     @Override
     public GrpcClientBuilder<U, R> maxInboundMessageSize(final int maxInboundMessageSize) {
-        this.maxInboundMessageSize = GrpcMessageSizeUtils.validateMaxInboundMessageSize(maxInboundMessageSize);
+        this.maxInboundMessageSize = maxInboundMessageSize;
         return this;
     }
 
@@ -123,11 +123,14 @@ final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
     private GrpcClientCallFactory newGrpcClientCallFactory() {
         SingleAddressHttpClientBuilder<U, R> builder = httpClientBuilderSupplier.get()
             .protocols(h2Default())
-            // Bound HTTP response aggregation to the gRPC inbound message-size limit so oversized unary (aggregated)
-            // responses are rejected before the whole body is buffered. gRPC frames its own messages, so a unary body
-            // is a single frame that maps cleanly to this bound; streaming responses are deframed incrementally and
+            // Bound HTTP response aggregation to an explicitly configured gRPC inbound message-size limit so oversized
+            // unary (aggregated) responses are rejected before the whole body is buffered; a unary body is a single
+            // gRPC frame that maps cleanly to this bound. Only an explicit builder value drives this backstop: an unset
+            // limit leaves it disabled (the warn-only default needs no HTTP reject, and a property-derived enforcing
+            // default is still enforced by the gRPC deframer). Streaming responses are deframed incrementally and
             // unaffected. Set before initializeHttp so users can still override it.
-            .maxAggregatedPayloadSize(GrpcMessageSizeUtils.httpAggregationLimitFor(effectiveMaxInboundMessageSize()));
+            .maxAggregatedPayloadSize(maxInboundMessageSize == null ? 0 :
+                    GrpcMessageSizeUtils.httpAggregationLimitFor(maxInboundMessageSize));
         builder.appendClientFilter(CatchAllHttpClientFilter.INSTANCE);
         if (appendTimeoutFilter) {
             builder.appendClientFilter(newGrpcDeadlineClientFilterFactory());
@@ -139,19 +142,13 @@ final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
         httpInitializer.initialize(builder);
         Duration timeout = isInfinite(defaultTimeout, GRPC_MAX_TIMEOUT) ? null : defaultTimeout;
         // Only override the config's default when the user set an explicit value, so an unset limit defers to the
-        // GrpcConfig default (which resolves the temporary system property, including its warn-only -1 selector).
+        // GrpcConfig default (which resolves the temporary properties and is warn-only by default).
         final GrpcClientCallConfig.Builder callConfigBuilder = new GrpcClientCallConfig.Builder()
                 .defaultTimeout(timeout);
         if (maxInboundMessageSize != null) {
             callConfigBuilder.maxInboundMessageSize(maxInboundMessageSize);
         }
         return GrpcClientCallFactory.from(builder.buildStreaming(), callConfigBuilder.build());
-    }
-
-    // The effective inbound limit: the user's explicit value, else the GrpcConfig default (property-derived).
-    private int effectiveMaxInboundMessageSize() {
-        return maxInboundMessageSize != null ? maxInboundMessageSize
-                : GrpcMessageSizeUtils.DEFAULT_MAX_INBOUND_MESSAGE_SIZE;
     }
 
     static final class CatchAllHttpClientFilter implements StreamingHttpClientFilterFactory {

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcClientBuilder.java
@@ -52,8 +52,7 @@ final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
     @Nullable
     private Duration defaultTimeout;
     private boolean appendTimeoutFilter = true;
-    @Nullable
-    private Integer maxInboundMessageSize;
+    private int maxInboundMessageSize = GrpcMessageSizeUtils.DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE;
     private HttpInitializer<U, R> httpInitializer = builder -> {
         // no-op
     };
@@ -123,14 +122,10 @@ final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
     private GrpcClientCallFactory newGrpcClientCallFactory() {
         SingleAddressHttpClientBuilder<U, R> builder = httpClientBuilderSupplier.get()
             .protocols(h2Default())
-            // Bound HTTP response aggregation to an explicitly configured gRPC inbound message-size limit so oversized
-            // unary (aggregated) responses are rejected before the whole body is buffered; a unary body is a single
-            // gRPC frame that maps cleanly to this bound. Only an explicit builder value drives this backstop: an unset
-            // limit leaves it disabled (the warn-only default needs no HTTP reject, and a property-derived enforcing
-            // default is still enforced by the gRPC deframer). Streaming responses are deframed incrementally and
-            // unaffected. Set before initializeHttp so users can still override it.
-            .maxAggregatedPayloadSize(maxInboundMessageSize == null ? 0 :
-                    GrpcMessageSizeUtils.httpAggregationLimitFor(maxInboundMessageSize));
+            // Backstop oversized unary (aggregated) responses at the HTTP layer before the whole body is buffered
+            // (streaming responses are deframed incrementally and unaffected); the limit defaults to the resolved
+            // client default, so unary stays bounded if it becomes enforcing. Set before initializeHttp to override.
+            .maxAggregatedPayloadSize(GrpcMessageSizeUtils.httpAggregationLimitFor(maxInboundMessageSize));
         builder.appendClientFilter(CatchAllHttpClientFilter.INSTANCE);
         if (appendTimeoutFilter) {
             builder.appendClientFilter(newGrpcDeadlineClientFilterFactory());
@@ -141,14 +136,11 @@ final class DefaultGrpcClientBuilder<U, R> implements GrpcClientBuilder<U, R> {
         builder.appendConnectionFactoryFilter(GrpcRequestTracker.filter());
         httpInitializer.initialize(builder);
         Duration timeout = isInfinite(defaultTimeout, GRPC_MAX_TIMEOUT) ? null : defaultTimeout;
-        // Only override the config's default when the user set an explicit value, so an unset limit defers to the
-        // GrpcConfig default (which resolves the client/server default properties and is warn-only by default).
-        final GrpcClientCallConfig.Builder callConfigBuilder = new GrpcClientCallConfig.Builder()
-                .defaultTimeout(timeout);
-        if (maxInboundMessageSize != null) {
-            callConfigBuilder.maxInboundMessageSize(maxInboundMessageSize);
-        }
-        return GrpcClientCallFactory.from(builder.buildStreaming(), callConfigBuilder.build());
+        final GrpcClientCallConfig callConfig = new GrpcClientCallConfig.Builder()
+                .defaultTimeout(timeout)
+                .maxInboundMessageSize(maxInboundMessageSize)
+                .build();
+        return GrpcClientCallFactory.from(builder.buildStreaming(), callConfig);
     }
 
     static final class CatchAllHttpClientFilter implements StreamingHttpClientFilterFactory {

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -77,11 +77,14 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
                 requireNonNull(httpServerBuilderSupplier.get(), "Supplier<HttpServerBuilder> result was null")
                     .protocols(h2Default())
                     .allowDropRequestTrailers(true)
-                    // Bound HTTP request aggregation to the gRPC inbound message-size limit so oversized unary
-                    // (aggregated) requests are rejected before the whole body is buffered; streaming requests are
-                    // deframed incrementally and unaffected. Applied before initializeHttp so users can override it.
-                    .maxAggregatedPayloadSize(
-                            GrpcMessageSizeUtils.httpAggregationLimitFor(effectiveMaxInboundMessageSize()));
+                    // Bound HTTP request aggregation to an explicitly configured gRPC inbound message-size limit so
+                    // oversized unary (aggregated) requests are rejected before the whole body is buffered; streaming
+                    // requests are deframed incrementally and unaffected. Only an explicit builder value drives this
+                    // backstop: an unset limit leaves it disabled (the warn-only default needs no HTTP reject, and a
+                    // property-derived enforcing default is still enforced by the gRPC deframer). Applied before
+                    // initializeHttp so users can override it.
+                    .maxAggregatedPayloadSize(maxInboundMessageSize == null ? 0 :
+                            GrpcMessageSizeUtils.httpAggregationLimitFor(maxInboundMessageSize));
     }
 
     @Override
@@ -106,7 +109,7 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
 
     @Override
     public GrpcServerBuilder maxInboundMessageSize(final int maxInboundMessageSize) {
-        this.maxInboundMessageSize = GrpcMessageSizeUtils.validateMaxInboundMessageSize(maxInboundMessageSize);
+        this.maxInboundMessageSize = maxInboundMessageSize;
         return this;
     }
 
@@ -155,19 +158,13 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     private Single<GrpcServerContext> doListen(final GrpcServiceFactory<?> serviceFactory) {
         interceptorBuilder = preBuild();
         // Only override the config's default when the user set an explicit value, so an unset limit defers to the
-        // GrpcConfig default (which resolves the temporary system property, including its warn-only -1 selector).
+        // GrpcConfig default (which resolves the temporary properties and is warn-only by default).
         final GrpcServiceConfig.Builder serviceConfigBuilder = new GrpcServiceConfig.Builder()
                 .executionContext(interceptorBuilder.contextBuilder.build());
         if (maxInboundMessageSize != null) {
             serviceConfigBuilder.maxInboundMessageSize(maxInboundMessageSize);
         }
         return serviceFactory.bind(this, serviceConfigBuilder.build());
-    }
-
-    // The effective inbound limit: the user's explicit value, else the GrpcConfig default (property-derived).
-    private int effectiveMaxInboundMessageSize() {
-        return maxInboundMessageSize != null ? maxInboundMessageSize
-                : GrpcMessageSizeUtils.DEFAULT_MAX_INBOUND_MESSAGE_SIZE;
     }
 
     private ExecutionContextInterceptorHttpServerBuilder preBuild() {

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -68,8 +68,7 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     @Nullable
     private Duration defaultTimeout;
     private boolean appendTimeoutFilter = true;
-    @Nullable
-    private Integer maxInboundMessageSize;
+    private int maxInboundMessageSize = GrpcMessageSizeUtils.DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE;
 
     // Do not use this ctor directly, GrpcServers is the entry point for creating a new builder.
     DefaultGrpcServerBuilder(final Supplier<HttpServerBuilder> httpServerBuilderSupplier) {
@@ -77,14 +76,11 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
                 requireNonNull(httpServerBuilderSupplier.get(), "Supplier<HttpServerBuilder> result was null")
                     .protocols(h2Default())
                     .allowDropRequestTrailers(true)
-                    // Bound HTTP request aggregation to an explicitly configured gRPC inbound message-size limit so
-                    // oversized unary (aggregated) requests are rejected before the whole body is buffered; streaming
-                    // requests are deframed incrementally and unaffected. Only an explicit builder value drives this
-                    // backstop: an unset limit leaves it disabled (the warn-only default needs no HTTP reject, and a
-                    // property-derived enforcing default is still enforced by the gRPC deframer). Applied before
-                    // initializeHttp so users can override it.
-                    .maxAggregatedPayloadSize(maxInboundMessageSize == null ? 0 :
-                            GrpcMessageSizeUtils.httpAggregationLimitFor(maxInboundMessageSize));
+                    // Backstop oversized unary (aggregated) requests at the HTTP layer before the whole body is
+                    // buffered (streaming requests are deframed incrementally and unaffected); the limit defaults to
+                    // the resolved server default, so unary stays bounded if it becomes enforcing. Applied before
+                    // initializeHttp to override.
+                    .maxAggregatedPayloadSize(GrpcMessageSizeUtils.httpAggregationLimitFor(maxInboundMessageSize));
     }
 
     @Override
@@ -157,14 +153,11 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
      */
     private Single<GrpcServerContext> doListen(final GrpcServiceFactory<?> serviceFactory) {
         interceptorBuilder = preBuild();
-        // Only override the config's default when the user set an explicit value, so an unset limit defers to the
-        // GrpcConfig default (which resolves the client/server default properties and is warn-only by default).
-        final GrpcServiceConfig.Builder serviceConfigBuilder = new GrpcServiceConfig.Builder()
-                .executionContext(interceptorBuilder.contextBuilder.build());
-        if (maxInboundMessageSize != null) {
-            serviceConfigBuilder.maxInboundMessageSize(maxInboundMessageSize);
-        }
-        return serviceFactory.bind(this, serviceConfigBuilder.build());
+        final GrpcServiceConfig serviceConfig = new GrpcServiceConfig.Builder()
+                .executionContext(interceptorBuilder.contextBuilder.build())
+                .maxInboundMessageSize(maxInboundMessageSize)
+                .build();
+        return serviceFactory.bind(this, serviceConfig);
     }
 
     private ExecutionContextInterceptorHttpServerBuilder preBuild() {

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/DefaultGrpcServerBuilder.java
@@ -158,7 +158,7 @@ final class DefaultGrpcServerBuilder implements GrpcServerBuilder, ServerBinder 
     private Single<GrpcServerContext> doListen(final GrpcServiceFactory<?> serviceFactory) {
         interceptorBuilder = preBuild();
         // Only override the config's default when the user set an explicit value, so an unset limit defers to the
-        // GrpcConfig default (which resolves the temporary properties and is warn-only by default).
+        // GrpcConfig default (which resolves the client/server default properties and is warn-only by default).
         final GrpcServiceConfig.Builder serviceConfigBuilder = new GrpcServiceConfig.Builder()
                 .executionContext(interceptorBuilder.contextBuilder.build());
         if (maxInboundMessageSize != null) {

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcMessageSizeUtils.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcMessageSizeUtils.java
@@ -15,18 +15,33 @@
  */
 package io.servicetalk.grpc.netty;
 
+import io.servicetalk.buffer.api.BufferAllocator;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.grpc.api.GrpcClientCallConfig;
+import io.servicetalk.grpc.api.GrpcExecutionContext;
+import io.servicetalk.grpc.api.GrpcExecutionStrategy;
+import io.servicetalk.grpc.api.GrpcServiceConfig;
+import io.servicetalk.transport.api.IoExecutor;
+
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
 
 /**
- * Coordinates the {@code maxInboundMessageSize} configured on the gRPC client/server builders with the underlying HTTP
- * transport. The builder API accepts {@code 0} (disables), a positive value (enforces), or a negative value (warns at
- * its magnitude). The HTTP aggregation backstop below is applied only for an explicitly configured enforcing value; an
- * unset or warn-only limit leaves it disabled, and a property-derived default is still enforced by the gRPC deframer.
+ * Coordinates the gRPC {@code maxInboundMessageSize} with the underlying HTTP transport's aggregation limit. The
+ * resolved per-role default is parsed once in {@code servicetalk-grpc-api} and read back via
+ * {@link #DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE} / {@link #DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE}; an unset builder
+ * limit falls back to it so oversized unary messages stay bounded even once the default becomes enforcing.
  */
 final class GrpcMessageSizeUtils {
 
     // A unary gRPC message is a single frame: a 5-byte header (1 compression flag + 4-byte length) plus the message.
     static final int GRPC_FRAME_HEADER_BYTES = 5;
+    // Read back from default-built configs (properties are parsed once, in servicetalk-grpc-api). The size is
+    // independent of the execution context, so the server default is read via a placeholder context.
+    static final int DEFAULT_CLIENT_MAX_INBOUND_MESSAGE_SIZE =
+            new GrpcClientCallConfig.Builder().build().maxInboundMessageSize();
+    static final int DEFAULT_SERVER_MAX_INBOUND_MESSAGE_SIZE =
+            new GrpcServiceConfig.Builder().executionContext(PlaceholderGrpcExecutionContext.INSTANCE).build()
+                    .maxInboundMessageSize();
 
     private GrpcMessageSizeUtils() {
         // No instances.
@@ -49,5 +64,37 @@ final class GrpcMessageSizeUtils {
     static int httpAggregationLimitFor(final int maxInboundMessageSize) {
         return maxInboundMessageSize <= 0 ? 0 :
                 addWithOverflowProtection(maxInboundMessageSize, GRPC_FRAME_HEADER_BYTES);
+    }
+
+    /**
+     * A placeholder {@link GrpcExecutionContext} used only to build a default {@link GrpcServiceConfig} and read its
+     * (context-independent) {@code maxInboundMessageSize}; its accessors are never invoked.
+     */
+    private static final class PlaceholderGrpcExecutionContext implements GrpcExecutionContext {
+        static final GrpcExecutionContext INSTANCE = new PlaceholderGrpcExecutionContext();
+
+        @Override
+        public BufferAllocator bufferAllocator() {
+            throw notUsed();
+        }
+
+        @Override
+        public IoExecutor ioExecutor() {
+            throw notUsed();
+        }
+
+        @Override
+        public Executor executor() {
+            throw notUsed();
+        }
+
+        @Override
+        public GrpcExecutionStrategy executionStrategy() {
+            throw notUsed();
+        }
+
+        private static UnsupportedOperationException notUsed() {
+            return new UnsupportedOperationException("Placeholder: accessors must never be invoked");
+        }
     }
 }

--- a/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcMessageSizeUtils.java
+++ b/servicetalk-grpc-netty/src/main/java/io/servicetalk/grpc/netty/GrpcMessageSizeUtils.java
@@ -15,40 +15,21 @@
  */
 package io.servicetalk.grpc.netty;
 
-import io.servicetalk.grpc.api.GrpcClientCallConfig;
-
 import static io.servicetalk.concurrent.internal.FlowControlUtils.addWithOverflowProtection;
-import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 
 /**
- * Validates the {@code maxInboundMessageSize} configured on the gRPC client/server builders and coordinates it with the
- * underlying HTTP transport. The builder API accepts {@code 0} (disables) or a positive value (enforces); the default
- * (including the temporary-system-property override and its warn-only {@code -1} selector) is resolved by
- * {@code servicetalk-grpc-api} and read back through {@link #DEFAULT_MAX_INBOUND_MESSAGE_SIZE}, so the property is
- * parsed in exactly one place.
+ * Coordinates the {@code maxInboundMessageSize} configured on the gRPC client/server builders with the underlying HTTP
+ * transport. The builder API accepts {@code 0} (disables), a positive value (enforces), or a negative value (warns at
+ * its magnitude). The HTTP aggregation backstop below is applied only for an explicitly configured enforcing value; an
+ * unset or warn-only limit leaves it disabled, and a property-derived default is still enforced by the gRPC deframer.
  */
 final class GrpcMessageSizeUtils {
 
     // A unary gRPC message is a single frame: a 5-byte header (1 compression flag + 4-byte length) plus the message.
     static final int GRPC_FRAME_HEADER_BYTES = 5;
-    // The default maxInboundMessageSize a builder applies when the user sets none. Read from a default-built config so
-    // the temporary system property is resolved solely in servicetalk-grpc-api (GrpcConfig). May be -1 (warn-only).
-    static final int DEFAULT_MAX_INBOUND_MESSAGE_SIZE =
-            new GrpcClientCallConfig.Builder().build().maxInboundMessageSize();
 
     private GrpcMessageSizeUtils() {
         // No instances.
-    }
-
-    /**
-     * Validate a user-supplied {@code maxInboundMessageSize} for a builder. The builder API does not expose the
-     * warn-only selector ({@code -1}); that is reachable only via the default system property.
-     *
-     * @param maxInboundMessageSize the configured value
-     * @return the validated value
-     */
-    static int validateMaxInboundMessageSize(final int maxInboundMessageSize) {
-        return ensureNonNegative(maxInboundMessageSize, "maxInboundMessageSize");
     }
 
     /**
@@ -57,12 +38,12 @@ final class GrpcMessageSizeUtils {
      * incrementally and are unaffected by the HTTP aggregation bound.
      * <p>
      * Only enforced when the gRPC limit is enforcing ({@code maxInboundMessageSize > 0}); for disabled ({@code 0}) or
-     * warn-only ({@code -1}) the HTTP aggregation bound is left disabled ({@code 0}) so those modes don't turn into a
+     * warn-only ({@code < 0}) the HTTP aggregation bound is left disabled ({@code 0}) so those modes don't turn into a
      * hard reject at the HTTP layer. A single-frame unary body is the {@link #GRPC_FRAME_HEADER_BYTES 5-byte frame
      * header} plus the message, so the header is added on top of the message-size limit (saturating at
      * {@link Integer#MAX_VALUE}) to let a maximum-size message through.
      *
-     * @param maxInboundMessageSize the configured maximum inbound message size ({@code 0}/{@code -1}/{@code > 0})
+     * @param maxInboundMessageSize the configured maximum inbound message size ({@code 0}/{@code < 0}/{@code > 0})
      * @return the HTTP {@code maxAggregatedPayloadSize} to apply, or {@code 0} to leave it disabled
      */
     static int httpAggregationLimitFor(final int maxInboundMessageSize) {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcInputValidationTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcInputValidationTest.java
@@ -50,29 +50,12 @@ class GrpcInputValidationTest {
     }
 
     @Test
-    void clientBuilderRejectsNegativeMaxInboundMessageSize() {
-        // Warn-only (-1) is property-only; the builder API rejects all negatives.
-        assertThrows(IllegalArgumentException.class,
-                () -> GrpcClients.forAddress("localhost", 0).maxInboundMessageSize(-1));
-        assertThrows(IllegalArgumentException.class,
-                () -> GrpcClients.forAddress("localhost", 0).maxInboundMessageSize(-2));
-    }
-
-    @Test
-    void serverBuilderRejectsNegativeMaxInboundMessageSize() {
-        assertThrows(IllegalArgumentException.class,
-                () -> GrpcServers.forAddress(localAddress(0)).maxInboundMessageSize(-1));
-        assertThrows(IllegalArgumentException.class,
-                () -> GrpcServers.forAddress(localAddress(0)).maxInboundMessageSize(-2));
-    }
-
-    @Test
     void buildersAcceptValidMaxInboundMessageSize() {
-        // 0 (disabled) and a positive value are both valid and must not throw.
+        // The sign selects the mode: 0 disables, positive enforces, negative warns at its magnitude. None throw.
         GrpcClients.forAddress("localhost", 0)
-                .maxInboundMessageSize(0).maxInboundMessageSize(4 * 1024 * 1024);
+                .maxInboundMessageSize(0).maxInboundMessageSize(4 * 1024 * 1024).maxInboundMessageSize(-1);
         GrpcServers.forAddress(localAddress(0))
-                .maxInboundMessageSize(0).maxInboundMessageSize(4 * 1024 * 1024);
+                .maxInboundMessageSize(0).maxInboundMessageSize(4 * 1024 * 1024).maxInboundMessageSize(-1);
     }
 
     private static void assertEarlyRequireNonNull(final Executable executable) {

--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLargeMessageTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcLargeMessageTest.java
@@ -49,8 +49,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GrpcLargeMessageTest {
 
-    // Larger than both the HTTP-level default aggregated payload limit and the gRPC default inbound message limit
-    // (both 4 MiB). Used with the gRPC limit disabled to prove neither default silently caps gRPC payloads.
+    // A multi-MiB payload used with the gRPC limit disabled to prove a large message round-trips end to end and is
+    // not silently capped by the coordinated HTTP aggregation bound. The built-in defaults are warn-only (per-role),
+    // so they would not reject regardless; disabling additionally turns off the HTTP aggregation backstop.
     private static final int PAYLOAD_SIZE = 8 * 1024 * 1024;
     // A small inbound limit and a message comfortably above it, for the enforcement tests.
     private static final int SMALL_LIMIT = 1024;
@@ -108,6 +109,33 @@ class GrpcLargeMessageTest {
             GrpcStatusException e = assertThrows(GrpcStatusException.class, () ->
                     client.sayHello(HelloRequest.newBuilder().setName(repeat(ABOVE_SMALL_LIMIT)).build()));
             assertThat(e.status().code(), equalTo(RESOURCE_EXHAUSTED));
+        }
+    }
+
+    @Test
+    void serverWarnsButServesRequestExceedingNegativeMaxInboundMessageSize() throws Exception {
+        // A negative value selects warn-only mode at abs(value): an oversized request is logged but still served.
+        final String large = repeat(ABOVE_SMALL_LIMIT);
+        try (GrpcServerContext server = forAddress(localAddress(0))
+                     .maxInboundMessageSize(-SMALL_LIMIT)
+                     .listenAndAwait(echoService());
+             BlockingGreeterClient client = forAddress(serverHostAndPort(server))
+                     .buildBlocking(new ClientFactory())) {
+            HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName(large).build());
+            assertThat(reply.getMessage(), equalTo(large));
+        }
+    }
+
+    @Test
+    void clientWarnsButDeliversResponseExceedingNegativeMaxInboundMessageSize() throws Exception {
+        // A negative value selects warn-only mode at abs(value): an oversized response is logged but still delivered.
+        final String large = repeat(ABOVE_SMALL_LIMIT);
+        try (GrpcServerContext server = forAddress(localAddress(0)).listenAndAwait(echoService());
+             BlockingGreeterClient client = forAddress(serverHostAndPort(server))
+                     .maxInboundMessageSize(-SMALL_LIMIT)
+                     .buildBlocking(new ClientFactory())) {
+            HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName(large).build());
+            assertThat(reply.getMessage(), equalTo(large));
         }
     }
 

--- a/servicetalk-http-api/docs/modules/ROOT/pages/programming-paradigms.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/programming-paradigms.adoc
@@ -16,23 +16,19 @@ programming paradigms.
 ====
 Whenever a payload body is *aggregated* into a single object (the aggregated paradigms below, or any filter that
 calls `toRequest()`/`toResponse()`), the whole body is buffered in memory. To guard against excessive memory
-consumption, ServiceTalk caps the size of an aggregated body at *4 MiB* by default. Requests that exceed the server's limit are
-rejected with a `413 Payload Too Large`; oversized responses surface a `PayloadTooLargeException` to the client.
+consumption, ServiceTalk limits the size of an aggregated body. The limit is measured against the fully decoded
+payload buffered at the point of aggregation -- that is, _after_ any decompression or body transformation applied
+by filters earlier in the pipeline -- not the bytes received from the network nor any declared `Content-Length`. A
+small compressed body that expands beyond the limit once decoded is therefore still subject to it. Bodies consumed
+purely as a stream are not affected.
 
-The limit is measured against the fully decoded payload buffered at the point of aggregation -- that is, _after_ any
-decompression or body transformation applied by filters earlier in the pipeline -- not the bytes received from the
-network nor any declared `Content-Length`. A small compressed body that expands beyond the limit once decoded is
-therefore rejected.
-
-Adjust or disable this via `HttpServerBuilder#maxAggregatedPayloadSize(int)` /
-`SingleAddressHttpClientBuilder#maxAggregatedPayloadSize(int)` (pass `0` to disable). A programmatically configured
-limit is definitive: it is always enforced and never runs in warn-only mode. Users who unexpectedly hit the
-default limit can temporarily change it globally with the
-`io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize` system property, which -- unlike the builder
-methods -- also accepts `-1` for *warn-only* mode, where oversized aggregated messages are still served/delivered
-but a warning is logged (rate-limited to once every five minutes per client/server) so you can evaluate the limit
-before enforcing it. An explicit builder call takes precedence over the property. This is a temporary
-property that will be removed in future releases. Bodies consumed purely as a stream are not affected.
+Configure this per client/server via `HttpServerBuilder#maxAggregatedPayloadSize(int)` /
+`SingleAddressHttpClientBuilder#maxAggregatedPayloadSize(int)`, where the sign selects the mode and the magnitude
+selects the threshold: a *positive* value enforces the limit (the server responds `413 Payload Too Large`; the
+client raises a `PayloadTooLargeException`), a *negative* value enables *warn-only* mode at its magnitude (oversized
+aggregated messages are still served/delivered, but a warning is logged, rate-limited to once every five minutes
+per client/server), and `0` disables the limit. By default the client warns at 64 MiB and the server warns at
+16 MiB; enforcing is planned to become the default for servers in a future release.
 ====
 
 [#service-programming-paradigms]

--- a/servicetalk-http-api/docs/modules/ROOT/pages/programming-paradigms.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/programming-paradigms.adoc
@@ -29,6 +29,11 @@ client raises a `PayloadTooLargeException`), a *negative* value enables *warn-on
 aggregated messages are still served/delivered, but a warning is logged, rate-limited to once every five minutes
 per client/server), and `0` disables the limit. By default the client warns at 64 MiB and the server warns at
 16 MiB; enforcing is planned to become the default for servers in a future release.
+
+The built-in defaults can be overridden globally with the
+`io.servicetalk.http.netty.defaultClientMaxAggregatedPayloadSize` and
+`io.servicetalk.http.netty.defaultServerMaxAggregatedPayloadSize` system properties (same sign convention); a
+per-builder call takes precedence.
 ====
 
 [#service-programming-paradigms]

--- a/servicetalk-http-api/docs/modules/ROOT/pages/programming-paradigms.adoc
+++ b/servicetalk-http-api/docs/modules/ROOT/pages/programming-paradigms.adoc
@@ -26,8 +26,8 @@ Configure this per client/server via `HttpServerBuilder#maxAggregatedPayloadSize
 `SingleAddressHttpClientBuilder#maxAggregatedPayloadSize(int)`, where the sign selects the mode and the magnitude
 selects the threshold: a *positive* value enforces the limit (the server responds `413 Payload Too Large`; the
 client raises a `PayloadTooLargeException`), a *negative* value enables *warn-only* mode at its magnitude (oversized
-aggregated messages are still served/delivered, but a warning is logged, rate-limited to once every five minutes
-per client/server), and `0` disables the limit. By default the client warns at 64 MiB and the server warns at
+aggregated messages are still served/delivered, but a warning is logged, rate-limited per client/server),
+and `0` disables the limit. By default the client warns at 64 MiB and the server warns at
 16 MiB; enforcing is planned to become the default for servers in a future release.
 
 The built-in defaults can be overridden globally with the

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -217,20 +217,24 @@ public interface HttpServerBuilder {
      * <p>
      * The limit applies only when a request is <strong>aggregated</strong> (an {@link HttpRequest aggregated
      * programming paradigm} or a filter calling {@link StreamingHttpRequest#toRequest()}); requests consumed as a
-     * {@link StreamingHttpRequest#payloadBody() stream} are not affected. Exceeding it raises a
-     * {@link PayloadTooLargeException}, which the default exception mapping turns into a
-     * {@link HttpResponseStatus#PAYLOAD_TOO_LARGE 413 Payload Too Large} response. The limit is measured against the
-     * fully decoded payload at the point of aggregation &mdash; <em>after</em> any decompression or body transformation
-     * by earlier filters &mdash; not the bytes received from the network nor any declared {@code Content-Length}.
+     * {@link StreamingHttpRequest#payloadBody() stream} are not affected. The limit is measured against the fully
+     * decoded payload at the point of aggregation &mdash; <em>after</em> any decompression or body transformation by
+     * earlier filters &mdash; not the bytes received from the network nor any declared {@code Content-Length}.
      * <p>
-     * The default is 4 MiB, overridable globally via the temporary
-     * {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system property, which also accepts
-     * {@code -1} for warn-only mode (oversized requests are served but logged); an explicit call here always takes
-     * precedence and is enforced. For an opt-in limit that fails fast on {@code Content-Length}, see
-     * {@code PayloadSizeLimitingHttpServiceFilter}; both apply.
+     * The sign of the argument selects the mode and the magnitude selects the threshold:
+     * <ul>
+     *     <li>a <strong>positive</strong> value enforces the limit, raising a {@link PayloadTooLargeException} that the
+     *     default exception mapping turns into a {@link HttpResponseStatus#PAYLOAD_TOO_LARGE 413 Payload Too Large}
+     *     response;</li>
+     *     <li>a <strong>negative</strong> value enables warn-only mode at {@code abs(value)} bytes: oversized requests
+     *     are still served, but a rate-limited warning is logged;</li>
+     *     <li>{@code 0} disables the limit entirely.</li>
+     * </ul>
+     * The default is warn-only at 16 MiB; enforcing is planned to become the default in a future release. For an opt-in
+     * limit that fails fast on {@code Content-Length}, see {@code PayloadSizeLimitingHttpServiceFilter}; both apply.
      *
      * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a request is aggregated;
-     * {@code 0} disables the limit. Must be non-negative.
+     * positive enforces at that size, negative warns at its magnitude, {@code 0} disables the limit
      * @return {@code this}
      */
     // FIXME: 0.43 - consider removing default impl

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpServerBuilder.java
@@ -213,28 +213,26 @@ public interface HttpServerBuilder {
     HttpServerBuilder allowDropRequestTrailers(boolean allowDrop);
 
     /**
-     * Sets the maximum size, in bytes, of an aggregated request payload body that this server will buffer in memory.
+     * Sets the maximum size, in bytes, of an aggregated request payload body this server buffers in memory.
      * <p>
-     * The limit applies only when a request is <strong>aggregated</strong> (an {@link HttpRequest aggregated
-     * programming paradigm} or a filter calling {@link StreamingHttpRequest#toRequest()}); requests consumed as a
-     * {@link StreamingHttpRequest#payloadBody() stream} are not affected. The limit is measured against the fully
-     * decoded payload at the point of aggregation &mdash; <em>after</em> any decompression or body transformation by
-     * earlier filters &mdash; not the bytes received from the network nor any declared {@code Content-Length}.
+     * Applies only when a request is <strong>aggregated</strong> (an {@link HttpRequest aggregated paradigm} or a
+     * filter calling {@link StreamingHttpRequest#toRequest()}); {@link StreamingHttpRequest#payloadBody() streamed}
+     * requests are unaffected. Measured against the fully decoded payload at aggregation &mdash; after any
+     * decompression or transformation by earlier filters &mdash; not the wire bytes or {@code Content-Length}.
      * <p>
-     * The sign of the argument selects the mode and the magnitude selects the threshold:
+     * The sign selects the mode, the magnitude the threshold:
      * <ul>
-     *     <li>a <strong>positive</strong> value enforces the limit, raising a {@link PayloadTooLargeException} that the
-     *     default exception mapping turns into a {@link HttpResponseStatus#PAYLOAD_TOO_LARGE 413 Payload Too Large}
-     *     response;</li>
-     *     <li>a <strong>negative</strong> value enables warn-only mode at {@code abs(value)} bytes: oversized requests
-     *     are still served, but a rate-limited warning is logged;</li>
-     *     <li>{@code 0} disables the limit entirely.</li>
+     *     <li><strong>positive</strong> enforces, raising a {@link PayloadTooLargeException} that the default exception
+     *     mapping turns into a {@link HttpResponseStatus#PAYLOAD_TOO_LARGE 413 Payload Too Large};</li>
+     *     <li><strong>negative</strong> warns at {@code abs(value)} bytes: oversized requests are still served, with a
+     *     rate-limited warning;</li>
+     *     <li>{@code 0} disables it.</li>
      * </ul>
-     * The default is warn-only at 16 MiB; enforcing is planned to become the default in a future release. For an opt-in
-     * limit that fails fast on {@code Content-Length}, see {@code PayloadSizeLimitingHttpServiceFilter}; both apply.
+     * Defaults to warn-only at 16 MiB; enforcing is planned to become the default in a future release. See also
+     * {@code PayloadSizeLimitingHttpServiceFilter} for a {@code Content-Length} fail-fast; both apply.
      *
-     * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a request is aggregated;
-     * positive enforces at that size, negative warns at its magnitude, {@code 0} disables the limit
+     * @param maxAggregatedPayloadSize bytes to buffer when a request is aggregated; positive enforces, negative warns
+     * at its magnitude, {@code 0} disables
      * @return {@code this}
      */
     // FIXME: 0.43 - consider removing default impl

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -163,27 +163,25 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
     SingleAddressHttpClientBuilder<U, R> allowDropResponseTrailers(boolean allowDrop);
 
     /**
-     * Sets the maximum size, in bytes, of an aggregated response payload body that this client will buffer in memory.
+     * Sets the maximum size, in bytes, of an aggregated response payload body this client buffers in memory.
      * <p>
-     * The limit applies only when a response is <strong>aggregated</strong> (an {@link HttpResponse aggregated
-     * programming paradigm} or a filter calling {@link StreamingHttpResponse#toResponse()}); responses consumed as a
-     * {@link StreamingHttpResponse#payloadBody() stream} are not affected. The limit is measured against the fully
-     * decoded payload at the point of aggregation &mdash; <em>after</em> any decompression or body transformation by
-     * earlier filters &mdash; not the bytes received from the network nor any declared {@code Content-Length}.
+     * Applies only when a response is <strong>aggregated</strong> (an {@link HttpResponse aggregated paradigm} or a
+     * filter calling {@link StreamingHttpResponse#toResponse()}); {@link StreamingHttpResponse#payloadBody() streamed}
+     * responses are unaffected. Measured against the fully decoded payload at aggregation &mdash; after any
+     * decompression or transformation by earlier filters &mdash; not the wire bytes or {@code Content-Length}.
      * <p>
-     * The sign of the argument selects the mode and the magnitude selects the threshold:
+     * The sign selects the mode, the magnitude the threshold:
      * <ul>
-     *     <li>a <strong>positive</strong> value enforces the limit, raising a {@link PayloadTooLargeException} to the
-     *     caller when an aggregated response exceeds it;</li>
-     *     <li>a <strong>negative</strong> value enables warn-only mode at {@code abs(value)} bytes: oversized responses
-     *     are still delivered, but a rate-limited warning suggesting the streaming APIs is logged;</li>
-     *     <li>{@code 0} disables the limit entirely.</li>
+     *     <li><strong>positive</strong> enforces, raising a {@link PayloadTooLargeException} to the caller;</li>
+     *     <li><strong>negative</strong> warns at {@code abs(value)} bytes: oversized responses are still delivered,
+     *     with a rate-limited warning suggesting the streaming APIs;</li>
+     *     <li>{@code 0} disables it.</li>
      * </ul>
-     * The default is warn-only at 64 MiB. For an opt-in limit that fails fast on {@code Content-Length}, see
-     * {@code PayloadSizeLimitingHttpRequesterFilter}; both apply.
+     * Defaults to warn-only at 64 MiB. See also {@code PayloadSizeLimitingHttpRequesterFilter} for a
+     * {@code Content-Length} fail-fast; both apply.
      *
-     * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a response is aggregated;
-     * positive enforces at that size, negative warns at its magnitude, {@code 0} disables the limit
+     * @param maxAggregatedPayloadSize bytes to buffer when a response is aggregated; positive enforces, negative warns
+     * at its magnitude, {@code 0} disables
      * @return {@code this}
      */
     // FIXME: 0.43 - consider removing default impl

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/SingleAddressHttpClientBuilder.java
@@ -167,19 +167,23 @@ public interface SingleAddressHttpClientBuilder<U, R> extends HttpClientBuilder<
      * <p>
      * The limit applies only when a response is <strong>aggregated</strong> (an {@link HttpResponse aggregated
      * programming paradigm} or a filter calling {@link StreamingHttpResponse#toResponse()}); responses consumed as a
-     * {@link StreamingHttpResponse#payloadBody() stream} are not affected. Exceeding it raises a
-     * {@link PayloadTooLargeException} to the caller. The limit is measured against the fully decoded payload at the
-     * point of aggregation &mdash; <em>after</em> any decompression or body transformation by earlier filters &mdash;
-     * not the bytes received from the network nor any declared {@code Content-Length}.
+     * {@link StreamingHttpResponse#payloadBody() stream} are not affected. The limit is measured against the fully
+     * decoded payload at the point of aggregation &mdash; <em>after</em> any decompression or body transformation by
+     * earlier filters &mdash; not the bytes received from the network nor any declared {@code Content-Length}.
      * <p>
-     * The default is 4 MiB, overridable globally via the temporary
-     * {@code io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize} system property, which also accepts
-     * {@code -1} for warn-only mode (oversized responses are delivered but logged); an explicit call here always takes
-     * precedence and is enforced. For an opt-in limit that fails fast on {@code Content-Length}, see
+     * The sign of the argument selects the mode and the magnitude selects the threshold:
+     * <ul>
+     *     <li>a <strong>positive</strong> value enforces the limit, raising a {@link PayloadTooLargeException} to the
+     *     caller when an aggregated response exceeds it;</li>
+     *     <li>a <strong>negative</strong> value enables warn-only mode at {@code abs(value)} bytes: oversized responses
+     *     are still delivered, but a rate-limited warning suggesting the streaming APIs is logged;</li>
+     *     <li>{@code 0} disables the limit entirely.</li>
+     * </ul>
+     * The default is warn-only at 64 MiB. For an opt-in limit that fails fast on {@code Content-Length}, see
      * {@code PayloadSizeLimitingHttpRequesterFilter}; both apply.
      *
      * @param maxAggregatedPayloadSize the maximum number of payload bytes to buffer when a response is aggregated;
-     * {@code 0} disables the limit. Must be non-negative.
+     * positive enforces at that size, negative warns at its magnitude, {@code 0} disables the limit
      * @return {@code this}
      */
     // FIXME: 0.43 - consider removing default impl

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
@@ -16,6 +16,7 @@
 package io.servicetalk.http.netty;
 
 import io.servicetalk.http.api.PayloadTooLargeException;
+import io.servicetalk.http.netty.HttpConfig.Role;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.http.netty.HttpConfig.Role.CLIENT;
 import static java.lang.System.nanoTime;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -56,18 +58,24 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
     // Identifies the owning client/server in the warning; null when not warn-only.
     @Nullable
     private final Object owner;
+    // The role (client/server) whose warning wording to emit; null when not warn-only.
+    @Nullable
+    private final Role role;
     @Nullable
     private final Throwable constructionSite;
 
-    private AggregatedPayloadSizeLimiter(final int maxAggregatedSize, final boolean warnOnly,
+    private AggregatedPayloadSizeLimiter(final int maxAggregatedSize, @Nullable final Role role,
                                          @Nullable final Object owner) {
         this.maxAggregatedSize = maxAggregatedSize;
+        final boolean warnOnly = role != null;
         // Seed in the past so the first time the limit is exceeded a warning is emitted immediately.
         this.lastWarnNanos = warnOnly ? new AtomicLong(nanoTime() - WARN_INTERVAL_NANOS) : null;
         this.maxObservedSize = warnOnly ? new AtomicLong() : null;
         this.owner = warnOnly ? owner : null;
+        this.role = role;
         this.constructionSite = warnOnly ? new Throwable(
-                "Client/server with a warn-only maxAggregatedPayloadSize created here (not an error)") : null;
+                "This " + role.description + " with a warn-only maxAggregatedPayloadSize created here (not an error)")
+                : null;
     }
 
     /**
@@ -78,7 +86,7 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
      * @return a limiter, or {@link #NONE} when {@code maxAggregatedSize <= 0}
      */
     static LongConsumer enforcing(final int maxAggregatedSize) {
-        return maxAggregatedSize <= 0 ? NONE : new AggregatedPayloadSizeLimiter(maxAggregatedSize, false, null);
+        return maxAggregatedSize <= 0 ? NONE : new AggregatedPayloadSizeLimiter(maxAggregatedSize, null, null);
     }
 
     /**
@@ -87,11 +95,12 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
      * per client/server).
      *
      * @param maxAggregatedSize the size in bytes above which a warning is emitted; {@code 0} or negative disables it
+     * @param role selects the warning wording (client vs. server)
      * @param owner identifies the owning client/server in the warning (e.g. its target/bind address)
      * @return a limiter, or {@link #NONE} when {@code maxAggregatedSize <= 0}
      */
-    static LongConsumer warning(final int maxAggregatedSize, @Nullable final Object owner) {
-        return maxAggregatedSize <= 0 ? NONE : new AggregatedPayloadSizeLimiter(maxAggregatedSize, true, owner);
+    static LongConsumer warning(final int maxAggregatedSize, final Role role, @Nullable final Object owner) {
+        return maxAggregatedSize <= 0 ? NONE : new AggregatedPayloadSizeLimiter(maxAggregatedSize, role, owner);
     }
 
     /**
@@ -117,15 +126,27 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
         assert lastWarnNanos != null;
         assert maxObservedSize != null;
         assert constructionSite != null;
+        assert role != null;
         final long maxObserved = maxObservedSize.accumulateAndGet(totalSize, Math::max);
         final long now = nanoTime();
         final long last = lastWarnNanos.get();
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
-            LOGGER.warn("Aggregated payload size={} exceeded the configured maximum of {} bytes for {}, but the " +
-                    "limit is configured in warn-only mode so the payload is allowed through. Largest payload " +
-                    "observed so far is {} bytes. Configure an enforcing maxAggregatedPayloadSize(int) to reject " +
-                    "oversized payloads. This warning is rate-limited to once per 5 minutes per client/server.",
-                    totalSize, maxAggregatedSize, owner, maxObserved, constructionSite);
+            if (role == CLIENT) {
+                LOGGER.warn("Aggregated payload size={} exceeded {} bytes for {}. This client is receiving very " +
+                        "large message bodies; consider using the streaming APIs instead to prevent memory pressure " +
+                        "issues. Largest payload observed so far is {} bytes. This warning is rate-limited to once " +
+                        "per 5 minutes per client.",
+                        totalSize, maxAggregatedSize, owner, maxObserved, constructionSite);
+            } else {
+                LOGGER.warn("Aggregated payload size={} exceeded the configured maximum of {} bytes for {}, but the " +
+                        "limit is configured in warn-only mode so the payload is allowed through. This server is " +
+                        "receiving very large message bodies; consider using the streaming APIs instead to prevent " +
+                        "memory pressure issues. Largest payload observed so far is {} bytes. Configure an enforcing " +
+                        "maxAggregatedPayloadSize(int) to reject oversized payloads; enforcing is planned to become " +
+                        "the default in a future release. This warning is rate-limited to once per 5 minutes per " +
+                        "server.",
+                        totalSize, maxAggregatedSize, owner, maxObserved, constructionSite);
+            }
         }
     }
 }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
@@ -132,19 +132,15 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
         final long last = lastWarnNanos.get();
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
             if (role == CLIENT) {
-                LOGGER.warn("Aggregated payload size={} exceeded {} bytes for {}. This client is receiving very " +
-                        "large message bodies; consider using the streaming APIs instead to prevent memory pressure " +
-                        "issues. Largest payload observed so far is {} bytes. This warning is rate-limited to once " +
-                        "per 5 minutes per client.",
+                LOGGER.warn("Aggregated payload size={} exceeded {} bytes for {} (largest observed {} bytes). This " +
+                        "client is buffering very large message bodies; consider the streaming APIs to avoid memory " +
+                        "pressure. Warn-only mode, rate-limited to once per 5 minutes per client.",
                         totalSize, maxAggregatedSize, owner, maxObserved, constructionSite);
             } else {
-                LOGGER.warn("Aggregated payload size={} exceeded the configured maximum of {} bytes for {}, but the " +
-                        "limit is configured in warn-only mode so the payload is allowed through. This server is " +
-                        "receiving very large message bodies; consider using the streaming APIs instead to prevent " +
-                        "memory pressure issues. Largest payload observed so far is {} bytes. Configure an enforcing " +
-                        "maxAggregatedPayloadSize(int) to reject oversized payloads; enforcing is planned to become " +
-                        "the default in a future release. This warning is rate-limited to once per 5 minutes per " +
-                        "server.",
+                LOGGER.warn("Aggregated payload size={} exceeded the configured {} bytes for {} (largest observed " +
+                        "{} bytes), allowed through in warn-only mode. Consider the streaming APIs to avoid memory " +
+                        "pressure, or set an enforcing maxAggregatedPayloadSize(int) to reject oversized payloads " +
+                        "(planned to become the default). Rate-limited to once per 5 minutes per server.",
                         totalSize, maxAggregatedSize, owner, maxObserved, constructionSite);
             }
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiter.java
@@ -134,13 +134,14 @@ final class AggregatedPayloadSizeLimiter implements LongConsumer {
             if (role == CLIENT) {
                 LOGGER.warn("Aggregated payload size={} exceeded {} bytes for {} (largest observed {} bytes). This " +
                         "client is buffering very large message bodies; consider the streaming APIs to avoid memory " +
-                        "pressure. Warn-only mode, rate-limited to once per 5 minutes per client.",
+                        "pressure, or set an enforcing maxAggregatedPayloadSize(int) to reject oversized responses. " +
+                        "Warn-only mode, rate-limited per client.",
                         totalSize, maxAggregatedSize, owner, maxObserved, constructionSite);
             } else {
                 LOGGER.warn("Aggregated payload size={} exceeded the configured {} bytes for {} (largest observed " +
                         "{} bytes), allowed through in warn-only mode. Consider the streaming APIs to avoid memory " +
                         "pressure, or set an enforcing maxAggregatedPayloadSize(int) to reject oversized payloads " +
-                        "(planned to become the default). Rate-limited to once per 5 minutes per server.",
+                        "(planned to become the default). Rate-limited per server.",
                         totalSize, maxAggregatedSize, owner, maxObserved, constructionSite);
             }
         }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpClientConfig.java
@@ -62,7 +62,7 @@ final class HttpClientConfig {
                 throw new IllegalArgumentException("Server Push is not supported by the client, " +
                         "expected MAX_CONCURRENT_STREAMS value is null or 0, settings=" + settings);
             }
-        });
+        }, HttpConfig.Role.CLIENT);
     }
 
     HttpClientConfig(final HttpClientConfig from) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -26,8 +26,6 @@ import java.util.function.LongConsumer;
 import javax.annotation.Nullable;
 
 import static io.servicetalk.http.netty.HttpProtocolConfigs.h1Default;
-import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
-import static java.lang.Integer.getInteger;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -37,60 +35,67 @@ import static java.util.Objects.requireNonNull;
 final class HttpConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpConfig.class);
 
-    static final int DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE = 4 * 1024 * 1024;
-    // Magic value accepted by the temporaryDefaultMaxAggregatedPayloadSize system property (but not by the
-    // maxAggregatedPayloadSize(int) builder API), and the built-in default: warn (rate-limited) when the
-    // DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE threshold is exceeded rather than rejecting. Eases rollout of a
-    // global limit; a value set programmatically via the builder is always definitive.
-    static final int WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE = -1;
-    // FIXME: 0.43 - remove this temporary property
+    static final int DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE = 64 * 1024 * 1024;
+    static final int DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE = 16 * 1024 * 1024;
+    // FIXME: 0.43 - remove these temporary properties
+    static final String DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY =
+            "io.servicetalk.http.netty.temporaryDefaultClientMaxAggregatedPayloadSize";
+    static final String DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY =
+            "io.servicetalk.http.netty.temporaryDefaultServerMaxAggregatedPayloadSize";
+    // Deprecated in favor of the client/server-specific properties above; kept for a release or two in case a
+    // deployment already relies on it. A role-specific property, when set, takes precedence over this legacy one.
     static final String DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY =
             "io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize";
-    static final int DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE;
+    // When set, override the built-in per-role default using the same sign convention as the builder API (see
+    // maxAggregatedPayloadSize(int)). Null when neither the role-specific nor the legacy property is set.
+    @Nullable
+    static final Integer DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_OVERRIDE;
+    @Nullable
+    static final Integer DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_OVERRIDE;
 
     static {
-        // Warn-only by default unless the temporary property overrides it. The property additionally accepts the
-        // warn-only magic value; only values below it are invalid. Don't throw from this static initializer; fall
-        // back to warn-only instead.
-        final int value = getInteger(DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY,
-                WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE);
-        if (value < WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE) {
-            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is invalid (expected >= {}). Falling back to " +
-                            "warn-only mode at {} bytes.",
-                    DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, value, WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE,
-                    DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE);
-            DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE = WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE;
-        } else {
-            DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE = value;
-            // getInteger can't distinguish "unset" (the warn-only default) from an explicit value; only warn about
-            // the temporary property when it is actually set.
-            if (System.getProperty(DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY) != null) {
-                if (value == WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE) {
-                    LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: Setting this property to -1 (warn-only mode) may " +
-                                    "be used temporarily to unblock deployment but exposes the service to the risk " +
-                                    "of aggregating unbounded amount of data on the heap. Configure appropriate " +
-                                    "value per client/server builder via maxAggregatedPayloadSize(int) instead.",
-                            DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, value);
-                } else {
-                    LOGGER.warn("-D{}={} This property will be removed in the future releases. Configure this value " +
-                                    "per client/server builder via maxAggregatedPayloadSize(int) instead.",
-                            DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, value);
-                }
-            }
+        final Integer legacy = parseTemporaryProperty(DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, true);
+        final Integer client = parseTemporaryProperty(DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, false);
+        final Integer server = parseTemporaryProperty(DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, false);
+        DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_OVERRIDE = client != null ? client : legacy;
+        DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_OVERRIDE = server != null ? server : legacy;
+    }
+
+    /**
+     * Whether a config belongs to a client or a server. Selects the built-in default aggregation limit and the wording
+     * of the warn-only log message.
+     */
+    enum Role {
+        CLIENT(DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, "client"),
+        SERVER(DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, "server");
+
+        // Negative => warn-only (rate-limited) at this magnitude by default rather than rejecting; a value set
+        // programmatically via the builder is always definitive.
+        final int defaultMaxAggregatedPayloadSize;
+        final String description;
+
+        Role(final int defaultWarnSize, final String description) {
+            this.defaultMaxAggregatedPayloadSize = -defaultWarnSize;
+            this.description = description;
         }
     }
 
     private final Consumer<H2ProtocolConfig> h2ConfigValidator;
+    private final Role role;
     @Nullable
     private H1ProtocolConfig h1Config;
     @Nullable
     private H2ProtocolConfig h2Config;
     private List<String> supportedAlpnProtocols;
     private boolean allowDropTrailers;
-    private int maxAggregatedPayloadSize = DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE;
+    private int maxAggregatedPayloadSize;
 
-    HttpConfig(final Consumer<H2ProtocolConfig> h2ConfigValidator) {
+    HttpConfig(final Consumer<H2ProtocolConfig> h2ConfigValidator, final Role role) {
         this.h2ConfigValidator = requireNonNull(h2ConfigValidator);
+        this.role = role;
+        final Integer override = role == Role.CLIENT ? DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_OVERRIDE :
+                DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_OVERRIDE;
+        this.maxAggregatedPayloadSize = override != null ? override : role.defaultMaxAggregatedPayloadSize;
         h1Config = h1Default();
         h2Config = null;
         supportedAlpnProtocols = emptyList();
@@ -98,11 +103,39 @@ final class HttpConfig {
 
     HttpConfig(final HttpConfig from) {
         this.h2ConfigValidator = from.h2ConfigValidator;
+        this.role = from.role;
         this.h1Config = from.h1Config;
         this.h2Config = from.h2Config;
         this.supportedAlpnProtocols = from.supportedAlpnProtocols;
         this.allowDropTrailers = from.allowDropTrailers;
         this.maxAggregatedPayloadSize = from.maxAggregatedPayloadSize;
+    }
+
+    // Don't throw from the static initializer; ignore an invalid value and fall back to the per-role defaults.
+    @Nullable
+    private static Integer parseTemporaryProperty(final String name, final boolean legacy) {
+        final String raw = System.getProperty(name);
+        if (raw == null) {
+            return null;
+        }
+        try {
+            final Integer value = Integer.valueOf(raw.trim());
+            if (legacy) {
+                LOGGER.warn("-D{}={} This property is deprecated in favor of -D{} and -D{} and will be removed in a " +
+                                "future release. Configure this value per client/server builder via " +
+                                "maxAggregatedPayloadSize(int) instead.", name, value,
+                        DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY,
+                        DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY);
+            } else {
+                LOGGER.warn("-D{}={} This property is temporary and will be removed in a future release. Configure " +
+                        "this value per client/server builder via maxAggregatedPayloadSize(int) instead.", name, value);
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is not a valid integer; ignoring it and using " +
+                    "the built-in per-client/server defaults.", name, raw);
+            return null;
+        }
     }
 
     @Nullable
@@ -128,7 +161,7 @@ final class HttpConfig {
     }
 
     void maxAggregatedPayloadSize(int maxAggregatedPayloadSize) {
-        this.maxAggregatedPayloadSize = ensureNonNegative(maxAggregatedPayloadSize, "maxAggregatedPayloadSize");
+        this.maxAggregatedPayloadSize = maxAggregatedPayloadSize;
     }
 
     /**
@@ -138,24 +171,23 @@ final class HttpConfig {
      * {@link ReadOnlyHttpServerConfig}) and shared across its connections.
      */
     LongConsumer newAggregatedPayloadSizeLimiter(@Nullable final Object owner) {
-        return toAggregatedPayloadSizeLimiter(maxAggregatedPayloadSize, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE, owner);
+        return toAggregatedPayloadSizeLimiter(maxAggregatedPayloadSize, role, owner);
     }
 
     /**
-     * Map a configured {@code maxAggregatedPayloadSize} to a limiter. {@code 0} disables it, {@code >0} enforces
-     * (rejects) at that size, and {@link #WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE -1} warns (without rejecting) at
-     * {@code resolvedDefault}. Because the {@code resolvedDefault} can itself be the warn-only ({@code -1}) or disabled
-     * ({@code 0}) selector when the default was set via system property, warn-only mode falls back to
-     * {@link #DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE} when {@code resolvedDefault} is not positive, so warn-only
-     * mode never silently collapses to "disabled".
+     * Map a configured {@code maxAggregatedPayloadSize} to a limiter: {@code 0} disables it, {@code >0} enforces
+     * (rejects) at that size, and {@code <0} warns (without rejecting) at {@code abs(configured)}. The sign selects the
+     * mode and the magnitude selects the threshold.
      */
-    static LongConsumer toAggregatedPayloadSizeLimiter(final int configured, final int resolvedDefault,
+    static LongConsumer toAggregatedPayloadSizeLimiter(final int configured, final Role role,
                                                        @Nullable final Object owner) {
-        if (configured == WARN_ONLY_MAX_AGGREGATED_PAYLOAD_SIZE) {
-            return AggregatedPayloadSizeLimiter.warning(
-                    resolvedDefault > 0 ? resolvedDefault : DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, owner);
+        if (configured >= 0) {
+            return AggregatedPayloadSizeLimiter.enforcing(configured);
         }
-        return AggregatedPayloadSizeLimiter.enforcing(configured);
+        // -Integer.MIN_VALUE overflows back to a negative value; clamp so it stays a warn-only limiter rather than
+        // collapsing to disabled.
+        final int warnThreshold = configured == Integer.MIN_VALUE ? Integer.MAX_VALUE : -configured;
+        return AggregatedPayloadSizeLimiter.warning(warnThreshold, role, owner);
     }
 
     void protocols(final HttpProtocolConfig... protocols) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -122,11 +122,12 @@ final class HttpConfig {
             final Integer value = Integer.valueOf(raw.trim());
             if (legacy) {
                 LOGGER.warn("-D{}={} is a deprecated legacy property, superseded by -D{} and -D{}, and will be " +
-                        "removed in a future release; set maxAggregatedPayloadSize(int) per client/server instead.",
+                        "removed in a future release; use those or set maxAggregatedPayloadSize(int) per " +
+                        "client/server instead.",
                         name, value, DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY,
                         DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY);
             } else {
-                LOGGER.info("-D{}={} overrides the built-in default maxAggregatedPayloadSize.", name, value);
+                LOGGER.debug("-D{}={}", name, value);
             }
             return value;
         } catch (NumberFormatException e) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -121,19 +121,18 @@ final class HttpConfig {
         try {
             final Integer value = Integer.valueOf(raw.trim());
             if (legacy) {
-                LOGGER.warn("-D{}={} This property is deprecated in favor of -D{} and -D{} and will be removed in a " +
-                                "future release. Configure this value per client/server builder via " +
-                                "maxAggregatedPayloadSize(int) instead.", name, value,
+                LOGGER.warn("-D{}={} is deprecated in favor of -D{} and -D{} and will be removed in a future " +
+                        "release; set maxAggregatedPayloadSize(int) per client/server instead.", name, value,
                         DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY,
                         DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY);
             } else {
-                LOGGER.warn("-D{}={} This property is temporary and will be removed in a future release. Configure " +
-                        "this value per client/server builder via maxAggregatedPayloadSize(int) instead.", name, value);
+                LOGGER.warn("-D{}={} is temporary and will be removed in a future release; set " +
+                        "maxAggregatedPayloadSize(int) per client/server instead.", name, value);
             }
             return value;
         } catch (NumberFormatException e) {
-            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is not a valid integer; ignoring it and using " +
-                    "the built-in per-client/server defaults.", name, raw);
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: not a valid integer; ignoring it and using the built-in " +
+                    "per-client/server defaults.", name, raw);
             return null;
         }
     }

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpConfig.java
@@ -37,13 +37,13 @@ final class HttpConfig {
 
     static final int DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE = 64 * 1024 * 1024;
     static final int DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE = 16 * 1024 * 1024;
-    // FIXME: 0.43 - remove these temporary properties
     static final String DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY =
-            "io.servicetalk.http.netty.temporaryDefaultClientMaxAggregatedPayloadSize";
+            "io.servicetalk.http.netty.defaultClientMaxAggregatedPayloadSize";
     static final String DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY =
-            "io.servicetalk.http.netty.temporaryDefaultServerMaxAggregatedPayloadSize";
-    // Deprecated in favor of the client/server-specific properties above; kept for a release or two in case a
-    // deployment already relies on it. A role-specific property, when set, takes precedence over this legacy one.
+            "io.servicetalk.http.netty.defaultServerMaxAggregatedPayloadSize";
+    // Deprecated legacy property, superseded by the client/server-specific properties above; kept for a release or
+    // two in case a deployment already relies on it. A role-specific property, when set, takes precedence over it.
+    // FIXME: 0.43 - remove this deprecated property
     static final String DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY =
             "io.servicetalk.http.netty.temporaryDefaultMaxAggregatedPayloadSize";
     // When set, override the built-in per-role default using the same sign convention as the builder API (see
@@ -54,9 +54,9 @@ final class HttpConfig {
     static final Integer DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_OVERRIDE;
 
     static {
-        final Integer legacy = parseTemporaryProperty(DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, true);
-        final Integer client = parseTemporaryProperty(DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, false);
-        final Integer server = parseTemporaryProperty(DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, false);
+        final Integer legacy = parseDefaultOverride(DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, true);
+        final Integer client = parseDefaultOverride(DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, false);
+        final Integer server = parseDefaultOverride(DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY, false);
         DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_OVERRIDE = client != null ? client : legacy;
         DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_OVERRIDE = server != null ? server : legacy;
     }
@@ -113,7 +113,7 @@ final class HttpConfig {
 
     // Don't throw from the static initializer; ignore an invalid value and fall back to the per-role defaults.
     @Nullable
-    private static Integer parseTemporaryProperty(final String name, final boolean legacy) {
+    private static Integer parseDefaultOverride(final String name, final boolean legacy) {
         final String raw = System.getProperty(name);
         if (raw == null) {
             return null;
@@ -121,13 +121,12 @@ final class HttpConfig {
         try {
             final Integer value = Integer.valueOf(raw.trim());
             if (legacy) {
-                LOGGER.warn("-D{}={} is deprecated in favor of -D{} and -D{} and will be removed in a future " +
-                        "release; set maxAggregatedPayloadSize(int) per client/server instead.", name, value,
-                        DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY,
+                LOGGER.warn("-D{}={} is a deprecated legacy property, superseded by -D{} and -D{}, and will be " +
+                        "removed in a future release; set maxAggregatedPayloadSize(int) per client/server instead.",
+                        name, value, DEFAULT_CLIENT_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY,
                         DEFAULT_SERVER_MAX_AGGREGATED_PAYLOAD_SIZE_PROPERTY);
             } else {
-                LOGGER.warn("-D{}={} is temporary and will be removed in a future release; set " +
-                        "maxAggregatedPayloadSize(int) per client/server instead.", name, value);
+                LOGGER.info("-D{}={} overrides the built-in default maxAggregatedPayloadSize.", name, value);
             }
             return value;
         } catch (NumberFormatException e) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServerConfig.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpServerConfig.java
@@ -46,7 +46,7 @@ final class HttpServerConfig {
                 throw new IllegalArgumentException(
                         "Server cannot set SETTINGS_ENABLE_PUSH value other than 0, settings=" + settings);
             }
-        });
+        }, HttpConfig.Role.SERVER);
     }
 
     HttpServerConfig(final HttpServerConfig from) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiterTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AggregatedPayloadSizeLimiterTest.java
@@ -24,7 +24,7 @@ import java.util.function.LongConsumer;
 import static io.servicetalk.http.netty.AggregatedPayloadSizeLimiter.NONE;
 import static io.servicetalk.http.netty.AggregatedPayloadSizeLimiter.enforcing;
 import static io.servicetalk.http.netty.AggregatedPayloadSizeLimiter.warning;
-import static io.servicetalk.http.netty.HttpConfig.DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE;
+import static io.servicetalk.http.netty.HttpConfig.Role.SERVER;
 import static io.servicetalk.http.netty.HttpConfig.toAggregatedPayloadSizeLimiter;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -45,7 +45,7 @@ class AggregatedPayloadSizeLimiterTest {
 
     @Test
     void warningNeverRejects() {
-        final LongConsumer limiter = warning(10, "test-owner");
+        final LongConsumer limiter = warning(10, SERVER, "test-owner");
         assertDoesNotThrow(() -> limiter.accept(10));
         // Over the limit it warns (rate-limited) but must not throw.
         assertDoesNotThrow(() -> limiter.accept(Long.MAX_VALUE));
@@ -55,14 +55,13 @@ class AggregatedPayloadSizeLimiterTest {
     void nonPositiveSizeIsDisabled() {
         assertSame(NONE, enforcing(0));
         assertSame(NONE, enforcing(-1));
-        assertSame(NONE, warning(0, "test-owner"));
+        assertSame(NONE, warning(0, SERVER, "test-owner"));
         assertDoesNotThrow(() -> NONE.accept(Long.MAX_VALUE));
     }
 
     @Test
     void mapEnforcesPositiveSize() {
-        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(10, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE,
-                "test-owner");
+        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(10, SERVER, "test-owner");
         assertNotSame(NONE, limiter);
         assertDoesNotThrow(() -> limiter.accept(10));
         assertThrows(PayloadTooLargeException.class, () -> limiter.accept(11));
@@ -70,45 +69,24 @@ class AggregatedPayloadSizeLimiterTest {
 
     @Test
     void mapZeroIsDisabled() {
-        assertSame(NONE, toAggregatedPayloadSizeLimiter(0, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE, "test-owner"));
+        assertSame(NONE, toAggregatedPayloadSizeLimiter(0, SERVER, "test-owner"));
     }
 
     @Test
-    void mapWarnOnlyWarnsAtDefault() {
-        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(-1, DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE,
-                "test-owner");
+    void mapNegativeWarnsAtMagnitude() {
+        // Negative selects warn-only mode at abs(value): over the magnitude it warns (rate-limited) but must not throw.
+        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(-10, SERVER, "test-owner");
         assertNotSame(NONE, limiter);
-        // Over the default it warns (rate-limited) but must not throw.
-        assertDoesNotThrow(() -> limiter.accept((long) DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE + 1));
+        assertDoesNotThrow(() -> limiter.accept(10));
+        assertDoesNotThrow(() -> limiter.accept(11));
+        assertDoesNotThrow(() -> limiter.accept(Long.MAX_VALUE));
     }
 
     @Test
-    void mapWarnOnlyAtRaisedDefault() {
-        final int raised = DEFAULT_MAX_AGGREGATED_PAYLOAD_SIZE_VALUE * 2;
-        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(-1, raised, "test-owner");
+    void mapIntegerMinValueWarnsRatherThanDisables() {
+        // -Integer.MIN_VALUE overflows back to a negative; the limiter must stay warn-only, not collapse to disabled.
+        final LongConsumer limiter = toAggregatedPayloadSizeLimiter(Integer.MIN_VALUE, SERVER, "test-owner");
         assertNotSame(NONE, limiter);
-        assertDoesNotThrow(() -> limiter.accept((long) raised + 1));
-    }
-
-    @Test
-    void mapWarnOnlyNeverCollapsesToDisabledWhenDefaultNonPositive() {
-        assertNotSame(NONE, toAggregatedPayloadSizeLimiter(-1, -1, "test-owner"));
-        assertNotSame(NONE, toAggregatedPayloadSizeLimiter(-1, 0, "test-owner"));
-        assertDoesNotThrow(() -> toAggregatedPayloadSizeLimiter(-1, -1, "test-owner").accept(Long.MAX_VALUE));
-    }
-
-    @Test
-    void configuredValueTakesPrecedenceOverPropertyDefault() {
-        // The configured (builder) value drives the mode; the property-resolved default only supplies the warn
-        // threshold. So an explicit builder call always wins over the property's mode.
-        // builder enforce beats property warn-only:
-        assertThrows(PayloadTooLargeException.class, () -> toAggregatedPayloadSizeLimiter(10, -1, "test-owner")
-                .accept(11));
-        // builder disable beats property warn-only:
-        assertSame(NONE, toAggregatedPayloadSizeLimiter(0, -1, "test-owner"));
-        // builder warn-only beats property enforce:
-        final LongConsumer warn = toAggregatedPayloadSizeLimiter(-1, 10, "test-owner");
-        assertNotSame(NONE, warn);
-        assertDoesNotThrow(() -> warn.accept(Long.MAX_VALUE));
+        assertDoesNotThrow(() -> limiter.accept(Long.MAX_VALUE));
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultAggregatedPayloadSizeLimitTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/DefaultAggregatedPayloadSizeLimitTest.java
@@ -31,7 +31,6 @@ import io.servicetalk.http.api.StreamingHttpRequester;
 import io.servicetalk.http.api.StreamingHttpResponse;
 import io.servicetalk.http.api.StreamingHttpResponseFactory;
 import io.servicetalk.http.api.StreamingHttpServiceFilter;
-import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.netty.internal.ExecutionContextExtension;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -141,18 +140,30 @@ class DefaultAggregatedPayloadSizeLimitTest {
 
     @ParameterizedTest
     @EnumSource(HttpProtocol.class)
-    void negativeServerLimitRejected(HttpProtocol protocol) {
-        // A programmatically configured limit must be non-negative; warn-only mode (-1) is only available via the
-        // system property, not through the builder API.
-        assertThrows(IllegalArgumentException.class,
-                () -> newServerBuilder(SERVER_CTX, protocol).maxAggregatedPayloadSize(-1));
+    void negativeServerLimitWarnsButServes(HttpProtocol protocol) throws Exception {
+        // A negative value selects warn-only mode at abs(value): oversized requests are logged but still served.
+        try (HttpServerContext server = startEchoServer(protocol, -MAX_PAYLOAD);
+             StreamingHttpClient client = newStreamingClient(server, protocol, 0)) {
+            HttpClient aggregated = client.asClient();
+            String body = repeat('x', MAX_PAYLOAD + 1);
+            HttpResponse response = aggregated.request(
+                    aggregated.post("/").payloadBody(alloc(client).fromAscii(body))).toFuture().get();
+            assertThat(response.status(), is(OK));
+            assertThat(response.payloadBody().toString(US_ASCII), equalTo(body));
+        }
     }
 
     @ParameterizedTest
     @EnumSource(HttpProtocol.class)
-    void negativeClientLimitRejected(HttpProtocol protocol) {
-        assertThrows(IllegalArgumentException.class, () ->
-                newClientBuilder(HostAndPort.of("localhost", 8080), CLIENT_CTX, protocol).maxAggregatedPayloadSize(-1));
+    void negativeClientLimitWarnsButDelivers(HttpProtocol protocol) throws Exception {
+        // A negative value selects warn-only mode at abs(value): oversized responses are logged but still delivered.
+        try (HttpServerContext server = startFixedResponseServer(protocol, MAX_PAYLOAD + 1);
+             StreamingHttpClient client = newStreamingClient(server, protocol, -MAX_PAYLOAD)) {
+            HttpClient aggregated = client.asClient();
+            HttpResponse response = aggregated.request(aggregated.get("/")).toFuture().get();
+            assertThat(response.status(), is(OK));
+            assertThat(response.payloadBody().readableBytes(), is(MAX_PAYLOAD + 1));
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Motivation

The recently added aggregated payload size limits defaulted to 4 MiB warn-only for both clients and servers, with enforcement planned to become the default everywhere. We want per-role defaults, a softer stance for clients, and a way to opt into warn-only mode programmatically.

Modifications

- Default limits are now per role: clients warn at 64 MiB, servers warn at 16 MiB. Clients are no longer planned to enforce by default; servers still are. The client warning points users at the streaming APIs to avoid memory pressure.
- `maxAggregatedPayloadSize(int)` uses the value's sign to select the mode: positive enforces (rejects), negative warns at its magnitude, 0 disables. The previous non-negative requirement is dropped.
- Split the temporary `...temporaryDefaultMaxAggregatedPayloadSize` system property into client- and server-specific properties, keeping the original as a deprecated fallback for a release or two.
- Update the builder javadoc and `programming-paradigms.adoc` to the new contract and refresh the aggregation limit tests.

Result

Clients and servers get sensible, separately tunable warn-only defaults, and warn-only mode is reachable through the builder API.