### PR TITLE
use netty 4.1.x releases for prb runs

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -31,10 +31,11 @@ jobs:
             os_label: macos
           # FIXME: 0.43 - remove after dropping support for Netty 4.1.x
           # Verify that ServiceTalk remains compatible with the latest Netty 4.1.x release at runtime.
+          # The range keeps resolution on releases.
           - java: 11
             os: ubuntu-latest
             os_label: ubuntu-netty-4.1
-            netty: '4.1.+'
+            netty: '[4.1,4.2)'
     steps:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
 #### Motivation

We should be consistent in using releases for prb CI runs but right now our version selector picks netty 4.1.x snapshots for that matrix element.

 #### Modifications

Use a maven range, which shouldn't include the snapshot repo.