### PR TITLE
opentelemetry-http: await span export in filter tests instead of sleeping

### DIFF
--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryGrpcFilterTest.java
@@ -47,6 +47,7 @@ import static io.opentelemetry.api.internal.InstrumentationUtil.suppressInstrume
 import static io.servicetalk.concurrent.api.Single.succeeded;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.opentelemetry.http.AbstractOpenTelemetryFilter.INSTRUMENTATION_SCOPE_NAME;
+import static io.servicetalk.opentelemetry.http.TestUtils.awaitSpans;
 import static io.servicetalk.opentelemetry.http.TestUtils.sleep;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -198,6 +199,9 @@ class OpenTelemetryGrpcFilterTest {
             }
         });
 
+        // Suppression must yield only the server span. Await it deterministically, then settle briefly so a
+        // regression that wrongly created client spans would surface before we assert the exact count.
+        awaitSpans(otelTesting, 1);
         sleep();
 
         // Should have 0 spans because suppression context was active
@@ -212,7 +216,7 @@ class OpenTelemetryGrpcFilterTest {
 
         // Execute gRPC call within suppression context
         client.asBlockingClient().test(newRequest());
-        sleep();
+        awaitSpans(otelTesting, 3);
 
         // Should have 2 client spans and 1 server span
         assertThat(otelTesting.getSpans()).hasSize(3);
@@ -254,7 +258,7 @@ class OpenTelemetryGrpcFilterTest {
     }
 
     private void assertTraceStructure() throws InterruptedException {
-        sleep();
+        awaitSpans(otelTesting, 2);
         assertThat(otelTesting.getSpans()).hasSize(2); // client + server spans
         // Verify they're part of the same trace
         assertThat(findSpanByKind(SpanKind.CLIENT).getTraceId())

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpRequesterFilterTest.java
@@ -80,6 +80,7 @@ import static io.servicetalk.opentelemetry.http.AbstractOpenTelemetryHttpRequest
 import static io.servicetalk.opentelemetry.http.TestUtils.SPAN_STATE_SERIALIZER;
 import static io.servicetalk.opentelemetry.http.TestUtils.TRACING_TEST_LOG_LINE_PREFIX;
 import static io.servicetalk.opentelemetry.http.TestUtils.TestTracingClientLoggerFilter;
+import static io.servicetalk.opentelemetry.http.TestUtils.awaitSpans;
 import static io.servicetalk.opentelemetry.http.TestUtils.clientBuilder;
 import static io.servicetalk.opentelemetry.http.TestUtils.sleep;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
@@ -122,9 +123,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
-                // Allow span export to complete before assertions to avoid flakiness, especially on HTTP/2.
-                sleep();
-
+                awaitSpans(otelTesting, 1);
                 verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
@@ -157,6 +156,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
+                awaitSpans(otelTesting, 2);
                 verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
@@ -236,6 +236,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                 verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestPath,
                         serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                         TRACING_TEST_LOG_LINE_PREFIX);
+                awaitSpans(otelTesting, 3);
                 assertThat(otelTesting.getSpans()).hasSize(3);
                 assertThat(otelTesting.getSpans()).extracting("traceId")
                         .containsExactly(serverSpanState.getTraceId(), serverSpanState.getTraceId(),
@@ -283,6 +284,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                     .addHeader("some-request-header", "request-header-value")).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
+                awaitSpans(otelTesting, 1);
                 verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
@@ -436,7 +438,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                     verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), "/",
                             serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                             TRACING_TEST_LOG_LINE_PREFIX);
-                    sleep();
+                    awaitSpans(otelTesting, 1);
                     assertThat(otelTesting.getSpans()).hasSize(1);
                     assertThat(otelTesting.getSpans()).extracting("traceId")
                             .containsExactly(serverSpanState.getTraceId());
@@ -466,7 +468,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                     // onExchangeFinally() observes the complete dispatch lifecycle and may run after the tracing
                     // span ends, which only covers request sent through response received.
                     assertTrue(lifecycleObserver.awaitExchangeFinally(10, SECONDS));
-                    sleep();
+                    awaitSpans(otelTesting, 1);
                     otelTesting.assertTraces().hasTracesSatisfyingExactly(ta ->
                             ta.hasSpansSatisfyingExactly(span -> {
                                 span.hasAttribute(TestHttpLifecycleObserver.ON_NEW_EXCHANGE_KEY, "set");
@@ -478,7 +480,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                     context.close();
                     context = null;
                     assertThrows(Exception.class, () -> client.request(client.get("/")).toFuture().get());
-                    sleep();
+                    awaitSpans(otelTesting, 1);
                     otelTesting.assertTraces().hasTracesSatisfyingExactly(ta ->
                             ta.hasSpansSatisfyingExactly(span -> {
                                 span.hasEventsSatisfying(eventData -> {
@@ -522,7 +524,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                     .appendConnectionFilter(filter)
                     .build()) {
                     client.request(client.get(requestUrl)).toFuture().get();
-                sleep();
+                awaitSpans(otelTesting, 3);
 
                 // Should have 3 spans: logical client span, physical client span, and server span
                 assertThat(otelTesting.getSpans()).hasSize(3);
@@ -558,7 +560,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                     .appendClientFilter(filter)
                     .build()) {
                 client.request(client.get(requestUrl)).toFuture().get();
-                sleep();
+                awaitSpans(otelTesting, 2);
 
                 // Should have 2 spans: logical client span and server span
                 otelTesting.assertTraces().hasTracesSatisfyingExactly(ta -> ta.hasSpansSatisfyingExactly(
@@ -589,7 +591,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                     .appendConnectionFilter(filter)
                     .build()) {
                 client.request(client.get(requestUrl)).toFuture().get();
-                sleep();
+                awaitSpans(otelTesting, 2);
 
                 // Should have 2 spans: physical client span and server span
                 otelTesting.assertTraces().hasTracesSatisfyingExactly(ta -> ta.hasSpansSatisfyingExactly(
@@ -629,6 +631,9 @@ class OpenTelemetryHttpRequesterFilterTest {
                     }
                 });
             }
+            // Suppression must yield only the server span. Await it deterministically, then settle briefly so a
+            // regression that wrongly created client spans would surface before we assert the exact count.
+            awaitSpans(otelTesting, 1);
             sleep();
 
             // Should have 1 span: server span
@@ -667,7 +672,7 @@ class OpenTelemetryHttpRequesterFilterTest {
                     return resp;
                 }).toFuture().get();
             }
-            sleep();
+            awaitSpans(otelTesting, 3);
 
             // Should have 3 spans: server span, logical client span, and physical client span.
             assertThat(otelTesting.getSpans()).hasSize(3);

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilterTest.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/OpenTelemetryHttpServiceFilterTest.java
@@ -88,6 +88,7 @@ import static io.servicetalk.http.netty.AsyncContextHttpFilterVerifier.verifySer
 import static io.servicetalk.opentelemetry.http.OpenTelemetryHttpRequesterFilterTest.verifyTraceIdPresentInLogs;
 import static io.servicetalk.opentelemetry.http.TestUtils.SPAN_STATE_SERIALIZER;
 import static io.servicetalk.opentelemetry.http.TestUtils.TRACING_TEST_LOG_LINE_PREFIX;
+import static io.servicetalk.opentelemetry.http.TestUtils.awaitSpans;
 import static io.servicetalk.opentelemetry.http.TestUtils.clientBuilder;
 import static io.servicetalk.opentelemetry.http.TestUtils.httpServerBuilder;
 import static io.servicetalk.opentelemetry.http.TestUtils.sleep;
@@ -126,6 +127,7 @@ class OpenTelemetryHttpServiceFilterTest {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
+                awaitSpans(otelTesting, 1);
                 verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
@@ -179,6 +181,7 @@ class OpenTelemetryHttpServiceFilterTest {
                 HttpResponse response = client.request(client.get(requestUrl)).toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
+                awaitSpans(otelTesting, 2);
                 verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
@@ -233,6 +236,7 @@ class OpenTelemetryHttpServiceFilterTest {
             verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), "/",
                 serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                 TRACING_TEST_LOG_LINE_PREFIX);
+            awaitSpans(otelTesting, 2);
             assertThat(otelTesting.getSpans()).hasSize(2);
             assertThat(otelTesting.getSpans()).extracting("traceId")
                 .containsExactly(serverSpanState.getTraceId(), serverSpanState.getTraceId());
@@ -262,6 +266,7 @@ class OpenTelemetryHttpServiceFilterTest {
                     .toFuture().get();
                 TestSpanState serverSpanState = response.payloadBody(SPAN_STATE_SERIALIZER);
 
+                awaitSpans(otelTesting, 1);
                 verifyTraceIdPresentInLogs(loggerStringWriter.stableAccumulated(1000), requestUrl,
                     serverSpanState.getTraceId(), serverSpanState.getSpanId(),
                     TRACING_TEST_LOG_LINE_PREFIX);
@@ -311,7 +316,7 @@ class OpenTelemetryHttpServiceFilterTest {
             request.trailers().set("x-request-trailer", "request-trailer");
             request.payloadBody().writeAscii("bar");
             client.request(request).toFuture().get();
-            sleep();
+            awaitSpans(otelTesting, 1);
             otelTesting.assertTraces()
                     .hasTracesSatisfyingExactly(ta ->
                             ta.hasSpansSatisfyingExactly(span -> checkAttributes(useOffloading, expected, span)));
@@ -336,7 +341,7 @@ class OpenTelemetryHttpServiceFilterTest {
                     () -> client.request(request).toFuture().get());
             assertThat(ex.getCause()).isInstanceOf(http2 ? Http2Exception.class : ClosedChannelException.class);
 
-            sleep();
+            awaitSpans(otelTesting, 1);
             otelTesting.assertTraces()
                     .hasTracesSatisfyingExactly(ta ->
                             ta.hasSpansSatisfyingExactly(span -> checkAttributes(useOffloading, expected, span)));
@@ -359,7 +364,7 @@ class OpenTelemetryHttpServiceFilterTest {
             HttpResponse resp = client.request(request).toFuture().get();
             assertThat(resp.status()).isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR);
 
-            sleep();
+            awaitSpans(otelTesting, 1);
             otelTesting.assertTraces()
                     .hasTracesSatisfyingExactly(ta ->
                             ta.hasSpansSatisfyingExactly(span -> checkAttributes(useOffloading, expected, span)));
@@ -383,7 +388,7 @@ class OpenTelemetryHttpServiceFilterTest {
             ExecutionException ex = assertThrows(ExecutionException.class, () -> streamingClient.request(request)
                     .flatMap(StreamingHttpResponse::toResponse).toFuture().get());
             assertThat(ex.getCause()).isSameAs(DELIBERATE_EXCEPTION);
-            sleep();
+            awaitSpans(otelTesting, 1);
             otelTesting.assertTraces()
                     .hasTracesSatisfyingExactly(ta ->
                             ta.hasSpansSatisfyingExactly(span -> {
@@ -417,7 +422,7 @@ class OpenTelemetryHttpServiceFilterTest {
             response.payloadBody().ignoreElements().subscribe().cancel();
         });
         // For the HTTP/1.x server, we don't necessarily see the cancellation until we shutdown the server.
-        sleep();
+        awaitSpans(otelTesting, 1);
         otelTesting.assertTraces()
                 .hasTracesSatisfyingExactly(ta ->
                         ta.hasSpansSatisfyingExactly(span -> checkAttributes(useOffloading, expected, span)));
@@ -442,7 +447,7 @@ class OpenTelemetryHttpServiceFilterTest {
             response.cancel(true);
         });
         // For the HTTP/1.x server, we don't necessarily see the cancellation until we shutdown the server.
-        sleep();
+        awaitSpans(otelTesting, 1);
         otelTesting.assertTraces()
                 .hasTracesSatisfyingExactly(ta ->
                         ta.hasSpansSatisfyingExactly(span -> checkAttributes(useOffloading, expected, span)));

--- a/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestUtils.java
+++ b/servicetalk-opentelemetry-http/src/test/java/io/servicetalk/opentelemetry/http/TestUtils.java
@@ -37,6 +37,7 @@ import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.transport.api.HostAndPort;
 import io.servicetalk.transport.api.ServerContext;
 
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +50,7 @@ import static io.servicetalk.data.jackson.JacksonSerializerFactory.JACKSON;
 import static io.servicetalk.http.api.HttpSerializers.jsonSerializer;
 import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
 import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class TestUtils {
 
@@ -97,6 +99,18 @@ public final class TestUtils {
             Thread.sleep(millis);
         } catch (InterruptedException ex) {
             throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Wait until at least {@code expectedSpanCount} spans have been exported, working around the race where a client
+     * observes the response before the server-side span is ended (span completion runs after the response terminal
+     * is delivered downstream; see {@code AfterFinallyHttpOperator}).
+     */
+    static void awaitSpans(OpenTelemetryExtension otelTesting, int expectedSpanCount) throws InterruptedException {
+        final long deadline = System.nanoTime() + MILLISECONDS.toNanos(DEFAULT_SLEEP_TIME);
+        while (otelTesting.getSpans().size() < expectedSpanCount && System.nanoTime() < deadline) {
+            Thread.sleep(10);
         }
     }
 


### PR DESCRIPTION
Motivation:
The server span is ended after the response terminal is delivered downstream (AfterFinallyHttpOperator runs its callback last), so a client can observe the full response before the span is exported to the in-memory exporter. Tests that asserted on spans right after the response future resolved were racy - most visibly on HTTP/2 - and leaned on fixed sleeps that only usually covered the gap.

Modifications:
- Add TestUtils.awaitSpans(...), which polls the in-memory exporter until the expected span count is present, bounded by DEFAULT_SLEEP_TIME.
- Use it as a barrier before span/trace assertions in OpenTelemetryHttpServiceFilterTest, OpenTelemetryHttpRequesterFilterTest, and OpenTelemetryGrpcFilterTest, replacing the sleep()-before-assert pattern.
- Leave sleeps that create a scenario (load balancer readiness, pre-cancel in-flight delay) in place.

Result:
Span assertions wait deterministically for export rather than a fixed delay, removing the flake. Test-only change; no production code affected.

May fix #3343.