### PR TITLE
serializer: align message size warn interval and default with http/grpc

### DIFF
--- a/servicetalk-data-protobuf/src/test/java/io/servicetalk/data/protobuf/ProtobufSerializerFactoryTest.java
+++ b/servicetalk-data-protobuf/src/test/java/io/servicetalk/data/protobuf/ProtobufSerializerFactoryTest.java
@@ -169,7 +169,8 @@ class ProtobufSerializerFactoryTest {
         // The default (PROTOBUF singleton) limit is warn-only, so an oversized message is delivered, not rejected.
         StreamingSerializerDeserializer<DummyMessage> serializer =
                 PROTOBUF.streamingSerializerDeserializer(DummyMessage.class);
-        DummyMessage oversized = newMsg(4 * 1024 * 1024 + 1);
+        // Exceeds the serializer's 16 MiB warn-only default.
+        DummyMessage oversized = newMsg(16 * 1024 * 1024 + 1);
         Buffer buffer = DEFAULT_ALLOCATOR.newBuffer();
         oversized.writeDelimitedTo(asOutputStream(buffer));
 

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 
 import static java.lang.Integer.getInteger;
 import static java.lang.System.nanoTime;
-import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.HOURS;
 
 /**
  * Enforces (or warns on) the maximum size of a length-prefixed message for the streaming serializers in this package,
@@ -41,13 +41,13 @@ final class MessageSizeLimiter {
      */
     static final int WARN_ONLY = -1;
 
-    static final int DEFAULT_MAX_MESSAGE_SIZE_VALUE = 4 * 1024 * 1024;
+    static final int DEFAULT_MAX_MESSAGE_SIZE_VALUE = 16 * 1024 * 1024;
     // FIXME: 0.43 - remove this temporary property
     static final String DEFAULT_MAX_MESSAGE_SIZE_PROPERTY =
             "io.servicetalk.serializer.utils.temporaryDefaultMaxMessageSize";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageSizeLimiter.class);
-    private static final long WARN_INTERVAL_NANOS = MINUTES.toNanos(5);
+    private static final long WARN_INTERVAL_NANOS = HOURS.toNanos(2);
 
     /**
      * A limiter that never rejects or warns, regardless of message size (the limit is disabled).
@@ -161,8 +161,8 @@ final class MessageSizeLimiter {
         if (now - last >= WARN_INTERVAL_NANOS && lastWarnNanos.compareAndSet(last, now)) {
             LOGGER.warn("Message-Length {} exceeded the configured maximum of {} bytes, but the limit is configured " +
                     "in warn-only mode so the message is allowed through. Largest message observed so far is {} " +
-                    "bytes. Configure an enforcing maxMessageSize to reject oversized messages. This warning is " +
-                    "rate-limited to once per 5 minutes.", length, maxMessageSize, maxObserved, constructionSite);
+                    "bytes. Configure an enforcing maxMessageSize to reject oversized messages. Rate-limited per " +
+                    "serializer.", length, maxMessageSize, maxObserved, constructionSite);
         }
     }
 }


### PR DESCRIPTION
Motivation

The streaming serializer MessageSizeLimiter warned once every 5 minutes at a 4 MiB default, while the HTTP (AggregatedPayloadSizeLimiter) and gRPC (GrpcMessageSizeLimiter) limiters already used a 2-hour interval and larger, per-role defaults. 4 MiB is grpc-java's enforcing-reject default, not a "this is anomalous" line, so it is noisy as a warn-only trigger.

Unlike HTTP/gRPC, the serializers are direction-agnostic singletons (the shared HttpSerializers instances and the protobuf factory use them on both client and server), so there is no Role to key a per-side default off of.

Modifications

- Warn interval 5 minutes -> 2 hours, matching the other two limiters.
- Default warn threshold 4 MiB -> 16 MiB. Usage is symmetric, so pick the more protective of the two reference values (server 16 MiB vs client 64 MiB); warn-only only logs, so erring protective is cheap.