### PR TITLE
http-netty: validate the HTTP/2 ':path' pseudo-header

### DIFF
--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ClientDuplexHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.INFORMATION
 import static io.servicetalk.http.api.HttpResponseStatus.StatusClass.SUCCESSFUL_2XX;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h2HeadersSanitizeForH1;
+import static io.servicetalk.http.netty.H2ToStH1Utils.invalidPathReason;
 import static io.servicetalk.http.netty.HeaderUtils.REQ_EXPECT_CONTINUE;
 import static io.servicetalk.http.netty.HeaderUtils.responseMayHaveContentLength;
 import static io.servicetalk.http.netty.HeaderUtils.serverMaySendPayloadBodyFor;
@@ -87,7 +88,17 @@ final class H2ToStH1ClientDuplexHandler extends AbstractH2DuplexHandler {
                 // The ":scheme" and ":path" pseudo-header fields MUST be omitted for CONNECT.
                 // https://tools.ietf.org/html/rfc7540#section-8.3
                 h2Headers.scheme(scheme.name());
-                h2Headers.path(metaData.requestTarget());
+                // RFC 9113 8.3.1: an http/https URI with no path component MUST send "/", matching what
+                // HttpRequestEncoder writes for HTTP/1.x. 8.1.1 forbids forwarding a malformed request, so reject
+                // before the value reaches HPACK. IllegalArgumentException because the caller supplied this target
+                // through the public API - inbound, a bad :path is a peer protocol violation and resets the stream.
+                final String requestTarget = metaData.requestTarget();
+                final String path = requestTarget.isEmpty() ? "/" : requestTarget;
+                final String pathError = invalidPathReason(path);
+                if (pathError != null) {
+                    throw new IllegalArgumentException(pathError);
+                }
+                h2Headers.path(path);
             }
             try {
                 writeMetaData(ctx, metaData, h2Headers, true, promise);

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1ServerDuplexHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,12 @@ import javax.annotation.Nullable;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderValues.ZERO;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.METHOD;
-import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.PATH;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
 import static io.servicetalk.http.api.HttpRequestMethod.Properties.NONE;
 import static io.servicetalk.http.netty.H2ToStH1ClientDuplexHandler.isInterim;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersToH2Headers;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h2HeadersSanitizeForH1;
+import static io.servicetalk.http.netty.H2ToStH1Utils.invalidPathReason;
 import static io.servicetalk.http.netty.HeaderUtils.clientMaySendPayloadBodyFor;
 import static io.servicetalk.http.netty.HeaderUtils.shouldAddZeroContentLength;
 
@@ -94,9 +94,10 @@ final class H2ToStH1ServerDuplexHandler extends AbstractH2DuplexHandler {
             if (!readHeaders) {
                 closeHandler.protocolPayloadBeginInbound(ctx);
                 CharSequence pathSequence = h2Headers.path();
-                if (pathSequence == null) {
-                    throw protocolError(ctx, streamId, false,
-                            "Incoming request must have '" + PATH.value() + "' header");
+                // Covers absent, empty and illegal characters in one pass.
+                final String pathError = invalidPathReason(pathSequence);
+                if (pathError != null) {
+                    throw protocolError(ctx, streamId, false, pathError);
                 }
                 CharSequence method = h2Headers.method();
                 if (method == null) {

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/H2ToStH1Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import javax.annotation.Nullable;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.TE;
 import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
@@ -69,6 +70,50 @@ final class H2ToStH1Utils {
 
     static void h2HeadersSanitizeForH1(Http2Headers h2Headers) {
         h2HeadersCompressCookieCrumbs(h2Headers);
+    }
+
+    /**
+     * Validate a {@code :path} pseudo-header value: non-empty, visible US-ASCII only ({@code VCHAR},
+     * {@code 0x21-0x7e}).
+     * <p>
+     * <a href="https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1">RFC 9113, 8.3.1</a> requires "exactly one valid
+     * value", non-empty for an {@code http}/{@code https} URI, and its {@code absolute-path [ "?" query ]} production
+     * resolves through <a href="https://www.rfc-editor.org/rfc/rfc9110#section-4.1">RFC 9110, 4.1</a> to
+     * <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.3">RFC 3986, 3.3</a>, which is US-ASCII only:
+     * {@code SP}, {@code DEL}, the controls and {@code obs-text} ({@code 0x80-0xff}) are all excluded, so anything
+     * outside that set must be percent-encoded by whoever produces the URI. The laxer generic field rules (8.2.1,
+     * {@code field-vchar}, which permit {@code obs-text} and interior {@code SP}) are not the authority for a
+     * pseudo-header: 8.3 makes an invalid one malformed and
+     * <a href="https://www.rfc-editor.org/rfc/rfc9113#section-8.1.1">8.1.1</a> a {@code PROTOCOL_ERROR} that
+     * {@code MUST NOT} be forwarded, "deliberately strict" because of attacks against HTTP.
+     * <p>
+     * We enforce the {@code VCHAR} superset, not the exact {@code pchar} set, matching {@code HttpObjectDecoder} for
+     * an HTTP/1.x request-target: {@code pchar} also excludes {@code #}, {@code [}, {@code ]} and {@code |}, commonly
+     * sent unencoded, so rejecting those is a separate compatibility decision.
+     *
+     * @param path the {@code :path} pseudo-header value to validate, {@code null} if absent
+     * @return a description of why {@code path} is invalid, or {@code null} if it is valid
+     */
+    @Nullable
+    static String invalidPathReason(@Nullable final CharSequence path) {
+        if (path == null) {
+            return "':path' is missing";
+        }
+        final int len = path.length();
+        if (len == 0) {
+            // CONNECT omits :path entirely and never reaches here. An outbound request with no path component sends
+            // "/" instead of an empty value, so only a peer can trigger this.
+            return "':path' must not be empty";
+        }
+        for (int i = 0; i < len; ++i) {
+            final char c = path.charAt(i);
+            if (!HttpObjectDecoder.isVCHAR(c)) {
+                // Keep the "expected" wording identical to HttpObjectDecoder's request-target check.
+                return "':path' contains an illegal character at index " + i + ": 0x" + Integer.toHexString(c) +
+                        ", expected [VCHAR (0x21-0x7e)]";
+            }
+        }
+        return null;
     }
 
     /**

--- a/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
+++ b/servicetalk-http-netty/src/main/java/io/servicetalk/http/netty/HttpObjectDecoder.java
@@ -1081,7 +1081,7 @@ abstract class HttpObjectDecoder<T extends HttpMetaData> extends ByteToMessageDe
         return value == SP || value == HT;
     }
 
-    static boolean isVCHAR(final byte value) {
+    static boolean isVCHAR(final int value) {
         return value >= '!' && value <= '~';
     }
 

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/AbstractH2DuplexHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@ package io.servicetalk.http.netty;
 
 import io.servicetalk.buffer.api.Buffer;
 import io.servicetalk.http.api.EmptyHttpHeaders;
+import io.servicetalk.http.api.Http2ErrorCode;
 import io.servicetalk.http.api.Http2Exception;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
 import io.servicetalk.http.api.HttpMetaData;
+import io.servicetalk.http.api.HttpRequestMetaData;
 import io.servicetalk.http.api.HttpResponseStatus;
 import io.servicetalk.http.api.StreamingHttpRequest;
 import io.servicetalk.http.api.StreamingHttpResponse;
@@ -34,14 +36,22 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
 import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
 import io.netty.handler.codec.http2.Http2DataFrame;
+import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2FrameStream;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.handler.codec.http2.Http2ResetFrame;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
 
 import static io.netty.buffer.ByteBufUtil.writeAscii;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
@@ -55,6 +65,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
 import static io.servicetalk.http.api.HttpHeaderValues.ZERO;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_2_0;
+import static io.servicetalk.http.api.HttpRequestMethod.CONNECT;
 import static io.servicetalk.http.api.HttpRequestMethod.GET;
 import static io.servicetalk.http.api.HttpRequestMethod.HEAD;
 import static io.servicetalk.http.api.StreamingHttpRequests.newRequest;
@@ -62,10 +73,12 @@ import static io.servicetalk.http.api.StreamingHttpResponses.newResponse;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -77,6 +90,19 @@ import static org.mockito.Mockito.when;
 class AbstractH2DuplexHandlerTest {
 
     private static final HttpHeadersFactory HEADERS_FACTORY = H2HeadersFactory.INSTANCE;
+
+    // One case per shape; the exhaustive per-octet contract is in H2ToStH1UtilsTest.
+    private static final String[] ILLEGAL_PATHS = {
+            "/a b",                                     // SP
+            "/a" + (char) 0x09 + "b",                   // HTAB
+            "/a" + (char) 0x0d + (char) 0x0a + "X: y",  // CRLF, header injection when downgraded to HTTP/1.1
+            "/a" + (char) 0x00 + "b",                   // NUL
+            "/a" + (char) 0x7f + "b",                   // DEL
+            " /a",                                      // leading SP
+            "/a ",                                      // trailing SP
+            "/a" + (char) 0xe9 + "b",                   // obs-text
+            "/a" + (char) 0x0161 + "b",                 // above one octet
+    };
 
     private enum Variant {
 
@@ -419,8 +445,113 @@ class AbstractH2DuplexHandlerTest {
         dataFrame.release();
     }
 
+    @ParameterizedTest(name = "{displayName} [{index}] path={0} endStream={1}")
+    @MethodSource("illegalPathsAndEndStream")
+    void serverRejectsIllegalPath(String path, boolean endStream) {
+        setUp(Variant.SERVER_HANDLER);
+        Http2Headers headers = newTestHeaders().method(HttpMethod.GET.asciiName()).path(path);
+
+        Http2Exception e = assertThrows(Http2Exception.class,
+                () -> channel.writeInbound(headersFrame(headers, endStream)));
+        assertThat(e.getMessage(), startsWith("':path'"));
+        assertThat(e.errorCode(), is(Http2ErrorCode.PROTOCOL_ERROR));
+        assertThat("Illegal :path was surfaced", channel.inboundMessages(), is(empty()));
+        assertThat("No RST_STREAM was sent", channel.outboundMessages(), contains(instanceOf(Http2ResetFrame.class)));
+        assertThat(((Http2ResetFrame) channel.outboundMessages().peek()).errorCode(),
+                is(Http2Error.PROTOCOL_ERROR.code()));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] path={0}")
+    @ValueSource(strings = {"/", "*", "/ok", "/a?q=1", "/a%20b"})
+    void serverAcceptsLegalPath(String path) {
+        setUp(Variant.SERVER_HANDLER);
+        channel.writeInbound(headersFrame(
+                newTestHeaders().method(HttpMethod.GET.asciiName()).path(path), true));
+
+        HttpRequestMetaData metaData = channel.readInbound();
+        assertThat(metaData.requestTarget(), equalTo(path));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] path={0}")
+    @MethodSource("illegalPaths")
+    void clientRejectsIllegalRequestTarget(String path) {
+        setUp(Variant.CLIENT_HANDLER);
+        // writeOutbound is varargs: pass only the request, or extra args land in outboundMessages().
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> channel.writeOutbound(newRequest(GET, path, HTTP_2_0,
+                        HEADERS_FACTORY.newHeaders(), DEFAULT_ALLOCATOR, HEADERS_FACTORY)));
+        assertThat(e.getMessage(), startsWith("':path'"));
+        assertThat("Illegal :path was written", channel.outboundMessages(), is(empty()));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] path={0}")
+    @ValueSource(strings = {"/", "*", "/ok", "/a?q=1", "/a%20b"})
+    void clientAcceptsLegalRequestTarget(String path) {
+        setUp(Variant.CLIENT_HANDLER);
+        channel.writeOutbound(newRequest(GET, path, HTTP_2_0, HEADERS_FACTORY.newHeaders(),
+                DEFAULT_ALLOCATOR, HEADERS_FACTORY));
+
+        Http2HeadersFrame frame = channel.readOutbound();
+        assertThat(frame.headers().path(), contentEqualTo(path));
+    }
+
+    /**
+     * RFC 9113 8.3.1: no path component sends {@code "/"}, as {@code HttpRequestEncoder} does for HTTP/1.x.
+     */
+    @Test
+    void clientSubstitutesSlashForEmptyRequestTarget() {
+        setUp(Variant.CLIENT_HANDLER);
+        channel.writeOutbound(newRequest(GET, "", HTTP_2_0, HEADERS_FACTORY.newHeaders(),
+                DEFAULT_ALLOCATOR, HEADERS_FACTORY));
+
+        Http2HeadersFrame frame = channel.readOutbound();
+        assertThat(frame.headers().path(), contentEqualTo("/"));
+    }
+
+    /**
+     * An empty {@code :path} on the wire is malformed; only the outbound side substitutes.
+     */
+    @Test
+    void serverRejectsEmptyPath() {
+        setUp(Variant.SERVER_HANDLER);
+        Http2Headers headers = newTestHeaders().method(HttpMethod.GET.asciiName()).path("");
+
+        Http2Exception e = assertThrows(Http2Exception.class,
+                () -> channel.writeInbound(headersFrame(headers, true)));
+        assertThat(e.getMessage(), startsWith("':path'"));
+        assertThat(channel.inboundMessages(), is(empty()));
+    }
+
+    /**
+     * RFC 9113 8.3.1 omits {@code :path} for CONNECT, so the non-empty check must not reject it.
+     */
+    @Test
+    void clientConnectOmitsPath() {
+        setUp(Variant.CLIENT_HANDLER);
+        channel.writeOutbound(newRequest(CONNECT, "example.com:443", HTTP_2_0, HEADERS_FACTORY.newHeaders(),
+                DEFAULT_ALLOCATOR, HEADERS_FACTORY));
+
+        Http2HeadersFrame frame = channel.readOutbound();
+        assertThat(frame.headers().path(), is(nullValue()));
+        assertThat(frame.headers().scheme(), is(nullValue()));
+    }
+
+    private static Stream<String> illegalPaths() {
+        return Stream.of(ILLEGAL_PATHS);
+    }
+
+    private static Stream<Arguments> illegalPathsAndEndStream() {
+        // The rejection sits above the endStream branch in H2ToStH1ServerDuplexHandler#channelRead; pin both flags.
+        return illegalPaths().flatMap(p -> Stream.of(Arguments.of(p, true), Arguments.of(p, false)));
+    }
+
+    /**
+     * Configured as the inbound pipeline really configures it, in particular {@code validateValues=false}, which
+     * {@link ServiceTalkHttp2HeadersDecoder#newHeaders()} inherits from Netty's default. Pseudo-header values are
+     * therefore unvalidated on the wire; a validating test factory would pass on a flag that is off in production.
+     */
     private static Http2Headers newTestHeaders() {
-        return new ServiceTalkHttp2Headers(HEADERS_FACTORY.newHeaders(), false, true, true);
+        return new ServiceTalkHttp2Headers(HEADERS_FACTORY.newHeaders(), false, true, false);
     }
 
     private static Http2HeadersFrame headersFrame(Http2Headers headers, boolean endStream) {

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2PriorKnowledgeFeatureParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2019-2021, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -349,6 +349,78 @@ class H2PriorKnowledgeFeatureParityTest {
                 assertEquals(responseBody, response.payloadBody(textSerializerUtf8()));
             }
         }
+    }
+
+    /**
+     * An illegal request-target must fail locally on both protocols and never reach the server.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] client={0}, h2PriorKnowledge={1}, target={2}")
+    @MethodSource("clientExecutorsIllegalTargets")
+    void illegalRequestTargetIsRejectedLocally(HttpTestExecutionStrategy strategy, boolean h2PriorKnowledge,
+                                               String requestTarget) throws Exception {
+        setUp(strategy, h2PriorKnowledge);
+        AtomicInteger serverRequests = new AtomicInteger();
+        InetSocketAddress serverAddress = bindHttpSynchronousResponseServer(r -> serverRequests.incrementAndGet());
+        try (BlockingHttpClient client = forSingleAddress(HostAndPort.of(serverAddress))
+                .protocols(h2PriorKnowledge ? h2Default() : h1Default())
+                .executionStrategy(clientExecutionStrategy).buildBlocking()) {
+            // The cause chains differ - HTTP/1.x wraps IllegalCharacterException, HTTP/2 throws
+            // IllegalArgumentException straight out of write() - so IllegalArgumentException is the common shape.
+            // Asserting it stops a failure for any other reason from passing.
+            Exception e = assertThrows(Exception.class, () -> client.request(client.get(requestTarget)));
+            assertThat(e, instanceOf(IOException.class));
+            assertThat("No IllegalArgumentException in: " + causeChain(e),
+                    hasIllegalArgumentCause(e), is(true));
+            assertThat("Request reached the server", serverRequests.get(), is(0));
+        }
+    }
+
+    private static boolean hasIllegalArgumentCause(Throwable t) {
+        for (Throwable c = t; c != null; c = c.getCause() == c ? null : c.getCause()) {
+            if (c instanceof IllegalArgumentException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String causeChain(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable c = t; c != null; c = c.getCause() == c ? null : c.getCause()) {
+            sb.append(sb.length() == 0 ? "" : " <- ").append(c.getClass().getName());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * RFC 9113 8.3.1: no path component sends {@code "/"}, as {@code HttpRequestEncoder} does for HTTP/1.x, so an
+     * empty request-target must succeed on both protocols rather than fail.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] client={0}, h2PriorKnowledge={1}")
+    @MethodSource("clientExecutors")
+    void emptyRequestTargetIsSentAsSlash(HttpTestExecutionStrategy strategy, boolean h2PriorKnowledge)
+            throws Exception {
+        setUp(strategy, h2PriorKnowledge);
+        BlockingQueue<String> targets = new LinkedBlockingQueue<>();
+        InetSocketAddress serverAddress = bindHttpSynchronousResponseServer(r -> targets.add(r.requestTarget()));
+        try (BlockingHttpClient client = forSingleAddress(HostAndPort.of(serverAddress))
+                .protocols(h2PriorKnowledge ? h2Default() : h1Default())
+                .executionStrategy(clientExecutionStrategy).buildBlocking()) {
+            client.request(client.get(""));
+            assertThat(targets.take(), equalTo("/"));
+        }
+    }
+
+    private static Stream<Arguments> clientExecutorsIllegalTargets() {
+        // Only targets both codecs reject locally. obs-text is absent on purpose: HTTP/2 rejects it, but
+        // HttpRequestEncoder writes it as UTF-8, so HTTP/1.x only fails later at the peer's decoder.
+        return clientExecutors().flatMap(base -> Stream.of(
+                        "/a b",                                     // SP
+                        "/a" + (char) 0x09 + "b",                    // HTAB
+                        "/a" + (char) 0x0d + (char) 0x0a + "X: y",   // CRLF
+                        "/a" + (char) 0x00 + "b",                    // NUL
+                        "/a" + (char) 0x7f + "b")                    // DEL
+                .map(target -> Arguments.of(base.get()[0], base.get()[1], target)));
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] strategy={0}, h2PriorKnowledge={1}, strictRfc6265={2}, " +
@@ -1543,7 +1615,24 @@ class H2PriorKnowledgeFeatureParityTest {
         assertH2ServerResetsStreamWithProtocolError(headerName, "some-value");
     }
 
+    // A peer that skips validation can put an illegal :path on the wire. Only proves the wiring, so one case per
+    // RFC 9113 rule - the per-octet contract is in H2ToStH1UtilsTest, handler behaviour in AbstractH2DuplexHandlerTest.
+    @ParameterizedTest(name = "{displayName} [{index}] path={0}")
+    @MethodSource("illegalPaths")
+    void h2ServerResetsStreamForIllegalPath(String path) throws Exception {
+        assertH2ServerResetsStreamWithProtocolError(headers -> headers.path(path));
+    }
+
+    private static Stream<String> illegalPaths() {
+        return Stream.of("/a" + (char) 0x0d + (char) 0x0a + "X: y", "/a b", "/a" + (char) 0xe9 + "b", "");
+    }
+
     private void assertH2ServerResetsStreamWithProtocolError(CharSequence headerName, CharSequence headerValue)
+            throws Exception {
+        assertH2ServerResetsStreamWithProtocolError(headers -> headers.add(headerName, headerValue));
+    }
+
+    private void assertH2ServerResetsStreamWithProtocolError(Consumer<Http2Headers> customizer)
             throws Exception {
         setUp(DEFAULT, true);
         try (ServerContext serverContext = HttpServers.forAddress(localAddress(0))
@@ -1607,8 +1696,8 @@ class H2PriorKnowledgeFeatureParityTest {
                         .method("POST")
                         .path("/")
                         .scheme("http")
-                        .authority("localhost")
-                        .add(headerName, headerValue);
+                        .authority("localhost");
+                customizer.accept(headers);
                 stream.writeAndFlush(new DefaultHttp2HeadersFrame(headers)).sync();
 
                 Http2StreamFrame resetFrame = frames.take();

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ToStH1UtilsTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ToStH1UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2021, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,15 @@ import io.servicetalk.http.api.HttpCookiePair;
 import io.servicetalk.http.api.HttpHeaders;
 import io.servicetalk.http.api.HttpHeadersFactory;
 
+import io.netty.util.AsciiString;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static io.netty.util.internal.PlatformDependent.hashCodeAscii;
 import static io.servicetalk.buffer.api.CharSequences.caseInsensitiveHashCode;
@@ -32,10 +37,18 @@ import static io.servicetalk.http.api.HttpHeaderNames.ACCEPT_PATCH;
 import static io.servicetalk.http.api.HttpHeaderNames.COOKIE;
 import static io.servicetalk.http.api.HttpHeaderNames.EXPIRES;
 import static io.servicetalk.http.netty.H2ToStH1Utils.h1HeadersSplitCookieCrumbs;
+import static io.servicetalk.http.netty.H2ToStH1Utils.invalidPathReason;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 class H2ToStH1UtilsTest {
 
@@ -80,5 +93,71 @@ class H2ToStH1UtilsTest {
                 new DefaultHttpCookiePair("c", "d"),
                 new DefaultHttpCookiePair("e", "f")));
         assertThat(headers.get(secondHeaderName), equalTo(secondHeaderValue));
+    }
+
+    /**
+     * An octet is permitted in a {@code :path} iff it is visible US-ASCII (VCHAR, 0x21-0x7e). All three positions are
+     * checked because the generic field rules of RFC 9113 8.2.1 prohibit SP/HTAB only at the edges, whereas the 8.3.1
+     * {@code :path} production admits neither anywhere.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] octet={0}")
+    @MethodSource("octets")
+    void pathOctetContract(int octet) {
+        final boolean permitted = octet >= 0x21 && octet <= 0x7e;
+        final char c = (char) octet;
+        for (final String path : asList(c + "/ab", "/a" + c + "b", "/ab" + c)) {
+            assertThat("path=" + path, invalidPathReason(path) == null, is(permitted));
+            // AsciiString is the type HPACK produces inbound, so cover the ingress type too.
+            assertThat("AsciiString path=" + path,
+                    invalidPathReason(new AsciiString(path.getBytes(ISO_8859_1))) == null, is(permitted));
+        }
+    }
+
+    /**
+     * obs-text is rejected even though RFC 9110 5.5 permits it in a generic field value, because the RFC 9113 8.3.1
+     * {@code :path} production is US-ASCII only. Named explicitly so that editing {@link #pathOctetContract(int)}'s
+     * single predicate cannot silently re-permit the range.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] octet={0}")
+    @ValueSource(ints = {0x80, 0x9f, 0xa0, 0xc3, 0xe9, 0xfe, 0xff})
+    void pathRejectsObsText(int octet) {
+        assertThat(invalidPathReason("/a" + (char) octet + "b"), notNullValue());
+        assertThat(invalidPathReason(new AsciiString(new byte[]{'/', 'a', (byte) octet, 'b'})), notNullValue());
+    }
+
+    /**
+     * Regression guard against narrowing the scan to a single octet: each of these chars has a low byte that is a
+     * legal VCHAR, so narrowing would accept it.
+     */
+    @ParameterizedTest(name = "{displayName} [{index}] char=U+{0}")
+    @ValueSource(strings = {"0121", "0161", "017e", "1161", "ff21"})
+    void pathRejectsCharsAboveOneByte(String hexChar) {
+        final char c = (char) Integer.parseInt(hexChar, 16);
+        assertThat("low byte is not a legal VCHAR, so this proves nothing",
+                (c & 0xff) >= 0x21 && (c & 0xff) <= 0x7e, is(true));
+        assertThat(invalidPathReason("/a" + c + "b"), notNullValue());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] path={0}")
+    @ValueSource(strings = {"/", "*", "/ok", "/a?q=1", "/a%20b", "/~!$&'()+,;=:@"})
+    void pathAcceptsValidTargets(String path) {
+        assertThat(invalidPathReason(path), nullValue());
+    }
+
+    @Test
+    void invalidPathReasonMessages() {
+        assertThat(invalidPathReason(null), containsString("missing"));
+        assertThat(invalidPathReason(""), containsString("must not be empty"));
+        // Two illegal octets: the first must be the one reported.
+        final String message = invalidPathReason("/a b" + (char) 0x0d + "c");
+        assertThat(message, containsString("index 2"));
+        assertThat(message, containsString("0x20"));
+        assertThat(message, containsString("expected [VCHAR (0x21-0x7e)]"));
+        // The offending value is never echoed back, only its position and code point.
+        assertThat(message, not(containsString("/a")));
+    }
+
+    private static IntStream octets() {
+        return IntStream.rangeClosed(0x00, 0xff);
     }
 }

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkHttp2HeadersTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/ServiceTalkHttp2HeadersTest.java
@@ -75,4 +75,30 @@ class ServiceTalkHttp2HeadersTest {
         assertDoesNotThrow(() -> newHeaders(false).add("Uppercase-And-Space Name", "v"));
         assertDoesNotThrow(() -> newHeaders(false).add(new AsciiString(new byte[]{(byte) 0xF0}), "v"));
     }
+
+    /**
+     * Pseudo-header values live in raw fields rather than in the underlying {@code HttpHeaders}, so they skip its
+     * validation, and the container's own check is gated on {@code validateValues}, which is {@code false} on both
+     * real paths. That is why {@code :path} validation lives in the duplex handlers.
+     */
+    @Test
+    void pseudoHeaderValuesAreNotValidatedByTheContainer() {
+        assertDoesNotThrow(() -> newHeaders(true).path("/a" + (char) 0x0d + (char) 0x0a + "X: y"));
+        assertDoesNotThrow(() -> newHeaders(true).method("GET" + (char) 0x00));
+    }
+
+    /**
+     * Turning {@code validateValues} on would still not cover {@code :path}: it enforces the generic
+     * {@code field-value} grammar of RFC 9110, 5.5, which permits obs-text and interior SP. Both values below are
+     * legal field values yet illegal in the RFC 9113, 8.3.1 {@code absolute-path [ "?" query ]} production.
+     */
+    @Test
+    void valueValidationIsTooWeakForPath() {
+        final Http2Headers validating = new ServiceTalkHttp2Headers(
+                new H2HeadersFactory(true, false, true).newHeaders(), false, true, true);
+        // Sanity check that the flag is on: CR is prohibited even by the generic grammar.
+        assertThrows(IllegalArgumentException.class, () -> validating.path("/a" + (char) 0x0d + "b"));
+        assertDoesNotThrow(() -> validating.path("/a b"));
+        assertDoesNotThrow(() -> validating.path("/a" + (char) 0xe9 + "b"));
+    }
 }


### PR DESCRIPTION
#### Motivation
Nothing validated ':path' characters, so a peer could send CR, LF, NUL or SP in it and we would hand it to the service and re-emit it on an HTTP/1.1 downgrade - the header-injection route RFC 9113, 8.2.1 calls out as request smuggling. Outbound we sent an empty ':path' where 8.3.1 requires "/", and HPACK silently mangled any non-ASCII target.

#### Modifications:
- Validate ':path' in both duplex handlers: non-empty, VCHAR only (0x21-0x7e), per RFC 9113, 8.3.1.
- Inbound violations become a PROTOCOL_ERROR stream error; outbound ones fail the write before the value reaches HPACK.
- Send "/" for an empty request-target, as HTTP/1.x already does.

#### Result:
An illegal ':path' no longer crosses the HTTP/2 boundary in either direction, and an empty request-target is sent as "/" on both protocols.

A raw non-ASCII target now fails instead of being silently corrupted; use path(String) or requestTarget(String, Charset) to percent-encode, which the request-target API already requires. HTTP/1.x is unchanged.
