### PR TITLE
Deflake processor GC tests

### DIFF
--- a/servicetalk-concurrent-api/gradle/spotbugs/test-exclusions.xml
+++ b/servicetalk-concurrent-api/gradle/spotbugs/test-exclusions.xml
@@ -51,13 +51,10 @@
     <Method name="multiRequests"/>
     <Bug pattern="VA_PRIMITIVE_ARRAY_PASSED_TO_OBJECT_VARARG"/>
   </Match>
-  <!-- The tests want to verify objects are GCed, so they force a call to System.gc() intentionally -->
+  <!-- Tests use this utility to verify objects are GCed, so it forces calls to System.gc() intentionally -->
   <Match>
-    <Or>
-      <Class name="io.servicetalk.concurrent.api.CompletableProcessorTest"/>
-      <Class name="io.servicetalk.concurrent.api.SingleProcessorTest"/>
-    </Or>
-    <Method name="synchronousCancelStillAllowsForGC"/>
+    <Class name="io.servicetalk.concurrent.api.GcTestUtils"/>
+    <Method name="assertEventuallyEnqueued"/>
     <Bug pattern="DM_GC"/>
   </Match>
   <Match>

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/CompletableProcessorTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.GcTestUtils.assertEventuallyEnqueued;
 import static io.servicetalk.concurrent.api.Single.collectUnordered;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
@@ -38,7 +39,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -119,9 +119,7 @@ class CompletableProcessorTest {
         ReferenceQueue<Subscriber> queue = new ReferenceQueue<>();
         WeakReference<Subscriber> subscriberRef =
                 synchronousCancelStillAllowsForGCDoSubscribe(processor, queue);
-        System.gc();
-        Thread.sleep(300);
-        assertEquals(subscriberRef, queue.remove(100));
+        assertEventuallyEnqueued(processor, subscriberRef, queue);
     }
 
     private WeakReference<Subscriber> synchronousCancelStillAllowsForGCDoSubscribe(

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/GcTestUtils.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/GcTestUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+final class GcTestUtils {
+    private static final int MAX_GC_ATTEMPTS = 10;
+    private static final long QUEUE_WAIT_MILLIS = 1_000;
+
+    private GcTestUtils() {
+        // No instances.
+    }
+
+    static <T> void assertEventuallyEnqueued(Object keepAlive, WeakReference<T> expected,
+                                             ReferenceQueue<T> queue) throws InterruptedException {
+        Reference<? extends T> actual = null;
+        // Keep the owner alive while collecting the referent. Otherwise, collecting the owner and all its fields could
+        // make this assertion pass even if the owner still retains the referent.
+        synchronized (keepAlive) {
+            for (int i = 0; i < MAX_GC_ATTEMPTS && actual == null; ++i) {
+                System.gc();
+                actual = queue.remove(QUEUE_WAIT_MILLIS);
+            }
+        }
+        assertSame(expected, actual, "Weak reference was not enqueued after " + MAX_GC_ATTEMPTS +
+                " GC attempts; referent was " + (expected.get() == null ? "cleared" : "still reachable"));
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/GcTestUtils.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/GcTestUtils.java
@@ -32,15 +32,12 @@ final class GcTestUtils {
     static <T> void assertEventuallyEnqueued(Object keepAlive, WeakReference<T> expected,
                                              ReferenceQueue<T> queue) throws InterruptedException {
         Reference<? extends T> actual = null;
-        // Keep the owner alive while collecting the referent. Otherwise, collecting the owner and all its fields could
-        // make this assertion pass even if the owner still retains the referent.
-        synchronized (keepAlive) {
-            for (int i = 0; i < MAX_GC_ATTEMPTS && actual == null; ++i) {
-                System.gc();
-                actual = queue.remove(QUEUE_WAIT_MILLIS);
-            }
+        for (int i = 0; i < MAX_GC_ATTEMPTS && actual == null; ++i) {
+            System.gc();
+            actual = queue.remove(QUEUE_WAIT_MILLIS);
         }
         assertSame(expected, actual, "Weak reference was not enqueued after " + MAX_GC_ATTEMPTS +
-                " GC attempts; referent was " + (expected.get() == null ? "cleared" : "still reachable"));
+                " GC attempts; referent was " + (expected.get() == null ? "cleared" : "still reachable") +
+                "; parent: " + keepAlive);
     }
 }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/SingleProcessorTest.java
@@ -31,13 +31,13 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.api.GcTestUtils.assertEventuallyEnqueued;
 import static io.servicetalk.concurrent.api.Single.collectUnordered;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -193,9 +193,7 @@ class SingleProcessorTest {
         ReferenceQueue<Subscriber<Integer>> queue = new ReferenceQueue<>();
         WeakReference<Subscriber<Integer>> subscriberRef =
                 synchronousCancelStillAllowsForGCDoSubscribe(processor, queue);
-        System.gc();
-        Thread.sleep(300);
-        assertEquals(subscriberRef, queue.remove(100));
+        assertEventuallyEnqueued(processor, subscriberRef, queue);
     }
 
     private WeakReference<Subscriber<Integer>> synchronousCancelStillAllowsForGCDoSubscribe(


### PR DESCRIPTION
## Summary

- replace the processor tests' one-shot GC timing assumption with bounded reference-queue retries
- keep the processor strongly reachable while waiting, so the test still detects subscriber retention
- share the GC assertion between `SingleProcessorTest` and `CompletableProcessorTest`

## Root cause

The tests assumed that one best-effort `System.gc()` request and reference-queue processing would complete within roughly 400 ms. GC and weak-reference enqueueing have no such timing guarantee, so `ReferenceQueue.remove(100)` could time out even when the processor no longer retained the subscriber.

## Verification

- targeted `SingleProcessorTest.synchronousCancelStillAllowsForGC`: passed
- forced stress run: 50/50 passed
- clean, uncached `servicetalk-concurrent-api` suite: 3,293 tests, 9 skipped, 0 failures, 0 errors
- Checkstyle, SpotBugs, and PMD: passed

Fixes #3392
