### PR TITLE
Fix flaky H2ResponseCancelTest

### DIFF
--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/H2ResponseCancelTest.java
@@ -60,6 +60,7 @@ import static io.servicetalk.http.netty.HttpProtocol.HTTP_2;
 import static io.servicetalk.http.netty.TestServiceStreaming.SVC_ECHO;
 import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -148,7 +149,9 @@ class H2ResponseCancelTest extends AbstractNettyHttpServerTest {
 
         ExecutionException e = assertThrows(ExecutionException.class,
                 () -> makeRequest(newRequest(connection, "close")));
-        assertThat(e.getCause(), instanceOf(H2StreamResetException.class));
+        // The client may observe either the reset frame or the closed child channel, depending on which event wins.
+        assertThat(e.getCause(), anyOf(instanceOf(H2StreamResetException.class),
+                instanceOf(ClosedChannelException.class)));
 
         // Mak sure we can use the same connection for future requests:
         assertSerializedResponse(makeRequest(newRequest(connection, "ok")), HTTP_2_0, OK, "ok");


### PR DESCRIPTION
#### Motivation

`H2ResponseCancelTest.testServerClosesStreamNotConnection()` is flaky because closing an HTTP/2 stream can produce either an `H2StreamResetException` or a `ClosedChannelException`, depending on whether the reset frame or the closed child channel is observed first.

Closes #3425.

#### Modifications

- Accept either `H2StreamResetException` or `ClosedChannelException`.
- Document why both outcomes are valid.

#### Result

The test tolerates both valid race outcomes while continuing to verify that the parent HTTP/2 connection remains open and reusable.

There are no production behavior, API, or compatibility changes.