### PR TITLE
examples: add virtual threads HTTP example and guide

### DIFF
--- a/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -5,6 +5,7 @@
 ** xref:{page-version}@servicetalk::async-context.adoc[Asynchronous Context]
 
 * xref:{page-version}@servicetalk::performance.adoc[Performance]
+* xref:{page-version}@servicetalk::virtual-threads.adoc[Virtual Threads]
 
 * Examples
 +

--- a/docs/modules/ROOT/pages/performance.adoc
+++ b/docs/modules/ROOT/pages/performance.adoc
@@ -123,6 +123,10 @@ for your use case allows ServiceTalk to be more optimal and reduce offloading
 * Opting-out of some or all offloading through use of
 xref:{page-version}@servicetalk::performance.adoc#ExecutionStrategy[ExecutionStrategy]
 
+For applications serving many concurrent, mostly-waiting requests with a blocking programming model, the offloading
+`Executor` can instead be backed by virtual threads. See xref:{page-version}@servicetalk::virtual-threads.adoc[Virtual
+Threads].
+
 == Tuning options and recommendations
 
 The following sections will offer suggestions that may improve performance depending on your use-case.

--- a/docs/modules/ROOT/pages/virtual-threads.adoc
+++ b/docs/modules/ROOT/pages/virtual-threads.adoc
@@ -113,6 +113,33 @@ breaks, so it is easy to miss when benchmarking. Code that relied on a value sur
 requests will also stop working. For implicitly propagating per-request state, prefer
 xref:{page-version}@servicetalk-concurrent-api::async-context.adoc[`AsyncContext`].
 
+=== AsyncContext does not propagate to threads you spawn
+
+xref:{page-version}@servicetalk-concurrent-api::async-context.adoc[`AsyncContext`] is bound to the current thread and
+is not an `InheritableThreadLocal`. ServiceTalk propagates it across its own asynchronous boundaries, but a thread your
+application starts inside a handler does not inherit it and sees an empty context — anything relying on `AsyncContext`,
+such as tracing spans, MDC, or auth, is absent there.
+
+Virtual threads make spawning a thread or subtask per unit of work — via `StructuredTaskScope`,
+`Thread.ofVirtual().start(...)`, or a fan-out to downstream calls — common, so this is more likely to occur. Capture
+and reinstall the context across the boundary with `AsyncContext.wrapCallable` / `wrapRunnable`, or wrap a JDK executor
+with `AsyncContext.wrapJdkExecutorService`:
+
+[source, java]
+----
+// Each forked subtask runs on its own virtual thread. Wrap it so it inherits the handler's AsyncContext; without the
+// wrapCallable, these calls (and any tracing/MDC they depend on) would run with an empty context.
+try (var scope = StructuredTaskScope.open()) {
+    var user = scope.fork(AsyncContext.wrapCallable(() -> userClient.lookup(id)));
+    var prefs = scope.fork(AsyncContext.wrapCallable(() -> prefsClient.lookup(id)));
+    scope.join();
+    return render(user.get(), prefs.get());
+}
+----
+
+The `wrap*` helpers share one `ContextMap` across the parent and all spawned tasks: a task's writes are visible to the
+others, and concurrent writes to the same key race. This is what you want for read-mostly context (tracing, MDC, auth).
+
 === Pinning
 
 As noted under <<Prerequisites>>, a virtual thread that blocks while holding a monitor pins its carrier thread. JDK 25

--- a/docs/modules/ROOT/pages/virtual-threads.adoc
+++ b/docs/modules/ROOT/pages/virtual-threads.adoc
@@ -1,0 +1,121 @@
+// Configure {source-root} values based on how this document is rendered: on GitHub or not
+ifdef::env-github[]
+:source-root:
+endif::[]
+ifndef::env-github[]
+ifndef::source-root[:source-root: https://github.com/apple/servicetalk/blob/{page-origin-refname}]
+endif::[]
+
+= Virtual Threads
+
+ServiceTalk can run application request handling on
+link:https://openjdk.org/jeps/444[virtual threads]. No special mode is
+required: virtual threads are enabled by supplying an offloading `Executor` that starts a virtual thread per task.
+This page explains when that is worthwhile, how to configure it, and the trade-offs to be aware of.
+
+== Why virtual threads?
+
+A fixed platform-thread pool is an efficient, well-understood default, and it remains the right choice for most
+applications.
+
+Platform threads map to OS threads, which are expensive and limited, so a fixed pool caps how many blocking operations
+can be in flight at once. Virtual threads are cheap to create and park, so blocking calls no longer tie up a scarce
+resource.
+
+The sweet spot is an application serving many concurrent requests that spend most of their time *waiting* (for example
+on an upstream HTTP or database call) and expressed with a
+xref:{page-version}@servicetalk-http-api::blocking-safe-by-default.adoc#programming-models[blocking programming model].
+Virtual threads let you keep straightforward, sequential blocking code while scaling to far more in-flight requests than
+a fixed pool would allow. As with any performance change, benchmark it against your current configuration before
+adopting it.
+
+== Prerequisites
+
+Virtual threads require *JDK 25 or later*.
+
+While virtual threads are available from JDK 21, ServiceTalk recommends JDK 25 as the first release suitable for
+large-scale production use. Earlier releases pin the carrier (platform) thread whenever a virtual thread blocks inside a
+`synchronized` block or method, which under load silently starves the small carrier pool and negates the benefit.
+link:https://openjdk.org/jeps/491[JEP 491] resolved this in JDK 24, and JDK 25 is the first Long-Term-Support release to
+include it.
+
+== Enabling virtual threads
+
+ServiceTalk splits work between the `IoExecutor` (Netty's event loops) and an *offloading* `Executor` that runs
+application code away from the event loop — see
+xref:{page-version}@servicetalk::performance.adoc#safe-to-block[Safe-to-block (offloading)]. To use virtual threads,
+supply an offloading `Executor` that starts a virtual thread per task and leave the `IoExecutor` at its default. Give
+the threads a name rather than accepting the default `VirtualThread[#N]` names — named threads are far easier to pick
+out in thread dumps, logs, and profilers, which matters for any serious workload:
+
+[source, java]
+----
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Executors;
+import io.servicetalk.http.netty.HttpServers;
+
+import java.util.concurrent.ThreadFactory;
+
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static java.util.concurrent.Executors.newThreadPerTaskExecutor;
+
+ThreadFactory factory = Thread.ofVirtual().name("servicetalk-vt-", 0).factory();
+Executor executor = Executors.from(newThreadPerTaskExecutor(factory));
+
+HttpServers.forPort(8080)
+        .executor(executor)
+        .listenBlockingAndAwait((ctx, request, responseFactory) ->
+                responseFactory.ok().payloadBody("Hello World!", textSerializerUtf8()))
+        .awaitShutdown();
+----
+
+Each offloaded request now runs on a fresh virtual thread; blocking within the handler parks that virtual thread instead
+of holding a platform thread. A runnable version is in the
+xref:{page-version}@servicetalk-examples::http/index.adoc#VirtualThreads[virtual threads example].
+
+[IMPORTANT]
+Leave the `IoExecutor` on platform threads. Netty's event loops must never run on virtual threads — blocking or parking
+an event loop stalls every connection it serves. Virtual threads belong on the offloading `Executor` only.
+
+=== Client side
+
+The benefit is overwhelmingly on the server side. On a client, ServiceTalk's offloading `Executor` only runs response
+signals and filters; the blocking client APIs block the *caller's* thread, which ServiceTalk does not own. Supplying a
+virtual-thread `Executor` to a client therefore moves the needle only if you have installed genuinely *blocking*
+client-side filters — an uncommon case. If your calling code makes many concurrent blocking client calls, the threads
+worth making virtual are the ones in your application that issue those calls, not ServiceTalk's client executor.
+
+== Gotchas
+
+=== Monitoring assumptions
+
+Monitoring built around a bounded pool no longer reflects reality. There is no pool to observe — no meaningful active
+thread count, pool size, or queue depth — and a new thread exists per request rather than a stable, reusable set. Any
+dashboards, alerts, or tooling that watch thread-pool behaviour (including your own executor instrumentation and
+thread-dump-based analysis) will not report what you expect and need to be revisited.
+
+=== No built-in capacity limit
+
+A fixed pool provides an implicit back-pressure ceiling: once every thread is busy and the queue is full, the server
+sheds load. A virtual-thread executor is effectively unbounded and imposes no such limit, so an overload can create
+unbounded in-flight work rather than being rejected. Bound concurrency explicitly — for example with a capacity limiter
+from
+xref:{page-version}@servicetalk-examples::http/index.adoc#TrafficResiliency[traffic resilience] — rather than relying on
+a thread pool's size to cap it.
+
+=== ThreadLocal as a cache
+
+With a fixed pool a few dozen threads serve every request, so an expensive object stashed in a `ThreadLocal` (a
+`SimpleDateFormat`, a scratch buffer, a reusable parser) is created a handful of times during warmup and then reused for
+free. Under virtual threads each request runs on a new thread, so anything placed in a `ThreadLocal` is initialized on
+the way in and discarded on the way out. What was a cache becomes per-request allocation and GC pressure — and nothing
+breaks, so it is easy to miss when benchmarking. Code that relied on a value surviving on the same thread across
+requests will also stop working. For implicitly propagating per-request state, prefer
+xref:{page-version}@servicetalk-concurrent-api::async-context.adoc[`AsyncContext`].
+
+=== Pinning
+
+As noted under <<Prerequisites>>, a virtual thread that blocks while holding a monitor pins its carrier thread. JDK 25
+removes this for `synchronized`, but blocking inside native frames or foreign functions can still pin. If throughput
+does not scale as expected, profile for pinning — for example with the `jdk.VirtualThreadPinned` JDK Flight Recorder
+event.

--- a/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/_partials/nav-versioned.adoc
@@ -19,6 +19,7 @@
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Retries[Retries]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#uds[Unix Domain Sockets]
 ** xref:{page-version}@servicetalk-examples::http/index.adoc#Files[Files]
+** xref:{page-version}@servicetalk-examples::http/index.adoc#VirtualThreads[Virtual Threads]
 ** xref:{page-version}@servicetalk-examples::http/service-composition.adoc[Service Composition]
 * xref:{page-version}@servicetalk-examples::grpc/index.adoc[gRPC]
 ** xref:{page-version}@servicetalk-examples::grpc/index.adoc#HelloWorld[Hello World]

--- a/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
+++ b/servicetalk-examples/docs/modules/ROOT/pages/http/index.adoc
@@ -419,3 +419,13 @@ This example demonstrates asynchronous request processing where the response pay
 
 * link:{source-root}/servicetalk-examples/http/files/src/main/java/io/servicetalk/examples/http/files/FilesServer.java[FilesServer] - a server whose response body is streamed from a file.
 * link:{source-root}/servicetalk-examples/http/files/src/main/java/io/servicetalk/examples/http/files/FilesClient.java[FilesClient] - a client that requests and prints response contents.
+
+[#VirtualThreads]
+== Virtual Threads
+
+This example runs request handling on virtual threads by supplying an offloading `Executor` backed by the JDK's
+virtual-thread-per-task executor, while leaving the `IoExecutor` on platform threads. See the
+xref:{page-version}@servicetalk::virtual-threads.adoc[Virtual Threads guide] for when this is worthwhile and the
+trade-offs involved. Requires JDK 25 or later.
+
+* link:{source-root}/servicetalk-examples/http/virtual-threads/src/main/java/io/servicetalk/examples/http/virtualthreads/VirtualThreadServer.java[VirtualThreadServer] - a blocking "Hello World" server whose request handling runs on virtual threads.

--- a/servicetalk-examples/http/virtual-threads/README.adoc
+++ b/servicetalk-examples/http/virtual-threads/README.adoc
@@ -1,0 +1,15 @@
+== ServiceTalk HTTP Virtual Threads Example
+
+Runs HTTP request handling on link:https://openjdk.org/jeps/444[virtual threads] by supplying an offloading `Executor`
+backed by a named virtual-thread-per-task factory, while leaving the `IoExecutor` (Netty's event loops) on platform
+threads.
+
+See the
+xref:{page-version}@servicetalk::virtual-threads.adoc[Virtual Threads guide] for when this is worthwhile, the
+trade-offs, and the gotchas.
+
+[IMPORTANT]
+This example requires *JDK 25 or later* at runtime. Its main source uses virtual-thread APIs the JDK 17 builder cannot
+compile, so it is built with a JDK 25 toolchain rather than the builder JDK. Its build tasks are enabled only when a
+JDK 25 is being exercised - a JDK 25 Gradle runtime, or `TEST_JAVA_VERSION=25` - and are otherwise skipped, so it
+neither builds nor appears in your IDE on older JDKs.

--- a/servicetalk-examples/http/virtual-threads/build.gradle
+++ b/servicetalk-examples/http/virtual-threads/build.gradle
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+apply from: "../../gradle/idea.gradle"
+
+// This example's main source uses virtual-thread APIs the JDK 17 builder cannot compile, so it is built with a
+// JDK 25 toolchain. JDK 25 is the recommended runtime - the first LTS where carrier-thread pinning on `synchronized`
+// is resolved (JEP 491). Its tasks are gated on a JDK 25 being available (a JDK 25 Gradle runtime or
+// TEST_JAVA_VERSION=25) and skipped otherwise, so builds on other JDKs don't fail resolving an unavailable toolchain.
+//
+// Because auto-download is disabled and CI installs JDK 25 only on the matrix `java: 25` leg, we build this example
+// only when a JDK 25 is actually being exercised: the JDK 25 CI leg (TEST_JAVA_VERSION=25, which is where a JDK 25
+// toolchain is discoverable) or a JDK 25 Gradle runtime. On other legs its tasks are disabled so they don't fail
+// resolving an unavailable toolchain. This mirrors the TEST_JAVA_VERSION gating used for module tests.
+def requiredMajorVersion = 25
+def testJavaVersion = System.getenv("TEST_JAVA_VERSION")
+def jdk25Exercised = JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25) ||
+    (testJavaVersion != null && testJavaVersion.isInteger() && testJavaVersion.toInteger() >= requiredMajorVersion)
+
+if (jdk25Exercised) {
+  java {
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(requiredMajorVersion)
+    }
+  }
+} else {
+  tasks.withType(JavaCompile).configureEach { enabled = false }
+  tasks.withType(Javadoc).configureEach { enabled = false }
+  tasks.withType(JavaExec).configureEach { enabled = false }
+}
+
+dependencies {
+  implementation project(":servicetalk-annotations")
+  implementation project(":servicetalk-concurrent-api")
+  implementation project(":servicetalk-http-netty")
+
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}

--- a/servicetalk-examples/http/virtual-threads/gradle.lockfile
+++ b/servicetalk-examples/http/virtual-threads/gradle.lockfile
@@ -1,0 +1,37 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+# To regenerate this file, run: ./gradlew :servicetalk-examples:http:servicetalk-examples-http-virtual-threads:dependencies --write-locks
+com.google.code.findbugs:jsr305:3.0.2=compileClasspath,runtimeClasspath
+io.netty:netty-bom:4.2.17.Final=runtimeClasspath
+io.netty:netty-buffer:4.2.17.Final=runtimeClasspath
+io.netty:netty-codec-base:4.2.17.Final=runtimeClasspath
+io.netty:netty-codec-compression:4.2.17.Final=runtimeClasspath
+io.netty:netty-codec-dns:4.2.17.Final=runtimeClasspath
+io.netty:netty-codec-http2:4.2.17.Final=runtimeClasspath
+io.netty:netty-codec-http:4.2.17.Final=runtimeClasspath
+io.netty:netty-codec-marshalling:4.2.17.Final=runtimeClasspath
+io.netty:netty-codec-protobuf:4.2.17.Final=runtimeClasspath
+io.netty:netty-codec:4.2.17.Final=runtimeClasspath
+io.netty:netty-common:4.2.17.Final=runtimeClasspath
+io.netty:netty-handler:4.2.17.Final=runtimeClasspath
+io.netty:netty-resolver-dns-classes-macos:4.2.17.Final=runtimeClasspath
+io.netty:netty-resolver-dns-native-macos:4.2.17.Final=runtimeClasspath
+io.netty:netty-resolver-dns:4.2.17.Final=runtimeClasspath
+io.netty:netty-resolver:4.2.17.Final=runtimeClasspath
+io.netty:netty-tcnative-boringssl-static:2.0.81.Final=runtimeClasspath
+io.netty:netty-tcnative-classes:2.0.81.Final=runtimeClasspath
+io.netty:netty-transport-classes-epoll:4.2.17.Final=runtimeClasspath
+io.netty:netty-transport-classes-io_uring:4.2.17.Final=runtimeClasspath
+io.netty:netty-transport-classes-kqueue:4.2.17.Final=runtimeClasspath
+io.netty:netty-transport-native-epoll:4.2.17.Final=runtimeClasspath
+io.netty:netty-transport-native-io_uring:4.2.17.Final=runtimeClasspath
+io.netty:netty-transport-native-kqueue:4.2.17.Final=runtimeClasspath
+io.netty:netty-transport-native-unix-common:4.2.17.Final=runtimeClasspath
+io.netty:netty-transport:4.2.17.Final=runtimeClasspath
+org.apache.logging.log4j:log4j-api:2.24.3=runtimeClasspath
+org.apache.logging.log4j:log4j-core:2.24.3=runtimeClasspath
+org.apache.logging.log4j:log4j-slf4j-impl:2.24.3=runtimeClasspath
+org.jctools:jctools-core:4.0.6=runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=runtimeClasspath
+empty=annotationProcessor

--- a/servicetalk-examples/http/virtual-threads/src/main/java/io/servicetalk/examples/http/virtualthreads/VirtualThreadServer.java
+++ b/servicetalk-examples/http/virtual-threads/src/main/java/io/servicetalk/examples/http/virtualthreads/VirtualThreadServer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.examples.http.virtualthreads;
+
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.Executors;
+import io.servicetalk.http.netty.HttpServers;
+
+import java.util.concurrent.ThreadFactory;
+
+import static io.servicetalk.http.api.HttpSerializers.textSerializerUtf8;
+import static java.util.concurrent.Executors.newThreadPerTaskExecutor;
+
+/**
+ * A "Hello World" server that runs request handling on virtual threads.
+ * <p>
+ * Virtual threads are enabled by supplying an offloading {@link Executor} that starts a fresh virtual thread per
+ * task. The {@code IoExecutor} (Netty's event loops) is deliberately left at its platform-thread default: only
+ * offloaded application work runs on virtual threads.
+ */
+public final class VirtualThreadServer {
+
+    public static void main(String... args) throws Exception {
+        // Name the virtual threads (rather than the default "VirtualThread[#N]") so they are identifiable in thread
+        // dumps, logs, and profilers - important when debugging a real workload.
+        ThreadFactory factory = Thread.ofVirtual().name("servicetalk-vt-", 0).factory();
+        Executor executor = Executors.from(newThreadPerTaskExecutor(factory));
+
+        HttpServers.forPort(8080)
+                .executor(executor)
+                .listenBlockingAndAwait((ctx, request, responseFactory) ->
+                        // This runs on a virtual thread. Blocking here (a downstream client call, a JDBC query,
+                        // ...) parks the virtual thread without holding onto a platform thread, so a small number
+                        // of event-loop threads can carry a large number of concurrent, mostly-waiting requests.
+                        responseFactory.ok().payloadBody(
+                                "Hello World! (from " + Thread.currentThread() + ')', textSerializerUtf8()))
+                .awaitShutdown();
+    }
+}

--- a/servicetalk-examples/http/virtual-threads/src/main/java/io/servicetalk/examples/http/virtualthreads/package-info.java
+++ b/servicetalk-examples/http/virtual-threads/src/main/java/io/servicetalk/examples/http/virtualthreads/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ElementsAreNonnullByDefault
+package io.servicetalk.examples.http.virtualthreads;
+
+import io.servicetalk.annotations.ElementsAreNonnullByDefault;

--- a/servicetalk-examples/http/virtual-threads/src/main/resources/log4j2.xml
+++ b/servicetalk-examples/http/virtual-threads/src/main/resources/log4j2.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %30t [%-5level] %-30logger{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <!-- Prints server start and shutdown -->
+    <Logger name="io.servicetalk.http.netty.NettyHttpServer" level="DEBUG"/>
+
+    <!-- Use `-Dservicetalk.logger.level=DEBUG` to change the root logger level via command line  -->
+    <Root level="${sys:servicetalk.logger.level:-INFO}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -85,6 +85,7 @@ include "servicetalk-annotations",
         "servicetalk-examples:http:timeout",
         "servicetalk-examples:http:loadbalancer",
         "servicetalk-examples:http:files",
+        "servicetalk-examples:http:virtual-threads",
         "servicetalk-gradle-plugin-internal",
         "servicetalk-grpc-api",
         "servicetalk-grpc-health",
@@ -175,3 +176,4 @@ project(":servicetalk-examples:http:https-proxy").name = "servicetalk-examples-h
 project(":servicetalk-examples:http:redirects").name = "servicetalk-examples-http-redirects"
 project(":servicetalk-examples:http:compression").name = "servicetalk-examples-http-compression"
 project(":servicetalk-examples:http:files").name = "servicetalk-examples-http-files"
+project(":servicetalk-examples:http:virtual-threads").name = "servicetalk-examples-http-virtual-threads"


### PR DESCRIPTION
Motivation

ServiceTalk can run request handling on virtual threads, but there was no example or guidance showing how.

Modifications

- Add a Virtual Threads guide: when to use them, configuring the offloading executor while leaving the IoExecutor on platform threads, and trade-offs.
- Add a runnable HTTP server example.
- The example's main source needs JDK 25 APIs, so it compiles with a JDK 25 toolchain, gated on a JDK 25 being exercised; the JDK 17 builder is unchanged.

Result

A guide and runnable example. No production code changes.