### PR TITLE
loadbalancer: fix OutlierDetectorConfig copy constructor and align builder javadoc

### DIFF
--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/LoadBalancerBuilder.java
@@ -88,8 +88,8 @@ public interface LoadBalancerBuilder<ResolvedAddress, C extends LoadBalancedConn
      * that have been determined to be unhealthy or slow. The details of the selection process are determined by the
      * {@link LoadBalancingPolicy} while the health status is determined by the outlier detection configuration.
      *
-     * @param outlierDetectorConfig the {@link OutlierDetectorConfig} to use, or {@code null} to use the default
-     *                              outlier detection.
+     * @param outlierDetectorConfig the {@link OutlierDetectorConfig} to use. If not set, the configuration built by
+     *                              {@code new OutlierDetectorConfig.Builder().build()} is used.
      * @return {code this}
      * @see #loadBalancingPolicy(LoadBalancingPolicy)
      * @see OutlierDetectorConfigs for common preconfigured policies

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/OutlierDetectorConfig.java
@@ -461,6 +461,10 @@ public final class OutlierDetectorConfig {
          */
         public Builder(final OutlierDetectorConfig outlierDetectorConfig) {
             this.ewmaHalfLife = outlierDetectorConfig.ewmaHalfLife;
+            this.ewmaCancellationPenalty = outlierDetectorConfig.ewmaCancellationPenalty;
+            this.ewmaErrorPenalty = outlierDetectorConfig.ewmaErrorPenalty;
+            this.concurrentRequestPenalty = outlierDetectorConfig.concurrentRequestPenalty;
+            this.cancellationIsError = outlierDetectorConfig.cancellationIsError;
             this.failedConnectionsThreshold = outlierDetectorConfig.failedConnectionsThreshold;
             this.intervalJitter = outlierDetectorConfig.failureDetectorIntervalJitter;
             this.serviceDiscoveryResubscribeInterval = outlierDetectorConfig.serviceDiscoveryResubscribeInterval;
@@ -653,7 +657,8 @@ public final class OutlierDetectorConfig {
          * <p>
          * These tasks can include detection of outlier or the active revival checks.
          * <p>
-         * This method will also use either the default jitter or the provided interval, whichever is smaller.
+         * When no explicit jitter is provided, the jitter is derived from {@code interval}: half the interval when it
+         * is shorter than 5 seconds, otherwise a 3 second default.
          * <p>
          * Defaults to 10 second interval with 3 second jitter.
          *

--- a/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilder.java
+++ b/servicetalk-loadbalancer/src/main/java/io/servicetalk/loadbalancer/RoundRobinLoadBalancerBuilder.java
@@ -145,7 +145,7 @@ public interface RoundRobinLoadBalancerBuilder<ResolvedAddress, C extends LoadBa
      * Use a negative value of the argument to disable health checking.
      *
      * @param threshold number of consecutive connection failures to consider a host unhealthy and eligible for
-     * background health checking. Use negative value to disable the health checking mechanism.
+     * background health checking. Use negative value to disable the health checking mechanism. Must not be {@code 0}.
      * @return {@code this}.
      * @see #backgroundExecutor(Executor)
      */


### PR DESCRIPTION
Motivation:

The OutlierDetectorConfig copy constructor silently dropped several fields, and a few load balancer builder javadocs described behavior the implementation does not match.

Modifications:

- OutlierDetectorConfig.Builder(OutlierDetectorConfig) now copies ewmaCancellationPenalty, ewmaErrorPenalty, concurrentRequestPenalty, and cancellationIsError, so a builder created from an existing config round-trips faithfully instead of resetting those four to defaults.
- LoadBalancerBuilder.outlierDetectorConfig(...) javadoc no longer claims null selects the default (the setter rejects null); it names the actual default instead.
- failureDetectorInterval(Duration) javadoc describes the jitter it actually derives: half the interval below 5s, otherwise a 3s default.
- Document that healthCheckFailedConnectionsThreshold(int) rejects 0 on the deprecated RoundRobinLoadBalancerBuilder.

Result:

The copy constructor preserves all configured values, and the builder javadocs match actual behavior.