### PR TITLE
serializer: allow warn-only mode via a negative maxMessageSize

### DIFF
--- a/servicetalk-data-protobuf/src/main/java/io/servicetalk/data/protobuf/ProtobufSerializerFactory.java
+++ b/servicetalk-data-protobuf/src/main/java/io/servicetalk/data/protobuf/ProtobufSerializerFactory.java
@@ -34,7 +34,8 @@ import javax.annotation.Nullable;
  * <a href="https://developers.google.com/protocol-buffers/">protocol buffer</a>.
  * <p>
  * Use {@link #PROTOBUF} for the default configuration, or construct an instance via
- * {@link #ProtobufSerializerFactory(int)} to bound the maximum size of streaming (VarInt length-prefixed) messages.
+ * {@link #ProtobufSerializerFactory(int)} to configure the maximum size of streaming (VarInt length-prefixed)
+ * messages.
  */
 public final class ProtobufSerializerFactory {
     /**
@@ -59,11 +60,12 @@ public final class ProtobufSerializerFactory {
 
     /**
      * Create a factory that bounds the maximum size of messages accepted by its streaming deserializers.
-     * @param maxMessageSize The maximum length (in bytes) declared by a streaming frame's length prefix that will be
-     * accepted during deserialization. A frame declaring a larger length is rejected before any of its bytes are
-     * buffered. {@code 0} disables the limit; {@code -1} warns at the default threshold without rejecting; other
-     * negative values are rejected. This applies only to streaming deserialization; single-message serialization is
-     * not length-prefixed and is unaffected.
+     * @param maxMessageSize The maximum length (in bytes) declared by a streaming frame's length prefix accepted
+     * during deserialization. The sign selects the mode, the magnitude the threshold: <em>positive</em> enforces,
+     * rejecting a frame declaring a larger length before any of its bytes are buffered; <em>negative</em> warns at
+     * {@code abs(value)} bytes (oversized frames are still delivered, with a rate-limited warning); {@code 0} disables
+     * it. This applies only to streaming deserialization; single-message serialization is not length-prefixed and is
+     * unaffected.
      */
     public ProtobufSerializerFactory(final int maxMessageSize) {
         this.maxMessageSize = maxMessageSize;
@@ -95,8 +97,8 @@ public final class ProtobufSerializerFactory {
     /**
      * Get a {@link StreamingSerializerDeserializer} which supports &lt;VarInt length, value&gt; encoding as described
      * in <a href="https://developers.google.com/protocol-buffers/docs/techniques">Protobuf Streaming</a>. The
-     * deserialized message size is limited to this factory's configured maximum (the default for {@link #PROTOBUF},
-     * configurable via {@link #ProtobufSerializerFactory(int)}).
+     * deserialized message size is checked against this factory's configured maximum (the default for
+     * {@link #PROTOBUF}, configurable via {@link #ProtobufSerializerFactory(int)}).
      * @param parser The {@link Parser} used to serialize and deserialize.
      * @param <T> The type to serialize and deserialize.
      * @return a {@link StreamingSerializerDeserializer} which supports &lt;VarInt length, value&gt; encoding as
@@ -117,8 +119,8 @@ public final class ProtobufSerializerFactory {
     /**
      * Get a {@link StreamingSerializerDeserializer} which supports &lt;VarInt length, value&gt; encoding as described
      * in <a href="https://developers.google.com/protocol-buffers/docs/techniques">Protobuf Streaming</a>. The
-     * deserialized message size is limited to this factory's configured maximum (the default for {@link #PROTOBUF},
-     * configurable via {@link #ProtobufSerializerFactory(int)}).
+     * deserialized message size is checked against this factory's configured maximum (the default for
+     * {@link #PROTOBUF}, configurable via {@link #ProtobufSerializerFactory(int)}).
      * @param clazz Used to obtain a {@link Parser} which is used to serialize and deserialize.
      * @param <T> The type to serialize and deserialize.
      * @return a {@link StreamingSerializerDeserializer} which supports &lt;VarInt length, value&gt; encoding as

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializer.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializer.java
@@ -26,7 +26,6 @@ import java.util.function.BiFunction;
 import java.util.function.ToIntFunction;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.lang.Integer.BYTES;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -42,13 +41,12 @@ public final class FixedLengthStreamingSerializer<T> implements StreamingSeriali
     private final MessageSizeLimiter sizeLimiter;
 
     /**
-     * Create a new instance that limits deserialized messages to the default maximum size
+     * Create a new instance that warns (without rejecting) when a deserialized message exceeds the default threshold
      * ({@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_VALUE} bytes). The default can be changed globally via the
      * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property (a temporary property that will be
-     * removed in a future release), which also accepts {@code -1} to enable warn-only mode globally (a rate-limited
-     * log instead of rejecting). Use
-     * {@link #FixedLengthStreamingSerializer(SerializerDeserializer, ToIntFunction, int)} to configure a different
-     * limit or disable it.
+     * removed in a future release), using the same sign convention as
+     * {@link #FixedLengthStreamingSerializer(SerializerDeserializer, ToIntFunction, int)}. Use that constructor to
+     * enforce a limit, warn at a different threshold, or disable it per serializer.
      * @param serializer The {@link SerializerDeserializer} used to serialize/deserialize individual objects.
      * @param bytesEstimator Provides the length in bytes for each {@link T} being serialized.
      */
@@ -62,16 +60,16 @@ public final class FixedLengthStreamingSerializer<T> implements StreamingSeriali
      * Create a new instance.
      * @param serializer The {@link SerializerDeserializer} used to serialize/deserialize individual objects.
      * @param bytesEstimator Provides the length in bytes for each {@link T} being serialized.
-     * @param maxMessageSize The maximum length (in bytes) declared by a frame's length prefix that will be accepted
-     * during deserialization. A frame declaring a larger length is rejected with a
-     * {@link io.servicetalk.serializer.api.MaxMessageSizeExceededException} before any of its bytes are buffered.
-     * {@code 0} disables the limit and any positive value enforces it. Must be non-negative.
+     * @param maxMessageSize The maximum length (in bytes) declared by a frame's length prefix accepted during
+     * deserialization. The sign selects the mode, the magnitude the threshold: <em>positive</em> enforces, rejecting a
+     * frame declaring a larger length with a {@link io.servicetalk.serializer.api.MaxMessageSizeExceededException}
+     * before any of its bytes are buffered; <em>negative</em> warns at {@code abs(value)} bytes (oversized frames are
+     * still delivered, with a rate-limited warning); {@code 0} disables it.
      */
     public FixedLengthStreamingSerializer(final SerializerDeserializer<T> serializer,
                                           final ToIntFunction<T> bytesEstimator,
                                           final int maxMessageSize) {
-        this(serializer, bytesEstimator,
-                MessageSizeLimiter.forMaxMessageSize(ensureNonNegative(maxMessageSize, "maxMessageSize")));
+        this(serializer, bytesEstimator, MessageSizeLimiter.forMaxMessageSize(maxMessageSize));
     }
 
     private FixedLengthStreamingSerializer(final SerializerDeserializer<T> serializer,

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializer.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializer.java
@@ -43,8 +43,7 @@ public final class FixedLengthStreamingSerializer<T> implements StreamingSeriali
     /**
      * Create a new instance that warns (without rejecting) when a deserialized message exceeds the default threshold
      * ({@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_VALUE} bytes). The default can be changed globally via the
-     * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property (a temporary property that will be
-     * removed in a future release), using the same sign convention as
+     * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property, using the same sign convention as
      * {@link #FixedLengthStreamingSerializer(SerializerDeserializer, ToIntFunction, int)}. Use that constructor to
      * enforce a limit, warn at a different threshold, or disable it per serializer.
      * @param serializer The {@link SerializerDeserializer} used to serialize/deserialize individual objects.

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
@@ -34,8 +34,12 @@ import static java.util.concurrent.TimeUnit.HOURS;
  */
 final class MessageSizeLimiter {
     static final int DEFAULT_MAX_MESSAGE_SIZE_VALUE = 16 * 1024 * 1024;
-    // FIXME: 0.43 - remove this temporary property
     static final String DEFAULT_MAX_MESSAGE_SIZE_PROPERTY =
+            "io.servicetalk.serializer.utils.defaultMaxMessageSize";
+    // Deprecated legacy property, superseded by the property above; kept for a release or two in case a deployment
+    // already relies on it. The permanent property, when set, takes precedence over it.
+    // FIXME: 0.43 - remove this deprecated property
+    static final String LEGACY_DEFAULT_MAX_MESSAGE_SIZE_PROPERTY =
             "io.servicetalk.serializer.utils.temporaryDefaultMaxMessageSize";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageSizeLimiter.class);
@@ -48,29 +52,16 @@ final class MessageSizeLimiter {
 
     // The value the 2-arg (default) serializer constructors resolve to, using the same sign convention as
     // forMaxMessageSize: 0 disables, >0 enforces, <0 warns at abs(value). Defaults to warn-only at
-    // DEFAULT_MAX_MESSAGE_SIZE_VALUE bytes, overridable by the temporary property above.
+    // DEFAULT_MAX_MESSAGE_SIZE_VALUE bytes, overridable by the properties above.
     static final int DEFAULT_MAX_MESSAGE_SIZE;
 
     static {
-        // Warn-only by default unless the temporary property overrides it. Don't throw from this static initializer -
-        // fall back to warn-only so a bad property can't break serializer construction (e.g. the static
-        // HttpSerializers instances).
-        int value = -DEFAULT_MAX_MESSAGE_SIZE_VALUE;
-        final String raw = System.getProperty(DEFAULT_MAX_MESSAGE_SIZE_PROPERTY);
-        if (raw != null) {
-            try {
-                value = Integer.parseInt(raw.trim());
-                LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: this is a temporary property that will be removed in " +
-                        "a future release; set maxMessageSize per serializer via the 3-arg " +
-                        "FixedLengthStreamingSerializer / VarIntLengthStreamingSerializer constructor instead.",
-                        DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value);
-            } catch (NumberFormatException e) {
-                LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: not a valid integer; ignoring it and using the " +
-                        "built-in warn-only default of {} bytes.", DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, raw,
-                        DEFAULT_MAX_MESSAGE_SIZE_VALUE);
-            }
-        }
-        DEFAULT_MAX_MESSAGE_SIZE = value;
+        // The permanent property takes precedence over the deprecated legacy one, which takes precedence over the
+        // built-in warn-only default.
+        final Integer configured = parseDefaultOverride(DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, false);
+        final Integer legacy = parseDefaultOverride(LEGACY_DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, true);
+        DEFAULT_MAX_MESSAGE_SIZE = configured != null ? configured :
+                legacy != null ? legacy : -DEFAULT_MAX_MESSAGE_SIZE_VALUE;
     }
 
     private final int maxMessageSize;
@@ -126,6 +117,32 @@ final class MessageSizeLimiter {
                     "Message-Length " + length + " exceeds maximum " + maxMessageSize);
         }
         maybeWarn(length);
+    }
+
+    // Don't throw from the static initializer; ignore an invalid value and fall back to the built-in default so a bad
+    // property can't break serializer construction (e.g. the static HttpSerializers instances).
+    @Nullable
+    private static Integer parseDefaultOverride(final String name, final boolean legacy) {
+        final String raw = System.getProperty(name);
+        if (raw == null) {
+            return null;
+        }
+        try {
+            final Integer value = Integer.valueOf(raw.trim());
+            if (legacy) {
+                LOGGER.warn("-D{}={} is a deprecated legacy property, superseded by -D{}, and will be removed in a " +
+                        "future release; use that or set maxMessageSize per serializer via the 3-arg " +
+                        "FixedLengthStreamingSerializer / VarIntLengthStreamingSerializer constructor instead.",
+                        name, value, DEFAULT_MAX_MESSAGE_SIZE_PROPERTY);
+            } else {
+                LOGGER.debug("-D{}={}", name, value);
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: not a valid integer; ignoring it and using the built-in " +
+                    "default of {} bytes.", name, raw, DEFAULT_MAX_MESSAGE_SIZE_VALUE);
+            return null;
+        }
     }
 
     private void maybeWarn(final int length) {

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/MessageSizeLimiter.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 
-import static java.lang.Integer.getInteger;
 import static java.lang.System.nanoTime;
 import static java.util.concurrent.TimeUnit.HOURS;
 
@@ -34,13 +33,6 @@ import static java.util.concurrent.TimeUnit.HOURS;
  * {@code maxAggregatedPayloadSize} / {@code AggregatedPayloadSizeLimiter} for HTTP client/server.
  */
 final class MessageSizeLimiter {
-    /**
-     * Magic {@code maxMessageSize} value, and the built-in default: warn (rate-limited) at the default threshold when
-     * a message exceeds it, but let it through rather than rejecting. Mirrors HTTP {@code maxAggregatedPayloadSize}
-     * warn-only mode. Configure an enforcing (positive) {@code maxMessageSize} for steady-state protection.
-     */
-    static final int WARN_ONLY = -1;
-
     static final int DEFAULT_MAX_MESSAGE_SIZE_VALUE = 16 * 1024 * 1024;
     // FIXME: 0.43 - remove this temporary property
     static final String DEFAULT_MAX_MESSAGE_SIZE_PROPERTY =
@@ -54,42 +46,31 @@ final class MessageSizeLimiter {
      */
     static final MessageSizeLimiter NONE = new MessageSizeLimiter(0, false);
 
-    // The value the 2-arg (default) serializer constructors resolve to. A value of 0 disables the limit; -1 selects
-    // warn-only mode at the default threshold (the built-in default); other negatives are invalid and fall back to
-    // warn-only.
+    // The value the 2-arg (default) serializer constructors resolve to, using the same sign convention as
+    // forMaxMessageSize: 0 disables, >0 enforces, <0 warns at abs(value). Defaults to warn-only at
+    // DEFAULT_MAX_MESSAGE_SIZE_VALUE bytes, overridable by the temporary property above.
     static final int DEFAULT_MAX_MESSAGE_SIZE;
 
     static {
-        // Warn-only by default unless the temporary property overrides it. Mirror the validation applied by
-        // forMaxMessageSize: 0 disables, -1 is warn-only, other negatives are invalid. Don't throw from this static
-        // initializer - fall back to warn-only so a bad property can't break serializer construction (e.g. the static
+        // Warn-only by default unless the temporary property overrides it. Don't throw from this static initializer -
+        // fall back to warn-only so a bad property can't break serializer construction (e.g. the static
         // HttpSerializers instances).
-        final int value = getInteger(DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, WARN_ONLY);
-        if (value < WARN_ONLY) {
-            LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: The value is invalid (expected >= {}). Falling back to " +
-                            "warn-only mode at {} bytes.",
-                    DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value, WARN_ONLY, DEFAULT_MAX_MESSAGE_SIZE_VALUE);
-            DEFAULT_MAX_MESSAGE_SIZE = WARN_ONLY;
-        } else {
-            DEFAULT_MAX_MESSAGE_SIZE = value;
-            // getInteger can't distinguish "unset" (the warn-only default) from an explicit value; only warn about
-            // the temporary property when it is actually set.
-            if (System.getProperty(DEFAULT_MAX_MESSAGE_SIZE_PROPERTY) != null) {
-                if (value == WARN_ONLY) {
-                    LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: Setting this property to -1 (warn-only mode) may " +
-                                    "be used temporarily to unblock deployment but exposes the service to the risk " +
-                                    "of aggregating unbounded amount of data on the heap. Configure appropriate " +
-                                    "value per serializer via the 3-arg FixedLengthStreamingSerializer / " +
-                                    "VarIntLengthStreamingSerializer constructor instead.",
-                            DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value);
-                } else {
-                    LOGGER.warn("-D{}={} This property will be removed in the future release. Configure this value " +
-                                    "per serializer via the 3-arg FixedLengthStreamingSerializer / " +
-                                    "VarIntLengthStreamingSerializer constructor instead.",
-                            DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value);
-                }
+        int value = -DEFAULT_MAX_MESSAGE_SIZE_VALUE;
+        final String raw = System.getProperty(DEFAULT_MAX_MESSAGE_SIZE_PROPERTY);
+        if (raw != null) {
+            try {
+                value = Integer.parseInt(raw.trim());
+                LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: this is a temporary property that will be removed in " +
+                        "a future release; set maxMessageSize per serializer via the 3-arg " +
+                        "FixedLengthStreamingSerializer / VarIntLengthStreamingSerializer constructor instead.",
+                        DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, value);
+            } catch (NumberFormatException e) {
+                LOGGER.warn("-D{}={} DANGEROUS_CONFIG_WARNING: not a valid integer; ignoring it and using the " +
+                        "built-in warn-only default of {} bytes.", DEFAULT_MAX_MESSAGE_SIZE_PROPERTY, raw,
+                        DEFAULT_MAX_MESSAGE_SIZE_VALUE);
             }
         }
+        DEFAULT_MAX_MESSAGE_SIZE = value;
     }
 
     private final int maxMessageSize;
@@ -114,24 +95,20 @@ final class MessageSizeLimiter {
     }
 
     /**
-     * Resolve a {@code maxMessageSize} config value into a limiter: {@code 0} disables it, {@code > 0} enforces
-     * (rejects) at that size, and {@link #WARN_ONLY -1} warns (without rejecting) at the default threshold. Other
-     * negative values are rejected. Warn-only falls back to {@link #DEFAULT_MAX_MESSAGE_SIZE_VALUE} when the resolved
-     * default is not positive, so it never silently collapses to "disabled".
+     * Resolve a {@code maxMessageSize} config value into a limiter: {@code 0} disables the limit, {@code > 0} enforces
+     * (rejects) at that many bytes, and {@code < 0} warns (without rejecting) at {@code abs(value)} bytes. The sign
+     * selects the mode and the magnitude selects the threshold.
      */
     static MessageSizeLimiter forMaxMessageSize(final int maxMessageSize) {
         if (maxMessageSize == 0) {
             return NONE;
         }
-        if (maxMessageSize == WARN_ONLY) {
-            return new MessageSizeLimiter(
-                    DEFAULT_MAX_MESSAGE_SIZE > 0 ? DEFAULT_MAX_MESSAGE_SIZE : DEFAULT_MAX_MESSAGE_SIZE_VALUE, true);
+        if (maxMessageSize > 0) {
+            return new MessageSizeLimiter(maxMessageSize, false);
         }
-        if (maxMessageSize < 0) {
-            throw new IllegalArgumentException("maxMessageSize: " + maxMessageSize +
-                    " (expected >= 0, or -1 for warn-only)");
-        }
-        return new MessageSizeLimiter(maxMessageSize, false);
+        // -Integer.MIN_VALUE overflows back to a negative value; clamp so it stays a warn-only limiter.
+        final int warnThreshold = maxMessageSize == Integer.MIN_VALUE ? Integer.MAX_VALUE : -maxMessageSize;
+        return new MessageSizeLimiter(warnThreshold, true);
     }
 
     /**

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializer.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializer.java
@@ -26,7 +26,6 @@ import java.util.function.BiFunction;
 import java.util.function.ToIntFunction;
 import javax.annotation.Nullable;
 
-import static io.servicetalk.utils.internal.NumberUtils.ensureNonNegative;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -52,13 +51,12 @@ public final class VarIntLengthStreamingSerializer<T> implements StreamingSerial
     private final MessageSizeLimiter sizeLimiter;
 
     /**
-     * Create a new instance that limits deserialized messages to the default maximum size
+     * Create a new instance that warns (without rejecting) when a deserialized message exceeds the default threshold
      * ({@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_VALUE} bytes). The default can be changed globally via the
      * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property (a temporary property that will be
-     * removed in a future release), which also accepts {@code -1} to enable warn-only mode globally (a rate-limited
-     * log instead of rejecting). Use
-     * {@link #VarIntLengthStreamingSerializer(SerializerDeserializer, ToIntFunction, int)} to configure a different
-     * limit or disable it.
+     * removed in a future release), using the same sign convention as
+     * {@link #VarIntLengthStreamingSerializer(SerializerDeserializer, ToIntFunction, int)}. Use that constructor to
+     * enforce a limit, warn at a different threshold, or disable it per serializer.
      *
      * @param serializer The {@link SerializerDeserializer} used to serialize/deserialize individual objects.
      * @param bytesEstimator Estimates the length in bytes for each {@link T} being serialized.
@@ -74,16 +72,16 @@ public final class VarIntLengthStreamingSerializer<T> implements StreamingSerial
      *
      * @param serializer The {@link SerializerDeserializer} used to serialize/deserialize individual objects.
      * @param bytesEstimator Estimates the length in bytes for each {@link T} being serialized.
-     * @param maxMessageSize The maximum length (in bytes) declared by a frame's length prefix that will be accepted
-     * during deserialization. A frame declaring a larger length is rejected with a
-     * {@link io.servicetalk.serializer.api.MaxMessageSizeExceededException} before any of its bytes are buffered.
-     * {@code 0} disables the limit and any positive value enforces it. Must be non-negative.
+     * @param maxMessageSize The maximum length (in bytes) declared by a frame's length prefix accepted during
+     * deserialization. The sign selects the mode, the magnitude the threshold: <em>positive</em> enforces, rejecting a
+     * frame declaring a larger length with a {@link io.servicetalk.serializer.api.MaxMessageSizeExceededException}
+     * before any of its bytes are buffered; <em>negative</em> warns at {@code abs(value)} bytes (oversized frames are
+     * still delivered, with a rate-limited warning); {@code 0} disables it.
      */
     public VarIntLengthStreamingSerializer(final SerializerDeserializer<T> serializer,
                                            final ToIntFunction<T> bytesEstimator,
                                            final int maxMessageSize) {
-        this(serializer, bytesEstimator,
-                MessageSizeLimiter.forMaxMessageSize(ensureNonNegative(maxMessageSize, "maxMessageSize")));
+        this(serializer, bytesEstimator, MessageSizeLimiter.forMaxMessageSize(maxMessageSize));
     }
 
     private VarIntLengthStreamingSerializer(final SerializerDeserializer<T> serializer,

--- a/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializer.java
+++ b/servicetalk-serializer-utils/src/main/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializer.java
@@ -53,8 +53,7 @@ public final class VarIntLengthStreamingSerializer<T> implements StreamingSerial
     /**
      * Create a new instance that warns (without rejecting) when a deserialized message exceeds the default threshold
      * ({@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_VALUE} bytes). The default can be changed globally via the
-     * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property (a temporary property that will be
-     * removed in a future release), using the same sign convention as
+     * {@value MessageSizeLimiter#DEFAULT_MAX_MESSAGE_SIZE_PROPERTY} system property, using the same sign convention as
      * {@link #VarIntLengthStreamingSerializer(SerializerDeserializer, ToIntFunction, int)}. Use that constructor to
      * enforce a limit, warn at a different threshold, or disable it per serializer.
      *

--- a/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializerTest.java
+++ b/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/FixedLengthStreamingSerializerTest.java
@@ -59,10 +59,14 @@ class FixedLengthStreamingSerializerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {-1, -2})
-    void negativeMaxMessageSizeRejected(int maxMessageSize) {
-        assertThrows(IllegalArgumentException.class, () -> new FixedLengthStreamingSerializer<>(
-                stringSerializer(UTF_8), String::length, maxMessageSize));
+    @ValueSource(ints = {-1, -8})
+    void negativeMaxMessageSizeWarnsButAcceptsOversizedFrame(int maxMessageSize) throws Exception {
+        // A negative limit is warn-only at abs(value), so an oversized frame is delivered, not rejected.
+        FixedLengthStreamingSerializer<String> serializer = new FixedLengthStreamingSerializer<>(
+                stringSerializer(UTF_8), String::length, maxMessageSize);
+
+        assertThat(serializer.deserialize(serializer.serialize(from("123456789"), DEFAULT_ALLOCATOR),
+                DEFAULT_ALLOCATOR).toFuture().get(), contains("123456789"));
     }
 
     @Test

--- a/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/MessageSizeLimiterTest.java
+++ b/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/MessageSizeLimiterTest.java
@@ -19,7 +19,6 @@ import io.servicetalk.serializer.api.MaxMessageSizeExceededException;
 
 import org.junit.jupiter.api.Test;
 
-import static io.servicetalk.serializer.utils.MessageSizeLimiter.WARN_ONLY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -42,11 +41,12 @@ class MessageSizeLimiterTest {
 
     @Test
     void warnOnlyAllowsAboveLimit() {
-        assertDoesNotThrow(() -> MessageSizeLimiter.forMaxMessageSize(WARN_ONLY).checkMessageSize(Integer.MAX_VALUE));
+        assertDoesNotThrow(() -> MessageSizeLimiter.forMaxMessageSize(-8).checkMessageSize(9));
     }
 
     @Test
-    void invalidMaxMessageSizeRejected() {
-        assertThrows(IllegalArgumentException.class, () -> MessageSizeLimiter.forMaxMessageSize(-2));
+    void warnOnlyMinValueDoesNotOverflow() {
+        assertDoesNotThrow(
+                () -> MessageSizeLimiter.forMaxMessageSize(Integer.MIN_VALUE).checkMessageSize(Integer.MAX_VALUE));
     }
 }

--- a/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializerTest.java
+++ b/servicetalk-serializer-utils/src/test/java/io/servicetalk/serializer/utils/VarIntLengthStreamingSerializerTest.java
@@ -107,10 +107,14 @@ class VarIntLengthStreamingSerializerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {-1, -2})
-    void negativeMaxMessageSizeRejected(int maxMessageSize) {
-        assertThrows(IllegalArgumentException.class, () -> new VarIntLengthStreamingSerializer<>(
-                stringSerializer(UTF_8), String::length, maxMessageSize));
+    @ValueSource(ints = {-1, -8})
+    void negativeMaxMessageSizeWarnsButAcceptsOversizedFrame(int maxMessageSize) throws Exception {
+        // A negative limit is warn-only at abs(value), so an oversized frame is delivered, not rejected.
+        VarIntLengthStreamingSerializer<String> serializer = new VarIntLengthStreamingSerializer<>(
+                stringSerializer(UTF_8), String::length, maxMessageSize);
+
+        assertThat(serializer.deserialize(serializer.serialize(from("123456789"), DEFAULT_ALLOCATOR),
+                DEFAULT_ALLOCATOR).toFuture().get(), contains("123456789"));
     }
 
     @Test


### PR DESCRIPTION
Motivation

The streaming serializers bound a length-prefixed message's size to guard against DoS via unbounded aggregation, like HTTP (maxAggregatedPayloadSize) and gRPC (maxInboundMessageSize). Those select the mode from the value's sign - positive enforces, negative warns at its magnitude, 0 disables - but the serializer constructors rejected all negatives, so per-serializer warn-only was unreachable.

Modifications

- VarIntLengthStreamingSerializer / FixedLengthStreamingSerializer accept a negative maxMessageSize as warn-only at its magnitude, resolving the sign like GrpcMessageSizeLimiter/HttpConfig; the non-negative requirement and the -1 sentinel are dropped.
- The default is now warn-only at 16 MiB stored as a negative (unchanged behavior); update the javadoc and tests.

Result

Warn-only mode is reachable through the serializer constructors, matching HTTP and gRPC. Note: temporaryDefaultMaxMessageSize=-1 now means "warn at 1 byte" rather than 16 MiB; warn-only is already the default, so unset it.